### PR TITLE
Disable auto fill option for password on /admin/users/[ID] page

### DIFF
--- a/app/views/spree/admin/users/_form.html.haml
+++ b/app/views/spree/admin/users/_form.html.haml
@@ -18,7 +18,7 @@
   .omega.five.columns
     = f.field_container :password do
       = f.label :password, t(".password")
-      = f.password_field :password, class: "fullwidth"
+      = f.password_field :password, class: "fullwidth", autocomplete: "new-password"
       = f.error_message_on :password
     = f.field_container :password do
       = f.label :password_confirmation, t(".confirm_password")


### PR DESCRIPTION
What? Why?
Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/9337

If the browser has a user's login data stored and the super admin wants to make changes on the /admin/users/[ID] page, there is an error, because the password is prefilled but the password confirmation is empty.
In this PR we have disabled the autofill option for the password field to resolve the above issue.

What should we test?
- As a user log in and save the login data in your browser.
- As a super admin go to the /admin/users/[ID] page of that user.
- See that the password field is not auto-filled.
![password_field_not_auto_filled](https://user-images.githubusercontent.com/62114687/175874613-ea5d60db-082f-4a55-9899-76b974501034.png)


Release notes
Changelog Category: User-facing changes | Technical changes

Dependencies
No dependencies.