### PR TITLE
Add tags to producer-only order cycle interface

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/tags_with_translation.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/tags_with_translation.js.coffee
@@ -3,6 +3,7 @@ angular.module("admin.utils").directive "tagsWithTranslation", ($timeout) ->
   templateUrl: "admin/tags_input.html"
   scope:
     object: "="
+    form: "="
     tagsAttr: "@?"
     tagListAttr: "@?"
     findTags: "&"
@@ -18,7 +19,15 @@ angular.module("admin.utils").directive "tagsWithTranslation", ($timeout) ->
       scope.limitReached = scope.object[scope.tagsAttr].length >= scope.max if scope.max != undefined
       scope.object[scope.tagListAttr] = (tag.text for tag in scope.object[scope.tagsAttr]).join(",")
 
+    scope.$watch "object", (newObject) -> 
+      scope.object = newObject
+      init()
+
     $timeout ->
+      init()
+    
+    init = ->
+      return unless scope.object
       # Initialize properties if necessary
       scope.tagsAttr ||= "tags"
       scope.tagListAttr ||= "tag_list"

--- a/app/views/admin/order_cycles/_simple_form.html.haml
+++ b/app/views/admin/order_cycles/_simple_form.html.haml
@@ -19,6 +19,10 @@
     %tr.products
       %td{ ng: { include: "'admin/panels/exchange_products_simple.html'" } }
 
+%br
+= label_tag t('.tags')
+%tags-with-translation{ object: 'order_cycle.outgoing_exchanges[0]', form: 'order_cycle_form' }
+
 %br/
 = label_tag t('.fees')
 = render 'coordinator_fees', f: f

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1218,6 +1218,7 @@ en:
         customer_instructions_placeholder: Pick-up or delivery notes
         products: Products
         fees: Fees
+        tags: Tags
       destroy_errors:
         orders_present: That order cycle has been selected by a customer and cannot be deleted. To prevent customers from accessing it, please close it instead.
         schedule_present: That order cycle is linked to a schedule and cannot be deleted. Please unlink or delete the schedule first.

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -635,6 +635,13 @@ describe '
       check   "order_cycle_incoming_exchange_0_variants_#{v3.id}"
       uncheck "order_cycle_incoming_exchange_0_variants_#{v3.id}"
 
+      # Add tags
+      expect(page).to have_content "TAGS"
+
+      within "tags-with-translation" do
+        find(:css, "tags-input .tags input").set "wholesale\n"
+      end
+
       # And I select some fees and update
       click_link 'order_cycle_coordinator_fee_0_remove'
       expect(page).not_to have_select 'order_cycle_coordinator_fee_0_id'
@@ -669,6 +676,9 @@ describe '
       ex = oc.exchanges.outgoing.first
       expect(ex.pickup_time).to eq('xy')
       expect(ex.pickup_instructions).to eq('yyz')
+
+      # And it should have the tags
+      expect(ex.tag_list).to eq ['wholesale']
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #9248

##### What has changed?
Add tag list editor to an order cycle for producer-only (not a hub) user:
<img width="335" alt="Capture d’écran 2022-06-27 à 15 20 18" src="https://user-images.githubusercontent.com/296452/175951707-3465ea75-829b-42ce-b116-2d1e7d1d4666.png">

##### What has not changed?
Use this interface to specify tag rule:
<img width="670" alt="Capture d’écran 2022-06-27 à 15 20 39" src="https://user-images.githubusercontent.com/296452/175951904-c8249c6c-bc06-47e6-ab13-2b6c75caeb30.png">

##### ... and, as a result:
<img width="799" alt="Capture d’écran 2022-06-27 à 15 21 49" src="https://user-images.githubusercontent.com/296452/175951944-b90b569f-c18d-47b6-aa03-d45c4a719e83.png">



#### What should we test?
 - Login in as simple producer
 - I can add tags on the order cycle
 - I can set up tags on enterprise settings, customers and shipping/payment methods
 - The rule defined works as expected.

Also test the old system, ie. when it's a hub, and have the outgoing products interface with tags:
<img width="949" alt="Capture d’écran 2022-06-28 à 15 06 44" src="https://user-images.githubusercontent.com/296452/176186039-d03387f7-217f-400b-b83b-edccd9456cc3.png">



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
