### PR TITLE
Admin, Edit order: Can add note on order

### DIFF
--- a/app/assets/javascripts/admin/spree/orders/shipments.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/shipments.js.erb
@@ -43,6 +43,9 @@ $(document).ready(function() {
   $('a.edit-tracking').click(toggleTrackingEdit);
   $('a.cancel-tracking').click(toggleTrackingEdit);
 
+  $('a.edit-note').click(toggleNoteEdit);
+  $('a.cancel-note').click(toggleNoteEdit);
+
   handle_tracking_save = function(){
     var link = $(this);
     var shipment_number = link.data('shipment-number');

--- a/app/assets/javascripts/admin/spree/orders/shipments.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/shipments.js.erb
@@ -43,7 +43,7 @@ $(document).ready(function() {
   $('a.edit-tracking').click(toggleTrackingEdit);
   $('a.cancel-tracking').click(toggleTrackingEdit);
 
-  $('a.edit-note').click(toggleNoteEdit);
+  $('a.edit-note.icon-edit').click(toggleNoteEdit);
   $('a.cancel-note').click(toggleNoteEdit);
 
   handle_tracking_save = function(){
@@ -62,5 +62,23 @@ $(document).ready(function() {
       console.log(msg);
     });
   }
+
+  handle_note_save = function(){
+    var link = $(this);
+    var note = link.parents('tbody').find('#note').val();
+    var url = Spree.url( Spree.routes.orders_api + "/" + order_number);
+
+    $.ajax({
+      type: "PUT",
+      url: url,
+      data: { note: note }
+    }).done(function( msg ) {
+      window.location.reload();
+    }).error(function( msg ) {
+      console.log(msg);
+    });
+  }
+
   $('[data-hook=admin_order_edit_form] a.save-tracking').click(handle_tracking_save);
+  $('[data-hook=admin_order_edit_form] a.save-note').click(handle_note_save);
 });

--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -145,6 +145,12 @@ toggleTrackingEdit = function(){
   link.parents('tbody').find('tr.show-tracking').toggle();
 }
 
+toggleNoteEdit = function(){
+  var link = $(this);
+  link.parents('tbody').find('tr.edit-note').toggle();
+  link.parents('tbody').find('tr.show-note').toggle();
+}
+
 toggleMethodEdit = function(){
   var link = $(this);
   link.parents('tbody').find('tr.edit-method').toggle();

--- a/app/controllers/api/v0/orders_controller.rb
+++ b/app/controllers/api/v0/orders_controller.rb
@@ -26,6 +26,13 @@ module Api
         }
       end
 
+      def update
+        authorize! :admin, order
+
+        order.update!(order_params)
+        render json: order, serializer: Api::OrderDetailedSerializer, current_order: order
+      end
+
       def ship
         authorize! :admin, order
 
@@ -71,6 +78,10 @@ module Api
           where(number: params[:id]).
           includes(line_items: { variant: [:product, :stock_items, :default_price] }).
           first!
+      end
+
+      def order_params
+        params.permit(:note)
       end
     end
   end

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -6,6 +6,7 @@
     = render 'spree/admin/orders/insufficient_stock_lines', insufficient_stock_lines: @order.insufficient_stock_lines
 
   = render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order }
+  = render partial: "spree/admin/orders/note", locals: { order: @order }
 
   = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.line_item_adjustments, :title => t(".line_item_adjustments")}
   = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => order_adjustments_for_display(@order), :title => t(".order_adjustments")}

--- a/app/views/spree/admin/orders/_note.html.haml
+++ b/app/views/spree/admin/orders/_note.html.haml
@@ -1,9 +1,10 @@
 %table.index.edit-note-table
   %tr.edit-note.hidden.total
-    %td{ :colspan => "5" }
+    %td{ colspan: "5", data: { controller: "input-char-count" }, style: "position: relative;" }
       %label
         = t(".note_label")
-      = text_field_tag :note, @order.note
+      = text_field_tag :note, @order.note, { maxLength: 280, data: { "input-char-count-target": "input" } }
+      %span.edit-note-count{ data: { "input-char-count-target": "count" }, style: "position: absolute; right: 7px; top: 7px; font-size: 11px;" }
 
     %td.actions
       = link_to '', '', class: 'save-note icon_link icon-ok no-text with-tip', data: { action: 'save' }, title: I18n.t('actions.save')

--- a/app/views/spree/admin/orders/_note.html.haml
+++ b/app/views/spree/admin/orders/_note.html.haml
@@ -1,0 +1,22 @@
+%table.index.edit-note-table
+  %tr.edit-note.hidden.total
+    %td{ :colspan => "5" }
+      %label
+        = t(".note_label")
+      = text_field_tag :note, @order.note
+
+    %td.actions
+      = link_to '', '', class: 'save-note icon_link icon-ok no-text with-tip', data: { action: 'save' }, title: I18n.t('actions.save')
+      = link_to '', '', class: 'cancel-note icon_link icon-cancel no-text with-tip', data: { action: 'cancel' }, title: I18n.t('actions.cancel')
+
+  %tr.show-note.total
+    %td{ :colspan => "5" }
+      - if order.note.present?
+        %strong
+          = t(".note_label")
+        = order.note
+      - else
+        = t(".no_note_present")
+
+    %td.actions
+      = link_to '', '', class: 'edit-note icon_link icon-edit no-text with-tip', data: { action: 'edit' }, title: Spree.t('edit')

--- a/app/webpacker/controllers/input_char_count_controller.js
+++ b/app/webpacker/controllers/input_char_count_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static targets = ["count", "input"];
+
+  connect() {
+    this.inputTarget.addEventListener("keyup", this.countCharacters.bind(this));
+    this.countCharacters();
+  }
+
+  countCharacters() {
+    this.displayCount(
+      this.inputTarget.value.length,
+      this.inputTarget.maxLength
+    );
+  }
+
+  displayCount(count, max) {
+    this.countTarget.textContent = `${count}/${max}`;
+  }
+}

--- a/app/webpacker/css/admin/orders.scss
+++ b/app/webpacker/css/admin/orders.scss
@@ -90,6 +90,18 @@ table.index td.actions {
   text-align: left;
 }
 
+table.edit-note-table {
+	margin-top: -15px;
+
+	tr:first-child th, tr:first-child td {
+		border-top: none;
+	}
+
+	td.actions {
+		width: 15%;
+	}
+}
+
 .index-controls {
 
   button {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -838,6 +838,9 @@ en:
         variants_without_unit_value: "WARNING: Some variants do not have a unit value"
         all: "All"
       select_variant: "Select a variant"
+      note:
+        note_label: "Note:"
+        no_note_present: "No note provided."
     enterprise:
       select_outgoing_oc_products_from: Select outgoing OC products from
 
@@ -3782,6 +3785,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           from: "From"
           to: "Bill to"
           shipping: "Shipping"
+        note:
+          note_label: "Note:"
+          no_note_present: "No note provided."
         form:
           distribution_fields:
             title: "Distribution"

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -18,7 +18,7 @@ Openfoodnetwork::Application.routes.draw do
 
       resources :variants, :only => [:index]
 
-      resources :orders, only: [:index, :show] do
+      resources :orders, only: [:index, :show, :update] do
         member do
           put :capture
           put :ship

--- a/db/migrate/20220629080906_add_note_to_orders.rb
+++ b/db/migrate/20220629080906_add_note_to_orders.rb
@@ -1,0 +1,5 @@
+class AddNoteToOrders < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spree_orders, :note, :string, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_21_230907) do
+ActiveRecord::Schema.define(version: 2022_06_29_080906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -596,6 +596,7 @@ ActiveRecord::Schema.define(version: 2022_06_21_230907) do
     t.integer "created_by_id"
     t.decimal "included_tax_total", precision: 10, scale: 2, default: "0.0", null: false
     t.decimal "additional_tax_total", precision: 10, scale: 2, default: "0.0", null: false
+    t.string "note", default: "", null: false
     t.index ["completed_at", "user_id", "created_by_id", "created_at"], name: "spree_orders_completed_at_user_id_created_by_id_created_at_idx"
     t.index ["customer_id"], name: "index_spree_orders_on_customer_id"
     t.index ["distributor_id"], name: "index_spree_orders_on_distributor_id"

--- a/spec/javascripts/stimulus/input_char_count_controller_test.js
+++ b/spec/javascripts/stimulus/input_char_count_controller_test.js
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { Application } from "stimulus";
+import input_char_count_controller from "../../../app/webpacker/controllers/input_char_count_controller";
+
+describe("InputCharCountController", () => {
+  beforeAll(() => {
+    const application = Application.start();
+    application.register("input-char-count", input_char_count_controller);
+  });
+
+  describe("default behavior", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `<div data-controller="input-char-count">
+        <input type='text' maxLength='280' id='input' data-input-char-count-target='input' value='Hello' />
+        <span id='count' data-input-char-count-target='count'></span>
+      </div>`;
+    });
+
+    it("handle the content", () => {
+      const input = document.getElementById("input");
+      const count = document.getElementById("count");
+      // Default value
+      expect(count.textContent).toBe("5/280");
+
+      input.value = "Hello world";
+      input.dispatchEvent(new Event("keyup"));
+
+      expect(count.textContent).toBe("11/280");
+    });
+  });
+});

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -525,6 +525,17 @@ describe '
         expect(page).to have_content test_tracking_number
       end
 
+      it "can edit note" do
+        test_note = "this is a note"
+        expect(page).to_not have_content test_note
+
+        find('.edit-note.icon-edit').click
+        fill_in "note", with: test_note
+        find('.save-note').click
+
+        expect(page).to have_content test_note
+      end
+
       it "viewing shipping fees" do
         shipping_fee = order.shipment_adjustments.first
 


### PR DESCRIPTION
#### What? Why?

Closes #9178

Add a small input that permit user to add a note on an order.
<img width="990" alt="Capture d’écran 2022-06-30 à 15 39 01" src="https://user-images.githubusercontent.com/296452/176691772-fab5e563-2f86-4082-bd3a-d8938e18ad8c.png">
<img width="974" alt="Capture d’écran 2022-06-30 à 15 39 11" src="https://user-images.githubusercontent.com/296452/176691788-effd8d7d-703d-4832-9730-ae7b978ba00d.png">



<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, on order edition page, you can add a note

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
