### PR TITLE
Phone number validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,6 +133,8 @@ gem 'flipper-ui'
 
 gem "view_component", require: "view_component/engine"
 
+gem "phonelib"
+
 group :production, :staging do
   gem 'ddtrace'
   gem 'rack-timeout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,6 +436,7 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.2.3)
+    phonelib (0.6.58)
     power_assert (2.0.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -775,6 +776,7 @@ DEPENDENCIES
   paypal-sdk-merchant (= 1.117.2)
   pdf-reader
   pg (~> 1.2.3)
+  phonelib
   pry (~> 0.13.0)
   pry-byebug (~> 3.9.0)
   puma

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -65,7 +65,7 @@ describe "Registration", js: true do
       # Filling in Contact Details
       fill_in 'enterprise_contact', with: 'Saskia Munroe'
       expect(page).to have_field 'enterprise_email_address', with: user.email
-      fill_in 'enterprise_phone', with: '12 3456 7890'
+      fill_in 'enterprise_phone', with: '03 1234 5678'
       click_button "Continue"
       expect(page).to have_content 'Last step to add My Awesome Enterprise!'
 


### PR DESCRIPTION
#### What? Why?

Closes openfoodfoundation/openfoodnetwork#9568

Doesn't prevent the user from advancing to the third step of enterprise registration, only alerts of the error when the user tries to create the profile, as shown below:
![Screenshot from 2022-06-30 18-04-47](https://user-images.githubusercontent.com/2237750/176778357-b2d46d5c-fa45-402a-8370-87163a34e762.png)

I thought this would be acceptable since it occurs in the same way when trying to create an enterprise with an already taken name:
![Screenshot from 2022-06-30 18-04-13](https://user-images.githubusercontent.com/2237750/176778474-039cea2c-e009-4d7d-bb8f-3da120757296.png)


#### What should we test?
1. Go to the contact step of the profile registration, new enterprise on the administration page or settings page of an enterprise (`/register`, `/admin/enterprises/new` and `/admin/enterprises/<enterprise_name>/edit#!/contact` respectively)
2. Enter an invalid number on the Phone field
3. Click on the `continue`, `create` or `update` button
4. See an error raised in the same page as before preventing the registration, creation or update of the enterprise.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.
