### PR TITLE
Admin, Products list: fix variant creation when unit is not well formatted and on_demand is checked or on_hand is filled

### DIFF
--- a/app/assets/javascripts/admin/utils/services/errors_parser.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/errors_parser.js.coffee
@@ -5,15 +5,16 @@ angular.module("admin.utils").factory "ErrorsParser", ->
       return defaultContent unless errors?
 
       errorsString = ""
-      if errors.length > 0
+      if Array.isArray(errors)
         # it is an array of errors
         errorsString = errors.join("\n") + "\n"
-      else
+      else if typeof errors == "object"
         # it is a hash of errors
         keys = Object.keys(errors)
         for key in keys
           errorsString += errors[key].join("\n") + "\n"
-
+      else # string
+        errorsString = errors
       this.defaultIfEmpty(errorsString, defaultContent)
 
     defaultIfEmpty: (content, defaultContent) =>

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -76,7 +76,7 @@ module Spree
 
         product_set.collection.each { |p| authorize! :update, p }
 
-        if product_set.save && product_set.errors.empty?
+        if product_set.save
           redirect_to main_app.bulk_products_api_v0_products_path(bulk_index_query)
         elsif product_set.errors.present?
           render json: { errors: product_set.errors }, status: :bad_request

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -76,7 +76,7 @@ module Spree
 
         product_set.collection.each { |p| authorize! :update, p }
 
-        if product_set.save
+        if product_set.save && product_set.errors.empty?
           redirect_to main_app.bulk_products_api_v0_products_path(bulk_index_query)
         elsif product_set.errors.present?
           render json: { errors: product_set.errors }, status: :bad_request

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -114,6 +114,11 @@ module Sets
 
       variant = product.variants.create(variant_attributes)
 
+      if variant.errors.present?
+        product.errors.merge!(variant.errors)
+        return false
+      end
+
       begin
         variant.on_demand = on_demand if on_demand.present?
         variant.on_hand = on_hand.to_i if on_hand.present?

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -97,6 +97,7 @@ module Sets
       variants_attributes.each do |attributes|
         create_or_update_variant(product, attributes)
       end
+      product.errors.empty?
     end
 
     def create_or_update_variant(product, variant_attributes)

--- a/spec/javascripts/unit/admin/utils/services/errors_parser_spec.js.coffee
+++ b/spec/javascripts/unit/admin/utils/services/errors_parser_spec.js.coffee
@@ -10,6 +10,9 @@ describe "ErrorsParser service", ->
     it "returns empty string for nil errors", ->
       expect(errorsParser.toString(null)).toEqual ""
 
+    it  "returns string for string errors", ->
+      expect(errorsParser.toString("error")).toEqual "error"
+
     it "returns the elements in the array if an array is provided", ->
       expect(errorsParser.toString(["1", "2"])).toEqual "1\n2\n"
 

--- a/spec/services/sets/product_set_spec.rb
+++ b/spec/services/sets/product_set_spec.rb
@@ -173,10 +173,8 @@ describe Sets::ProductSet do
                 end
 
                 it 'does not create variant and notifies bugsnag still raising the exception' do
-                  expect(Bugsnag).to receive(:notify)
                   number_of_variants = Spree::Variant.all.size
-                  expect { product_set.save }
-                    .to raise_error(StandardError)
+                  expect(product_set.save).to eq(false)
                   expect(Spree::Variant.all.size).to eq number_of_variants
                   expect(Spree::Variant.last.sku).not_to eq('321')
                 end

--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -303,7 +303,6 @@ describe '
       end
 
       it "creating a variant with unit value is: '120g' and 'on_hand' filled" do
-        pending "#9068"
         within "tr#v_#{Spree::Variant.second.id}" do
           page.find(".add-variant").click
         end
@@ -315,11 +314,10 @@ describe '
         end
 
         click_button 'Save Changes', match: :first
-        expect(page.find("#status-message")).to have_content "Changes saved."
+        expect(page.find("#status-message")).to have_content "Unit value can't be blank Unit value is not a number"
       end
 
       it "creating a variant with unit value is: '120g' and 'on_demand' checked" do
-        pending "#9068"
         within "tr#v_#{Spree::Variant.second.id}" do
           page.find(".add-variant").click
         end
@@ -331,7 +329,7 @@ describe '
         end
 
         click_button 'Save Changes', match: :first
-        expect(page.find("#status-message")).to have_content "Changes saved."
+        expect(page.find("#status-message")).to have_content "Unit value can't be blank Unit value is not a number"
       end
     end
   end

--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -278,8 +278,6 @@ describe '
     end
 
     context "handle the 'on_demand' variant case creation" do
-      # let(:variant) { create(:variant, product: p) }
-
       before do
         p = Spree::Product.first
         p.master.update_attribute(:on_hand, 5)
@@ -291,16 +289,46 @@ describe '
       end
 
       it "when variant unit value is: '120'" do
-        fill_in "variant_unit_value_with_description", with: "120"
-        check "variant_on_demand"
+        within "tr#v_#{Spree::Variant.second.id}" do
+          page.find(".add-variant").click
+        end
+
+        within "tr#v_-1" do
+          fill_in "variant_unit_value_with_description", with: "120"
+          fill_in "variant_price", with: "6.66"
+        end
 
         click_button 'Save Changes', match: :first
         expect(page.find("#status-message")).to have_content "Changes saved."
       end
 
-      it "when variant unit value is: '120g'" do
-        fill_in "variant_unit_value_with_description", with: "120g"
-        check "variant_on_demand"
+      it "creating a variant with unit value is: '120g' and 'on_hand' filled" do
+        pending "#9068"
+        within "tr#v_#{Spree::Variant.second.id}" do
+          page.find(".add-variant").click
+        end
+
+        within "tr#v_-1" do
+          fill_in "variant_unit_value_with_description", with: "120g"
+          fill_in "variant_price", with: "6.66"
+          fill_in "variant_on_hand", with: "222"
+        end
+
+        click_button 'Save Changes', match: :first
+        expect(page.find("#status-message")).to have_content "Changes saved."
+      end
+
+      it "creating a variant with unit value is: '120g' and 'on_demand' checked" do
+        pending "#9068"
+        within "tr#v_#{Spree::Variant.second.id}" do
+          page.find(".add-variant").click
+        end
+
+        within "tr#v_-1" do
+          fill_in "variant_unit_value_with_description", with: "120g"
+          fill_in "variant_price", with: "6.66"
+          check "variant_on_demand"
+        end
 
         click_button 'Save Changes', match: :first
         expect(page.find("#status-message")).to have_content "Changes saved."

--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -227,51 +227,85 @@ describe '
     expect(page).to have_field "product_name", with: 'Big Bag Of Apples'
   end
 
-  it "creating new variants" do
-    # Given a product without variants or a unit
-    p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1000)
-    login_as_admin
-    visit spree.admin_products_path
+  context "creating new variants" do
+    before do
+      # Given a product without variants or a unit
+      p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1000)
+      login_as_admin
+      visit spree.admin_products_path
 
-    # I should see an add variant button
-    page.find('a.view-variants').click
-
-    # When I add three variants
-    page.find('a.add-variant', visible: true).click
-    page.find('a.add-variant', visible: true).click
-
-    # They should be added, and should not see edit buttons for new variants
-    expect(page).to have_selector "tr.variant", count: 3
-    expect(page).to have_selector "a.edit-variant", count: 1
-
-    # When I remove two, they should be removed
-    accept_alert do
-      page.all('a.delete-variant', visible: true).first.click
+      # I should see an add variant button
+      page.find('a.view-variants').click
     end
-    expect(page).to have_selector "tr.variant", count: 2
-    page.all('a.delete-variant', visible: true).first.click
-    expect(page).to have_selector "tr.variant", count: 1
 
-    # When I fill out variant details and hit update
-    fill_in "variant_display_name", with: "Case of 12 Bottles"
-    fill_in "variant_unit_value_with_description", with: "3 (12x250 mL bottles)"
-    fill_in "variant_display_as", with: "Case"
-    fill_in "variant_price", with: "4.0"
-    fill_in "variant_on_hand", with: "10"
+    it "handle the default behaviour" do
+      # When I add three variants
+      page.find('a.add-variant', visible: true).click
+      page.find('a.add-variant', visible: true).click
 
-    click_button 'Save Changes', match: :first
-    expect(page.find("#status-message")).to have_content "Changes saved."
+      # They should be added, and should not see edit buttons for new variants
+      expect(page).to have_selector "tr.variant", count: 3
+      expect(page).to have_selector "a.edit-variant", count: 1
 
-    updated_variant = Spree::Variant.where(deleted_at: nil).last
-    expect(updated_variant.display_name).to eq "Case of 12 Bottles"
-    expect(updated_variant.unit_value).to eq 3000
-    expect(updated_variant.unit_description).to eq "(12x250 mL bottles)"
-    expect(updated_variant.display_as).to eq "Case"
-    expect(updated_variant.price).to eq 4.0
-    expect(updated_variant.on_hand).to eq 10
+      # When I remove two, they should be removed
+      accept_alert do
+        page.all('a.delete-variant', visible: true).first.click
+      end
+      expect(page).to have_selector "tr.variant", count: 2
+      page.all('a.delete-variant', visible: true).first.click
+      expect(page).to have_selector "tr.variant", count: 1
 
-    # Then I should see edit buttons for the new variant
-    expect(page).to have_selector "a.edit-variant", visible: true
+      # When I fill out variant details and hit update
+      fill_in "variant_display_name", with: "Case of 12 Bottles"
+      fill_in "variant_unit_value_with_description", with: "3 (12x250 mL bottles)"
+      fill_in "variant_display_as", with: "Case"
+      fill_in "variant_price", with: "4.0"
+      fill_in "variant_on_hand", with: "10"
+
+      click_button 'Save Changes', match: :first
+      expect(page.find("#status-message")).to have_content "Changes saved."
+
+      updated_variant = Spree::Variant.where(deleted_at: nil).last
+      expect(updated_variant.display_name).to eq "Case of 12 Bottles"
+      expect(updated_variant.unit_value).to eq 3000
+      expect(updated_variant.unit_description).to eq "(12x250 mL bottles)"
+      expect(updated_variant.display_as).to eq "Case"
+      expect(updated_variant.price).to eq 4.0
+      expect(updated_variant.on_hand).to eq 10
+
+      # Then I should see edit buttons for the new variant
+      expect(page).to have_selector "a.edit-variant", visible: true
+    end
+
+    context "handle the 'on_demand' variant case creation" do
+      # let(:variant) { create(:variant, product: p) }
+
+      before do
+        p = Spree::Product.first
+        p.master.update_attribute(:on_hand, 5)
+        p.save
+        v1 = FactoryBot.create(:variant, product: p, is_master: false, on_hand: 4)
+        v2 = FactoryBot.create(:variant, product: p, is_master: false, on_demand: true)
+        p.variants << v1
+        p.variants << v2
+      end
+
+      it "when variant unit value is: '120'" do
+        fill_in "variant_unit_value_with_description", with: "120"
+        check "variant_on_demand"
+
+        click_button 'Save Changes', match: :first
+        expect(page.find("#status-message")).to have_content "Changes saved."
+      end
+
+      it "when variant unit value is: '120g'" do
+        fill_in "variant_unit_value_with_description", with: "120g"
+        check "variant_on_demand"
+
+        click_button 'Save Changes', match: :first
+        expect(page.find("#status-message")).to have_content "Changes saved."
+      end
+    end
   end
 
   it "updating product attributes" do


### PR DESCRIPTION

 

#### What? Why?

Closes #9068
Many errors that were intricate. 
But now, we display the original errors on why the variant saving failed. 


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, visit page `/admin/products`
- Create a new variant with `12g` in `unit` column (for example), and `on_hand` filled or `on_demand` checked
- This should display errors:

<img width="636" alt="Capture d’écran 2022-07-05 à 16 44 35" src="https://user-images.githubusercontent.com/296452/177354956-d1396998-ed02-4015-a946-24cbe64bcbe6.png">

Creating variants should be the same as before. 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
