### PR TITLE
Can send invoice if ABN is not required

### DIFF
--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -126,7 +126,7 @@ module Spree
       end
 
       def require_distributor_abn
-        return if @order.distributor.abn.present?
+        return if @order.distributor.can_invoice?
 
         flash[:error] = t(:must_have_valid_business_number,
                           enterprise_name: @order.distributor.name)

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -480,18 +480,31 @@ describe '
       end
       
       context "Check send/print invoice links" do
-        context "when abn number is not mandatory to send/print invoices" do
+        
+        shared_examples_for 'can send/print invoices' do
           before do
-            Spree::Config[:enterprise_number_required_on_invoices?] = false
+            visit spree.edit_admin_order_path(order)
+            find("#links-dropdown .ofn-drop-down").click
           end
 
-          it "should display normal links" do
-            visit spree.edit_admin_order_path(order)
-
-            find("#links-dropdown .ofn-drop-down").click
+          it 'shows the right links' do
             expect(page).to have_link "Send Invoice", href: spree.invoice_admin_order_path(order)
             expect(page).to have_link "Print Invoice", href: spree.print_admin_order_path(order)
           end
+
+          it 'can send invoices' do
+            click_link "Send Invoice"
+            expect(page).to have_content "Invoice email has been sent"
+          end
+        end
+
+        context "when abn number is not mandatory to send/print invoices" do
+          before do
+            Spree::Config[:enterprise_number_required_on_invoices?] = false
+            distributor1.update_attribute(:abn, "")
+          end
+
+          it_should_behave_like 'can send/print invoices'
         end
 
         context "when abn number is mandatory to send/print invoices" do
@@ -504,13 +517,7 @@ describe '
               distributor1.update_attribute(:abn, '12345678')
             end
             
-            it "should display normal links" do
-              visit spree.edit_admin_order_path(order)
-
-              find("#links-dropdown .ofn-drop-down").click
-              expect(page).to have_link "Send Invoice", href: spree.invoice_admin_order_path(order)
-              expect(page).to have_link "Print Invoice", href: spree.print_admin_order_path(order)
-            end
+            it_should_behave_like 'can send/print invoices'
           end
 
           context "and a abn number is not set on the distributor" do


### PR DESCRIPTION
#### What? Why?

Closes #9382

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Copy/paste from #9382 

###### As a superadmin:
1. Uncheck the option "Require an ABN to generate an invoice?"
###### As a Hub:
1. Delete any number existing in the ABN field under admin/enterprises/baguette/edit#!/business_details
2. Visit the order edit page for a order in state = complete
3. Try to send the invoice per Email.
4. See the red banner; check your email -> no invoice is sent
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
