### PR TITLE
Feature/update orders table

### DIFF
--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -4,6 +4,8 @@ module Spree
   class OrdersController < ::BaseController
     include OrderCyclesHelper
     include Rails.application.routes.url_helpers
+    include CablecarResponses
+
 
     layout 'darkswarm'
 
@@ -99,7 +101,8 @@ module Spree
       else
         flash[:error] = I18n.t(:orders_could_not_cancel)
       end
-      redirect_to request.referer || main_app.order_path(@order)
+      render status: :found,
+             operations: cable_car.redirect_to(url: request.referer || main_app.order_path(@order))
     end
 
     private

--- a/app/views/spree/users/_open_orders.html.haml
+++ b/app/views/spree/users/_open_orders.html.haml
@@ -11,8 +11,7 @@
         %th.order7.show-for-large-up.text-right= t('.cancel')
       %tbody.transaction-group{"ng-repeat" => "order in Orders.changeable", "ng-class-odd"=>"'odd'", "ng-class-even"=>"'even'"}
         %tr.order-row
-          %td.order1
-            %a{"ng-href" => "{{::order.path}}", "ng-bind" => "::order.number"}
+          %td.order1{"ng-bind" => "::order.number"}
           %td.order2
             %a{"ng-href" => "{{::Orders.shopsByID[order.shop_id].hash}}#{main_app.shop_path}", "ng-bind" => "::Orders.shopsByID[order.shop_id].name"}
           %td.order3.show-for-large-up{"ng-bind" => "::order.changes_allowed_until"}

--- a/app/views/spree/users/_past_orders.html.haml
+++ b/app/views/spree/users/_past_orders.html.haml
@@ -11,8 +11,7 @@
         %th.order7.text-right= t('.view')
       %tbody.transaction-group{"ng-repeat" => "order in Orders.all | filter:{changes_allowed:false} as pastOrders", "ng-class-odd"=>"'odd'", "ng-class-even"=>"'even'"}
         %tr.order-row
-          %td.order1
-            %a{"ng-href" => "{{::order.path}}", "ng-bind" => "::order.number"}
+          %td.order1{"ng-bind" => "::order.number"}
           %td.order2
             %a{"ng-href" => "{{::Orders.shopsByID[order.shop_id].hash}}#{main_app.shop_path}", "ng-bind" => "::Orders.shopsByID[order.shop_id].name"}
           %td.order3.show-for-large-up{"ng-bind" => "::order.completed_at"}

--- a/app/views/spree/users/_past_orders.html.haml
+++ b/app/views/spree/users/_past_orders.html.haml
@@ -8,7 +8,7 @@
         %th.order4.show-for-large-up= t('.items')
         %th.order5.text-right= t('.total')
         %th.order6.text-right.show-for-large-up= t('.paid?')
-        %th.order7.text-right= t('.view')
+        %th.order7.text-right= t('.status')
       %tbody.transaction-group{"ng-repeat" => "order in Orders.all | filter:{changes_allowed:false} as pastOrders", "ng-class-odd"=>"'odd'", "ng-class-even"=>"'even'"}
         %tr.order-row
           %td.order1{"ng-bind" => "::order.number"}
@@ -18,5 +18,6 @@
           %td.order4.show-for-large-up{"ng-bind" => "::order.item_count"}
           %td.order5.text-right{"ng-class" => "{'debit': order.payment_state != 'paid', 'credit': order.payment_state == 'paid'}","ng-bind" => "::order.total | localizeCurrency"}
           %td.order6.text-right.show-for-large-up{"ng-class" => "{'debit': order.payment_state != 'paid', 'credit': order.payment_state == 'paid'}", "ng-bind" => "::(order.payment_state == 'paid' ? 'say_yes' : 'say_no') | t"}
-          %td.order7.text-right
-            %a{"ng-href" => "{{::order.path}}" }= t('.view')
+            %td.order7.text-right{ "ng-switch" => "::order.state"  }
+              %a{ "ng-switch-when" => "complete", "ng-href" => "{{::order.path}}" }= t('.completed')
+              %span{ "ng-switch-when" => "canceled" }= t('.cancelled')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4208,7 +4208,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         items: Items
         total: Total
         paid?: Paid?
-        view: View
+        status: Status
+        completed: Completed
+        cancelled: Cancelled
       saved_cards:
         default?: Default?
         delete?: Delete?

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -457,7 +457,9 @@ describe Spree::OrdersController, type: :controller do
       context "when the order is not yet complete" do
         it "responds with forbidden" do
           spree_put :cancel, params
-          expect(response.status).to redirect_to order_path(order)
+
+          expect(response).to have_http_status(:found)
+          expect(response.body).to match(order_path(order)).and match("redirect")
           expect(flash[:error]).to eq I18n.t(:orders_could_not_cancel)
         end
       end
@@ -474,7 +476,9 @@ describe Spree::OrdersController, type: :controller do
 
         it "responds with success" do
           spree_put :cancel, params
-          expect(response.status).to redirect_to order_path(order)
+
+          expect(response).to have_http_status(:found)
+          expect(response.body).to match(order_path(order)).and match("redirect")
           expect(flash[:success]).to eq I18n.t(:orders_your_order_has_been_cancelled)
         end
       end

--- a/spec/system/consumer/account_spec.rb
+++ b/spec/system/consumer/account_spec.rb
@@ -93,8 +93,8 @@ describe '
           visit '/account'
           expect(page).to have_content I18n.t('spree.users.orders.open_orders')
 
-          expect(page).to have_link d1o1.number, href: order_path(d1o1)
-          expect(page).to have_link d1o2.number, href: order_path(d1o2)
+          expect(page).to have_link 'Edit', href: order_path(d1o1)
+          expect(page).to have_link 'Edit', href: order_path(d1o2)
           expect(page).to have_link(distributor1.name,
                                     href: "#{distributor1.permalink}/shop", count: 2)
           expect(page).to have_link I18n.t('spree.users.open_orders.cancel'),


### PR DESCRIPTION
#### What? Why?
This issue makes light changes in the account#/orders page and renders a flash when orders are cancelled.
Closes #9304 
Closes #8806 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit page account/orders
- Cancel an Open Order
- Ascertain that a flash message is displayed
---
- Ascertain that the Order Number is no longer a link
- Ascertain that the view column has been renamed to status
- Ascertain that only orders with Completed status have a link to the orders#show page
- Ascertain that orders with Cancelled status don't have a link to the orders#show page

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

SS:

![ezgif com-gif-maker(8)](https://user-images.githubusercontent.com/87677429/177714093-1e41ed1f-89ad-4894-b0c8-509e8e3f0da7.gif)


