### PR TITLE
Admin, Reports: format all currency columns as numerical values (and no as currency value)

### DIFF
--- a/lib/reporting/reports/bulk_coop/supplier_report.rb
+++ b/lib/reporting/reports/bulk_coop/supplier_report.rb
@@ -24,10 +24,6 @@ module Reporting
           }
         end
 
-        def columns_format
-          { sum_total: :currency }
-        end
-
         def rules
           [
             {

--- a/lib/reporting/reports/enterprise_fee_summary/scope.rb
+++ b/lib/reporting/reports/enterprise_fee_summary/scope.rb
@@ -366,7 +366,7 @@ module Reporting
           chain_to_scope do
             select(
               <<-JOIN_STRING.strip_heredoc
-                SUM(spree_adjustments.amount)::NUMERIC AS total_amount,
+                SUM(spree_adjustments.amount) AS total_amount,
                   spree_payment_methods.name AS payment_method_name,
                   spree_shipping_methods.name AS shipping_method_name,
                   hubs.name AS hub_name,

--- a/lib/reporting/reports/enterprise_fee_summary/scope.rb
+++ b/lib/reporting/reports/enterprise_fee_summary/scope.rb
@@ -366,7 +366,7 @@ module Reporting
           chain_to_scope do
             select(
               <<-JOIN_STRING.strip_heredoc
-                SUM(spree_adjustments.amount)::TEXT AS total_amount,
+                SUM(spree_adjustments.amount)::NUMERIC AS total_amount,
                   spree_payment_methods.name AS payment_method_name,
                   spree_shipping_methods.name AS shipping_method_name,
                   hubs.name AS hub_name,

--- a/lib/reporting/reports/packing/base.rb
+++ b/lib/reporting/reports/packing/base.rb
@@ -26,7 +26,7 @@ module Reporting
         end
 
         def columns_format
-          { price: :currency, quantity: :quantity }
+          { quantity: :quantity }
         end
 
         def custom_headers

--- a/spec/lib/reports/enterprise_fee_summary/enterprise_fee_summary_report_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/enterprise_fee_summary_report_spec.rb
@@ -116,37 +116,37 @@ describe Reporting::Reports::EnterpriseFeeSummary::Base do
 
       expected_result = [
         ["Admin", "Sample Coordinator", "Coordinator Fee 1", "Another Customer",
-         "Coordinator", "All", "Sample Coordinator Tax", "512.00"],
+         "Coordinator", "All", "Sample Coordinator Tax", 512],
         ["Admin", "Sample Coordinator", "Coordinator Fee 1", "Sample Customer",
-         "Coordinator", "All", "Sample Coordinator Tax", "1024.00"],
+         "Coordinator", "All", "Sample Coordinator Tax", 1024],
         ["Admin", "Sample Distributor", "Distributor Fee 1", "Another Customer",
-         "Outgoing", "Sample Distributor", "Sample Distributor Tax", "4.00"],
+         "Outgoing", "Sample Distributor", "Sample Distributor Tax", 4],
         ["Admin", "Sample Distributor", "Distributor Fee 1", "Sample Customer",
-         "Outgoing", "Sample Distributor", "Sample Distributor Tax", "8.00"],
+         "Outgoing", "Sample Distributor", "Sample Distributor Tax", 8],
         ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Another Customer",
-         nil, nil, nil, "2.00"],
+         nil, nil, nil, 2],
         ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
-         nil, nil, nil, "4.00"],
+         nil, nil, nil, 4],
         ["Sales", "Sample Coordinator", "Coordinator Fee 2", "Another Customer",
-         "Coordinator", "All", "Various", "1024.00"],
+         "Coordinator", "All", "Various", 1024],
         ["Sales", "Sample Coordinator", "Coordinator Fee 2", "Sample Customer",
-         "Coordinator", "All", "Various", "2048.00"],
+         "Coordinator", "All", "Various", 2048],
         ["Sales", "Sample Distributor", "Distributor Fee 2", "Another Customer",
-         "Outgoing", "Sample Distributor", "Sample Product Tax", "8.00"],
+         "Outgoing", "Sample Distributor", "Sample Product Tax", 8],
         ["Sales", "Sample Distributor", "Distributor Fee 2", "Sample Customer",
-         "Outgoing", "Sample Distributor", "Sample Product Tax", "16.00"],
+         "Outgoing", "Sample Distributor", "Sample Product Tax", 16],
         ["Sales", "Sample Producer", "Producer Fee 1", "Another Customer",
-         "Incoming", "Sample Producer", "Sample Producer Tax", "64.00"],
+         "Incoming", "Sample Producer", "Sample Producer Tax", 64],
         ["Sales", "Sample Producer", "Producer Fee 1", "Sample Customer",
-         "Incoming", "Sample Producer", "Sample Producer Tax", "128.00"],
+         "Incoming", "Sample Producer", "Sample Producer Tax", 128],
         ["Sales", "Sample Producer", "Producer Fee 2", "Another Customer",
-         "Incoming", "Sample Producer", "Sample Product Tax", "128.00"],
+         "Incoming", "Sample Producer", "Sample Product Tax", 128],
         ["Sales", "Sample Producer", "Producer Fee 2", "Sample Customer",
-         "Incoming", "Sample Producer", "Sample Product Tax", "256.00"],
+         "Incoming", "Sample Producer", "Sample Product Tax", 256],
         ["Shipment", "Sample Distributor", "Sample Shipping Method", "Another Customer",
-         nil, nil, "Platform Rate", "1.00"],
+         nil, nil, "Platform Rate", 1],
         ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
-         nil, nil, "Platform Rate", "2.00"]
+         nil, nil, "Platform Rate", 2]
       ]
 
       expected_result.each_with_index do |expected_attributes, row_index|
@@ -173,7 +173,7 @@ describe Reporting::Reports::EnterpriseFeeSummary::Base do
 
         expected_result = [
           ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
-           nil, nil, "Platform Rate", "1.00"]
+           nil, nil, "Platform Rate", 1]
         ]
 
         expected_result.each_with_index do |expected_attributes, row_index|
@@ -208,9 +208,9 @@ describe Reporting::Reports::EnterpriseFeeSummary::Base do
 
         expected_result = [
           ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
-           nil, nil, nil, "2.00"],
+           nil, nil, nil, 2],
           ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
-           nil, nil, "Platform Rate", "1.00"]
+           nil, nil, "Platform Rate", 1]
         ]
 
         expected_result.each_with_index do |expected_attributes, row_index|
@@ -233,7 +233,7 @@ describe Reporting::Reports::EnterpriseFeeSummary::Base do
 
         expected_result = [
           ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
-           nil, nil, "Platform Rate", "1.00"]
+           nil, nil, "Platform Rate", 1]
         ]
 
         expected_result.each_with_index do |expected_attributes, row_index|
@@ -280,17 +280,17 @@ describe Reporting::Reports::EnterpriseFeeSummary::Base do
 
         expected_result = [
           ["Admin", "Sample Coordinator", "Sample Coordinator Fee", "Sample Customer",
-           "Incoming", "Sample Producer", "Sample Coordinator Tax", "512.00"],
+           "Incoming", "Sample Producer", "Sample Coordinator Tax", 512],
           ["Admin", "Sample Coordinator", "Sample Coordinator Fee", "Sample Customer",
-           "Outgoing", "Sample Distributor", "Sample Coordinator Tax", "512.00"],
+           "Outgoing", "Sample Distributor", "Sample Coordinator Tax", 512],
           ["Admin", "Sample Distributor", "Sample Distributor Fee", "Sample Customer",
-           "Incoming", "Sample Producer", "Sample Distributor Tax", "4.00"],
+           "Incoming", "Sample Producer", "Sample Distributor Tax", 4],
           ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
-           nil, nil, nil, "2.00"],
+           nil, nil, nil, 2],
           ["Sales", "Sample Producer", "Sample Producer Fee", "Sample Customer",
-           "Outgoing", "Sample Distributor", "Sample Producer Tax", "64.00"],
+           "Outgoing", "Sample Distributor", "Sample Producer Tax", 64],
           ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
-           nil, nil, "Platform Rate", "1.00"]
+           nil, nil, "Platform Rate", 1]
         ]
 
         expected_result.each_with_index do |expected_attributes, row_index|
@@ -361,27 +361,27 @@ describe Reporting::Reports::EnterpriseFeeSummary::Base do
 
         expected_result = [
           ["Admin", "Sample Coordinator", "Coordinator Fee A", "Sample Customer",
-           "Coordinator", "All", "Coordinator Tax A", "15.00"],
+           "Coordinator", "All", "Coordinator Tax A", 15],
           ["Admin", "Sample Coordinator", "Coordinator Fee A", "Sample Customer",
-           "Incoming", entire_orders_text, "Coordinator Tax A", "15.00"],
+           "Incoming", entire_orders_text, "Coordinator Tax A", 15],
           ["Admin", "Sample Coordinator", "Coordinator Fee A", "Sample Customer",
-           "Outgoing", entire_orders_text, "Coordinator Tax A", "15.00"],
+           "Outgoing", entire_orders_text, "Coordinator Tax A", 15],
           ["Admin", "Sample Coordinator", "Coordinator Fee B", "Sample Customer",
-           "Coordinator", "All", various_tax_categories_text, "20.00"],
+           "Coordinator", "All", various_tax_categories_text, 20],
           ["Admin", "Sample Coordinator", "Coordinator Fee C", "Sample Customer",
-           "Coordinator", "All", nil, "25.00"],
+           "Coordinator", "All", nil, 25],
           ["Admin", "Sample Distributor", "Distributor Fee A", "Sample Customer",
-           "Incoming", entire_orders_text, various_tax_categories_text, "30.00"],
+           "Incoming", entire_orders_text, various_tax_categories_text, 30],
           ["Admin", "Sample Distributor", "Distributor Fee A", "Sample Customer",
-           "Outgoing", entire_orders_text, various_tax_categories_text, "30.00"],
+           "Outgoing", entire_orders_text, various_tax_categories_text, 30],
           ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
-           nil, nil, nil, "2.00"],
+           nil, nil, nil, 2],
           ["Sales", "Sample Producer", "Producer Fee A", "Sample Customer",
-           "Incoming", entire_orders_text, "Producer Tax A", "10.00"],
+           "Incoming", entire_orders_text, "Producer Tax A", 10],
           ["Sales", "Sample Producer", "Producer Fee A", "Sample Customer",
-           "Outgoing", entire_orders_text, "Producer Tax A", "10.00"],
+           "Outgoing", entire_orders_text, "Producer Tax A", 10],
           ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
-           nil, nil, "Platform Rate", "1.00"]
+           nil, nil, "Platform Rate", 1]
         ]
 
         expected_result.each_with_index do |expected_attributes, row_index|


### PR DESCRIPTION
#### What? Why?

Closes #9384 

I didn't delete the option to format columns as currency value, and `format_currency` still exists: 

https://github.com/openfoodfoundation/openfoodnetwork/blob/a1adcadd6ccfc415f255b456f76fd5e68e8395a8/lib/reporting/report_row_builder.rb#L108-L110

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, generate reports, and check that each columns are numerical formatted (and not currency formatted)
- See the linked issue for the concerned reports

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
