### PR TITLE
Admin, Reports,  Order Cycle Customer Totals: Remove paid?, order cycle and payment method columns from summary row

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_customer_totals.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_customer_totals.rb
@@ -121,10 +121,7 @@ module Reporting
             ship_price: order.ship_total,
             pay_fee_price: order.payment_fee,
             total_price: order.total,
-            paid: order.paid?,
             comments: order.special_instructions,
-            order_cycle: order.order_cycle&.name,
-            payment_method: order.payments.first&.payment_method&.name,
             order_number: order.number,
             date: order.completed_at.strftime("%F %T"),
           }

--- a/spec/fixtures/reports/orders_and_fulfillment/order_cycle_customer_totals_report.csv
+++ b/spec/fixtures/reports/orders_and_fulfillment/order_cycle_customer_totals_report.csv
@@ -1,3 +1,3 @@
 Hub,Customer,Email,Phone,Producer,Product,Variant,Quantity,Item ($),Item + Fees ($),Admin & Handling ($),Ship ($),Pay fee ($),Total ($),Paid?,Shipping,Delivery?,Ship Street,Ship Street 2,Ship City,Ship Postcode,Ship State,Comments,SKU,Order Cycle,Payment Method,Customer Code,Tags,Billing Street,Billing Street 2,Billing City,Billing Postcode,Billing State,Order number,Date
 Apple Market,John Doe,john@example.net,123-456-7890,Apple Farmer,Apples,"1g, S",1,10.0,10.0,"","","","",No,UPS Ground,Yes,10 Lovely Street,Northwest,Herndon,20170,Victoria,"",APP,"","",JHN,"",10 Lovely Street,Northwest,Herndon,20170,Victoria,R644360121,2022-05-26 00:00:00
-Apple Market,John Doe,"","","","","",TOTAL,10.0,10.0,0,0.0,0,10.0,No,"","","","","","","","","","","","","","","","","","",R644360121,2022-05-26 00:00:00
+Apple Market,John Doe,"","","","","",TOTAL,10.0,10.0,0,0.0,0,10.0,"","","","","","","","","","","","","","","","","","","",R644360121,2022-05-26 00:00:00


### PR DESCRIPTION
#### What? Why?

Closes #9319
<img width="1863" alt="Capture d’écran 2022-07-11 à 15 22 37" src="https://user-images.githubusercontent.com/296452/178274530-26e5c3e9-3b1a-4863-920e-efb02ddea29c.png">

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, on `Order Cycle Customer Totals` report, check that `paid?`, `order cycle` and `payment method` columns are empty for the summary row

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
