### PR TITLE
Handle for invalid referer for embedded page service

### DIFF
--- a/app/services/embedded_page_service.rb
+++ b/app/services/embedded_page_service.rb
@@ -68,12 +68,12 @@ class EmbeddedPageService
   end
 
   def current_referer
-    return if @request.referer.blank?
-
-    uri = URI(@request.referer)
-    return if uri.host.blank?
+    uri = URI.parse(@request.referer)
+    return unless uri.is_a?(URI::HTTP) && uri.host.present?
 
     uri.host.downcase
+  rescue URI::InvalidURIError
+    false
   end
 
   def current_referer_without_www

--- a/spec/services/embedded_page_service_spec.rb
+++ b/spec/services/embedded_page_service_spec.rb
@@ -74,7 +74,7 @@ describe EmbeddedPageService do
     context "when the request's referer is malformed" do
       let(:request) {
         ActionController::TestRequest.new(
-          { 'HTTP_HOST' => 'ofn-instance.com', 'HTTP_REFERER' => 'hello' }, nil, nil
+          { 'HTTP_HOST' => 'ofn-instance.com', 'HTTP_REFERER' => 'hello# 32' }, nil, nil
         )
       }
       before do


### PR DESCRIPTION
#### What? Why?

Closes #9355 

In some cases the referer of the current url is invalid and not a valid url. In these cases the current behaviour throws an unhandled exception and the page could not been visit.


#### What should we test?

- I could not reproduce it in Chrome or in Firefox :-1:  

#### Release notes

Changelog Category: User facing changes 

The title of the pull request will be included in the release notes.
