### PR TITLE
Pre-select the last order cycle on all orders and fullfillment reports

### DIFF
--- a/app/views/admin/reports/filters/_orders_and_fulfillment.html.haml
+++ b/app/views/admin/reports/filters/_orders_and_fulfillment.html.haml
@@ -11,4 +11,4 @@
 .row
   .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
   .omega.fourteen.columns
-    = f.select(:order_cycle_id_in, report_order_cycle_options(@data.order_cycles), {selected: params.dig(:q, :order_cycle_id_in)}, {class: "select2 fullwidth", multiple: true})
+    = f.select(:order_cycle_id_in, report_order_cycle_options(@data.order_cycles), { selected: params.dig(:q, :order_cycle_id_in) || @data.order_cycles.last&.id }, {class: "select2 fullwidth", multiple: true})

--- a/spec/system/admin/reports/orders_and_fulfillment_spec.rb
+++ b/spec/system/admin/reports/orders_and_fulfillment_spec.rb
@@ -95,6 +95,14 @@ describe "Orders And Fulfillment" do
                             ])
       end
 
+      it "pre selects the last order cycle when it exists" do
+        order_cycle = create(:simple_order_cycle, distributors: [distributor])
+
+        visit current_path
+
+        expect(find('#q_order_cycle_id_in').value).to eq [order_cycle.id.to_s]
+      end
+
       it "handles order cycles with nil opening or closing times" do
         distributor = create(:distributor_enterprise)
         oc = create(:simple_order_cycle, name: "My Order Cycle", distributors: [distributor],


### PR DESCRIPTION
#### What? Why?
Closes #9398

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit admin/reports/orders_and_fulfillment/ 
- Ascertain that the last order cycle has already been selected
- Ascertain that the last order cycle is selected for every report type 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
