### PR TITLE
Fix text alignment for category radio button under shipping method

### DIFF
--- a/app/views/spree/admin/shipping_methods/_form.html.haml
+++ b/app/views/spree/admin/shipping_methods/_form.html.haml
@@ -27,7 +27,7 @@
       -# The 'Category' label here is just a logical descriptor for the data we are trying to collect for 'requires_ship_address'
       -# and does not relate to shipping categories in any way.
       = f.label :require_ship_address, t(:category)
-    .two.columns
+    .three.columns
       = f.radio_button :require_ship_address, true
       &nbsp;
       = f.label :delivery, t(:delivery)


### PR DESCRIPTION
#### What? Why?

Closes #9231


#### What should we test?
 - Visit page /admin/shipping_methods/new
 - for `category` text `delivery` should be displayed next to the radio button
 - Visit page /admin/shipping_methods/[number]/edit
 - for `category` text `delivery` should be displayed next to the radio button

#### Dependencies
Edit Page
![shipping_method_edit_page](https://user-images.githubusercontent.com/62114687/179366738-00051892-4f1c-402c-a5b6-b44ef5f48b5e.png)

New Page
![shipping_method_new_page](https://user-images.githubusercontent.com/62114687/179366746-f20678f5-2873-4cdb-b41e-c4d303a912c6.png)



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes



#### Dependencies
No dependencies



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
