### PR TITLE
Moves matomo_tag into head section

### DIFF
--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -32,6 +32,8 @@
     = csrf_meta_tags
     %meta{name: "turbo-cache-control", content: "no-cache"}
 
+    = render "layouts/matomo_tag"
+
   %body{ class: body_classes, "body-scroll": "true", "data-turbo": "false" }
     / [if lte IE 8]
       = render partial: "shared/ie_warning"
@@ -56,7 +58,5 @@
     = inject_current_order
     = inject_currency_config
     = yield :injection_data
-
-    = render "layouts/matomo_tag"
 
     = render "layouts/login_modal"


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/9418 to comply with Matomo guidelines.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Moves Matomo tracking code (configured in https://github.com/openfoodfoundation/openfoodnetwork/blob/master/app/views/layouts/_matomo_tag.html.haml) within the `<head></head>` section of pages which use the `darkswarm` layout.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

It's a good idea to take staging-FR for this one as it is the only staging server which has Matomo setup (AFAIK).

Before staging this PR:

- visit the home page and check the source (shortcut `ctrl+u` or by appending `view-source:` in the URL)
- find Matomo tracking code
- it should be outside the `<head></head>` section of the page

After staging the PR:

- repeat the above
- the Matomo tracking code should now be inside the `<head></head>` section of the page
- make sure two sections are visible: one should be the `container` URL and the second one identifies the `siteID` number

![image](https://user-images.githubusercontent.com/49817236/179540564-b4688b14-4e1f-4c82-96e4-3407968b8e7a.png)

**Bonus points**: a sanity check that the tracking code is working as before would be great.

The quickest test I can think of is:

- on a browser allowing for cookies (Chrome/Chromium has cookies enabled by default)
- visit `https://staging.coopcircuits.fr/?mtmPreviewMode=aSBgrfIY` -> a preview tab should appear at the bottom of the screen
- Click "Login"
- On the Login modal click Sign up tab
- Click "Sign up button" -> it should trigger a green check (bottom left of the preview box) :heavy_check_mark: 

![image](https://user-images.githubusercontent.com/49817236/179543352-fa1299c8-938a-4985-8ed0-73fc01260df2.png)


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Moves matomo_tag into head section

