### PR TITLE
Adds js window element to container code

### DIFF
--- a/app/views/layouts/_matomo_tag.html.haml
+++ b/app/views/layouts/_matomo_tag.html.haml
@@ -1,7 +1,7 @@
 
 - if Spree::Config.matomo_tag_manager_url.present?
   :javascript
-    var _mtm = _mtm || [];
+    var _mtm = window._mtm = window._mtm || [];
     _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     var u="#{Spree::Config.matomo_tag_manager_url}";

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -14,6 +14,7 @@
       = favicon_link_tag "/favicon-staging.ico"
     %link{href: "https://fonts.googleapis.com/css?family=Roboto:400,300italic,400italic,300,700,700italic|Oswald:300,400,700", rel: "stylesheet", type: "text/css"}
     %link{href: asset_pack_path("media/fonts/OFN-v2.woff"), rel: "preload", as: "font", crossorigin: "anonymous"}
+    = render "layouts/matomo_tag"
     = language_meta_tags
 
     = stylesheet_pack_tag "darkswarm", "data-turbo-track": "reload"
@@ -57,6 +58,5 @@
     = inject_currency_config
     = yield :injection_data
 
-    = render "layouts/matomo_tag"
 
     = render "layouts/login_modal"


### PR DESCRIPTION
#### What? Why?

Follow-up from https://github.com/openfoodfoundation/openfoodnetwork/pull/9417#issuecomment-1189931261:

- Adds the window element on Matomo container code snippet (following the code snippet on the reference below)
- Moves matomo tag to upper position within head section (following "as high as possible" see Reference below)

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Reference taken from Matomo tag manager section (for a given container):

![image](https://user-images.githubusercontent.com/49817236/179929272-4210eb1e-db3a-4571-9154-65172b1de8e6.png)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

See testing notes on https://github.com/openfoodfoundation/openfoodnetwork/pull/9417#issue-1308094500

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
