### PR TITLE
Run Mayhem for API only when triggered manually

### DIFF
--- a/.github/workflows/mapi.yml
+++ b/.github/workflows/mapi.yml
@@ -1,5 +1,5 @@
 name: 'Mayhem for API'
-on: [push]
+on: workflow_dispatch
 jobs:
   test:
     if: ${{ github.repository_owner == 'openfoodfoundation' }}


### PR DESCRIPTION
#### What? Why?

It currently always fails and we are not using it. We may use it in the
future though and the results can be interesting. So I'm keeping it but
it's not triggered on every pull request. How to trigger:

https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Just passing specs.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: echnical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
