### PR TITLE
User account, Credit cards: Do not allow to check "Allow charges" if no credit cards marked as default

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
@@ -20,3 +20,7 @@ angular.module('Darkswarm').controller "CreditCardsCtrl", ($scope, $http, Credit
     ).finally ->
       window.location.reload()
 
+
+  $scope.hasOneDefaultSavedCards = () ->
+    $scope.savedCreditCards.length > 0 && $scope.savedCreditCards.some((card) -> card.is_default)
+

--- a/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
@@ -22,5 +22,4 @@ angular.module('Darkswarm').controller "CreditCardsCtrl", ($scope, $http, Credit
 
 
   $scope.hasOneDefaultSavedCards = () ->
-    $scope.savedCreditCards.length > 0 && $scope.savedCreditCards.some((card) -> card.is_default)
-
+    $scope.savedCreditCards.some((card) -> card.is_default)

--- a/app/views/spree/users/_authorised_shops.html.haml
+++ b/app/views/spree/users/_authorised_shops.html.haml
@@ -12,5 +12,6 @@
         name: 'allow_charges',
         ng: { model: 'customer.allow_charges',
           change: 'customer.update()',
+          disabled: "!hasOneDefaultSavedCards()",
           "true-value" => "true",
           "false-value" => "false" } }

--- a/app/views/spree/users/_authorised_shops.html.haml
+++ b/app/views/spree/users/_authorised_shops.html.haml
@@ -7,7 +7,7 @@
     %th= t(".allow_charges?")
   %tr.customer{ id: "customer{{ customer.id }}", ng: { repeat: "customer in customers" } }
     %td.shop{ ng: { bind: 'shopsByID[customer.enterprise_id].name' } }
-    %td.allow_charges
+    %td.allow_charges{ tooltip: "{{ hasOneDefaultSavedCards() ? null : \'" + t('.no_default_saved_cards_tooltip') + "\' }}" }
       %input{ type: 'checkbox',
         name: 'allow_charges',
         ng: { model: 'customer.allow_charges',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4232,6 +4232,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       authorised_shops:
         shop_name: "Shop Name"
         allow_charges?: "Allow Charges to Default Card?"
+        no_default_saved_cards_tooltip: To allow charges, you should have one credit cards marked as default
     localized_number:
       invalid_format: has an invalid format. Please enter a number.
     api:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4232,7 +4232,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       authorised_shops:
         shop_name: "Shop Name"
         allow_charges?: "Allow Charges to Default Card?"
-        no_default_saved_cards_tooltip: To allow charges, you should have one credit cards marked as default
+        no_default_saved_cards_tooltip: You need to mark one credit card as default to allow charges.
     localized_number:
       invalid_format: has an invalid format. Please enter a number.
     api:

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -213,6 +213,17 @@ describe Spree::CreditCardsController, type: :controller do
               expect(customer1.reload.allow_charges).to be false
               expect(customer2.reload.allow_charges).to be false
             end
+
+            context "when has any other saved cards" do
+              let!(:second_card) {
+                create(:stored_credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_AZNMJ')
+              }
+
+              it "should assign the second one as the default one" do
+                spree_delete :destroy, params
+                expect(Spree::CreditCard.find_by(id: second_card.id).is_default).to eq true
+              end
+            end
           end
         end
       end

--- a/spec/system/consumer/account/cards_spec.rb
+++ b/spec/system/consumer/account/cards_spec.rb
@@ -105,5 +105,21 @@ describe "Credit Cards", js: true do
       expect(page).to have_content I18n.t('js.changes_saved')
       expect(customer.reload.allow_charges).to be true
     end
+
+    it "assign the default card to the next one when the default is deleted" do
+      visit "/account"
+      find("a", text: /Credit Cards/i).click
+
+      within(".card#card#{default_card.id}") do
+        click_button "Delete"
+      end
+
+      expect(page).to have_content "Your card has been removed"
+
+      within ".card#card#{non_default_card.id}" do
+        expect(find_field('default_card')).to be_checked
+      end
+      expect(non_default_card.reload.is_default).to be true
+    end
   end
 end

--- a/spec/system/consumer/account/cards_spec.rb
+++ b/spec/system/consumer/account/cards_spec.rb
@@ -121,5 +121,18 @@ describe "Credit Cards", js: true do
       end
       expect(non_default_card.reload.is_default).to be true
     end
+
+    context "when no default card" do
+      before do
+        default_card.destroy
+      end
+
+      it "then all 'allow_charges' inputs are disabled" do
+        visit "/account"
+        find("a", text: /Credit Cards/i).click
+
+        expect(find_field('allow_charges', disabled: true)).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #8897

This PR basically does two things:
 - It's impossible to check the "Allow Charges to Default Card?" checkbox if no default credit card
<img width="604" alt="Capture d’écran 2022-07-21 à 14 57 34" src="https://user-images.githubusercontent.com/296452/180233483-06cb9837-f249-4a52-abf2-d6a189b0e614.png">

 - When deleting the default card and if another saved card is present, then select the first as the default one
![2022-07-21 16 06 45](https://user-images.githubusercontent.com/296452/180234135-8ac895ad-2e42-4869-b57e-70703b13a0bf.gif)



<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a user, visit page `/account#/cards`
- If no card, then add one
- If one card and
  - marked as default: you should be able to allow charges from Authorised Shops
  - not marked as default: you should not be able to check the checkboxes
- If more than one card, delete the default one, then, the next should be marked as default

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
