### PR TITLE
Support WEBP images again

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -84,8 +84,8 @@ class Enterprise < ApplicationRecord
   has_one_attached :promo_image
   has_one_attached :terms_and_conditions
 
-  validates :logo, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml)\Z}
-  validates :promo_image, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml)\Z}
+  validates :logo, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
+  validates :promo_image, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
   validates :terms_and_conditions, content_type: {
     in: "application/pdf",
     message: I18n.t(:enterprise_terms_and_conditions_type_error),

--- a/app/models/enterprise_group.rb
+++ b/app/models/enterprise_group.rb
@@ -28,8 +28,8 @@ class EnterpriseGroup < ApplicationRecord
   has_one_attached :logo
   has_one_attached :promo_image
 
-  validates :logo, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml)\Z}
-  validates :promo_image, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml)\Z}
+  validates :logo, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
+  validates :promo_image, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
 
   scope :by_position, -> { order('position ASC') }
   scope :on_front_page, -> { where(on_front_page: true) }

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -11,7 +11,7 @@ module Spree
 
     has_one_attached :attachment
 
-    validates :attachment, attached: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml)\Z}
+    validates :attachment, attached: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
     validate :no_attachment_errors
 
     def variant(name)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3926,7 +3926,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           paypal:
             no_payment_via_admin_backend: Paypal payments cannot be captured in the Backoffice
       products:
-        image_upload_error: "The product image was not recognised. Please upload an image in PNG or JPG format."
+        image_upload_error: "Please upload the image in JPG, PNG, GIF, SVG or WEBP format."
         new:
           title: "New Product"
           new_product: "New Product"

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -590,8 +590,8 @@ describe '
       attach_file('image_attachment', unsupported_image_file_path)
       click_button "Create"
 
-      expect(page).to have_text "The product image was not recognised."
-      expect(page).to have_text "Please upload an image in PNG or JPG format."
+      expect(page).to have_text "Attachment has an invalid content type"
+      expect(page).to have_text "Please upload the image in JPG, PNG, GIF, SVG or WEBP format."
     end
 
     it "deleting product images", js: true do


### PR DESCRIPTION

#### What? Why?

We introduced a list of formats we support and forgot to add webp. Now I
added that as allowed format again and modified the error message.

I removed the first sentence from the error message because it's very
similar to the default error which is shown as well.

![Screenshot from 2022-07-22 21-09-13](https://user-images.githubusercontent.com/3524483/180427571-000dd06e-afc6-4cb2-af72-545537073833.png)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Upload a webp image, a jpg image and try to upload a bmp image for a product.
- Try the same for an enterprise logo / promo image and an enterprise group.
- 


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
