### PR TITLE
Display fees name instead of type on invoices

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -32,18 +32,6 @@ module CheckoutHelper
       }
     end
 
-    enterprise_fee_adjustments = adjustments.select { |a|
-      a.originator_type == 'EnterpriseFee' && a.adjustable_type != 'Spree::LineItem'
-    }
-    adjustments.reject! { |a|
-      a.originator_type == 'EnterpriseFee' && a.adjustable_type != 'Spree::LineItem'
-    }
-    unless exclude.include? :admin_and_handling
-      adjustments << Spree::Adjustment.new(
-        label: I18n.t(:orders_form_admin), amount: enterprise_fee_adjustments.sum(&:amount)
-      )
-    end
-
     adjustments
   end
 

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -35,10 +35,6 @@ module CheckoutHelper
     adjustments
   end
 
-  def display_line_item_fees_total_for(order)
-    Spree::Money.new order.adjustments.enterprise_fee.sum(:amount), currency: order.currency
-  end
-
   def checkout_line_item_fees(order)
     order.line_item_adjustments.enterprise_fee
   end

--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -30,13 +30,6 @@
           %td.text-right
             %span.order-total.item-total= display_checkout_subtotal(@order)
           %td
-        -if display_line_item_fees_total_for(@order) != Spree::Money.new(0 , currency: @order.currency)
-          %tr
-            %td.text-right{colspan:"3"}
-              = t :orders_form_admin
-            %td.text-right
-              %span.order-total.distribution-total= display_line_item_fees_total_for(@order)
-            %td
 
         - checkout_adjustments_for(@order, exclude: [:line_item]).reject{ |a| a.amount == 0 }.reverse_each do |adjustment|
           %tr.order-adjustment

--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -38,7 +38,7 @@
               %span.order-total.distribution-total= display_line_item_fees_total_for(@order)
             %td
 
-        - checkout_adjustments_for(@order, exclude: [:line_item, :admin_and_handling]).reject{ |a| a.amount == 0 }.reverse_each do |adjustment|
+        - checkout_adjustments_for(@order, exclude: [:line_item]).reject{ |a| a.amount == 0 }.reverse_each do |adjustment|
           %tr.order-adjustment
             %td.text-right{:colspan => "3"}
               = adjustment.label

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2278,7 +2278,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   orders_form_empty_cart: "Empty cart"
   orders_form_update_cart: "Update"
   orders_form_subtotal: "Produce subtotal"
-  orders_form_admin: "Admin & Handling"
   orders_form_total: "Total"
   orders_oc_expired_headline: "Orders have closed for this order cycle"
   orders_oc_expired_text: "Sorry, orders for this order cycle closed %{time} ago! Please contact your hub directly to see if they can accept late orders."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2907,7 +2907,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   action_required: "Action required"
   tag_rules: "Tag Rules"
   enterprise_fee_whole_order: Whole order
-  enterprise_fee_by: "%{name} fee by %{role} %{enterprise_name}"
+  enterprise_fee_by_name: "%{name} fee by %{role} %{enterprise_name}"
   validation_msg_relationship_already_established: "^That relationship is already established."
   validation_msg_at_least_one_hub: "^At least one hub must be selected"
   validation_msg_tax_category_cant_be_blank: "^Tax Category can't be blank"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2907,7 +2907,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   action_required: "Action required"
   tag_rules: "Tag Rules"
   enterprise_fee_whole_order: Whole order
-  enterprise_fee_by: "%{type} fee by %{role} %{enterprise_name}"
+  enterprise_fee_by: "%{name} fee by %{role} %{enterprise_name}"
   validation_msg_relationship_already_established: "^That relationship is already established."
   validation_msg_at_least_one_hub: "^At least one hub must be selected"
   validation_msg_tax_category_cant_be_blank: "^Tax Category can't be blank"

--- a/lib/open_food_network/enterprise_fee_applicator.rb
+++ b/lib/open_food_network/enterprise_fee_applicator.rb
@@ -30,7 +30,7 @@ module OpenFoodNetwork
     end
 
     def base_adjustment_label
-      I18n.t(:enterprise_fee_by, type: enterprise_fee.fee_type, role: role,
+      I18n.t(:enterprise_fee_by, name: enterprise_fee.name, role: role,
                                  enterprise_name: enterprise_fee.enterprise.name)
     end
 

--- a/lib/open_food_network/enterprise_fee_applicator.rb
+++ b/lib/open_food_network/enterprise_fee_applicator.rb
@@ -30,8 +30,8 @@ module OpenFoodNetwork
     end
 
     def base_adjustment_label
-      I18n.t(:enterprise_fee_by, name: enterprise_fee.name, role: role,
-                                 enterprise_name: enterprise_fee.enterprise.name)
+      I18n.t(:enterprise_fee_by_name, name: enterprise_fee.name, role: role,
+                                      enterprise_name: enterprise_fee.enterprise.name)
     end
 
     def tax_category(target)

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -131,7 +131,7 @@ describe CheckoutHelper, type: :helper do
     let(:enterprise_fee) { create(:enterprise_fee, amount: 123) }
     let!(:fee_adjustment) {
       create(:adjustment, originator: enterprise_fee, adjustable: order,
-                          order: order)
+                          order: order, label: "Enterprise Fee")
     }
 
     before do
@@ -148,7 +148,7 @@ describe CheckoutHelper, type: :helper do
       expect(adjustments).to include shipping_adjustment
 
       admin_fee_summary = adjustments.reject { |a| a.id == shipping_adjustment.id }.first
-      expect(admin_fee_summary.label).to eq "Shipping"
+      expect(admin_fee_summary.label).to eq "Enterprise Fee"
       expect(admin_fee_summary.amount).to eq 123
     end
 

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -145,11 +145,8 @@ describe CheckoutHelper, type: :helper do
       adjustments = helper.checkout_adjustments_for(order)
 
       shipping_adjustment = order.shipment_adjustments.first
-      expect(adjustments).to include shipping_adjustment
 
-      admin_fee_summary = adjustments.reject { |a| a.id == shipping_adjustment.id }.first
-      expect(admin_fee_summary.label).to eq "Enterprise Fee"
-      expect(admin_fee_summary.amount).to eq 123
+      expect(adjustments).to match_array [shipping_adjustment, fee_adjustment]
     end
 
     context "tax rate adjustments" do

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -148,7 +148,7 @@ describe CheckoutHelper, type: :helper do
       expect(adjustments).to include shipping_adjustment
 
       admin_fee_summary = adjustments.last
-      expect(admin_fee_summary.label).to eq I18n.t(:orders_form_admin)
+      expect(admin_fee_summary.label).to eq "Shipping"
       expect(admin_fee_summary.amount).to eq 123
     end
 

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -147,7 +147,7 @@ describe CheckoutHelper, type: :helper do
       shipping_adjustment = order.shipment_adjustments.first
       expect(adjustments).to include shipping_adjustment
 
-      admin_fee_summary = adjustments.last
+      admin_fee_summary = adjustments.reject { |a| a.id == shipping_adjustment.id }.first
       expect(admin_fee_summary.label).to eq "Shipping"
       expect(admin_fee_summary.amount).to eq 123
     end

--- a/spec/lib/open_food_network/enterprise_fee_applicator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_fee_applicator_spec.rb
@@ -64,7 +64,7 @@ module OpenFoodNetwork
     describe "making labels" do
       let(:variant) { double(:variant, product: double(:product, name: 'Bananas')) }
       let(:enterprise_fee) {
-        double(:enterprise_fee, fee_type: 'packing',
+        double(:enterprise_fee, name: 'packing name',
                                 enterprise: double(:enterprise, name: 'Ballantyne'))
       }
       let(:applicator) { EnterpriseFeeApplicator.new enterprise_fee, variant, 'distributor' }
@@ -72,7 +72,7 @@ module OpenFoodNetwork
       describe "#line_item_adjustment_label" do
         it "makes an adjustment label for a line item" do
           expect(applicator.send(:line_item_adjustment_label)).
-            to eq("Bananas - packing fee by distributor Ballantyne")
+            to eq("Bananas - packing name fee by distributor Ballantyne")
         end
       end
 
@@ -81,7 +81,7 @@ module OpenFoodNetwork
 
         it "makes an adjustment label for an order" do
           expect(applicator.send(:order_adjustment_label)).
-            to eq("Whole order - packing fee by distributor Ballantyne")
+            to eq("Whole order - packing name fee by distributor Ballantyne")
         end
       end
     end

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -215,7 +215,8 @@ describe '
         it "displays GST for enterprise fees" do
           pending "ii) for legend see picture on PR #9495"
           # enterprise fee of $20.00
-          expect(page).to have_content "Admin & Handling 1 $20.00 $120.00"
+          expect(page).to have_content "Whole order - #{enterprise_fee.name} fee by coordinator " \
+                                       "#{user1.enterprises.first.name} 1 $20.00 (included) $120.00"
         end
 
         it "displays the taxes correctly" do
@@ -225,7 +226,8 @@ describe '
           expect(page).to have_content "#{Spree::Product.second.name} 3 $250.08 $1,500.45"
           expect(page).to have_content "(1g)" # display as
           # Enterprise fee
-          expect(page).to have_content "Admin & Handling 1 $120.00"
+          expect(page).to have_content "Whole order - #{enterprise_fee.name} fee by coordinator " \
+                                       "#{user1.enterprises.first.name} 1 $15.65 (included) $120.00"
           # Shipping
           expect(page).to have_content "Shipping 1 $9.14 (included) $100.55"
           # Order Totals
@@ -257,7 +259,8 @@ describe '
           expect(page).to have_content "(1g)" # display as
           expect(page).to have_content "3 $500.15 $1,500.45 20.0%"
           # Enterprise fee
-          expect(page).to have_content "Admin & Handling $120.00"
+          expect(page).to have_content "#{enterprise_fee.name} fee by coordinator " \
+                                       "#{user1.enterprises.first.name} $120.00"
           # Shipping
           expect(page).to have_content "Shipping $100.55 10.0%"
           # Tax totals
@@ -357,14 +360,16 @@ describe '
         it "displays GST for enterprise fees" do
           pending "v) for legend see picture on PR #9495"
           # enterprise fee of $24.00
-          expect(page).to have_content "Admin & Handling 1 $20.00 $120.00"
+          expect(page).to have_content "Whole order - #{enterprise_fee.name} fee by coordinator " \
+                                       "#{user1.enterprises.first.name} 1 $20.00 $120.00"
         end
 
         it "displays the taxes correctly" do
           # header
           expect(page).to have_content "Item Qty GST Price"
           # Enterprise fee
-          expect(page).to have_content "Admin & Handling 1 $120.00"
+          expect(page).to have_content "Whole order - #{enterprise_fee.name} fee by coordinator " \
+                                       "#{user1.enterprises.first.name} 1 $18.00 $120.00"
           # Shipping
           expect(page).to have_content "Shipping 1 $10.06 $100.55"
           # Order Totals
@@ -395,7 +400,8 @@ describe '
           expect(page).to have_content "(1g)" # display as
           expect(page).to have_content "3 $500.15 $1,500.45 20.0%"
           # Enterprise fee
-          expect(page).to have_content "Admin & Handling $120.00"
+          expect(page).to have_content "#{enterprise_fee.name} fee by coordinator " \
+                                       "#{user1.enterprises.first.name} $120.00"
           # Shipping
           expect(page).to have_content "Shipping $100.55 10.0%"
           # Tax totals

--- a/spec/system/consumer/shopping/cart_spec.rb
+++ b/spec/system/consumer/shopping/cart_spec.rb
@@ -106,14 +106,14 @@ describe "full-page cart", js: true do
           visit main_app.cart_path
         end
 
-        it "shows admin and handlings row" do
+        it "shows enterprise fees row row" do
           expect(page).to have_selector('#cart-detail')
-          expect(page).to have_content('Admin & Handling')
+          expect(page).to have_content("Whole order - #{handling_fee.name} fee by distributor #{order_cycle.coordinator.name}")
           expect(page).to have_selector '.cart-item-price',
                                         text: with_currency(0.86)
           expect(page).to have_selector '.order-total.item-total',
                                         text: with_currency(2.58)
-          expect(page).to have_selector '.order-total.distribution-total',
+          expect(page).to have_selector '.order-adjustment .total',
                                         text: with_currency(1.00)
           expect(page).to have_selector '.order-total.grand-total', text: with_currency(3.58) # price * 3 + 1
         end


### PR DESCRIPTION
#### What? Why?

Closes #8904

Two steps: 
 - change the way the adjustment label is computed/formatted. There's no migration here, so, to test, this needs a new order (in order to create new adjustment). We now use the fee name instead of the fee type to create the adjustment label
 - Do not merge "Admin & Handling" fees for an order, but let's keep the adjustments split.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a hub manager, edit fee name () and add fees to an order
- As a customer, checkout, see that invoice clearly display adjustment fees by name and not merged:
<img width="655" alt="Capture d’écran 2022-07-22 à 16 41 14" src="https://user-images.githubusercontent.com/296452/180469395-36d0935d-ef02-4c8c-a8e2-4d698cefbe51.png">


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
