### PR TITLE
Cancel Orders in Bulk

### DIFF
--- a/app/assets/javascripts/admin/orders/controllers/bulk_cancel_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/bulk_cancel_controller.js.coffee
@@ -1,0 +1,14 @@
+angular.module("admin.orders").controller "bulkCancelCtrl", ($scope, $http, $timeout) ->
+
+  $scope.cancelOrder = (orderIds, sendEmailCancellation, restock_items) ->
+    $http(
+      method: 'post'
+      url: "/admin/orders/bulk_cancel?order_ids=#{orderIds}&send_cancellation_email=#{sendEmailCancellation}&restock_items=#{restock_items}" ).then(->
+        window.location.reload()
+      )
+
+  $scope.cancelSelectedOrders = ->
+    ofnCancelOrderAlert((confirm, sendEmailCancellation, restock_items) ->
+      if confirm
+        $scope.cancelOrder $scope.selected_orders, sendEmailCancellation, restock_items
+    )

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -67,6 +67,18 @@ module Spree
         load_spree_api_key
       end
 
+      def bulk_cancel
+        order_ids = params[:order_ids].split(',')
+
+        Spree::Order.where(id: order_ids).find_each do |order|
+          order.send_cancellation_email = params[:send_cancellation_email] != "false"
+          order.restock_items = params.fetch(:restock_items, "true") == "true"
+          order.cancel
+        end
+
+        flash[:success] = Spree.t(:order_updated)
+      end
+
       def fire
         event = params[:e]
         @order.send_cancellation_email = params[:send_cancellation_email] != "false"

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -99,7 +99,7 @@ module Spree
           item.order.changes_allowed?
       end
 
-      can [:cancel], Spree::Order do |order|
+      can [:cancel, :bulk_cancel], Spree::Order do |order|
         order.user == user
       end
 

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -33,6 +33,9 @@
             %div.menu_item
               %span.name.invoices-modal{'ng-controller' => 'bulkInvoiceCtrl', 'ng-click' => 'createBulkInvoice()' }
                 = t('.print_invoices')
+            %div.menu_item
+              %span.name{'ng-controller' => 'bulkCancelCtrl', 'ng-click' => 'cancelSelectedOrders()' }
+                = t('.cancel_orders')
 
     
     = render partial: 'per_page_controls', locals: { position: "right" }
@@ -43,7 +46,7 @@
   %thead
     %tr
       %th
-        %input{type: 'checkbox', 'ng-change' => 'toggleAll()', 'ng-model' => 'select_all'}
+        %input#selectAll{type: 'checkbox', 'ng-change' => 'toggleAll()', 'ng-model' => 'select_all'}
       %th
         = t(:products_distributor)
         %th
@@ -113,3 +116,5 @@
 
 .no-objects-found{'ng-show' => "!RequestMonitor.loading && orders.length == 0"}
   = t('.no_orders_found')
+
+= render 'spree/admin/shared/custom-confirm'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3810,6 +3810,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           results_found: "%{number} Results found."
           viewing: "Viewing %{start} to %{end}."
           print_invoices: "Print Invoices"
+          cancel_orders: "Cancel Orders"
           selected:
             zero: "No order selected"
             one: "1 order selected"

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -31,6 +31,7 @@ Spree::Core::Engine.routes.draw do
   end
 
   resource :account, :controller => 'users'
+  match '/admin/orders/bulk_cancel' => 'admin/orders#bulk_cancel', :as => "admin_bulk_cancel", via: :post
 
   match '/admin/orders/bulk_management' => 'admin/orders#bulk_management', :as => "admin_bulk_order_management", via: :get
   match '/admin/payment_methods/show_provider_preferences' => 'admin/payment_methods#show_provider_preferences', :via => :get

--- a/spec/system/admin/bulk_order_cancellation_spec.rb
+++ b/spec/system/admin/bulk_order_cancellation_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+describe '
+  As an Administrator
+  I want to be able to delete orders in bulk
+' do
+  include AdminHelper
+  include AuthenticationHelper
+  include WebHelper
+
+  context "deleting orders" do
+    let!(:o1) {
+      create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
+                                      completed_at: Time.zone.now )
+    }
+    let!(:o2) {
+      create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
+                                      completed_at: Time.zone.now )
+    }
+
+    before :each do
+      login_as_admin_and_visit spree.admin_orders_path
+    end
+
+    it "deletes orders" do
+      # Verify that the orders have a STATE of COMPLETE
+      expect(page).to have_selector('span', text: 'COMPLETE', count: 2)
+
+      page.check('selectAll')
+      page.find('.ofn-drop-down').click
+      page.find('.menu').find('span', text: 'Cancel Orders').click
+
+      within '.modal' do
+        click_on "OK"
+      end
+
+      # Verify that the orders have a STATE of CANCELLED
+      expect(page).to have_selector('span', text: 'CANCELLED', count: 2)
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #9422

![ezgif com-gif-maker(3)](https://user-images.githubusercontent.com/87677429/189815064-ab5239d6-f0e3-48bb-b195-c9c754f2912e.gif)


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Login is enterprise manager/ Super Admin
- Visit page `admin/orders`
- Select multiple or a single order
- Click on `Cancel Orders` from the actions dropdown
- Verify that the orders _which can be cancelled_ are cancelled.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
