### PR TITLE
Un-comments config line for local wkhtmltopdf directory

### DIFF
--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,6 +1,6 @@
 Rails.application.reloader.to_prepare do
   WickedPdf.config = {
-    #:wkhtmltopdf => '/usr/local/bin/wkhtmltopdf',
+    :wkhtmltopdf => '/usr/local/bin/wkhtmltopdf',
     #:layout => "pdf.html",
     :exe_path => `bundle exec which wkhtmltopdf`.chomp
   }


### PR DESCRIPTION
#### What? Why?

Concerns dev environment only (AFAIAK).
Un-comments config line for local `wkhtmltopdf` directory.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Upgrading environment (Ubuntu 20.04 -> Ubuntu 22.04) let do some issues with the current `wkhtmltopdf` gem and local installation.

Un-commenting the line pointing out to correct version fixes the problem.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
