### PR TITLE
Invoice print spec: added tax

### DIFF
--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -182,6 +182,7 @@ FactoryBot.define do
       product_price { 0 }
       tax_rate_amount { 0 }
       tax_rate_name { "" }
+      included_in_price { "" }
       zone { create(:zone_with_member) }
     end
 
@@ -193,7 +194,8 @@ FactoryBot.define do
       product = FactoryBot.create(:taxed_product, zone: proxy.zone,
                                                   price: proxy.product_price,
                                                   tax_rate_amount: proxy.tax_rate_amount,
-                                                  tax_rate_name: proxy.tax_rate_name)
+                                                  tax_rate_name: proxy.tax_rate_name,
+                                                  included_in_price: proxy.included_in_price)
       FactoryBot.create(:line_item, order: order, product: product, price: product.price)
       order.reload
     end

--- a/spec/factories/product_factory.rb
+++ b/spec/factories/product_factory.rb
@@ -67,6 +67,7 @@ FactoryBot.define do
     transient do
       tax_rate_amount { 0 }
       tax_rate_name { "" }
+      included_in_price { "" }
       zone { nil }
     end
 
@@ -77,7 +78,7 @@ FactoryBot.define do
 
       create(:tax_rate, amount: proxy.tax_rate_amount,
                         tax_category: product.tax_category,
-                        included_in_price: true,
+                        included_in_price: proxy.included_in_price,
                         calculator: Calculator::DefaultTax.new,
                         zone: proxy.zone,
                         name: proxy.tax_rate_name)

--- a/spec/features/admin/invoice_print_spec.rb
+++ b/spec/features/admin/invoice_print_spec.rb
@@ -173,14 +173,20 @@ describe '
 
       before do
         order1.reload
-        break unless order1.next! until order1.delivery?
+        while !order1.delivery?
+          break if !order1.next!
+        end
         order1.select_shipping_method(shipping_method.id)
         order1.recreate_all_fees!
-        break unless order1.next! until order1.payment?
+        while !order1.payment?
+          break if !order1.next!
+        end
 
         create(:payment, state: "checkout", order: order1, amount: order1.reload.total,
                          payment_method: create(:payment_method, distributors: [distributor]))
-        break unless order1.next! until order1.complete?
+        while !order1.complete?
+          break if !order1.next!
+        end
       end
 
       context "legacy invoice" do
@@ -224,10 +230,10 @@ describe '
           expect(page).to have_content "Item Qty Unit price (Incl. tax)"
           expect(page).to have_content "Total price (Incl. taTax rate"
           # first line item, no tax
-          expect(page).to have_content "#{Spree::Product.first.name}"
+          expect(page).to have_content Spree::Product.first.name.to_s
           expect(page).to have_content "1 $12.54 $12.54 0.0% (1g)"
           # second line item, included tax
-          expect(page).to have_content "#{Spree::Product.second.name}"
+          expect(page).to have_content Spree::Product.second.name.to_s
           expect(page).to have_content "3 $500.15 $1,500.45 20.0% (1g)"
           # Enterprise fee
           expect(page).to have_content "Admin & Handling $120.00"
@@ -235,13 +241,13 @@ describe '
           expect(page).to have_content "Shipping $100.55 20.0%"
           # Order Totals
           expect(page).to have_content "Total (Incl. tax): $1,733.54"
-          expect(page).to have_content "Total tax (20.0%): $16.76"
+          expect(page).to have_content "Total tax (20.0%): $270.08"
           expect(page).to have_content "Total (Excl. tax): $1,446.70"
         end
       end
     end
 
-        context "added" do
+    context "added" do
       let(:shipping_tax_rate_added) {
         create(:tax_rate, amount: 0.20, included_in_price: false, zone: zone)
       }
@@ -285,14 +291,20 @@ describe '
 
       before do
         order2.reload
-        break unless order2.next! until order2.delivery?
+        while !order2.delivery?
+          break if !order2.next!
+        end
         order2.select_shipping_method(shipping_method.id)
         order2.recreate_all_fees!
-        break unless order2.next! until order2.payment?
+        while !order2.payment?
+          break if !order2.next!
+        end
 
         create(:payment, state: "checkout", order: order2, amount: order2.reload.total,
                          payment_method: create(:payment_method, distributors: [distributor]))
-        break unless order2.next! until order2.complete?
+        while !order2.complete?
+          break if !order2.next!
+        end
       end
 
       context "legacy invoice" do
@@ -340,7 +352,7 @@ describe '
           # first line item, no tax
           expect(page).to have_content "#{Spree::Product.first.name} 1 $12.54 $12.54 0.0% (1g)"
           # second line item, included tax
-          expect(page).to have_content "#{Spree::Product.second.name}"
+          expect(page).to have_content Spree::Product.second.name.to_s
           expect(page).to have_content "3 $500.15 $1,500.45 20.0% (1g)"
           # Enterprise fee
           expect(page).to have_content "Admin & Handling $120.00"
@@ -348,7 +360,7 @@ describe '
           expect(page).to have_content "Shipping $100.55 20.0%"
           # Order Totals
           expect(page).to have_content "Total (Incl. tax): $2,077.74"
-          expect(page).to have_content "Total tax (20.0%): $20.11"
+          expect(page).to have_content "Total tax (20.0%): $324.09"
           expect(page).to have_content "Total (Excl. tax): $1,733.54"
         end
       end

--- a/spec/features/admin/invoice_print_spec.rb
+++ b/spec/features/admin/invoice_print_spec.rb
@@ -11,7 +11,10 @@ describe '
 
   let(:user) { create(:user) }
   let(:product) { create(:simple_product) }
-  let(:distributor) { create(:distributor_enterprise, owner: user, charges_sales_tax: true) }
+  let(:distributor) {
+    create(:distributor_enterprise, owner: user, with_payment_and_shipping: true,
+                                    charges_sales_tax: true)
+  }
   let(:order_cycle) do
     create(:simple_order_cycle, name: 'One', distributors: [distributor],
                                 variants: [product.variants.first])
@@ -121,27 +124,120 @@ describe '
   it_behaves_like "Check display on each invoice: legacy and alternative", false
   it_behaves_like "Check display on each invoice: legacy and alternative", true
 
-  describe "an order with added taxes" do
-    let!(:order) do
-      create(:order_with_taxes, distributor: distributor, ship_address: create(:address),
-                                line_items_count: 0,
-                                product_price: 10, tax_rate_amount: 0.2,
-                                included_in_price: false,
-                                tax_rate_name: "Veggies").tap do |order|
-                                  order.create_tax_charge!
-                                  order.update_shipping_fees!
-                                  order.save
-                                end
-    end
+  describe "an order with taxes" do
+    let(:user1) { create(:user, enterprises: [distributor]) }
+    let!(:zone) { create(:zone_with_member) }
+    let(:address) { create(:address) }
 
-    context "legacy invoice" do
+    context "included" do
+      let(:shipping_tax_rate_included) {
+        create(:tax_rate, amount: 0.20, included_in_price: true, zone: zone)
+      }
+      let(:shipping_tax_category) { create(:tax_category, tax_rates: [shipping_tax_rate_included]) }
+      let!(:shipping_method) {
+        create(:shipping_method_with, :expensive_name, distributors: [distributor],
+                                                       tax_category: shipping_tax_category)
+      }
+      let(:enterprise_fee) {
+        create(:enterprise_fee, enterprise: user1.enterprises.first,
+                                tax_category: product2.tax_category,
+                                calculator: Calculator::FlatRate.new(preferred_amount: 120.0))
+      }
+      let(:order_cycle) {
+        create(:simple_order_cycle, coordinator: distributor,
+                                    coordinator_fees: [enterprise_fee], distributors: [distributor],
+                                    variants: [product1.variants.first, product2.variants.first])
+      }
+
+      let(:order1) {
+        create(:order, order_cycle: order_cycle, distributor: user1.enterprises.first,
+                       ship_address: address, bill_address: address)
+      }
+      let(:product1) {
+        create(:taxed_product, zone: zone, price: 12.54, tax_rate_amount: 0,
+                               included_in_price: true)
+      }
+      let(:product2) {
+        create(:taxed_product, zone: zone, price: 500.15, tax_rate_amount: 0.2,
+                               included_in_price: true)
+      }
+
+      let!(:line_item1) {
+        create(:line_item, variant: product1.variants.first, price: 12.54, quantity: 1,
+                           order: order1)
+      }
+      let!(:line_item2) {
+        create(:line_item, variant: product2.variants.first, price: 500.15, quantity: 3,
+                           order: order1)
+      }
+
       before do
-        allow(Spree::Config).to receive(:invoice_style2?).and_return(false)
-        login_as_admin_and_visit spree.print_admin_order_path(order)
+        order1.reload
+        break unless order1.next! until order1.delivery?
+        order1.select_shipping_method(shipping_method.id)
+        order1.recreate_all_fees!
+        break unless order1.next! until order1.payment?
+
+        create(:payment, state: "checkout", order: order1, amount: order1.reload.total,
+                         payment_method: create(:payment_method, distributors: [distributor]))
+        break unless order1.next! until order1.complete?
       end
-      it "displays the taxes correctly" do
-        convert_pdf_to_page
-        expect(page).to have_content "GST Total: $2.00"
+
+      context "legacy invoice" do
+        before do
+          allow(Spree::Config).to receive(:invoice_style2?).and_return(false)
+          login_as_admin_and_visit spree.print_admin_order_path(order1)
+          convert_pdf_to_page
+        end
+
+        it "displays $0.0 when a line item has no tax" do
+          pending
+          # first line item, no tax
+          expect(page).to have_content "#{Spree::Product.first.name} (1g) 1 $0.0 $12.54"
+        end
+
+        it "displays the taxes correctly" do
+          # header
+          expect(page).to have_content "Item Qty GST Price"
+          # second line item, included tax
+          expect(page).to have_content "#{Spree::Product.second.name} (1g) 3 $250.08 $1,500.45"
+          # Enterprise fee
+          expect(page).to have_content "Admin & Handling 1 $120.00"
+          # Shipping
+          expect(page).to have_content "Shipping 1 $16.76 (included) $100.55"
+          # Order Totals
+          expect(page).to have_content "GST Total: $286.84"
+          expect(page).to have_content "Total (Excl. tax): $1,446.70"
+          expect(page).to have_content "Total (Incl. tax): $1,733.54"
+        end
+      end
+
+      context "alternative invoice" do
+        before do
+          allow(Spree::Config).to receive(:invoice_style2?).and_return(true)
+          login_as_admin_and_visit spree.print_admin_order_path(order1)
+          convert_pdf_to_page
+        end
+
+        it "displays the taxes correctly" do
+          # header
+          expect(page).to have_content "Item Qty Unit price (Incl. tax)"
+          expect(page).to have_content "Total price (Incl. taTax rate"
+          # first line item, no tax
+          expect(page).to have_content "#{Spree::Product.first.name}"
+          expect(page).to have_content "1 $12.54 $12.54 0.0% (1g)"
+          # second line item, included tax
+          expect(page).to have_content "#{Spree::Product.second.name}"
+          expect(page).to have_content "3 $500.15 $1,500.45 20.0% (1g)"
+          # Enterprise fee
+          expect(page).to have_content "Admin & Handling $120.00"
+          # Shipping
+          expect(page).to have_content "Shipping $100.55 20.0%"
+          # Order Totals
+          expect(page).to have_content "Total (Incl. tax): $1,733.54"
+          expect(page).to have_content "Total tax (20.0%): $16.76"
+          expect(page).to have_content "Total (Excl. tax): $1,446.70"
+        end
       end
     end
   end

--- a/spec/features/admin/invoice_print_spec.rb
+++ b/spec/features/admin/invoice_print_spec.rb
@@ -197,9 +197,15 @@ describe '
         end
 
         it "displays $0.0 when a line item has no tax" do
-          pending
+          pending "i) for legend see picture on PR #9495"
           # first line item, no tax
           expect(page).to have_content "#{Spree::Product.first.name} (1g) 1 $0.0 $12.54"
+        end
+
+        it "displays GST for enterprise fees" do
+          pending "ii) for legend see picture on PR #9495"
+          # enterprise fee of $20.00
+          expect(page).to have_content "Admin & Handling 1 $20.00 $120.00"
         end
 
         it "displays the taxes correctly" do
@@ -314,15 +320,21 @@ describe '
           convert_pdf_to_page
         end
         it "displays $0.0 when a line item has no tax" do
-          pending
-          # first line item, no tax
+          pending "iii) for legend see picture on PR #9495"
+          # first line item, no tax - display $0.0
           expect(page).to have_content "#{Spree::Product.first.name} (1g) 1 $0.0 $12.54"
         end
 
         it "displays the added tax on the GST colum" do
-          pending "closing #7983"
-          # second line item, added tax
+          pending "closing #7983, iv) for legend see picture on PR #9495"
+          # second line item, added tax of $300.09
           expect(page).to have_content "#{Spree::Product.second.name} (1g) 3 $300.09 $1,500.45"
+        end
+
+        it "displays GST for enterprise fees" do
+          pending "v) for legend see picture on PR #9495"
+          # enterprise fee of $24.00
+          expect(page).to have_content "Admin & Handling 1 $20.00 $120.00"
         end
 
         it "displays the taxes correctly" do

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -424,7 +424,7 @@ describe '
       end
       let!(:order) do
         create(:order_with_taxes, distributor: distributor1, ship_address: create(:address),
-                                  product_price: 110, tax_rate_amount: 0.1,
+                                  product_price: 110, tax_rate_amount: 0.1, included_in_price: true,
                                   tax_rate_name: "Tax 1").tap do |order|
                                     order.create_tax_charge!
                                     order.update_shipping_fees!

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -208,8 +208,13 @@ describe '
       create(:order, order_cycle: order_cycle, distributor: user1.enterprises.first,
                      ship_address: address, bill_address: address)
     }
-    let(:product1) { create(:taxed_product, zone: zone, price: 12.54, tax_rate_amount: 0) }
-    let(:product2) { create(:taxed_product, zone: zone, price: 500.15, tax_rate_amount: 0.2) }
+    let(:product1) {
+      create(:taxed_product, zone: zone, price: 12.54, tax_rate_amount: 0, included_in_price: true)
+    }
+    let(:product2) {
+      create(:taxed_product, zone: zone, price: 500.15, tax_rate_amount: 0.2,
+                             included_in_price: true)
+    }
 
     let!(:line_item1) {
       create(:line_item, variant: product1.variants.first, price: 12.54, quantity: 1, order: order1)

--- a/spec/system/consumer/shopping/cart_spec.rb
+++ b/spec/system/consumer/shopping/cart_spec.rb
@@ -22,7 +22,7 @@ describe "full-page cart", js: true do
       create(:enterprise_fee, amount: 11.00, tax_category: product_with_tax.tax_category)
     }
     let(:product_with_tax) {
-      create(:taxed_product, supplier: supplier, zone: zone, price: 110.00, tax_rate_amount: 0.1)
+      create(:taxed_product, supplier: supplier, zone: zone, price: 110.00, tax_rate_amount: 0.1, included_in_price: true)
     }
     let(:product_with_fee) {
       create(:simple_product, supplier: supplier, price: 0.86, on_hand: 100)

--- a/spec/system/consumer/shopping/checkout_spec.rb
+++ b/spec/system/consumer/shopping/checkout_spec.rb
@@ -21,7 +21,7 @@ describe "As a consumer I want to check out my cart", js: true do
   let(:fee_tax_rate) { create(:tax_rate, amount: 0.10, zone: zone, included_in_price: true) }
   let(:fee_tax_category) { create(:tax_category, tax_rates: [fee_tax_rate]) }
   let(:product) {
-    create(:taxed_product, supplier: supplier, price: 10, zone: zone, tax_rate_amount: 0.1)
+    create(:taxed_product, supplier: supplier, price: 10, zone: zone, tax_rate_amount: 0.1, included_in_price: true)
   }
   let(:variant) { product.variants.first }
   let(:order) {


### PR DESCRIPTION
#### What? Why?

Relates to #7983.

Aim is to capture the current behavior for on what concerns the displaying of taxes on both `legacy` and `alternative` invoices.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- changes the order and product factories to consider added (not-included) tax rates/amounts
- fixes broken specs due to factory change
- adds 4 test cases around these 4 invoices/test cases - displaying below for clarity:

  - included tax, legacy invoice
  - included tax, alternative invoice
  - added tax, legacy invoice
  - added tax, alternative invoice

![image](https://user-images.githubusercontent.com/49817236/183123171-31163b8f-c10b-47ff-8e9f-83db4a8711c6.png)

Yellow boxes refer to issue #7983.

Pending examples have been numbered i) to v) and referenced in the pic above and spec.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

Relates to #7983.

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
