### PR TITLE
Change translation for calculator section from Calculator to Fees

### DIFF
--- a/app/views/spree/admin/shared/_calculator_fields.html.haml
+++ b/app/views/spree/admin/shared/_calculator_fields.html.haml
@@ -1,5 +1,5 @@
 %fieldset#calculator_fields.no-border-bottom
-  %legend{align: "center"}= t(:calculator)
+  %legend{align: "center"}= t(:fees)
   #preference-settings
     .row
       .alpha.four.columns


### PR DESCRIPTION
#### What? Why?

Closes #9423
The section to set up shipping or payment methods fees is currently called 'Calculator'. We need to change it to 'Fees'
![change_calculator_to_fees](https://user-images.githubusercontent.com/62114687/181971001-4be51799-a841-4d25-988d-d0fdb183e4f9.png)




#### What should we test?
Visit the below areas and check if the section which was named `Calculator` in green color is now changed to `Fees`
/admin/shipping_methods/new
/admin/shipping_methods/[NUMBER]/edit
/admin/payment_methods/new
/admin/payment_methods/[NUMBER]/edit


#### Release notes
Changelog Category: User-facing changes

#### Dependencies
No dependencies


