### PR TITLE
Upgrades rspec-rails to 5.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,7 +151,7 @@ group :test, :development do
   gem 'json_spec', '~> 1.1.4'
   gem 'knapsack'
   gem 'letter_opener', '>= 1.4.1'
-  gem 'rspec-rails', ">= 3.5.2"
+  gem 'rspec-rails', '~> 5.0.3'
   gem 'rspec-retry'
   gem 'rswag-specs'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -524,7 +524,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-rails (5.0.2)
+    rspec-rails (5.0.3)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)
@@ -781,7 +781,7 @@ DEPENDENCIES
   rexml
   roadie-rails
   roo
-  rspec-rails (>= 3.5.2)
+  rspec-rails (~> 5.0.3)
   rspec-retry
   rswag-api
   rswag-specs
@@ -821,4 +821,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.1.4
+   2.2.32


### PR DESCRIPTION
#### What? Why?

Relates to #https://github.com/openfoodfoundation/openfoodnetwork/pull/9430

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Attempts to upgrade rspec-rails to 5.0.2. [Upgrade to 5.1.2](https://github.com/openfoodfoundation/openfoodnetwork/pull/9430) was throwing weird errors in which the expected actually equals the result :eyes: 

```
  1) Spree::Admin::BaseController rendering as json ActiveModelSerializer when data is an object when an ams prefix is passed passes a prefix to the serializer method and renders with serializer
     Failure/Error: render options.merge(json: data, serializer: serializer(ams_prefix))
     
       #<Spree::Admin::BaseController:0x0000000034c538> received :render with unexpected arguments
         expected: ({:json=>{:attr=>"value"}, :serializer=>"SerializerClass"})
              got: ({:json=>{:attr=>"value"}, :serializer=>"SerializerClass"})
       Diff:
```

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
