### PR TITLE
Add matomo_tag to /register pages

### DIFF
--- a/app/views/layouts/_matomo_tag.html.haml
+++ b/app/views/layouts/_matomo_tag.html.haml
@@ -1,0 +1,8 @@
+
+- if Spree::Config.matomo_tag_manager_url.present?
+  :javascript
+    var _mtm = window._mtm = window._mtm || [];
+    _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    var u="#{Spree::Config.matomo_tag_manager_url}";
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u; s.parentNode.insertBefore(g,s);

--- a/app/views/layouts/_matomo_tracking.html.haml
+++ b/app/views/layouts/_matomo_tracking.html.haml
@@ -1,12 +1,4 @@
 
-- if Spree::Config.matomo_tag_manager_url.present?
-  :javascript
-    var _mtm = window._mtm = window._mtm || [];
-    _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    var u="#{Spree::Config.matomo_tag_manager_url}";
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u; s.parentNode.insertBefore(g,s);
-
 - if Spree::Config.matomo_url.present?
   :javascript
     var _paq = window._paq || [];

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -14,7 +14,7 @@
       = favicon_link_tag "/favicon-staging.ico"
     %link{href: "https://fonts.googleapis.com/css?family=Roboto:400,300italic,400italic,300,700,700italic|Oswald:300,400,700", rel: "stylesheet", type: "text/css"}
     %link{href: asset_pack_path("media/fonts/OFN-v2.woff"), rel: "preload", as: "font", crossorigin: "anonymous"}
-    = render "layouts/matomo_tag"
+    = render "layouts/matomo_tracking"
     = language_meta_tags
 
     = stylesheet_pack_tag "darkswarm", "data-turbo-track": "reload"

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -14,6 +14,7 @@
       = favicon_link_tag "/favicon-staging.ico"
     %link{href: "https://fonts.googleapis.com/css?family=Roboto:400,300italic,400italic,300,700,700italic|Oswald:300,400,700", rel: "stylesheet", type: "text/css"}
     %link{href: asset_pack_path("media/fonts/OFN-v2.woff"), rel: "preload", as: "font", crossorigin: "anonymous"}
+    = render "layouts/matomo_tag"
     = render "layouts/matomo_tracking"
     = language_meta_tags
 

--- a/app/views/layouts/registration.html.haml
+++ b/app/views/layouts/registration.html.haml
@@ -9,6 +9,7 @@
     - else
       = favicon_link_tag "/favicon-staging.ico"
     %link{href: "https://fonts.googleapis.com/css?family=Roboto:400,300italic,400italic,300,700,700italic|Oswald:300,400,700", rel: "stylesheet", type: "text/css"}
+    = render "layouts/matomo_tag"
     = language_meta_tags
 
     = stylesheet_pack_tag "darkswarm"


### PR DESCRIPTION
#### What? Why?

Closes #9534
Prepares https://github.com/openfoodfoundation/wishlist/issues/257

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Currently, we are adding both the tracking code and the code manager to our page layouts, because these were defined in the same file.

This PR:
- separates the respective matomo code snippets into two files:
  - `matomo_tag` (should only contain tag manager code)
  - `matomo_tracking` (should only contain general tracking code)

- adds the matomo_tag to the `/register` page - complying with #https://github.com/openfoodfoundation/wishlist/issues/257
- adds both tracking codes to our darkswarm template -> this should keep the same tracking code on all pages **as before**. #https://github.com/openfoodfoundation/wishlist/issues/257 is not closed by this issue.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Best tested on staging-FR.

A) We'll need to check the presence/absence of the matomo code snippets **A and B**:

![image](https://user-images.githubusercontent.com/49817236/184145098-1541b004-588a-4864-9b2b-5a02bb96c065.png)

**Before staging**

Test 1

- Login as a customer
- Visit `/register` page
- check the source code of the URL
- Expected outcome: there should be no matomo code on this page **(no code)**

Test 2

- Login as a customer
- Visit the homepage
- check the source code of the URL
- Expected outcome: the tag manager code and the tracking should be visible **(A + B)**

**After staging**

Test 1

- Login as a customer
- Visit `/register` page
- check the source code of the URL
- Expected outcome: the tag manager code should be visible **(A)**

Test 2

- Login as a customer
- Visit the homepage
- check the source code of the URL
- Expected outcome: the tag manager code and the tracking should be visible -> i.e., no change is expected **(A + B)**

B) In addition to this, we should run a sanity test to make sure we have no regressions on our Matomo implementation. The behavior should not change with this PR, i.e. before and after staging we should be able to:

- trigger tags -> to test, user the URL `https://staging.coopcircuits.fr/?mtmPreviewMode=aSBgrfIY#/login` (make sure cookies are accepted)
- track site visits (site_id=15, for staging FR), as before (make sure cookies are accepted)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Adds matomo_tag to /register pages template
