### PR TITLE
Adds debug gem to the stack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,6 +158,7 @@ group :test, :development do
   gem 'shoulda-matchers'
   gem 'timecop'
   gem 'webdrivers'
+  gem 'debug', '>= 1.0.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,9 @@ GEM
       debase-ruby_core_source (= 0.10.12)
       msgpack
     debase-ruby_core_source (0.10.12)
+    debug (1.6.1)
+      irb (>= 1.3.6)
+      reline (>= 0.3.1)
     debugger-linecache (1.2.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
@@ -337,7 +340,10 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     immigrant (0.3.6)
       activerecord (>= 3.0)
+    io-console (0.5.11)
     ipaddress (0.8.3)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     jmespath (1.6.1)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -494,6 +500,8 @@ GEM
     redcarpet (3.5.1)
     redis (4.7.1)
     regexp_parser (2.5.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     request_store (1.5.0)
       rack (>= 1.4)
     responders (3.0.1)
@@ -717,6 +725,7 @@ DEPENDENCIES
   database_cleaner
   db2fog!
   ddtrace
+  debug (>= 1.0.0)
   debugger-linecache
   devise
   devise-encryptable


### PR DESCRIPTION
#### What? Why?

Adds debug gem to the stack

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This PR is motivated by the poor readability of the byebug console. Adding to this, it seems that rails 7 will be shipped by default with `debug` instead of `byebug`. Debug is much readable by default:

![image](https://user-images.githubusercontent.com/49817236/183055281-9a4d8c21-645d-4553-93b6-3e29ccabe81d.png)

vs.

![image](https://user-images.githubusercontent.com/49817236/183055310-ebf39a18-dcc4-4442-8fce-d2ac970a8e01.png)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build
- Instead of typing `byebug` in the code we'll need to use `binding.break`
- Make some queries on to the objects on that spec - see the colors!! :rainbow: 
- Maybe interesting other options See also the [how to use section](https://github.com/ruby/debug#how-to-use)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

Ruby (MRI) 2.6 - but we're in 3.0.3, so we should be good.

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
