### PR TITLE
Make the shop url clickable

### DIFF
--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -70,8 +70,8 @@
       %div{'ofn-with-tip' => t('.link_to_front_tip')}
         %a= t('admin.whats_this')
     .eight.columns.omega
-      = surround main_app.root_url, "/shop" do
-        {{Enterprise.permalink}}
+      - front_shop_path = "#{main_app.root_url}#{@enterprise.permalink}/shop"
+      = link_to front_shop_path, front_shop_path , target: "_blank"
   .row
     .three.columns.alpha
       = f.label :id, t('.ofn_uid')

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -137,6 +137,13 @@ describe '
 
     select2_select eg1.name, from: 'enterprise_group_ids'
 
+    within(".permalink") do
+      link_path = "#{main_app.root_url}#{@enterprise.permalink}/shop"
+      link = find_link(link)
+      expect(link[:href]).to eq link_path
+      expect(link[:target]).to eq '_blank'
+    end
+
     accept_alert do
       click_link "Payment Methods"
     end
@@ -186,7 +193,7 @@ describe '
     shop_message_input = page.find("text-angular#enterprise_preferred_shopfront_message div[id^='taTextElement']")
     shop_message_input.native.send_keys('This is my shopfront message.')
     expect(page).to have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_close_at"
-    #using "find" as fields outside of the screen and are not visible  
+    #using "find" as fields outside of the screen and are not visible
     find(:xpath, '//*[@id="enterprise_preferred_shopfront_order_cycle_order_orders_open_at"]').trigger("click")
     find(:xpath, '//*[@id="enterprise_enable_subscriptions_true"]').trigger("click")
 
@@ -483,7 +490,7 @@ describe '
           within(".side_menu") do
             click_link "Shop Preferences"
           end
-          
+
           choose "enterprise_preferred_shopfront_product_sorting_method_by_category"
           find("#s2id_autogen7").click
           find(".select2-result-label", text: "Tricky Taxon").click
@@ -504,7 +511,7 @@ describe '
           within(".side_menu") do
             click_link "Shop Preferences"
           end
-          
+
           choose "enterprise_preferred_shopfront_product_sorting_method_by_producer"
           find("#s2id_autogen8").click
           find(".select2-result-label", text: "First Supplier").click


### PR DESCRIPTION
#### What? Why?

Closes #9427 

On the admin dashboard, in "[Enterprises](https://coopcircuits.fr/admin/enterprises)" > "Primary details", the url pointing to the shop is not clickable. => Now the link is not only a text fragment but an a-tag with a target attribute to open the shop in an own tab.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit "[Enterprises](https://coopcircuits.fr/admin/enterprises)" > "Primary details"
- Click the shop-url

#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.


#### Dependencies



#### Documentation updates

