### PR TITLE
Removes byebug and pry-byebug; keeps pry :broom: 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -160,7 +160,6 @@ group :test, :development do
 end
 
 group :test do
-  gem 'byebug'
   gem 'pdf-reader'
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
@@ -175,7 +174,6 @@ group :development do
   gem 'foreman'
   gem 'listen'
   gem 'pry', '~> 0.13.0'
-  gem 'pry-byebug', '~> 3.9.0'
   gem 'rubocop'
   gem 'rubocop-rails'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,6 @@ GEM
     bullet (7.0.2)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (11.1.3)
     cable_ready (5.0.0.pre3)
       rails (>= 5.2)
       thread-local (>= 1.1.0)
@@ -432,9 +431,6 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -712,7 +708,6 @@ DEPENDENCIES
   bootsnap
   bugsnag
   bullet
-  byebug
   cable_ready (= 5.0.0.pre3)
   cancancan (~> 1.15.0)
   capybara
@@ -773,7 +768,6 @@ DEPENDENCIES
   pdf-reader
   pg (~> 1.2.3)
   pry (~> 0.13.0)
-  pry-byebug (~> 3.9.0)
   puma
   rack-mini-profiler (< 3.0.0)
   rack-rewrite


### PR DESCRIPTION
#### What? Why?

Continues https://github.com/openfoodfoundation/openfoodnetwork/pull/9531.

Removes unused byebug and pry-byebug gems from gemfile and Gemfile.lock.

Some thoughts:
- `pry-byebug` is removed - ok to do so?
- `pry` is not removed yet - do you think we should?

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Removes byebug and pry-byebug; keeps pry :broom: 

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
