### PR TITLE
Split Checkout: add error message when no shipping methods are available to the customer

### DIFF
--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -23,6 +23,8 @@ class SplitCheckoutController < ::BaseController
     redirect_to_step_based_on_order unless params[:step]
     check_step if params[:step]
     recalculate_tax if params[:step] == "summary"
+
+    flash_error_when_no_shipping_method_available if available_shipping_methods.none?
   end
 
   def update
@@ -46,6 +48,10 @@ class SplitCheckoutController < ::BaseController
   end
 
   private
+
+  def flash_error_when_no_shipping_method_available
+    flash[:error] = I18n.t('split_checkout.errors.no_shipping_methods_available')
+  end
 
   def clear_invalid_payments
     @order.payments.with_state(:invalid).delete_all

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1903,6 +1903,7 @@ en:
       invalid_email: "Please enter a valid email address"
       select_a_shipping_method: Select a shipping method
       select_a_payment_method: Select a payment method
+      no_shipping_methods_available: Checkout is not possible due to absence of shipping options. Please contact the shop owner.
   order_paid: PAID
   order_not_paid: NOT PAID
   order_total: Total order

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -60,6 +60,9 @@ describe "As a consumer, I want to checkout my order", js: true do
   let(:shipping_backoffice_only) {
     create(:shipping_method, require_ship_address: true, name: "Shipping Backoffice Only", display_on: "back_end")
   }
+  let(:shipping_methods) {
+    [free_shipping_with_required_address, free_shipping, shipping_with_fee, free_shipping_without_required_address, tagged_shipping]
+  }
 
   before do
     allow(Flipper).to receive(:enabled?).with(:split_checkout).and_return(true)
@@ -68,7 +71,7 @@ describe "As a consumer, I want to checkout my order", js: true do
     add_enterprise_fee enterprise_fee
     set_order order
 
-    distributor.shipping_methods.push(free_shipping_with_required_address, free_shipping, shipping_with_fee, free_shipping_without_required_address, tagged_shipping)
+    distributor.shipping_methods.push(shipping_methods)
   end
 
   context "guest checkout when distributor doesn't allow guest orders" do

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -142,6 +142,23 @@ describe "As a consumer, I want to checkout my order", js: true do
       expect_to_be_on_first_step
     end
 
+    context "when no shipping methods are available" do
+      before do
+        shipping_methods.each { |sm| sm.update(tag_list: "hidden") }
+      end
+
+      it "should display an error message" do
+        create(:filter_shipping_methods_tag_rule,
+               enterprise: distributor,
+               is_default: true,
+               preferred_shipping_method_tags: "hidden",
+               preferred_matched_shipping_methods_visibility: 'hidden')
+
+        visit checkout_path
+        expect(page).to have_content "Checkout is not possible due to absence of shipping options. Please contact the shop owner."
+      end
+    end
+
     it "should display error when fields are empty" do
       click_on "Checkout as guest"
       click_button "Next - Payment method"


### PR DESCRIPTION
#### What? Why?

Closes #9145
This adds a flash error message when no available shippings methods:
<img width="737" alt="Capture d’écran 2022-08-08 à 16 25 49" src="https://user-images.githubusercontent.com/296452/183449036-9e302d87-9663-4380-90c0-523ee3922b11.png">
<img width="1101" alt="Capture d’écran 2022-08-08 à 16 42 56" src="https://user-images.githubusercontent.com/296452/183449059-9b6c02f3-56ad-45f7-bf33-5bd0f5d3d323.png">

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

No shipping methods can occurs either:
  - hub didn't configure any shipping methods
  - no shipping methods are available due to tag rules

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes