### PR TITLE
Removes selenium-webdriver and webdriver gems; updates spec_helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,10 +152,8 @@ group :test, :development do
   gem 'rspec-rails', ">= 3.5.2"
   gem 'rspec-retry'
   gem 'rswag-specs'
-  gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'timecop'
-  gem 'webdrivers'
   gem 'debug', '>= 1.0.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -580,11 +580,6 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     sd_notify (0.1.1)
-    selenium-webdriver (4.3.0)
-      childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
     semantic_range (3.0.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
@@ -657,10 +652,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.17.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -793,7 +784,6 @@ DEPENDENCIES
   rubocop-rails
   sd_notify
   select2-rails!
-  selenium-webdriver
   shoulda-matchers
   sidekiq
   sidekiq-scheduler
@@ -813,7 +803,6 @@ DEPENDENCIES
   view_component_storybook
   web!
   web-console
-  webdrivers
   webmock
   webpacker (~> 5)
   whenever

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,6 @@
 require 'base_spec_helper'
 
 require 'database_cleaner'
-require 'webdrivers'
-require 'selenium-webdriver'
 require 'view_component/test_helpers'
 
 # This spec_helper.rb is being used by the custom engines in engines/. The engines are not set up to
@@ -13,17 +11,6 @@ unless ENV['DISABLE_KNAPSACK']
   require 'knapsack'
   Knapsack.tracker.config(enable_time_offset_warning: false) unless ENV['CI']
   Knapsack::Adapters::RSpecAdapter.bind
-end
-
-Capybara.register_driver :chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(
-    args: %w[headless disable-gpu no-sandbox window-size=1280,768]
-  )
-  options.add_preference(:download, default_directory: DownloadsHelper.path.to_s)
-
-  Capybara::Selenium::Driver
-    .new(app, browser: :chrome, options: options)
-    .tap { |driver| driver.browser.download_path = DownloadsHelper.path.to_s }
 end
 
 Capybara.javascript_driver = :chrome
@@ -44,13 +31,6 @@ RSpec.configure do |config|
   }
   config.before(:each)           { DatabaseCleaner.start }
   config.after(:each)            { DatabaseCleaner.clean }
-
-  def restart_driver
-    Capybara.send('session_pool').values
-      .select { |s| s.driver.is_a?(Capybara::Selenium::Driver) }
-      .each { |s| s.driver.reset! }
-  end
-  config.before(:all) { restart_driver }
 
   config.after(:each, js: true) do
     Capybara.reset_sessions!

--- a/spec/system/consumer/cookies_spec.rb
+++ b/spec/system/consumer/cookies_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'system_helper'
 
-feature "Cookies", js: true do
+describe "Cookies", js: true do
   describe "banner" do
     # keeps banner toggle config unchanged
     around do |example|


### PR DESCRIPTION
#### What? Why?

Testing whether we still need webdriver and selenium-webdriver - I don't think so, we're on system specs, right?

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

If not, we would not need to maintain these gems. These were mostly used in feature specs, which should be gone now, with the exception of `spec/features/admin/invoice_print_spec.rb`, always ran with `js: false`.

Additional changes:

- spec_helper.rb - we don't use everything which mentions the removed gems

- This was breaking a cookie spec which was moved from engines to the system spec folder -> not sure this is the best option.

- for some unclear reason, this surfaced two errors on invoice print spec; fixed here. If we decide not to merge this PR this probably needs to be committed on a separate PR.

PS: Great to know we have cookie specs! I was unaware of this; this relates to https://github.com/openfoodfoundation/openfoodnetwork/issues/8130

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
