### PR TITLE
Control capybara headless mode for testing via environment variable

### DIFF
--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -2,6 +2,8 @@
 
 require "capybara/cuprite"
 
+headless = ActiveModel::Type::Boolean.new.cast(ENV.fetch("HEADLESS", true))
+
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,
@@ -13,7 +15,7 @@ Capybara.register_driver(:cuprite) do |app|
       # Don't load scripts from external sources, like google maps or stripe
       url_whitelist: ["http://localhost", "http://0.0.0.0", "http://127.0.0.1"],
       inspector: true,
-      headless: true,
+      headless: headless,
       js_errors: true,
     }
   )


### PR DESCRIPTION
#### What? Why?

For developer convenience I want to run the headfull capybara mode without changing the configuration file all the time. I just want to control it with an environment variable to turn it on if I need to see what happens inside the browser.



#### What should we test?

- It is only for the test environment
- run `HEADLESS=false bundle exec rails rspec spec/system/**` 
- browser will open and executing the system tests

#### Release notes

Changelog Category: Technical changes

The title of the pull request will be included in the release notes.


#### Dependencies

#### Documentation updates
