### PR TITLE
Add order note at the end of both invoices following current UI patterns.

### DIFF
--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -6,7 +6,6 @@ module Spree
     include Rails.application.routes.url_helpers
     include CablecarResponses
 
-
     layout 'darkswarm'
 
     rescue_from ActiveRecord::RecordNotFound, with: :render_404

--- a/app/services/permitted_attributes/checkout.rb
+++ b/app/services/permitted_attributes/checkout.rb
@@ -12,9 +12,9 @@ module PermittedAttributes
           :email, :special_instructions,
           :existing_card_id, :shipping_method_id,
           { payments_attributes: [
-            :payment_method_id,
-            { source_attributes: PermittedAttributes::PaymentSource.attributes }
-          ],
+              :payment_method_id,
+              { source_attributes: PermittedAttributes::PaymentSource.attributes }
+            ],
             ship_address_attributes: PermittedAttributes::Address.attributes,
             bill_address_attributes: PermittedAttributes::Address.attributes }
         ],

--- a/app/views/spree/admin/orders/invoice.html.haml
+++ b/app/views/spree/admin/orders/invoice.html.haml
@@ -77,3 +77,6 @@
     = @order.distributor.invoice_text
 
 = render 'spree/shared/payment'
+
+- if @order.note.present?
+  = render partial: 'spree/shared/order_note'

--- a/app/views/spree/admin/orders/invoice2.html.haml
+++ b/app/views/spree/admin/orders/invoice2.html.haml
@@ -89,3 +89,6 @@
     = @order.distributor.invoice_text
 
 = render 'spree/shared/payment'
+
+- if @order.note.present?
+  = render partial: 'spree/shared/order_note'

--- a/app/views/spree/shared/_order_note.html.haml
+++ b/app/views/spree/shared/_order_note.html.haml
@@ -1,0 +1,4 @@
+%p.callout{style: "margin-top: 30px"}
+  %strong= t :additional_information 
+  %p{style: "margin: 5px"}
+    = @order.note

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,6 +187,7 @@ en:
   cardholder_name: "Cardholder name"
   community_forum_url: "Community forum URL"
   customer_instructions: "Customer instructions"
+  additional_information: "Additional Information"
   devise:
     passwords:
       spree_user:

--- a/spec/views/spree/admin/orders/invoice.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/invoice.html.haml_spec.rb
@@ -79,4 +79,11 @@ describe "spree/admin/orders/invoice.html.haml" do
     expect(rendered).to have_content "Shipping: Pickup"
     expect(rendered).to_not have_content adas_address_display
   end
+
+  it "displays order note on invoice when note is given" do
+    order.note = "Test note"
+
+    render
+    expect(rendered).to have_content "Test note"
+  end
 end


### PR DESCRIPTION
Add translation for note title in invoice

Update invoice spec to also test for order note

#### What? Why?

Closes #9179 

It shows the newly created [order note](https://github.com/openfoodfoundation/openfoodnetwork/issues/9178) under both the present invoice templated following current UI patterns.

![image](https://user-images.githubusercontent.com/65319144/183966148-66b740ba-edd3-40e4-9d70-6a96d463a1b4.png)



#### What should we test?

- Visit `admin/orders` page as admin/superadmin.
- Edit any one of the available orders to have a note.
- Click on the `Actions` button and select `Print invoice`.
- Ensure that the newly added note is visible at the very bottom of the invoice like shown in the screenshot above.
- Change to the alternate invoice template and ensure the note is still visible.
- Remove the note through the orders edit page.
- Again, print invoice under the `Actions` button.
- See that the note is no longer visible along with the title for both templates.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

