### PR TITLE
Disable header row bulk_coop report

### DIFF
--- a/app/views/admin/reports/_rendering_options.html.haml
+++ b/app/views/admin/reports/_rendering_options.html.haml
@@ -7,19 +7,27 @@
       .omega.fourteen.columns
         = select_tag(:report_subtype, options_for_select(@report_subtypes, @report_subtype))  
 
+.row.rendering-options{ "data-controller": "csv-select" }
+  .alpha.two.columns
+    = label_tag :report_format, t(".generate_report")
+  .omega.fourteen.columns{ style: "margin-bottom: 1.5em;" }
+    = select_tag :report_format, grouped_options_for_select({ |
+      t('.formatted_data') => { t('.on_screen') => '', "PDF" => 'pdf', t('.spreadsheet') => 'xlsx' }, |
+      t('.raw_data') => { "CSV" => 'csv' }, |
+    }), { "data-csv-select-target": "reportType", "data-action": "csv-select#handleSelectChange" }
 
-- if @report.header_option? || @report.summary_row_option?
-  .row
-    .alpha.two.columns= label_tag nil, t(".display")
-    .omega.fourteen.columns
-      - if @report.header_option?
-        %span.inline-checkbox{ style: "margin-right: 1rem;" }
-          = check_box_tag :display_header_row, true, params[:display_header_row]
-          = label_tag :display_header_row, t(".header_row")
-      - if @report.summary_row_option?
-        %span.inline-checkbox
-          = check_box_tag :display_summary_row, true, params[:display_summary_row]
-          = label_tag :display_summary_row, t(".summary_row")
+  - if @report.header_option? || @report.summary_row_option?
+    .row
+      .alpha.two.columns= label_tag nil, t(".display")
+      .omega.fourteen.columns
+        - if @report.header_option?
+          %span.inline-checkbox{ style: "margin-right: 1rem;" }
+            = check_box_tag :display_header_row, true, params[:display_header_row]
+            = label_tag :display_header_row, t(".header_row")
+        - if @report.summary_row_option?
+          %span.inline-checkbox
+            = check_box_tag :display_summary_row, true, params[:display_summary_row], { "data-csv-select-target": "checkbox" }
+            = label_tag :display_summary_row, t(".summary_row"), { "data-csv-select-target": "label" }
 
 - if @report.available_headers.present?
   .row
@@ -33,14 +41,3 @@
       .omega.fourteen.columns
         = select_tag(:fields_to_hide, options_for_select(@report.available_headers, params[:fields_to_hide]),
                     class: "select2 fullwidth", multiple: true)
-
-.row.rendering-options
-  .alpha.two.columns
-    = label_tag :report_format, t(".generate_report")
-  .omega.fourteen.columns
-    = select_tag :report_format, grouped_options_for_select({ |
-      t('.formatted_data') => { t('.on_screen') => '', "PDF" => 'pdf', t('.spreadsheet') => 'xlsx' }, |
-      t('.raw_data') => { "CSV" => 'csv' }, |
-    })
-
-

--- a/app/webpacker/controllers/csv_select_controller.js
+++ b/app/webpacker/controllers/csv_select_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static targets = ["reportType", "checkbox", "label"]
+
+  handleSelectChange() {
+    this.reportTypeTarget.value == "csv" ? this.disableField() : this.enableField()
+  }
+
+  disableField() {
+    this.checkboxTarget.checked = false;
+    this.checkboxTarget.disabled = true;
+    this.labelTarget.classList.add("disabled");
+  }
+
+  enableField() {
+    this.checkboxTarget.checked = true;
+    this.checkboxTarget.disabled = false;
+    this.labelTarget.classList.remove("disabled");
+  }
+}


### PR DESCRIPTION
#### What? Why?
CSV reports: Grey out the option to add summary lines when csv is selected
Closes #9291

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit page `/admin/reports/bulk_coop`
- Select the Generate Report with 'csv'
- You should not be able to select 'summary row' in display field
![Captura de tela de 2022-08-16 16-33-32](https://user-images.githubusercontent.com/33104069/184966493-65239aa7-0193-44be-8695-f34bf69cddaf.png)


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
