### PR TITLE
Add missing validation messages to the German locale

### DIFF
--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -63,6 +63,36 @@ de_DE:
             limited_stock_but_no_count_on_hand: "muss angegeben werden, da nur begrenzte Lagerbestände verfügbar sind"
   errors:
     messages:
+      accepted: muss akzeptiert werden
+      blank: muss ausgefüllt werden
+      confirmation: stimmt nicht mit %{attribute} überein
+      empty: muss ausgefüllt werden
+      equal_to: muss genau %{count} sein
+      even: muss gerade sein
+      exclusion: ist nicht verfügbar
+      greater_than: muss größer als %{count} sein
+      greater_than_or_equal_to: muss größer oder gleich %{count} sein
+      inclusion: ist kein gültiger Wert
+      invalid: ist nicht gültig
+      less_than: muss kleiner als %{count} sein
+      less_than_or_equal_to: muss kleiner oder gleich %{count} sein
+      model_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
+      not_a_number: ist keine Zahl
+      not_an_integer: muss ganzzahlig sein
+      odd: muss ungerade sein
+      other_than: darf nicht gleich %{count} sein
+      present: darf nicht ausgefüllt werden
+      required: muss ausgefüllt werden
+      taken: ist bereits vergeben
+      too_long:
+        one: ist zu lang (mehr als 1 Zeichen)
+        other: ist zu lang (mehr als %{count} Zeichen)
+      too_short:
+        one: ist zu kurz (weniger als 1 Zeichen)
+        other: ist zu kurz (weniger als %{count} Zeichen)
+      wrong_length:
+        one: hat die falsche Länge (muss genau 1 Zeichen haben)
+        other: hat die falsche Länge (muss genau %{count} Zeichen haben)
       content_type_invalid: "hat ein ungültiges Datenformat"
       file_size_out_of_range: "Dateigröße %{file_size} liegt außerhalb des zulässigen Bereichs"
       limit_out_of_range: "Gesamtzahl liegt außerhalb des zulässigen Bereichs"


### PR DESCRIPTION
#### What? Why?

Closes #8443

The underlying issue is that openfoodnetwork relies on the [rails-i18n gem](https://github.com/svenfuchs/rails-i18n) to provide baseline localisation of core Rails copy. This gem uses `de` or `de-DE` as name for the German locale while openfoodnetwork uses `de_DE`. This mismatch prevents the baseline localisation from being included.

In this PR I have copy/pasted translations for active model messages which fixes the reported issue. However, there are more keys that should likely be included to prevent other translation issues in the future. See https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/de-DE.yml for a full reference. Let me know if you'd prefer a full inclusion of all these entries.

Another approach to solving this would be to rename the German locale to `de` or `de-DE`. This would adhere better to Rails community conventions but would be a breaking change for existing German deployments.

#### What should we test?

Follow the steps to reproduce in #8443

#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.
