### PR TITLE
Invoice print spec into rack-test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -163,6 +163,7 @@ group :test do
   gem 'simplecov', require: false
   gem 'test-prof'
   gem 'webmock'
+  gem 'rack-test', '~> 2.0.2'
   # See spec/spec_helper.rb for instructions
   # gem 'perftools.rb'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -762,6 +762,7 @@ DEPENDENCIES
   rack-mini-profiler (< 3.0.0)
   rack-rewrite
   rack-ssl
+  rack-test (~> 2.0.2)
   rack-timeout
   rails (>= 6.1.4)
   rails-controller-testing

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "system_helper"
 
 describe '
     As an administrator

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
+require "rack/test"
 require "system_helper"
 
 describe '
     As an administrator
     I want to print a invoice as PDF
-', js: false do
+', type: :rack do
+  
   include WebHelper
   include AuthenticationHelper
+
 
   let(:user) { create(:user) }
   let(:product) { create(:simple_product) }

--- a/spec/system/support/racktest_setup.rb
+++ b/spec/system/support/racktest_setup.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rack/test"
+
+headless = ActiveModel::Type::Boolean.new.cast(ENV.fetch("HEADLESS", true))
+
+Capybara.register_driver(:rack) do |app|
+  Capybara::RackTest::Driver.new(
+    app,
+    **{
+      respect_data_method: false,
+      follow_redirects: true,
+      redirect_limit: 5
+    }.freeze
+  )
+end
+
+# Configure Capybara to use :cuprite driver by default
+Capybara.default_driver = :rack
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+end

--- a/spec/system/support/racktest_setup.rb
+++ b/spec/system/support/racktest_setup.rb
@@ -15,9 +15,6 @@ Capybara.register_driver(:rack) do |app|
   )
 end
 
-# Configure Capybara to use :cuprite driver by default
-Capybara.default_driver = :rack
-
 RSpec.configure do |config|
   config.include Rack::Test::Methods
 end


### PR DESCRIPTION
#### What? Why?

Attempting to change invoice_print_spec.rb into a rack-test.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I can't seem to disable JS in system tests, I've tried removing `= Capybara.javascript_driver` from [cuprite_setup.rb](https://github.com/openfoodfoundation/openfoodnetwork/blob/5c41022f76feca4a73145484963f9c242183abad/spec/system/support/cuprite_setup.rb#L25), but it still did not work out.

Running the spec with enabled JS creates corrupt pdf file, which is noticed when converting them into html. One way to go around this is running the spec as a rack-test, instead of a system test. I think for this, we need to add the `rack-test` into the stack.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
