### PR TITLE
Moves invoice_spec.rb into /system; sets :rack_test as webdriver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,6 @@ jobs:
         specs:
           - "spec/controllers"
           - "spec/models"
-          - "spec/features/admin/[a-o0-9]*_spec.rb"
           - "spec/lib"
           - "spec/migrations"
           - "spec/serializers"

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "system_helper"
 
 describe '
     As an administrator

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -5,7 +5,7 @@ require "system_helper"
 describe '
     As an administrator
     I want to print a invoice as PDF
-', js: false do
+', type: :feature, js: false do
   include WebHelper
   include AuthenticationHelper
 

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -5,7 +5,7 @@ require "system_helper"
 describe '
     As an administrator
     I want to print a invoice as PDF
-', type: :feature, js: false do
+', type: :feature do
   include WebHelper
   include AuthenticationHelper
 
@@ -27,7 +27,12 @@ describe '
   end
 
   before do
+    Capybara.current_driver = :rack_test
     stub_request(:get, ->(uri) { uri.to_s.include? "/css/mail" })
+  end
+
+  after do
+    Capybara.use_default_driver
   end
 
   describe "that contains right Payment Description at Checkout information" do

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -22,7 +22,7 @@ Capybara.register_driver(:cuprite) do |app|
 end
 
 # Configure Capybara to use :cuprite driver by default
-Capybara.default_driver = Capybara.javascript_driver = :cuprite
+Capybara.javascript_driver = :cuprite
 
 RSpec.configure do |config|
   config.include CupriteHelpers, type: :system

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -22,7 +22,7 @@ Capybara.register_driver(:cuprite) do |app|
 end
 
 # Configure Capybara to use :cuprite driver by default
-Capybara.javascript_driver = :cuprite
+Capybara.default_driver = Capybara.javascript_driver = :cuprite
 
 RSpec.configure do |config|
   config.include CupriteHelpers, type: :system


### PR DESCRIPTION
#### What? Why?

Picks-up on #9576 and:

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- leaves the Cuprite as the default webdriver - not doing so seemed to break other system specs
- sets `:rack_test `as the `current_driver` webdriver, in a `before` block
- calls back the `default_driver`, in an `after` block
- removes the spec/features folder from `build.yml`

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
