### PR TITLE
Fix alignment for header Developer settings under Accounts settings

### DIFF
--- a/app/views/spree/users/show.html.haml
+++ b/app/views/spree/users/show.html.haml
@@ -23,14 +23,14 @@
     = render 'developer_settings' if @user.show_api_key_view
 
   .row.tabset-ctrl#account-tabs{ style: 'margin-bottom: 100px', navigate: 'true', selected: 'orders', prefix: 'account' }
-    .small.12.medium-3.columns.tab{ name: "orders" }
+    .small.12.medium-2.columns.tab{ name: "orders" }
       %a=t('.tabs.orders')
     - if Spree::Config.stripe_connect_enabled && Stripe.publishable_key
-      .small.12.medium-3.columns.tab{ name: "cards" }
+      .small.12.medium-2.columns.tab{ name: "cards" }
         %a=t('.tabs.cards')
-    .small.12.medium-3.columns.tab{ name: "transactions" }
+    .small.12.medium-2.columns.tab{ name: "transactions" }
       %a=t('.tabs.transactions')
-    .small.12.medium-3.columns.tab{ name: "settings" }
+    .small.12.medium-2.columns.tab{ name: "settings" }
       %a=t('.tabs.settings')
     // the api_keys partial is the only content for now, so we have to hide the whole tab for now
     // if there is new content, we will need to handle this inside the developer_settings partial


### PR DESCRIPTION
#### What? Why?

Closes #9579

All the `Headers` should appear in the same row for `Account Settings`
![accounts_setting](https://user-images.githubusercontent.com/62114687/187025571-af88cf90-8c9a-4a8e-873e-39ed01638426.png)


#### What should we test?
As a superadmin, toggle the Checkbox: "Show API key generation view", under /users/<user_id>/edit
As a customer, visit the /account#/ section
 "Developer Settings" tab should now be present beside other headers

#### Release notes
Changelog Category: User facing changes


#### Dependencies
No dependencies



