### PR TITLE
Avoid storybook deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -178,7 +178,7 @@ group :development do
   gem 'spring-commands-rspec'
   gem 'web-console'
 
-  gem "view_component_storybook", require: "view_component/storybook/engine"
+  gem "view_component_storybook"
 
   gem 'rack-mini-profiler', '< 3.0.0'
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,9 @@ require "rails"
   end
 end
 
+require "view_component"
+require "view_component/storybook"
+
 require_relative "../lib/open_food_network/i18n_config"
 require_relative '../lib/spree/core/environment'
 require_relative '../lib/spree/core/mail_interceptor'


### PR DESCRIPTION

#### What? Why?

Loading the storybook engine directly is deprecated and I followed the current documentation to load storybook in the app. This avoids a warning:

> DEPRECATION WARNING: This manually engine loading is deprecated and will be removed in v1.0.0. Remove `require "view_component/storybook/engine"`. (called from <top (required)> at config/application.rb:30)



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As dev: check that storybook still works.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
