### PR TITLE
Index tax totals correctly for invoice display

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -70,12 +70,11 @@ module CheckoutHelper
   def display_checkout_taxes_hash(order)
     totals = OrderTaxAdjustmentsFetcher.new(order).totals
 
-    totals.each_with_object({}) do |(tax_rate, tax_amount), hash|
-      hash[tax_rate] =
-        {
-          amount: Spree::Money.new(tax_amount, currency: order.currency),
-          percentage: number_to_percentage(tax_rate.amount * 100, precision: 1),
-        }
+    totals.map do |tax_rate, tax_amount|
+      {
+        amount: Spree::Money.new(tax_amount, currency: order.currency),
+        percentage: number_to_percentage(tax_rate.amount * 100, precision: 1),
+      }
     end
   end
 

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -71,9 +71,10 @@ module CheckoutHelper
     totals = OrderTaxAdjustmentsFetcher.new(order).totals
 
     totals.each_with_object({}) do |(tax_rate, tax_amount), hash|
-      hash[number_to_percentage(tax_rate.amount * 100, precision: 1)] =
+      hash[tax_rate] =
         {
           amount: Spree::Money.new(tax_amount, currency: order.currency),
+          percentage: number_to_percentage(tax_rate.amount * 100, precision: 1),
         }
     end
   end

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -72,7 +72,9 @@ module CheckoutHelper
 
     totals.each_with_object({}) do |(tax_rate, tax_amount), hash|
       hash[number_to_percentage(tax_rate.amount * 100, precision: 1)] =
-        Spree::Money.new tax_amount, currency: order.currency
+        {
+          amount: Spree::Money.new(tax_amount, currency: order.currency),
+        }
     end
   end
 

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -74,8 +74,9 @@ module CheckoutHelper
       {
         amount: Spree::Money.new(tax_amount, currency: order.currency),
         percentage: number_to_percentage(tax_rate.amount * 100, precision: 1),
+        rate_amount: tax_rate.amount,
       }
-    end
+    end.sort_by { |tax| tax[:rate_amount] }
   end
 
   def display_line_item_tax_rates(line_item)

--- a/app/views/spree/admin/orders/_invoice_table2.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table2.html.haml
@@ -50,7 +50,7 @@
     - display_checkout_taxes_hash(@order).each do |tax_rate, tax|
       %tr
         %td{:align => "right", :colspan => "3"}
-          = t(:tax_total, rate: tax_rate)
+          = t(:tax_total, rate: tax[:percentage])
         %td{:align => "right", :colspan => "2"}
           = tax[:amount]
     %tr

--- a/app/views/spree/admin/orders/_invoice_table2.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table2.html.haml
@@ -47,12 +47,12 @@
         %strong= @order.has_taxes_included ? t(:total_incl_tax) : t(:total_excl_tax)
       %td{:align => "right", :colspan => "2"}
         %strong= @order.has_taxes_included ? @order.display_total : display_checkout_total_less_tax(@order)
-    - display_checkout_taxes_hash(@order).each do |tax_rate, tax_value|
+    - display_checkout_taxes_hash(@order).each do |tax_rate, tax|
       %tr
         %td{:align => "right", :colspan => "3"}
           = t(:tax_total, rate: tax_rate)
         %td{:align => "right", :colspan => "2"}
-          = tax_value
+          = tax[:amount]
     %tr
       %td{:align => "right", :colspan => "3"}
         = @order.has_taxes_included ? t(:total_excl_tax) : t(:total_incl_tax)

--- a/app/views/spree/admin/orders/_invoice_table2.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table2.html.haml
@@ -47,7 +47,7 @@
         %strong= @order.has_taxes_included ? t(:total_incl_tax) : t(:total_excl_tax)
       %td{:align => "right", :colspan => "2"}
         %strong= @order.has_taxes_included ? @order.display_total : display_checkout_total_less_tax(@order)
-    - display_checkout_taxes_hash(@order).each do |tax_rate, tax|
+    - display_checkout_taxes_hash(@order).each do |tax|
       %tr
         %td{:align => "right", :colspan => "3"}
           = t(:tax_total, rate: tax[:percentage])

--- a/app/views/spree/admin/orders/ticket.html.haml
+++ b/app/views/spree/admin/orders/ticket.html.haml
@@ -60,7 +60,7 @@
       '\x0A',
       "#{display_checkout_taxes_hash(@order).map { |tax_rate, tax|
       '%31s%10s' %
-      [j(t(:tax_total, rate: tax_rate)),
+      [j(t(:tax_total, rate: tax[:percentage])),
       j(tax[:amount].format(with_currency: false))] +
       '" + \'\x0A\' + "'}.join }",
       "#{'%31s%10s' %

--- a/app/views/spree/admin/orders/ticket.html.haml
+++ b/app/views/spree/admin/orders/ticket.html.haml
@@ -58,7 +58,7 @@
       j(@order.display_total.format(with_currency: false))]}",
       '\x1B' + '\x45' + '\x0A', // bold off
       '\x0A',
-      "#{display_checkout_taxes_hash(@order).map { |tax_rate, tax|
+      "#{display_checkout_taxes_hash(@order).map { |tax|
       '%31s%10s' %
       [j(t(:tax_total, rate: tax[:percentage])),
       j(tax[:amount].format(with_currency: false))] +

--- a/app/views/spree/admin/orders/ticket.html.haml
+++ b/app/views/spree/admin/orders/ticket.html.haml
@@ -58,10 +58,10 @@
       j(@order.display_total.format(with_currency: false))]}",
       '\x1B' + '\x45' + '\x0A', // bold off
       '\x0A',
-      "#{display_checkout_taxes_hash(@order).map { |tax_rate, tax_value|
+      "#{display_checkout_taxes_hash(@order).map { |tax_rate, tax|
       '%31s%10s' %
       [j(t(:tax_total, rate: tax_rate)),
-      j(tax_value.format(with_currency: false))] +
+      j(tax[:amount].format(with_currency: false))] +
       '" + \'\x0A\' + "'}.join }",
       "#{'%31s%10s' %
       [j(t(:total_excl_tax)),

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -48,8 +48,9 @@ describe CheckoutHelper, type: :helper do
       order.save!
 
       expect(helper.display_checkout_taxes_hash(order)).to eq(
-        "10.0%" => {
+        tax_rate10 => {
           amount: Spree::Money.new(1, currency: order.currency),
+          percentage: "10.0%",
         }
       )
     end
@@ -60,8 +61,14 @@ describe CheckoutHelper, type: :helper do
       order.save!
 
       expect(helper.display_checkout_taxes_hash(order)).to eq(
-        "10.0%" => { amount: Spree::Money.new(1, currency: order.currency) },
-        "20.0%" => { amount: Spree::Money.new(2, currency: order.currency) },
+        tax_rate10 => {
+          amount: Spree::Money.new(1, currency: order.currency),
+          percentage: "10.0%",
+        },
+        tax_rate20 => {
+          amount: Spree::Money.new(2, currency: order.currency),
+          percentage: "20.0%",
+        },
       )
     end
 
@@ -70,16 +77,17 @@ describe CheckoutHelper, type: :helper do
       order.all_adjustments << other_adjustment2
       order.save!
 
-      # This passes because we override the hash entry exactly
-      # like the original code.
       expect(helper.display_checkout_taxes_hash(order)).to eq(
-        "20.0%" => { amount: Spree::Money.new(2, currency: order.currency) },
-        "20.0%" => { amount: Spree::Money.new(2, currency: order.currency) },
+        tax_rate20 => {
+          amount: Spree::Money.new(2, currency: order.currency),
+          percentage: "20.0%",
+        },
+        other_tax_rate20 => {
+          amount: Spree::Money.new(2, currency: order.currency),
+          percentage: "20.0%",
+        },
       )
 
-      pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/9605"
-
-      # This fails. We got only one result when we should have two.
       expect(helper.display_checkout_taxes_hash(order).size).to eq 2
     end
   end

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -48,7 +48,9 @@ describe CheckoutHelper, type: :helper do
       order.save!
 
       expect(helper.display_checkout_taxes_hash(order)).to eq(
-        "10.0%" => Spree::Money.new(1, currency: order.currency)
+        "10.0%" => {
+          amount: Spree::Money.new(1, currency: order.currency),
+        }
       )
     end
 
@@ -58,8 +60,8 @@ describe CheckoutHelper, type: :helper do
       order.save!
 
       expect(helper.display_checkout_taxes_hash(order)).to eq(
-        "10.0%" => Spree::Money.new(1, currency: order.currency),
-        "20.0%" => Spree::Money.new(2, currency: order.currency),
+        "10.0%" => { amount: Spree::Money.new(1, currency: order.currency) },
+        "20.0%" => { amount: Spree::Money.new(2, currency: order.currency) },
       )
     end
 
@@ -71,8 +73,8 @@ describe CheckoutHelper, type: :helper do
       # This passes because we override the hash entry exactly
       # like the original code.
       expect(helper.display_checkout_taxes_hash(order)).to eq(
-        "20.0%" => Spree::Money.new(2, currency: order.currency),
-        "20.0%" => Spree::Money.new(2, currency: order.currency),
+        "20.0%" => { amount: Spree::Money.new(2, currency: order.currency) },
+        "20.0%" => { amount: Spree::Money.new(2, currency: order.currency) },
       )
 
       pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/9605"

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -51,6 +51,7 @@ describe CheckoutHelper, type: :helper do
         {
           amount: Spree::Money.new(1, currency: order.currency),
           percentage: "10.0%",
+          rate_amount: 0.1,
         }
       ]
     end
@@ -60,14 +61,35 @@ describe CheckoutHelper, type: :helper do
       order.all_adjustments << adjustment2
       order.save!
 
-      expect(helper.display_checkout_taxes_hash(order)).to match_array [
+      expect(helper.display_checkout_taxes_hash(order)).to eq [
         {
           amount: Spree::Money.new(1, currency: order.currency),
           percentage: "10.0%",
+          rate_amount: 0.1,
         },
         {
           amount: Spree::Money.new(2, currency: order.currency),
           percentage: "20.0%",
+          rate_amount: 0.2,
+        },
+      ]
+    end
+
+    it "sorts adjustments by percentage" do
+      order.all_adjustments << adjustment2
+      order.all_adjustments << adjustment1
+      order.save!
+
+      expect(helper.display_checkout_taxes_hash(order)).to eq [
+        {
+          amount: Spree::Money.new(1, currency: order.currency),
+          percentage: "10.0%",
+          rate_amount: 0.1,
+        },
+        {
+          amount: Spree::Money.new(2, currency: order.currency),
+          percentage: "20.0%",
+          rate_amount: 0.2,
         },
       ]
     end
@@ -77,14 +99,16 @@ describe CheckoutHelper, type: :helper do
       order.all_adjustments << other_adjustment2
       order.save!
 
-      expect(helper.display_checkout_taxes_hash(order)).to match_array [
+      expect(helper.display_checkout_taxes_hash(order)).to eq [
         {
           amount: Spree::Money.new(2, currency: order.currency),
           percentage: "20.0%",
+          rate_amount: 0.2,
         },
         {
           amount: Spree::Money.new(2, currency: order.currency),
           percentage: "20.0%",
+          rate_amount: 0.2,
         },
       ]
 

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -39,20 +39,20 @@ describe CheckoutHelper, type: :helper do
       build(:adjustment, amount: 2, label: "20% tax", originator: other_tax_rate20)
     }
 
-    it "produces an empty hash without taxes" do
-      expect(helper.display_checkout_taxes_hash(order)).to eq({})
+    it "produces an empty array without taxes" do
+      expect(helper.display_checkout_taxes_hash(order)).to eq([])
     end
 
     it "shows a single tax adjustment" do
       order.all_adjustments << adjustment1
       order.save!
 
-      expect(helper.display_checkout_taxes_hash(order)).to eq(
-        tax_rate10 => {
+      expect(helper.display_checkout_taxes_hash(order)).to eq [
+        {
           amount: Spree::Money.new(1, currency: order.currency),
           percentage: "10.0%",
         }
-      )
+      ]
     end
 
     it "shows multiple tax adjustments" do
@@ -60,16 +60,16 @@ describe CheckoutHelper, type: :helper do
       order.all_adjustments << adjustment2
       order.save!
 
-      expect(helper.display_checkout_taxes_hash(order)).to eq(
-        tax_rate10 => {
+      expect(helper.display_checkout_taxes_hash(order)).to match_array [
+        {
           amount: Spree::Money.new(1, currency: order.currency),
           percentage: "10.0%",
         },
-        tax_rate20 => {
+        {
           amount: Spree::Money.new(2, currency: order.currency),
           percentage: "20.0%",
         },
-      )
+      ]
     end
 
     it "shows multiple tax adjustments with same percentage" do
@@ -77,16 +77,16 @@ describe CheckoutHelper, type: :helper do
       order.all_adjustments << other_adjustment2
       order.save!
 
-      expect(helper.display_checkout_taxes_hash(order)).to eq(
-        tax_rate20 => {
+      expect(helper.display_checkout_taxes_hash(order)).to match_array [
+        {
           amount: Spree::Money.new(2, currency: order.currency),
           percentage: "20.0%",
         },
-        other_tax_rate20 => {
+        {
           amount: Spree::Money.new(2, currency: order.currency),
           percentage: "20.0%",
         },
-      )
+      ]
 
       expect(helper.display_checkout_taxes_hash(order).size).to eq 2
     end

--- a/spec/system/admin/order_print_ticket_spec.rb
+++ b/spec/system/admin/order_print_ticket_spec.rb
@@ -92,10 +92,7 @@ describe '
       end
 
       def taxes_in_print_data
-        display_checkout_taxes_hash(order).map { |tax_rate, tax_value|
-          [tax_rate,
-           tax_value.format(with_currency: false)]
-        }
+        [["10.0%", "$11.00"]]
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #9605 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The displayed tax totals were wrong on the alternative invoice template when there were two tax distinct tax rates with the same percentage. The total would display only one of the two.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Have two tax rates in the same zone at 20%, for example one for shipping and one for products.
- Create an order with shipping and products which attract those taxes.
- Display the alternative invoice and check the total.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
