### PR TITLE
Load storybook only in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,7 @@ gem 'flipper'
 gem 'flipper-active_record'
 gem 'flipper-ui'
 
-gem "view_component", require: "view_component/engine"
+gem "view_component"
 
 group :production, :staging do
   gem 'ddtrace'

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,9 +20,6 @@ require "rails"
   end
 end
 
-require "view_component"
-require "view_component/storybook" if Rails.env.development?
-
 require_relative "../lib/open_food_network/i18n_config"
 require_relative '../lib/spree/core/environment'
 require_relative '../lib/spree/core/mail_interceptor'
@@ -34,6 +31,8 @@ if defined?(Bundler)
   # If you want your assets lazily compiled in production, use this line
   # Bundler.require(:default, :assets, Rails.env)
 end
+
+require "view_component/storybook" if Rails.env.development?
 
 module Openfoodnetwork
   class Application < Rails::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ require "rails"
 end
 
 require "view_component"
-require "view_component/storybook"
+require "view_component/storybook" if Rails.env.development?
 
 require_relative "../lib/open_food_network/i18n_config"
 require_relative '../lib/spree/core/environment'


### PR DESCRIPTION
#### What? Why?

Closes #9622 <!-- Insert issue number here. -->

The storybook gem is not available in other environments than development and the app fails to boot.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs pass.
- Deployment to staging works.
- The admin customers index page loads.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
