### PR TITLE
[Split Checkout] Recalculate tax on summary step

### DIFF
--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -22,6 +22,7 @@ class SplitCheckoutController < ::BaseController
   def edit
     redirect_to_step_based_on_order unless params[:step]
     check_step if params[:step]
+    @order.create_tax_charge! if params[:step] == "summary"
   end
 
   def update

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -22,7 +22,7 @@ class SplitCheckoutController < ::BaseController
   def edit
     redirect_to_step_based_on_order unless params[:step]
     check_step if params[:step]
-    @order.create_tax_charge! if params[:step] == "summary"
+    recalculate_tax if params[:step] == "summary"
   end
 
   def update
@@ -155,5 +155,10 @@ class SplitCheckoutController < ::BaseController
     when "payment"
       redirect_to checkout_step_path(:payment) if params[:step] == "summary"
     end
+  end
+
+  def recalculate_tax
+    @order.create_tax_charge!
+    @order.update_order!
   end
 end

--- a/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
@@ -10,26 +10,26 @@ describe "As a consumer, I want to see adjustment breakdown" do
   include AuthenticationHelper
   include WebHelper
 
-  let!(:address_within_zone) { create(:address, state_id: Spree::State.first.id) }
-  let!(:address_outside_zone) { create(:address, state_id: Spree::State.second.id) }
+  let!(:address_within_zone) { create(:address, state: Spree::State.first) }
+  let!(:address_outside_zone) { create(:address, state: Spree::State.second) }
   let!(:user_within_zone) {
-    create(:user, bill_address_id: address_within_zone.id,
-                  ship_address_id: address_within_zone.id)
+    create(:user, bill_address: address_within_zone,
+                  ship_address: address_within_zone)
   }
   let!(:user_outside_zone) {
-    create(:user, bill_address_id: address_outside_zone.id,
-                  ship_address_id: address_outside_zone.id)
+    create(:user, bill_address: address_outside_zone,
+                  ship_address: address_outside_zone)
   }
   let!(:zone) { create(:zone_with_state_member, name: 'Victoria', default_tax: false) }
   let!(:tax_category) { create(:tax_category, name: "Veggies", is_default: "f") }
   let!(:tax_rate) {
     create(:tax_rate, name: "Tax rate - included or not", amount: 0.13,
-                      zone_id: zone.id, tax_category_id: tax_category.id, included_in_price: false)
+                      zone: zone, tax_category: tax_category, included_in_price: false)
   }
   let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true) }
   let(:supplier) { create(:supplier_enterprise) }
   let!(:product_with_tax) {
-    create(:simple_product, supplier: supplier, price: 10, tax_category_id: tax_category.id)
+    create(:simple_product, supplier: supplier, price: 10, tax_category: tax_category)
   }
   let!(:variant_with_tax) { product_with_tax.variants.first }
   let!(:order_cycle) {

--- a/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
@@ -107,7 +107,8 @@ describe "As a consumer, I want to see adjustment breakdown" do
           click_on "Place order now"
 
           # DB checks
-          assert_db_tax_added
+          order_within_zone.reload
+          expect(order_within_zone.additional_tax_total).to eq(1.3)
 
           # UI checks
           expect(page).to have_selector('#order_total', text: with_currency(11.30))
@@ -134,7 +135,8 @@ describe "As a consumer, I want to see adjustment breakdown" do
           click_on "Complete order"
 
           # DB checks
-          assert_db_tax_added
+          order_within_zone.reload
+          expect(order_within_zone.additional_tax_total).to eq(1.3)
 
           # UI checks
           expect(page).to have_content("Confirmed")
@@ -164,7 +166,9 @@ describe "As a consumer, I want to see adjustment breakdown" do
           click_on "Place order now"
 
           # DB checks
-          assert_db_no_tax_added
+          order_outside_zone.reload
+          expect(order_outside_zone.included_tax_total).to eq(0.0)
+          expect(order_outside_zone.additional_tax_total).to eq(0.0)
 
           # UI checks
           expect(page).to have_content("Confirmed")
@@ -192,7 +196,9 @@ describe "As a consumer, I want to see adjustment breakdown" do
           click_on "Complete order"
 
           # DB checks
-          assert_db_no_tax_added
+          order_outside_zone.reload
+          expect(order_outside_zone.included_tax_total).to eq(0.0)
+          expect(order_outside_zone.additional_tax_total).to eq(0.0)
 
           # UI checks
           expect(page).to have_content("Confirmed")
@@ -236,7 +242,9 @@ describe "As a consumer, I want to see adjustment breakdown" do
             click_on "Complete order"
 
             # DB checks
-            assert_db_tax_added
+            order_outside_zone.reload
+            expect(order_outside_zone.included_tax_total).to eq(0.0)
+            expect(order_outside_zone.additional_tax_total).to eq(1.3)
 
             # UI checks - Order confirmation page should reflect changes
             expect(page).to have_content("Confirmed")
@@ -246,19 +254,5 @@ describe "As a consumer, I want to see adjustment breakdown" do
         end
       end
     end
-  end
-
-  private
-
-  def assert_db_tax_added
-    order_within_zone.reload
-    expect(order_outside_zone.included_tax_total).to eq(0.0)
-    expect(order_within_zone.additional_tax_total).to eq(1.3)
-  end
-
-  def assert_db_no_tax_added
-    order_outside_zone.reload
-    expect(order_outside_zone.included_tax_total).to eq(0.0)
-    expect(order_outside_zone.additional_tax_total).to eq(0.0)
   end
 end

--- a/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
@@ -118,10 +118,6 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
       context "on split-checkout" do
         before do
-          # WIP: Create order before split checkout is enabled.
-          # Otherwise the spec fails which may be a hint to issue 9153.
-          order_within_zone
-
           allow(Flipper).to receive(:enabled?).with(:split_checkout).and_return(true)
           allow(Flipper).to receive(:enabled?).with(:split_checkout, anything).and_return(true)
 

--- a/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
@@ -12,11 +12,11 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
   let!(:address_within_zone) { create(:address, state: Spree::State.first) }
   let!(:address_outside_zone) { create(:address, state: Spree::State.second) }
-  let!(:user_within_zone) {
+  let(:user_within_zone) {
     create(:user, bill_address: address_within_zone,
                   ship_address: address_within_zone)
   }
-  let!(:user_outside_zone) {
+  let(:user_outside_zone) {
     create(:user, bill_address: address_outside_zone,
                   ship_address: address_outside_zone)
   }
@@ -28,11 +28,11 @@ describe "As a consumer, I want to see adjustment breakdown" do
   }
   let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true) }
   let(:supplier) { create(:supplier_enterprise) }
-  let!(:product_with_tax) {
+  let(:product_with_tax) {
     create(:simple_product, supplier: supplier, price: 10, tax_category: tax_category)
   }
-  let!(:variant_with_tax) { product_with_tax.variants.first }
-  let!(:order_cycle) {
+  let(:variant_with_tax) { product_with_tax.variants.first }
+  let(:order_cycle) {
     create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor],
                                 coordinator: distributor, variants: [variant_with_tax])
   }
@@ -46,12 +46,12 @@ describe "As a consumer, I want to see adjustment breakdown" do
                             name: "Payment without Fee", description: "Payment without fee",
                             calculator: Calculator::FlatRate.new(preferred_amount: 0.00))
   }
-  let!(:order_within_zone) {
+  let(:order_within_zone) {
     create(:order, order_cycle: order_cycle, distributor: distributor, user: user_within_zone,
                    bill_address: address_within_zone, ship_address: address_within_zone,
                    state: "cart", line_items: [create(:line_item, variant: variant_with_tax)])
   }
-  let!(:order_outside_zone) {
+  let(:order_outside_zone) {
     create(:order, order_cycle: order_cycle, distributor: distributor, user: user_outside_zone,
                    bill_address: address_outside_zone, ship_address: address_outside_zone,
                    state: "cart", line_items: [create(:line_item, variant: variant_with_tax)])
@@ -118,6 +118,10 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
       context "on split-checkout" do
         before do
+          # WIP: Create order before split checkout is enabled.
+          # Otherwise the spec fails which may be a hint to issue 9153.
+          order_within_zone
+
           allow(Flipper).to receive(:enabled?).with(:split_checkout).and_return(true)
           allow(Flipper).to receive(:enabled?).with(:split_checkout, anything).and_return(true)
 

--- a/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
@@ -223,7 +223,6 @@ describe "As a consumer, I want to see adjustment breakdown" do
           end
 
           it "should re-calculate the tax accordingly" do
-            pending("#9153")
             select "Victoria", from: "order_bill_address_attributes_state_id"
 
             # it should not be necessary to save as new default bill address


### PR DESCRIPTION
#### What? Why?

Closes #9153 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


-  Go to https://staging.openfoodnetwork.org.uk/red-berries-hub/shop#/shop
-  Checkout the red berries with Nunavut state for customer + shipping method with tax
-  See the amount
-  Checkout again, but this time select Ontario as a state for the shopper. Same shipping method


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
