### PR TITLE
Delete duplicate customer entries

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -44,6 +44,11 @@ Metrics/BlockLength:
     "xdescribe",
   ]
 
+Rails/ApplicationRecord:
+  Exclude:
+    # Migrations should not contain application code:
+    - "db/migrate/*.rb"
+
 Rails/SkipsModelValidations:
   AllowedMethods:
     - "touch"

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# A customer record is created the first time a person orders from a shop.
+#
+# It's a relationship between a user and an enterprise but for guest orders it
+# can also be between an email address and an enterprise.
+#
+# The main purpose is tagging of customers to access private shops, receive
+# discounts et cetera. A customer record is also needed for subscriptions.
 class Customer < ApplicationRecord
   include SetUnusedAddressFields
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -14,7 +14,7 @@ class Customer < ApplicationRecord
 
   searchable_attributes :first_name, :last_name, :email, :code
 
-  belongs_to :enterprise
+  belongs_to :enterprise, optional: false
   belongs_to :user, class_name: "Spree::User"
   has_many :orders, class_name: "Spree::Order"
   before_destroy :update_orders_and_delete_canceled_subscriptions
@@ -33,7 +33,6 @@ class Customer < ApplicationRecord
   validates :code, uniqueness: { scope: :enterprise_id, allow_nil: true }
   validates :email, presence: true, 'valid_email_2/email': true,
                     uniqueness: { scope: :enterprise_id, message: I18n.t('validation_msg_is_associated_with_an_exising_customer') }
-  validates :enterprise, presence: true
 
   scope :of, ->(enterprise) { where(enterprise_id: enterprise) }
 

--- a/db/migrate/20220907055044_delete_duplicate_customers.rb
+++ b/db/migrate/20220907055044_delete_duplicate_customers.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class DeleteDuplicateCustomers < ActiveRecord::Migration[6.1]
+  class Customer < ActiveRecord::Base
+    belongs_to :bill_address, class_name: "SpreeAddress", dependent: :destroy
+    belongs_to :ship_address, class_name: "SpreeAddress", dependent: :destroy
+  end
+
+  class SpreeAddress < ActiveRecord::Base
+  end
+
+  class SpreeOrder < ActiveRecord::Base
+  end
+
+  class Subscription < ActiveRecord::Base
+  end
+
+  def up
+    say "#{grouped_duplicates.keys.count} customers with duplicates."
+
+    grouped_duplicates.map do |key, customers|
+      chosen = customers.first
+      others = customers - [chosen]
+
+      say "- #{key}"
+
+      # We can't tell which attributes or associations are the correct ones.
+      # Selection has been random so far and it's no regression to randomly
+      # select the attributes of the first customer record.
+      #
+      # However, we do need to update references to the customer.
+      update_references(others, chosen)
+
+      others.each(&:destroy!)
+    end
+  end
+
+  def grouped_duplicates
+    @grouped_duplicates ||= duplicate_records.group_by do |customer|
+      [customer.email, customer.enterprise_id]
+    end
+  end
+
+  def duplicate_records
+    customer_duplicates = <<~SQL
+      JOIN customers AS copy
+        ON customers.id != copy.id
+       AND customers.email = copy.email
+       AND customers.enterprise_id = copy.enterprise_id
+    SQL
+
+    Customer.joins(customer_duplicates)
+  end
+
+  def update_references(source_customers, destination_customer)
+    SpreeOrder.where(customer_id: source_customers.map(&:id)).
+      update_all(customer_id: destination_customer.id)
+
+    Subscription.where(customer_id: source_customers.map(&:id)).
+      update_all(customer_id: destination_customer.id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_13_195433) do
+ActiveRecord::Schema.define(version: 2022_09_07_055044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"


### PR DESCRIPTION
#### What? Why?

Addresses issue mentioned in https://github.com/openfoodfoundation/openfoodnetwork/issues/9002#issuecomment-1238934979.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I looked into au-prod, uk-prod and fr-prod databases and found that we have duplicate customer records. This is not allowed by our code but not enforced in the database. We seem to have some bug in the code which creates multiple records within the same second.

I'm adding a unique index to the database here so that attempts to create multiple records will fail in the future. Bugsnag should tell us when that happens. It's rare, only two or three times a year. So the impact of this error shouldn't be big but clearing it up is important to avoid bugs like:

- #9002 


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

uk-staging has duplicate customer records as well. Here's a full list:

```
select cc.id, cc.email, cc.user_id, cc.enterprise_id, cc.created_at from customers join customers as cc on customers.id!=cc.id and customers.email=cc.email and customers.enterprise_id=cc.enterprise_id;
  id  |           email           | user_id | enterprise_id |         created_at         
------+---------------------------+---------+---------------+----------------------------
  976 | 316_ofn_user@example.com  |     316 |           249 | 2020-04-21 15:28:32.016214
 5629 | 352_ofn_user@example.com  |     352 |           249 | 2020-07-30 20:08:36.865792
 6365 | 1647_ofn_user@example.com |    1647 |            80 | 2020-09-13 03:11:01.070989
 5666 | 2620_ofn_user@example.com |    2620 |            80 | 2020-08-02 20:55:38.357994
 4505 | 3729_ofn_user@example.com |    3729 |           632 | 2020-06-28 20:33:44.589617
 3221 | 3729_ofn_user@example.com |    3729 |           632 | 2020-06-08 14:45:29.422711
 8061 | 5504_ofn_user@example.com |    5504 |           237 | 2021-04-07 17:26:46.289783
  295 | 352_ofn_user@example.com  |     352 |           249 | 2019-05-12 15:41:05.895483
 2272 | 2620_ofn_user@example.com |    2620 |            80 | 2020-05-18 19:47:31.511082
 1939 | 1647_ofn_user@example.com |    1647 |            80 | 2020-05-08 23:32:46.499104
 5500 | 5504_ofn_user@example.com |    5504 |           237 | 2020-07-27 02:15:24.173698
  266 | 316_ofn_user@example.com  |     316 |           249 | 2019-04-26 14:42:12.962721
(12 rows)
```

**Before deploying**

- Look up some of these customers and take note of them. Here's one example: ![Screenshot from 2022-09-08 17-02-35](https://user-images.githubusercontent.com/3524483/189056817-742ce986-1cf5-4f2f-964e-1ff9714b449d.png)
- List all orders for the same email address.
- List subscriptions for those customers. Create subscriptions if none are present.

Then deploy:

- The deployment should remove duplicates. You can do this only once.
- Check back on the customers again and now you should have only one.
- All orders for that email address should now belong to the one record.
- The subscriptions should also be consolidated.
- The migration does *not* try to merge tags or addresses because we can't know which ones are right. The outcome will be random (one record is chosen). But when a user logs in at the moment, it's already random which customer record is used.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

When we prepare the release with this change, it would be useful to compile lists of customers affected by this. We can then contact the enterprises to check the tags. The command to get a list on a production database:
```sql
-- psql -h localhost openfoodnetwork ofn_user
select cc.email, cc.enterprise_id, enterprises.name from customers join customers as cc on customers.id!=cc.id and customers.email=cc.email and customers.enterprise_id=cc.enterprise_id join enterprises on cc.enterprise_id=enterprises.id order by enterprise_id, email;
```