### PR TITLE
Splits tests into existing/non-existing shops

### DIFF
--- a/spec/system/consumer/shops_spec.rb
+++ b/spec/system/consumer/shops_spec.rb
@@ -23,9 +23,38 @@ describe 'Shops', js: true do
     producer.set_producer_property 'Organic', 'NASAA 12345'
   end
 
-  it "searches by URL" do
-    visit shops_path(anchor: "/?query=xyzzy")
-    expect(page).to have_content "Sorry, no results found for xyzzy"
+  context "searching enterprises" do
+    context "which exist" do
+      it "by URL" do
+        visit shops_path(anchor: "/?query=Enterprise")
+        expect(page).to have_content "Did you mean? #{distributor.name}"
+      end
+
+      it "by typing in the search field" do
+        visit shops_path
+        find('input').set("Enterprise")
+        expect(current_url).to have_content("/shops#/?query=Enterprise")
+        expect(page).to have_content "Did you mean? #{distributor.name}"
+      end
+    end
+
+    context "which do not exist" do
+      it "by URL" do
+        pending("#9649")
+        visit shops_path(anchor: "/?query=xyzzy")
+        expect(page).not_to have_content distributor.name
+        expect(page).to have_content "Sorry, no results found for xyzzy. Try another search?"
+      end
+
+      it "by typing in the search field" do
+        pending("#5467")
+        visit shops_path
+        find('input').set("xyzzy")
+        expect(current_url).to have_content("/shops#/?query=xyzzy")
+        expect(page).not_to have_content distributor.name
+        expect(page).to have_content "Sorry, no results found for xyzzy. Try another search?"
+      end
+    end
   end
 
   describe "listing shops" do


### PR DESCRIPTION
#### What? Why?

Closes #9643
Relates to #5467
Relates to #9649

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Since the bug is pre-existent, the main goal was to reproduce it in a spec (as a pending example) and to bring the build back to green.

The spec was changed to cover two ways to perform the shop search:
- via URL -> I'd be in favor of removing these, as I'm not very confident that the search is usually performed in this way by users. It seems to [relate to this finding](https://github.com/openfoodfoundation/openfoodnetwork/issues/9643#issuecomment-1240413524) that typing the URL actually makes the search work properly: I could not reproduce this behavior in the spec, only the failing scenario.

- by using the search box -> I think it should be the main goal here, in the context of a system spec (UI tests)

If we want to keep both maybe it could be improved with `shared_examples`.

It's now split into cases in which the query should i) return results ii) return no results.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
