### PR TITLE
Allow to change unit value for numbers with a comma separator on bulk product update

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -256,10 +256,10 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
 
   $scope.packVariant = (product, variant) ->
     if variant.hasOwnProperty("unit_value_with_description")
-      match = variant.unit_value_with_description.match(/^([\d\.]+(?= |$)|)( |)(.*)$/)
+      match = variant.unit_value_with_description.match(/^([\d\.\,]+(?= |$)|)( |)(.*)$/)
       if match
         product = BulkProducts.find product.id
-        variant.unit_value  = parseFloat(match[1])
+        variant.unit_value  = parseFloat(match[1].replace(",", "."))
         variant.unit_value  = null if isNaN(variant.unit_value)
         variant.unit_value *= product.variant_unit_scale if variant.unit_value && product.variant_unit_scale
         variant.unit_description = match[3]

--- a/app/assets/javascripts/admin/directives/display_as.js.coffee
+++ b/app/assets/javascripts/admin/directives/display_as.js.coffee
@@ -39,9 +39,9 @@ angular.module("ofn.admin").directive "ofnDisplayAs", (OptionValueNamer) ->
       # get relevant variant properties
       variant = scope.$eval(attrs.ofnDisplayAs) # Like this so we can switch between 'master' and 'variant'
       if variant.unit_value_with_description?
-        match = variant.unit_value_with_description.match(/^([\d\.]+(?= |$)|)( |)(.*)$/)
+        match = variant.unit_value_with_description.match(/^([\d\.\,]+(?= |$)|)( |)(.*)$/)
         if match
-          unit_value  = parseFloat(match[1])
+          unit_value  = parseFloat(match[1].replace(",", "."))
           unit_value  = null if isNaN(unit_value)
           unit_value *= variant_unit_scale if unit_value && variant_unit_scale
           unit_description = match[3]

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -667,6 +667,15 @@ describe "AdminProductEditCtrl", ->
           unit_description: ''
           unit_value_with_description: "12"
 
+      it "converts unit_value into a float when a comma separated number is provided", ->
+        testProduct = {id: 123, variant_unit_scale: 1.0}
+        testVariant = {unit_value_with_description: "250,5"}
+        $scope.packVariant(testProduct, testVariant)
+        expect(testVariant).toEqual
+          unit_value: 250.5
+          unit_description: ''
+          unit_value_with_description: "250,5"
+
 
     describe "filtering products", ->
       beforeEach ->


### PR DESCRIPTION
#### What? Why?

Closes #9569

Updated the JS to include comma separator similar to dot separator
[bulk_product_update_unit_value.webm](https://user-images.githubusercontent.com/62114687/189631972-ce029637-d34b-4388-84af-ac9c5b5a0992.webm)




#### What should we test?
 - Go to Products tab
 - On a variant line, type a number with comma separator in the "unit" field
 - Click "Save changes"
 - Allow to change unit value for numbers with a comma separator on bulk product update

#### Release notes
Changelog Category: User facing changes



#### Dependencies
No dependencies
