### PR TITLE
Fix sorting by date bug on bulk management page

### DIFF
--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -132,7 +132,7 @@
                 = t("admin.phone")
             %th.date{ 'ng-show' => 'columns.order_date.visible' }
               %a{ :href => '', 'ng-click' => "sorting.toggle('order.completed_at')" }
-                = t("admin.orders.bulk_management.order_date")
+                = t("admin.order_date")
             %th.producer{ 'ng-show' => 'columns.producer.visible' }
               %a{ :href => '', 'ng-click' => "sorting.toggle('supplier.name')" }
                 = t("admin.producer")


### PR DESCRIPTION
use date object direct from order instead of string from bulk page

#### What? Why?

Closes # 9661

pass date object to the sort function instead of string

#### What should we test?
sorting by date on bulk order management page

- Visit bulk orders management page.

#### Release notes

Changelog Category: User facing changes

Orders now correctly sort by date on the order management page

The title of the pull request will be included in the release notes.