### PR TITLE
Makes wicked-pdf config ENV-dependent

### DIFF
--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,9 +1,21 @@
-Rails.application.reloader.to_prepare do
-  WickedPdf.config = {
-    #:wkhtmltopdf => '/usr/local/bin/wkhtmltopdf',
-    #:layout => "pdf.html",
-    :exe_path => `bundle exec which wkhtmltopdf`.chomp
-  }
+if Rails.env.test?
+  Rails.application.reloader.to_prepare do
+    WickedPdf.config = {
+      #:wkhtmltopdf => '/usr/local/bin/wkhtmltopdf',
+      #:layout => "pdf.html",
+      :page_size => 'A3',
+      :exe_path => `bundle exec which wkhtmltopdf`.chomp
+    }
+  end
+else
+  Rails.application.reloader.to_prepare do
+    WickedPdf.config = {
+      #:wkhtmltopdf => '/usr/local/bin/wkhtmltopdf',
+      #:layout => "pdf.html",
+      :page_size => 'A4', # default
+      :exe_path => `bundle exec which wkhtmltopdf`.chomp
+    }
+  end
 end
 
 # A monkey-patch to remove WickedPdf's monkey-patch, as it clashes with ViewComponents.

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -208,7 +208,8 @@ describe '
         it "displays $0.0 when a line item has no tax" do
           pending "i) for legend see picture on PR #9495"
           # first line item, no tax
-          expect(page).to have_content "#{Spree::Product.first.name} (1g) 1 $0.0 $12.54"
+          expect(page).to have_content "#{Spree::Product.first.name} 1 $0.0 $12.54"
+          expect(page).to have_content "(1g)" # display as
         end
 
         it "displays GST for enterprise fees" do
@@ -221,7 +222,8 @@ describe '
           # header
           expect(page).to have_content "Item Qty GST Price"
           # second line item, included tax
-          expect(page).to have_content "#{Spree::Product.second.name} (1g) 3 $250.08 $1,500.45"
+          expect(page).to have_content "#{Spree::Product.second.name} 3 $250.08 $1,500.45"
+          expect(page).to have_content "(1g)" # display as
           # Enterprise fee
           expect(page).to have_content "Admin & Handling 1 $120.00"
           # Shipping
@@ -242,14 +244,18 @@ describe '
 
         it "displays the taxes correctly" do
           # header
-          expect(page).to have_content "Item Qty Unit price (Incl. tax)"
-          expect(page).to have_content "Total price (Incl. taTax rate"
+          expect(page).to have_content "Item Qty"
+          expect(page).to have_content "Unit price (Incl. tax)"
+          expect(page).to have_content "Total price (Incl. tax)"
+          expect(page).to have_content "Tax rate"
           # first line item, no tax
           expect(page).to have_content Spree::Product.first.name.to_s
-          expect(page).to have_content "1 $12.54 $12.54 0.0% (1g)"
+          expect(page).to have_content "(1g)" # display as
+          expect(page).to have_content "1 $12.54 $12.54 0.0%"
           # second line item, included tax
           expect(page).to have_content Spree::Product.second.name.to_s
-          expect(page).to have_content "3 $500.15 $1,500.45 20.0% (1g)"
+          expect(page).to have_content "(1g)" # display as
+          expect(page).to have_content "3 $500.15 $1,500.45 20.0%"
           # Enterprise fee
           expect(page).to have_content "Admin & Handling $120.00"
           # Shipping
@@ -337,13 +343,15 @@ describe '
         it "displays $0.0 when a line item has no tax" do
           pending "iii) for legend see picture on PR #9495"
           # first line item, no tax - display $0.0
-          expect(page).to have_content "#{Spree::Product.first.name} (1g) 1 $0.0 $12.54"
+          expect(page).to have_content "#{Spree::Product.first.name} 1 $0.0 $12.54"
+          expect(page).to have_content "(1g)" # display as
         end
 
         it "displays the added tax on the GST colum" do
           pending "closing #7983, iv) for legend see picture on PR #9495"
           # second line item, added tax of $300.09
-          expect(page).to have_content "#{Spree::Product.second.name} (1g) 3 $300.09 $1,500.45"
+          expect(page).to have_content "#{Spree::Product.second.name} 3 $300.09 $1,500.45"
+          expect(page).to have_content "(1g)" # display as
         end
 
         it "displays GST for enterprise fees" do
@@ -374,13 +382,18 @@ describe '
         end
         it "displays the taxes correctly" do
           # header
-          expect(page).to have_content "Item Qty Unit price (Incl. tax)"
-          expect(page).to have_content "Total price (Incl. taTax rate"
+          expect(page).to have_content "Item Qty"
+          expect(page).to have_content "Unit price (Incl. tax)"
+          expect(page).to have_content "Total price (Incl. tax)"
+          expect(page).to have_content "Tax rate"
           # first line item, no tax
-          expect(page).to have_content "#{Spree::Product.first.name} 1 $12.54 $12.54 0.0% (1g)"
+          expect(page).to have_content Spree::Product.first.name.to_s
+          expect(page).to have_content "(1g)" # display as
+          expect(page).to have_content "1 $12.54 $12.54 0.0%"
           # second line item, included tax
           expect(page).to have_content Spree::Product.second.name.to_s
-          expect(page).to have_content "3 $500.15 $1,500.45 20.0% (1g)"
+          expect(page).to have_content "(1g)" # display as
+          expect(page).to have_content "3 $500.15 $1,500.45 20.0%"
           # Enterprise fee
           expect(page).to have_content "Admin & Handling $120.00"
           # Shipping


### PR DESCRIPTION
#### What? Why?
Relates to https://github.com/openfoodfoundation/openfoodnetwork/pull/9442#issuecomment-1247919172

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Generating pdfs with a larger page size in test environment should prevent text clipping and make tests to pass more consistently across local environments/systems.

This PR:
- Makes wicked-pdf config ENV-dependent (`page_size` option)
- updates invoice_print_spec.rb to account for these changes (to text overlapp or clipping)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
