### PR TITLE
Send picked up emails when orders are picked up

### DIFF
--- a/app/mailers/spree/shipment_mailer.rb
+++ b/app/mailers/spree/shipment_mailer.rb
@@ -12,7 +12,8 @@ module Spree
     private
 
     def base_subject
-      "#{@shipment.order.distributor.name} #{default_i18n_subject} ##{@shipment.order.number}"
+      default_subject = !@delivery ? t('.picked_up_subject') : default_i18n_subject
+      "#{@shipment.order.distributor.name} #{default_subject} ##{@shipment.order.number}"
     end
   end
 end

--- a/app/mailers/spree/shipment_mailer.rb
+++ b/app/mailers/spree/shipment_mailer.rb
@@ -2,9 +2,10 @@
 
 module Spree
   class ShipmentMailer < BaseMailer
-    def shipped_email(shipment, resend = false)
+    def shipped_email(shipment, delivery:)
       @shipment = shipment.respond_to?(:id) ? shipment : Spree::Shipment.find(shipment)
-      subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '') + base_subject
+      @delivery = delivery
+      subject = base_subject
       mail(to: @shipment.order.email, from: from_address, subject: subject)
     end
 

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -343,7 +343,8 @@ module Spree
     end
 
     def send_shipped_email
-      ShipmentMailer.shipped_email(id).deliver_later
+      delivery = !!shipping_method.require_ship_address
+      ShipmentMailer.shipped_email(id, delivery: delivery).deliver_later
     end
 
     def update_adjustments

--- a/app/views/spree/shipment_mailer/shipped_email.html.haml
+++ b/app/views/spree/shipment_mailer/shipped_email.html.haml
@@ -1,7 +1,12 @@
 %h3
   = t('.dear_customer')
-%p.lead
-  = t('.instructions', distributor: @shipment.order.distributor.name)
+
+- if @delivery
+  %p.lead
+    = t('.instructions', distributor: @shipment.order.distributor.name)
+- else
+  %p.lead
+    = t('.picked_up_instructions', distributor: @shipment.order.distributor.name)
 
 %p
   %strong

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4221,6 +4221,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         thanks: "Thank you for your business."
         track_information: ! "Tracking Information: %{tracking}"
         track_link: ! "Tracking Link: %{url}"
+        picked_up_instructions: "Your order from %{distributor} has been picked-up"
     test_mailer:
       test_email:
         greeting: "Congratulations!"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4222,6 +4222,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         track_information: ! "Tracking Information: %{tracking}"
         track_link: ! "Tracking Link: %{url}"
         picked_up_instructions: "Your order from %{distributor} has been picked-up"
+        picked_up_subject: "Pick up Notification"
     test_mailer:
       test_email:
         greeting: "Congratulations!"

--- a/spec/mailers/shipment_mailer_spec.rb
+++ b/spec/mailers/shipment_mailer_spec.rb
@@ -17,31 +17,37 @@ describe Spree::ShipmentMailer do
 
   context ":from not set explicitly" do
     it "falls back to spree config" do
-      message = Spree::ShipmentMailer.shipped_email(shipment)
+      message = Spree::ShipmentMailer.shipped_email(shipment, delivery: true)
       expect(message.from).to eq [Spree::Config[:mails_from]]
     end
   end
 
   # Regression test for #2196
   it "doesn't include out of stock in the email body" do
-    shipment_email = Spree::ShipmentMailer.shipped_email(shipment)
+    shipment_email = Spree::ShipmentMailer.shipped_email(shipment, delivery: true)
     expect(shipment_email.body).to_not include(%{Out of Stock})
   end
 
   it "shipment_email accepts an shipment id as an alternative to an Shipment object" do
     expect(Spree::Shipment).to receive(:find).with(shipment.id).and_return(shipment)
     expect {
-      Spree::ShipmentMailer.shipped_email(shipment.id).deliver_now
+      Spree::ShipmentMailer.shipped_email(shipment.id, delivery: true).deliver_now
     }.to_not raise_error
   end
 
   it "includes the distributor's name in the subject" do
-    shipment_email = Spree::ShipmentMailer.shipped_email(shipment)
+    shipment_email = Spree::ShipmentMailer.shipped_email(shipment, delivery: true)
     expect(shipment_email.subject).to include("#{distributor.name} Shipment Notification")
   end
 
   it "includes the distributor's name in the body" do
-    shipment_email = Spree::ShipmentMailer.shipped_email(shipment)
+    shipment_email = Spree::ShipmentMailer.shipped_email(shipment, delivery: true)
     expect(shipment_email.body).to include("Your order from #{distributor.name} has been shipped")
+  end
+
+  it "picked_up email includes different text in body" do
+    text = "Your order from #{distributor.name} has been picked-up"
+    picked_up_email = Spree::ShipmentMailer.shipped_email(shipment, delivery: false)
+    expect(picked_up_email.body).to include(text)
   end
 end

--- a/spec/mailers/shipment_mailer_spec.rb
+++ b/spec/mailers/shipment_mailer_spec.rb
@@ -50,4 +50,9 @@ describe Spree::ShipmentMailer do
     picked_up_email = Spree::ShipmentMailer.shipped_email(shipment, delivery: false)
     expect(picked_up_email.body).to include(text)
   end
+
+  it "picked_up email has different subject" do
+    shipment_email = Spree::ShipmentMailer.shipped_email(shipment, delivery: false)
+    expect(shipment_email.subject).to include("#{distributor.name} Pick up Notification")
+  end
 end


### PR DESCRIPTION
#### What? Why?
Creates a new email called `picked up` that is sent to customers when they pick up their purchase from the shop

Closes #9561

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Login as a Customer
- Create an order and select `pick up` as the delivery method
- When your order is confirmed and shipped, Ascertain that you receive a similar email as below:
 
![pickedup](https://user-images.githubusercontent.com/87677429/190983174-ebb2381e-c4af-4032-9ce6-96adf86d883a.png)


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
