### PR TITLE
Add webhook triggered on Order Cycle Open

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,6 +136,8 @@ gem 'view_component_reflex', '3.1.14.pre9'
 
 gem 'mini_portile2', '~> 2.8'
 
+gem "faraday"
+
 group :production, :staging do
   gem 'ddtrace'
   gem 'rack-timeout'

--- a/Gemfile
+++ b/Gemfile
@@ -137,6 +137,7 @@ gem 'view_component_reflex', '3.1.14.pre9'
 gem 'mini_portile2', '~> 2.8'
 
 gem "faraday"
+gem "private_address_check"
 
 group :production, :staging do
   gem 'ddtrace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,6 +474,7 @@ GEM
       ttfunk
     pg (1.2.3)
     power_assert (2.0.2)
+    private_address_check (0.5.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -844,6 +845,7 @@ DEPENDENCIES
   paypal-sdk-merchant (= 1.117.2)
   pdf-reader
   pg (~> 1.2.3)
+  private_address_check
   pry (~> 0.13.0)
   puma
   rack-mini-profiler (< 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -801,6 +801,7 @@ DEPENDENCIES
   digest
   dotenv-rails
   factory_bot_rails (= 6.2.0)
+  faraday
   ffaker
   flipper
   flipper-active_record

--- a/app/controllers/webhook_endpoints_controller.rb
+++ b/app/controllers/webhook_endpoints_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class WebhookEndpointsController < ::BaseController
+  before_action :load_resource, only: :destroy
+
+  def create
+    webhook_endpoint = spree_current_user.webhook_endpoints.new(webhook_endpoint_params)
+
+    if webhook_endpoint.save
+      flash[:success] = t('.success')
+    else
+      flash[:error] = t('.error')
+    end
+
+    redirect_to redirect_path
+  end
+
+  def destroy
+    if @webhook_endpoint.destroy
+      flash[:success] = t('.success')
+    else
+      flash[:error] = t('.error')
+    end
+
+    redirect_to redirect_path
+  end
+
+  def load_resource
+    @webhook_endpoint = spree_current_user.webhook_endpoints.find(params[:id])
+  end
+
+  def webhook_endpoint_params
+    params.require(:webhook_endpoint).permit(:url)
+  end
+
+  def redirect_path
+    if request.referer.blank? || request.referer.include?(spree.account_path)
+      developer_settings_path
+    else
+      request.referer
+    end
+  end
+
+  def developer_settings_path
+    "#{spree.account_path}#/developer_settings"
+  end
+end

--- a/app/jobs/order_cycle_opened_job.rb
+++ b/app/jobs/order_cycle_opened_job.rb
@@ -3,15 +3,25 @@
 # Trigger jobs for any order cycles that recently opened
 class OrderCycleOpenedJob < ApplicationJob
   def perform
-    recently_opened_order_cycles.each do |order_cycle|
-      OrderCycleWebhookService.create_webhook_job(order_cycle, 'order_cycle.opened')
+    ActiveRecord::Base.transaction do
+      recently_opened_order_cycles.find_each do |order_cycle|
+        OrderCycleWebhookService.create_webhook_job(order_cycle, 'order_cycle.opened')
+      end
+      mark_as_opened(recently_opened_order_cycles)
     end
   end
 
   private
 
   def recently_opened_order_cycles
-    OrderCycle
+    @recently_opened_order_cycles ||= OrderCycle
+      .where(opened_at: nil)
       .where(orders_open_at: 1.hour.ago..Time.zone.now)
+      .lock.order(:id)
+  end
+
+  def mark_as_opened(order_cycles)
+    now = Time.zone.now
+    order_cycles.update_all(opened_at: now, updated_at: now)
   end
 end

--- a/app/jobs/order_cycle_opened_job.rb
+++ b/app/jobs/order_cycle_opened_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Trigger jobs for any order cycles that recently opened
+class OrderCycleOpenedJob < ApplicationJob
+  def perform
+    recently_opened_order_cycles.each do |order_cycle|
+      OrderCycleWebhookService.create_webhook_job(order_cycle, 'order_cycle.opened')
+    end
+  end
+
+  private
+
+  def recently_opened_order_cycles
+    OrderCycle
+      .where(orders_open_at: 1.hour.ago..Time.zone.now)
+  end
+end

--- a/app/jobs/webhook_delivery_job.rb
+++ b/app/jobs/webhook_delivery_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "faraday"
+
+# Deliver a webhook payload
+# As a delayed job, it can run asynchronously and handle retries.
+class WebhookDeliveryJob < ApplicationJob
+  queue_as :default
+
+  def perform(url, event, payload)
+    body = {
+      id: job_id,
+      at: Time.zone.now.to_s,
+      event: event,
+      data: payload,
+    }
+
+    notify_endpoint(url, body)
+  end
+
+  def notify_endpoint(url, body)
+    connection = Faraday.new(
+      request: { timeout: 30 },
+      headers: {
+        'User-Agent' => 'openfoodnetwork_webhook/1.0',
+        'Content-Type' => 'application/json',
+      }
+    )
+    connection.post(url, body.to_json)
+  end
+end

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -41,6 +41,7 @@ module Spree
     has_many :webhook_endpoints, dependent: :destroy
 
     accepts_nested_attributes_for :enterprise_roles, allow_destroy: true
+    accepts_nested_attributes_for :webhook_endpoints
 
     accepts_nested_attributes_for :bill_address
     accepts_nested_attributes_for :ship_address

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -38,6 +38,8 @@ module Spree
     has_many :customers
     has_many :credit_cards
     has_many :report_rendering_options, class_name: "::ReportRenderingOptions", dependent: :destroy
+    has_many :webhook_endpoints, dependent: :destroy
+
     accepts_nested_attributes_for :enterprise_roles, allow_destroy: true
 
     accepts_nested_attributes_for :bill_address

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Records a webhook url to send notifications to
+class WebhookEndpoint < ApplicationRecord
+  validates :url, presence: true
+end

--- a/app/services/order_cycle_webhook_service.rb
+++ b/app/services/order_cycle_webhook_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Create a webhook payload for an order cycle event.
+# The payload will be delivered asynchronously.
+class OrderCycleWebhookService
+  def self.create_webhook_job(order_cycle, event)
+    webhook_payload = order_cycle
+      .slice(:id, :name, :orders_open_at, :orders_close_at, :coordinator_id)
+      .merge(coordinator_name: order_cycle.coordinator.name)
+
+    # Endpoints for coordinator owner
+    webhook_endpoints = order_cycle.coordinator.owner.webhook_endpoints
+
+    webhook_endpoints.each do |endpoint|
+      WebhookDeliveryJob.perform_later(endpoint.url, event, webhook_payload)
+    end
+  end
+end

--- a/app/services/order_cycle_webhook_service.rb
+++ b/app/services/order_cycle_webhook_service.rb
@@ -11,6 +11,9 @@ class OrderCycleWebhookService
     # Endpoints for coordinator owner
     webhook_endpoints = order_cycle.coordinator.owner.webhook_endpoints
 
+    # Plus unique endpoints for distributor owners (ignore duplicates)
+    webhook_endpoints |= order_cycle.distributors.map(&:owner).flat_map(&:webhook_endpoints)
+
     webhook_endpoints.each do |endpoint|
       WebhookDeliveryJob.perform_later(endpoint.url, event, webhook_payload)
     end

--- a/app/services/permitted_attributes/user.rb
+++ b/app/services/permitted_attributes/user.rb
@@ -15,7 +15,10 @@ module PermittedAttributes
     private
 
     def permitted_attributes
-      [:email, :password, :password_confirmation, :disabled]
+      [
+        :email, :password, :password_confirmation, :disabled,
+        { webhook_endpoints_attributes: [:id, :url] },
+      ]
     end
   end
 end

--- a/app/views/spree/users/_developer_settings.html.haml
+++ b/app/views/spree/users/_developer_settings.html.haml
@@ -1,3 +1,4 @@
 %script{ type: "text/ng-template", id: "account/developer_settings.html" }
   %h3= t('.title')
   = render partial: 'api_keys'
+  = render partial: 'webhook_endpoints'

--- a/app/views/spree/users/_webhook_endpoints.html.haml
+++ b/app/views/spree/users/_webhook_endpoints.html.haml
@@ -1,0 +1,33 @@
+%section{ id: "webhook_endpoints" }
+  %hr
+  %h3= t('.title')
+  %p= t('.description')
+
+  %table{width: "100%"}
+    %thead
+      %tr
+        %th= t('.event_type.header')
+        %th= t('.url.header')
+        %th.actions
+    %tbody
+      -# Existing endpoints
+      - @user.webhook_endpoints.each do |webhook_endpoint|
+        %tr
+          %td= t('.event_types.order_cycle_opened') # For now, we only support one type.
+          %td= webhook_endpoint.url
+          %td.actions
+            - if webhook_endpoint.persisted?
+              = button_to account_webhook_endpoint_path(webhook_endpoint), method: :delete,
+                class: "tiny alert no-margin",
+                data: { confirm: I18n.t(:are_you_sure)} do
+                = I18n.t(:delete)
+
+      -# Create new
+      - if @user.webhook_endpoints.empty? # Only one allowed for now.
+        %tr
+          %td= t('.event_types.order_cycle_opened') # For now, we only support one type.
+          %td
+            = form_for(@user.webhook_endpoints.build, url: account_webhook_endpoints_path, id: 'new_webhook_endpoint') do |f|
+              = f.url_field :url, placeholder: t('.url.create_placeholder'), required: true, size: 64
+          %td.actions
+            = button_tag t(:create), class: 'button primary tiny no-margin', form: 'new_webhook_endpoint'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3562,6 +3562,14 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   previous: "Previous"
   last: "Last"
 
+  webhook_endpoints:
+    create:
+      success: Webhook endpoint successfully created
+      error: Webhook endpoint failed to create
+    destroy:
+      success: Webhook endpoint successfully deleted
+      error: Webhook endpoint failed to delete
+
   spree:
     order_updated: "Order Updated"
     add_country: "Add country"
@@ -4357,6 +4365,16 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       api_keys:
         regenerate_key: "Regenerate Key"
         title: API key
+      webhook_endpoints:
+        title: Webhook Endpoints
+        description: Events in the system may trigger webhooks to external systems.
+        event_types:
+          order_cycle_opened: Order Cycle Opened
+        event_type:
+          header: Event type
+        url:
+          header: Endpoint URL
+          create_placeholder: Enter the URL of the remote webhook endpoint
       developer_settings:
         title: Developer Settings
       form:

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -32,7 +32,9 @@ Spree::Core::Engine.routes.draw do
     put '/password/change' => 'user_passwords#update', :as => :update_password
   end
 
-  resource :account, :controller => 'users'
+  resource :account, :controller => 'users' do
+    resources :webhook_endpoints, only: [:create, :destroy], controller: '/webhook_endpoints'
+  end
 
   match '/admin/orders/bulk_management' => 'admin/orders#bulk_management', :as => "admin_bulk_order_management", via: :get
   match '/admin/payment_methods/show_provider_preferences' => 'admin/payment_methods#show_provider_preferences', :via => :get

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -15,5 +15,7 @@
       every: "5m"
     SubscriptionConfirmJob:
       every: "5m"
+    OrderCycleOpenedJob:
+      every: "5m"
     OrderCycleClosingJob:
       every: "5m"

--- a/db/migrate/20220919063831_add_opened_at_to_order_cycle.rb
+++ b/db/migrate/20220919063831_add_opened_at_to_order_cycle.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOpenedAtToOrderCycle < ActiveRecord::Migration[6.1]
+  def change
+    add_column :order_cycles, :opened_at, :timestamp
+  end
+end

--- a/db/migrate/20221028051650_create_webhook_endpoints.rb
+++ b/db/migrate/20221028051650_create_webhook_endpoints.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateWebhookEndpoints < ActiveRecord::Migration[6.1]
+  def change
+    create_table :webhook_endpoints do |t|
+      t.string :url, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20221028053214_add_spree_user_reference_to_webhook_endpoint.rb
+++ b/db/migrate/20221028053214_add_spree_user_reference_to_webhook_endpoint.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddSpreeUserReferenceToWebhookEndpoint < ActiveRecord::Migration[6.1]
+  def change
+    add_column :webhook_endpoints, :user_id, :bigint, default: 0, null: false
+    add_index :webhook_endpoints, :user_id
+    add_foreign_key :webhook_endpoints, :spree_users, column: :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -310,6 +310,7 @@ ActiveRecord::Schema.define(version: 2023_02_13_160135) do
     t.datetime "processed_at"
     t.boolean "automatic_notifications", default: false
     t.boolean "mails_sent", default: false
+    t.datetime "opened_at"
   end
 
   create_table "order_cycles_distributor_payment_methods", id: false, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1189,6 +1189,12 @@ ActiveRecord::Schema.define(version: 2023_02_13_160135) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  create_table "webhook_endpoints", force: :cascade do |t|
+    t.string "url", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "adjustment_metadata", "enterprises", name: "adjustment_metadata_enterprise_id_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1193,6 +1193,8 @@ ActiveRecord::Schema.define(version: 2023_02_13_160135) do
     t.string "url", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", default: 0, null: false
+    t.index ["user_id"], name: "index_webhook_endpoints_on_user_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
@@ -1299,4 +1301,5 @@ ActiveRecord::Schema.define(version: 2023_02_13_160135) do
   add_foreign_key "subscriptions", "spree_shipping_methods", column: "shipping_method_id", name: "subscriptions_shipping_method_id_fk"
   add_foreign_key "variant_overrides", "enterprises", column: "hub_id", name: "variant_overrides_hub_id_fk"
   add_foreign_key "variant_overrides", "spree_variants", column: "variant_id", name: "variant_overrides_variant_id_fk"
+  add_foreign_key "webhook_endpoints", "spree_users", column: "user_id"
 end

--- a/spec/controllers/webhook_endpoints_controller_spec.rb
+++ b/spec/controllers/webhook_endpoints_controller_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: false
+
+require 'spec_helper'
+require 'open_food_network/order_cycle_permissions'
+
+describe WebhookEndpointsController, type: :controller do
+  let(:user) { create(:admin_user) }
+
+  before { allow(controller).to receive(:spree_current_user) { user } }
+
+  describe "#create" do
+    it "creates a webhook_endpoint" do
+      expect {
+        spree_post :create, { url: "https://url" }
+      }.to change {
+        user.webhook_endpoints.count
+      }.by(1)
+
+      expect(flash[:success]).to be_present
+      expect(flash[:error]).to be_blank
+      expect(user.webhook_endpoints.first.url).to eq "https://url"
+    end
+
+    it "shows error if parameters not specified" do
+      expect {
+        spree_post :create, { url: "" }
+      }.to_not change {
+        user.webhook_endpoints.count
+      }
+
+      expect(flash[:success]).to be_blank
+      expect(flash[:error]).to be_present
+    end
+
+    it "redirects back to referrer" do
+      spree_post :create, { url: "https://url" }
+
+      expect(response).to redirect_to "/account#/developer_settings"
+    end
+  end
+
+  describe "#destroy" do
+    let!(:webhook_endpoint) { user.webhook_endpoints.create(url: "https://url") }
+
+    it "destroys a webhook_endpoint" do
+      webhook_endpoint2 = user.webhook_endpoints.create!(url: "https://url2")
+
+      expect {
+        spree_delete :destroy, { id: webhook_endpoint.id }
+      }.to change {
+        user.webhook_endpoints.count
+      }.by(-1)
+
+      expect(flash[:success]).to be_present
+      expect(flash[:error]).to be_blank
+
+      expect{ webhook_endpoint.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(webhook_endpoint2.reload).to be_present
+    end
+
+    it "redirects back to developer settings tab" do
+      spree_delete :destroy, id: webhook_endpoint.id
+
+      expect(response).to redirect_to "/account#/developer_settings"
+    end
+  end
+end

--- a/spec/jobs/order_cycle_opened_job_spec.rb
+++ b/spec/jobs/order_cycle_opened_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OrderCycleOpenedJob do
+  let(:oc_opened_before) {
+    create(:order_cycle, orders_open_at: Time.zone.now - 1.hour)
+  }
+  let(:oc_opened_now) {
+    create(:order_cycle, orders_open_at: Time.zone.now)
+  }
+  let(:oc_opening_soon) {
+    create(:order_cycle, orders_open_at: Time.zone.now + 1.minute)
+  }
+
+  it "enqueues jobs for recently opened order cycles only" do
+    expect(OrderCycleWebhookService)
+      .to receive(:create_webhook_job).with(oc_opened_now, 'order_cycle.opened')
+
+    expect(OrderCycleWebhookService)
+      .to_not receive(:create_webhook_job).with(oc_opened_before, 'order_cycle.opened')
+
+    expect(OrderCycleWebhookService)
+      .to_not receive(:create_webhook_job).with(oc_opening_soon, 'order_cycle.opened')
+
+    OrderCycleOpenedJob.perform_now
+  end
+
+  pending "doesn't trigger jobs open more than once"
+end

--- a/spec/jobs/order_cycle_opened_job_spec.rb
+++ b/spec/jobs/order_cycle_opened_job_spec.rb
@@ -26,5 +26,37 @@ describe OrderCycleOpenedJob do
     OrderCycleOpenedJob.perform_now
   end
 
-  pending "doesn't trigger jobs open more than once"
+  describe "concurrency", concurrency: true do
+    let(:breakpoint) { Mutex.new }
+
+    it "doesn't place duplicate job when run concurrently" do
+      oc_opened_now
+
+      # Pause jobs when placing new job:
+      breakpoint.lock
+      allow(OrderCycleOpenedJob).to(
+        receive(:new).and_wrap_original do |method, *args|
+          breakpoint.synchronize {}
+          method.call(*args)
+        end
+      )
+
+      expect(OrderCycleWebhookService)
+        .to receive(:create_webhook_job).with(oc_opened_now, 'order_cycle.opened').once
+
+      # Start two jobs in parallel:
+      threads = [
+        Thread.new { OrderCycleOpenedJob.perform_now },
+        Thread.new { OrderCycleOpenedJob.perform_now },
+      ]
+
+      # Wait for both to jobs to pause.
+      # This can reveal a race condition.
+      sleep 0.1
+
+      # Resume and complete both jobs:
+      breakpoint.unlock
+      threads.each(&:join)
+    end
+  end
 end

--- a/spec/jobs/webhook_delivery_job_spec.rb
+++ b/spec/jobs/webhook_delivery_job_spec.rb
@@ -39,9 +39,13 @@ describe WebhookDeliveryJob do
   # To be implemented in following commits
   pending "can't access local secrets" # see https://medium.com/in-the-weeds/all-about-paperclips-cve-2017-0889-server-side-request-forgery-ssrf-vulnerability-8cb2b1c96fe8
 
-  describe "retrying" do
-    pending "doesn't retry on internal failure"
-    pending "retries after external failure"
-    pending "stops retrying after a while"
+  # Exceptions are considered a job failure, which the job runner
+  # (Sidekiq) and/or ActiveJob will handle and retry later.
+  describe "failure" do
+    it "raises error on server error" do
+      stub_request(:post, url).to_return(status: [500, "Internal Server Error"])
+
+      expect{ subject.perform_now }.to raise_error(StandardError, "500")
+    end
   end
 end

--- a/spec/jobs/webhook_delivery_job_spec.rb
+++ b/spec/jobs/webhook_delivery_job_spec.rb
@@ -22,7 +22,7 @@ describe WebhookDeliveryJob do
   end
 
   it "delivers a payload" do
-    Timecop.freeze(Time.zone.now) do
+    Timecop.freeze do
       expected_body = {
         id: /.+/,
         at: Time.zone.now.to_s,
@@ -48,9 +48,9 @@ describe WebhookDeliveryJob do
       ]
 
       private_addresses.each do |url|
-        # Unfortunately this isn't allowed in CI, but it should work in your
-        # development environment.
-        xit "rejects private address #{url}" do
+        it "rejects private address #{url}" do
+          # Github Actions doesn't allow local connections.
+          pending if ENV["CI"]
           expect {
             WebhookDeliveryJob.perform_now(url, event, data)
           }.to raise_error(PrivateAddressCheck::PrivateConnectionAttemptedError)

--- a/spec/jobs/webhook_delivery_job_spec.rb
+++ b/spec/jobs/webhook_delivery_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe WebhookDeliveryJob do
+  subject { WebhookDeliveryJob.new(url, event, data) }
+  let(:url) { 'https://test/endpoint' }
+  let(:event) { 'order_cycle.opened' }
+  let(:data) {
+    {
+      order_cycle_id: 123, name: "Order cycle 1", open_at: 1.minute.ago.to_s, tags: ["tag1", "tag2"]
+    }
+  }
+
+  before do
+    stub_request(:post, url)
+  end
+
+  it "sends a request to specified url" do
+    subject.perform_now
+    expect(a_request(:post, url)).to have_been_made.once
+  end
+
+  it "delivers a payload" do
+    Timecop.freeze(Time.zone.now) do
+      expected_body = {
+        id: /.+/,
+        at: Time.zone.now.to_s,
+        event: event,
+        data: data,
+      }
+
+      subject.perform_now
+      expect(a_request(:post, url).with(body: expected_body)).
+        to have_been_made.once
+    end
+  end
+
+  # To be implemented in following commits
+  pending "can't access local secrets" # see https://medium.com/in-the-weeds/all-about-paperclips-cve-2017-0889-server-side-request-forgery-ssrf-vulnerability-8cb2b1c96fe8
+
+  describe "retrying" do
+    pending "doesn't retry on internal failure"
+    pending "retries after external failure"
+    pending "stops retrying after a while"
+  end
+end

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -551,6 +551,30 @@ describe OrderCycle do
     end
   end
 
+  describe "opened_at " do
+    let!(:oc) {
+      create(:simple_order_cycle, orders_open_at: 2.days.ago, orders_close_at: 1.day.ago, opened_at: 1.week.ago)
+    }
+
+    it "reset opened_at if open date change in future" do
+      expect(oc.opened_at).to_not be_nil
+      oc.update!(orders_open_at: 1.week.from_now, orders_close_at: 2.weeks.from_now)
+      expect(oc.opened_at).to be_nil
+    end
+
+    it "it does not reset opened_at if open date is changed to be earlier" do
+      expect(oc.opened_at).to_not be_nil
+      oc.update!(orders_open_at: 3.days.ago)
+      expect(oc.opened_at).to_not be_nil
+    end
+
+    it "it does not reset opened_at if open date does not change" do
+      expect(oc.opened_at).to_not be_nil
+      oc.update!(orders_close_at: 1.day.from_now)
+      expect(oc.opened_at).to_not be_nil
+    end
+  end
+
   describe "processed_at " do
     let!(:oc) {
       create(:simple_order_cycle, orders_open_at: 1.week.ago, orders_close_at: 1.day.ago, processed_at: 1.hour.ago)
@@ -562,13 +586,13 @@ describe OrderCycle do
       expect(oc.processed_at).to be_nil
     end
 
-    it "it does not reset processed_at if close date change in the past" do
+    it "it does not reset processed_at if close date is changed to be earlier" do
       expect(oc.processed_at).to_not be_nil
       oc.update!(orders_close_at: 2.days.ago)
       expect(oc.processed_at).to_not be_nil
     end
 
-    it "it does not reset processed_at if close date do not change" do
+    it "it does not reset processed_at if close date does not change" do
       expect(oc.processed_at).to_not be_nil
       oc.update!(orders_open_at: 2.weeks.ago)
       expect(oc.processed_at).to_not be_nil

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -557,21 +557,18 @@ describe OrderCycle do
     }
 
     it "reset opened_at if open date change in future" do
-      expect(oc.opened_at).to_not be_nil
-      oc.update!(orders_open_at: 1.week.from_now, orders_close_at: 2.weeks.from_now)
-      expect(oc.opened_at).to be_nil
+      expect{ oc.update!(orders_open_at: 1.week.from_now, orders_close_at: 2.weeks.from_now) }
+        .to change { oc.opened_at }.to be_nil
     end
 
     it "it does not reset opened_at if open date is changed to be earlier" do
-      expect(oc.opened_at).to_not be_nil
-      oc.update!(orders_open_at: 3.days.ago)
-      expect(oc.opened_at).to_not be_nil
+      expect{ oc.update!(orders_open_at: 3.days.ago) }
+        .to_not change { oc.opened_at }
     end
 
     it "it does not reset opened_at if open date does not change" do
-      expect(oc.opened_at).to_not be_nil
-      oc.update!(orders_close_at: 1.day.from_now)
-      expect(oc.opened_at).to_not be_nil
+      expect{ oc.update!(orders_close_at: 1.day.from_now) }
+        .to_not change { oc.opened_at }
     end
   end
 

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -7,6 +7,7 @@ describe Spree::User do
 
   describe "associations" do
     it { is_expected.to have_many(:owned_enterprises) }
+    it { is_expected.to have_many(:webhook_endpoints).dependent(:destroy) }
 
     describe "addresses" do
       let(:user) { create(:user, bill_address: create(:address)) }

--- a/spec/models/webhook_endpoint_spec.rb
+++ b/spec/models/webhook_endpoint_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe WebhookEndpoint, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:url) }
+  end
+end

--- a/spec/system/consumer/account/developer_settings_spec.rb
+++ b/spec/system/consumer/account/developer_settings_spec.rb
@@ -35,6 +35,22 @@ describe "Developer Settings" do
           expect(page).to have_content "Key generated"
           expect(page).to have_input "api_key", with: user.reload.spree_api_key
         end
+
+        describe "Webhook Endpoints" do
+          it "creates a new webhook endpoint and deletes it" do
+            within "#webhook_endpoints" do
+              fill_in "webhook_endpoint_url", with: "https://url"
+
+              click_button I18n.t(:create)
+              expect(page.document).to have_content I18n.t('webhook_endpoints.create.success')
+              expect(page).to have_content "https://url"
+
+              click_button I18n.t(:delete)
+              expect(page.document).to have_content I18n.t('webhook_endpoints.destroy.success')
+              expect(page).to_not have_content "https://url"
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### What? Why?
- Closes #9616
   > As an API user I want to be notified when an OC opens.
    
A webhook can be sent to a service like Zapier, which can generate an email notification.

### How?
Currently, we have no way of sending a webhook. There's no pre-built way of doing this for Rails surprisingly, although [this tutorial](https://keygen.sh/blog/how-to-build-a-webhook-system-in-rails-using-sidekiq/#handing-delivery-timeouts) looks like a good formula. I followed this, but found some parts unnecessary, and ended up with a different solution.

My focus was on making this work firstly for this single event type. Of course we'd like to extend it to for other events in the future, but let's get one working first before making further decisions.

There's bit going on here. A quick summary:
1. **WebhookDeliveryJob**: a job that will be enqueued to deliver a payload for each triggered webhook
2. **WebhookEndpoint**: a model to store each webhook endpoint url (in the future it would also store the event type it is listening for).
3. **OrderCycleWebhookService**: create webhook payloads for an order cycle event.
4. **OrderCycleOpenedJob**: Uses OrderCycleWebhookService to schedule WebhookDeliveryJobs. The order cycle remembers if it's been opened, and can only open once. 
5. (removed)
6. **User account interface to manage webhooks**. I was surprised how hard it was to fiddle around and keep the form simple, but got there in the end. 
    - Rather than enable/disable as originally suggested, you can just create or delete which has the same effect.
    - a test mode hasn't been implemented  yet, in order to keep this PR from dragging out. 

|||
|---|---|
|<a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/4188088/223575770-879ca807-e87d-428c-b5e5-36895c7d7439.png"><img src="https://user-images.githubusercontent.com/4188088/223575770-879ca807-e87d-428c-b5e5-36895c7d7439.png" alt="Screen Shot 2023-03-08 at 10 14 45 am" width="400" style="max-width: 100%;"></a>|<a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/4188088/223576129-8a56fc13-9780-44f0-b8b9-ee588eff862e.png"><img src="https://user-images.githubusercontent.com/4188088/223576129-8a56fc13-9780-44f0-b8b9-ee588eff862e.png" alt="Screen Shot 2023-03-08 at 10 15 58 am" width="400" style="max-width: 100%;"></a><a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/4188088/223576140-ef99a59c-7ac5-477b-b67d-e1819cbf09b9.png"><img src="https://user-images.githubusercontent.com/4188088/223576140-ef99a59c-7ac5-477b-b67d-e1819cbf09b9.png" alt="Screen Shot 2023-03-08 at 10 16 27 am" width="400" style="max-width: 100%;"></a>|

### What should we test?
This is a new feature which doesn't touch any existing functionality.
It adds a new form to the Developer tab on the user Accounts page. 
Suggested tests:

1. **Prepare a webhook URL** ready to receive and capture a webhook payload. The easiest way is:
    - Visit https://webhook.site/
    - Copy **Your unique URL**
    - Keep the tab open to check results later.
2. **Create/edit a user with API access:** 
    - Admin > Users > Edit
    - Tick "SHOW API KEY VIEW FOR USER", save.
3. **Login as this user**
6. **Go to My account > Developer settings > Webhook Endpoints**
    - [x] Verify the interface as per [requirements](https://github.com/openfoodfoundation/openfoodnetwork/issues/9616#issue-1357577999).
8. **Enter your unique Webhook URL and click create**
    - [x] Verify that the URL has been saved.
9. **Set up an Order Cycle to open at the current time** (anytime in the last hour):
    - Admin > Order Cycles > + New Order Cycle
    - Choose co-ordinator and click continue
    - Enter a name, and choose a time that is about to pass
    - Save (no need to complete further steps).
10. **Wait** up to 5 minutes for the webhook event to be captured ☕️ 
    (refer back to the open tab for https://webhook.site/)
    - [x] Verify the result as per [requirements](https://github.com/openfoodfoundation/openfoodnetwork/issues/9616#issue-1357577999)
12. **De-activate the webhook:**
    - Go to My account > Developer settings > Webhook Endpoints
    - Delete the webhook endpoint URL.
9. **Set up another Order Cycle to open at the current time**
13. **Wait** minimum 5 mins
    - [x] Verify that no event was received.


### Release notes

Changelog Category: User facing changes

_If documentation has been written, share a link in the release notes_

<!-- #### Dependencies -->

### Documentation updates
I think it should be documented wherever the API is documented. But I can't find any public mention of the API??!
It seems worth mentioning in the user guide: https://guide.openfoodnetwork.org/

Ideally, a test mode will display the webhook payload format, and act as in-place documentation. But this will come in a future PR.

In the future, [I suggest we integrate with our OpenAPI documentation too](https://github.com/openfoodfoundation/openfoodnetwork/issues/9616#issuecomment-1425133692).