### PR TITLE
Redirect to shopfront when OC closes during checkout

### DIFF
--- a/app/controllers/concerns/order_stock_check.rb
+++ b/app/controllers/concerns/order_stock_check.rb
@@ -26,7 +26,10 @@ module OrderStockCheck
     current_order.set_order_cycle! nil
 
     flash[:info] = I18n.t('order_cycle_closed')
-    redirect_to main_app.shop_path
+    respond_to do |format|
+      format.json { render json: { path: main_app.shop_path }, status: :see_other }
+      format.html { redirect_to main_app.shop_path, status: :see_other }
+    end
   end
 
   private


### PR DESCRIPTION
#### What? Why?

Closes #9583 
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Login as user
- Create an order in an order cycle
- Get to the checkout screen
- As the enterprise owner, close the order cycle
- As the user, click on checkout
- Ascertain that you are redirected to the shop front
- Ascertain that there's a flash message informing you that the OC just closed

![ezgif com-gif-maker(2)](https://user-images.githubusercontent.com/87677429/193007585-a1eaa80e-c0e0-4477-8bc2-6be5afebf9ce.gif)


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
