### PR TITLE
Create a component to display/hide columns for report

### DIFF
--- a/app/components/multiple_checked_select_component.rb
+++ b/app/components/multiple_checked_select_component.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class MultipleCheckedSelectComponent < ViewComponent::Base
-  def initialize(name:, options:, selected:)
+  def initialize(name:, options:, selected:, filter_placeholder: "Filter options")
     @name = name
+    @filter_placeholder = filter_placeholder
     @options = options
     @selected = selected.map(&:to_sym)
   end

--- a/app/components/multiple_checked_select_component.rb
+++ b/app/components/multiple_checked_select_component.rb
@@ -4,6 +4,6 @@ class MultipleCheckedSelectComponent < ViewComponent::Base
   def initialize(name:, options:, selected:)
     @name = name
     @options = options.map { |option| [option[0], option[1].to_sym] }
-    @selected = selected.map(&:to_sym)
+    @selected = selected.nil? ? [] : selected.map(&:to_sym)
   end
 end

--- a/app/components/multiple_checked_select_component.rb
+++ b/app/components/multiple_checked_select_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MultipleCheckedSelectComponent < ViewComponent::Base
+  def initialize(name:, options:, selected:)
+    @name = name
+    @options = options
+    @selected = selected.map(&:to_sym)
+  end
+end

--- a/app/components/multiple_checked_select_component.rb
+++ b/app/components/multiple_checked_select_component.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class MultipleCheckedSelectComponent < ViewComponent::Base
-  def initialize(name:, options:, selected:, filter_placeholder: "Filter options")
+  def initialize(name:, options:, selected:)
     @name = name
-    @filter_placeholder = filter_placeholder
     @options = options.map { |option| [option[0], option[1].to_sym] }
     @selected = selected.map(&:to_sym)
   end

--- a/app/components/multiple_checked_select_component.rb
+++ b/app/components/multiple_checked_select_component.rb
@@ -4,7 +4,7 @@ class MultipleCheckedSelectComponent < ViewComponent::Base
   def initialize(name:, options:, selected:, filter_placeholder: "Filter options")
     @name = name
     @filter_placeholder = filter_placeholder
-    @options = options
+    @options = options.map { |option| [option[0], option[1].to_sym] }
     @selected = selected.map(&:to_sym)
   end
 end

--- a/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
+++ b/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
@@ -8,6 +8,6 @@
     %hr
     %div.menu_items
       - @options.each do |option|
-        %div.menu_item{ "data-multiple-checked-select-target": "option", "data-value": option[1], "data-label": option[0] }
+        %label.menu_item{ "data-multiple-checked-select-target": "option", "data-value": option[1], "data-label": option[0] }
           %input{ type: "checkbox", checked: @selected.include?(option[1]), name: "#{@name}[]", value: option[1] }
-          %label= option[0]
+          = option[0]

--- a/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
+++ b/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
@@ -9,5 +9,5 @@
     %div.menu_items
       - @options.each do |option|
         %label.menu_item{ "data-multiple-checked-select-target": "option", "data-value": option[1], "data-label": option[0] }
-          %input{ type: "checkbox", checked: @selected.include?(option[1]), name: "#{@name}[]", value: option[1] }
+          %input.redesigned-input{ type: "checkbox", checked: @selected.include?(option[1]), name: "#{@name}[]", value: option[1] }
           = option[0]

--- a/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
+++ b/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
@@ -6,10 +6,11 @@
     %div.filter
       %input{ type: "text", "data-multiple-checked-select-target": "filter", placeholder: @filter_placeholder }
     %hr
-    - @options.each do |option|
-      - classes = @selected.include?(option[1]) ? "selected" : ""
-      %div.menu_item{ class: classes, "data-multiple-checked-select-target": "option", "data-value": option[1], "data-label": option[0] }
-        %span.check
-        %span.name{id: option[1]}
-          = option[0]
+    %div.menu_items
+      - @options.each do |option|
+        - classes = @selected.include?(option[1]) ? "selected" : ""
+        %div.menu_item{ class: classes, "data-multiple-checked-select-target": "option", "data-value": option[1], "data-label": option[0] }
+          %span.check
+          %span.name{id: option[1]}
+            = option[0]
   %div{style: "display: none;", "data-multiple-checked-select-target": "inputs"}

--- a/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
+++ b/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
@@ -1,0 +1,13 @@
+.ofn-drop-down{ data: { controller: "multiple-checked-select", "multiple-checked-select-input-name-value": @name } }
+  %div{ "data-multiple-checked-select-target": "button" }
+    %span{ class: 'icon-reorder' }
+      = "&nbsp; #{t('admin.columns')}".html_safe
+    %span{ class: "icon-caret-down", "data-multiple-checked-select-target": "caret" }
+  %div.menu{ class: "hidden", "data-multiple-checked-select-target": "options" }
+    - @options.each do |option|
+      - classes = @selected.include?(option[1]) ? "selected" : ""
+      %div.menu_item{ class: classes, "data-multiple-checked-select-target": "option", "data-value": option[1] }
+        %span.check
+        %span.name{id: option[1]}
+          = option[0]
+  %div{style: "display: none;", "data-multiple-checked-select-target": "inputs"}

--- a/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
+++ b/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
@@ -1,7 +1,6 @@
-.ofn-drop-down{ data: { controller: "multiple-checked-select", "multiple-checked-select-input-name-value": @name } }
-  %div{ "data-multiple-checked-select-target": "button" }
-    %span{ class: 'icon-reorder' }
-      = "&nbsp; #{t('admin.columns')}".html_safe
+.ofn-drop-down.ofn-drop-down-v2{ data: { controller: "multiple-checked-select", "multiple-checked-select-input-name-value": @name } }
+  %div.ofn-drop-down-label{ "data-multiple-checked-select-target": "button" }
+    %span{class: "label"}= t('admin.columns')
     %span{ class: "icon-caret-down", "data-multiple-checked-select-target": "caret" }
   %div.menu{ class: "hidden", "data-multiple-checked-select-target": "options" }
     %div.filter

--- a/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
+++ b/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
@@ -1,4 +1,4 @@
-.ofn-drop-down.ofn-drop-down-v2{ data: { controller: "multiple-checked-select", "multiple-checked-select-input-name-value": @name } }
+.ofn-drop-down.ofn-drop-down-v2{ data: { controller: "multiple-checked-select" } }
   %div.ofn-drop-down-label{ "data-multiple-checked-select-target": "button" }
     %span{class: "label"}= t('admin.columns')
     %span{ class: "icon-caret-down", "data-multiple-checked-select-target": "caret" }
@@ -8,9 +8,6 @@
     %hr
     %div.menu_items
       - @options.each do |option|
-        - classes = @selected.include?(option[1]) ? "selected" : ""
-        %div.menu_item{ class: classes, "data-multiple-checked-select-target": "option", "data-value": option[1], "data-label": option[0] }
-          %span.check
-          %span.name
-            = option[0]
-  %div{style: "display: none;", "data-multiple-checked-select-target": "inputs"}
+        %div.menu_item{ "data-multiple-checked-select-target": "option", "data-value": option[1], "data-label": option[0] }
+          %input{ type: "checkbox", checked: @selected.include?(option[1]), name: "#{@name}[]", value: option[1] }
+          %label= option[0]

--- a/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
+++ b/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
@@ -11,6 +11,6 @@
         - classes = @selected.include?(option[1]) ? "selected" : ""
         %div.menu_item{ class: classes, "data-multiple-checked-select-target": "option", "data-value": option[1], "data-label": option[0] }
           %span.check
-          %span.name{id: option[1]}
+          %span.name
             = option[0]
   %div{style: "display: none;", "data-multiple-checked-select-target": "inputs"}

--- a/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
+++ b/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
@@ -4,9 +4,12 @@
       = "&nbsp; #{t('admin.columns')}".html_safe
     %span{ class: "icon-caret-down", "data-multiple-checked-select-target": "caret" }
   %div.menu{ class: "hidden", "data-multiple-checked-select-target": "options" }
+    %div.filter
+      %input{ type: "text", "data-multiple-checked-select-target": "filter", placeholder: @filter_placeholder }
+    %hr
     - @options.each do |option|
       - classes = @selected.include?(option[1]) ? "selected" : ""
-      %div.menu_item{ class: classes, "data-multiple-checked-select-target": "option", "data-value": option[1] }
+      %div.menu_item{ class: classes, "data-multiple-checked-select-target": "option", "data-value": option[1], "data-label": option[0] }
         %span.check
         %span.name{id: option[1]}
           = option[0]

--- a/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
+++ b/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
@@ -4,7 +4,7 @@
     %span{ class: "icon-caret-down", "data-multiple-checked-select-target": "caret" }
   %div.menu{ class: "hidden", "data-multiple-checked-select-target": "options" }
     %div.filter
-      %input{ type: "text", "data-multiple-checked-select-target": "filter", placeholder: @filter_placeholder }
+      %input{ type: "text", "data-multiple-checked-select-target": "filter", placeholder: I18n.t('components.multiple_checked_select.filter_placeholder') }
     %hr
     %div.menu_items
       - @options.each do |option|

--- a/app/views/admin/reports/_rendering_options.html.haml
+++ b/app/views/admin/reports/_rendering_options.html.haml
@@ -34,8 +34,7 @@
     - if feature? :report_inverse_columns_logic, spree_current_user
       .alpha.two.columns= label_tag nil, t(:report_columns)
       .omega.fourteen.columns
-        = select_tag(:fields_to_show, options_for_select(@report.available_headers, @params_fields_to_show),
-                    class: "select2 fullwidth", multiple: true)
+        = render MultipleCheckedSelectComponent.new(name: "fields_to_show", options: @report.available_headers, selected: @params_fields_to_show)
     - else
       .alpha.two.columns= label_tag nil, t(:report_hide_columns)
       .omega.fourteen.columns

--- a/app/webpacker/controllers/multiple_checked_select_controller.js
+++ b/app/webpacker/controllers/multiple_checked_select_controller.js
@@ -1,17 +1,10 @@
 import { Controller } from "stimulus";
 
 export default class extends Controller {
-  static targets = ["button", "caret", "options", "option", "inputs", "filter"];
-  static values = { inputName: String };
+  static targets = ["button", "caret", "options", "option", "filter"];
 
   connect() {
     this.buttonTarget.addEventListener("click", this.toggleOptions);
-    this.optionTargets.forEach((option) => {
-      option.addEventListener("click", (e) =>
-        this.selectOption(e, option.dataset.value)
-      );
-    });
-    this.buildInputs();
     document.addEventListener("click", this.closeOptions);
     this.filterTarget.addEventListener("input", this.filterOptions);
   }
@@ -45,25 +38,5 @@ export default class extends Controller {
       this.caretTarget.classList.remove("icon-caret-up");
       this.caretTarget.classList.add("icon-caret-down");
     }
-  };
-
-  selectOption = (event, value) => {
-    this.optionTargets
-      .find((option) => option.dataset.value === value)
-      .classList.toggle("selected");
-    this.buildInputs();
-  };
-
-  buildInputs = () => {
-    this.inputsTarget.innerHTML = "";
-    this.optionTargets
-      .filter((option) => option.classList.contains("selected"))
-      .forEach((option) => {
-        const input = document.createElement("input");
-        input.type = "hidden";
-        input.name = this.inputNameValue + "[]";
-        input.value = option.dataset.value;
-        this.inputsTarget.appendChild(input);
-      });
   };
 }

--- a/app/webpacker/controllers/multiple_checked_select_controller.js
+++ b/app/webpacker/controllers/multiple_checked_select_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static targets = ["button", "caret", "options", "option", "inputs"];
+  static values = { inputName: String };
+
+  connect() {
+    this.buttonTarget.addEventListener("click", this.toggleOptions);
+    this.optionTargets.forEach((option) => {
+      option.addEventListener("click", (e) =>
+        this.selectOption(e, option.dataset.value)
+      );
+    });
+    this.buildInputs();
+    document.addEventListener("click", this.closeOptions);
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.closeOptions);
+  }
+
+  toggleOptions = () => {
+    this.optionsTarget.classList.toggle("hidden");
+    this.caretTarget.classList.toggle("icon-caret-down");
+    this.caretTarget.classList.toggle("icon-caret-up");
+  };
+
+  closeOptions = (e) => {
+    if (!this.element.contains(e.target)) {
+      this.optionsTarget.classList.add("hidden");
+      this.caretTarget.classList.remove("icon-caret-up");
+      this.caretTarget.classList.add("icon-caret-down");
+    }
+  };
+
+  selectOption = (event, value) => {
+    this.optionTargets
+      .find((option) => option.dataset.value === value)
+      .classList.toggle("selected");
+    this.buildInputs();
+  };
+
+  buildInputs = () => {
+    this.inputsTarget.innerHTML = "";
+    this.optionTargets
+      .filter((option) => option.classList.contains("selected"))
+      .forEach((option) => {
+        const input = document.createElement("input");
+        input.type = "hidden";
+        input.name = this.inputNameValue + "[]";
+        input.value = option.dataset.value;
+        this.inputsTarget.appendChild(input);
+      });
+  };
+}

--- a/app/webpacker/controllers/multiple_checked_select_controller.js
+++ b/app/webpacker/controllers/multiple_checked_select_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "stimulus";
 
 export default class extends Controller {
-  static targets = ["button", "caret", "options", "option", "inputs"];
+  static targets = ["button", "caret", "options", "option", "inputs", "filter"];
   static values = { inputName: String };
 
   connect() {
@@ -13,11 +13,25 @@ export default class extends Controller {
     });
     this.buildInputs();
     document.addEventListener("click", this.closeOptions);
+    this.filterTarget.addEventListener("input", this.filterOptions);
   }
 
   disconnect() {
     document.removeEventListener("click", this.closeOptions);
   }
+
+  // private methods
+
+  filterOptions = (e) => {
+    const filter = e.target.value.toLowerCase();
+    this.optionTargets.forEach((option) => {
+      if (option.dataset["label"].toLowerCase().includes(filter)) {
+        option.classList.remove("hidden");
+      } else {
+        option.classList.add("hidden");
+      }
+    });
+  };
 
   toggleOptions = () => {
     this.optionsTarget.classList.toggle("hidden");

--- a/app/webpacker/css/admin/components/input.scss
+++ b/app/webpacker/css/admin/components/input.scss
@@ -8,3 +8,34 @@
     }
   }
 }
+
+input[type='checkbox'].redesigned-input {
+  position: relative;
+  top: 1px;
+  -moz-appearance:none;
+  -webkit-appearance:none;
+  -o-appearance:none;
+  appearance: none;
+  outline: none;
+  content: none;
+  cursor: pointer;
+
+  &:before {
+    font-family: "FontAwesome";
+    content: "\f00c";
+    font-size: 15px;
+    color: transparent !important;
+    background: transparent !important;
+    display: block;
+    width: 15px;
+    height: 15px;
+    border: 1px solid #809cb1;
+    margin-right: 7px;
+  }
+  
+  &:checked:before {
+    color: #5498DA !important;
+  }
+}
+
+

--- a/app/webpacker/css/admin/dropdown.scss
+++ b/app/webpacker/css/admin/dropdown.scss
@@ -98,6 +98,11 @@
 		.menu {
 			width: 100%;
 		}
+
+		.menu_items {
+			max-height: 200px;
+			overflow-y: scroll;
+		}
 	}
 
 	position: relative;

--- a/app/webpacker/css/admin/dropdown.scss
+++ b/app/webpacker/css/admin/dropdown.scss
@@ -65,6 +65,41 @@
 
 .ofn-drop-down {
 	@include ofn-drop-down-style;
+
+	&.ofn-drop-down-v2 {
+		border: 1px solid $pale-blue;
+		background-color: white;
+		padding: 0px;
+		
+		&:hover {
+			border-color: $spree-blue;
+		}
+
+		.ofn-drop-down-label {
+			color: $color-3;
+			padding: 10px;
+			width: 235px;
+			display: flex;
+			justify-content: space-between;
+
+			&:hover {
+				color: $color-3;
+			}
+
+			.label {
+				padding-right: 10px;
+			}
+
+			.icon-caret-down, .icon-caret-up {
+				padding-right: 0px;
+			}
+		}
+
+		.menu {
+			width: 100%;
+		}
+	}
+
 	position: relative;
 	float: left;
 

--- a/app/webpacker/css/admin/dropdown.scss
+++ b/app/webpacker/css/admin/dropdown.scss
@@ -99,6 +99,30 @@
 		z-index: 100;
     white-space: nowrap;
 
+		.filter {
+			padding-left: 5px;
+			padding-right: 5px;
+			position: relative;
+			
+			> input[type="text"] {
+				border: 1px solid rgba(18, 18, 18, 0.1);
+				width: 100%;
+				padding-left: 30px;
+				padding-top: 10px;
+				padding-bottom: 10px;
+				font-size: 13px;
+				color:#454545;
+			}
+
+			&:after {
+				content: "\f002";
+				font-family: FontAwesome;
+				position: absolute;
+				left: 15px;
+				top: 13px;
+				color:#454545;
+			}
+		}
 
 		.menu_item {
 			margin: 0px;
@@ -126,6 +150,10 @@
           content: "\2713";
         }
       }
+
+			&.hidden {
+				display: none;
+			}
 		}
 
 		.menu_item:hover {

--- a/app/webpacker/css/admin/dropdown.scss
+++ b/app/webpacker/css/admin/dropdown.scss
@@ -66,82 +66,6 @@
 .ofn-drop-down {
 	@include ofn-drop-down-style;
 
-	&.ofn-drop-down-v2 {
-		border: 1px solid $pale-blue;
-		background-color: white;
-		padding: 0px;
-		
-		&:hover {
-			border-color: $spree-blue;
-		}
-
-		.ofn-drop-down-label {
-			color: $color-3;
-			padding: 10px;
-			width: 235px;
-			display: flex;
-			justify-content: space-between;
-
-			&:hover {
-				color: $color-3;
-			}
-
-			.label {
-				padding-right: 10px;
-			}
-
-			.icon-caret-down, .icon-caret-up {
-				padding-right: 0px;
-			}
-		}
-
-		.menu {
-			width: 100%;
-		}
-
-		.menu_items {
-			max-height: 200px;
-			overflow-y: scroll;
-
-			label.menu_item {
-				margin-bottom: 5px;
-				color: #454545;
-				font-weight: 400;
-				cursor: pointer;
-				padding-top: 4px;
-				padding-bottom: 5px;
-
-				input {
-					position: relative;
-					top: 1px;
-					-moz-appearance:none;
-					-webkit-appearance:none;
-					-o-appearance:none;
-					outline: none;
-					content: none;
-					cursor: pointer;
-
-					&:before {
-						font-family: "FontAwesome";
-						content: "\f00c";
-						font-size: 15px;
-						color: transparent !important;
-						background: transparent !important;
-						display: block;
-						width: 15px;
-						height: 15px;
-						border: 1px solid #809cb1;
-						margin-right: 7px;
-					}
-
-					&:checked:before {
-						color: #5498DA !important;
-					}
-				}
-			}
-		}
-	}
-
 	position: relative;
 	float: left;
 
@@ -235,6 +159,54 @@
 
 		.menu_item:hover {
 			background-color: #ededed;
+		}
+	}
+}
+
+.ofn-drop-down-v2 {
+	border: 1px solid $pale-blue;
+	background-color: white;
+	padding: 0px;
+	
+	&:hover {
+		border-color: $spree-blue;
+	}
+
+	.ofn-drop-down-label {
+		color: $color-3;
+		padding: 10px;
+		width: 235px;
+		display: flex;
+		justify-content: space-between;
+
+		&:hover {
+			color: $color-3;
+		}
+
+		.label {
+			padding-right: 10px;
+		}
+
+		.icon-caret-down, .icon-caret-up {
+			padding-right: 0px;
+		}
+	}
+
+	.menu {
+		width: 100%;
+	}
+
+	.menu_items {
+		max-height: 200px;
+		overflow-y: scroll;
+
+		label.menu_item {
+			margin-bottom: 5px;
+			color: #454545;
+			font-weight: 400;
+			cursor: pointer;
+			padding-top: 4px;
+			padding-bottom: 5px;
 		}
 	}
 }

--- a/app/webpacker/css/admin/dropdown.scss
+++ b/app/webpacker/css/admin/dropdown.scss
@@ -102,6 +102,43 @@
 		.menu_items {
 			max-height: 200px;
 			overflow-y: scroll;
+
+			label.menu_item {
+				margin-bottom: 5px;
+				color: #454545;
+				font-weight: 400;
+				cursor: pointer;
+				padding-top: 4px;
+				padding-bottom: 5px;
+
+				input {
+					position: relative;
+					top: 1px;
+					-moz-appearance:none;
+					-webkit-appearance:none;
+					-o-appearance:none;
+					outline: none;
+					content: none;
+					cursor: pointer;
+
+					&:before {
+						font-family: "FontAwesome";
+						content: "\f00c";
+						font-size: 15px;
+						color: transparent !important;
+						background: transparent !important;
+						display: block;
+						width: 15px;
+						height: 15px;
+						border: 1px solid #809cb1;
+						margin-right: 7px;
+					}
+
+					&:checked:before {
+						color: #5498DA !important;
+					}
+				}
+			}
 		}
 	}
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -65,7 +65,8 @@ module.exports = function(api) {
           async: false
         }
       ],
-      ["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
+      ["@babel/plugin-proposal-private-property-in-object", { "loose": true }],
+      ["@babel/plugin-proposal-private-methods", { "loose": true }]
     ].filter(Boolean)
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4408,3 +4408,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       message_html: "<p>The change you wanted was rejected. Maybe you tried to change something you don't have access to.
       <br><h3><a href='/' >Return home</a></h3>
       </p>"
+  components:
+    multiple_checked_select:
+      filter_placeholder: "Filter options"


### PR DESCRIPTION
#### What? Why?
This PR implements, when `report_inverse_columns_logic` feature is toggled on, a new component to select/unselect column to be shown is report.

Closes #9625


#### Screenshots
<img width="439" alt="Capture d’écran 2022-09-27 à 16 34 56" src="https://user-images.githubusercontent.com/296452/192563305-4af24458-9182-4587-92dd-fb1ee5eee79e.png">

<img width="451" alt="Capture d’écran 2022-10-04 à 15 07 35" src="https://user-images.githubusercontent.com/296452/193827211-01b236e3-0ed0-4392-9beb-7b60f63ae205.png">

<img width="453" alt="Capture d’écran 2022-10-04 à 15 07 44" src="https://user-images.githubusercontent.com/296452/193827224-f666eebc-0aa2-47f6-bcec-0f0627d5e0cf.png">

#### What should we test?
- As a hub manager, check any report, such as `/admin/reports/orders_and_distributors`
- You should be able to select/unselect columns for report via the component.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
