### PR TITLE
Translation cleanup

### DIFF
--- a/app/helpers/admin/enterprise_groups_helper.rb
+++ b/app/helpers/admin/enterprise_groups_helper.rb
@@ -4,13 +4,12 @@ module Admin
   module EnterpriseGroupsHelper
     def enterprise_group_side_menu_items
       [
-        { name: 'primary_details', label: 'primary_details', icon_class: "icon-user",
-          selected: "selected" },
-        { name: 'users', label: 'users', icon_class: "icon-user" },
-        { name: 'about', label: 'about', icon_class: "icon-pencil" },
-        { name: 'images', label: 'images', icon_class: "icon-picture" },
-        { name: 'contact', label: 'admin_enterprise_groups_contact', icon_class: "icon-phone" },
-        { name: 'web', label: 'admin_enterprise_groups_web', icon_class: "icon-globe" },
+        { name: 'primary_details', icon_class: "icon-user", selected: "selected" },
+        { name: 'users', icon_class: "icon-user" },
+        { name: 'about', icon_class: "icon-pencil" },
+        { name: 'images', icon_class: "icon-picture" },
+        { name: 'contact', icon_class: "icon-phone" },
+        { name: 'web', icon_class: "icon-globe" },
       ]
     end
   end

--- a/app/views/admin/enterprise_groups/_form_about.html.haml
+++ b/app/views/admin/enterprise_groups/_form_about.html.haml
@@ -1,5 +1,5 @@
 %fieldset.alpha.no-border-bottom#about_panel{ data: { "tabs-and-panels-target": "panel" } }
-  %legend= t('about')
+  %legend= t('.about')
   = f.field_container :long_description do
     %text-angular{'id' => 'enterprise_group_long_description', 'name' => 'enterprise_group[long_description]', 'class' => 'text-angular', "textangular-links-target-blank" => true,
       'ta-toolbar' => "[['h1','h2','h3','h4','p'],['bold','italics','underline','clear'],['insertLink']]"}

--- a/app/views/admin/enterprise_groups/_form_address.html.haml
+++ b/app/views/admin/enterprise_groups/_form_address.html.haml
@@ -1,6 +1,6 @@
 = f.fields_for :address do |af|
   %fieldset.alpha.no-border-bottom#contact_panel{ data: { "tabs-and-panels-target": "panel" } }
-    %legend= t('admin_enterprise_groups_contact')
+    %legend= t('.contact')
     .row
       .alpha.three.columns
         = af.label :phone

--- a/app/views/admin/enterprise_groups/_form_images.html.haml
+++ b/app/views/admin/enterprise_groups/_form_images.html.haml
@@ -1,5 +1,5 @@
 %fieldset.alpha.no-border-bottom#images_panel{ data: { "tabs-and-panels-target": "panel" } }
-  %legend= t('images')
+  %legend= t('.images')
   .row
     .alpha.three.columns
       = f.label :logo, 'ofn-with-tip' => t('admin_enterprise_groups_data_powertip_logo')

--- a/app/views/admin/enterprise_groups/_form_primary_details.html.haml
+++ b/app/views/admin/enterprise_groups/_form_primary_details.html.haml
@@ -1,5 +1,5 @@
 %fieldset.alpha.no-border-bottom#primary_details_panel{ data: { "tabs-and-panels-target": "panel default" } }
-  %legend= t('primary_details')
+  %legend= t('.primary_details')
   = f.field_container :name do
     = f.label :name
     %br/

--- a/app/views/admin/enterprise_groups/_form_users.html.haml
+++ b/app/views/admin/enterprise_groups/_form_users.html.haml
@@ -1,5 +1,5 @@
 %fieldset.alpha.no-border-bottom#users_panel{ data: { "tabs-and-panels-target": "panel" } }
-  %legend= t('users')
+  %legend= t('.users')
   .row
     .three.columns.alpha
       =f.label :owner_id, t(:admin_enterprise_groups_owner)

--- a/app/views/admin/enterprise_groups/_form_web.html.haml
+++ b/app/views/admin/enterprise_groups/_form_web.html.haml
@@ -1,5 +1,5 @@
 %fieldset.alpha.no-border-bottom#web_panel{ data: { "tabs-and-panels-target": "panel" } }
-  %legend= t('admin_enterprise_groups_web')
+  %legend= t('.web')
   .row
     .alpha.three.columns
       = f.label :website

--- a/app/views/admin/enterprises/_form.html.haml
+++ b/app/views/admin/enterprises/_form.html.haml
@@ -2,20 +2,20 @@
   - case item[:name]
   - when 'primary_details'
     %fieldset.alpha.no-border-bottom{ id: "#{item[:name]}_panel", data: { controller: "primary-details", "primary-details-primary-producer-value": @enterprise.is_primary_producer.to_s, "primary-details-enterprise-sells-value": @enterprise.sells, "tabs-and-panels-target": "panel default" }}
-      %legend= t("#{ item[:name] }")
+      %legend= t(".#{ item[:name] }.legend")
       = render "admin/enterprises/form/#{ item[:form_name] || item[:name] }", f: f
 
   - when 'address'
     = f.fields_for :address do |af|
       %fieldset.alpha.no-border-bottom{ id: "#{item[:name]}_panel", data: { "tabs-and-panels-target": "panel" }}
-        %legend= t("#{ item[:name] }")
+        %legend= t(".#{ item[:name] }.legend")
         = render 'admin/enterprises/form/address', af: af
 
   - when 'enterprise_permissions'
     %fieldset.alpha.no-border-bottom{ id: "#{item[:name]}_panel", data: { "tabs-and-panels-target": "panel" }}
-      %legend= t("#{ item[:name] }")
+      %legend= t(".#{ item[:name] }.legend")
 
   - else
     %fieldset.alpha.no-border-bottom{ id: "#{item[:name]}_panel", data: { "tabs-and-panels-target": "panel"  }}
-      %legend= t("#{ item[:name] }")
+      %legend= t(".#{ item[:form_name] || item[:name] }.legend")
       = render "admin/enterprises/form/#{ item[:form_name] || item[:name] }", f: f

--- a/app/views/admin/enterprises/_new_form.html.haml
+++ b/app/views/admin/enterprises/_new_form.html.haml
@@ -1,9 +1,9 @@
 .row
   .three.columns.alpha
-    = f.label :name, t('admin.enterprises.form.primary_details.name')
+    = f.label :name, t('primary_details.name', scope: scope)
     %span.required *
   .nine.columns.omega
-    = f.text_field :name, { placeholder: t('admin.enterprises.form.primary_details.name_placeholder'), class: "fullwidth" }
+    = f.text_field :name, { placeholder: t('primary_details.name_placeholder', scope: scope), class: "fullwidth" }
 
 - if spree_current_user.admin?
   .row
@@ -17,8 +17,8 @@
       = f.hidden_field :owner_id, class: "select2 fullwidth", 'user-select' => 'Enterprise.owner'
 .row
   .three.columns.alpha
-    %label= t('admin.enterprises.form.primary_details.primary_producer')
-    %div{'ofn-with-tip' => t('admin.enterprises.form.primary_details.primary_producer_tip')}
+    %label= t('primary_details.primary_producer', scope: scope)
+    %div{'ofn-with-tip' => t('primary_details.primary_producer_tip', scope: scope)}
       %a= t('admin.whats_this')
   .five.columns.omega
     = f.check_box :is_primary_producer, 'ng-model' => 'Enterprise.is_primary_producer'
@@ -28,42 +28,42 @@
   .row
     .alpha.eleven.columns
       .three.columns.alpha
-        = f.label :sells, t('admin.enterprises.form.primary_details.sells')
-        %div{'ofn-with-tip' => t('admin.enterprises.form.primary_details.sells_tip')}
+        = f.label :sells, t('primary_details.sells', scope: scope)
+        %div{'ofn-with-tip' => t('primary_details.sells_tip', scope: scope)}
           %a What's this?
       .two.columns
         = f.radio_button :sells, "none", 'ng-model' => 'Enterprise.sells'
         &nbsp;
-        = f.label :sells, t('admin.enterprises.form.primary_details.none'), value: "none"
+        = f.label :sells, t('primary_details.none', scope: scope), value: "none"
       .two.columns
         = f.radio_button :sells, "own", 'ng-model' => 'Enterprise.sells'
         &nbsp;
-        = f.label :sells, t('admin.enterprises.form.primary_details.own'), value: "own"
+        = f.label :sells, t('primary_details.own', scope: scope), value: "own"
       .four.columns.omega
         = f.radio_button :sells, "any", 'ng-model' => 'Enterprise.sells'
         &nbsp;
-        = f.label :sells, t('admin.enterprises.form.primary_details.any'), value: "any"
+        = f.label :sells, t('primary_details.any', scope: scope), value: "any"
 
 .row
   .alpha.three.columns
     = f.label :contact_name, t('.contact_name')
   .omega.nine.columns
-    = f.text_field :contact_name, { placeholder: t('admin.enterprises.form.contact.name_placeholder')}
+    = f.text_field :contact_name, { placeholder: t('contact.name_placeholder', scope: scope)}
 .row
   .alpha.three.columns
-    = f.label :email_address, t('admin.enterprises.form.contact.email_address')
+    = f.label :email_address, t('contact.email_address', scope: scope)
   .omega.nine.columns
-    = f.text_field :email_address, { placeholder: t('admin.enterprises.form.contact.email_address_placeholder'), "ng-model" => "Enterprise.email_address" }
+    = f.text_field :email_address, { placeholder: t('contact.email_address_placeholder', scope: scope), "ng-model" => "Enterprise.email_address" }
 .row
   .alpha.three.columns
-    = f.label :phone, t('admin.enterprises.form.contact.phone')
+    = f.label :phone, t('contact.phone', scope: scope)
   .omega.nine.columns
-    = f.text_field :phone, { placeholder: t('admin.enterprises.form.contact.phone_placeholder')}
+    = f.text_field :phone, { placeholder: t('contact.phone_placeholder', scope: scope)}
 .row
   .alpha.three.columns
-    = f.label :website, t('admin.enterprises.form.contact.website')
+    = f.label :website, t('contact.website', scope: scope)
   .omega.nine.columns
-    = f.text_field :website, { placeholder: t('admin.enterprises.form.contact.website_placeholder')}
+    = f.text_field :website, { placeholder: t('contact.website_placeholder', scope: scope)}
 
 = f.fields_for :address do |af|
   .row

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -51,7 +51,7 @@
 
 = f.fields_for :business_address, @enterprise.business_address || @enterprise.build_business_address do |bf|
   %fieldset.alpha.no-border-bottom
-    %legend= t('business_address')
+    %legend= t('.business_address_legend')
     = render 'admin/enterprises/form/business_address', bf: bf
 
   .row{"data-controller": "updateinput"}
@@ -60,7 +60,7 @@
 
 .row
   %fieldset.alpha.no-border-bottom
-    %legend= t('.Invoice_item_sorting')
+    %legend= t('.invoice_item_sorting_legend')
   .three.columns.alpha
     %label= t('.sort_items_by_supplier?')
     %div{'ofn-with-tip' => t('.sort_items_by_supplier_tip')}

--- a/app/views/admin/enterprises/new.html.haml
+++ b/app/views/admin/enterprises/new.html.haml
@@ -17,4 +17,4 @@
 = form_for [main_app, :admin, @enterprise], html: { "nav-check" => '', "nav-callback" => '' } do |f|
   .row
     .twelve.columns.fullwidth_inputs{ ng: { controller: "NewEnterpriseController" } }
-      = render 'new_form', f: f
+      = render 'new_form', f: f, scope: 'admin.enterprises.form'

--- a/app/views/admin/shared/_side_menu.html.haml
+++ b/app/views/admin/shared/_side_menu.html.haml
@@ -4,7 +4,7 @@
     - next unless item[:show]
       %a.menu_item{ href: item[:href] || "##{item[:name]}_panel", id: item[:name], data: { action: "tabs-and-panels#changeActivePanel tabs-and-panels#changeActiveTab", "tabs-and-panels-target": "tab" }, class: item[:selected] }
         %i{ class: item[:icon_class] }
-        %span= t("#{item[:name] }")
+        %span= t(".enterprise.#{item[:name] }")
   - else
     - enterprise_group_side_menu_items.each do |item|
       %a.menu_item{ href: "##{item[:name]}_panel", class: item[:selected], id: item[:name], data: { action: "tabs-and-panels#changeActivePanel tabs-and-panels#changeActiveTab", "tabs-and-panels-target": "tab" } }

--- a/app/views/admin/shared/_side_menu.html.haml
+++ b/app/views/admin/shared/_side_menu.html.haml
@@ -9,5 +9,5 @@
     - enterprise_group_side_menu_items.each do |item|
       %a.menu_item{ href: "##{item[:name]}_panel", class: item[:selected], id: item[:name], data: { action: "tabs-and-panels#changeActivePanel tabs-and-panels#changeActiveTab", "tabs-and-panels-target": "tab" } }
         %i{ class: item[:icon_class] }
-        %span= t("#{item[:label] }")
+        %span= t(".enterprise_group.#{item[:name] }")
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -869,11 +869,15 @@ en:
         manage: Manage
       form:
         about_us:
+          legend: "About"
           desc_short: Short Description
           desc_short_placeholder: Tell us about your enterprise in one or two sentences
           desc_long: About Us
           desc_long_placeholder: Tell customers about yourself. This information appears on your public profile.
+        address:
+          legend: "Address"
         business_details:
+          legend: "Business Details"
           abn: ABN
           abn_placeholder: eg. 99 123 456 789
           acn: ACN
@@ -884,7 +888,8 @@ en:
           remove_terms_and_conditions: "Remove File"
           uploaded_on: "uploaded on"
           reset_form: "Reset Form"
-          Invoice_item_sorting: Invoice item sorting
+          business_address_legend: "Business Address"
+          invoice_item_sorting_legend: "Invoice item sorting"
           sort_items_by_supplier?: Sort items by supplier?
           sort_items_by_supplier_tip: "When enabled, Items will be sorted by supplier name."
           enabled: Enable
@@ -898,6 +903,7 @@ en:
           legal_phone_number: Legal phone number
           phone_placeholder: "98 123 4565"
         contact:
+          legend: "Contact"
           name: Name
           name_placeholder: eg. Gustav Plum
           email_address: Public Email Address
@@ -911,14 +917,17 @@ en:
           website: Website
           website_placeholder: eg. www.truffles.com
         enterprise_fees:
+          legend: "Enterprise Fees"
           name: Name
           fee_type: Fee Type
           manage_fees: Manage Enterprise Fees
           no_fees_yet: You don't have any enterprise fees yet.
           create_button: Create One Now
         enterprise_permissions:
+          legend: "Enterprise Permissions"
           enterprise_relationships: Enterprise Relationships
         images:
+          legend: "Images"
           logo: Logo
           promo_image_placeholder: 'This image is displayed in "About Us"'
           promo_image_note1: 'PLEASE NOTE:'
@@ -927,6 +936,7 @@ en:
           remove_logo: "Remove Image"
           remove_promo_image: "Remove Image"
         inventory_settings:
+          legend: "Inventory Settings"
           text1: You may opt to manage stock levels and prices in via your
           inventory: inventory
           text2: >
@@ -937,6 +947,7 @@ en:
           preferred_product_selection_from_inventory_only_yes: New products can be put into my shopfront (recommended)
           preferred_product_selection_from_inventory_only_no: New products must be added to my inventory before they can be put into my shopfront
         payment_methods:
+          legend: "Payment Methods"
           name: Name
           applies: Applies?
           manage: Manage Payment Methods
@@ -944,6 +955,7 @@ en:
           create_button: Create New Payment Method
           create_one_button: Create One Now
         primary_details:
+          legend: "Primary Details"
           name: Name
           name_placeholder: eg. Professor Plum's Biodynamic Truffles
           groups: Groups
@@ -962,6 +974,8 @@ en:
           visible: Public
           not_visible: Hidden
           hidden: Hide all references
+        properties:
+          legend: "Properties"
         permalink:
           permalink: Permalink (no spaces)
           permalink_tip: "This permalink is used to create the url to your shop: %{link}your-shop-name/shop"
@@ -970,6 +984,7 @@ en:
           ofn_uid: OFN UID
           ofn_uid_tip: The unique id used to identify the enterprise on Open Food Network.
         shipping_methods:
+          legend: "Shipping Methods"
           name: "Name"
           applies: "Active?"
           manage: "Manage Shipping Methods"
@@ -977,6 +992,7 @@ en:
           create_one_button: "Create One Now"
           no_method_yet: "You don't have any shipping methods yet."
         shop_preferences:
+          legend: "Shop Preferences"
           shopfront_requires_login: "Publicly visible shopfront?"
           shopfront_requires_login_tip: "Choose whether customers must login to view the shopfront or if it's visible to everybody."
           shopfront_requires_login_false: "Public"
@@ -1022,6 +1038,7 @@ en:
           enabled: "Enabled"
           disabled: "Disabled"
         social:
+          legend: "Social"
           twitter_placeholder: "eg. @the_prof"
           instagram_placeholder: "eg. the_prof"
           facebook_placeholder: "eg. www.facebook.com/PageNameHere"
@@ -1039,6 +1056,7 @@ en:
             i_agree: I Agree
             cancel: Cancel
         tag_rules:
+          legend: "Tag Rules"
           default_rules:
             by_default: By Default
             no_rules_yet: No default rules apply yet
@@ -1049,6 +1067,7 @@ en:
           add_new_rule: '+ Add A New Rule'
           add_new_tag: '+ Add A New Tag'
         users:
+          legend: "Users"
           email_confirmation_notice_html: "Email confirmation is pending. We've sent a confirmation email to %{email}."
           resend: Resend
           owner: 'Owner'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2840,7 +2840,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   contact: "Contact"
   web: "Web"
   primary_details: "Primary Details"
-  adrdress: "Address"
   contact: "Contact"
   social: "Social"
   business_details: "Business Details"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,7 +340,6 @@ en:
   producers_join: Australian producers are now welcome to join the Open Food Network. #FIXME
   charges_sales_tax: Charges GST?
   business_address: "Business Address"
-  enterprise_permissions: "Enterprise Permissions"
   print_invoice: "Print Invoice"
   print_ticket: "Print Ticket"
   select_ticket_printer: "Select printer for tickets"
@@ -452,6 +451,8 @@ en:
     destroy: "Destroy"
     rename: "Rename"
 
+# Admin
+#
   admin:
     adjustments:
       skipped_changing_canceled_order: "You can't change a cancelled order."
@@ -858,7 +859,6 @@ en:
         no_note_present: "No note provided."
     enterprise:
       select_outgoing_oc_products_from: Select outgoing OC products from
-
     enterprises:
       index:
         title: Enterprises
@@ -1306,6 +1306,23 @@ en:
         has_no_shipping_methods: "%{enterprise} has no shipping methods"
         has_no_enterprise_fees: "%{enterprise} has no enterprise fees"
       side_menu:
+        enterprise:
+          primary_details: "Primary Details"
+          address: "Address"
+          contact: "Contact"
+          social: "Social"
+          about: "About"
+          business_details: "Business Details"
+          images: "Images"
+          properties: "Properties"
+          shipping_methods: "Shipping Methods"
+          payment_methods: "Payment Methods"
+          enterprise_fees: "Enterprise Fees"
+          enterprise_permissions: "Enterprise Permissions"
+          inventory_settings: "Inventory Settings"
+          tag_rules: "Tag Rules"
+          shop_preferences: "Shop Preferences"
+          users: "Users"
         enterprise_group:
           primary_details: "Primary Details"
           users: "Users"
@@ -2879,8 +2896,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   primary_details: "Primary Details"
   contact: "Contact"
   social: "Social"
-  business_details: "Business Details"
-  properties: "Properties"
   shipping: "Shipping"
   shipping_methods: "Shipping Methods"
   payment_methods: "Payment Methods"
@@ -2890,9 +2905,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   payment_updated: "Payment Updated"
   cannot_perform_operation: "Could not update the payment"
   action_required: "Action required"
-  inventory_settings: "Inventory Settings"
   tag_rules: "Tag Rules"
-  shop_preferences: "Shop Preferences"
   enterprise_fee_whole_order: Whole order
   enterprise_fee_by: "%{type} fee by %{role} %{enterprise_name}"
   validation_msg_relationship_already_established: "^That relationship is already established."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1286,6 +1286,14 @@ en:
         has_no_payment_methods: "%{enterprise} has no payment methods"
         has_no_shipping_methods: "%{enterprise} has no shipping methods"
         has_no_enterprise_fees: "%{enterprise} has no enterprise fees"
+      side_menu:
+        enterprise_group:
+          primary_details: "Primary Details"
+          users: "Users"
+          about: "About"
+          images: "Images"
+          contact: "Contact"
+          web: "Web Resources"
     enterprise_issues:
       create_new: Create New
       resend_email: Resend Email
@@ -2515,7 +2523,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   admin_enterprise_groups_data_powertip: "The primary user responsible for this group."
   admin_enterprise_groups_data_powertip_logo: "This is the logo for the group"
   admin_enterprise_groups_data_powertip_promo_image: "This image is displayed at the top of the Group profile"
-  admin_enterprise_groups_contact: "Contact"
   admin_enterprise_groups_contact_phone_placeholder: "eg. 98 7654 3210"
   admin_enterprise_groups_contact_address1_placeholder: "eg. 123 High Street"
   admin_enterprise_groups_contact_city: "Suburb"
@@ -2524,7 +2531,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   admin_enterprise_groups_contact_zipcode_placeholder: "eg. 3070"
   admin_enterprise_groups_contact_state_id: "State"
   admin_enterprise_groups_contact_country_id: "Country"
-  admin_enterprise_groups_web: "Web Resources"
   admin_enterprise_groups_web_twitter: "eg. @the_prof"
   admin_enterprise_groups_web_website_placeholder: "eg. www.truffles.com"
   admin_order_cycles: "Admin Order Cycles"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -637,6 +637,18 @@ en:
     enterprise_groups:
       index:
         new_button: New Enterprise Group
+      form_primary_details:
+        primary_details: "Primary Details"
+      form_users:
+        users: "Users"
+      form_about:
+        about: "About"
+      form_images:
+        images: "Images"
+      form_address:
+        contact: "Contact"
+      form_web:
+        web: "Web Resources"
 
     enterprise_roles:
       form:


### PR DESCRIPTION
#### What? Why?

Translation code cleanup. 
I was going to add a new side menu item for Enterprises, but noticed the existing translations don't follow the [guidelines](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-%28i18n%29#development) at all. In order to add new code that meets the guidelines (and learn how it all works), I had a go at updating this first.

This removes some global keys, and creates some new more specific ones.

#### What should we test?

The following pages are changed to use new, specifically scoped keys. 

* [New Enterprise](http://localhost:3000/admin/enterprises/new)
  **All labels**
* [Enterprise Edit](http://localhost:3000/admin/enterprises/mary-s-online-shop/edit)
   The text for each **side menu item** and **form legend title** (primary details, address, etc)
* [Enterprise Group Edit](http://localhost:3000/admin/enterprise_groups/producer-group/edit)
   The text for each **side menu item** and **form legend title** (primary details, address, etc)

The following global keys are now unused and have now been deleted:

```yaml
adrdress: "Address"

enterprise_permissions: "Enterprise Permissions"
business_details: "Business Details"
properties: "Properties"
inventory_settings: "Inventory Settings"
shop_preferences: "Shop Preferences"

admin_enterprise_groups_contact: "Contact"
admin_enterprise_groups_web: "Web Resources"
```
(I looked as hard as I could to check they're not used, but could be wrong)

#### Release notes

Changelog Category: Technical changes

