### PR TITLE
Remove now unnecessary uglifier gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,6 @@ gem 'coffee-rails', '~> 5.0.0'
 
 gem 'mini_racer', '0.4.0'
 
-gem 'uglifier', '>= 1.0.3'
 
 gem 'angular_rails_csrf'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,8 +640,6 @@ GEM
     ttfunk (1.7.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.3.0)
     uniform_notifier (1.16.0)
     valid_email2 (4.0.4)
@@ -809,7 +807,6 @@ DEPENDENCIES
   test-prof
   test-unit (~> 3.5)
   timecop
-  uglifier (>= 1.0.3)
   valid_email2
   vcr
   view_component

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,12 +51,6 @@ Openfoodnetwork::Application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 
-  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  # config.assets.precompile += %w( search.js )
-
-  require 'uglifier'
-  config.assets.js_compressor = Uglifier.new(mangle: false, harmony: true)
-
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -51,12 +51,6 @@ Openfoodnetwork::Application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 
-  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  # config.assets.precompile += %w( search.js )
-
-  require 'uglifier'
-  config.assets.js_compressor = Uglifier.new(mangle: false, harmony: true)
-
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 


### PR DESCRIPTION
#### What? Why?

Remove `uglifier` dependency since it seems to be useless with Rails6.
https://www.mintbit.com/blog/rails-5-6-upgrade-es6-uglifier-bug

+ `uglifier` seems (regarding Q/A, blog posts, ...) to be not functional with ES6 (maybe use terser?)

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Go through the checkout. That should be enough to make sure that Javascript is working. :smile: 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
