### PR TITLE
[Shopfront] Hide hub with "hide all references" setup in producers profiles

### DIFF
--- a/app/serializers/api/enterprise_shopfront_serializer.rb
+++ b/app/serializers/api/enterprise_shopfront_serializer.rb
@@ -63,7 +63,7 @@ module Api
 
     def hubs
       ActiveModel::ArraySerializer.new(
-        enterprise.distributors, each_serializer: Api::EnterpriseThinSerializer
+        enterprise.distributors.not_hidden, each_serializer: Api::EnterpriseThinSerializer
       )
     end
 

--- a/spec/serializers/api/enterprise_shopfront_serializer_spec.rb
+++ b/spec/serializers/api/enterprise_shopfront_serializer_spec.rb
@@ -50,6 +50,15 @@ describe Api::EnterpriseShopfrontSerializer do
     expect(serializer.serializable_hash[:hubs].to_json).to match hub.name
   end
 
+  context 'when hub is marked as hidden' do
+    before { hub.update_column(:visible, 'hidden') }
+
+    it 'serializes an array of public hubs' do
+      expect(serializer.serializable_hash[:hubs]).to be_a ActiveModel::ArraySerializer
+      expect(serializer.serializable_hash[:hubs].to_json).not_to match hub.name
+    end
+  end
+
   it "serializes an array of producers that are public or linked by links" do
     expect(serializer.serializable_hash[:producers]).to be_a ActiveModel::ArraySerializer
     expect(serializer.serializable_hash[:producers].to_json).to match producer.name


### PR DESCRIPTION
#### What? Why?

Closes #9468 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?


- Connect as admin or superadmin to a hub
- In admin dashboard > Enterprises settings, set "Visible in search?" to "Hide all references"
- Go to one of the hub producer's shopfront (alternatively, go to another hub provided by the supplier)
- Click on the "Producers" tab to display the producers list.
- Click on the supplier's link, this opens a popup with producers' details
- You can see a link to the hub (below the label "SHOP FOR XXX PRODUCTS AT:")
- The hub with "Hide all references" should not be shown on the popup


#### Release notes

[Shopfront] Hide hub with "hide all references" setup in producers profiles

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
