### PR TITLE
Ignore paperclip columns to prepare for deletion

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -16,6 +16,19 @@ class Enterprise < ApplicationRecord
     large: { resize_to_fill: [1200, 260] },
   }.freeze
 
+  self.ignored_columns = %i(terms_and_conditions_file_name
+                            terms_and_conditions_content_type
+                            terms_and_conditions_file_size
+                            terms_and_conditions_updated_at
+                            logo_file_name
+                            logo_content_type
+                            logo_file_size
+                            logo_updated_at
+                            promo_image_file_name
+                            promo_image_content_type
+                            promo_image_file_size
+                            promo_image_updated_at)
+
   searchable_attributes :sells, :is_primary_producer
   searchable_associations :properties
   searchable_scopes :is_primary_producer, :is_distributor, :is_hub, :activated, :visible,

--- a/app/models/enterprise_group.rb
+++ b/app/models/enterprise_group.rb
@@ -5,6 +5,15 @@ require 'open_food_network/locking'
 class EnterpriseGroup < ApplicationRecord
   include PermalinkGenerator
 
+  self.ignored_columns = %i(logo_file_name
+                            logo_content_type
+                            logo_file_size
+                            logo_updated_at
+                            promo_image_file_name
+                            promo_image_content_type
+                            promo_image_file_size
+                            promo_image_updated_at)
+
   acts_as_list
 
   has_and_belongs_to_many :enterprises, join_table: 'enterprise_groups_enterprises'

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -9,6 +9,11 @@ module Spree
       large: { resize_to_limit: [600, 600] },
     }.freeze
 
+    self.ignored_columns = %i(attachment_file_name
+                              attachment_content_type
+                              attachment_file_size
+                              attachment_updated_at)
+
     has_one_attached :attachment
 
     validates :attachment, attached: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -12,7 +12,9 @@ module Spree
     self.ignored_columns = %i(attachment_file_name
                               attachment_content_type
                               attachment_file_size
-                              attachment_updated_at)
+                              attachment_updated_at
+                              attachment_width
+                              attachment_height)
 
     has_one_attached :attachment
 

--- a/app/models/terms_of_service_file.rb
+++ b/app/models/terms_of_service_file.rb
@@ -5,6 +5,11 @@ class TermsOfServiceFile < ApplicationRecord
 
   validates :attachment, attached: true
 
+  self.ignored_columns = %i(attachment_file_name
+                            attachment_content_type
+                            attachment_file_size
+                            attachment_updated_at)
+
   # The most recently uploaded file is the current one.
   def self.current
     order(:id).last

--- a/app/views/spree/admin/images/edit.html.haml
+++ b/app/views/spree/admin/images/edit.html.haml
@@ -7,7 +7,7 @@
 
 = form_for [:admin, @product, @image], url: admin_product_image_path(@product, @image, @url_filters), html: { multipart: true } do |f|
   %fieldset
-    %legend{align: "center"}= @image.attachment&.filename
+    %legend{align: "center"}= @image.attachment.filename
     .field.alpha.three.columns.align-center
       = f.label t('spree.thumbnail')
       %br/

--- a/app/views/spree/admin/images/edit.html.haml
+++ b/app/views/spree/admin/images/edit.html.haml
@@ -7,7 +7,7 @@
 
 = form_for [:admin, @product, @image], url: admin_product_image_path(@product, @image, @url_filters), html: { multipart: true } do |f|
   %fieldset
-    %legend{align: "center"}= @image.attachment_file_name
+    %legend{align: "center"}= @image.attachment&.filename
     .field.alpha.three.columns.align-center
       = f.label t('spree.thumbnail')
       %br/


### PR DESCRIPTION
#### What? Why?

First part of #9726 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
As mentioned [here](https://github.com/openfoodfoundation/openfoodnetwork/issues/9726#issue-1394115178), Paperclip was replaced with Active Storage but the columns were not removed. 
This PR adds the ignored_columns to the following models:
1. Enterprise
2. EnterpriseGroup
3. TermsOfServiceFile
4. Spree::Image

This prevents server errors during deployment if Rails tries to access these columns that were just deleted.
This has to be deployed before the next pull request is merged.

Removed a reference to `attachment_file_name` in `spree/admin/images/edit.html` and replaced it with `attachment.filename` method of active storage

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit a shop page and verify that all images are still displayed (as much as before on staging).


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

