### PR TITLE
Add used feature toggles to appear in the admin UI

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -40,7 +40,7 @@ module Api
       end
 
       def restrict_feature
-        not_found unless Flipper.enabled?(:api_v1, @current_api_user)
+        not_found unless OpenFoodNetwork::FeatureToggle.enabled?(:api_v1, @current_api_user)
       end
 
       def current_ability

--- a/app/controllers/concerns/order_stock_check.rb
+++ b/app/controllers/concerns/order_stock_check.rb
@@ -39,7 +39,7 @@ module OrderStockCheck
   end
 
   def reset_order_to_cart
-    return if Flipper.enabled? :split_checkout, spree_current_user
+    return if OpenFoodNetwork::FeatureToggle.enabled? :split_checkout, spree_current_user
 
     OrderCheckoutRestart.new(@order).call
   end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -25,7 +25,7 @@ module Spree
         order.payment_required?
       }
       go_to_state :confirmation, if: ->(order) {
-        Flipper.enabled? :split_checkout, order.created_by
+        OpenFoodNetwork::FeatureToggle.enabled? :split_checkout, order.created_by
       }
       go_to_state :complete
     end
@@ -311,7 +311,7 @@ module Spree
     # Creates new tax charges if there are any applicable rates. If prices already
     # include taxes then price adjustments are created instead.
     def create_tax_charge!
-      return if state.in?(["cart", "address", "delivery"]) && Flipper.enabled?(:split_checkout)
+      return if state.in?(["cart", "address", "delivery"]) && OpenFoodNetwork::FeatureToggle.enabled?(:split_checkout)
 
       clear_legacy_taxes!
 

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -84,7 +84,7 @@ Openfoodnetwork::Application.routes.draw do
       end
 
       get '/reports/:report_type(/:report_subtype)', to: 'reports#show',
-          constraints: lambda { |_| Flipper.enabled?(:api_reports) }
+          constraints: lambda { |_| OpenFoodNetwork::FeatureToggle.enabled?(:api_reports) }
     end
 
     namespace :v1 do

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -3,15 +3,14 @@
 module OpenFoodNetwork
   # Feature toggles are configured via Flipper.
   #
-  # We define features in the initializer and then it can be customised via the
-  # web interface on each server.
-  #
   # - config/initializers/flipper.rb
   # - http://localhost:3000/admin/feature-toggle/features
   #
   module FeatureToggle
     def self.enabled?(feature_name, user = nil)
-      Flipper.enabled?(feature_name, user)
+      feature = Flipper.feature(feature_name)
+      feature.add unless feature.exist?
+      feature.enabled?(user)
     end
   end
 end

--- a/spec/controllers/payment_gateways/stripe_controller_spec.rb
+++ b/spec/controllers/payment_gateways/stripe_controller_spec.rb
@@ -88,8 +88,10 @@ module PaymentGateways
 
         context "using split checkout" do
           before do
-            allow(Flipper).to receive(:enabled?).with(:split_checkout) { true }
-            allow(Flipper).to receive(:enabled?).with(:split_checkout, anything) { true }
+            allow(OpenFoodNetwork::FeatureToggle).
+              to receive(:enabled?).with(:split_checkout) { true }
+            allow(OpenFoodNetwork::FeatureToggle).
+              to receive(:enabled?).with(:split_checkout, anything) { true }
 
             order.update_attribute :state, "confirmation"
           end

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -16,8 +16,10 @@ describe SplitCheckoutController, type: :controller do
   let(:shipping_method) { distributor.shipping_methods.first }
 
   before do
-    allow(Flipper).to receive(:enabled?).with(:split_checkout) { true }
-    allow(Flipper).to receive(:enabled?).with(:split_checkout, anything) { true }
+    allow(OpenFoodNetwork::FeatureToggle).
+      to receive(:enabled?).with(:split_checkout) { true }
+    allow(OpenFoodNetwork::FeatureToggle).
+      to receive(:enabled?).with(:split_checkout, anything) { true }
 
     exchange.variants << order.line_items.first.variant
     allow(controller).to receive(:current_order) { order }

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -13,6 +13,13 @@ module OpenFoodNetwork
         Flipper.enable(:foo)
         expect(FeatureToggle.enabled?(:foo)).to be true
       end
+
+      it "adds features to the database for easy admin in the UI" do
+        feature = Flipper.feature(:sparkling_new)
+
+        expect { FeatureToggle.enabled?(:sparkling_new) }.
+          to change { feature.exist? }.from(false).to(true)
+      end
     end
   end
 end

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -33,6 +33,7 @@ describe '
 
   shared_examples "Can access Customers reports and generate report" do |inverse_columns_logic|
     before do
+      allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).and_call_original
       allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).with(
         :report_inverse_columns_logic, anything
       ).and_return(inverse_columns_logic)
@@ -225,6 +226,7 @@ describe '
     }
 
     before do
+      allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).and_call_original
       allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).with(
         :report_inverse_columns_logic, anything
       ).and_return(inverse_columns_logic)

--- a/spec/system/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/system/consumer/shopping/checkout_auth_spec.rb
@@ -83,8 +83,8 @@ describe "As a consumer I want to check out my cart", js: true do
 
       context "split checkout" do
         before do
-          allow(Flipper).to receive(:enabled?).with(:split_checkout) { true }
-          allow(Flipper).to receive(:enabled?).with(:split_checkout, anything) { true }
+          allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).with(:split_checkout) { true }
+          allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).with(:split_checkout, anything) { true }
         end
         include_examples "with different checkout types", "split_checkout"
       end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -65,8 +65,8 @@ describe "As a consumer, I want to checkout my order", js: true do
   }
 
   before do
-    allow(Flipper).to receive(:enabled?).with(:split_checkout).and_return(true)
-    allow(Flipper).to receive(:enabled?).with(:split_checkout, anything).and_return(true)
+    allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).with(:split_checkout).and_return(true)
+    allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).with(:split_checkout, anything).and_return(true)
 
     add_enterprise_fee enterprise_fee
     set_order order

--- a/spec/system/consumer/split_checkout_tax_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_incl_spec.rb
@@ -111,8 +111,10 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
       context "on split-checkout" do
         before do
-          allow(Flipper).to receive(:enabled?).with(:split_checkout).and_return(true)
-          allow(Flipper).to receive(:enabled?).with(:split_checkout, anything).and_return(true)
+          allow(OpenFoodNetwork::FeatureToggle).
+            to receive(:enabled?).with(:split_checkout).and_return(true)
+          allow(OpenFoodNetwork::FeatureToggle).
+            to receive(:enabled?).with(:split_checkout, anything).and_return(true)
 
           set_order order_within_zone
           login_as(user_within_zone)
@@ -169,8 +171,10 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
       context "on split-checkout" do
         before do
-          allow(Flipper).to receive(:enabled?).with(:split_checkout).and_return(true)
-          allow(Flipper).to receive(:enabled?).with(:split_checkout, anything).and_return(true)
+          allow(OpenFoodNetwork::FeatureToggle).
+            to receive(:enabled?).with(:split_checkout).and_return(true)
+          allow(OpenFoodNetwork::FeatureToggle).
+            to receive(:enabled?).with(:split_checkout, anything).and_return(true)
 
           set_order order_outside_zone
           login_as(user_outside_zone)

--- a/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
@@ -118,8 +118,10 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
       context "on split-checkout" do
         before do
-          allow(Flipper).to receive(:enabled?).with(:split_checkout).and_return(true)
-          allow(Flipper).to receive(:enabled?).with(:split_checkout, anything).and_return(true)
+          allow(OpenFoodNetwork::FeatureToggle).
+            to receive(:enabled?).with(:split_checkout).and_return(true)
+          allow(OpenFoodNetwork::FeatureToggle).
+            to receive(:enabled?).with(:split_checkout, anything).and_return(true)
 
           set_order order_within_zone
           login_as(user_within_zone)
@@ -179,8 +181,10 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
       context "on split-checkout" do
         before do
-          allow(Flipper).to receive(:enabled?).with(:split_checkout).and_return(true)
-          allow(Flipper).to receive(:enabled?).with(:split_checkout, anything).and_return(true)
+          allow(OpenFoodNetwork::FeatureToggle).
+            to receive(:enabled?).with(:split_checkout).and_return(true)
+          allow(OpenFoodNetwork::FeatureToggle).
+            to receive(:enabled?).with(:split_checkout, anything).and_return(true)
 
           set_order order_outside_zone
           login_as(user_outside_zone)


### PR DESCRIPTION

#### What? Why?

Closes #9125 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The admin UI shows only features which were added to the database. We always had to look up a feature's name add it manually before we could enable it. Now it will appear in the UI after some code asked if it was enabled.

This only adds a database query once when the feature doesn't exist yet. The `feature.exist?` call only performs an in-memory lookup in the memoizer.

This implementation is slightly different to what I suggested in the issue. I thought we had to maintain a list of features and add them add boot time. But I think that it's better to avoid maintaining that list and to avoid the work during boot time. One day we still want to remove old features from the database but I checked current production servers and I couldn't see any unused features. Lets do that when it actually becomes a problem.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit `/admin/feature-toggle/`.
- Delete all features.
- Go to `/admin/reports/orders_and_distributors`
- Then reload the feature toggle page and assert `report_inverse_columns_logic` being there.
- Visit `https://staging.openfoodnetwork.org.au/api/v1/customers`.
- Assert that `api_v1` is in the feature toggle list.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
