### PR TITLE
Translate error messages when creating products

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,11 +44,14 @@ en:
         state: State
         source: Source
       spree/product:
+        name: "Product Name"
+        price: "Price"
         primary_taxon: "Product Category"
         supplier: "Supplier"
         shipping_category_id: "Shipping Category"
         variant_unit: "Variant Unit"
         variant_unit_name: "Variant Unit Name"
+        unit_value: "Unit value"
       spree/credit_card:
         base: "Credit Card"
         number: "Number"


### PR DESCRIPTION
#### What? Why?

Closes #9559.

This PR is adding missing translation to for name & price in spree/product in config/locales/{lang}.yml.
This fixs the missing error message describe in the issue: https://github.com/openfoodfoundation/openfoodnetwork/issues/9559



#### What should we test?
Similar to the Steps to Reproduce in the issue: https://github.com/openfoodfoundation/openfoodnetwork/issues/9559

At first I added translation into every config/locales/{lang}.yml but @jibees warned me about this:

> Actually, we use Transifex to manage our i18n. Therefore, we only update the en.yml file and then when new keys appears (ie. when PR is merged), instance managers are aware of those key and can translate those new keys inside Transifex. After that, we pull the each file from Transifex.
> 
> That's why here, you only need to modify en.yml file ;) Sorry about that! That's maybe not clear enough.
> 
> Source: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-%28i18n%29_
> 

So I just changed en.yml file. 


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
