### PR TITLE
Delete unused paperclip columns.

### DIFF
--- a/db/migrate/20221003185301_remove_attachment_fields_from_terms_of_service_files.rb
+++ b/db/migrate/20221003185301_remove_attachment_fields_from_terms_of_service_files.rb
@@ -1,0 +1,8 @@
+class RemoveAttachmentFieldsFromTermsOfServiceFiles < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :terms_of_service_files, :attachment_file_name, :string
+    remove_column :terms_of_service_files, :attachment_content_type, :string
+    remove_column :terms_of_service_files, :attachment_file_size, :integer
+    remove_column :terms_of_service_files, :attachment_updated_at, :datetime
+  end
+end

--- a/db/migrate/20221004164815_remove_terms_and_conditions_fields_from_enterprise.rb
+++ b/db/migrate/20221004164815_remove_terms_and_conditions_fields_from_enterprise.rb
@@ -1,0 +1,8 @@
+class RemoveTermsAndConditionsFieldsFromEnterprise < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :enterprises, :terms_and_conditions_file_name, :string
+    remove_column :enterprises, :terms_and_conditions_content_type, :string
+    remove_column :enterprises, :terms_and_conditions_file_size, :integer
+    remove_column :enterprises, :terms_and_conditions_updated_at, :datetime
+  end
+end

--- a/db/migrate/20221004164934_remove_logo_fields_from_enterprise.rb
+++ b/db/migrate/20221004164934_remove_logo_fields_from_enterprise.rb
@@ -1,0 +1,8 @@
+class RemoveLogoFieldsFromEnterprise < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :enterprises, :logo_file_name, :string
+    remove_column :enterprises, :logo_content_type, :string
+    remove_column :enterprises, :logo_file_size, :integer
+    remove_column :enterprises, :logo_updated_at, :datetime
+  end
+end

--- a/db/migrate/20221004165028_remove_promo_image_fields_from_enterprise.rb
+++ b/db/migrate/20221004165028_remove_promo_image_fields_from_enterprise.rb
@@ -1,0 +1,8 @@
+class RemovePromoImageFieldsFromEnterprise < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :enterprises, :promo_image_file_name, :string
+    remove_column :enterprises, :promo_image_content_type, :string
+    remove_column :enterprises, :promo_image_file_size, :integer
+    remove_column :enterprises, :promo_image_updated_at, :datetime
+  end
+end

--- a/db/migrate/20221004165116_remove_logo_fields_from_enterprise_group.rb
+++ b/db/migrate/20221004165116_remove_logo_fields_from_enterprise_group.rb
@@ -1,0 +1,8 @@
+class RemoveLogoFieldsFromEnterpriseGroup < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :enterprise_groups, :logo_file_name, :string
+    remove_column :enterprise_groups, :logo_content_type, :string
+    remove_column :enterprise_groups, :logo_file_size, :integer
+    remove_column :enterprise_groups, :logo_updated_at, :datetime
+  end
+end

--- a/db/migrate/20221004165206_remove_promo_image_fields_from_enterprise_group.rb
+++ b/db/migrate/20221004165206_remove_promo_image_fields_from_enterprise_group.rb
@@ -1,0 +1,8 @@
+class RemovePromoImageFieldsFromEnterpriseGroup < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :enterprise_groups, :promo_image_file_name, :string
+    remove_column :enterprise_groups, :promo_image_content_type, :string
+    remove_column :enterprise_groups, :promo_image_file_size, :integer
+    remove_column :enterprise_groups, :promo_image_updated_at, :datetime
+  end
+end

--- a/db/migrate/20221004165343_remove_attachment_fields_from_spree_asset.rb
+++ b/db/migrate/20221004165343_remove_attachment_fields_from_spree_asset.rb
@@ -4,6 +4,8 @@ class RemoveAttachmentFieldsFromSpreeAsset < ActiveRecord::Migration[6.1]
     remove_column :spree_assets, :attachment_content_type, :string
     remove_column :spree_assets, :attachment_file_size, :integer
     remove_column :spree_assets, :attachment_updated_at, :datetime
+    remove_column :spree_assets, :attachment_width, :integer
+    remove_column :spree_assets, :attachment_height, :integer
   end
 end
 

--- a/db/migrate/20221004165343_remove_attachment_fields_from_spree_asset.rb
+++ b/db/migrate/20221004165343_remove_attachment_fields_from_spree_asset.rb
@@ -1,0 +1,9 @@
+class RemoveAttachmentFieldsFromSpreeAsset < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :spree_assets, :attachment_file_name, :string
+    remove_column :spree_assets, :attachment_content_type, :string
+    remove_column :spree_assets, :attachment_file_size, :integer
+    remove_column :spree_assets, :attachment_updated_at, :datetime
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -420,8 +420,6 @@ ActiveRecord::Schema.define(version: 2022_10_04_165343) do
 
   create_table "spree_assets", id: :serial, force: :cascade do |t|
     t.integer "viewable_id"
-    t.integer "attachment_width"
-    t.integer "attachment_height"
     t.integer "position"
     t.string "viewable_type", limit: 50
     t.string "type", limit: 75

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_07_055044) do
+ActiveRecord::Schema.define(version: 2022_10_04_165343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -140,16 +140,8 @@ ActiveRecord::Schema.define(version: 2022_09_07_055044) do
     t.string "name", limit: 255
     t.boolean "on_front_page"
     t.integer "position"
-    t.string "promo_image_file_name", limit: 255
-    t.string "promo_image_content_type", limit: 255
-    t.integer "promo_image_file_size"
-    t.datetime "promo_image_updated_at"
     t.text "description"
     t.text "long_description"
-    t.string "logo_file_name", limit: 255
-    t.string "logo_content_type", limit: 255
-    t.integer "logo_file_size"
-    t.datetime "logo_updated_at"
     t.integer "address_id"
     t.string "email", limit: 255, default: "", null: false
     t.string "website", limit: 255, default: "", null: false
@@ -212,14 +204,6 @@ ActiveRecord::Schema.define(version: 2022_09_07_055044) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "distributor_info"
-    t.string "logo_file_name", limit: 255
-    t.string "logo_content_type", limit: 255
-    t.integer "logo_file_size"
-    t.datetime "logo_updated_at"
-    t.string "promo_image_file_name", limit: 255
-    t.string "promo_image_content_type", limit: 255
-    t.integer "promo_image_file_size"
-    t.datetime "promo_image_updated_at"
     t.string "facebook", limit: 255
     t.string "instagram", limit: 255
     t.string "linkedin", limit: 255
@@ -235,10 +219,6 @@ ActiveRecord::Schema.define(version: 2022_09_07_055044) do
     t.boolean "display_invoice_logo", default: false
     t.boolean "allow_order_changes", default: false, null: false
     t.boolean "enable_subscriptions", default: false, null: false
-    t.string "terms_and_conditions_file_name", limit: 255
-    t.string "terms_and_conditions_content_type", limit: 255
-    t.integer "terms_and_conditions_file_size"
-    t.datetime "terms_and_conditions_updated_at"
     t.integer "business_address_id"
     t.boolean "show_customer_names_to_suppliers", default: false, null: false
     t.string "visible", limit: 255, default: "public", null: false
@@ -442,13 +422,9 @@ ActiveRecord::Schema.define(version: 2022_09_07_055044) do
     t.integer "viewable_id"
     t.integer "attachment_width"
     t.integer "attachment_height"
-    t.integer "attachment_file_size"
     t.integer "position"
     t.string "viewable_type", limit: 50
-    t.string "attachment_content_type", limit: 255
-    t.string "attachment_file_name", limit: 255
     t.string "type", limit: 75
-    t.datetime "attachment_updated_at"
     t.text "alt"
     t.index ["viewable_id"], name: "index_assets_on_viewable_id"
     t.index ["viewable_type", "type"], name: "index_assets_on_viewable_type_and_type"
@@ -1194,10 +1170,6 @@ ActiveRecord::Schema.define(version: 2022_09_07_055044) do
   create_table "terms_of_service_files", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "attachment_file_name"
-    t.string "attachment_content_type"
-    t.integer "attachment_file_size"
-    t.datetime "attachment_updated_at"
   end
 
   create_table "variant_overrides", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
#### What? Why?

Closes #9726

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
Removes unused paperclip columns from the following tables.
1. enterprises
2. enterprise_groups
3. terms_of_service_files
4. spree_assets


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit a shop page and verify that all images are still displayed (as much as before on staging).

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
Remove unused paperclip columns from the following tables.
1. enterprises
2. enterprise_groups
3. terms_of_service_files
4. spree_assets


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->
https://github.com/openfoodfoundation/openfoodnetwork/pull/9730
