### PR TITLE
Avoid error when sending empty variant attributes in bulk product edit

### DIFF
--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -110,6 +110,8 @@ module Sets
     end
 
     def create_variant(product, variant_attributes)
+      return if variant_attributes.blank?
+
       on_hand = variant_attributes.delete(:on_hand)
       on_demand = variant_attributes.delete(:on_demand)
 

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -47,10 +47,9 @@ module Sets
     end
 
     def update_product(product, attributes)
-      original_supplier = product.supplier_id
       return false unless update_product_only_attributes(product, attributes)
 
-      ExchangeVariantDeleter.new.delete(product) if original_supplier != product.supplier_id
+      ExchangeVariantDeleter.new.delete(product) if product.saved_change_to_supplier_id?
 
       update_product_variants(product, attributes) &&
         update_product_master(product, attributes)


### PR DESCRIPTION
#### What? Why?

I noticed a [failing spec](https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/3124728304/jobs/5070966119) when [removing rspec-retry](https://github.com/openfoodfoundation/openfoodnetwork/pull/9635) and it consistently failed on my local machine. It seems that rspec-retry was hiding a specced bug.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

In 2019 Pau observed an error where an empty attributes hash was passed to the bulk product update method. He added an automated test but wasn't able to reproduce the error.

A recent change in logic made the spec fail but rspec-retry hid that fail because it would succeed on a second try (not sure why). I now changed the logic to ignore empty attributes properly and avoid an error trying to create a new variant when no attributes are given.

* f940397781cc5387fa73f1b0a5e15d72d681175d Pau's spec
* 6f228781d47552eabf2de7a1a5c020504a9d28ca Fixing error detection



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Go to bulk products edit.
- Create new variants and edit existing variants.
- Everything should work as expected.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
