### PR TITLE
Fix layout of 'Create a new product' button in dashboard overview

### DIFF
--- a/app/views/spree/admin/overview/_products.html.haml
+++ b/app/views/spree/admin/overview/_products.html.haml
@@ -24,6 +24,6 @@
           = t(".active_products", count: @product_count )
         %span.three.columns.omega
           %span.icon-remove-sign
-      %a.eight.columns.alpha.button.bottom.red{ href: "#{new_admin_product_path}" }
+      %a.sixteen.columns.alpha.button.bottom.red{ href: "#{new_admin_product_path}" }
         = t "spree_admin_enterprises_create_new_product"
         %span.icon-arrow-right


### PR DESCRIPTION
#### What? Why?

The layout of the 'Create a new product' button in dashboard overview was broken if there were no products available yet.

Before:
![image](https://user-images.githubusercontent.com/1790176/194535055-cb205ab0-0e5a-4b2f-87e4-8d81b01364c7.png)

After:
![image](https://user-images.githubusercontent.com/1790176/194535095-68e9d5e4-d350-4f3f-bd79-9862359f38e4.png)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Make sure you have more than one enterprise in your account.
- Make sure you have no active products.
- Visit /admin page.
- Make sure the layout of the products section is fixed.
- Make sure the layout of the rest of the page is not broken.
- Create at least one product.
- Make sure the layout of the products section is not broken.
- Make sure the layout of the rest of the page is not broken.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
