### PR TITLE
Fixed same enterprise appear several times in the fee dropdown list

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
@@ -18,7 +18,8 @@ angular.module('admin.orderCycles')
       OrderCycle.exchangeDirection(exchange)
 
     $scope.enterprisesWithFees = ->
-      $scope.enterprises[id] for id in [OrderCycle.participatingEnterpriseIds()..., [OrderCycle.order_cycle.coordinator_id]...] when $scope.enterpriseFeesForEnterprise(id).length > 0
+      ids = [OrderCycle.participatingEnterpriseIds()..., [OrderCycle.order_cycle.coordinator_id]...]
+      $scope.enterprises[id] for id in Array.from(new Set(ids)) when $scope.enterpriseFeesForEnterprise(id).length > 0
 
     $scope.removeExchange = ($event, exchange) ->
       $event.preventDefault()

--- a/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
@@ -93,9 +93,9 @@ angular.module('admin.orderCycles').factory 'OrderCycle', ($resource, $window, $
       variant_ids
 
     participatingEnterpriseIds: ->
-      suppliers = (exchange.enterprise_id for exchange in this.order_cycle.incoming_exchanges)
-      distributors = (exchange.enterprise_id for exchange in this.order_cycle.outgoing_exchanges)
-      jQuery.unique(suppliers.concat(distributors)).sort()
+      suppliers = (parseInt(exchange.enterprise_id) for exchange in this.order_cycle.incoming_exchanges)
+      distributors = (parseInt(exchange.enterprise_id) for exchange in this.order_cycle.outgoing_exchanges)
+      Array.from(new Set([suppliers..., distributors...]))
 
     exchangesByDirection: (direction) ->
       if direction == 'incoming'

--- a/spec/javascripts/unit/admin/order_cycles/controllers/order_cycle_exchanges_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/order_cycles/controllers/order_cycle_exchanges_controller_spec.js.coffee
@@ -57,6 +57,21 @@ describe 'AdminOrderCycleExchangesCtrl', ->
       {id: 2, name: 'Pepper Tree Place'},
       {id: 4, name: 'coordinator'}
       ])
+  
+  it 'Finds unique enterprises participating in the order cycle that have fees', ->
+    scope.enterpriseFeesForEnterprise = (enterprise_id) ->
+      EnterpriseFee.forEnterprise(parseInt(enterprise_id))
+    scope.enterprises = 
+      1: {id: 1, name: 'Eaterprises'}
+      2: {id: 2, name: 'Pepper Tree Place'}
+      3: {id: 3, name: 'South East'}
+      4: {id: 4, name: 'coordinator'}
+    OrderCycle.participatingEnterpriseIds = jasmine.createSpy('participatingEnterpriseIds').and.returnValue([2, 2])
+    EnterpriseFee.enterprise_fees = [ {enterprise_id: 2} ]
+    expect(scope.enterprisesWithFees()).toEqual([
+      {id: 2, name: 'Pepper Tree Place'},
+      {id: 4, name: 'coordinator'}
+      ])
 
   it 'Removes order cycle exchanges', ->
     scope.removeExchange(event, 'exchange')


### PR DESCRIPTION
#### What? Why?
When choosing to apply fees in steps 3 and 4 of a hub's order cycle, the same enterprises was appearing several time in the drop-down list.
Closes #9603 

**Before:**
<img width="1440" alt="Screenshot 2022-10-08 at 6 15 56 PM" src="https://user-images.githubusercontent.com/39980734/194709295-127f47c9-00bd-4ac4-9869-cc7e5526e6e5.png">
<img width="1440" alt="Screenshot 2022-10-08 at 6 16 26 PM" src="https://user-images.githubusercontent.com/39980734/194709301-29a78f44-ac97-479e-9ba9-02c5ea0ab9ff.png">


**After:**

<img width="1440" alt="Screenshot 2022-10-08 at 6 17 03 PM" src="https://user-images.githubusercontent.com/39980734/194709313-fd5594c9-ae22-46f6-af6b-89af20d71447.png">
<img width="1440" alt="Screenshot 2022-10-08 at 6 40 27 PM" src="https://user-images.githubusercontent.com/39980734/194709320-c12576a3-7407-4905-a847-f45b12d926d2.png">


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


 - Connect to an account that has a producer-hub enterprise (with at least one available product so it can be added as a supplier)
 - Create or edit an order cycle
 - At step 2, choose the hub as the supplier, then click "Add fee"
 - See that the hub should not appears several times


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Admin facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
