### PR TITLE
Fix snail issue for all shipping method fees

### DIFF
--- a/app/controllers/spree/admin/shipping_methods_controller.rb
+++ b/app/controllers/spree/admin/shipping_methods_controller.rb
@@ -95,11 +95,20 @@ module Spree
       end
 
       def check_shipping_fee_input
-        shipping_amount = permitted_resource_params.dig('calculator_attributes', 'preferred_amount')
+        shipping_fees = permitted_resource_params['calculator_attributes']&.slice(
+          :preferred_flat_percent, :preferred_amount,
+          :preferred_first_item, :preferred_additional_item,
+          :preferred_minimal_amount, :preferred_normal_amount,
+          :preferred_discount_amount, :preferred_per_unit
+        )
 
-        unless shipping_amount.nil? || Float(shipping_amount, exception: false) 
-          flash[:error] = I18n.t(:calculator_preferred_value_error) 
-          return redirect_to location_after_save      
+        return unless shipping_fees
+
+        shipping_fees.each do |_, shipping_amount|
+          unless shipping_amount.nil? || Float(shipping_amount, exception: false)
+            flash[:error] = I18n.t(:calculator_preferred_value_error)
+            return redirect_to location_after_save
+          end
         end
       end
     end

--- a/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
@@ -31,14 +31,21 @@ describe Spree::Admin::ShippingMethodsController, type: :controller do
       expect(shipping_method.reload.calculator.preferred_currency).to eq "EUR"
     end
 
-    it "diplay error message on update if preferred_amount input is invalid" do
-      shipping_method.calculator = create(:calculator_flat_rate, calculable: shipping_method)
-      params[:shipping_method][:calculator_attributes][:preferred_amount] = "\'20.0'"
+    %i[
+      preferred_flat_percent preferred_amount
+      preferred_first_item preferred_additional_item
+      preferred_minimal_amount preferred_normal_amount
+      preferred_discount_amount preferred_per_unit
+    ].each do |shipping_amount|
+      it "diplay error message on update if #{shipping_amount} input is invalid" do
+        shipping_method.calculator = create(:calculator_flat_rate, calculable: shipping_method)
+        params[:shipping_method][:calculator_attributes][shipping_amount] = "\'20.0'"
 
-      spree_post :update, params
+        spree_post :update, params
 
-      expect(flash[:error]).to match I18n.t(:calculator_preferred_value_error) 
-      expect(response).to redirect_to spree.edit_admin_shipping_method_path(shipping_method)
+        expect(flash[:error]).to match I18n.t(:calculator_preferred_value_error)
+        expect(response).to redirect_to spree.edit_admin_shipping_method_path(shipping_method)
+      end
     end
 
     it "updates preferred_per_unit of a Weight calculator" do


### PR DESCRIPTION
#### What? Why?

Closes #8249 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

flat percent --> snail
flat rate (per order) --> OK
flexible rate --> snail
flat rate (per item) --> OK
price sack --> snail
weight (per kg or lb) --> probably snail

As an Admin:

- edit a shipping method
- on the calculator section choose one of the calculators marked with "snail" above
- click update
- type in an invalid value (e.g. some text or numbers with comma as separator)
- click update --> snail


<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
