### PR TITLE
BOM: fix displaying a modal when changing date range with modifying quantities on line items 

### DIFF
--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -22,9 +22,9 @@
         = t("date_range")
       %br
         %div{ data: { controller: "flatpickr", "flatpickr-mode-value": "range", "flatpickr-default-date": "{{ [startDate, endDate] }}" } }
-          %input.datepicker.fullwidth{ class: "datepicker", data: { "flatpickr-target": "instance" } }
-          %input{ type: "text", id: 'start_date_filter', 'ng-model': "startDate", data: { "flatpickr-target": "start" }, style: "display: none;", "confirm-change": "confirmRefresh()" }
-          %input{ type: "text", id: 'end_date_filter', 'ng-model': "endDate", data: { "flatpickr-target": "end" }, style: "display: none;", "confirm-change": "confirmRefresh()"}
+          %input.datepicker.fullwidth{ class: "datepicker", data: { "flatpickr-target": "instance" }, ng: { focus: "confirmRefresh()" } }
+          %input{ type: "text", id: 'start_date_filter', 'ng-model': "startDate", data: { "flatpickr-target": "start" }, style: "display: none;" }
+          %input{ type: "text", id: 'end_date_filter', 'ng-model': "endDate", data: { "flatpickr-target": "end" }, style: "display: none;" }
     .one.column &nbsp;
     .filter_select{ :class => "three columns" }
       %label{ :for => 'supplier_filter' }

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -609,14 +609,9 @@ describe '
         end
 
         it "shows a dialog and keeps changes when confirm dialog is rejected" do
-          pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/9757"
-
-          page.driver.dismiss_modal :confirm,
-                                    text: "Unsaved changes exist and will be lost if you continue." do
+          dismiss_confirm "Unsaved changes exist and will be lost if you continue." do
             find("input.datepicker").click
-            select_dates_from_daterangepicker(today - 9.days, today)
           end
-          sleep 2
           expect(page).to have_selector "#save-bar"
           within("tr#li_#{li2.id} td.quantity") do
             expect(page).to have_selector "input[name=quantity].ng-dirty"


### PR DESCRIPTION
#### What? Why?

Closes #9757

I don't want to spend too much time on it. Here's my proposal:

As an admin, on Bulk Order Management, change quantity on a line item, you should see the input as _dirty_ and a saving bar
<img width="700" alt="Capture d’écran 2022-10-10 à 11 18 49" src="https://user-images.githubusercontent.com/296452/194834649-8978039b-dd40-4f43-9690-2eff20ce7e34.png">

when clicking on date range picker, you should then see a alert that prevent you: 

<img width="496" alt="Capture d’écran 2022-10-10 à 11 18 54" src="https://user-images.githubusercontent.com/296452/194834839-03a0edb6-a459-4c0a-b4a6-75900a4eb4eb.png">

No matter if you click on "Annuler" (cancel) or "Ok", the date picker will open. 





<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
See previous section

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
