### PR TITLE
Stabilise spec by waiting for JS requests

### DIFF
--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -223,8 +223,16 @@ describe '
 
         click_button 'Create'
 
-        expect(page).to have_select 'new_supplier_id'
-        expect(page).not_to have_select 'new_supplier_id', with_options: [supplier_unmanaged.name]
+        # Wait for API requests to finish:
+        sleep 2
+
+        expect(page).to have_select 'new_supplier_id', with_options: [
+          "Managed supplier",
+          "Permitted supplier",
+        ]
+        expect(page).not_to have_select 'new_supplier_id', with_options: [
+          "Unmanaged supplier",
+        ]
         select 'Managed supplier', from: 'new_supplier_id'
         click_button 'Add supplier'
         select 'Permitted supplier', from: 'new_supplier_id'


### PR DESCRIPTION


#### What? Why?

Closes #6624 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Well, two seconds is just a guess. Ideally the page wouldn't display until we have everything loaded. But this logic will be replaced when we chuck out AngularJS.

This version passed over 100 runs with a busy CPU on my machine.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
