### PR TITLE
Fix for: [Admin][Permissions] Granting permission to a shop displays it in "Producers" list as if it was a supplier #9589

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -210,16 +210,6 @@ class Enterprise < ApplicationRecord
       joins(:enterprise_roles).where('enterprise_roles.user_id = ?', user.id)
     end
   }
-  scope :relatives_of_one_union_others, lambda { |one, others|
-    where("
-      enterprises.id IN
-        (SELECT child_id FROM enterprise_relationships WHERE enterprise_relationships.parent_id=?)
-      OR enterprises.id IN
-        (SELECT parent_id FROM enterprise_relationships WHERE enterprise_relationships.child_id=?)
-      OR enterprises.id IN
-        (?)
-    ", one, one, others)
-  }
 
   scope :parents_of_one_union_others, lambda { |one, others|
     where("

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -221,6 +221,15 @@ class Enterprise < ApplicationRecord
     ", one, one, others)
   }
 
+  scope :parents_of_one_union_others, lambda { |one, others|
+    where("
+      enterprises.id IN
+        (SELECT parent_id FROM enterprise_relationships WHERE enterprise_relationships.child_id=?)
+      OR enterprises.id IN
+        (?)
+      ", one, others)
+  }
+
   def business_address_empty?(attributes)
     attributes_exists = attributes['id'].present?
     attributes_empty = attributes.slice(:company, :address1, :city, :phone,
@@ -273,9 +282,9 @@ class Enterprise < ApplicationRecord
     ", id, id)
   end
 
-  def plus_relatives_and_oc_producers(order_cycles)
+  def plus_parents_and_order_cycle_producers(order_cycles)
     oc_producer_ids = Exchange.in_order_cycle(order_cycles).incoming.pluck :sender_id
-    Enterprise.not_hidden.is_primary_producer.relatives_of_one_union_others(id, oc_producer_ids | [id])
+    Enterprise.not_hidden.is_primary_producer.parents_of_one_union_others(id, oc_producer_ids | [id])
   end
 
   def relatives_including_self

--- a/app/serializers/api/enterprise_shopfront_serializer.rb
+++ b/app/serializers/api/enterprise_shopfront_serializer.rb
@@ -54,7 +54,7 @@ module Api
 
     def producers
       ActiveModel::ArraySerializer.new(
-        enterprise.plus_relatives_and_oc_producers(
+        enterprise.plus_parents_and_order_cycle_producers(
           OrderCycle.not_closed.with_distributor(enterprise)
         ),
         each_serializer: Api::EnterpriseThinSerializer

--- a/spec/serializers/api/enterprise_shopfront_serializer_spec.rb
+++ b/spec/serializers/api/enterprise_shopfront_serializer_spec.rb
@@ -6,8 +6,8 @@ describe Api::EnterpriseShopfrontSerializer do
   let!(:hub) { create(:distributor_enterprise, with_payment_and_shipping: true) }
   let!(:producer) { create(:supplier_enterprise) }
   let!(:producer_hidden) { create(:supplier_enterprise_hidden) }
-  let!(:relationship) { create(:enterprise_relationship, parent: hub, child: producer) }
-  let!(:relationship2) { create(:enterprise_relationship, parent: hub, child: producer_hidden) }
+  let!(:relationship) { create(:enterprise_relationship, parent: producer, child: hub) }
+  let!(:relationship2) { create(:enterprise_relationship, parent: producer_hidden, child: hub) }
 
   let!(:taxon1) { create(:taxon, name: 'Meat') }
   let!(:taxon2) { create(:taxon, name: 'Veg') }

--- a/spec/system/consumer/shops_spec.rb
+++ b/spec/system/consumer/shops_spec.rb
@@ -42,6 +42,7 @@ describe 'Shops', js: true do
       it "by URL" do
         pending("#9649")
         visit shops_path(anchor: "/?query=xyzzy")
+        sleep 1
         expect(page).not_to have_content distributor.name
         expect(page).to have_content "Sorry, no results found for xyzzy. Try another search?"
       end

--- a/spec/system/consumer/shops_spec.rb
+++ b/spec/system/consumer/shops_spec.rb
@@ -17,7 +17,7 @@ describe 'Shops', js: true do
                                 coordinator: create(:distributor_enterprise))
   }
   let!(:producer) { create(:supplier_enterprise) }
-  let!(:er) { create(:enterprise_relationship, parent: distributor, child: producer) }
+  let!(:er) { create(:enterprise_relationship, parent: producer, child: distributor) }
 
   before do
     producer.set_producer_property 'Organic', 'NASAA 12345'
@@ -96,7 +96,7 @@ describe 'Shops', js: true do
     let!(:hub) { create(:distributor_enterprise, with_payment_and_shipping: false) }
     let!(:order_cycle) { create(:simple_order_cycle, distributors: [hub], coordinator: hub) }
     let!(:producer) { create(:supplier_enterprise) }
-    let!(:er) { create(:enterprise_relationship, parent: hub, child: producer) }
+    let!(:er) { create(:enterprise_relationship, parent: producer, child: hub) }
 
     it "does not show hubs that are not ready for checkout" do
       visit shops_path


### PR DESCRIPTION
#### What? Why?

Closes #9589

Fix for: [Admin][Permissions] Granting permission to a shop displays it in "Producers" list as if it was a supplier.

This PR resolves the problem whereby Shop B shows on Shop A's producers list even though Shop B is its distributor when Shop A grants permission to Shop B.

This PR also assures that a shop will only be listed as a "Producer" in a shop's "Producers" list if it supplies to that specific shop, which means only if it has granted that specific shop permission to sell its products.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


- Connect to a producer's shop (shop A)
- Grant permission "add to order cycle" from this producer to another producer shop (shop B)
- Go to shop A url and click on the "Producers" tab
- See that shop B does not appear
- Other parts of the app are not affected by the change
 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->
No


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
No


![Screenshot 2022-10-11 at 9 46 29 PM](https://user-images.githubusercontent.com/88281470/195193143-e80e9564-5011-423b-a0c7-af90a19643cc.png)
![Screenshot 2022-10-11 at 9 46 54 PM](https://user-images.githubusercontent.com/88281470/195193147-29cf0eb8-cc9a-46bd-bc8c-cd2d6879be32.png)
![Screenshot 2022-10-11 at 9 47 05 PM](https://user-images.githubusercontent.com/88281470/195193149-06c28518-872d-4adf-ab5e-d2bd3a0bf966.png)