### PR TITLE
Product creation minor improvements

### DIFF
--- a/app/views/spree/admin/products/_primary_taxon_form.html.haml
+++ b/app/views/spree/admin/products/_primary_taxon_form.html.haml
@@ -1,6 +1,6 @@
-= f.field_container :primary_taxon_id do
+= f.field_container :primary_taxon do
   = f.label :primary_taxon_id, t('.product_category')
   %span.required *
   %br
   = f.collection_select(:primary_taxon_id, Spree::Taxon.order(:name), :id, :name, {:include_blank => true}, {:class => "select2 fullwidth"})
-  = f.error_message_on :primary_taxon_id
+  = f.error_message_on :primary_taxon

--- a/app/views/spree/admin/products/_tax_category_form.html.haml
+++ b/app/views/spree/admin/products/_tax_category_form.html.haml
@@ -1,6 +1,5 @@
 = f.field_container :tax_category_id do
   = f.label :tax_category_id, t(:tax_category)
-  %span.required *
   %br
   = f.collection_select(:tax_category_id, Spree::TaxCategory.all, :id, :name, {:include_blank => Spree::Config.products_require_tax_category ? false : t(:none)}, {:class => "select2 fullwidth"})
   = f.error_message_on :tax_category_id

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -10,7 +10,6 @@
         .eight.columns.alpha
           = f.field_container :supplier do
             = f.label :supplier_id, t(".supplier")
-            %span.required *
             = f.select :supplier_id, options_from_collection_for_select(@producers, :id, :name, @product.supplier_id), {}, { "data-controller": "tom-select", class: "primary" }
             = f.error_message_on :supplier
         .eight.columns.omega

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -24,7 +24,7 @@
           = f.field_container :units do
             = f.label :variant_unit_with_scale, t(".units")
             %span.required *
-            %select{id: 'product_variant_unit_with_scale', 'ng-model' => 'product.variant_unit_with_scale', 'ng-options' => 'unit[1] as unit[0] for unit in variant_unit_options',"data-controller": "tom-select", class: "primary"}
+            %select{id: 'product_variant_unit_with_scale', 'ng-model' => 'product.variant_unit_with_scale', 'ng-options' => 'unit[1] as unit[0] for unit in variant_unit_options', "data-controller": "tom-select","data-tom-select-options-value": '{"allowEmptyOption":false}', class: "primary"}
               %option{'value' => '', 'ng-hide' => "hasUnit(product)"}
             %input{ type: 'hidden', 'ng-value': 'product.variant_unit', "ng-init": "product.variant_unit='#{@product.variant_unit}'", name: 'product[variant_unit]' }
             %input{ type: 'hidden', 'ng-value': 'product.variant_unit_scale', "ng-init": "product.variant_unit_scale='#{@product.variant_unit_scale}'", name: 'product[variant_unit_scale]' }

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -35,6 +35,7 @@
             %input.fullwidth{ id: 'product_unit_value_with_description', 'ng-model' => 'product.master.unit_value_with_description', :type => 'text', placeholder: "eg. 2", 'ng-disabled' => "!hasUnit(product)" }
             %input{ type: 'hidden', 'ng-value': 'product.master.unit_value', "ng-init": "product.master.unit_value='#{@product.master.unit_value}'", name: 'product[unit_value]' }
             %input{ type: 'hidden', 'ng-value': 'product.master.unit_description', "ng-init": "product.master.unit_description='#{@product.master.unit_description}'", name: 'product[unit_description]' }
+            = f.error_message_on :unit_value
         = render 'display_as', f: f
         .six.columns.omega{ 'ng-show' => "product.variant_unit_with_scale == 'items'" }
           = f.field_container :unit_name do

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -21,13 +21,14 @@
             = f.error_message_on :name
       .sixteen.columns.alpha
         .eight.columns.alpha
-          = f.field_container :units do
+          = f.field_container :variant_unit do
             = f.label :variant_unit_with_scale, t(".units")
             %span.required *
             %select{id: 'product_variant_unit_with_scale', 'ng-model' => 'product.variant_unit_with_scale', 'ng-options' => 'unit[1] as unit[0] for unit in variant_unit_options', "data-controller": "tom-select","data-tom-select-options-value": '{"allowEmptyOption":false}', class: "primary"}
               %option{'value' => '', 'ng-hide' => "hasUnit(product)"}
             %input{ type: 'hidden', 'ng-value': 'product.variant_unit', "ng-init": "product.variant_unit='#{@product.variant_unit}'", name: 'product[variant_unit]' }
             %input{ type: 'hidden', 'ng-value': 'product.variant_unit_scale', "ng-init": "product.variant_unit_scale='#{@product.variant_unit_scale}'", name: 'product[variant_unit_scale]' }
+            = f.error_message_on :variant_unit
         .two.columns
           = f.field_container :unit_value do
             = f.label :unit_value_with_description, t(".value"), 'ng-disabled' => "!hasUnit(product)"

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -59,7 +59,7 @@ describe '
       expect(page).to have_field 'product_on_demand', checked: true
       expect(page).to have_field 'product_tax_category_id', with: tax_category.id
       expect(page.find("div[id^='taTextElement']")).to have_content 'A description...'
-      expect(page.find("#product_units_field")).to have_content 'Weight (kg)'
+      expect(page.find("#product_variant_unit_field")).to have_content 'Weight (kg)'
 
       expect(page).to have_content "Name can't be blank"
     end


### PR DESCRIPTION
#### What? Why?

Closes #9298

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- [x] remove red star on Tax category
- [x] remove red star on Supplier
- [x] remove the option to select a blank 'unit size' in the dropdown 
- [x] Add red highlighting and little text 'can't be blank' under the field: unit size 
- [x] Add red highlighting and little text 'can't be blank' under the field: unit value
- [x] Add red highlighting and little text 'can't be blank' under the field: product category
- [ ] Add "unit value" in the content of the red box at the top of the page

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- same steps as in https://github.com/openfoodfoundation/openfoodnetwork/issues/9298#issue-1268100585
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
