### PR TITLE
Fix: spanish language translation in globe menu - dev local 

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,5 @@
 es:
-  language_name: "Inglés"
+  language_name: "Español"
   activerecord:
     models:
       spree/product: Producto


### PR DESCRIPTION
#### What? Why?

Just a very little fix: In dev env, the indication for spanish langage in the dropdown menu is wrong (Inglès instead of Espagñol -> when you click on Inglès, you get the spanish translation):

<img width="962" alt="Capture d’écran 2022-10-12 à 12 24 08" src="https://user-images.githubusercontent.com/16537140/195579611-d9012ac8-f3de-4bfc-bfe1-0f7059430a18.png">



<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This was fixed by modifiying the locales/es.yml file from Inglès to Español.

<img width="382" alt="Capture d’écran 2022-10-13 à 11 35 05" src="https://user-images.githubusercontent.com/16537140/195579644-f1ef817c-14b9-45be-94ce-9a6812a21488.png">


