### PR TITLE
Fix snail issue for all enterprise fees

### DIFF
--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -58,6 +58,34 @@ describe '
     expect(page).to have_selector "#sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_flat_percent[value='12.34']"
   end
 
+  it "creating an enterprise fee with invalid amount shows error flash message" do
+    # Given an enterprise
+    e = create(:supplier_enterprise, name: 'Feedme')
+
+    # When I go to the enterprise fees page
+    login_as_admin_and_visit admin_enterprise_fees_path
+
+    # And I fill in the fields for a new enterprise fee and click update
+    select 'Feedme', from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
+    select 'Admin', from: 'sets_enterprise_fee_set_collection_attributes_0_fee_type'
+    fill_in 'sets_enterprise_fee_set_collection_attributes_0_name', with: 'Hello!'
+    select 'GST', from: 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id'
+    select 'Flat Percent', from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+    click_button 'Update'
+
+    # Then I should see my fee and fields for the calculator
+    expect(page).to have_content "Your enterprise fees have been updated."
+    expect(page).to have_selector "input[value='Hello!']"
+
+    # When I fill in the calculator fields and click update
+    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_flat_percent',
+            with: "\'20.0'"
+    click_button 'Update'
+
+    # Then I should see the flash error message
+    expect(flash_message).to eq('Invalid input. Please use only numbers. For example: 10, 5.5, -20')
+  end
+
   context "editing an enterprise fee" do
     # Given an enterprise fee
     let!(:fee) { create(:enterprise_fee) }
@@ -105,6 +133,16 @@ describe '
       click_button 'Update'
 
       expect(fee.reload.calculator_type).to eq("Calculator::PerItem")
+    end
+
+    it 'shows error flash when updating fee amount with invalid values' do
+      # When I fill in the calculator fields and click update
+      fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_flat_percent',
+              with: "\'20.0'"
+      click_button 'Update'
+
+      # Then I should see the flash error message
+      expect(flash_message).to eq('Invalid input. Please use only numbers. For example: 10, 5.5, -20')
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #8250 

#### What should we test?

This is the current status of the calculators:

- flat percent --> OK
- flat rate (per order) --> snail
- flexible rate --> snail
- flat rate (per item) --> snail
- price sack --> snail
- weight (per kg or lb) --> snail

Steps to Reproduce
As an Admin:

- edit an enterprise fee
- choose one of the calculators marked with "snail" above
- click update
- type in an invalid value (e.g. some text or numbers with comma as separator)
- click update --> snail

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
