### PR TITLE
Add sort by product name in order cycle supplier totals by distributor report

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor.rb
@@ -24,7 +24,8 @@ module Reporting
               header: true,
             },
             {
-              group_by: proc { |line_items, _row| line_items.first.variant }
+              group_by: proc { |line_items, _row| line_items.first.variant },
+              sort_by: proc { |variant| variant.product.name }
             },
             {
               group_by: :hub,

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
@@ -31,6 +31,14 @@ module Reporting
           expect(report.rows.first.producer).to eq supplier.name
           expect(report.rows.first.hub).to eq distributor.name
         end
+
+        it "lists products sorted by name" do
+          order.line_items[0].variant.product.update(name: "Cucumber")
+          order.line_items[1].variant.product.update(name: "Apple")
+          order.line_items[2].variant.product.update(name: "Banane")
+          product_names = report.rows.map(&:product).filter(&:present?)
+          expect(product_names).to eq(["Apple", "Banane", "Cucumber"])
+        end
       end
     end
   end

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
@@ -23,7 +23,7 @@ module Reporting
         end
 
         it "generates the report" do
-          expect(report_table.length).to eq(2)
+          expect(report_table.length).to eq(6)
         end
 
         it "has a variant row under the distributor" do

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
@@ -9,7 +9,7 @@ module Reporting
         let!(:distributor) { create(:distributor_enterprise) }
 
         let!(:order) do
-          create(:completed_order_with_totals, line_items_count: 1, distributor: distributor)
+          create(:completed_order_with_totals, line_items_count: 3, distributor: distributor)
         end
 
         let(:current_user) { distributor.owner }


### PR DESCRIPTION
add sort by product name to order_cycle_supplier_totals_by_distributor report rules

#### What? Why?

Closes #9678<!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
I updated the second rule in the report's rules to sort the item by product name. 


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- described on: #9678

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
