### PR TITLE
Comments out and adds pending on flaky examples

### DIFF
--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -381,7 +381,8 @@ describe '
           expect(page).to have_no_selector "tr#li_#{li2.id}"
         end
 
-        it "displays all line items when 'All' is selected from distributor filter" do
+        xit "displays all line items when 'All' is selected from distributor filter" do
+          pending "#9809"
           expect(page).to have_selector "tr#li_#{li2.id}"
           select2_select d1.name, from: "distributor_filter"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
@@ -457,7 +458,8 @@ describe '
           visit_bulk_order_management
         end
 
-        it "allows filters to be used in combination" do
+        xit "allows filters to be used in combination" do
+          pending "#9811"
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
           select2_select oc1.name, from: "order_cycle_filter"
@@ -476,7 +478,8 @@ describe '
           expect(page).to have_selector "tr#li_#{li2.id}"
         end
 
-        it "displays a 'Clear All' button which sets all select filters to 'All'" do
+        xit "displays a 'Clear All' button which sets all select filters to 'All'" do
+          pending "#9810"
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
           select2_select oc1.name, from: "order_cycle_filter"


### PR DESCRIPTION
#### What? Why?

Relates to https://github.com/openfoodfoundation/openfoodnetwork/issues/9812.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We need to get the build green asap, and address the flaky specs separately.

`Pending` assumes that examples will fail, which is not always the case with flaky examples. So, if a pending example passes then that example is reported as failing -> red build...

To prevent this, it was opted for commenting `it` blocks with `xit` instead, but referencing the issue number, with the `pending`.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Consistently green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
