### PR TITLE
Replaces js select2 methods by find/click methods

### DIFF
--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -370,23 +370,25 @@ describe '
         it "displays a select box for distributors, which filters line items by the selected distributor" do
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
-          open_select2 "#s2id_distributor_filter"
+          find("#s2id_distributor_filter").click
           expect(page).to have_selector "div.select2-drop-active ul.select2-results li", text: "All"
           Enterprise.is_distributor.map(&:name).each do |dn|
             expect(page).to have_selector "div.select2-drop-active ul.select2-results li", text: dn
           end
-          close_select2
-          select2_select d1.name, from: "distributor_filter"
+          find(".select2-result-label", text: d1.name.to_s).click
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
         end
 
-        xit "displays all line items when 'All' is selected from distributor filter" do
-          pending "#9809"
+        it "displays all line items when 'All' is selected from distributor filter" do
+          # displays orders from one enterprise only
           expect(page).to have_selector "tr#li_#{li2.id}"
-          select2_select d1.name, from: "distributor_filter"
+          find("#s2id_distributor_filter").click
+          find(".select2-result-label", text: d1.name.to_s).click
           expect(page).to have_no_selector "tr#li_#{li2.id}"
-          select2_select "All", from: "distributor_filter"
+          # displays orders from all enterprises
+          find("#s2id_distributor_filter").click
+          find(".select2-result-label", text: "All").click
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
         end


### PR DESCRIPTION
#### What? Why?

Closes #9809.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Using helper methods like `select2` (which come from `./spec/support/request/web_helper.rb`) seems to introduce flakyness in this example; the approach chosen to improve this was to replace these by `find/click` routines, in separate lines.

**Before this PR**
`./flaky_spec_script.sh 100 ./spec/system/admin/bulk_order_management_spec.rb:352`
 
yields `92 of 100 passed (92%)`

**After this PR**
`./flaky_spec_script.sh 100 ./spec/system/admin/bulk_order_management_spec.rb:352`
 
yields `99 of 100 passed (99%)`


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
