### PR TITLE
Add pointer cursor when hovering a clickable product description

### DIFF
--- a/app/webpacker/css/darkswarm/_shop-product-rows.scss
+++ b/app/webpacker/css/darkswarm/_shop-product-rows.scss
@@ -148,6 +148,7 @@
             overflow: hidden;
             text-overflow: ellipsis;
             margin-bottom: 0.75rem;
+            cursor: pointer;
           }
 
           .product-properties {


### PR DESCRIPTION
#### What? Why?

Closes #9703 

- A product description can be clicked to open a modal and read the whole production description
- However, it is not clear that it is clickable, since the cursor does not change to pointer when hovering the product description
- The solution proposed is to enforce the pointer cursor through the CSS

Before:
<img width="551" alt="image" src="https://user-images.githubusercontent.com/77734864/196582121-a1798d56-c2f3-4c22-b7f6-dda1b0505c07.png">

After:
<img width="498" alt="image" src="https://user-images.githubusercontent.com/77734864/196582216-49ad0a70-dd68-44ec-8e65-4da95bd07974.png">


#### What should we test?
- Visit a shop that contains a product with description
- Hover over the product description
- The cursor should be pointer, not text

#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.
