### PR TITLE
Extracts routing outside it block

### DIFF
--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -190,10 +190,13 @@ describe '
         expect(page).not_to have_selector "#p_#{order.variants.first.product_id}"
       end
 
-      it 'keeps the line item on the order (admin)' do
-        visit spree.admin_orders_path
-        find(".icon-edit").click
-        expect(page).to have_content(line_item.product.name.to_s)
+      context "a deleted line item from a shipped order" do
+        before do
+          login_as_admin_and_visit spree.edit_admin_order_path(order)
+        end
+        it 'keeps the line item on the order (admin)' do
+          expect(page).to have_content(line_item.product.name.to_s)
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Relates #9825

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Not sure it addresses the issue, both failing examples on #9825 were triggering routing within the `it` block.

If I understand correctly, in theory, if a previous routing was not finished, and a new routing is requested the spec spec might fail with this error.

Separating routing requests may help prevent this - a tentative approach.

WSC we get clearer context and specs, and get closer to the [one assertion per it block](https://www.betterspecs.org/#single) practice.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
