### PR TITLE
Fix unit description UI issue on updating a Product having imperial weight (oz)

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -262,8 +262,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
         variant.unit_value  = parseFloat(match[1].replace(",", "."))
         variant.unit_value  = null if isNaN(variant.unit_value)
         if variant.unit_value && product.variant_unit_scale
-          variant_unit_value = variant.unit_value * product.variant_unit_scale
-          variant.unit_value = parseFloat(variant_unit_value.toFixed(8))
+          variant.unit_value = parseFloat(bigDecimal.multiply(variant.unit_value, product.variant_unit_scale, 2))
         variant.unit_description = match[3]
 
   $scope.incrementLimit = ->

--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -262,7 +262,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
         variant.unit_value  = parseFloat(match[1].replace(",", "."))
         variant.unit_value  = null if isNaN(variant.unit_value)
         if variant.unit_value && product.variant_unit_scale
-          variant.unit_value = parseFloat(bigDecimal.multiply(variant.unit_value, product.variant_unit_scale, 2))
+          variant.unit_value = parseFloat(window.bigDecimal.multiply(variant.unit_value, product.variant_unit_scale, 2))
         variant.unit_description = match[3]
 
   $scope.incrementLimit = ->

--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -261,7 +261,9 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
         product = BulkProducts.find product.id
         variant.unit_value  = parseFloat(match[1].replace(",", "."))
         variant.unit_value  = null if isNaN(variant.unit_value)
-        variant.unit_value *= product.variant_unit_scale if variant.unit_value && product.variant_unit_scale
+        if variant.unit_value && product.variant_unit_scale
+          variant_unit_value = variant.unit_value * product.variant_unit_scale
+          variant.unit_value = parseFloat(variant_unit_value.toFixed(8))
         variant.unit_description = match[3]
 
   $scope.incrementLimit = ->

--- a/app/assets/javascripts/admin/services/bulk_products.js.coffee
+++ b/app/assets/javascripts/admin/services/bulk_products.js.coffee
@@ -66,7 +66,7 @@ angular.module("ofn.admin").factory "BulkProducts", (ProductResource, dataFetche
       if variant.unit_value?
         if product.variant_unit_scale
           variant_unit_value = @divideAsInteger variant.unit_value, product.variant_unit_scale
-          parseFloat(bigDecimal.round(variant_unit_value, 2))
+          parseFloat(window.bigDecimal.round(variant_unit_value, 2))
         else
           variant.unit_value
       else

--- a/app/assets/javascripts/admin/services/bulk_products.js.coffee
+++ b/app/assets/javascripts/admin/services/bulk_products.js.coffee
@@ -65,7 +65,8 @@ angular.module("ofn.admin").factory "BulkProducts", (ProductResource, dataFetche
     variantUnitValue: (product, variant) ->
       if variant.unit_value?
         if product.variant_unit_scale
-          @divideAsInteger variant.unit_value, product.variant_unit_scale
+          variant_unit_value = @divideAsInteger variant.unit_value, product.variant_unit_scale
+          parseFloat(variant_unit_value.toFixed(8))
         else
           variant.unit_value
       else

--- a/app/assets/javascripts/admin/services/bulk_products.js.coffee
+++ b/app/assets/javascripts/admin/services/bulk_products.js.coffee
@@ -66,7 +66,7 @@ angular.module("ofn.admin").factory "BulkProducts", (ProductResource, dataFetche
       if variant.unit_value?
         if product.variant_unit_scale
           variant_unit_value = @divideAsInteger variant.unit_value, product.variant_unit_scale
-          parseFloat(variant_unit_value.toFixed(8))
+          parseFloat(bigDecimal.round(variant_unit_value, 2))
         else
           variant.unit_value
       else

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -676,6 +676,15 @@ describe "AdminProductEditCtrl", ->
           unit_description: ''
           unit_value_with_description: "250,5"
 
+      it "rounds off the unit_value upto 8 decimal places and removes the trailing zeroes", ->
+        testProduct = {id: 123, variant_unit_scale: 28.35}
+        testVariant = {unit_value_with_description: "1234.5"}
+        $scope.packVariant(testProduct, testVariant)
+        expect(testVariant).toEqual
+          unit_value: 34998.075
+          unit_description: ''
+          unit_value_with_description: "1234.5"
+
 
     describe "filtering products", ->
       beforeEach ->

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -681,7 +681,7 @@ describe "AdminProductEditCtrl", ->
         testVariant = {unit_value_with_description: "1234.5"}
         $scope.packVariant(testProduct, testVariant)
         expect(testVariant).toEqual
-          unit_value: 34998.075
+          unit_value: 1234.5
           unit_description: ''
           unit_value_with_description: "1234.5"
 

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -517,6 +517,10 @@ describe "AdminProductEditCtrl", ->
 
   describe "submitting products to be updated", ->
     describe "packing products", ->
+      beforeEach ->
+        window.bigDecimal = jasmine.createSpyObj "bigDecimal", ["multiply"]
+        window.bigDecimal.multiply.and.callFake (a, b, c) -> (a * b).toFixed(c)
+
       it "extracts variant_unit_with_scale into variant_unit and variant_unit_scale", ->
         testProduct =
           id: 1
@@ -589,6 +593,8 @@ describe "AdminProductEditCtrl", ->
 
       beforeEach ->
         BulkProducts.products = [testProduct]
+        window.bigDecimal = jasmine.createSpyObj "bigDecimal", ["multiply"]
+        window.bigDecimal.multiply.and.callFake (a, b, c) -> (a * b).toFixed(c)
 
       it "extracts unit_value and unit_description from unit_value_with_description", ->
         testProduct = {id: 123, variant_unit_scale: 1.0}

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -676,14 +676,14 @@ describe "AdminProductEditCtrl", ->
           unit_description: ''
           unit_value_with_description: "250,5"
 
-      it "rounds off the unit_value upto 8 decimal places and removes the trailing zeroes", ->
+      it "rounds off the unit_value upto 2 decimal places", ->
         testProduct = {id: 123, variant_unit_scale: 28.35}
-        testVariant = {unit_value_with_description: "1234.5"}
+        testVariant = {unit_value_with_description: "1234.567"}
         $scope.packVariant(testProduct, testVariant)
         expect(testVariant).toEqual
-          unit_value: 1234.5
+          unit_value: 1234.57
           unit_description: ''
-          unit_value_with_description: "1234.5"
+          unit_value_with_description: "1234.567"
 
 
     describe "filtering products", ->

--- a/spec/javascripts/unit/admin/services/bulk_products_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/bulk_products_spec.js.coffee
@@ -152,10 +152,10 @@ describe "BulkProducts service", ->
       variant = {unit_value: 5}
       expect(BulkProducts.variantUnitValue(product, variant)).toEqual 5000
 
-    it "returns the scaled value rounded off upto 8 decimal points removing the trailing zeroes", ->
+    it "returns the scaled value rounded off upto 2 decimal points", ->
       product = {variant_unit_scale: 28.35}
       variant = {unit_value: 1234.5}
-      expect(BulkProducts.variantUnitValue(product, variant)).toEqual 43.54497354
+      expect(BulkProducts.variantUnitValue(product, variant)).toEqual 43.54
 
     it "returns the unscaled value when the product has no scale", ->
       product = {}

--- a/spec/javascripts/unit/admin/services/bulk_products_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/bulk_products_spec.js.coffee
@@ -152,6 +152,11 @@ describe "BulkProducts service", ->
       variant = {unit_value: 5}
       expect(BulkProducts.variantUnitValue(product, variant)).toEqual 5000
 
+    it "returns the scaled value rounded off upto 8 decimal points removing the trailing zeroes", ->
+      product = {variant_unit_scale: 28.35}
+      variant = {unit_value: 1234.5}
+      expect(BulkProducts.variantUnitValue(product, variant)).toEqual 43.54497354
+
     it "returns the unscaled value when the product has no scale", ->
       product = {}
       variant = {unit_value: 5}

--- a/spec/javascripts/unit/admin/services/bulk_products_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/bulk_products_spec.js.coffee
@@ -3,6 +3,8 @@ describe "BulkProducts service", ->
 
   beforeEach ->
     module "ofn.admin"
+    window.bigDecimal = jasmine.createSpyObj "bigDecimal", ["round"]
+    window.bigDecimal.round.and.callFake (a, b) -> a.toFixed(b)
 
   beforeEach inject (_BulkProducts_, _$httpBackend_) ->
     BulkProducts = _BulkProducts_


### PR DESCRIPTION
#### What? Why?

Closes #9679

##### Screen Recording
[unit_value_issue.webm](https://user-images.githubusercontent.com/62114687/196766985-0dece014-1795-48bd-8517-e3cc6950a685.webm)

##### Solution Proposed
When we create a Product with imperial weight as (oz), column `unit_with_scale` under Product is saved with value `28.35`
It simultaneously creates a Variant  associated with the Product. The variant has a column `unit_value` which is also set to `28.35`

Now in the UI of products page  we see the `unit_description` as `1`. Please refer the ss below
![unit_description](https://user-images.githubusercontent.com/62114687/196768678-0e4ce592-6bc3-4f98-bc91-f83361815e66.png)

Now when user updates this `unit_description` to `1234.5`, following calculation occur

The `unit_value` of Variant is calculated as `unit_description * unit_with_scale ` i.e  `1234.5 * 28.35` that is equal to `34998.075000000004`, this gets saved in the DB

Now again via JS the updated `unit_description` is calculated using below formaula
```
 divideAsInteger: (a, b) ->
      (a * 1000000000) / (b * 1000000000)
```
this code is present in `app/assets/javascripts/admin/services/bulk_products.js.coffee`
which returns
 
```
(34998.075000000004 * 1000000000) / (28.35 * 1000000000) = 
1234.5000000000002
```

Hence to resolve the above issue, the multiplication and division we do, result is being rounded off upto 8 deciaml places and then trailing zeroes are being removed i.e `parseFloat(number.toFixed(8))`
Now the calculation looks like
The `unit_value` of Variant is calculated as `unit_description * unit_with_scale ` i.e  `1234.5 * 28.35` = `34998.075`

`unit_description` is calculated as
```
(34998.075 * 1000000000) / (28.35 * 1000000000) =
1234.5
```

#### What should we test?
 - Create or edit a product with weight in oz
 - Enter 1234.5 or 1234.6
 - Save

#### Release notes
Changelog Category: User facing changes


#### Dependencies
No dependencies
