### PR TITLE
Prevent users from changing API keys for others

### DIFF
--- a/app/controllers/spree/api_keys_controller.rb
+++ b/app/controllers/spree/api_keys_controller.rb
@@ -32,7 +32,7 @@ module Spree
     def load_object
       @user ||= find_user
       if @user
-        authorize! params[:action].to_sym, @user
+        authorize! :update, @user
       else
         redirect_to main_app.login_path
       end

--- a/spec/controllers/spree/api_keys_controller_spec.rb
+++ b/spec/controllers/spree/api_keys_controller_spec.rb
@@ -9,6 +9,7 @@ describe Spree::ApiKeysController, type: :controller, performance: true do
   include ControllerRequestsHelper
 
   let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
   let(:redirect_path) { "#{spree.account_path}#/developer_settings" }
 
   before do
@@ -19,6 +20,15 @@ describe Spree::ApiKeysController, type: :controller, performance: true do
     it "creates a new api key" do
       expect { spree_post :create }.to change { user.reload.spree_api_key }
       expect(user.spree_api_key).to be_present
+    end
+
+    it "denies creating a new api key for other user" do
+      expect {
+        spree_post :create, id: other_user.id
+        other_user.reload
+      }.to_not change {
+        other_user.spree_api_key
+      }
     end
 
     it "redirects to the api keys tab on account page " do


### PR DESCRIPTION

#### What? Why?

It was checking for the permission to create a user which everyone can do. Now it's checking for updating that particular user and doesn't allow generating new keys for other users any more.

This would have been an inconvenience but not a big security issue because you can't view the key of another user.



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Edit a user as super admin and allow to view and change API keys.
- Log in as that user and generate a new key.
- You should be able to see a new key.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
