### PR TITLE
Brings back rspec_retry; Creates helper method for flaky spec #9811

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,6 +153,7 @@ group :test, :development do
   gem 'knapsack'
   gem 'letter_opener', '>= 1.4.1'
   gem 'rspec-rails', ">= 3.5.2"
+  gem 'rspec-retry'
   gem 'rswag-specs'
   gem 'shoulda-matchers'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -592,6 +592,8 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.10.3)
     rswag-api (2.6.0)
       railties (>= 3.1, < 7.1)
@@ -858,6 +860,7 @@ DEPENDENCIES
   roadie-rails
   roo
   rspec-rails (>= 3.5.2)
+  rspec-retry
   rswag-api
   rswag-specs
   rswag-ui

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -11,6 +11,7 @@ require 'view_component/test_helpers'
 
 require_relative "../config/environment"
 require 'rspec/rails'
+require 'rspec/retry'
 require 'capybara'
 require 'paper_trail/frameworks/rspec'
 require "factory_bot_rails"
@@ -57,6 +58,9 @@ RSpec.configure do |config|
   # automatically. This will be the default behavior in future versions of
   # rspec-rails.
   config.infer_base_class_for_anonymous_controllers = false
+
+  # Show retries in test output
+  config.verbose_retry = true
 
   # Force colored output, whether or not the output is a TTY
   config.color_mode = :on

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -127,6 +127,11 @@ module WebHelper
     page.find(:css, 'body').click
   end
 
+  def click_on_select2(value, options)
+    find("#s2id_#{options[:from]}").click
+    find(:css, ".select2-result-label", text: options[:select_text] || value).click
+  end
+
   def tomselect_search_and_select(value, options)
     tomselect_wrapper = page.find("[name='#{options[:from]}']").sibling(".ts-wrapper")
     tomselect_wrapper.find(".ts-control").click

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -473,7 +473,7 @@ describe '
           visit_bulk_order_management
         end
 
-        it "allows filters to be used in combination" do
+        it "allows filters to be used in combination", retry: 2 do
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
           click_on_select2 oc1.name, from: "order_cycle_filter"
@@ -492,7 +492,7 @@ describe '
           expect(page).to have_selector "tr#li_#{li2.id}"
         end
 
-        it "displays a 'Clear All' button which sets all select filters to 'All'" do
+        it "displays a 'Clear All' button which sets all select filters to 'All'", retry: 2 do
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
           click_on_select2 oc1.name, from: "order_cycle_filter"

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -476,24 +476,18 @@ describe '
         it "allows filters to be used in combination" do
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
-          find("#s2id_order_cycle_filter").click
-          find(".select2-result-label", text: oc1.name.to_s).click
+          click_on_select2 oc1.name, from: "order_cycle_filter"
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
-          find("#s2id_distributor_filter").click
-          find(".select2-result-label", text: d1.name.to_s).click
-          find("#s2id_supplier_filter").click
-          find(".select2-result-label", text: s1.name.to_s).click
+          click_on_select2 d1.name, from: "distributor_filter"
+          click_on_select2 s1.name, from: "supplier_filter"
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
-          find("#s2id_distributor_filter").click
-          find(".select2-result-label", text: d2.name.to_s).click
-          find("#s2id_supplier_filter").click
-          find(".select2-result-label", text: s2.name.to_s).click
+          click_on_select2 d2.name, from: "distributor_filter"
+          click_on_select2 s2.name, from: "supplier_filter"
           expect(page).to have_no_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
-          find("#s2id_order_cycle_filter").click
-          find(".select2-result-label", text: oc2.name.to_s).click
+          click_on_select2 oc2.name, from: "order_cycle_filter"
           expect(page).to have_no_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
         end
@@ -501,12 +495,9 @@ describe '
         it "displays a 'Clear All' button which sets all select filters to 'All'" do
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
-          find("#s2id_order_cycle_filter").click
-          find(".select2-result-label", text: oc1.name.to_s).click
-          find("#s2id_distributor_filter").click
-          find(".select2-result-label", text: d1.name.to_s).click
-          find("#s2id_supplier_filter").click
-          find(".select2-result-label", text: s1.name.to_s).click
+          click_on_select2 oc1.name, from: "order_cycle_filter"
+          click_on_select2 d1.name, from: "distributor_filter"
+          click_on_select2 s1.name, from: "supplier_filter"
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
           expect(page).to have_button "Clear All"

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -473,33 +473,40 @@ describe '
           visit_bulk_order_management
         end
 
-        xit "allows filters to be used in combination" do
-          pending "#9811"
+        it "allows filters to be used in combination" do
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
-          select2_select oc1.name, from: "order_cycle_filter"
+          find("#s2id_order_cycle_filter").click
+          find(".select2-result-label", text: oc1.name.to_s).click
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
-          select2_select d1.name, from: "distributor_filter"
-          select2_select s1.name, from: "supplier_filter"
+          find("#s2id_distributor_filter").click
+          find(".select2-result-label", text: d1.name.to_s).click
+          find("#s2id_supplier_filter").click
+          find(".select2-result-label", text: s1.name.to_s).click
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
-          select2_select d2.name, from: "distributor_filter"
-          select2_select s2.name, from: "supplier_filter"
+          find("#s2id_distributor_filter").click
+          find(".select2-result-label", text: d2.name.to_s).click
+          find("#s2id_supplier_filter").click
+          find(".select2-result-label", text: s2.name.to_s).click
           expect(page).to have_no_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
-          select2_select oc2.name, from: "order_cycle_filter"
+          find("#s2id_order_cycle_filter").click
+          find(".select2-result-label", text: oc2.name.to_s).click
           expect(page).to have_no_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
         end
 
-        xit "displays a 'Clear All' button which sets all select filters to 'All'" do
-          pending "#9810"
+        it "displays a 'Clear All' button which sets all select filters to 'All'" do
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
-          select2_select oc1.name, from: "order_cycle_filter"
-          select2_select d1.name, from: "distributor_filter"
-          select2_select s1.name, from: "supplier_filter"
+          find("#s2id_order_cycle_filter").click
+          find(".select2-result-label", text: oc1.name.to_s).click
+          find("#s2id_distributor_filter").click
+          find(".select2-result-label", text: d1.name.to_s).click
+          find("#s2id_supplier_filter").click
+          find(".select2-result-label", text: s1.name.to_s).click
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
           expect(page).to have_button "Clear All"


### PR DESCRIPTION
#### What? Why?

**The problem**

Some specs are flaky because the behavior of the app is flaky itself ([example below](https://github.com/openfoodfoundation/openfoodnetwork/pull/9831#issuecomment-1285312478)).

We've figured the best way is address this and avoid a flood of flaky specs is to bring back `rspec_retry` and mark the flaky example with `retry:`.

**Which settings should we choose?**

Here I've chosen to mark the two examples in this PR with `retry: 2, retry_wait: 2`. 

If we're conservative and consider a fail rate of 0.1, then the probability of failing a second rerun should be 0.1^2 (1%). With a default wait time between re-runs of 2s this would add 4 seconds wait time (I think the wait time is added each time the spec is ran, also at the first attempt) and the spec run time. 

Something to keep in mind is that if these settings are changed on the globally (through a global variable or on `base_spec_helper.rb`) then the retries will run on **all** failing specs - this is a bug, mentioned on the gem documentation - and something we which we want to avoid. I've also tested this locally and could confirm it.

The PR also creates a click_select2 helper method to improve flakiness (issue #9811 and #9810).


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Brings back `rspec_retry`, marks flaky specs with retry option.
Replaces the helper method with more find/click routine.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- we should get a consistent, green build
- only the specs marked with `retry: 2, retry_wait: 2` should re-run, when failing, waiting 2 seconds preceding each retry.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
