### PR TITLE
Format reports as list, even if only one sub-type available

### DIFF
--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -15,6 +15,5 @@
           %td
             - if report_subtypes.empty?
               - name = I18n.t(:name, scope: [:admin, :reports, report_type])
-              - url = main_app.admin_report_url(report_type: report_type)
-              - report_subtypes = [[name, url]]
+              - report_subtypes = [[name, nil]]
             = render partial: "report_subtype", locals: { report_subtypes: report_subtypes, report_type: report_type }

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -14,7 +14,9 @@
             = I18n.t(:name, scope: [:admin, :reports, report_type])
           %td
             - if report_subtypes.empty?
-              - name = I18n.t(:name, scope: [:admin, :reports, report_type])
-              - url = main_app.admin_report_url(report_type: report_type)
-              = link_to name, url
+              %ul{style: "margin-left: 12pt"}
+                %li
+                  - name = I18n.t(:name, scope: [:admin, :reports, report_type])
+                  - url = main_app.admin_report_url(report_type: report_type)
+                  = link_to name, url
             = render partial: "report_subtype", locals: { report_subtypes: report_subtypes, report_type: report_type }

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -14,9 +14,7 @@
             = I18n.t(:name, scope: [:admin, :reports, report_type])
           %td
             - if report_subtypes.empty?
-              %ul{style: "margin-left: 12pt"}
-                %li
-                  - name = I18n.t(:name, scope: [:admin, :reports, report_type])
-                  - url = main_app.admin_report_url(report_type: report_type)
-                  = link_to name, url
+              - name = I18n.t(:name, scope: [:admin, :reports, report_type])
+              - url = main_app.admin_report_url(report_type: report_type)
+              - report_subtypes = [[name, url]]
             = render partial: "report_subtype", locals: { report_subtypes: report_subtypes, report_type: report_type }


### PR DESCRIPTION
#### What? Why?

Even if there is only one sub-report available for a certain report type, it will now be displayed as a list to make it look like all the other listed reports.

Before:
![image](https://user-images.githubusercontent.com/1790176/197642797-c8c5d6a1-44a8-495c-b82e-684560cf01fe.png)

After:
![image](https://user-images.githubusercontent.com/1790176/197642912-e8ac533e-f8f7-4741-b9cd-d17f9152e501.png)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit /admin/reports page.
- Make sure all reports are displayed as a list.
- Make sure everything is well aligned.
- Make sure all reports are there (some will only show as super admin).
- Make sure all the links to reports are working.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
