### PR TITLE
Corrupt image files are accepted, processable_image validation added : Close #9863

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -96,14 +96,11 @@ class Enterprise < ApplicationRecord
   has_one_attached :promo_image
   has_one_attached :terms_and_conditions
 
-  validates :logo,
-             processable_image: true, # added processable_image: true
-             content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}  
+  validates :logo, processable_image: true,
+                   content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
+  validates :promo_image, processable_image: true,
+                          content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
 
-  validates :promo_image, 
-              processable_image: true, # added processable_image: true
-              content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}  
-              
   validates :terms_and_conditions, content_type: {
     in: "application/pdf",
     message: I18n.t(:enterprise_terms_and_conditions_type_error),

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -96,8 +96,8 @@ class Enterprise < ApplicationRecord
   has_one_attached :promo_image
   has_one_attached :terms_and_conditions
 
-  validates :logo, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
-  validates :promo_image, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
+  validates :logo, processable_image: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} # added processable_image: true
+  validates :promo_image, processable_image: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} # added processable_image: true
   validates :terms_and_conditions, content_type: {
     in: "application/pdf",
     message: I18n.t(:enterprise_terms_and_conditions_type_error),

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -96,8 +96,14 @@ class Enterprise < ApplicationRecord
   has_one_attached :promo_image
   has_one_attached :terms_and_conditions
 
-  validates :logo, processable_image: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} # added processable_image: true
-  validates :promo_image, processable_image: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} # added processable_image: true
+  validates :logo,
+             processable_image: true, # added processable_image: true
+             content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}  
+
+  validates :promo_image, 
+              processable_image: true, # added processable_image: true
+              content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}  
+              
   validates :terms_and_conditions, content_type: {
     in: "application/pdf",
     message: I18n.t(:enterprise_terms_and_conditions_type_error),

--- a/app/models/enterprise_group.rb
+++ b/app/models/enterprise_group.rb
@@ -37,13 +37,11 @@ class EnterpriseGroup < ApplicationRecord
   has_one_attached :logo
   has_one_attached :promo_image
 
-  validates :logo, 
-              processable_image: true,  # added processable_image: true,
-              content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
+  validates :logo, processable_image: true,
+                   content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
 
-  validates :promo_image, 
-              processable_image: true, # added processable_image: true
-              content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} 
+  validates :promo_image, processable_image: true,
+                          content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
 
   scope :by_position, -> { order('position ASC') }
   scope :on_front_page, -> { where(on_front_page: true) }

--- a/app/models/enterprise_group.rb
+++ b/app/models/enterprise_group.rb
@@ -37,8 +37,13 @@ class EnterpriseGroup < ApplicationRecord
   has_one_attached :logo
   has_one_attached :promo_image
 
-  validates :logo, processable_image: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} # added processable_image: true,
-  validates :promo_image, processable_image: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} # added processable_image: true
+  validates :logo, 
+              processable_image: true,  # added processable_image: true,
+              content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
+
+  validates :promo_image, 
+              processable_image: true, # added processable_image: true
+              content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} 
 
   scope :by_position, -> { order('position ASC') }
   scope :on_front_page, -> { where(on_front_page: true) }

--- a/app/models/enterprise_group.rb
+++ b/app/models/enterprise_group.rb
@@ -37,8 +37,8 @@ class EnterpriseGroup < ApplicationRecord
   has_one_attached :logo
   has_one_attached :promo_image
 
-  validates :logo, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
-  validates :promo_image, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
+  validates :logo, processable_image: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} # added processable_image: true,
+  validates :promo_image, processable_image: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} # added processable_image: true
 
   scope :by_position, -> { order('position ASC') }
   scope :on_front_page, -> { where(on_front_page: true) }

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -18,7 +18,11 @@ module Spree
 
     has_one_attached :attachment
 
-    validates :attachment, attached: true, processable_image: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} # added processable_image: true,
+    validates :attachment, 
+                attached: true, 
+                processable_image: true, # added processable_image: true
+                content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}  
+                
     validate :no_attachment_errors
 
     def variant(name)

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -18,7 +18,7 @@ module Spree
 
     has_one_attached :attachment
 
-    validates :attachment, attached: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
+    validates :attachment, attached: true, processable_image: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z} # added processable_image: true,
     validate :no_attachment_errors
 
     def variant(name)

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -18,11 +18,10 @@ module Spree
 
     has_one_attached :attachment
 
-    validates :attachment, 
-                attached: true, 
-                processable_image: true, # added processable_image: true
-                content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}  
-                
+    validates :attachment, attached: true,
+                           processable_image: true,
+                           content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}
+
     validate :no_attachment_errors
 
     def variant(name)


### PR DESCRIPTION
#### What? Why?

Close #9863

A user can upload files which are named like example.jpg but are not valid images, upload succeeds but the image can't be displayed.




#### What should we test?
Upload an invalid image, validation will generate an error

 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 

processable_image validation added




#### Dependencies
None



#### Documentation updates
One would needs to look at the error message that should be generated, in case an invalid image is used.