### PR TITLE
Build: use the latest version of `actions/upload-artifact`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Archive failed tests screenshots
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: failed-tests-screenshots
           path: tmp/capybara/screenshots/*.png

--- a/.github/workflows/mapi.yml
+++ b/.github/workflows/mapi.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Archive HTML report
     - name: Archive Mayhem for API report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: mapi-report
         path: mapi.html


### PR DESCRIPTION
#### What? Why?

```
Node.js 12 actions are deprecated.
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: actions/upload-artifact
```

Context: https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/3319769563

#### What should we test?
Green build is enough

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
