### PR TITLE
Remove outdated ignoring of Paperclip columns

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -16,19 +16,6 @@ class Enterprise < ApplicationRecord
     large: { resize_to_fill: [1200, 260] },
   }.freeze
 
-  self.ignored_columns = %i(terms_and_conditions_file_name
-                            terms_and_conditions_content_type
-                            terms_and_conditions_file_size
-                            terms_and_conditions_updated_at
-                            logo_file_name
-                            logo_content_type
-                            logo_file_size
-                            logo_updated_at
-                            promo_image_file_name
-                            promo_image_content_type
-                            promo_image_file_size
-                            promo_image_updated_at)
-
   searchable_attributes :sells, :is_primary_producer
   searchable_associations :properties
   searchable_scopes :is_primary_producer, :is_distributor, :is_hub, :activated, :visible,

--- a/app/models/enterprise_group.rb
+++ b/app/models/enterprise_group.rb
@@ -5,15 +5,6 @@ require 'open_food_network/locking'
 class EnterpriseGroup < ApplicationRecord
   include PermalinkGenerator
 
-  self.ignored_columns = %i(logo_file_name
-                            logo_content_type
-                            logo_file_size
-                            logo_updated_at
-                            promo_image_file_name
-                            promo_image_content_type
-                            promo_image_file_size
-                            promo_image_updated_at)
-
   acts_as_list
 
   has_and_belongs_to_many :enterprises, join_table: 'enterprise_groups_enterprises'

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -9,13 +9,6 @@ module Spree
       large: { resize_to_limit: [600, 600] },
     }.freeze
 
-    self.ignored_columns = %i(attachment_file_name
-                              attachment_content_type
-                              attachment_file_size
-                              attachment_updated_at
-                              attachment_width
-                              attachment_height)
-
     has_one_attached :attachment
 
     validates :attachment, attached: true, content_type: %r{\Aimage/(png|jpeg|gif|jpg|svg\+xml|webp)\Z}

--- a/app/models/terms_of_service_file.rb
+++ b/app/models/terms_of_service_file.rb
@@ -5,11 +5,6 @@ class TermsOfServiceFile < ApplicationRecord
 
   validates :attachment, attached: true
 
-  self.ignored_columns = %i(attachment_file_name
-                            attachment_content_type
-                            attachment_file_size
-                            attachment_updated_at)
-
   # The most recently uploaded file is the current one.
   def self.current
     order(:id).last


### PR DESCRIPTION
Those columns have been removed from the database and don't need to be ignored any more.

#### What? Why?

Follow up from:

* #9730
* #9738

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We should have removed this code when we removed the columns but I overlooked that when reviewing those pull requests. It was quicker for me to do it than open a new issue.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Upload a product image and it should display.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
