### PR TITLE
Adds ignore tag for pull_request dependabot branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
   pull_request:
+    branches-ignore:    
+      - 'dependabot/*'
 
 env:
   DISABLE_KNAPSACK: true


### PR DESCRIPTION
#### What? Why?

Closes #9882

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds an ignore tag for dependabot PRs, as suggested [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-branches-and-tags) and discussed [here](https://openfoodnetwork.slack.com/archives/C2GQ45KNU/p1666775836518709?thread_ts=1666575671.345089&cid=C2GQ45KNU).

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build.
- Dependabot PRs should run the same jobs as any other PRs


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Adds ignore tag for pull_request dependabot branches
