### PR TITLE
Excludes build triggers using /** syntax for branch pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   workflow_dispatch:
   push:
-  pull_request:
     branches-ignore:    
-      - 'dependabot/*'
+      - 'dependabot/**'
+  pull_request:
 
 env:
   DISABLE_KNAPSACK: true


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/9882.
Replaces #9883.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- Using the `/*` syntax did not work; going for  `/**`
- setting the exclusion for push, instead of pull-requests, as suggested [on the previous review](https://github.com/openfoodfoundation/openfoodnetwork/pull/9883#discussion_r1006276606).

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build.
- Dependabot PRs should run the same jobs as any other PRs


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Excludes push request for dependabot using /** syntax

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
