### PR TITLE
Small improvements on `script/rspec-slow-repeat` file

### DIFF
--- a/script/rspec-slow-repeat
+++ b/script/rspec-slow-repeat
@@ -19,13 +19,11 @@ passed=0
 # Check via uname the environment we are running in to get the number of cores
 if [[ "`uname`" == "Darwin" ]]; then
   processors="`sysctl -n hw.ncpu.`"
-  env="mac"
 else
   processors="`cat /proc/cpuinfo | grep -c processor`"
-  env="linux"
 fi
 
-echo "Running $n times on a $env with $processors cores"
+echo "Running $n times with $processors cores"
 
 for i in `seq $processors`; do
   yes > /dev/null &

--- a/script/rspec-slow-repeat
+++ b/script/rspec-slow-repeat
@@ -15,7 +15,17 @@ fi
 
 n="$1"
 passed=0
-processors="`cat /proc/cpuinfo | grep -c processor`"
+
+# Check via uname the environment we are running in to get the number of cores
+if [[ "`uname`" == "Darwin" ]]; then
+  processors="`sysctl -n hw.ncpu.`"
+  env="mac"
+else
+  processors="`cat /proc/cpuinfo | grep -c processor`"
+  env="linux"
+fi
+
+echo "Running $n times on a $env with $processors cores"
 
 for i in `seq $processors`; do
   yes > /dev/null &

--- a/script/rspec-slow-repeat
+++ b/script/rspec-slow-repeat
@@ -25,6 +25,9 @@ fi
 
 echo "Running $n times with $processors cores"
 
+# The purpose here is to occupy the CPU (yes command is not multi-threaded and it occupies only one core)
+# Start one process for each core, and then simulating a very busy CI environment with a 100% CPU load
+# increasing the chance of race conditions when executing specs.
 for i in `seq $processors`; do
   yes > /dev/null &
 done

--- a/script/rspec-slow-repeat
+++ b/script/rspec-slow-repeat
@@ -10,7 +10,12 @@
 function finish() {
   echo "Exiting..."
   killall yes
-  exit 0
+  if [ "$pass_rate" -lt 100 ]; then
+    echo "Check tmp/rspec.log for details."
+    exit 1
+  else
+    exit 0
+  fi
 }
 
 trap finish SIGINT

--- a/script/rspec-slow-repeat
+++ b/script/rspec-slow-repeat
@@ -7,6 +7,14 @@
 # You can use the resulting pass rate to asses if your code changes fixed it
 # or not. In the end I would run a spec 100 times to be sure it's stable.
 
+function finish() {
+  echo "Exiting..."
+  killall yes
+  exit 0
+}
+
+trap finish SIGINT
+
 if [ "$#" -lt 1 ]; then
   echo "Usage:   $0 <n> [rspec params]"
   echo "Example: $0 30 spec/system/admin/order_cycles/simple_spec.rb:202"
@@ -44,7 +52,7 @@ for i in `seq "$n"`; do
   fi
 done
 
-killall yes
-
 pass_rate="$(( passed * 100 / n))"
 echo "$passed of $n passed ($pass_rate%)"
+
+finish

--- a/script/rspec-slow-repeat
+++ b/script/rspec-slow-repeat
@@ -9,7 +9,7 @@
 
 function finish() {
   echo "Exiting..."
-  killall yes
+  pkill -P $$
   if [ "$pass_rate" -lt 100 ]; then
     echo "Check tmp/rspec.log for details."
     exit 1


### PR DESCRIPTION
#### What? Why?

 - `/proc/cpuinfo` is not available on Darwin arch (ie. mac) 


#### What should we test?
 - run `script/rspec-slow-repeat` on both linux and mac. Should work. 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
