### PR TITLE
Wraps expectation on within block

### DIFF
--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -714,7 +714,9 @@ describe '
     input = find(".flatpickr-calendar.open .flatpickr-minute")
     input.send_keys datetime.strftime("%M").to_s.strip
     input.send_keys :enter
-    expect(page).to have_content "You have unsaved changes"
+    within "#save-bar" do
+      expect(page).to have_content "You have unsaved changes"
+    end
   end
 
   it "deleting an order cycle" do


### PR DESCRIPTION
#### What? Why?

Closes #9805

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The `#save-bar` or similar warnings appearing on the bottom of the page seem to account for some flaky specs. When running in headless mode, the bar is not really visible, but the assertion usually works.

One option would be to maximize the window before the assertion, with `page.windows[0].maximize`. This, however, still did not make the save bar visible.

The chosen approach was rather to "guide" capybara into the the `#save-bar` element, and look for the content within.

Got `100 of 100 passed (100%)` locally :green_circle: 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
