### PR TITLE
Changes click method making it overlap-safe

### DIFF
--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -319,7 +319,7 @@ describe '
 
       it "creating a variant with unit value is: '120g' and 'on_demand' checked" do
         within "tr#v_#{Spree::Variant.second.id}" do
-          page.find(".add-variant").click
+          page.find(".add-variant").trigger("click")
         end
 
         within "tr#v_-1" do


### PR DESCRIPTION
#### What? Why?

Closes #9894

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The example was failing probably because the toggling of the variant line was not occurring quickly enough. We were getting an error due to overlap of elements.

Following the [recommendation in the error](https://github.com/openfoodfoundation/openfoodnetwork/issues/9894#issue-1425412915), this PR replaces the click method by the overlap-safe method `.trigger("click")`.

Pass rate was `100%` locally :green_circle: 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
