### PR TITLE
[9845] Make checkout terms and conditions label clickable

### DIFF
--- a/app/views/checkout/_platform_terms_of_service.html.haml
+++ b/app/views/checkout/_platform_terms_of_service.html.haml
@@ -1,4 +1,10 @@
 %p
-  %input{ type: "checkbox", id: "accept_terms", ng: { model: "platform_tos_accepted", init: "platform_tos_accepted = #{platform_tos_already_accepted?}" } }
-  %label.small{for: "platform_tos_accepted"}
+  %input{ type: "checkbox",
+    id: "accept_terms",
+    ng: {
+      model: "platform_tos_accepted",
+      init: "platform_tos_accepted = #{platform_tos_already_accepted?}"
+    }
+  }
+  %label.small{for: "accept_terms"}
     = t(".message_html", tos_link: link_to_platform_terms)


### PR DESCRIPTION
#### What? Why?

Closes #9845 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The `for` attribute on the `label` component did not match the `id` attribute on the `input`. As a result, the `label` was incorrectly associated with the input and a click of the label did not trigger a click on the checkbox. This is a common UX pattern for other checkbox input/label combinations in the checkout flow.

See https://www.geeksforgeeks.org/how-to-create-an-html-checkbox-with-a-clickable-label/ for more information on making a checkboxes label clickable.



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit the checkout page on service that requires terms and conditions to be accepted when checking out.
- Ensure the terms and conditions need at the bottom of the checkout page show
- Ensure that clicking the checkbox still works
- Ensure that the link in the terms and conditions label still work
- Ensure clicking the label now checks the terms and conditions box

#### Release notes

<!-- Please select one for your PR and delete the other. -->

User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Make checkout terms and conditions label clickable