### PR TITLE
Wraps success message around within block; adds retry option

### DIFF
--- a/spec/system/admin/shipping_methods_spec.rb
+++ b/spec/system/admin/shipping_methods_spec.rb
@@ -103,7 +103,7 @@ describe 'shipping methods' do
       login_as enterprise_user
     end
 
-    it "creating a shipping method" do
+    it "creating a shipping method", retry: 2 do
       visit admin_enterprises_path
       within("#e_#{distributor1.id}") { click_link 'Settings' }
       within(".side_menu") do
@@ -130,7 +130,9 @@ describe 'shipping methods' do
       end
       click_button "Create"
 
-      expect(page).to have_content 'Shipping Method "Teleport" has been successfully created!'
+      within ".flash-container" do
+        expect(page).to have_content 'Shipping Method "Teleport" has been successfully created!'
+      end
       expect(page).to have_content "Editing Shipping Method"
 
       expect(first('tags-input .tag-list ti-tag-item')).to have_content "local"


### PR DESCRIPTION
#### What? Why?

Closes #9902 - first attempt was [here](https://github.com/openfoodfoundation/openfoodnetwork/commit/14955ac8ca6fe70a580699f6e9df1bbef9074c6c).

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- wraps the flash message around a within block
- adds the `retry: 2` option

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category:  Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
