### PR TITLE
Adds retry: 2 option

### DIFF
--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -706,7 +706,7 @@ describe '
     end
   end
 
-  it "modify the minute of a order cycle with the keyboard, check that the modifications are taken into account" do
+  it "modify the minute of a order cycle with the keyboard, check that the modifications are taken into account", retry: 2 do
     order_cycle = create(:simple_order_cycle, name: "Translusent Berries")
     login_as_admin_and_visit admin_order_cycles_path
     find("#oc#{order_cycle.id}_orders_close_at").click


### PR DESCRIPTION
#### What? Why?

Closes #9805

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I've tried changing window sizes with on the spec itself with page.current_window.resize_to(2048, 1024). I could verify the change is effective but I the banner still was not visible. The spec passed in any case, so I have no further suggestions on this one.

Added the `retry: 2` as a safeguard, it seems unlikely to fail twice in a row.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
