### PR TITLE
[Product Import] Wrong error message when shipping category does not match predefined shipping categories

### DIFF
--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -299,7 +299,7 @@ module ProductImport
         entry.public_send("#{type}_category_id=", index[category])
       else
         mark_as_invalid(entry, attribute: "#{type}_category",
-                               error: I18n.t('admin.product_import.model.not_found'))
+                               error: I18n.t('admin.product_import.model.category_not_found'))
       end
     end
 

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -68,7 +68,7 @@ module ProductImport
 
     def invalid_attributes
       invalid_attrs = {}
-      errors = @product_validations ? self.errors.messages.merge(@product_validations.messages) : self.errors.messages
+      errors = @product_validations ? @product_validations.messages.merge(self.errors.messages) : self.errors.messages
       errors.each do |attr, message|
         invalid_attrs[attr.to_s] = "#{attr.to_s.capitalize} #{message.first}"
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -706,6 +706,7 @@ en:
         conditional_blank: can't be blank if unit_type is blank
         no_product: did not match any products in the database
         not_found: not found in database
+        category_not_found: doesn't match allowed categories. See the correct categories to choose from on the product import page, or check that there's no mispelling.
         not_updatable: cannot be updated on existing products via product import
         blank: can't be blank
         products_no_permission: you do not have permission to manage products for this enterprise

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -706,7 +706,7 @@ en:
         conditional_blank: can't be blank if unit_type is blank
         no_product: did not match any products in the database
         not_found: not found in database
-        category_not_found: doesn't match allowed categories. See the correct categories to choose from on the product import page, or check that there's no mispelling.
+        category_not_found: doesn't match allowed categories. See the correct categories to choose from on the product import page, or check that there's no misspelling.
         not_updatable: cannot be updated on existing products via product import
         blank: can't be blank
         products_no_permission: you do not have permission to manage products for this enterprise

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -272,6 +272,26 @@ describe ProductImport::ProductImporter do
     end
   end
 
+  describe "when shipping category is not found" do
+    let(:csv_data) {
+      CSV.generate do |csv|
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type",
+                "variant_unit_name", "on_demand", "shipping_category"]
+        csv << ["Shipping Test", enterprise.name, "Vegetables", "5", "3.20", "500", "g", "", nil,
+                "not_found"]
+      end
+    }
+    let(:importer) { import_data csv_data }
+
+    it "raises an error" do
+      importer.validate_entries
+      entries = JSON.parse(importer.entries_json)
+      error = entries['2']['errors']['shipping_category'] 
+
+      expect(error).to include "Shipping_category doesn't match allowed categories"
+    end
+  end
+
   describe "when enterprises are not valid" do
     let(:csv_data) {
       CSV.generate do |csv|

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -286,7 +286,7 @@ describe ProductImport::ProductImporter do
     it "raises an error" do
       importer.validate_entries
       entries = JSON.parse(importer.entries_json)
-      error = entries['2']['errors']['shipping_category'] 
+      error = entries['2']['errors']['shipping_category']
 
       expect(error).to include "Shipping_category doesn't match allowed categories"
     end


### PR DESCRIPTION
#### What? Why?
Closes #9781

> When importing a .csv with products with shipping categories:
> - that contains a mispelling in the name: for instance "Default " (with one extra space)
> - or that doesn't match one of the predefined categories (see the list below)
> The error displayed to the user is: "- Shipping_category can't be blank ", whereas the category isn't blank.
> This is misleading for the user, and they contact us asking why they have this error whereas the shipping category is filled in.

- The reason why the error message is "can't be blank" is because of [new product validations](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/app/models/product_import/entry_validator.rb#L343-L348)
- And since product validations are proritized over "common" attributes validations (see below), the "can't be blank" error message is displayed to the user
https://github.com/openfoodfoundation/openfoodnetwork/blob/68b2e48fb3bcce2899573d3a341b62eb7b689235/app/models/product_import/spreadsheet_entry.rb#L71

- My solution was to swap the priorization, so the custom error message can be displayed
  - I didn't find any side effects in this solution, so any thoughts about it are welcome!

Before:
<img width="1234" alt="image" src="https://user-images.githubusercontent.com/77734864/198904845-b8125a00-1e29-41a1-a639-f6198a9e92b7.png">

After:
<img width="1347" alt="image" src="https://user-images.githubusercontent.com/77734864/198892378-3f3cd977-cc1a-4303-a205-52334e23e7fa.png">


#### What should we test?

- Visit `/admin/product_import`

1. New product import
- Upload a .csv with a non existing product AND wrong/mispelled shipping category. Example:  [Bug-shipping-error-new-product.csv](https://github.com/openfoodfoundation/openfoodnetwork/files/9896986/Bug-shipping-error-new-product.csv)
- Compare error message with the expected one (Shipping_category doesn't match allowed categories[...])

2. New variant import
- Same as before, but with a new variant import.

#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.
