### PR TITLE
Create cdn_url method to handle image content direct access

### DIFF
--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -40,7 +40,7 @@ module Spree
 
       return unless attachment.attached?
 
-      variant(size).blob.url
+      variant(size).blob.processed.url
     end
 
     # if there are errors from the plugin, then add a more meaningful message

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -36,9 +36,11 @@ module Spree
     end
 
     def cdn_url(size)
-      return url(size) if ENV["S3_BUCKET"].nil?
+      return url(size) unless cdn_activated?
 
-      variant(size).service_url
+      return unless attachment.attached?
+
+      variant(size).blob.url
     end
 
     # if there are errors from the plugin, then add a more meaningful message
@@ -51,6 +53,10 @@ module Spree
       end
 
       false
+    end
+
+    def cdn_activated?
+      Rails.application.config.active_storage.service != :local
     end
   end
 end

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -35,6 +35,12 @@ module Spree
       Rails.application.routes.url_helpers.url_for(variant(size))
     end
 
+    def cdn_url(size)
+      return url(size) if ENV["S3_BUCKET"].nil?
+
+      variant(size).service_url
+    end
+
     # if there are errors from the plugin, then add a more meaningful message
     def no_attachment_errors
       return if errors[:attachment].empty?

--- a/app/serializers/api/admin/product_serializer.rb
+++ b/app/serializers/api/admin/product_serializer.rb
@@ -13,11 +13,11 @@ module Api
       has_one :master, serializer: Api::Admin::VariantSerializer
 
       def image_url
-        object.images.first&.url(:product) || "/noimage/product.png"
+        object.images.first&.cdn_url(:product) || "/noimage/product.png"
       end
 
       def thumb_url
-        object.images.first&.url(:mini) || "/noimage/mini.png"
+        object.images.first&.cdn_url(:mini) || "/noimage/mini.png"
       end
 
       def on_hand

--- a/app/views/spree/admin/images/edit.html.haml
+++ b/app/views/spree/admin/images/edit.html.haml
@@ -14,6 +14,10 @@
       - # A Rails bug makes it necessary to call `main_app.url_for` here.
       - # https://github.com/rails/rails/issues/31325
       = link_to image_tag(main_app.url_for(@image.variant(:small))), main_app.url_for(@image.variant(:product))
+    .field.alpha.three.columns.align-center
+      = f.label t('spree.cdn_thumbnail')
+      %br/
+      = link_to image_tag(@image.cdn_url(:small)), @image.cdn_url(:small)
     .nine.columns.omega
       = render partial: 'form', locals: { f: f }
     .clear

--- a/app/views/spree/admin/images/edit.html.haml
+++ b/app/views/spree/admin/images/edit.html.haml
@@ -17,7 +17,9 @@
     .field.alpha.three.columns.align-center
       = f.label t('spree.cdn_thumbnail')
       %br/
-      = link_to image_tag(@image.cdn_url(:small)), @image.cdn_url(:small)
+      - # A Rails bug makes it necessary to call `main_app.url_for` here.
+      - # https://github.com/rails/rails/issues/31325
+      = link_to image_tag(main_app.url_for(@image.variant(:small).blob)), main_app.url_for(@image.variant(:product).blob)
     .nine.columns.omega
       = render partial: 'form', locals: { f: f }
     .clear


### PR DESCRIPTION
#### What? Why?

The objective is to find a way to render image attachments directly from the cloud storage solution (AWS S3).
We are facing some performance issues on FR Prod. It may not be the only reason, but to reduce Nginx and Puma stress can help improving performance a bit. Especially that these files are actually public.

Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/9859.

#### What should we test?
The feature will be active on Admin side first.
- Visit any pages listing products on Admin side
- Visit a Image Edit page where a new image version is shown (CDN Image)

#### Release notes

Changelog Category: Technical changes
