### PR TITLE
Uses wait_untill to assure JS element appears

### DIFF
--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -714,9 +714,8 @@ describe '
     input = find(".flatpickr-calendar.open .flatpickr-minute")
     input.send_keys datetime.strftime("%M").to_s.strip
     input.send_keys :enter
-    within "#save-bar" do
-      expect(page).to have_content "You have unsaved changes"
-    end
+    wait_until { page.find("#save-bar").present? }
+    expect(page).to have_content "You have unsaved changes"
   end
 
   it "deleting an order cycle" do


### PR DESCRIPTION
#### What? Why?

Closes #9805

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Uses the "giant big sledgehammer" `wait_until` helper to assure the JS element appears - as mentioned here:
https://www.varvet.com/blog/why-wait_until-was-removed-from-capybara/

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
