### PR TITLE
Disables default loading of webmock and some seldom used gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,7 +166,7 @@ group :test do
   gem 'simplecov', require: false
   gem 'test-prof'
   gem 'vcr'
-  gem 'webmock'
+  gem 'webmock', require: false
   # See spec/spec_helper.rb for instructions
   # gem 'perftools.rb'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -150,10 +150,10 @@ group :test, :development do
   gem "factory_bot_rails", '6.2.0', require: false
   gem 'fuubar', '~> 2.5.1'
   gem 'json_spec', '~> 1.1.4'
-  gem 'knapsack'
+  gem 'knapsack', require: false
   gem 'letter_opener', '>= 1.4.1'
   gem 'rspec-rails', ">= 3.5.2"
-  gem 'rspec-retry'
+  gem 'rspec-retry', require: false
   gem 'rswag-specs'
   gem 'shoulda-matchers'
   gem 'timecop'
@@ -164,8 +164,8 @@ group :test do
   gem 'pdf-reader'
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
-  gem 'test-prof'
-  gem 'vcr'
+  gem 'test-prof', require: false
+  gem 'vcr', require: false
   gem 'webmock', require: false
   # See spec/spec_helper.rb for instructions
   # gem 'perftools.rb'


### PR DESCRIPTION
#### What? Why?

Came up [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/9895#discussion_r1008978610).

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds `require: false` to some gems on the `Gemfile`.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
