### PR TITLE
Cache default country for an hour

### DIFF
--- a/app/models/spree/address.rb
+++ b/app/models/spree/address.rb
@@ -29,12 +29,7 @@ module Spree
     delegate :name, to: :state, prefix: true, allow_nil: true
 
     def self.default
-      country = begin
-        DefaultCountry.country
-      rescue StandardError
-        Spree::Country.first
-      end
-      new(country: country)
+      new(country: DefaultCountry.country)
     end
 
     def full_name

--- a/app/models/spree/country.rb
+++ b/app/models/spree/country.rb
@@ -6,6 +6,12 @@ module Spree
 
     validates :name, :iso_name, presence: true
 
+    def self.cached_find_by(attrs)
+      Rails.cache.fetch("countries/#{attrs.hash}", expires_in: 1.hour) do
+        find_by(attrs)
+      end
+    end
+
     def <=>(other)
       name <=> other.name
     end

--- a/app/services/default_country.rb
+++ b/app/services/default_country.rb
@@ -10,6 +10,6 @@ class DefaultCountry
   end
 
   def self.country
-    Spree::Country.find_by(iso: ENV["DEFAULT_COUNTRY_CODE"]) || Spree::Country.first
+    Spree::Country.cached_find_by(iso: ENV["DEFAULT_COUNTRY_CODE"]) || Spree::Country.first
   end
 end

--- a/app/services/default_stock_location.rb
+++ b/app/services/default_stock_location.rb
@@ -5,17 +5,6 @@
 class DefaultStockLocation
   NAME = 'default'
 
-  def self.create!
-    country = Spree::Country.find_by(iso: ENV['DEFAULT_COUNTRY_CODE'])
-    state = country.states.first
-    Spree::StockLocation.create!(name: NAME, country_id: country.id, state_id: state.id,
-                                 backorderable_default: false)
-  end
-
-  def self.destroy_all
-    Spree::StockLocation.where(name: NAME).destroy_all
-  end
-
   def self.find_or_create
     Spree::StockLocation.find_or_create_by(name: NAME)
   end

--- a/spec/services/default_stock_location_spec.rb
+++ b/spec/services/default_stock_location_spec.rb
@@ -3,34 +3,6 @@
 require 'spec_helper'
 
 describe DefaultStockLocation do
-  describe '.create!' do
-    it "names the location 'OFN default'" do
-      stock_location = described_class.create!
-      expect(stock_location.name).to eq('default')
-    end
-
-    it 'sets the location in the default country' do
-      default_country = Spree::Country.find_by(iso: ENV['DEFAULT_COUNTRY_CODE'])
-      stock_location = described_class.create!
-      expect(stock_location.country).to eq(default_country)
-    end
-
-    it 'sets the first state in the country' do
-      default_country = Spree::Country.find_by(iso: ENV['DEFAULT_COUNTRY_CODE'])
-      stock_location = described_class.create!
-      expect(stock_location.state).to eq(default_country.states.first)
-    end
-  end
-
-  describe '.destroy_all' do
-    it "removes all stock locations named 'default'" do
-      create(:stock_location)
-
-      expect { described_class.destroy_all }
-        .to change { Spree::StockLocation.count }.to(0)
-    end
-  end
-
   describe '.find_or_create' do
     context 'when a location named default already exists' do
       let!(:location) do


### PR DESCRIPTION
#### What? Why?

Partly addresses #9859  <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Datadog shows that the single query the database spends most time on is fetching countries. So here's a little effort to cache some of those queries. But I think that this is not caching the bulk of the queries.

My theory from Datadog insights: When displaying a shop, we serialize the enterprise with the address including a country. We fetch a country for every displayed address, actually. Even though Rails should be clever in caching. Caching the association of the address needs some consideration. I tried overriding Country.find but it wasn't used when calling address.country. We could override Address#country but then we don't leverage Rails' caching of the association of the same object. Asking Redis for the country all the time is probably not that much faster than fetching it once from the database.

Three more thoughts:

- This could be a unimportant because downtime problems may come from memory leaks or other long running queries.
- Upgrading Rails may help, even though I haven't seen any cache related improvements in the next version.
- We could try ActiveModelSerializers.config.perform_caching to cache the AddressSerializer results. That would be much more efficient.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Check out with a new user.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
