### PR TITLE
Cache address JSON to avoid database queries

### DIFF
--- a/app/serializers/api/address_serializer.rb
+++ b/app/serializers/api/address_serializer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Api::AddressSerializer < ActiveModel::Serializer
-  # cached
-  # delegate :cache_key, to: :object
+  cached
+  delegate :cache_key, to: :object
 
   attributes :id, :zipcode, :city, :state_name, :state_id,
              :phone, :firstname, :lastname, :address1, :address2, :city, :country_id,

--- a/spec/serializers/api/address_serializer_spec.rb
+++ b/spec/serializers/api/address_serializer_spec.rb
@@ -29,10 +29,10 @@ describe Api::AddressSerializer do
       }
     end
 
-    it "updates even when database wasn't changed" do
+    it "uses stored result when database wasn't changed" do
       expect {
         address.first_name = "Nick"
-      }.to change {
+      }.to_not change {
         serializer.to_json
       }
     end

--- a/spec/serializers/api/address_serializer_spec.rb
+++ b/spec/serializers/api/address_serializer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Api::AddressSerializer do
+  subject(:serializer) { described_class.new(address) }
+  let(:address) { build(:address) }
+
+  describe "#country_name" do
+    it "provides the country's name" do
+      address.country.name = "Australia"
+      expect(serializer.country_name).to eq "Australia"
+    end
+  end
+
+  describe "#state_name" do
+    it "provides the state's abbreviation" do
+      address.state.abbr = "Vic"
+      expect(serializer.state_name).to eq "Vic"
+    end
+  end
+
+  describe "caching" do
+    it "updates with the record" do
+      expect {
+        address.update!(first_name: "Nick")
+      }.to change {
+        serializer.to_json
+      }
+    end
+
+    it "updates even when database wasn't changed" do
+      expect {
+        address.first_name = "Nick"
+      }.to change {
+        serializer.to_json
+      }
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Helping with #9859.


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Datadog showed that our database is quite busy querying the country all the time. One source of these queries is the shop front which serializes enterprises including their addresses.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit a shopfront and add to the cart.
- Go to the checkout and enter your address.
- Complete the checkout.
- Everything should work as before.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
