### PR TITLE
Load product images in the shop lazily to improve performance

### DIFF
--- a/app/views/shop/products/_summary.html.haml
+++ b/app/views/shop/products/_summary.html.haml
@@ -2,7 +2,7 @@
   %a{"ng-click" => "triggerProductModal()"}
     %span.product-thumb__bulk-label{"ng-if" => "::product.group_buy"}
       = t(".bulk")
-    %img{"ng-src" => "{{::product.primaryImageOrMissing}}"}
+    %img{"ng-src" => "{{::product.primaryImageOrMissing}}", loading: "lazy"}
 
 .summary
   .summary-header


### PR DESCRIPTION

#### What? Why?

Helping with https://github.com/openfoodfoundation/openfoodnetwork/issues/9859.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Using this new HTML attribute tells the browse to load images only when they are close to the viewport.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit a shopfront with lots of images.
- All images should still be displayed but some may appear with a delay when scrolling.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
