### PR TITLE
Update Transifex config format for latest version

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[open-food-network.enyml]
+[o:open-food-foundation:p:open-food-network:r:enyml]
 file_filter = config/locales/<lang>.yml
 source_lang = en
 type = YML


### PR DESCRIPTION
#### What? Why?

This updates the Transifex config as required by the latest version (CLI 1.4.1; APIv3)

If you have the Transifex CLI client installed, you may need to update it to the latest version:

    tx update

> Congratulations, you are up to date with  1.4.1


#### What should we test?
This can be tested in a development environment by running the following:

    tx pull

You are expecting a successful result, eg:

```
# Getting info about resources

open-food-network.enyml - Done
[##############################] (1 / 1)

# Pulling files
...
```

#### Release notes
Changelog Category: Technical changes

#### Dependencies
It doesn't depend on an OFN PR, but may require the latest version of the Transifex CLI client (see above)


#### Documentation updates
I don't think we need to update either of these:
 - https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-(i18n)#transifex-client
 - https://github.com/openfoodfoundation/openfoodnetwork/wiki/Releasing#pull-translations-in

(Although I have made some improvements to the former already)
