### PR TITLE
Fix flatpickr system spec: `spec/system/flatpickr_spec.rb`

### DIFF
--- a/spec/system/flatpickr_spec.rb
+++ b/spec/system/flatpickr_spec.rb
@@ -9,7 +9,7 @@ describe "Test Flatpickr" do
   context "orders" do
     it "opens the datepicker and closes it using the 'CLOSE' button" do
       login_as_admin_and_visit 'admin/orders'
-      open_datepicker('#q_completed_at_gteq')       
+      open_datepicker('.datepicker')
       # Looks for the close button and click it
       within(".flatpickr-calendar.open") do
         expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
@@ -19,16 +19,9 @@ describe "Test Flatpickr" do
       expect(page).not_to have_selector '.flatpickr-calendar.open'
     end
     
-    it "opens the datepicker and sets date to today" do
-      login_as_admin_and_visit 'admin/orders'
-      open_datepicker('#q_completed_at_gteq')
-      choose_today_from_datepicker
-      check_fielddate('#q_completed_at_gteq', Date.today())       
-    end
-    
     it "opens the datepicker and closes it by clicking outside" do
       login_as_admin_and_visit 'admin/orders'
-      open_datepicker('#q_completed_at_gteq')
+      open_datepicker('.datepicker')
       find("#admin-menu").click       
       # Should no more have opened flatpickr
       expect(page).not_to have_selector '.flatpickr-calendar.open'


### PR DESCRIPTION
#### What? Why?
On `/admin/orders`, we now have a date range picker. This spec seems to test only the behavior of flatpickr, which is an external dependencies ; we probably shouldn't test it since it's not our responsibilities. Leave the spec as it for now.



Context: _Originally posted by @filipefurtad0 in https://github.com/openfoodfoundation/openfoodnetwork/issues/9938#issuecomment-1303554311_

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

As the build seems to not run this one, I would say: _nothing_

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
