### PR TITLE
Conditionally send cancellation email when cancelling order.

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -40,6 +40,7 @@ Metrics/BlockLength:
     "resources",
     "scenario",
     "shared_examples",
+    "shared_examples_for",
     "xdescribe",
   ]
 

--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -4,7 +4,8 @@ $(document).ready(function() {
 
   initAlert()
   initConfirm()
-  initCancelOrder()
+  initButtonCancel()
+  initLinkCancel()
 
   if ($('#variant_autocomplete_template').length > 0) {
     window.variantTemplate = Handlebars.compile($('#variant_autocomplete_template').text());
@@ -276,17 +277,23 @@ ofnConfirm = function(callback) {
   $('#custom-confirm').show();
 }
 
-initCancelOrder = function() {
-    $('#cancel_order_form').submit(function(e){
-        ofnCancelOrderAlert((confirm, sendEmailCancellation, restock_items) => {
-            if (confirm) {
-                var redirectTo = new URL(Spree.routes.cancel_order.toString());
-                redirectTo.searchParams.append("send_cancellation_email", sendEmailCancellation);
-                redirectTo.searchParams.append("restock_items", restock_items);
-                window.location.href = redirectTo.toString();
-            }
-        });
-        e.preventDefault();
-        return false;
+initCancelAction = function(e){
+  ofnCancelOrderAlert((confirm, sendEmailCancellation, restock_items) => {
+      if (confirm) {
+          var redirectTo = new URL(Spree.routes.cancel_order.toString());
+          redirectTo.searchParams.append("send_cancellation_email", sendEmailCancellation);
+          redirectTo.searchParams.append("restock_items", restock_items);
+          window.location.href = redirectTo.toString();
+      }
     });
+  e.preventDefault();
+  return false;
+};
+
+initButtonCancel = function() {
+  $('#cancel_order_form').submit(initCancelAction)
+}
+
+initLinkCancel = function() {
+  $('#links-dropdown a[href$="cancel"]').click(initCancelAction);
 }

--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -105,8 +105,7 @@ module Spree
       def cancel_order_link
         { name: t(:cancel_order),
           url: spree.fire_admin_order_path(@order.number, e: 'cancel'),
-          icon: 'icon-trash',
-          confirm: t(:are_you_sure) }
+          icon: 'icon-trash' }
       end
 
       def cancel_event_link

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -156,6 +156,33 @@ describe '
     end
   end
 
+  context "cancelling an order" do
+    let(:line_item) { create(:line_item) }
+
+    before do
+      order.line_items << line_item
+      login_as_admin  
+      visit spree.edit_admin_order_path(order)
+    end
+
+    context "when using the cancel button" do
+      before do 
+        find("#cancel_order_form").click
+      end
+
+      it_should_behave_like "Cancelling the order"
+    end
+
+    context "when using the cancel option in the dropdown" do  
+      before do 
+        find("#links-dropdown .ofn-drop-down").click
+        find('a[href$="cancel"]').click
+      end
+
+      it_should_behave_like "Cancelling the order"
+    end
+  end
+
   it "displays error when incorrect distribution for products is chosen" do
     d = create(:distributor_enterprise)
     oc = create(:simple_order_cycle, distributors: [d])

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -543,7 +543,10 @@ describe '
           end
 
           it 'can send invoices' do
-            click_link "Send Invoice"
+            accept_alert "An invoice for this order will be sent to the customer. "\
+                         "Are you sure you want to continue?" do
+              click_link "Send Invoice"
+            end
             expect(page).to have_content "Invoice email has been sent"
           end
         end

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -123,6 +123,7 @@ describe '
       let(:shipment) { order.shipments.first }
 
       it "and by default an Email is sent and the items are restocked" do
+        expect_any_instance_of(Spree::StockLocation).to receive(:restock).at_least(1).times
         expect do
           within(".modal") do
             click_on("OK")
@@ -133,6 +134,7 @@ describe '
       end
 
       it "and then the order is cancelled and email is not sent when unchecked" do
+        expect_any_instance_of(Spree::StockLocation).to receive(:restock).at_least(1).times
         expect do
           within(".modal") do 
             uncheck("send_cancellation_email")
@@ -144,6 +146,7 @@ describe '
       end
 
       it "and the items are not restocked when the user uncheck the checkbox to restock items" do
+        expect_any_instance_of(Spree::StockLocation).not_to receive(:restock)
         expect do
           within(".modal") do
             uncheck("restock_items")


### PR DESCRIPTION
#### What? Why?

- Closes #9128 

Since implementation of https://github.com/openfoodfoundation/openfoodnetwork/pull/8766 users can choose if a cancellation email should be sent when an order is being cancelled. However this only applies when the order is cancelled because the last line item is deleted (on order edit page or BOM).

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

1- Log is an enterprise user
2- Cancel an order with the button
3- See the modal
4- Test the the checkbox is ticked by default and than unchecking it works

Repeat with the action dropdown and in superadmin.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
