### PR TITLE
Packing reports: translate columns name in the columns selector component

### DIFF
--- a/lib/reporting/report_renderer.rb
+++ b/lib/reporting/report_renderer.rb
@@ -15,7 +15,7 @@ module Reporting
     end
 
     def html_render?
-      @report.params[:report_format].in?(['', 'pdf'])
+      @report.params[:report_format].in?([nil, '', 'pdf'])
     end
 
     def display_header_row?

--- a/lib/reporting/reports/packing/base.rb
+++ b/lib/reporting/reports/packing/base.rb
@@ -29,13 +29,6 @@ module Reporting
           { quantity: :quantity }
         end
 
-        def custom_headers
-          return {} if html_render?
-
-          # Use non translated headers to avoid breaking changes
-          @custom_headers ||= report_data.columns.index_by(&:itself).symbolize_keys
-        end
-
         def default_params
           # Prevent breaking change in this report by hidding new columns by default
           { fields_to_hide: ["phone", "price"],


### PR DESCRIPTION
#### What? Why?

- Closes #9944

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, go to Packing Report, such as `/admin/reports/packing/customer`
- Columns selector should be translated to your language (easier to debug if not english then):
<img width="485" alt="Capture d’écran 2022-11-07 à 13 51 21" src="https://user-images.githubusercontent.com/296452/200314874-ddbf5776-5ba1-4cbb-a35b-1f4f9a514de3.png">

 - Generating report in html should translate the columns name:
<img width="1413" alt="Capture d’écran 2022-11-07 à 13 52 46" src="https://user-images.githubusercontent.com/296452/200315166-4f6f99c9-60e8-4505-8b0f-380a284378e8.png">

 - Exporting in CSV, JSON or XLSX ~shouldn't~ should translate columns name: ~, they should stay in english~ 
<img width="678" alt="Capture d’écran 2022-11-07 à 15 52 53" src="https://user-images.githubusercontent.com/296452/200340975-90229e62-3a76-4d09-88cb-864b2e0698f2.png">

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
