### PR TITLE
Enterprise logo: Resize and crop logo instead of just resizing --> logo should fit into a square

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -6,9 +6,9 @@ class Enterprise < ApplicationRecord
   # The next Rails version will have named variants but we need to store them
   # ourselves for now.
   LOGO_SIZES = {
-    thumb: { resize_to_limit: [100, 100] },
-    small: { resize_to_limit: [180, 180] },
-    medium: { resize_to_limit: [300, 300] },
+    thumb: { gravity: "Center", resize: "100x100^", crop: '100x100+0+0' },
+    small: { gravity: "Center", resize: "180x180^", crop: '180x180+0+0' },
+    medium: { gravity: "Center", resize: "300x300^", crop: '300x300+0+0' },
   }.freeze
   PROMO_IMAGE_SIZES = {
     thumb: { resize_to_limit: [100, 100] },

--- a/app/views/admin/enterprises/form/_images.html.haml
+++ b/app/views/admin/enterprises/form/_images.html.haml
@@ -5,6 +5,7 @@
     100 x 100 pixels
   .omega.eight.columns
     %img{ class: 'image-field-group__preview-image', ng: { src: '{{ Enterprise.logo.thumb }}', if: 'Enterprise.logo' } }
+    %br
     = f.file_field :logo
     %a.button.red{ href: '', ng: {click: 'removeLogo()', if: 'Enterprise.logo'} }
       = t('.remove_logo')

--- a/app/views/admin/enterprises/form/_images.html.haml
+++ b/app/views/admin/enterprises/form/_images.html.haml
@@ -4,7 +4,7 @@
     %br
     100 x 100 pixels
   .omega.eight.columns
-    %img{ class: 'image-field-group__preview-image', ng: { src: '{{ Enterprise.logo.medium }}', if: 'Enterprise.logo' } }
+    %img{ class: 'image-field-group__preview-image', ng: { src: '{{ Enterprise.logo.thumb }}', if: 'Enterprise.logo' } }
     = f.file_field :logo
     %a.button.red{ href: '', ng: {click: 'removeLogo()', if: 'Enterprise.logo'} }
       = t('.remove_logo')


### PR DESCRIPTION
#### What? Why?

- Closes #9626


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, change enterprise logo in `/admin/enterprises/[ENTERPRISE_PERMALINK]/edit#!#images_panel`
- Use a non square image, and upload it.
- Displayed image should fit a 100*100 square ; image should be cropped at its center
<img width="655" alt="Capture d’écran 2022-11-08 à 14 58 56" src="https://user-images.githubusercontent.com/296452/200583882-d47fa8eb-1064-425a-8dba-1990b58d58b1.png">

- As a shopper, visit the enterpise shopfront. Image should be cropped and 100*100 with right ratio:
<img width="519" alt="Capture d’écran 2022-11-08 à 14 58 08" src="https://user-images.githubusercontent.com/296452/200583694-e0cb60f9-aee9-4306-a528-26b57e3b3487.png">


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
