### PR TITLE
Fix flaky taxonomy spec by asserting on page redirect and adding retry: 3

### DIFF
--- a/spec/system/admin/configuration/taxonomies_spec.rb
+++ b/spec/system/admin/configuration/taxonomies_spec.rb
@@ -43,12 +43,13 @@ describe "Taxonomies" do
   end
 
   context "edit" do
-    it "should allow an admin to update an existing taxonomy" do
+    it "should allow an admin to update an existing taxonomy", retry: 3 do
       create(:taxonomy)
       click_link "Taxonomies"
       within_row(1) { find(".icon-edit").click }
       fill_in "taxonomy_name", with: "sports 99"
       click_button "Update"
+      expect(page).to have_current_path spree.admin_taxonomies_path
       expect(page).to have_content("successfully updated!")
       expect(page).to have_content("sports 99")
     end


### PR DESCRIPTION
#### What? Why?

- Closes #9957
- fixes an error 500 appearing in the console, when running the spec:
`2022-11-08 19:46:30 +0000 Rack app ("GET /throbber.gif" - (127.0.0.1)): #<ActionController::RoutingError: No route matches [GET] "/throbber.gif">
`
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- Attempts to stabilize the spec by asserting on the URL -> page redirection should occur after the "Update" click. The numbers were not that great though, I got `94 of 100 passed (94%)` before and after these changes; then, after adding the `retry: 3` observed no failures in 100 runs.

- replaces the reference to `/throbber.gif` which seems not to be in the code base, thereby fixing an error 500 seen in the console and test output, when running the spec.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build; no errors on the console and test output.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
