### PR TITLE
Improve input validation on Enterprise fees page

### DIFF
--- a/app/controllers/admin/enterprise_fees_controller.rb
+++ b/app/controllers/admin/enterprise_fees_controller.rb
@@ -106,7 +106,7 @@ module Admin
           :preferred_flat_percent, :preferred_amount,
           :preferred_first_item, :preferred_additional_item,
           :preferred_minimal_amount, :preferred_normal_amount,
-          :preferred_discount_amount, :preferred_per_unit
+          :preferred_discount_amount, :preferred_per_unit, :preferred_max_items, :preffered_currency
         )
 
         next unless enterprise_fees

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -254,14 +254,13 @@ describe '
     expect(page).to have_content "Your enterprise fees have been updated."
     expect(page).to have_content "MAX ITEMS:"
     expect(page).to have_selector "#sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_max_items"
-    #expect(page).to have_field "input[value='0']"
-    
-    #Fill in the calculator fields and click update
+
+    # Fill in the calculator fields and click update
     fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_first_item',
             with: "22.00"
     fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_additional_item',
             with: "25.00"
-    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_max_items', 
+    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_max_items',
             with: "10"
     fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_currency',
             with: "AUD"
@@ -272,11 +271,11 @@ describe '
 
     # Update the max input field with invalid input
     expect(page).to have_selector "#sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_max_items"
-    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_max_items', 
+    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_max_items',
             with: "invalid input"
     click_button 'Update'
 
-    #Should return a flas error message and updated information should be kept
+    # Should return a flas error message and updated information should be kept
     expect(flash_message).to eq('Invalid input. Please use only numbers. For example: 10, 5.5, -20')
     expect(page).to have_selector 'input[value="10"]'
   end

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -234,4 +234,50 @@ describe '
                                   options: ['First Distributor', 'Second Distributor'])
     end
   end
+
+  it "for enterprise fees FLEXIBLE RATE calculator should validate all fields and keep information when submission of form validation fails" do
+    # Given an enterprise
+    e = create(:supplier_enterprise, name: 'Feedme')
+
+    # Go to the enterprise fees page
+    login_as_admin_and_visit admin_enterprise_fees_path
+
+    # Fill in the fields for a new enterprise fee and click update
+    select 'Feedme', from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
+    select 'Admin', from: 'sets_enterprise_fee_set_collection_attributes_0_fee_type'
+    fill_in 'sets_enterprise_fee_set_collection_attributes_0_name', with: 'Hello!'
+    select 'GST', from: 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id'
+    select 'Flexible Rate', from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+    click_button 'Update'
+
+    # See my fee and fields for the calculator and a success flash message
+    expect(page).to have_content "Your enterprise fees have been updated."
+    expect(page).to have_content "MAX ITEMS:"
+    expect(page).to have_selector "#sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_max_items"
+    #expect(page).to have_field "input[value='0']"
+    
+    #Fill in the calculator fields and click update
+    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_first_item',
+            with: "22.00"
+    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_additional_item',
+            with: "25.00"
+    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_max_items', 
+            with: "10"
+    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_currency',
+            with: "AUD"
+    click_button 'Update'
+
+    # Then I should see the flash success message
+    expect(flash_message).to eq('Your enterprise fees have been updated.')
+
+    # Update the max input field with invalid input
+    expect(page).to have_selector "#sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_max_items"
+    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_max_items', 
+            with: "invalid input"
+    click_button 'Update'
+
+    #Should return a flas error message and updated information should be kept
+    expect(flash_message).to eq('Invalid input. Please use only numbers. For example: 10, 5.5, -20')
+    expect(page).to have_selector 'input[value="10"]'
+  end
 end


### PR DESCRIPTION
#### Improved enterprise fee validation of input? ''?

- Closes #9860 

<!-- Just a s4-bug fix-->



#### Steps to reproduce as an admin?

- edit an enterprise fee
- choose flexible rate calculator
- click update
- type in an invalid value on 'max items' (e.g. some text or numbers with comma as separator)
- click update --> invalid input is highlighted

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
