### PR TITLE
Xero report: Avoid js error due to missing element, check it exists before setting any properties

### DIFF
--- a/app/webpacker/controllers/csv_select_controller.js
+++ b/app/webpacker/controllers/csv_select_controller.js
@@ -10,14 +10,22 @@ export default class extends Controller {
   }
 
   disableField() {
-    this.checkboxTarget.checked = false;
-    this.checkboxTarget.disabled = true;
-    this.labelTarget.classList.add("disabled");
+    if (this.hasCheckboxTarget) {
+      this.checkboxTarget.checked = false;
+      this.checkboxTarget.disabled = true;
+    }
+    if (this.hasLabelTarget) {
+      this.labelTarget.classList.add("disabled");
+    }
   }
 
   enableField() {
-    this.checkboxTarget.checked = true;
-    this.checkboxTarget.disabled = false;
-    this.labelTarget.classList.remove("disabled");
+    if (this.hasCheckboxTarget) {
+      this.checkboxTarget.checked = true;
+      this.checkboxTarget.disabled = false;
+    }
+    if (this.hasLabelTarget) {
+      this.labelTarget.classList.remove("disabled");
+    }
   }
 }

--- a/app/webpacker/controllers/csv_select_controller.js
+++ b/app/webpacker/controllers/csv_select_controller.js
@@ -1,10 +1,12 @@
 import { Controller } from "stimulus";
 
 export default class extends Controller {
-  static targets = ["reportType", "checkbox", "label"]
+  static targets = ["reportType", "checkbox", "label"];
 
   handleSelectChange() {
-    this.reportTypeTarget.value == "csv" ? this.disableField() : this.enableField()
+    this.reportTypeTarget.value == "csv"
+      ? this.disableField()
+      : this.enableField();
   }
 
   disableField() {


### PR DESCRIPTION
#### What? Why?

- Closes #9964


#### What should we test?
 - Behavior introduced by https://github.com/openfoodfoundation/openfoodnetwork/pull/9563 shouldn't have change
 - Opening a Xero report and selecting CSV export shouldn't trigger any errors

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category:Technical changes
