### PR TITLE
Sanitize `image_name` by removing all questions marks when saving any capybara screenshots

### DIFF
--- a/spec/system/support/cuprite_helpers.rb
+++ b/spec/system/support/cuprite_helpers.rb
@@ -16,7 +16,7 @@ module CupriteHelpers
   # Use our `Capybara.save_path` to store screenshots with other capybara artifacts
   # (Rails screenshots path is not configurable https://github.com/rails/rails/blob/49baf092439fc74fc3377b12e3334c3dd9d0752f/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb#L79)
   def absolute_image_path
-    Rails.root.join("#{Capybara.save_path}/screenshots/#{image_name}.png")
+    Rails.root.join("#{Capybara.save_path}/screenshots/#{image_name.parameterize}.png")
   end
 
   # Make failure screenshots compatible with multi-session setup.


### PR DESCRIPTION
#### What? Why?

- Closes #9972 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

- Run a spec that, when failing, could contains a question mark in its name, such as `spec/system/admin/order_spec.rb:150`
- Make it failed (change expecting values)
- Saved screenshots should not contain any question mark:

```
tmp/capybara/screenshots/failures_r_spec_example_groups_as_an_administrator_i_want_to_create_and_edit_orders_deleting_item_of_an_order_when_there_a_more_than_one_items_in_the_order_show_a_modal__are_you_sure__that_the_user_confirm_an_425.png
```
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
