### PR TITLE
Remove N+1 query loading tags for each order cycle exchange

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -116,21 +116,7 @@ module Admin
 
     # Fetches tags for all customers of the enterprise and returns a hash indexed by customer_id
     def customer_tags_by_id
-      customer_tags = ::ActsAsTaggableOn::Tag.
-        joins(:taggings).
-        includes(:taggings).
-        where(taggings:
-                { taggable_type: 'Customer',
-                  taggable_id: Customer.of(managed_enterprise_id),
-                  context: 'tags' })
-
-      customer_tags.each_with_object({}) do |tag, indexed_hash|
-        tag.taggings.each do |tagging|
-          customer_id = tagging.taggable_id
-          indexed_hash[customer_id] ||= []
-          indexed_hash[customer_id] << tag.name
-        end
-      end
+      BatchTaggableTagsQuery.call(Customer.of(managed_enterprise_id))
     end
   end
 end

--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -162,25 +162,20 @@ module Admin
       [:index]
     end
 
+    def managed_enterprise_id
+      Enterprise.managed_by(spree_current_user).select('enterprises.id').
+        find_by(id: params[:enterprise_id])
+    end
+
     def subscription_params
       @subscription_params ||= PermittedAttributes::Subscription.new(params).call.
         to_h.with_indifferent_access
     end
 
     def payment_method_tags_by_id
-      payment_method_tags = ::ActsAsTaggableOn::Tag.
-        joins(:taggings).
-        includes(:taggings).
-        where(taggings: { taggable_type: "Spree::PaymentMethod",
-                          taggable_id: Spree::PaymentMethod.from(Enterprise.managed_by(spree_current_user).
-                          select('enterprises.id').find_by(id: params[:enterprise_id])),
-                          context: 'tags' })
-
-      payment_method_tags.each_with_object({}) do |tag, hash|
-        payment_method_id = tag.taggings.first.taggable_id
-        hash[payment_method_id] ||= []
-        hash[payment_method_id] << tag.name
-      end
+      @payment_method_tags_by_id ||= BatchTaggableTagsQuery.call(
+        Spree::PaymentMethod.from(managed_enterprise_id)
+      )
     end
   end
 end

--- a/app/queries/batch_taggable_tags_query.rb
+++ b/app/queries/batch_taggable_tags_query.rb
@@ -2,7 +2,7 @@
 
 class BatchTaggableTagsQuery
   def self.call(taggables)
-    tags = ::ActsAsTaggableOn::Tag.
+    ::ActsAsTaggableOn::Tag.
       joins(:taggings).
       includes(:taggings).
       where(taggings:
@@ -10,9 +10,7 @@ class BatchTaggableTagsQuery
           taggable_type: taggables.model.to_s,
           taggable_id: taggables,
           context: 'tags'
-        })
-
-    tags.each_with_object({}) do |tag, indexed_hash|
+        }).order("tags.name").each_with_object({}) do |tag, indexed_hash|
       tag.taggings.each do |tagging|
         indexed_hash[tagging.taggable_id] ||= []
         indexed_hash[tagging.taggable_id] << tag.name

--- a/app/queries/batch_taggable_tags_query.rb
+++ b/app/queries/batch_taggable_tags_query.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class BatchTaggableTagsQuery
+  def self.call(taggables)
+    tags = ::ActsAsTaggableOn::Tag.
+      joins(:taggings).
+      includes(:taggings).
+      where(taggings:
+        {
+          taggable_type: taggables.model.to_s,
+          taggable_id: taggables,
+          context: 'tags'
+        })
+
+    tags.each_with_object({}) do |tag, indexed_hash|
+      tag.taggings.each do |tagging|
+        indexed_hash[tagging.taggable_id] ||= []
+        indexed_hash[tagging.taggable_id] << tag.name
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/exchange_serializer.rb
+++ b/app/serializers/api/admin/exchange_serializer.rb
@@ -49,7 +49,7 @@ module Api
       end
 
       def tag_list
-        preloaded_tag_list.join(",(pre)")
+        preloaded_tag_list.join(",")
       end
 
       def tags

--- a/app/serializers/api/admin/exchange_serializer.rb
+++ b/app/serializers/api/admin/exchange_serializer.rb
@@ -42,12 +42,18 @@ module Api
           .visible_variants_for_outgoing_exchanges_to(object.receiver)
       end
 
+      def preloaded_tag_list
+        return object.tag_list unless options[:preloaded_tags]
+
+        options.dig(:preloaded_tags, object.id) || []
+      end
+
       def tag_list
-        object.tag_list.join(",")
+        preloaded_tag_list.join(",(pre)")
       end
 
       def tags
-        object.tag_list.map{ |t| { text: t } }
+        preloaded_tag_list.map { |tag| { text: tag } }
       end
     end
   end

--- a/app/serializers/api/admin/order_cycle_serializer.rb
+++ b/app/serializers/api/admin/order_cycle_serializer.rb
@@ -34,7 +34,8 @@ module Api
 
         ActiveModel::ArraySerializer.
           new(scoped_exchanges, each_serializer: Api::Admin::ExchangeSerializer,
-                                current_user: options[:current_user])
+                                current_user: options[:current_user],
+                                preloaded_tags: BatchTaggableTagsQuery.call(scoped_exchanges))
       end
 
       def editable_variants_for_incoming_exchanges

--- a/spec/queries/batch_taggable_tags_query_spec.rb
+++ b/spec/queries/batch_taggable_tags_query_spec.rb
@@ -13,7 +13,7 @@ describe BatchTaggableTagsQuery do
     )
     expect(tags).to eq(
       {
-        customer_i.id => ["volunteer", "member"],
+        customer_i.id => ["member", "volunteer"],
         customer_ii.id => ["member"],
       }
     )

--- a/spec/queries/batch_taggable_tags_query_spec.rb
+++ b/spec/queries/batch_taggable_tags_query_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe BatchTaggableTagsQuery do
+  it "fetches tags for multiple models in one query" do
+    customer_i = create(:customer, tag_list: "member,volunteer")
+    customer_ii = create(:customer, tag_list: "member")
+    customer_iii = create(:customer, tag_list: nil)
+
+    tags = BatchTaggableTagsQuery.call(
+      Customer.where(id: [customer_i, customer_ii, customer_iii])
+    )
+    expect(tags).to eq(
+      {
+        customer_i.id => ["volunteer", "member"],
+        customer_ii.id => ["member"],
+      }
+    )
+  end
+end

--- a/spec/support/query_counter.rb
+++ b/spec/support/query_counter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class QueryCounter
+  QUERY_TYPES = [:delete, :insert, :select, :update].freeze
+
+  attr_reader :queries
+
+  def initialize
+    @queries = {}
+    @subscriber = ActiveSupport::Notifications.
+      subscribe("sql.active_record") do |_name, _started, _finished, _unique_id, payload|
+      type = get_type(payload[:sql])
+      next if QUERY_TYPES.exclude?(type) || pg_query?(payload[:sql])
+
+      table = get_table(payload[:sql])
+      @queries[type] ||= {}
+      @queries[type][table] ||= 0
+      @queries[type][table] += 1
+    end
+  end
+
+  def stop
+    ActiveSupport::Notifications.unsubscribe("sql.active_record")
+  end
+
+  private
+
+  def get_table(sql)
+    sql_parts = sql.split(" ")
+    case get_type(sql)
+    when :insert
+      sql_parts[3]
+    when :update
+      sql_parts[1]
+    else
+      table_index = sql_parts.index("FROM")
+      sql_parts[table_index + 1]
+    end.gsub(/(\\|")/, "").to_sym
+  end
+
+  def get_type(sql)
+    sql.split(" ")[0].downcase.to_sym
+  end
+
+  def pg_query?(sql)
+    sql.include?("SELECT a.attname") || sql.include?("pg_attribute")
+  end
+end


### PR DESCRIPTION
#### What? Why?

- For https://github.com/openfoodfoundation/openfoodnetwork/issues/5213 

When an order cycle is loaded in the admin area a separate query is made to fetch the tags for each and every exchange that belongs to the order cycle. This changes things so tags are fetched for every order cycle exchange in a single query.

#### What should we test?

1. Find an order cycle which has multiple exchanges with tags, the more the easier it might be notice a difference, there should be less queries in any case.
2. Compare the before and after performance of `/admin/order_cycles/:id.json`. This URL is loaded via AJAX on the edit order cycle page.

#### Release notes

Remove N+1 query loading tags for each order cycle exchange

Changelog Category: Technical changes