### PR TITLE
[Admin][Enterprise Settings] Show spinner when enterprise sells option changes

### DIFF
--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -32,6 +32,8 @@
     .four.columns.omega
       = f.radio_button :sells, "any", 'ng-model' => 'Enterprise.sells', data: {action: "change->primary-details#enterpriseSellsChanged"}
       = f.label :sells, t('.any'), value: "any"
+      %span{ style: "width: 30px; height: 30px;", class: "hidden", data: { "primary-details-target": "spinner" } }
+        = render partial: "components/admin_spinner"
 .row
   .three.columns.alpha
     %label= t('.visible_in_search')

--- a/app/webpacker/controllers/primary_details_controller.js
+++ b/app/webpacker/controllers/primary_details_controller.js
@@ -3,6 +3,7 @@ import CableReady from "cable_ready";
 
 export default class extends Controller {
   static values = { primaryProducer: String, enterpriseSells: String };
+  static targets = ["spinner"];
 
   primaryProducerChanged(event) {
     this.primaryProducerValue = event.currentTarget.checked;
@@ -12,6 +13,7 @@ export default class extends Controller {
   enterpriseSellsChanged(event) {
     if (event.currentTarget.checked) {
       this.enterpriseSellsValue = event.currentTarget.value;
+      this.spinnerTarget.classList.remove("hidden");
       this.makeRequest();
     }
   }
@@ -25,6 +27,9 @@ export default class extends Controller {
       }
     )
       .then((data) => data.json())
-      .then(CableReady.perform);
+      .then((operation) => {
+        CableReady.perform(operation);
+        this.spinnerTarget.classList.add("hidden");
+      });
   }
 }


### PR DESCRIPTION
#### What? Why?

- Closes #9637 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit page `admin/<enterprise permalink>/edit` 
- Ascertain when enterprise's `sells` value is changed, a spinner shows up until the permalink settings shows up
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
