### PR TITLE
Cuprite bump: Updates helper to click on css element...

### DIFF
--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -154,7 +154,7 @@ module WebHelper
 
   def fill_in_tag(tag_name, selector = "tags-input .tags input")
     expect(page).to have_selector selector
-    find(:css, selector).send_keys ""
+    find(:css, selector).click
     find(:css, selector).set "#{tag_name}\n"
     expect(page).to have_selector ".tag-list .tag-item span", text: tag_name
   end


### PR DESCRIPTION
...instead of passing empty_keys.

#### What? Why?

- Prepares #9423

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

On #9423 is failing with
```

     Failure/Error: find(:css, selector).send_keys ""
     
     ArgumentError:
       empty keys passed


```

I think this can be fixed by replacing 

`find(:css, selector).send_keys ""`
by
`find(:css, selector).click`

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build on #9423.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
