### PR TITLE
unlock the ofn-install installation process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,6 +136,8 @@ gem 'flipper-ui'
 
 gem "view_component"
 
+gem 'mini_portile2', '~> 2.8'
+
 group :production, :staging do
   gem 'ddtrace'
   gem 'rack-timeout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -823,6 +823,7 @@ DEPENDENCIES
   listen
   mime-types
   mimemagic (> 0.3.5)
+  mini_portile2 (~> 2.8)
   mini_racer (= 0.4.0)
   monetize (~> 1.11)
   oauth2 (~> 1.4.7)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,6 @@
 ActiveRecord::Schema.define(version: 2022_10_07_105052) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|


### PR DESCRIPTION
#### What? Why?

- Closes #10001 

- missing dependency added to Gemfile
- pg_stat_statement extension creation taken off from the schema.rb file because this postgresql extension is in reality created by the datadog role in ofn-install ( see : https://github.com/openfoodfoundation/ofn-install/blob/master/roles/datadog/tasks/pg_stats.yml#L2 ). It can not be created by rake because it is executed with the ofn-user which does not have the SUPERUSER right requested to create the extension ( see : https://www.postgresql.org/docs/current/pgstatstatements.html ) 


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
As explained in the issue 
- begin with a clean environment : gem folder empty and a brand new postgresql instance
- run `bundle install --deployment` => it should now be successful
- run then `bundle exec rake db:schema:load`=> it should also be successful

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
