### PR TITLE
Revert "Load product images in the shop lazily to improve performance"

### DIFF
--- a/app/views/shop/products/_summary.html.haml
+++ b/app/views/shop/products/_summary.html.haml
@@ -2,7 +2,7 @@
   %a{"ng-click" => "triggerProductModal()"}
     %span.product-thumb__bulk-label{"ng-if" => "::product.group_buy"}
       = t(".bulk")
-    %img{"ng-src" => "{{::product.primaryImageOrMissing}}", loading: "lazy"}
+    %img{"ng-src" => "{{::product.primaryImageOrMissing}}"}
 
 .summary
   .summary-header


### PR DESCRIPTION
Reverts openfoodfoundation/openfoodnetwork#9927

Closes #10063

Seems like Safari 15.6 is not that ready for that `loading` attribute (some edge cases aren't functional. Seems like we are in such an edge case) (source: https://caniuse.com/loading-lazy-attr)

