### PR TITLE
Adds expectation to assure login was sucessful

### DIFF
--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -32,5 +32,6 @@ module AuthenticationHelper
   def expect_logged_in
     # Ensure page has been reloaded after submitting login form
     expect(page).to_not have_selector ".menu #login-link"
+    expect(page).to_not have_content "Login"
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #9913

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This spec was failing consistently in a locally environment and sometimes passing on the CI.

The assertion on the helper now assures the "Login" wording disappears, before continuing the tests on the page. 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
