### PR TITLE
Redirect to shopfront when Order cycle closes during split checkout 

### DIFF
--- a/app/controllers/concerns/order_stock_check.rb
+++ b/app/controllers/concerns/order_stock_check.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module OrderStockCheck
+  include CablecarResponses
   extend ActiveSupport::Concern
 
   def valid_order_line_items?
@@ -29,6 +30,9 @@ module OrderStockCheck
 
     flash[:info] = I18n.t('order_cycle_closed')
     respond_to do |format|
+      format.cable_ready {
+        render status: :see_other, operations: cable_car.redirect_to(url: main_app.shop_path)
+      }
       format.json { render json: { path: main_app.shop_path }, status: :see_other }
       format.html { redirect_to main_app.shop_path, status: :see_other }
     end


### PR DESCRIPTION
#### What? Why?

- Closes #9733 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Please follow the steps outlined under `Steps to Reproduce` [here](https://github.com/openfoodfoundation/openfoodnetwork/issues/9733#issue-1396232792) in order to test this. 

Thanks to @drummer83 for the detailed steps above. 

#### Release notes

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
