### PR TITLE
[WIP 🚧 ] Admin - Order edition, behind feature toggle `admin_style_v2`: adjust colors

### DIFF
--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -133,7 +133,7 @@ module Spree
         event_label = I18n.t("cancel", scope: "actions")
         button_link_to(event_label,
                        fire_admin_order_url(@order, e: "cancel"),
-                       method: :put, icon: "icon-cancel", form_id: "cancel_order_form")
+                       method: :put, icon: "icon-remove", form_id: "cancel_order_form")
       end
 
       def resume_event_link

--- a/app/views/spree/admin/orders/_note.html.haml
+++ b/app/views/spree/admin/orders/_note.html.haml
@@ -20,7 +20,8 @@
         = t(".no_note_present")
 
     %td.actions
-      = link_to '', '', class: 'edit-note icon_link icon-edit no-text with-tip', data: { action: 'edit' }, title: Spree.t('edit')
-      - if @order.note.present?
-        = link_to '', '', class: 'delete-note icon_link icon-trash no-text with-tip', data: { action: 'remove' }, title: Spree.t('delete')
+      .flex
+        = link_to '', '', class: 'edit-note icon_link icon-edit no-text with-tip', data: { action: 'edit' }, title: Spree.t('edit')
+        - if @order.note.present?
+          = link_to '', '', class: 'delete-note icon_link icon-trash no-text with-tip', data: { action: 'remove' }, title: Spree.t('delete')
 

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -70,8 +70,9 @@
 
         %td.actions
           - if can?(:update, shipment) && !shipment.canceled?
-            = link_to '', '', :class => 'save-tracking icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, :title => I18n.t('actions.save')
-            = link_to '', '', :class => 'cancel-tracking icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => I18n.t('actions.cancel')
+            .flex
+              = link_to '', '', :class => 'save-tracking icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, :title => I18n.t('actions.save')
+              = link_to '', '', :class => 'cancel-tracking icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => I18n.t('actions.cancel')
 
       %tr.show-tracking.total
         %td{ :colspan => "5" }

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -26,7 +26,7 @@
         = Spree.t(:price)
       %th
         = Spree.t(:quantity)
-      %th
+      %th.force-rounded-right
         = Spree.t(:total)
       %th.orders-actions.actions{ "data-hook" => "admin_order_form_line_items_header_actions" }
 

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -85,6 +85,7 @@
 
         %td.actions
           - if can?(:update, shipment) && shipment.can_modify?
-            = link_to '', '', :class => 'edit-tracking icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')
-            - if shipment.tracking.present?
-              = link_to '', '', :class => 'delete-tracking icon_link icon-trash no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'remove' }, :title => Spree.t('delete')
+            .flex
+              = link_to '', '', :class => 'edit-tracking icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')
+              - if shipment.tracking.present?
+                = link_to '', '', :class => 'delete-tracking icon_link icon-trash no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'remove' }, :title => Spree.t('delete')

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -57,8 +57,8 @@
             %span
               = shipment.fee_adjustment.display_amount
 
-        - if shipment.fee_adjustment.present? && shipment.can_modify?
-          %td.actions
+        %td.actions
+          - if shipment.fee_adjustment.present? && shipment.can_modify?
             - if can? :update, shipment
               = link_to '', '', :class => 'edit-method icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')
 

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -19,10 +19,11 @@
 
       %td.cart-item-delete.actions{ "data-hook" => "cart_item_delete" }
         - if shipment.can_modify? && can?(:update, shipment)
-          = link_to '', '#', :class => 'save-item icon_link icon-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => t('actions.save'), :style => 'display: none'
-          = link_to '', '#', :class => 'cancel-item icon_link icon-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => t('actions.cancel'), :style => 'display: none'
-          = link_to '', '#', :class => 'edit-item icon_link icon-edit no-text with-tip', :data => {:action => 'edit'}, :title => t('actions.edit')
-          = link_to '', '#', :class => 'delete-item icon-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => t('actions.delete')
+          .flex
+            = link_to '', '#', :class => 'save-item icon_link icon-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => t('actions.save'), :style => 'display: none'
+            = link_to '', '#', :class => 'cancel-item icon_link icon-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => t('actions.cancel'), :style => 'display: none'
+            = link_to '', '#', :class => 'edit-item icon_link icon-edit no-text with-tip', :data => {:action => 'edit'}, :title => t('actions.edit')
+            = link_to '', '#', :class => 'delete-item icon-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => t('actions.delete')
 
 = render 'spree/admin/shared/custom-alert'
 = render 'spree/admin/shared/custom-confirm'

--- a/app/views/spree/admin/payments/_list.html.haml
+++ b/app/views/spree/admin/payments/_list.html.haml
@@ -15,5 +15,6 @@
         %td.align-center
           %span{class: "state #{payment.state}"}= t(payment.state, scope: "spree.payment_states", default: payment.state.capitalize)
         %td.actions
-          - payment.actions.each do |action|
-            = link_to_with_icon "icon-#{action}", Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: {action: action, disable_with: ""}
+          .flex
+            - payment.actions.each do |action|
+              = link_to_with_icon "icon-#{action}", Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: {action: action, disable_with: ""}

--- a/app/views/spree/admin/shared/_head.html.haml
+++ b/app/views/spree/admin/shared/_head.html.haml
@@ -14,7 +14,10 @@
 
 %link{:href => "https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600,700&subset=latin,cyrillic,greek,vietnamese", :rel => "stylesheet", :type => "text/css"}
 
-= stylesheet_pack_tag 'admin-styles', media: "screen, print"
+- if feature?(:admin_style_v2, spree_current_user)
+  = stylesheet_pack_tag 'admin-styles-v2', media: "screen, print"
+- else
+  = stylesheet_pack_tag 'admin-styles', media: "screen, print"
 = render "layouts/bugsnag_js"
 = javascript_include_tag 'admin/all'
 

--- a/app/webpacker/css/admin/all.scss
+++ b/app/webpacker/css/admin/all.scss
@@ -127,5 +127,3 @@
 @import "app/components/pagination_component/pagination_component";
 @import "app/components/table_header_component/table_header_component";
 @import "app/components/search_input_component/search_input_component";
-
-@import "v2/main.scss";

--- a/app/webpacker/css/admin/globals/palette.scss
+++ b/app/webpacker/css/admin/globals/palette.scss
@@ -1,0 +1,16 @@
+// Basic color palette for admin
+$color-1:                        #FFFFFF !default;    // White
+$color-2:                        #9FC820 !default;    // Green
+$color-3:                        #5498DA !default;    // Light Blue
+$color-4:                        #6788A2 !default;    // Dark Blue
+$color-5:                        #C60F13 !default;    // Red
+$color-6:                        #FF9300 !default;    // Yellow
+
+@mixin basicColorPalette($color1, $color2, $color3, $color4, $color5, $color6) {
+  $color-1: $color1 !global;
+  $color-2: $color2 !global;
+  $color-3: $color3 !global;
+  $color-4: $color4 !global;
+  $color-5: $color5 !global;
+  $color-6: $color6 !global;
+}

--- a/app/webpacker/css/admin/globals/variables.scss
+++ b/app/webpacker/css/admin/globals/variables.scss
@@ -9,14 +9,6 @@ $base-font-family: "Open Sans", "Helvetica Neue", "Helvetica", Helvetica, Arial,
 // Colors
 //--------------------------------------------------------------
 
-// Basic color palette for admin
-$color-1:                        #FFFFFF !default;    // White
-$color-2:                        #9FC820 !default;    // Green
-$color-3:                        #5498DA !default;    // Light Blue
-$color-4:                        #6788A2 !default;    // Dark Blue
-$color-5:                        #C60F13 !default;    // Red
-$color-6:                        #FF9300 !default;    // Yellow
-
 // Body base colors
 $color-body-bg:                  $color-1 !default;
 $color-body-text:                $color-4 !default;

--- a/app/webpacker/css/admin/v2/components/buttons.scss
+++ b/app/webpacker/css/admin/v2/components/buttons.scss
@@ -14,6 +14,8 @@ select[type="button"],
 button:not(.no-text),
 .button,
 .actions a:not(.no-text),
+fieldset .filter-actions button, // Be more specific to be sure to override the form button style (with a white border)
+fieldset .filter-actions .button:hover,
 .admin__section-header .ofn-drop-down // Same behavior as the button
 {
   @include backgroundAndBorder($v2-blue-light);

--- a/app/webpacker/css/admin/v2/components/buttons.scss
+++ b/app/webpacker/css/admin/v2/components/buttons.scss
@@ -62,7 +62,6 @@ fieldset .filter-actions .button:hover,
   }
 }
 
-#table-filter fieldset:has(.actions) {
-  // do not apply border to filter actions as it's drawn by the #table-filter .actions before and after pseudo elements
+#table-filter fieldset {
   border-bottom: 0;
 }

--- a/app/webpacker/css/admin/v2/components/buttons.scss
+++ b/app/webpacker/css/admin/v2/components/buttons.scss
@@ -30,7 +30,8 @@ button:not(.no-text),
   }
 
   &.secondary,
-  &.cancel {
+  &.cancel,
+  &.icon-remove {
     background-color: $white;
     border: 2px solid $v2-blue-light;
     color: $v2-blue-light;

--- a/app/webpacker/css/admin/v2/components/buttons.scss
+++ b/app/webpacker/css/admin/v2/components/buttons.scss
@@ -11,9 +11,9 @@ select[type="submit"],
 input[type="button"],
 select[type="button"],
 .select2-container-multi [type="button"].select2-choices,
-button,
+button:not(.no-text),
 .button,
-.actions a:not([class*="icon-"]),
+.actions a:not(.no-text),
 .admin__section-header .ofn-drop-down // Same behavior as the button
 {
   &.disabled,

--- a/app/webpacker/css/admin/v2/components/buttons.scss
+++ b/app/webpacker/css/admin/v2/components/buttons.scss
@@ -16,19 +16,17 @@ button:not(.no-text),
 .actions a:not(.no-text),
 .admin__section-header .ofn-drop-down // Same behavior as the button
 {
+  @include backgroundAndBorder($v2-blue-light);
+
+  &:hover {
+    @include backgroundAndBorder($v2-blue);
+    box-shadow: $v2-box-shadow;
+  }
+
   &.disabled,
   &[disabled] {
     @include backgroundAndBorder($v2-light-grey);
-  }
-
-  &:not(.disabled):not([disabled]):not(.secondary):not(.cancel) {
-    // Change the color of the button only if it's not disabled
-    @include backgroundAndBorder($v2-blue-light);
-
-    &:hover {
-      @include backgroundAndBorder($v2-blue);
-      box-shadow: $v2-box-shadow;
-    }
+    box-shadow: none;
   }
 
   &.secondary,

--- a/app/webpacker/css/admin/v2/components/buttons.scss
+++ b/app/webpacker/css/admin/v2/components/buttons.scss
@@ -21,7 +21,7 @@ button,
     @include backgroundAndBorder($v2-light-grey);
   }
 
-  &:not(.disabled):not([disabled]):not(.secondary) {
+  &:not(.disabled):not([disabled]):not(.secondary):not(.cancel) {
     // Change the color of the button only if it's not disabled
     @include backgroundAndBorder($v2-blue-light);
 
@@ -31,7 +31,8 @@ button,
     }
   }
 
-  &.secondary {
+  &.secondary,
+  &.cancel {
     background-color: $white;
     border: 2px solid $v2-blue-light;
     color: $v2-blue-light;

--- a/app/webpacker/css/admin/v2/components/dropdown.scss
+++ b/app/webpacker/css/admin/v2/components/dropdown.scss
@@ -1,0 +1,9 @@
+/* Override app/webpacker/css/admin/dropdown.scss */
+
+.ofn-drop-down,
+.ofn-drop-down-with-prepend .ofn-drop-down-prepend {
+  background-color: white;
+  &.disabled {
+    opacity: 0.9;
+  }
+}

--- a/app/webpacker/css/admin/v2/components/sidebar.scss
+++ b/app/webpacker/css/admin/v2/components/sidebar.scss
@@ -1,0 +1,5 @@
+/* Override file app/webpacker/css/admin/components/sidebar.scss */
+
+#sidebar .sidebar-title {
+  color: $v2-blue;
+}

--- a/app/webpacker/css/admin/v2/components/sidebar.scss
+++ b/app/webpacker/css/admin/v2/components/sidebar.scss
@@ -1,5 +1,11 @@
 /* Override file app/webpacker/css/admin/components/sidebar.scss */
 
-#sidebar .sidebar-title {
-  color: $v2-blue;
+#sidebar {
+  border-color: #e7e7e7;
+  .sidebar-title {
+    color: $v2-blue;
+    & > span {
+      background-color: $v2-body-bg;
+    }
+  }
 }

--- a/app/webpacker/css/admin/v2/components/tables.scss
+++ b/app/webpacker/css/admin/v2/components/tables.scss
@@ -1,5 +1,9 @@
 /* Overide tables.scss app/webpacker/css/admin/components/tables.scss */
 
+table {
+  background-color: white;
+}
+
 table thead th {
   background-color: $v2-medium-light-grey;
   border: none;
@@ -43,8 +47,9 @@ table tbody tr {
   }
 }
 
-table th.actions,
-table td.actions {
+table thead tr th.actions,
+table tbody tr td.actions {
+  background-color: $v2-body-bg !important;
   // Special for icons in the actions column
   [class*="icon-"],
   button[class*="icon-"]:not(.disabled):not([disabled]):not(.secondary):not(.cancel) {
@@ -83,7 +88,10 @@ table td.actions {
 table#listing_orders {
   thead th.actions,
   thead td.actions {
-    background-color: $v2-medium-light-grey;
+    background-color: $v2-medium-light-grey !important;
+  }
+  tbody tr td.actions {
+    background-color: white !important;
   }
   td {
     // When the table is the listing of orders, we need to increase the height of the cells

--- a/app/webpacker/css/admin/v2/components/tables.scss
+++ b/app/webpacker/css/admin/v2/components/tables.scss
@@ -49,6 +49,15 @@ table td.actions {
   // Special for icons in the actions column
   [class*="icon-"] {
     color: $v2-blue;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    &:before {
+      width: auto;
+      padding: 0;
+    }
+
     &.no-text {
       border: 2px solid $v2-blue-light;
       background-color: $v2-blue-lightest;

--- a/app/webpacker/css/admin/v2/components/tables.scss
+++ b/app/webpacker/css/admin/v2/components/tables.scss
@@ -1,8 +1,6 @@
 /* Overide tables.scss app/webpacker/css/admin/components/tables.scss */
 
-table thead th,
-table thead th.actions,
-table thead td.actions {
+table thead th {
   background-color: $v2-medium-light-grey;
   border: none;
   color: $v2-blue;
@@ -15,24 +13,23 @@ table thead td.actions {
   }
 }
 
+table tr:not([class*="state"]) {
+  th:first-child,
+  td:first-child {
+    border-left: none;
+  }
+}
+
 table tbody tr {
   &:first-child th,
   &:first-child td {
     border-top: none; // Don't show the top border of the first row
   }
-  td:not(:first-child) {
-    border-left: none; // Only show left border on the first cells, as it indicates the order state by its color
-  }
 
   td {
-    border-bottom: none; // By default, do not show the border of the cells
-    border-right: none;
-    border-top: none;
-
+    border: none;
     border-bottom: 2px solid $v2-medium-light-grey;
-    &.actions {
-      border-bottom: 2px solid $v2-medium-light-grey !important; // needs to be important because of already defined with important
-    }
+
     > .flex {
       display: flex;
       column-gap: 10px;
@@ -78,11 +75,22 @@ table td.actions {
   }
 }
 
-table#listing_orders td {
-  // When the table is the listing of orders, we need to increase the height of the cells
-  padding: 20px 0;
+table#listing_orders {
+  thead th.actions,
+  thead td.actions {
+    background-color: $v2-medium-light-grey;
+  }
+  td {
+    // When the table is the listing of orders, we need to increase the height of the cells
+    padding: 20px 0;
 
-  &.actions {
-    padding-left: 20px;
+    &.actions {
+      padding-left: 20px;
+      border-bottom: 2px solid $v2-medium-light-grey !important; // needs to be important because of already defined with important
+    }
+
+    &:not(:first-child) {
+      border-left: none; // Only show left border on the first cells, as it indicates the order state by its color
+    }
   }
 }

--- a/app/webpacker/css/admin/v2/components/tables.scss
+++ b/app/webpacker/css/admin/v2/components/tables.scss
@@ -1,6 +1,8 @@
 /* Overide tables.scss app/webpacker/css/admin/components/tables.scss */
 
-table thead th {
+table thead th,
+table thead th.actions,
+table thead td.actions {
   background-color: $v2-medium-light-grey;
   border: none;
   color: $v2-blue;
@@ -47,7 +49,8 @@ table tbody tr {
 table th.actions,
 table td.actions {
   // Special for icons in the actions column
-  [class*="icon-"] {
+  [class*="icon-"],
+  button[class*="icon-"]:not(.disabled):not([disabled]):not(.secondary):not(.cancel) {
     color: $v2-blue;
     display: flex;
     justify-content: center;

--- a/app/webpacker/css/admin/v2/components/tables.scss
+++ b/app/webpacker/css/admin/v2/components/tables.scss
@@ -79,7 +79,8 @@ table tbody tr td.actions {
   .icon-edit:hover,
   .icon-capture:hover,
   .icon-ok:hover,
-  .icon-plus:hover {
+  .icon-plus:hover,
+  .icon-road:hover {
     background-color: $v2-blue;
     color: $color-1;
   }

--- a/app/webpacker/css/admin/v2/components/tables.scss
+++ b/app/webpacker/css/admin/v2/components/tables.scss
@@ -47,17 +47,20 @@ table tbody tr {
 table th.actions,
 table td.actions {
   // Special for icons in the actions column
-  [class*="icon-"].no-text {
-    border: 2px solid $v2-blue-light;
-    background-color: $v2-blue-lightest;
+  [class*="icon-"] {
+    color: $v2-blue;
+    &.no-text {
+      border: 2px solid $v2-blue-light;
+      background-color: $v2-blue-lightest;
 
-    &:hover {
-      border-color: $v2-blue;
-      background-color: $v2-blue-light;
-      box-shadow: $v2-box-shadow;
+      &:hover {
+        border-color: $v2-blue;
+        background-color: $v2-blue-light;
+        box-shadow: $v2-box-shadow;
 
-      &:before {
-        color: white;
+        &:before {
+          color: white;
+        }
       }
     }
   }

--- a/app/webpacker/css/admin/v2/components/tables.scss
+++ b/app/webpacker/css/admin/v2/components/tables.scss
@@ -71,6 +71,13 @@ table td.actions {
       }
     }
   }
+  .icon-edit:hover,
+  .icon-capture:hover,
+  .icon-ok:hover,
+  .icon-plus:hover {
+    background-color: $v2-blue;
+    color: $color-1;
+  }
 }
 
 table#listing_orders {

--- a/app/webpacker/css/admin/v2/components/tables.scss
+++ b/app/webpacker/css/admin/v2/components/tables.scss
@@ -73,6 +73,8 @@ table tbody tr td.actions {
 
     &.no-text {
       border: 2px solid $v2-blue-light;
+      display: flex; // Be sure that display: flex; is applied
+      padding-top: 0;
 
       &:hover {
         border-color: $v2-blue;

--- a/app/webpacker/css/admin/v2/components/tables.scss
+++ b/app/webpacker/css/admin/v2/components/tables.scss
@@ -60,11 +60,9 @@ table td.actions {
 
     &.no-text {
       border: 2px solid $v2-blue-light;
-      background-color: $v2-blue-lightest;
 
       &:hover {
         border-color: $v2-blue;
-        background-color: $v2-blue-light;
         box-shadow: $v2-box-shadow;
 
         &:before {

--- a/app/webpacker/css/admin/v2/components/tables.scss
+++ b/app/webpacker/css/admin/v2/components/tables.scss
@@ -4,6 +4,14 @@ table {
   background-color: white;
 }
 
+table thead tr:first-child th:first-child {
+  border-top-left-radius: 3px;
+}
+
+table thead tr:first-child th:last-child,
+table thead th.force-rounded-right {
+  border-top-right-radius: 3px;
+}
 table thead th {
   background-color: $v2-medium-light-grey;
   border: none;

--- a/app/webpacker/css/admin/v2/components/tom_select.scss
+++ b/app/webpacker/css/admin/v2/components/tom_select.scss
@@ -1,0 +1,47 @@
+/* Override app/webpacker/css/admin/components/tom_select.scss */
+
+.ts-wrapper.primary.focus .ts-control,
+.ts-wrapper.primary .ts-control {
+  background-color: transparent;
+  border: 1px solid $v2-light-grey;
+  color: $v2-medium-grey;
+
+  &:after {
+    border-color: $v2-medium-grey transparent transparent transparent;
+  }
+}
+
+.ts-wrapper.dropdown-active.primary .ts-control {
+  background-color: transparent;
+  border-color: $v2-light-grey;
+  color: $v2-medium-grey;
+
+  &:after {
+    border-color: transparent transparent $v2-medium-grey transparent;
+  }
+}
+
+.ts-wrapper.dropdown-active.focus .ts-control {
+  border-color: $v2-medium-grey;
+}
+
+.dropdown-input-wrap {
+  .dropdown-input {
+    border: 1px solid $v2-light-grey;
+  }
+}
+
+.ts-dropdown .create:hover,
+.ts-dropdown #admin-menu li.selected a.create,
+#admin-menu li.selected .ts-dropdown a.create,
+.ts-dropdown .option:hover,
+.ts-dropdown #admin-menu li.selected a.option,
+#admin-menu li.selected .ts-dropdown a.option,
+.ts-dropdown .active {
+  background-color: $v2-blue;
+  color: $white;
+}
+
+.ts-dropdown.single {
+  border-color: $v2-medium-grey;
+}

--- a/app/webpacker/css/admin/v2/components/tom_select.scss
+++ b/app/webpacker/css/admin/v2/components/tom_select.scss
@@ -2,7 +2,7 @@
 
 .ts-wrapper.primary.focus .ts-control,
 .ts-wrapper.primary .ts-control {
-  background-color: transparent;
+  background-color: white;
   border: 1px solid $v2-light-grey;
   color: $v2-medium-grey;
 

--- a/app/webpacker/css/admin/v2/main.scss
+++ b/app/webpacker/css/admin/v2/main.scss
@@ -1,14 +1,12 @@
 @import "variables.scss";
 @import "shared/typography.scss";
 
-body.admin.admin-v2 {
-  @import "navigation.scss";
-  @import "plugins/select2.scss";
-  @import "plugins/powertip.scss";
-  @import "plugins/flatpickr-customization.scss";
-  @import "shared/forms.scss";
-  @import "components/buttons.scss";
-  @import "components/tables.scss";
-  @import "components/progress.scss";
-  @import "components/sidebar.scss";
-}
+@import "navigation.scss";
+@import "plugins/select2.scss";
+@import "plugins/powertip.scss";
+@import "plugins/flatpickr-customization.scss";
+@import "shared/forms.scss";
+@import "components/buttons.scss";
+@import "components/tables.scss";
+@import "components/progress.scss";
+@import "components/sidebar.scss";

--- a/app/webpacker/css/admin/v2/main.scss
+++ b/app/webpacker/css/admin/v2/main.scss
@@ -10,3 +10,4 @@
 @import "components/tables.scss";
 @import "components/progress.scss";
 @import "components/sidebar.scss";
+@import "components/tom_select.scss";

--- a/app/webpacker/css/admin/v2/main.scss
+++ b/app/webpacker/css/admin/v2/main.scss
@@ -10,4 +10,5 @@ body.admin.admin-v2 {
   @import "components/buttons.scss";
   @import "components/tables.scss";
   @import "components/progress.scss";
+  @import "components/sidebar.scss";
 }

--- a/app/webpacker/css/admin/v2/main.scss
+++ b/app/webpacker/css/admin/v2/main.scss
@@ -11,3 +11,7 @@
 @import "components/progress.scss";
 @import "components/sidebar.scss";
 @import "components/tom_select.scss";
+
+body {
+  background-color: $v2-body-bg;
+}

--- a/app/webpacker/css/admin/v2/main.scss
+++ b/app/webpacker/css/admin/v2/main.scss
@@ -11,6 +11,7 @@
 @import "components/progress.scss";
 @import "components/sidebar.scss";
 @import "components/tom_select.scss";
+@import "components/dropdown.scss";
 
 body {
   background-color: $v2-body-bg;

--- a/app/webpacker/css/admin/v2/navigation.scss
+++ b/app/webpacker/css/admin/v2/navigation.scss
@@ -60,3 +60,14 @@
     color: $v2-medium-dark-grey;
   }
 }
+
+nav.menu ul li a,
+nav.menu ul #admin-menu li.selected a,
+#admin-menu nav.menu ul li.selected a {
+  &:hover {
+    border-bottom-color: $v2-green;
+    border-top-color: transparent;
+    border-right-color: transparent;
+    border-left-color: transparent;
+  }
+}

--- a/app/webpacker/css/admin/v2/navigation.scss
+++ b/app/webpacker/css/admin/v2/navigation.scss
@@ -61,13 +61,24 @@
   }
 }
 
-nav.menu ul li a,
-nav.menu ul #admin-menu li.selected a,
-#admin-menu nav.menu ul li.selected a {
-  &:hover {
-    border-bottom-color: $v2-green;
-    border-top-color: transparent;
-    border-right-color: transparent;
-    border-left-color: transparent;
+nav.menu ul li,
+nav.menu ul #admin-menu li,
+#admin-menu nav.menu ul li {
+  &.active {
+    a {
+      color: $v2-blue-dark;
+      border-bottom-color: $v2-blue-dark;
+    }
+  }
+
+  &.selected a,
+  a {
+    &:hover {
+      color: $v2-blue-dark;
+      border-bottom-color: $v2-blue-dark;
+      border-top-color: transparent;
+      border-right-color: transparent;
+      border-left-color: transparent;
+    }
   }
 }

--- a/app/webpacker/css/admin/v2/plugins/powertip.scss
+++ b/app/webpacker/css/admin/v2/plugins/powertip.scss
@@ -28,4 +28,31 @@
   &.sw:before {
     border-right-color: $v2-blue;
   }
+
+  &.edit,
+  &.green,
+  &.capture,
+  &.save,
+  &.add {
+    background-color: $v2-blue;
+
+    &.n:before,
+    &.ne:before,
+    &.nw:before {
+      border-top-color: $v2-blue;
+    }
+    &.e:before,
+    &.nw:before,
+    &.sw:before {
+      border-right-color: $v2-blue;
+    }
+    &.s:before,
+    &.se:before,
+    &.sw:before {
+      border-bottom-color: $v2-blue;
+    }
+    &.w:before {
+      border-left-color: $v2-blue;
+    }
+  }
 }

--- a/app/webpacker/css/admin/v2/plugins/select2.scss
+++ b/app/webpacker/css/admin/v2/plugins/select2.scss
@@ -37,6 +37,12 @@
 }
 
 .select2-container-multi {
+  &.select2-dropdown-open,
+  &.select2-container-active {
+    .select2-choices {
+      border-color: $v2-medium-grey !important;
+    }
+  }
   .select2-choices {
     border-color: $v2-medium-grey !important;
     .select2-search-choice {

--- a/app/webpacker/css/admin/v2/plugins/select2.scss
+++ b/app/webpacker/css/admin/v2/plugins/select2.scss
@@ -2,7 +2,7 @@
 
 .select2-container {
   .select2-choice {
-    background-color: transparent;
+    background-color: white;
     border: 1px solid $v2-light-grey !important;
     color: $v2-medium-grey !important;
     padding-left: 5px;

--- a/app/webpacker/css/admin/v2/shared/forms.scss
+++ b/app/webpacker/css/admin/v2/shared/forms.scss
@@ -25,7 +25,7 @@ fieldset {
 }
 
 fieldset label {
-  color: $v2-medium-grey;
+  color: $v2-medium-dark-grey;
 }
 
 fieldset legend {

--- a/app/webpacker/css/admin/v2/shared/forms.scss
+++ b/app/webpacker/css/admin/v2/shared/forms.scss
@@ -30,6 +30,7 @@ fieldset label {
 
 fieldset legend {
   color: $v2-blue;
+  background-color: $v2-body-bg;
 }
 
 input[type="checkbox"],

--- a/app/webpacker/css/admin/v2/shared/typography.scss
+++ b/app/webpacker/css/admin/v2/shared/typography.scss
@@ -10,8 +10,6 @@
 }
 
 body.admin.admin-v2 {
-  color: $v2-body-grey;
-
   a:not(.button) {
     @include v2-link-color();
   }

--- a/app/webpacker/css/admin/v2/shared/typography.scss
+++ b/app/webpacker/css/admin/v2/shared/typography.scss
@@ -9,8 +9,6 @@
   }
 }
 
-body.admin.admin-v2 {
-  a:not(.button) {
-    @include v2-link-color();
-  }
+a:not(.button) {
+  @include v2-link-color();
 }

--- a/app/webpacker/css/admin/v2/variables.scss
+++ b/app/webpacker/css/admin/v2/variables.scss
@@ -21,3 +21,5 @@ $v2-green: #019854;
 $v2-green-light: #01cb70;
 
 $v2-box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25); // Default box shadow for actions stuff
+
+$v2-body-bg: #f7f9fa;

--- a/app/webpacker/css/admin/v2/variables.scss
+++ b/app/webpacker/css/admin/v2/variables.scss
@@ -7,7 +7,7 @@ $v2-orange-lightest: #fcdbd4;
 
 $v2-dark-grey: #333333;
 $v2-medium-dark-grey: #444444;
-$v2-body-grey: #666666;
+$v2-body-grey: $color-4;
 $v2-medium-grey: #717171;
 $v2-medium-light-grey: #e6e6e6;
 $v2-light-grey: #e7e7e7;

--- a/app/webpacker/packs/admin-styles-v2.scss
+++ b/app/webpacker/packs/admin-styles-v2.scss
@@ -1,0 +1,4 @@
+@import '../css/admin/globals/palette';
+@include basicColorPalette(#FFFFFF, #69A95D, #14B6CC, #484848, #C1122B, #F27052);
+
+@import "../css/admin/all.scss";

--- a/app/webpacker/packs/admin-styles-v2.scss
+++ b/app/webpacker/packs/admin-styles-v2.scss
@@ -2,3 +2,5 @@
 @include basicColorPalette(#FFFFFF, #69A95D, #14B6CC, #484848, #C1122B, #F27052);
 
 @import "../css/admin/all.scss";
+
+@import "../css/admin/v2/main.scss";

--- a/app/webpacker/packs/admin-styles.scss
+++ b/app/webpacker/packs/admin-styles.scss
@@ -1,1 +1,3 @@
+@import '../css/admin/globals/palette';
+
 @import "../css/admin/all.scss";


### PR DESCRIPTION
#### What? Why?

- Closes #10075 

<img width="1421" alt="Capture d’écran 2022-12-05 à 10 23 02" src="https://user-images.githubusercontent.com/296452/205600957-7c57e5f6-b8ff-4a2e-b474-75e254343a26.png">


<img width="1389" alt="Capture d’écran 2022-12-05 à 10 23 16" src="https://user-images.githubusercontent.com/296452/205601009-612ef58a-9e97-440a-81b5-56ea6e6f4843.png">


#### What should we test?
 - As an admin, with feature `admin_style_v2` activated, go to `/admin/order/R[ORDER_NUMBER]/edit`: you should see the design
 - As an admin, without feature `admin_style_v2`, nothing should change

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
