### PR TITLE
Translating text 'None' for tax and shipping categories of the product

### DIFF
--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -45,12 +45,12 @@
 
     = f.field_container :shipping_categories do
       = f.label :shipping_category_id, t(:shipping_categories)
-      = f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => 'None' }, { :class => 'select2' })
+      = f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => t(:none) }, { :class => 'select2' })
       = f.error_message_on :shipping_category
 
     = f.field_container :tax_category do
       = f.label :tax_category_id, t(:tax_category)
-      = f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => 'None' }, { :class => 'select2' })
+      = f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => t(:none) }, { :class => 'select2' })
       = f.error_message_on :tax_category
 
   .clear


### PR DESCRIPTION
#### What? Why?

- Closes #10060

Translating text 'None' for tax and shipping category selection on product edit page.

#### What should we test?
The text 'None' should be translated to the language set on the home page on product edit and creation page under admin.

1. Log in on the home page.
1. Change language to any other than English.
2. Go to product page under admin section.
3. Click on new product
   4. click the drop down menu for shipping and tax categories. 
   5. Verify that the 'None' text is translated to the language set.
4. Click on 'edit' button on one of the existing product and verify the same for this page.

#### Release notes

Changelog Category: User facing changes 
