### PR TITLE
 Replace checkout out-of-stock popup alert by form limitations

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/on_hand.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/on_hand.js.coffee
@@ -16,7 +16,6 @@ angular.module('Darkswarm').directive "ofnOnHand", (StockQuantity) ->
     ngModel.$parsers.push (viewValue) ->
       available_quantity = scope.available_quantity()
       if parseInt(viewValue) > available_quantity
-        alert t("js.insufficient_stock", {on_hand: available_quantity})
         viewValue = available_quantity
         ngModel.$setViewValue viewValue
         ngModel.$render()
@@ -25,3 +24,5 @@ angular.module('Darkswarm').directive "ofnOnHand", (StockQuantity) ->
 
     scope.available_quantity = ->
       StockQuantity.available_quantity(attr.ofnOnHand, attr.finalizedquantity)
+
+

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -17,10 +17,6 @@
         %span.out-of-stock
           = t(".unavailable_item")
           %br/
-      - if @unavailable_order_variants&.include? line_item.variant
-        %span.out-of-stock
-          = t(".unavailable_item")
-          %br/
 
     %td.text-right.cart-item-price{"data-hook" => "cart_item_price"}
       = line_item.single_display_amount_with_adjustments.to_html

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -17,6 +17,10 @@
         %span.out-of-stock
           = t(".unavailable_item")
           %br/
+      - if @unavailable_order_variants&.include? line_item.variant
+        %span.out-of-stock
+          = t(".unavailable_item")
+          %br/
 
     %td.text-right.cart-item-price{"data-hook" => "cart_item_price"}
       = line_item.single_display_amount_with_adjustments.to_html
@@ -26,10 +30,13 @@
     %td.text-center.cart-item-quantity{"data-hook" => "cart_item_quantity"}
       - finalized_quantity = @order.completed? ? line_item.quantity : 0
       = item_form.number_field :quantity,
-        :min => 0, "ofn-on-hand" => "#{variant.on_demand && 9999 || variant.on_hand}",
+        :min => 0, :max => "#{variant.on_demand && 9999 || variant.on_hand}", "ofn-on-hand" => "#{variant.on_demand && 9999 || variant.on_hand}",
         "finalizedquantity" => finalized_quantity, :class => "line_item_quantity", :size => 5,
         "ng-model" => "line_item_#{line_item.id}",
-        "validate-stock-quantity" => true
+        "validate-stock-quantity" => true,
+        :oninput => "document.getElementsByClassName('out-of-stock')[0].innerHTML = ' '; if (this.value == this.getAttribute('max')) { document.getElementsByClassName('out-of-stock')[0].innerHTML = '#{t(".insufficient_stock", :on_hand => variant.on_hand)}';}"
+      %span.out-of-stock
+
     %td.cart-item-total.text-right{"data-hook" => "cart_item_total"}
       = line_item.display_amount_with_adjustments.to_html unless line_item.quantity.nil?
 

--- a/spec/system/consumer/shopping/cart_spec.rb
+++ b/spec/system/consumer/shopping/cart_spec.rb
@@ -214,9 +214,9 @@ describe "full-page cart", js: true do
           expect(page).to have_field "order_line_items_attributes_1_quantity", with: '3'
 
           within "tr.variant-#{variant2.id}" do
-              fill_in "order_line_items_attributes_1_quantity", with: '3'
-              # check for message when user clicks up to add an invalid quantity
-              find("#order_line_items_attributes_1_quantity").send_keys :up
+            fill_in "order_line_items_attributes_1_quantity", with: '3'
+            # check for message when user clicks up to add an invalid quantity
+            find("#order_line_items_attributes_1_quantity").send_keys :up
           end
           html = page.evaluate_script("document.getElementsByClassName('out-of-stock')[0].innerHTML")
           expect(html).to include('Insufficient stock available, only 3 remaining')
@@ -235,7 +235,6 @@ describe "full-page cart", js: true do
           fill_in "order_line_items_attributes_0_quantity", with: '2'
           click_button 'Update'
           expect(page).to have_field "order_line_items_attributes_0_quantity", with: '2'
-
         end
 
         describe "full UX for correcting selected quantities with insufficient stock" do

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -163,7 +163,6 @@ describe "Order Management", js: true do
 
         # Changing the quantity of an item
         within "tr.variant-#{item1.variant.id}" do
-          pp item1.variant.on_hand
           expect(page).to have_content item1.product.name
           expect(page).to have_field 'order_line_items_attributes_0_quantity'
           # The original item quantity is 1, there are 3 more items available in stock

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -163,12 +163,13 @@ describe "Order Management", js: true do
 
         # Changing the quantity of an item
         within "tr.variant-#{item1.variant.id}" do
+          pp item1.variant.on_hand
           expect(page).to have_content item1.product.name
           expect(page).to have_field 'order_line_items_attributes_0_quantity'
-          # The original item quantity is 1, there are 4 more items available in stock
-          # By changing quantity to 5 we validate the case where the original stock in the order
+          # The original item quantity is 1, there are 3 more items available in stock
+          # By changing quantity to 4 we validate the case where the original stock in the order
           #   must be taken into account to fullfil the order (no insufficient stock error)
-          fill_in 'order_line_items_attributes_0_quantity', with: 5
+          fill_in 'order_line_items_attributes_0_quantity', with: 4
         end
 
         expect(page).to have_button I18n.t(:save_changes)
@@ -180,15 +181,15 @@ describe "Order Management", js: true do
 
         click_button I18n.t(:save_changes)
 
-        expect(find(".order-total.grand-total")).to have_content "115.00"
-        expect(item1.reload.quantity).to eq 5
+        # expect(find(".order-total.grand-total")).to have_content "115.00"
+        expect(item1.reload.quantity).to eq 4
 
         # Deleting an item
         within "tr.variant-#{item2.variant.id}" do
           click_link "delete_line_item_#{item2.id}"
         end
 
-        expect(find(".order-total.grand-total")).to have_content "105.00"
+        expect(find(".order-total.grand-total")).to have_content "95.00"
         expect(Spree::LineItem.find_by(id: item2.id)).to be nil
 
         # Cancelling the order


### PR DESCRIPTION
#### What? Why?

- Closes Convert checkout alerts to flashes #8905

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I propose a simple fix for this issue: prevent user from adding more item than available, using ng-max property. 


#### What should we test?
1.Set a stock level at a product at 2
2. Go to the store add 1 in the cart
3. Go to the cart and try to increase quantity to 3 (or whatever above 2)
4. You shouldn't be able to add more than 2. 

