### PR TITLE
[Admin][Order Cycle] Enable save btn after removing fee

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_basic_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_basic_controller.js.coffee
@@ -38,3 +38,4 @@ angular.module('admin.orderCycles')
     $scope.removeCoordinatorFee = ($event, index) ->
       $event.preventDefault()
       OrderCycle.removeCoordinatorFee(index)
+      $scope.order_cycle_form.$dirty = true

--- a/spec/javascripts/unit/admin/order_cycles/controllers/order_cycle_basic_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/order_cycles/controllers/order_cycle_basic_controller_spec.js.coffee
@@ -9,6 +9,7 @@ describe 'AdminOrderCycleBasicCtrl', ->
 
   beforeEach ->
     scope =
+      order_cycle_form: jasmine.createSpyObj('order_cycle_form', ['$dirty', '$setPristine'])
       $watch: jasmine.createSpy('$watch')
     event =
       preventDefault: jasmine.createSpy('preventDefault')


### PR DESCRIPTION
#### What? Why?

- Closes #10005 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Login as an enterprise manager who manages a `shop`
- Navigate to  `/admin/order_cycles`
- click edit an order cycle
- Remove an existing fee
- Ascertain that the `save` button becomes enabled

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
