### PR TITLE
[Split Checkout] Stop horizontal scroll on body in order summary page

### DIFF
--- a/app/views/spree/orders/edit.html.haml
+++ b/app/views/spree/orders/edit.html.haml
@@ -25,7 +25,7 @@
   .sub-header.show-for-medium-down
     = render partial: "shopping_shared/order_cycles"
 
-  %fieldset.footer-pad
+  #cart-container
     - if @order.line_items.empty?
       %div.row{"data-hook" => "empty_cart"}
         %p= t(:your_cart_is_empty)

--- a/app/webpacker/css/darkswarm/cart-page.scss
+++ b/app/webpacker/css/darkswarm/cart-page.scss
@@ -1,3 +1,8 @@
+#cart-container {
+  padding: 25px;
+  padding-bottom: 100px;
+}
+
 #update-cart {
   #errorExplanation {
     display: none;
@@ -6,6 +11,8 @@
 
 #cart-detail {
   width: 100%;
+  display: block;
+  overflow-x: auto;
 
   .cart-item-delete,
   .bought-item-delete {

--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -306,3 +306,8 @@
     }
   }
 }
+
+#line-items {
+  display: block;
+  overflow-x: auto;
+}


### PR DESCRIPTION
#### What? Why?

- Closes #9976 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Login as user and populate cart with some products (with long names)
- Navigate to checkout. Make sure you've split checkout enabled.
- Ascertain in the `Order Summary` page, the body doesn't scroll

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
