### PR TITLE
Fix: Transparent background of 'Complete Order' area on Firefox mobile

### DIFF
--- a/app/webpacker/controllers/sticky_controller.js
+++ b/app/webpacker/controllers/sticky_controller.js
@@ -15,7 +15,7 @@ export default class extends Controller {
     this.containerTarget.style.bottom = "-1px";
     const observer = new IntersectionObserver(
       ([e]) => {
-        e.target.classList.toggle("sticked", e.intersectionRatio < 1);
+        e.target.classList.toggle("sticked", e.intersectionRatio <= 1);
       },
       { threshold: [1] }
     );


### PR DESCRIPTION
#### What? Why?

- Closes #9975 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Login as user in firefox mobile, place an order and proceed to the `Order Summary` page on 
- Make sure you have split checkout enabled
- Checkout and proceed to the `Order Summary` page 
- Verify that the "Complete Order" area is not transparent

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
