### PR TITLE
Display producer's name in products inspite of hide all refs option

### DIFF
--- a/app/assets/javascripts/darkswarm/services/enterprise_modal.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/enterprise_modal.js.coffee
@@ -2,6 +2,7 @@ angular.module('Darkswarm').factory "EnterpriseModal", ($modal, $rootScope, $htt
   # Build a modal popup for an enterprise.
   new class EnterpriseModal
     open: (enterprise)->
+      return if enterprise.visible == 'hidden'
       scope = $rootScope.$new(true) # Spawn an isolate to contain the enterprise
       scope.embedded_layout = window.location.search.indexOf("embedded_shopfront=true") != -1
 

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -267,8 +267,7 @@ class Enterprise < ApplicationRecord
 
   def plus_parents_and_order_cycle_producers(order_cycles)
     oc_producer_ids = Exchange.in_order_cycle(order_cycles).incoming.pluck :sender_id
-    Enterprise.not_hidden.is_primary_producer
-      .parents_of_one_union_others(id, oc_producer_ids | [id])
+    Enterprise.is_primary_producer.parents_of_one_union_others(id, oc_producer_ids | [id])
   end
 
   def relatives_including_self

--- a/app/serializers/api/enterprise_thin_serializer.rb
+++ b/app/serializers/api/enterprise_thin_serializer.rb
@@ -2,7 +2,7 @@
 
 module Api
   class EnterpriseThinSerializer < ActiveModel::Serializer
-    attributes :name, :id, :active, :path
+    attributes :name, :id, :active, :path, :visible
 
     has_one :address, serializer: Api::AddressSerializer
 

--- a/app/views/shop/products/_summary.html.haml
+++ b/app/views/shop/products/_summary.html.haml
@@ -10,11 +10,12 @@
       %a{"ng-click" => "triggerProductModal()", href: 'javascript:void(0)'}
         %span{"ng-bind" => "::product.name"}
     .product-description{ng: {"bind-html": "::product.description_html", click: "triggerProductModal()", show: "product.description_html.length"}}
-    .product-producer
-      = t :products_from
-      %span
-        %enterprise-modal
-          %span{"ng-bind" => "::enterprise.name"}
+    %div{ "ng-switch" => "enterprise.visible" }
+      .product-producer
+        = t :products_from
+        %span{ "ng-switch-when": "hidden", "ng-bind" => "::enterprise.name"}
+        %span{ "ng-switch-default": true }
+          %enterprise-modal{"ng-bind" => "::enterprise.name"}
 
     .product-properties.filter-shopfront.property-selectors
       %filter-selector{ 'selector-set' => "productPropertySelectors", objects: "[product] | propertiesWithValuesOf" }

--- a/app/views/shopping_shared/tabs/_producers.html.haml
+++ b/app/views/shopping_shared/tabs/_producers.html.haml
@@ -6,6 +6,9 @@
           = t :shopping_producers_of_hub, hub: '{{ shopfront.name }}'
         %ul.small-block-grid-1.medium-block-grid-2.large-block-grid-3
           %li{"ng-repeat" => "enterprise in shopfront.producers"}
-            %enterprise-modal
+            %enterprise-modal{"ng-if": "enterprise.visible != 'hidden'"}
+              %i.ofn-i_036-producers
+              {{ enterprise.name }}
+            %span{"ng-if": "enterprise.visible == 'hidden'"}
               %i.ofn-i_036-producers
               {{ enterprise.name }}

--- a/spec/system/consumer/shopping/products_spec.rb
+++ b/spec/system/consumer/shopping/products_spec.rb
@@ -41,6 +41,30 @@ describe "As a consumer I want to view products" do
       set_order order
     end
 
+    describe "supplier's name is displayed" do
+      before do
+        exchange1.update_attribute :pickup_time, "monday"
+        add_variant_to_order_cycle(exchange1, variant)
+      end
+
+      it "shows supplier's name" do
+        visit shop_path
+        expect(page).to have_content supplier.name
+        page.find("span", text: supplier.name).click
+        assert_selector ".reveal-modal"
+      end
+
+      it "shows supplier's name even when supplier's visibility is hidden" do
+        supplier.visible = 'hidden'
+        supplier.save
+        visit shop_path
+        expect(page).to have_content supplier.name
+        # Does not open the modal though
+        page.find("span", text: supplier.name).click
+        assert_no_selector ".reveal-modal"
+      end
+    end
+
     describe "viewing HTML product descriptions" do
       before do
         exchange1.update_attribute :pickup_time, "monday"

--- a/spec/system/consumer/shopping/shopping_spec.rb
+++ b/spec/system/consumer/shopping/shopping_spec.rb
@@ -42,15 +42,43 @@ describe "As a consumer I want to shop with a distributor" do
       expect(first("distributor img")['src']).to include "logo-white.png"
     end
 
-    it "shows the producers for a distributor" do
-      exchange = Exchange.find(oc1.exchanges.to_enterprises(distributor).outgoing.first.id)
-      add_variant_to_order_cycle(exchange, variant)
-
-      visit shop_path
-      within ".tab-buttons" do
-        click_link "Producers"
+    describe "producers tab" do
+      before do
+        exchange = Exchange.find(oc1.exchanges.to_enterprises(distributor).outgoing.first.id)
+        add_variant_to_order_cycle(exchange, variant)
+        visit shop_path
+        within ".tab-buttons" do
+          click_link "Producers"
+        end
       end
-      expect(page).to have_content supplier.name
+
+      it "shows the producers for a distributor" do
+        expect(page).to have_content supplier.name
+        find("a", text: supplier.name).click
+        within ".reveal-modal" do
+          expect(page).to have_content supplier.name
+        end
+      end
+
+      context "when the producer visibility is set to 'hidden'" do
+        before do
+          supplier.visible = "hidden"
+          supplier.save
+          visit shop_path
+          within ".tab-buttons" do
+            click_link "Producers"
+          end
+        end
+
+        it "shows the producer name" do
+          expect(page).to have_content supplier.name
+        end
+
+        it "does not show the producer modal" do
+          expect(page).to_not have_link supplier.name
+          expect(page).to_not have_selector ".reveal-modal"
+        end
+      end
     end
 
     describe "selecting an order cycle" do

--- a/spec/system/consumer/shops_spec.rb
+++ b/spec/system/consumer/shops_spec.rb
@@ -231,6 +231,24 @@ describe 'Shops' do
         expect(page).to have_content "Shop for #{producer.name} products at:".upcase
       end
     end
+
+    context "when visibility is `hidden`" do
+      before do
+        producer.visible = "hidden"
+        producer.save
+        visit shops_path
+        expand_active_table_node distributor.name
+      end
+
+      it "shows the producer name" do
+        expect(page).to have_content producer.name
+      end
+
+      it "does not show the producer modal" do
+        open_enterprise_modal producer
+        expect(page).to_not have_selector(".reveal-modal")
+      end
+    end
   end
 
   describe "viewing closed shops by URL" do


### PR DESCRIPTION
selected

#### What? Why?

- Closes #9698

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Login as admin and navigate to `enterprises/<name>/edit` of a `producer`
- Select `hide all references`
- Navigate to any open OC that display's the producer's products
- Ascertain that you can see the producer's name listed alongside its product 
<img width="903" alt="Capture d’écran 2023-03-09 à 15 42 57" src="https://user-images.githubusercontent.com/296452/224059352-66cfa7dd-9fb9-41e6-a26e-1ef5374234f9.png">
- Ascertain that you can see the producer's name listed in the producers name, but no modal should open
<img width="778" alt="Capture d’écran 2023-03-09 à 16 08 26" src="https://user-images.githubusercontent.com/296452/224066392-04e9ef18-319f-4442-ab1d-780f3af88cab.png">

When visibility is by default, nothing should change. 
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
