### PR TITLE
Updating price, on_hand, on_demand validations for product import

### DIFF
--- a/spec/models/product_import/entry_validator_spec.rb
+++ b/spec/models/product_import/entry_validator_spec.rb
@@ -37,7 +37,9 @@ describe ProductImport::EntryValidator do
       enterprise_id: enterprise.id,
       producer: enterprise,
       producer_id: enterprise.id,
-      distributor: enterprise
+      distributor: enterprise,
+      price: "1.0",
+      on_hand: "1"
     )
   end
 
@@ -51,7 +53,9 @@ describe ProductImport::EntryValidator do
       enterprise_id: enterprise.id,
       producer: enterprise,
       producer_id: enterprise.id,
-      distributor: enterprise
+      distributor: enterprise,
+      price: "1.0",
+      on_hand: "1"
     )
   end
 
@@ -99,7 +103,7 @@ describe ProductImport::EntryValidator do
     it "validates a product" do
       entries = [potato_variant]
       entry_validator.validate_all(entries)
-      expect(potato_variant.errors.count).to eq 1
+      expect(potato_variant.errors.count).to eq 4
     end
   end
 

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -651,7 +651,7 @@ describe ProductImport::ProductImporter do
       let(:csv_data) {
         CSV.generate do |csv|
           csv << ["name", "display_name", "distributor", "producer", "on_hand", "price", "units"]
-          csv << ["Oats", "Porridge Oats", enterprise2.name, enterprise.name, "900", "", "500"]
+          csv << ["Oats", "Porridge Oats", enterprise2.name, enterprise.name, "900", "1.0", "500"]
         end
       }
       let(:importer) { import_data csv_data, import_into: 'inventories' }
@@ -679,7 +679,7 @@ describe ProductImport::ProductImporter do
         CSV.generate do |csv|
           csv << ["name", "distributor", "producer", "on_hand", "price", "units",
                   "variant_unit_name"]
-          csv << ["Cabbage", enterprise2.name, enterprise.name, "900", "", "1", "Whole"]
+          csv << ["Cabbage", enterprise2.name, enterprise.name, "900", "1.0", "1", "Whole"]
         end
       }
       let(:importer) { import_data csv_data, import_into: 'inventories' }


### PR DESCRIPTION
#### What? Why?

- Closes #9978 & #10101

Added validation to catch the following during product import:
1. Non numeric  `UNITS` value
   1.  Greater than zero condition for #10101 
1. `PRICE` validation.
1. `ON_HAND` and `ON_DEMAND` validation.
   1. Invalidating entries for the following 
   1. `ON_HAND = <Non integer or -ve integer>`
   1. `ON_HAND = <EMPTY>` when `ON_DEMAND !=1` 
   1. `ON_DEMAND = <Non Integer or any other value than 0 or 1>`
   1. `ON_DEMAND = <EMPTY or 0> when ON_HAND = <EMPTY>`
1.  Changing the error message for `CATEGORY` to `admin.product_import.model.category_not_found` from `error_not_found_in_database`


#### What should we test?
- Test the above validations by uploading [test-import.csv](https://github.com/openfoodfoundation/openfoodnetwork/files/10200249/test-import.csv).
- Check for various combinations for `ON_HAND` and `ON_DEMAND`.

#### Follow ups
1. Add `conditional_blank` error message for the relation between `ON_HAND` and `ON_DEMAND` (similar to `variant_type` and `unit_type`).
2. The UI currently shows some fields populated by default data even when its empty in the file (Eg: `ON HAND` is set to 0 when empty) and empty for some cases when there should have been an entry (eg: Non numeric value for `PRICE` is not shown). Even though these are caught in validation with appropriate error messages, it could be confusing for the user if error message could be contradictory to what is show to the user. Eg: `Price` as incorrect value for non numeric data but empty cell is shown on the UI)
    1. update the rendering logic to reflect the actual data from the file. (Make sure not to break any existing usecase that could be tied) 