### PR TITLE
Downgrade `zeitwerk` to `2.6.4`, since it raises `Zeitwerk::Error`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -747,7 +747,7 @@ GEM
     xml-simple (1.1.8)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.6)
+    zeitwerk (2.6.4)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
#### What? Why?

Since updates made on PR #9961 (I guess), I have a few ` Zeitwerk::Error`

```
...
wants to manage directory /Users/jibees/dev/openfoodnetwork/lib/reporting, which is already managed by
...
```


Basically this PR downgrade zeitwerk version then that has been updated (why?) with 7c7e5aaa5972b6377a5eaedba25fec8b29d8ef65.


#### What should we test?
Green build + a deployment

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
