### PR TITLE
Fix missing payment_states translation in payment report

### DIFF
--- a/lib/reporting/reports/payments/itemised_payment_totals.rb
+++ b/lib/reporting/reports/payments/itemised_payment_totals.rb
@@ -6,7 +6,9 @@ module Reporting
       class ItemisedPaymentTotals < Base
         def columns
           {
-            payment_state: proc { |orders| orders.first.payment_state },
+            payment_state: proc { |orders|
+              I18n.t("js.admin.orders.payment_states.#{orders.first.payment_state}") 
+            },
             distributor: proc { |orders| orders.first.distributor.name },
             product_total_price: proc { |orders| orders.to_a.sum(&:item_total) },
             shipping_total_price: proc { |orders| orders.sum(&:ship_total) },

--- a/lib/reporting/reports/payments/payment_totals.rb
+++ b/lib/reporting/reports/payments/payment_totals.rb
@@ -6,7 +6,9 @@ module Reporting
       class PaymentTotals < Base
         def columns
           {
-            payment_state: proc { |orders| orders.first.payment_state },
+            payment_state: proc { |orders|
+              I18n.t("js.admin.orders.payment_states.#{orders.first.payment_state}") 
+            },
             distributor: proc { |orders| orders.first.distributor.name },
             product_total_price: proc { |orders| orders.to_a.sum(&:item_total) },
             shipping_total_price: proc { |orders| orders.sum(&:ship_total) },

--- a/lib/reporting/reports/payments/payments_by_payment_type.rb
+++ b/lib/reporting/reports/payments/payments_by_payment_type.rb
@@ -15,7 +15,9 @@ module Reporting
 
         def columns
           {
-            payment_state: proc { |payments| payments.first.order.payment_state },
+            payment_state: proc { |payments|
+              I18n.t("js.admin.orders.payment_states.#{payments.first.order.payment_state}") 
+            },
             distributor: proc { |payments| payments.first.order.distributor.name },
             payment_type: proc { |payments| payments.first.payment_method.name },
             total_price: proc { |payments| payments.sum(&:amount) }

--- a/spec/lib/reports/payments/itemised_payment_totals_spec.rb
+++ b/spec/lib/reports/payments/itemised_payment_totals_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Reporting
+  module Reports
+    module Payments
+      describe ItemisedPaymentTotals do
+        context "As a site admin" do
+          let(:user) do
+            user = create(:user)
+            user.spree_roles << Spree::Role.find_or_create_by!(name: 'admin')
+            user
+          end
+          subject do
+            Base.new user, {}
+          end
+
+          let!(:distributor) { create(:distributor_enterprise) }
+
+          let!(:order) do
+            create(:completed_order_with_totals, line_items_count: 1, distributor: distributor)
+          end
+
+          let(:current_user) { distributor.owner }
+          let(:params) { { display_summary_row: false } }
+          let(:report) do
+            ItemisedPaymentTotals.new(current_user, params)
+          end
+
+          let(:table_headers) do
+            report.table_headers
+          end
+
+          let(:report_table) do
+            report.table_rows
+          end
+
+          it "generates the report" do
+            expect(report_table.length).to eq(1)
+          end
+
+          it "Should return headers" do
+            expect(report.table_headers).to eq([
+                                                 "Payment State",
+                                                 "Distributor",
+                                                 "Product Total ($)",
+                                                 "Shipping Total ($)",
+                                                 "Outstanding Balance ($)",
+                                                 "Total ($)"
+                                               ])
+          end
+          it "translates payment_states" do
+            first_row_first_column_value = report_table.first.first
+            translated_payment_state = i18n_translate("balance_due")
+            expect(translated_payment_state).to eq first_row_first_column_value
+          end
+
+          # Helper methods for example group
+          def i18n_translate(translation_key, options = {})
+            I18n.t("js.admin.orders.payment_states.#{translation_key}", **options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/reports/payments/payment_totals_spec.rb
+++ b/spec/lib/reports/payments/payment_totals_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Reporting
+  module Reports
+    module Payments
+      describe PaymentTotals do
+        context "As a site admin" do
+          let(:user) do
+            user = create(:user)
+            user.spree_roles << Spree::Role.find_or_create_by!(name: 'admin')
+            user
+          end
+          subject do
+            Base.new user, {}
+          end
+
+          let!(:distributor) { create(:distributor_enterprise) }
+
+          let!(:order) do
+            create(:completed_order_with_totals, line_items_count: 1, distributor: distributor)
+          end
+
+          let(:current_user) { distributor.owner }
+          let(:params) { { display_summary_row: false } }
+          let(:report) do
+            PaymentTotals.new(current_user, params)
+          end
+
+          let(:table_headers) do
+            report.table_headers
+          end
+
+          let(:report_table) do
+            report.table_rows
+          end
+
+          it "generates the report" do
+            expect(report_table.length).to eq(1)
+          end
+
+          it "Should return headers" do
+            expect(report.table_headers).to eq([
+                                                 "Payment State",
+                                                 "Distributor",
+                                                 "Product Total ($)",
+                                                 "Shipping Total ($)",
+                                                 "Total ($)",
+                                                 "EFT ($)",
+                                                 "PayPal ($)",
+                                                 "Outstanding Balance ($)"
+                                               ])
+          end
+
+          it "translates payment_states" do
+            first_row_first_column_value = report_table.first.first
+            translated_payment_state = i18n_translate("balance_due")
+            expect(translated_payment_state).to eq first_row_first_column_value
+          end
+
+          # Helper methods for example group
+          def i18n_translate(translation_key, options = {})
+            I18n.t("js.admin.orders.payment_states.#{translation_key}", **options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/reports/payments/payments_by_payment_type_spec.rb
+++ b/spec/lib/reports/payments/payments_by_payment_type_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Reporting
+  module Reports
+    module Payments
+      describe PaymentsByPaymentType do
+        let!(:distributor) { create(:distributor_enterprise, name: "Apple Market") }
+        let!(:customer) { create(:customer, enterprise: distributor, user: user, code: "JHN") }
+        let(:user) { create(:user, email: "john@example.net") }
+        let(:current_user) { distributor.owner }
+        let(:params) { { display_summary_row: true, q: search_params } }
+        let(:search_params) {
+          { completed_at_gt: 1.week.before(order_date), completed_at_lt: 1.week.after(order_date) }
+        }
+        let(:report) { described_class.new(current_user, params) }
+        let(:order_date) { Date.parse("2022-05-26") }
+
+        let(:report_table) do
+          report.table_rows
+        end
+
+        let(:table_headers) do
+          report.table_headers
+        end
+
+        context "displaying payments by payment type" do
+          let!(:order) {
+            create(
+              :order_ready_to_ship,
+              user: customer.user,
+              customer: customer, distributor: distributor,
+              completed_at: order_date,
+            )
+          }
+          let(:completed_payment) { order.payments.completed.first }
+
+          it "generates the report" do
+            expect(report_table.length).to eq(1)
+          end
+
+          it "Should return headers" do
+            expect(report.table_headers).to eq([
+                                                 "Payment State",
+                                                 "Distributor",
+                                                 "Payment Type",
+                                                 "Total ($)"
+                                               ])
+          end
+
+          it "translates payment_states" do
+            first_row_first_column_value = report_table.first.first
+            translated_payment_state = i18n_translate("paid")
+            expect(first_row_first_column_value).to eq translated_payment_state
+          end
+
+          # Helper methods for example group
+          def i18n_translate(translation_key, options = {})
+            I18n.t("js.admin.orders.payment_states.#{translation_key}", **options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/admin/reports/payments_report_spec.rb
+++ b/spec/system/admin/reports/payments_report_spec.rb
@@ -49,7 +49,7 @@ describe "Payments Reports" do
       ].join(" ").upcase)
 
       expect(page.find("table.report__table tbody tr").text).to have_content([
-        order.payment_state,
+        i18n_translate(order.payment_state),
         order.distributor.name,
         order.item_total.to_f + other_order.item_total.to_f,
         order.ship_total.to_f + other_order.ship_total.to_f,
@@ -86,7 +86,7 @@ describe "Payments Reports" do
       ].join(" ").upcase)
 
       expect(page.find("table.report__table tbody tr").text).to have_content([
-        order.payment_state,
+        i18n_translate(order.payment_state),
         order.distributor.name,
         order.item_total.to_f + other_order.item_total.to_f,
         order.ship_total.to_f + other_order.ship_total.to_f,
@@ -96,5 +96,8 @@ describe "Payments Reports" do
         order.outstanding_balance + other_order.outstanding_balance,
       ].join(" "))
     end
+  end
+  def i18n_translate(translation_key, options = {})
+    I18n.t("js.admin.orders.payment_states.#{translation_key}", **options)
   end
 end


### PR DESCRIPTION
Co-authored-by: Aaron Zhang <aaronzh@umich.edu>
Co-authored-by: Crystal Sun <crysun@umich.edu>

#### What? Why?

- Closes #9723

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


- Log in as an admin and change language to non-english language
- Navigate to path admin/reports/payment/itemised_payment_totals
- Generate a report that includes the column "Payment State"
- Check to make sure the row value is correctly translated
- Repeat this for path admin/reports/payment/payment_totals and admin/reports/payment/payments_by_payment_type

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
