### PR TITLE
Removes line break for displaying product units

### DIFF
--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -223,8 +223,9 @@ describe '
           # header
           expect(page).to have_content "Item Qty GST Price"
           # second line item, included tax
-          expect(page).to have_content "#{Spree::Product.second.name} 3 $250.08 $1,500.45"
+          expect(page).to have_content Spree::Product.second.name.to_s
           expect(page).to have_content "(1g)" # display as
+          expect(page).to have_content "3 $250.08 $1,500.45"
           # Enterprise fee
           expect(page).to have_content "Whole order - #{enterprise_fee.name} fee by coordinator " \
                                        "#{user1.enterprises.first.name} 1 $15.65 (included) $120.00"
@@ -346,15 +347,17 @@ describe '
         it "displays $0.0 when a line item has no tax" do
           pending "iii) for legend see picture on PR #9495"
           # first line item, no tax - display $0.0
-          expect(page).to have_content "#{Spree::Product.first.name} 1 $0.0 $12.54"
+          expect(page).to have_content Spree::Product.first.name.to_s
           expect(page).to have_content "(1g)" # display as
+          expect(page).to have_content "1 $0.0 $12.54"
         end
 
         it "displays the added tax on the GST colum" do
           pending "closing #7983, iv) for legend see picture on PR #9495"
           # second line item, added tax of $300.09
-          expect(page).to have_content "#{Spree::Product.second.name} 3 $300.09 $1,500.45"
+          expect(page).to have_content Spree::Product.second.name.to_s
           expect(page).to have_content "(1g)" # display as
+          expect(page).to have_content "3 $300.09 $1,500.45"
         end
 
         it "displays GST for enterprise fees" do


### PR DESCRIPTION
#### What? Why?

- Closes #9556.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Due to some inconsistencies on how the text is parsed from the pdf file, sometimes the `display as` bit appears within the line item line, sometimes does not.

The PR splits the assertion on the line item line in 3 parts, so this inconsistency does not play a role anymore:
- line item name
- display as
- price / taxes

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
