### PR TITLE
[OFN-9870] Correct error message for differing variant_unit_name for same product in import

### DIFF
--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -211,7 +211,7 @@ module ProductImport
       reference_entry = all_entries_for_product(entry).first
       return if entry.variant_unit_name.to_s == reference_entry.variant_unit_name.to_s
 
-      mark_as_not_updatable(entry, "variant_unit_name")
+      mark_as_values_must_be_same(entry, "variant_unit_name")
     end
 
     def producer_validation(entry)
@@ -423,6 +423,11 @@ module ProductImport
     def mark_as_not_updatable(entry, attribute)
       mark_as_invalid(entry, attribute: attribute,
                              error: I18n.t("admin.product_import.model.not_updatable"))
+    end
+
+    def mark_as_values_must_be_same(entry, attribute)
+      mark_as_invalid(entry, attribute: attribute,
+                             error: I18n.t("admin.product_import.model.values_must_be_same"))
     end
 
     def import_into_inventory?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -730,6 +730,7 @@ en:
         not_found: not found in database
         category_not_found: doesn't match allowed categories. See the correct categories to choose from on the product import page, or check that there's no misspelling.
         not_updatable: cannot be updated on existing products via product import
+        values_must_be_same: must be the same for products with the same name
         blank: can't be blank
         products_no_permission: you do not have permission to manage products for this enterprise
         inventory_no_permission: you do not have permission to create inventory for this producer


### PR DESCRIPTION
#### What? Why?

- Closes #9870 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- When importing products, it is required that any two products with the same name have the same value for `variant_unit_name`. An error is thrown if `variant_unit_name` differs between products with the same name, however, the current error message for this case: "Variant_unit_name cannot be updated on existing products via product import" does not accurately reflect the cause of the error.

- This updates the error message to "Variant_unit_name must be the same for products with the same name." which accurately identifies the source of the error.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit the product import page
- Upload a product_list template that contains two products with the same name, but differing `variant_unit_name` values
> - https://github.com/openfoodfoundation/openfoodnetwork/issues/9870 includes a 'Steps to Reproduce' section with a malformed .csv example that can be used to test
- Ensure that the error message for `variant_unit_name` correctly reads: "Variant_unit_name must be the same for products with the same name."
- Attached is a screenshot of how the error message should display

![image](https://user-images.githubusercontent.com/25915763/208561775-6c9ed024-b309-409c-9a3f-c372cdadb771.png)


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
