### PR TITLE
When `split_checkout` is enabled, redirect to split checkout controller in any cases

### DIFF
--- a/app/constraints/feature_toggle_constraint.rb
+++ b/app/constraints/feature_toggle_constraint.rb
@@ -3,11 +3,16 @@
 require "open_food_network/feature_toggle"
 
 class FeatureToggleConstraint
-  def initialize(feature_name)
+  def initialize(feature_name, negate: false)
     @feature = feature_name
+    @negate = negate
   end
 
   def matches?(request)
+    enabled?(request) ^ @negate
+  end
+
+  def enabled?(request)
     OpenFoodNetwork::FeatureToggle.enabled?(@feature, current_user(request))
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,7 @@ Openfoodnetwork::Application.routes.draw do
   end
 
    # When the split_checkout feature is disabled for the current user, use the legacy checkout
-  constraints ->(request) { OpenFoodNetwork::FeatureToggle.disabled? :split_checkout, request.env['warden']&.user } do
+  constraints FeatureToggleConstraint.new(:split_checkout, negate: true) do
     get '/checkout', to: 'checkout#edit'
     put '/checkout', to: 'checkout#update', as: :update_checkout
     get '/checkout/:state', to: 'checkout#edit', as: :checkout_state

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,11 +91,17 @@ Openfoodnetwork::Application.routes.draw do
       get '/checkout/:step', to: 'split_checkout#edit', as: :checkout_step
       put '/checkout/:step', to: 'split_checkout#update', as: :checkout_update
     end
+
+    # Redirects to the new checkout for any other 'step' (ie. /checkout/cart from the legacy checkout)
+    get '/checkout/:other', to: redirect('/checkout')
   end
 
-  get '/checkout', to: 'checkout#edit'
-  put '/checkout', to: 'checkout#update', as: :update_checkout
-  get '/checkout/:state', to: 'checkout#edit', as: :checkout_state
+   # When the split_checkout feature is disabled for the current user, use the legacy checkout
+  constraints ->(request) { OpenFoodNetwork::FeatureToggle.disabled? :split_checkout, request.env['warden']&.user } do
+    get '/checkout', to: 'checkout#edit'
+    put '/checkout', to: 'checkout#update', as: :update_checkout
+    get '/checkout/:state', to: 'checkout#edit', as: :checkout_state
+  end
 
   get 'embedded_shopfront/shopfront_session', to: 'application#shopfront_session'
   post 'embedded_shopfront/enable', to: 'application#enable_embedded_styles'

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -12,5 +12,9 @@ module OpenFoodNetwork
       feature.add unless feature.exist?
       feature.enabled?(user)
     end
+
+    def self.disabled?(feature_name, user = nil)
+      !enabled?(feature_name, user)
+    end
   end
 end

--- a/spec/constraints/feature_toggle_constraint_spec.rb
+++ b/spec/constraints/feature_toggle_constraint_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe FeatureToggleConstraint do
+  subject { described_class.new("baking") }
+  let(:request) { double(env: env) }
+  let(:env) { {} }
+
+  it "constraints an unknown feature" do
+    expect(subject.matches?(request)).to eq false
+  end
+
+  it "allows an activated feature" do
+    Flipper.enable("baking")
+
+    expect(subject.matches?(request)).to eq true
+  end
+
+  it "negates results" do
+    subject = described_class.new("baking", negate: true)
+
+    expect(subject.matches?(request)).to eq true
+
+    Flipper.enable("baking")
+    expect(subject.matches?(request)).to eq false
+  end
+end

--- a/spec/requests/checkout/routes_spec.rb
+++ b/spec/requests/checkout/routes_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'checkout endpoints', type: :request do
+  include ShopWorkflow
+
+  let!(:shop) { create(:enterprise) }
+  let!(:order_cycle) { create(:simple_order_cycle) }
+  let!(:exchange) {
+    create(:exchange, order_cycle: order_cycle, sender: order_cycle.coordinator, receiver: shop,
+                      incoming: false, pickup_time: "Monday")
+  }
+  let!(:line_item) { create(:line_item, order: order, quantity: 3, price: 5.00) }
+  let!(:payment_method) {
+    create(:bogus_payment_method, distributor_ids: [shop.id], environment: Rails.env)
+  }
+  let!(:check_payment_method) {
+    create(:payment_method, distributor_ids: [shop.id], environment: Rails.env)
+  }
+  let!(:shipping_method) { create(:shipping_method, distributor_ids: [shop.id]) }
+  let!(:shipment) { create(:shipment_with, :shipping_method, shipping_method: shipping_method) }
+  let!(:order) {
+    create(:order, shipments: [shipment], distributor: shop, order_cycle: order_cycle)
+  }
+
+  before do
+    order_cycle_distributed_variants = double(:order_cycle_distributed_variants)
+    allow(OrderCycleDistributedVariants).to receive(:new)
+      .and_return(order_cycle_distributed_variants)
+    allow(order_cycle_distributed_variants).to receive(:distributes_order_variants?)
+      .and_return(true)
+
+    set_order order
+  end
+
+  context "when getting the cart `/checkout/cart`" do
+    let(:path) { "/checkout/cart" }
+
+    context "using the legacy checkout" do
+      it "do not redirect" do
+        get path
+        puts response.redirect_url
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "using the split checkout" do
+      before do
+        # feature toggle is enabled
+        Flipper.enable(:split_checkout)
+      end
+
+      it "redirect to the split checkout" do
+        get path
+        expect(response.status).to redirect_to("/checkout")
+
+        # follow the redirect
+        get response.redirect_url
+        expect(response.status).to redirect_to("/checkout/details")
+      end
+    end
+  end
+end


### PR DESCRIPTION


#### What? Why?

- Closes #9573

Even if `/checkout/cart` (legacy checkout) is requested,  redirect to `/checkout` (ie. split checkout controller then)



#### What should we test?

1. As a superadmin, visit the `/admin/features/split_checkout` and fully enable the feature. Logout.
2. Log in as a customer, and start checkout on any given shop.
3. While on the Details step, replace `/checkout/details` by `/checkout/cart`
4. Notice you are now on the legacy checkout

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

