### PR TITLE
prevent loading the reporting module if already loaded [dev environment]

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -156,6 +156,7 @@ module Openfoodnetwork
     initializer "ofn.reports" do |app|
       module ::Reporting; end
       Rails.application.reloader.to_prepare do
+        next if defined?(::Reporting) && defined?(::Reporting::Errors)
         loader = Zeitwerk::Loader.new
         loader.push_dir("#{Rails.root}/lib/reporting", namespace: ::Reporting)
         loader.enable_reloading


### PR DESCRIPTION
#### What? Why?

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
This PR is created after the [discussion](https://github.com/openfoodfoundation/openfoodnetwork/pull/10145)
I described the details on this [comment](https://github.com/openfoodfoundation/openfoodnetwork/pull/10145#issuecomment-1361045969)


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- edit the code
- refresh the browser
- -> error
- refresh a second time.

Screencast: https://user-images.githubusercontent.com/16113997/208862989-08b20c10-6b08-4127-94ab-838db8c1ce82.mp4
The link used in the screencast: http://localhost:3000/admin
The edited file: `app/constraints/feature_toggle_constraint.rb`
 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category:  Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
