### PR TITLE
Adds coverage for error message in product and inventory import

### DIFF
--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -382,36 +382,67 @@ describe "Product Import", js: true do
                                  with: "3.2"
     end
 
-    it "handles the Items unit for inventory import" do
-      product = create(:simple_product, supplier: enterprise, on_hand: nil, name: 'Aubergine',
-                                        unit_value: '1', variant_unit_scale: nil, variant_unit: "items", variant_unit_name: "Bag")
-      csv_data = CSV.generate do |csv|
-        csv << ["name", "distributor", "producer", "category", "on_hand", "price", "unit_type",
-                "units", "on_demand", "variant_unit_name"]
-        csv << ["Aubergine", "Another Enterprise", "User Enterprise", "Vegetables", "", "3.3",
-                "kg", "1", "true", "Bag"]
+    describe "Item type products" do
+      let!(:product) {
+        create(:simple_product, supplier: enterprise, on_hand: nil, name: 'Aubergine',
+                                unit_value: '1', variant_unit_scale: nil, variant_unit: "items", variant_unit_name: "Bag")
+      }
+      it "are sucessfully imported to inventory" do
+        csv_data = CSV.generate do |csv|
+          csv << ["name", "distributor", "producer", "category", "on_hand", "price", "unit_type",
+                  "units", "on_demand", "variant_unit_name"]
+          csv << ["Aubergine", "Another Enterprise", "User Enterprise", "Vegetables", "", "3.3",
+                  "kg", "1", "true", "Bag"]
+        end
+
+        File.write('/tmp/test.csv', csv_data)
+        visit main_app.admin_product_import_path
+        select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
+        attach_file 'file', '/tmp/test.csv'
+        click_button 'Upload'
+        proceed_to_validation
+        expect(page).to have_selector '.item-count', text: "1"
+        expect(page).to have_no_selector '.invalid-count'
+        expect(page).to have_selector '.inv-create-count', text: '1'
+        save_data
+
+        expect(page).to have_selector '.inv-created-count', text: '1'
+
+        visit main_app.admin_inventory_path
+
+        expect(page).to have_content "Aubergine"
+        expect(page).to have_select "variant-overrides-#{Spree::Product.find_by(name: 'Aubergine').variants.first.id}-on_demand",
+                                    selected: "Yes"
+        expect(page).to have_input "variant-overrides-#{Spree::Product.find_by(name: 'Aubergine').variants.first.id}-price",
+                                   with: "3.3"
       end
 
-      File.write('/tmp/test.csv', csv_data)
-      visit main_app.admin_product_import_path
-      select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
-      attach_file 'file', '/tmp/test.csv'
-      click_button 'Upload'
-      proceed_to_validation
-      expect(page).to have_selector '.item-count', text: "1"
-      expect(page).to have_no_selector '.invalid-count'
-      expect(page).to have_selector '.inv-create-count', text: '1'
-      save_data
+      it "displays the appropriate error message, when variant unit names are inconsistent" do
+        csv_data = CSV.generate do |csv|
+          csv << ["name", "distributor", "producer", "category", "on_hand", "price", "unit_type",
+                  "units", "on_demand", "variant_unit_name"]
+          csv << ["Aubergine", "Another Enterprise", "User Enterprise", "Vegetables", "", "3.3",
+                  "kg", "1", "true", "Bag"]
+          csv << ["Aubergine", "Another Enterprise", "User Enterprise", "Vegetables", "", "6.6",
+                  "kg", "1", "true", "Big-Bag"]
+        end
 
-      expect(page).to have_selector '.inv-created-count', text: '1'
+        File.write('/tmp/test.csv', csv_data)
+        visit main_app.admin_product_import_path
+        select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
+        attach_file 'file', '/tmp/test.csv'
+        click_button 'Upload'
+        proceed_to_validation
 
-      visit main_app.admin_inventory_path
+        find('div.header-description', text: 'Items contain errors').click
+        expect(page).to have_content "Variant_unit_name cannot be updated on existing products via product import"
+        expect(page).to have_content "Imported file contains invalid entries"
+        expect(page).to have_no_selector 'input[type=submit][value="Save"]'
 
-      expect(page).to have_content "Aubergine"
-      expect(page).to have_select "variant-overrides-#{Spree::Product.find_by(name: 'Aubergine').variants.first.id}-on_demand",
-                                  selected: "Yes"
-      expect(page).to have_input "variant-overrides-#{Spree::Product.find_by(name: 'Aubergine').variants.first.id}-price",
-                                 with: "3.3"
+        visit main_app.admin_inventory_path
+
+        expect(page).not_to have_content "Aubergine"
+      end
     end
 
     it "handles on_demand and on_hand validations with inventory" do

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -153,7 +153,7 @@ describe "Product Import", js: true do
 
       proceed_to_validation
       find('div.header-description', text: 'Items contain errors').click
-      expect(page).to have_content "Variant_unit_name cannot be updated on existing products via product import"
+      expect(page).to have_content "Variant_unit_name must be the same for products with the same name"
       expect(page).to have_content "Imported file contains invalid entries"
 
       expect(page).to have_no_selector 'input[type=submit][value="Save"]'
@@ -458,7 +458,7 @@ describe "Product Import", js: true do
         proceed_to_validation
 
         find('div.header-description', text: 'Items contain errors').click
-        expect(page).to have_content "Variant_unit_name cannot be updated on existing products via product import"
+        expect(page).to have_content "Variant_unit_name must be the same for products with the same name"
         expect(page).to have_content "Imported file contains invalid entries"
         expect(page).to have_no_selector 'input[type=submit][value="Save"]'
 


### PR DESCRIPTION
#### What? Why?

It will be updated after merging 10174 - done :heavy_check_mark: 

- Relates to #10174

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds coverage for product and inventory import (Items), to make sure error messages are displayed.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
