### PR TITLE
[OFN-9834] Preserve 'Items' unit size selection on new product form e…

### DIFF
--- a/app/assets/javascripts/admin/products/controllers/units_controller.js.coffee
+++ b/app/assets/javascripts/admin/products/controllers/units_controller.js.coffee
@@ -21,8 +21,14 @@ angular.module("admin.products")
         else
           $scope.product.variant_unit = $scope.product.variant_unit_with_scale
           $scope.product.variant_unit_scale = null
-      else if $scope.product.variant_unit && $scope.product.variant_unit_scale
-        $scope.product.variant_unit_with_scale = VariantUnitManager.getUnitWithScale($scope.product.variant_unit, parseFloat($scope.product.variant_unit_scale))
+      else if $scope.product.variant_unit
+        # Preserves variant_unit_with_scale when form validation fails and reload triggers
+        if $scope.product.variant_unit_scale
+          $scope.product.variant_unit_with_scale = VariantUnitManager.getUnitWithScale(
+            $scope.product.variant_unit, parseFloat($scope.product.variant_unit_scale)
+          )
+        else
+          $scope.product.variant_unit_with_scale = $scope.product.variant_unit
       else
         $scope.product.variant_unit = $scope.product.variant_unit_scale = null
 

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -64,6 +64,19 @@ describe '
       expect(page).to have_content "Name can't be blank"
     end
 
+    it "preserves 'Items' 'Unit Size' selection when submitting with error" do
+      login_to_admin_section
+
+      click_link 'Products'
+      click_link 'New Product'
+
+      select "Items", from: 'product_variant_unit_with_scale'
+
+      click_button 'Create'
+
+      expect(page.find("#product_variant_unit_field")).to have_content 'Items'
+    end
+
     it "assigning important attributes", js: true do
       login_to_admin_section
 


### PR DESCRIPTION
#### What? Why?

- Closes partially #9834, Part 1: "If 'item' is selected as unit size and a value is entered in 'unit name', these values are not kept if product creation fails due to some other missing information (e.g. product name)..."

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This change ensures a more consistent UX for users when an error occurs on submission of an invalid form during the product creation process. It preserves unit size and value if they have been selected but an error occurs during form submission.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit the product creation page
- Select a 'Unit Size' and enter a corresponding 'Value'
- Submit the form in an invalid state e.g. without a product name
- Ensure 'Unit Size' and 'Value' are preserved for all possible 'Unit Size' selections

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

N/A

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

N/A
