### PR TITLE
Bulk Coop Report: Setup orders permission with searchparams

### DIFF
--- a/lib/reporting/reports/bulk_coop/base.rb
+++ b/lib/reporting/reports/bulk_coop/base.rb
@@ -29,7 +29,7 @@ module Reporting
         end
 
         def order_permissions
-          @order_permissions ||= ::Permissions::Order.new(@user)
+          @order_permissions ||= ::Permissions::Order.new(@user, @params)
         end
 
         def report_line_items


### PR DESCRIPTION
#### What? Why?
Comes from #10159 but still need to check if no regression introduced here

params contains `q` key that filter on `completed_at_gt`, `completed_at_lt` and `distributor_id_in`

On my local setup, `CompleteVisibleOrders.new(order_permissions).query.count` decrease from 147 to 125



This PR should make some specs red, as with this PR canceled orders are not retrieved via report. [Discussion opened here](https://github.com/openfoodfoundation/openfoodnetwork/issues/10159#issuecomment-1365028624).

- Closes # <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
