### PR TITLE
Admin, Order cycle: User can tag an incoming exchange

### DIFF
--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -3,12 +3,12 @@
   %td.products.panel-toggle.text-center{ name: "products" }
     {{ exchangeSelectedVariants(exchange) }} / {{ exchangeTotalVariants(exchange) }}
     = t('.selected')
+  %td.tags.panel-toggle.text-center{ name: "tags", ng: { if: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }
+    {{ exchange.tags.length }}
   - if type == 'supplier'
     %td.receival-details
       = text_field_tag 'order_cycle_incoming_exchange_{{ $index }}_receival_instructions', '', 'id' => 'order_cycle_incoming_exchange_{{ $index }}_receival_instructions', 'placeholder' => t('.receival_instructions_placeholder'), 'ng-model' => 'exchange.receival_instructions'
   - if type == 'distributor'
-    %td.tags.panel-toggle.text-center{ name: "tags", ng: { if: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }
-      {{ exchange.tags.length }}
     %td.collection-details
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'ng-init' => 'setPickupTimeFieldDirty($index)', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'required' => 'required', 'placeholder' => t('.pickup_time_placeholder'), 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator', 'maxlength' => 35
       %span.icon-question-sign{'ofn-with-tip' => t('.pickup_time_tip')}
@@ -31,7 +31,7 @@
 
 - if type == 'supplier'
   %tr.panel-row{ object: "exchange",
-    panels: "{products: 'exchange_products_supplied'}",
+    panels: "{products: 'exchange_products_supplied', tags: 'exchange_tags'}",
     locals: "$index,exchangeTotalVariants,order_cycle,exchange,enterprises,setExchangeVariants,selectAllVariants,suppliedVariants,removeDistributionOfVariant,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading",
     colspan: if feature?(:admin_style_v2, spree_current_user) then 5 else 4 end }
 - if type == 'distributor'

--- a/app/views/admin/order_cycles/incoming.html.haml
+++ b/app/views/admin/order_cycles/incoming.html.haml
@@ -27,6 +27,8 @@
             %a{href: '#', 'ng-click' => "OrderCycle.toggleAllProducts('incoming')"}
               %span{'ng-show' => "OrderCycle.showProducts['incoming']"}= t(:collapse_all)
               %span{'ng-hide' => "OrderCycle.showProducts['incoming']"}= t(:expand_all)
+        %th{ ng: { if: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }
+          = t('.tags')
         %th= t('.receival_details')
         %th= t('.fees')
         %th.actions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1201,6 +1201,7 @@ en:
         incoming: "Incoming"
         supplier: "Supplier"
         products: "Products"
+        tags: "Tags"
         receival_details: "Receival Details"
         fees: "Fees"
         save: "Save"

--- a/lib/open_food_network/order_cycle_form_applicator.rb
+++ b/lib/open_food_network/order_cycle_form_applicator.rb
@@ -25,11 +25,13 @@ module OpenFoodNetwork
         if exchange_exists?(exchange[:enterprise_id], @order_cycle.coordinator_id, true)
           update_exchange(exchange[:enterprise_id], @order_cycle.coordinator_id, true,
                           variant_ids: variant_ids, enterprise_fee_ids: enterprise_fee_ids,
-                          receival_instructions: exchange[:receival_instructions] )
+                          receival_instructions: exchange[:receival_instructions],
+                          tag_list: exchange[:tag_list] )
         else
           add_exchange(exchange[:enterprise_id], @order_cycle.coordinator_id, true,
                        variant_ids: variant_ids, enterprise_fee_ids: enterprise_fee_ids,
-                       receival_instructions: exchange[:receival_instructions], )
+                       receival_instructions: exchange[:receival_instructions],
+                       tag_list: exchange[:tag_list] )
         end
       end
 

--- a/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
@@ -14,7 +14,7 @@ module OpenFoodNetwork
         supplier_id = 456
 
         incoming_exchange = { enterprise_id: supplier_id, incoming: true,
-                              variants: { '1' => true, '2' => false, '3' => true }, enterprise_fee_ids: [1, 2], receival_instructions: 'receival instructions' }
+                              variants: { '1' => true, '2' => false, '3' => true }, enterprise_fee_ids: [1, 2], receival_instructions: 'receival instructions', tag_list: 'wholesale' }
 
         oc = double(:order_cycle, coordinator_id: coordinator_id, exchanges: [],
                                   incoming_exchanges: [incoming_exchange], outgoing_exchanges: [])
@@ -27,7 +27,7 @@ module OpenFoodNetwork
         expect(applicator).to receive(:exchange_exists?).with(supplier_id, coordinator_id,
                                                               true).and_return(false)
         expect(applicator).to receive(:add_exchange).with(supplier_id, coordinator_id, true,
-                                                          variant_ids: [1, 3], enterprise_fee_ids: [1, 2], receival_instructions: 'receival instructions')
+                                                          variant_ids: [1, 3], enterprise_fee_ids: [1, 2], receival_instructions: 'receival instructions', tag_list: 'wholesale')
         expect(applicator).to receive(:destroy_untouched_exchanges)
 
         applicator.go!
@@ -62,7 +62,7 @@ module OpenFoodNetwork
         supplier_id = 456
 
         incoming_exchange = { enterprise_id: supplier_id, incoming: true,
-                              variants: { '1' => true, '2' => false, '3' => true }, enterprise_fee_ids: [1, 2], receival_instructions: 'receival instructions' }
+                              variants: { '1' => true, '2' => false, '3' => true }, enterprise_fee_ids: [1, 2], receival_instructions: 'receival instructions', tag_list: 'wholesale' }
 
         oc = double(:order_cycle,
                     coordinator_id: coordinator_id,
@@ -79,7 +79,7 @@ module OpenFoodNetwork
         expect(applicator).to receive(:exchange_exists?).with(supplier_id, coordinator_id,
                                                               true).and_return(true)
         expect(applicator).to receive(:update_exchange).with(supplier_id, coordinator_id, true,
-                                                             variant_ids: [1, 3], enterprise_fee_ids: [1, 2], receival_instructions: 'receival instructions')
+                                                             variant_ids: [1, 3], enterprise_fee_ids: [1, 2], receival_instructions: 'receival instructions', tag_list: "wholesale")
         expect(applicator).to receive(:destroy_untouched_exchanges)
 
         applicator.go!

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -242,6 +242,11 @@ describe '
         select_incoming_variant supplier_managed, 0, variant_managed
         select_incoming_variant supplier_permitted, 1, variant_permitted
 
+        page.find("table.exchanges tr.supplier-#{supplier_managed.id} td.tags").click
+        within ".exchange-tags" do
+          find(:css, "tags-input .tags input").set "supplier\n"
+        end
+
         click_button 'Save and Next'
         expect(page).to have_content 'Your order cycle has been updated.'
         expect(page).to_not have_content "Loading..."
@@ -291,6 +296,8 @@ describe '
         expect(order_cycle.distributor_payment_methods).to match_array(
           order_cycle.attachable_distributor_payment_methods
         )
+        incoming_exchange = order_cycle.exchanges.incoming.from_enterprise(supplier_managed).first
+        expect(incoming_exchange.tag_list).to eq(["supplier"])
       end
 
       context "editing an order cycle" do


### PR DESCRIPTION


#### What? Why?
- Closes #9528

As they could tag outgoing exchange, now hub manager can tag an incoming exchange:
<img width="1375" alt="Capture d’écran 2022-12-26 à 15 00 06" src="https://user-images.githubusercontent.com/296452/209556414-3cdf5228-fa06-4ef8-91db-4fbb73f536c3.png">


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

Actually, I'm not sure how to test it. 
Copied/paster from linked issue:

1. Login in as hub
2. I can add tags on step 2 of the order cycle
3. I can set up tags on enterprise settings, customers and shipping/payment methods
4. The rule defined works as expected.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
