### PR TITLE
Admin: Include a "None" option for calculator type user in shipping method and payment method forms

### DIFF
--- a/app/models/calculator/none.rb
+++ b/app/models/calculator/none.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: false
+
+module Calculator
+  class None < Spree::Calculator
+    def self.description
+      I18n.t(:none)
+    end
+
+    def compute(_object = nil)
+      0
+    end
+  end
+end

--- a/app/models/spree/payment_method.rb
+++ b/app/models/spree/payment_method.rb
@@ -113,7 +113,7 @@ module Spree
     end
 
     def init
-      self.calculator ||= ::Calculator::FlatRate.new(preferred_amount: 0)
+      self.calculator ||= ::Calculator::None.new
     end
 
     def has_distributor?(distributor)

--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -32,6 +32,8 @@ module Spree
     validate :at_least_one_shipping_category
     validates :display_on, inclusion: { in: DISPLAY_ON_OPTIONS.values }, allow_nil: true
 
+    after_initialize :init
+
     after_save :touch_distributors
 
     scope :managed_by, lambda { |user|
@@ -108,6 +110,10 @@ module Spree
 
     def self.frontend
       where(display_on: [nil, ""])
+    end
+
+    def init
+      self.calculator ||= ::Calculator::None.new
     end
 
     private

--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -69,10 +69,6 @@ module Spree
       tracking_url.gsub(/:tracking/, tracking) unless tracking.blank? || tracking_url.blank?
     end
 
-    def self.calculators
-      spree_calculators.__send__ model_name_without_spree_namespace
-    end
-
     # Some shipping methods are only meant to be set via backend
     def frontend?
       display_on != "back_end"

--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -109,7 +109,7 @@ module Spree
     end
 
     def init
-      self.calculator ||= ::Calculator::None.new
+      self.calculator ||= ::Calculator::None.new if new_record?
     end
 
     private

--- a/config/application.rb
+++ b/config/application.rb
@@ -116,7 +116,8 @@ module Openfoodnetwork
           Calculator::FlexiRate,
           Calculator::PerItem,
           Calculator::PriceSack,
-          Calculator::Weight
+          Calculator::Weight,
+          Calculator::None
         ]
 
         app.config.spree.calculators.add_class('enterprise_fees')
@@ -135,7 +136,8 @@ module Openfoodnetwork
           Calculator::FlatRate,
           Calculator::FlexiRate,
           Calculator::PerItem,
-          Calculator::PriceSack
+          Calculator::PriceSack,
+          Calculator::None
         ]
 
         app.config.spree.calculators.add_class('tax_rates')

--- a/spec/lib/reports/enterprise_fee_summary/enterprise_fee_summary_report_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/enterprise_fee_summary_report_spec.rb
@@ -646,12 +646,12 @@ describe Reporting::Reports::EnterpriseFeeSummary::Base do
 
     describe "for specified payment methods" do
       let!(:payment_method_a) do
-        method = create(:payment_method, name: "Payment A", distributors: [distributor])
+        method = create(:payment_method, :flat_rate, name: "Payment A", distributors: [distributor])
         method.calculator.update_attribute(:preferred_amount, 1)
         method
       end
       let!(:payment_method_b) do
-        method = create(:payment_method, name: "Payment B", distributors: [distributor])
+        method = create(:payment_method, :flat_rate, name: "Payment B", distributors: [distributor])
         method.calculator.update_attribute(:preferred_amount, 1)
         method
       end

--- a/spec/system/admin/payment_method_spec.rb
+++ b/spec/system/admin/payment_method_spec.rb
@@ -251,6 +251,14 @@ describe '
     let!(:payment_method) { create(:payment_method, calculator: calculator) }
     before { login_as_admin_and_visit spree.edit_admin_payment_method_path payment_method }
 
+    it "handle the 'None' calculator" do
+      select2_select "None", from: 'calc_type'
+      click_button 'Update'
+      expect(page).to have_content("Payment Method has been successfully updated!")
+      expect(payment_method.reload.calculator_type).to eq "Calculator::None"
+      expect(page).to have_select "calc_type", selected: "None"
+    end
+
     context "using Flat Percent calculator" do
       before { select2_select "Flat Percent", from: 'calc_type' }
 

--- a/spec/system/admin/payment_method_spec.rb
+++ b/spec/system/admin/payment_method_spec.rb
@@ -247,9 +247,12 @@ describe '
   end
 
   describe "Setting transaction fees", js: true do
-    let(:calculator) { build(:calculator) }
-    let!(:payment_method) { create(:payment_method, calculator: calculator) }
+    let!(:payment_method) { create(:payment_method) }
     before { login_as_admin_and_visit spree.edit_admin_payment_method_path payment_method }
+
+    it "set by default 'None' as calculator" do
+      expect(page).to have_select "calc_type", selected: "None"
+    end
 
     it "handle the 'None' calculator" do
       select2_select "None", from: 'calc_type'
@@ -273,9 +276,11 @@ describe '
     end
 
     context "using Flat Rate (per order) calculator" do
-      # flat rate per order is the default calculator; no need select it and update page
+      before { select2_select "Flat Rate (per order)", from: 'calc_type' }
 
       it "inserts values which persist" do
+        expect(page).to have_content("you must save first before")
+        click_button 'Update'
         fill_in "Amount", with: 2.2
         click_button 'Update'
         expect(page).to have_content("Payment Method has been successfully updated!")

--- a/spec/system/admin/shipping_methods_spec.rb
+++ b/spec/system/admin/shipping_methods_spec.rb
@@ -83,6 +83,15 @@ describe 'shipping methods' do
 
       expect(@shipping_method.reload.calculator_type).to eq("Calculator::PerItem")
     end
+
+    it "handle when updating calculator type to 'None'" do
+      visit spree.edit_admin_shipping_method_path(@shipping_method)
+
+      select2_select 'None', from: 'calc_type'
+      click_button 'Update'
+      
+      expect(@shipping_method.reload.calculator_type).to eq "Calculator::None"
+    end
   end
 
   context "as an enterprise user", js: true do


### PR DESCRIPTION
#### What? Why?

This PR creates a `None` calculator for both shipping method and payment method.

<img width="769" alt="Capture d’écran 2022-12-27 à 15 26 14" src="https://user-images.githubusercontent.com/296452/209680427-b62cc965-46a9-4398-893d-ba1970deaf88.png">


Closes #9424

#### What should we test?

- As an admin, check that payment methods and shipping methods doesn't need to set a calculator and can be set to none. 
- check that this None calculator is well handled in each part of the app where they should be. 
- by default, when creating a new shipping method or payment method, calculator should be set to `None`

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
