### PR TITLE
Comments out flaky example with xit

### DIFF
--- a/spec/system/admin/order_cycles/complex_creating_specific_time_spec.rb
+++ b/spec/system/admin/order_cycles/complex_creating_specific_time_spec.rb
@@ -49,7 +49,8 @@ describe '
     payment_method_ii.update!(name: "Cash")
   end
 
-  it "creating an order cycle with full interface", retry: 3 do
+  xit "creating an order cycle with full interface", retry: 3 do
+    # pending issue #10042, see below
     ## CREATE
     login_as_admin_and_visit admin_order_cycles_path
     click_link 'New Order Cycle'
@@ -68,8 +69,8 @@ describe '
     expect(page).to have_content 'Your order cycle has been created.'
 
     ## UPDATE
-    add_supplier_with_fees
-    add_distributor_with_fees
+    add_supplier_with_fees # pending issue #10042
+    add_distributor_with_fees # pending issue #10042
     select_distributor_shipping_methods
     select_distributor_payment_methods
     click_button 'Save and Back to List'


### PR DESCRIPTION
#### What? Why?

Relates to #9817

`Retry: 3` was not enough to prevent flakyness, and occasional failure. I believe we might have two sources of inconsistent behavior: when adding a supplier and when adding a distributor. I guess, these two, combined, lead to higher fail rates.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Comments spec out with `xit` as [agreed here](https://github.com/openfoodfoundation/openfoodnetwork/issues/9817#issuecomment-1357931653) -> `pending()` is not appropriate here, as the spec sometimes passes - `pending()` assumes it always fails.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
