### PR TITLE
Remove popup alert around insufficient stock for a product on `/cart` page

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/on_hand.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/on_hand.js.coffee
@@ -16,7 +16,6 @@ angular.module('Darkswarm').directive "ofnOnHand", (StockQuantity) ->
     ngModel.$parsers.push (viewValue) ->
       available_quantity = scope.available_quantity()
       if parseInt(viewValue) > available_quantity
-        alert t("js.insufficient_stock", {on_hand: available_quantity})
         viewValue = available_quantity
         ngModel.$setViewValue viewValue
         ngModel.$render()

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -8,10 +8,11 @@
 
       = render 'spree/shared/line_item_name', line_item: line_item
 
-      - if @insufficient_stock_lines&.include? line_item
-        %span.out-of-stock
-          = variant.in_stock? ? t(".insufficient_stock", :on_hand => variant.on_hand) : t(".out_of_stock")
-          %br/
+      %span.out-of-stock{ "data-cart-target": "outOfStockMessage",
+                          "style": "display: #{@insufficient_stock_lines&.include?(line_item) ? 'inline' : 'none'};",
+                          "data-line-item-id": line_item.id }
+        = variant.in_stock? ? t(".insufficient_stock", :on_hand => variant.on_hand) : t(".out_of_stock")
+        %br/
 
       - if @unavailable_order_variants&.include? line_item.variant
         %span.out-of-stock
@@ -25,8 +26,13 @@
         = line_item.unit_price_price_and_unit
     %td.text-center.cart-item-quantity{"data-hook" => "cart_item_quantity"}
       - finalized_quantity = @order.completed? ? line_item.quantity : 0
+      - max_quantity = variant.on_demand && 9999 || variant.on_hand
       = item_form.number_field :quantity,
-        :min => 0, "ofn-on-hand" => "#{variant.on_demand && 9999 || variant.on_hand}",
+        :min => 0,
+        :max => max_quantity,
+        "data-line-item-id" => line_item.id,
+        "data-action": "change->cart#onQuantityChange",
+        "ofn-on-hand" => max_quantity,
         "finalizedquantity" => finalized_quantity, :class => "line_item_quantity", :size => 5,
         "ng-model" => "line_item_#{line_item.id}",
         "validate-stock-quantity" => true

--- a/app/views/spree/orders/edit.html.haml
+++ b/app/views/spree/orders/edit.html.haml
@@ -34,7 +34,7 @@
     - else
       %div{"data-hook" => "outside_cart_form"}
         = form_for @order, :url => main_app.update_cart_path,
-          :html => {id: 'update-cart', name: "form", "ng-controller"=> 'CartFormCtrl'} do |order_form|
+          :html => {id: 'update-cart', name: "form", "ng-controller"=> 'CartFormCtrl', "data-controller": "cart"} do |order_form|
           %div{"data-hook" => "inside_cart_form"}
             %div{"data-hook" => "cart_items"}
               .row

--- a/app/webpacker/controllers/cart_controller.js
+++ b/app/webpacker/controllers/cart_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static targets = ["outOfStockMessage"];
+
+  onQuantityChange(e) {
+    // find the out of stock message that matches the line item id
+    const message = this.outOfStockMessageTargets.find((t) => {
+      return t.dataset.lineItemId == e.currentTarget.dataset.lineItemId;
+    });
+    // if the max is reached, then display the out of stock message
+    if (e.currentTarget.value > e.currentTarget.max) {
+      message.style.display = "inline";
+    } else {
+      // otherwise, hide the out of stock message
+      message.style.display = "none";
+    }
+  }
+}

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -156,6 +156,7 @@ describe "Order Management", js: true do
       end
 
       it "allows quantity to be changed, items to be removed and the order to be cancelled" do
+        item1.variant.update!(on_hand: 5, on_demand: false)
         visit order_path(order)
 
         expect(page).to have_button I18n.t(:order_saved), disabled: true


### PR DESCRIPTION

#### What? Why?
 - shows instead a inline message, near the product name, the same that was used on the first show of the page
 - it's now dynamic: once the user change the value of the quantity, it updates the warning message to show or hide regarding its quantity value
<img width="1230" alt="Capture d’écran 2023-01-03 à 16 56 04" src="https://user-images.githubusercontent.com/296452/210393469-83bdf912-e586-432e-910a-63cbbbe75800.png">


- Closes #8905

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
1. Set a stock level at a product at 2
2. Go to the store add 1 in the cart
3. Go to the cart and try to increase quantity to 3
4. You should see a warning message.

You can try another scenario, which is slightly difference: product added in cart is already out of stock
1. Set a stock level at a product at 2
2. Go to the store add 2 in the cart
3. Set the product at 1 in the admin
4. Go to the cart page. You should see an error message.
5. Change the quantity. Error message should disappear.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes