### PR TITLE
Link relative report path instead of absolute URL

### DIFF
--- a/app/views/admin/reports/_report_subtype.html.haml
+++ b/app/views/admin/reports/_report_subtype.html.haml
@@ -1,5 +1,5 @@
 %ul{style: "margin-left: 12pt"}
   - report_subtypes.each do |report_subtype|
     %li
-      - url = main_app.admin_report_url(report_type: report_type, report_subtype: report_subtype[1])
+      - url = main_app.admin_report_path(report_type: report_type, report_subtype: report_subtype[1])
       = link_to report_subtype[0], url

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = @report_title
 
-= form_for @report.search, :url => url_for(only_path: false) do |f|
+= form_for @report.search, :url => url_for do |f|
   %fieldset.no-border-bottom.print-hidden
     %legend{ align: 'center'}= t(:report_filters)
     = render partial: "admin/reports/filters/#{@report_type}", locals: { f: f }


### PR DESCRIPTION
#### What? Why?


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
You can reach a development server under localhost, 127.0.0.1, 0.0.0.0 or other names you define in your environment. The reports were using absolute links to localhost though and therefore breaking your session (login) while navigating.

I'm not sure why this was done though. Sebastian didn't explain this in the commit message and it may have been accidental.



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit reports.
- Choose a report.
- Display report data on screen.
- Download data as CSV.

All should work as before.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
