### PR TITLE
[Enterprise->Create] Show correct error message when user inputs url in instagram field

### DIFF
--- a/app/assets/javascripts/darkswarm/services/enterprise_registration_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/enterprise_registration_service.js.coffee
@@ -55,6 +55,10 @@ angular.module('Darkswarm').factory "EnterpriseRegistrationService", ($http, Reg
       ).catch((response) ->
         Loading.clear()
         alert(t('failed_to_update_enterprise_unknown'))
+        if response.data.errors.instagram
+          igErr = document.querySelector("#instagram-error")
+          igErr.style.display = 'block'
+          igErr.textContent = response.data.errors.instagram[0]
       )
 
     prepare: =>

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -459,11 +459,11 @@ class Enterprise < ApplicationRecord
   end
 
   def correct_instagram_url(url)
-    url && strip_url(url.downcase).sub(%r{www.instagram.com/}, '').sub(%r{instagram.com/}, '').delete("@")
+    url && strip_url(url.downcase).sub(%r{(www\.)?instagram.com/}, '').delete("@")
   end
 
   def correct_twitter_url(url)
-    url && strip_url(url).sub(%r{www.twitter.com/}, '').delete("@")
+    url && strip_url(url).sub(%r{(www\.)?twitter.com/}, '').delete("@")
   end
 
   def set_unused_address_fields

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -450,7 +450,8 @@ class Enterprise < ApplicationRecord
   end
 
   def strip_url(url)
-    url&.sub(%r{(https?://)?}, '')
+    # Strip protocol and trailing slash
+    url&.sub(%r{(https?://)?}, '')&.sub(%r{/\z}, '')
   end
 
   def correct_whatsapp_url(phone_number)

--- a/app/views/registration/steps/_about.html.haml
+++ b/app/views/registration/steps/_about.html.haml
@@ -10,7 +10,7 @@
             %span{ ng: { class: "{brick: !enterprise.is_primary_producer, turquoise: enterprise.is_primary_producer}" } }
               {{ enterprise.name }}
 
-    %form{ name: 'about', novalidate: true, ng: { controller: "RegistrationFormCtrl", submit: "update('images',about)" } }
+    %form{ name: 'about', novalidate: true, ng: { controller: "RegistrationFormCtrl", submit: "selectIfValid('images', about)" } }
       .row
         .small-12.columns
           .alert-box.info{ "ofn-inline-alert" => true, ng: { show: "visible" } }

--- a/app/views/registration/steps/_social.html.haml
+++ b/app/views/registration/steps/_social.html.haml
@@ -37,6 +37,7 @@
               .field
                 %label{ for: 'enterprise_instagram' }= t(".instagram")+":"
                 %input.chunky{ id: 'enterprise_instagram', placeholder: "{{'registration.steps.social.instagram_placeholder' | t}}", ng: { model: 'enterprise.instagram' } }
+                %span.error.small-12.columns#instagram-error{ style: "display: none" }
 
       .row.buttons
         .small-12.columns

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -171,8 +171,8 @@ describe Enterprise do
         expect(e).to_not be_valid
       end
 
-      it "invalidates the instagram attribute https://instagram.com/user/" do
-        e = build(:enterprise, instagram: 'https://instagram.com/user/')
+      it "invalidates the instagram attribute https://www.instagram.com/p/Cpg4McNPyJA/" do
+        e = build(:enterprise, instagram: 'https://www.instagram.com/p/Cpg4McNPyJA/')
         expect(e).to_not be_valid
       end
 

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -125,6 +125,13 @@ describe "Registration" do
       click_button "Continue"
       expect(page).to have_content 'How can people find My Awesome Enterprise online?'
 
+      # Filling in social with invalid value for instagram
+      fill_in "enterprise_instagram", with: "www.instagram.com/coopcircuits/ "
+      click_button "Continue"
+      accept_alert "Failed to update your enterprise." do
+        expect(page).to have_content "Must be user name only eg. the_prof"
+      end
+
       # Filling in social
       fill_in 'enterprise_website', with: 'www.shop.com'
       fill_in 'enterprise_facebook', with: 'FaCeBoOk'

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -117,8 +117,8 @@ describe "Registration" do
       click_button "Continue"
       expect(page).to have_content 'How can people find My Awesome Enterprise online?'
 
-      # Filling in social with invalid value for instagram - slash after InStAgRaM
-      fill_in "enterprise_instagram", with: 'www.instagram.com/InStAgRaM/'
+      # Filling in social with invalid value for instagram - a link to a post instead of user
+      fill_in "enterprise_instagram", with: 'https://www.instagram.com/p/Cpg4McNPyJA/'
       accept_alert "Failed to update your enterprise." do
         click_button "Continue"
       end
@@ -129,7 +129,7 @@ describe "Registration" do
       fill_in 'enterprise_facebook', with: 'FaCeBoOk'
       fill_in 'enterprise_linkedin', with: 'LiNkEdIn'
       fill_in 'enterprise_twitter', with: 'https://www.twitter.com/@TwItTeR'
-      fill_in 'enterprise_instagram', with: 'www.instagram.com/InStAgRaM'
+      fill_in 'enterprise_instagram', with: 'https://www.instagram.com/OpenFoodNetwork/'
       click_button "Continue"
       expect(page).to have_content 'Finished!'
 
@@ -147,7 +147,7 @@ describe "Registration" do
       expect(e.facebook).to eq "FaCeBoOk"
       expect(e.linkedin).to eq "LiNkEdIn"
       expect(e.twitter).to eq "TwItTeR"
-      expect(e.instagram).to eq "instagram"
+      expect(e.instagram).to eq "openfoodnetwork"
 
       click_link "Go to Enterprise Dashboard"
       expect(page).to have_content "CHOOSE YOUR PACKAGE"

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -98,7 +98,6 @@ describe "Registration" do
       click_button "Continue"
       expect(page).to have_content 'Step 1. Select Logo Image'
 
-
       # Images
       # Upload logo image
       attach_file "image-select", Rails.root.join("spec/fixtures/files/logo.png"), visible: false
@@ -118,12 +117,12 @@ describe "Registration" do
       click_button "Continue"
       expect(page).to have_content 'How can people find My Awesome Enterprise online?'
 
-      # Filling in social with invalid value for instagram
-      fill_in "enterprise_instagram", with: "www.instagram.com/coopcircuits/ "
-      click_button "Continue"
+      # Filling in social with invalid value for instagram - slash after InStAgRaM
+      fill_in "enterprise_instagram", with: 'www.instagram.com/InStAgRaM/'
       accept_alert "Failed to update your enterprise." do
-        expect(page).to have_content "Must be user name only eg. the_prof"
+        click_button "Continue"
       end
+      expect(page).to have_content "Must be user name only eg. the_prof"
 
       # Filling in social
       fill_in 'enterprise_website', with: 'www.shop.com'

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -128,7 +128,7 @@ describe "Registration" do
       fill_in 'enterprise_website', with: 'www.shop.com'
       fill_in 'enterprise_facebook', with: 'FaCeBoOk'
       fill_in 'enterprise_linkedin', with: 'LiNkEdIn'
-      fill_in 'enterprise_twitter', with: 'https://www.twitter.com/@TwItTeR'
+      fill_in 'enterprise_twitter', with: 'https://twitter.com/@OpenFoodNet'
       fill_in 'enterprise_instagram', with: 'https://www.instagram.com/OpenFoodNetwork/'
       click_button "Continue"
       expect(page).to have_content 'Finished!'
@@ -146,7 +146,7 @@ describe "Registration" do
       expect(e.website).to eq "www.shop.com"
       expect(e.facebook).to eq "FaCeBoOk"
       expect(e.linkedin).to eq "LiNkEdIn"
-      expect(e.twitter).to eq "TwItTeR"
+      expect(e.twitter).to eq "OpenFoodNet"
       expect(e.instagram).to eq "openfoodnetwork"
 
       click_link "Go to Enterprise Dashboard"

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -98,13 +98,6 @@ describe "Registration" do
       click_button "Continue"
       expect(page).to have_content 'Step 1. Select Logo Image'
 
-      # Enterprise should be updated
-      e.reload
-      expect(e.description).to eq "Short description"
-      expect(e.long_description).to eq "Long description"
-      expect(e.abn).to eq '12345'
-      expect(e.acn).to eq '54321'
-      expect(e.charges_sales_tax).to be true
 
       # Images
       # Upload logo image
@@ -142,7 +135,15 @@ describe "Registration" do
       expect(page).to have_content 'Finished!'
 
       # Done
+      # Check values set in about tab
       e.reload
+      expect(e.description).to eq "Short description"
+      expect(e.long_description).to eq "Long description"
+      expect(e.abn).to eq '12345'
+      expect(e.acn).to eq '54321'
+      expect(e.charges_sales_tax).to be true
+
+      # Check values set in social tab
       expect(e.website).to eq "www.shop.com"
       expect(e.facebook).to eq "FaCeBoOk"
       expect(e.linkedin).to eq "LiNkEdIn"


### PR DESCRIPTION
#### What? Why?

- Closes #10216

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit page `/register`
- Register an enterprise
- At the last page `Social`, input a url like `www.github.com` in the `Instagram:` field
- Ascertain that the relevant error shows up below the field.

![Screenshot 2023-01-04 at 20-49-01 Register - OFN Demo Site](https://user-images.githubusercontent.com/87677429/210584567-2b36055c-12fa-4395-9e17-c1dbabc9b9c1.png)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
