### PR TITLE
Load js from stripe asynchronously and defer its execution

### DIFF
--- a/app/views/shared/_stripe_js.html.haml
+++ b/app/views/shared/_stripe_js.html.haml
@@ -2,4 +2,4 @@
   %script{type: "text/javascript"}
     = raw render file: "spec/support/fixtures/stripejs-mock.js"
 - else
-  %script{src: "https://js.stripe.com/v3/", type: "text/javascript"}
+  %script{src: "https://js.stripe.com/v3/", type: "text/javascript", async: true, defer: true}


### PR DESCRIPTION
#### What? Why?
Seems like using those two options prevents error from stripe, such as:

```
(index):1 Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('https://js.stripe.com') does not match the recipient window's origin ('http://localhost:3000').
```

- Closes #10228

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Pretty well explained in the original issue. I'd add, don't hesitate to test twice because of false positive.

Also, I'd add testing adding a stripe payment in the backend (the view is shared between shopfront and admin, every-time we need to insert that stripe js script)

_dcook_: Recommend doing a test with network throttling to see if slow loading of Stripe API is handled. 
For example in Chrome > DevTools > Network > Throttling > Slow 3G
![Screen Shot 2023-01-05 at 1 13 15 pm](https://user-images.githubusercontent.com/4188088/210686343-5cdb6ddc-fffd-4973-931d-1500a0654f61.png)


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
