### PR TITLE
Admin, edit variant: only allow numerical values for weight, height, width and depth fields

### DIFF
--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -66,12 +66,12 @@
     .field
       = f.label 'weight', t(:weight)+' (kg)'
       - value = number_with_precision(@variant.weight, precision: 2)
-      = f.text_field 'weight', value: value, class: 'fullwidth'
+      = f.number_field 'weight', value: value, class: 'fullwidth', step: 0.01
 
   - [:height, :width, :depth].each do |field|
     .field
       = f.label field, t(field)
       - value = number_with_precision(@variant.send(field), precision: 2)
-      = f.text_field field, value: value, class: 'fullwidth'
+      = f.number_field field, value: value, class: 'fullwidth', step: 0.01
 
 .clear


### PR DESCRIPTION
#### What? Why?

- Closes #10221 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
<img width="476" alt="Capture d’écran 2023-03-01 à 16 32 43" src="https://user-images.githubusercontent.com/296452/222186469-267afc44-7e94-43d7-969b-e2e9a1603d9a.png">



#### What should we test?
 - As an admin, visit `/admin/products/XXXXXX/variants/XXXX/edit`, ie. _edit variant page_
 - Check that you couldn't enter anything else than numeric value in field for weight, height, width and depth fields.
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
