### PR TITLE
Admin, BOM: Don't display "group by size" if group by product value is actually null

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -219,7 +219,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
 
   $scope.getGroupBySizeFormattedValueWithUnitName = (value, unitsProduct, unitsVariant) ->
     scale = $scope.getScale(unitsProduct, unitsVariant)
-    if scale
+    if scale && value
       value = value / scale if scale != 28.35 && scale != 1 && scale != 453.6 # divide by scale if not smallest unit
       $scope.getFormattedValueWithUnitName(value, unitsProduct, unitsVariant, scale)
     else

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -348,6 +348,19 @@ describe "LineItemsCtrl", ->
           spyOn(VariantUnitManager, "getUnitName").and.returnValue "lb"
           expect(scope.formattedValueWithUnitName(2, unitsProduct, unitsVariant)).toEqual "2 lb"
 
+      describe "get group by size formatted value with unit name", ->
+        beforeEach ->
+          spyOn(VariantUnitManager, "getUnitName").and.returnValue "kg"
+        
+        unitsProduct = { variant_unit: "weight", variant_unit_scale: 1000 }
+         
+        it "returns the formatted value with unit name", ->
+          expect(scope.getGroupBySizeFormattedValueWithUnitName(1000, unitsProduct)).toEqual "1 kg"
+
+        it "handle the case when the value is actually null or empty", ->
+          expect(scope.getGroupBySizeFormattedValueWithUnitName(null, unitsProduct)).toEqual ""
+          expect(scope.getGroupBySizeFormattedValueWithUnitName("", unitsProduct)).toEqual ""
+
 
       describe "updating the price upon updating the weight of a line item", ->
         beforeEach ->


### PR DESCRIPTION
#### What? Why?
- Closes #10222
Previously, we displayed `0 kg` (if `kg` is the unit value)

<img width="417" alt="Capture d’écran 2023-01-06 à 14 41 16" src="https://user-images.githubusercontent.com/296452/211023856-5e95a9b9-2ef6-4bb3-b195-81fc9c5a4417.png">
<img width="1300" alt="Capture d’écran 2023-01-06 à 14 41 38" src="https://user-images.githubusercontent.com/296452/211023913-8eaa104b-9bf4-49bb-b7f8-c53775628210.png">


#### What should we test?
- Go to `admin/orders/bulk_management`
- Select a product with no group by option
- Check the first column in the summary box is empty
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes