### PR TITLE
SplitCheckout: Fix an error when loading Stripe payment script

### DIFF
--- a/app/views/shared/_stripe_js.html.haml
+++ b/app/views/shared/_stripe_js.html.haml
@@ -3,3 +3,13 @@
     = raw render file: "spec/support/fixtures/stripejs-mock.js"
 - else
   %script{src: "https://js.stripe.com/v3/", type: "text/javascript"}
+  :javascript
+    // persist initial stripe iFrame DOM Object across turbo AJAX page requests
+    let stripeIFrameQuery = 'iframe[src^="https://js.stripe.com"]';
+    document.addEventListener('turbo:before-render', function (event) {
+      const stripeIFrame = document.querySelector(stripeIFrameQuery);
+      const newStripeIFrame = event.detail.newBody.querySelector(stripeIFrameQuery);
+      if (stripeIFrame && !newStripeIFrame){
+        event.detail.newBody.appendChild(stripeIFrame)
+      }
+    });


### PR DESCRIPTION


#### What? Why?

- Closes #10228
Found this workaround here: https://github.com/hotwired/turbo/issues/270#issuecomment-1068130327

This js hack persists the original iframe object downloaded from stripe in the new body sent by Turbo (instead of using the new one, in the new body)
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Well explained in the original issue. I still can see the error (ie. `Failed to execute 'postMessage' on 'DOMWindow': The target origin provided...`with my PR), but it seems like this is ok anyway (ie. can submit the form without any error at a user point of view)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
