### PR TITLE
Fix decimal display for imperial weight on Cart, Order Confirmation page and Confirmation emails

### DIFF
--- a/app/services/variant_units/option_value_namer.rb
+++ b/app/services/variant_units/option_value_namer.rb
@@ -56,7 +56,7 @@ module VariantUnits
     def option_value_value_unit_scaled
       unit_scale, unit_name = scale_for_unit_value
 
-      value = BigDecimal(@variant.unit_value / unit_scale, 6)
+      value = BigDecimal(@variant.unit_value / unit_scale, 6).truncate(2)
 
       [value, unit_name]
     end

--- a/app/services/variant_units/option_value_namer.rb
+++ b/app/services/variant_units/option_value_namer.rb
@@ -56,7 +56,7 @@ module VariantUnits
     def option_value_value_unit_scaled
       unit_scale, unit_name = scale_for_unit_value
 
-      value = BigDecimal(@variant.unit_value / unit_scale, 6).truncate(2)
+      value = (@variant.unit_value / unit_scale).to_d.truncate(2)
 
       [value, unit_name]
     end

--- a/spec/services/variant_units/option_value_namer_spec.rb
+++ b/spec/services/variant_units/option_value_namer_spec.rb
@@ -145,6 +145,15 @@ module VariantUnits
         allow(v).to receive(:unit_value) { nil }
         expect(subject.send(:option_value_value_unit)).to eq [nil, nil]
       end
+
+      it "truncates value to 2 decimals maximum" do
+        oz_scale = 28.35
+        p = double(:product, variant_unit: 'weight', variant_unit_scale: oz_scale)
+        allow(v).to receive(:product) { p }
+        # The unit_value is stored rounded to 2 decimals
+        allow(v).to receive(:unit_value) { (12.5 * oz_scale).round(2) }
+        expect(subject.send(:option_value_value_unit)).to eq [BigDecimal(12.5, 6), 'oz']
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #9720

When adding 12.5 as product weight in an imperial (oz) system, it is displayed in cart and order confirmation with a huge number of unnecessary decimals, it also happens in the order confirmation emails. 

#### What should we test?
- Create or edit a product with weight in oz
- Enter a weight with a decimal ie 11.3 
- Save
- As a customer put the product in your cart
- Check the /cart page

![Mushroom_in_cart](https://user-images.githubusercontent.com/40413322/211703160-78b4fcb5-9824-45a2-9b4a-318ba9ad716c.png)
- Check out
- Check the order confirmation

![confirmed_mushroom_order](https://user-images.githubusercontent.com/40413322/211703230-e8aaf27c-5a18-4aa3-aeaa-fce33cc1bba9.png)
- Check email confirmations, if using a local environment you should see emails being generated in `tmp/letter_opener/` , check the two latest generated emails

![mushroom_confirmation_email](https://user-images.githubusercontent.com/40413322/211703866-e7885af5-d3fb-443c-b83c-06c6e481a737.png)
 
#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.

#### Dependencies
N/A

#### Documentation updates
N/A