### PR TITLE
Render reports in a separate process (feature-toggled)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -692,6 +692,7 @@ Rails/ApplicationJob:
     - 'app/jobs/heartbeat_job.rb'
     - 'app/jobs/order_cycle_closing_job.rb'
     - 'app/jobs/order_cycle_notification_job.rb'
+    - 'app/jobs/report_job.rb'
     - 'app/jobs/subscription_confirm_job.rb'
     - 'app/jobs/subscription_placement_job.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -695,6 +695,7 @@ Rails/ApplicationJob:
     - 'app/jobs/report_job.rb'
     - 'app/jobs/subscription_confirm_job.rb'
     - 'app/jobs/subscription_placement_job.rb'
+    - 'spec/services/job_processor_spec.rb'
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -55,10 +55,11 @@ module Admin
 
     def render_report_as(format)
       if OpenFoodNetwork::FeatureToggle.enabled?(:background_reports, spree_current_user)
-        job = ReportJob.perform_later(
+        job = ReportJob.new
+        JobProcessor.perform_forked(
+          job,
           report_class, spree_current_user, params, format
         )
-        sleep 1 until job.done?
 
         # This result has been rendered by Rails in safe mode already.
         job.result.html_safe # rubocop:disable Rails/OutputSafety

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -19,7 +19,7 @@ module Admin
     end
 
     def show
-      @report = report_class.new(spree_current_user, params, request)
+      @report = report_class.new(spree_current_user, params, render: render_data?)
 
       if report_format.present?
         export_report
@@ -45,8 +45,12 @@ module Admin
       @report_subtype = report_subtype
       @report_title = report_title
       @rendering_options = rendering_options
-      @table = @report.to_html if request.post?
+      @table = @report.to_html if render_data?
       @data = Reporting::FrontendData.new(spree_current_user)
+    end
+
+    def render_data?
+      request.post?
     end
   end
 end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -24,17 +24,17 @@ module Admin
       if report_format.present?
         export_report
       else
-        render_report
+        show_report
       end
     end
 
     private
 
     def export_report
-      send_data @report.render_as(report_format), filename: report_filename
+      send_data render_report_as(report_format), filename: report_filename
     end
 
-    def render_report
+    def show_report
       assign_view_data
       render "show"
     end
@@ -45,12 +45,26 @@ module Admin
       @report_subtype = report_subtype
       @report_title = report_title
       @rendering_options = rendering_options
-      @table = @report.to_html if render_data?
+      @table = render_report_as(:html) if render_data?
       @data = Reporting::FrontendData.new(spree_current_user)
     end
 
     def render_data?
       request.post?
+    end
+
+    def render_report_as(format)
+      if OpenFoodNetwork::FeatureToggle.enabled?(:background_reports, spree_current_user)
+        job = ReportJob.perform_later(
+          report_class, spree_current_user, params, format
+        )
+        sleep 1 until job.done?
+
+        # This result has been rendered by Rails in safe mode already.
+        job.result.html_safe # rubocop:disable Rails/OutputSafety
+      else
+        @report.render_as(format)
+      end
     end
   end
 end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -49,6 +49,7 @@ module Admin
                         I18n.t(:name, scope: [:admin, :reports, @report_type])
                       end
       @rendering_options = rendering_options
+      @table = @report.to_html if request.post?
       @data = Reporting::FrontendData.new(spree_current_user)
     end
   end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -43,11 +43,7 @@ module Admin
       @report_type = report_type
       @report_subtypes = report_subtypes
       @report_subtype = report_subtype
-      @report_title = if report_subtype
-                        report_subtype_title
-                      else
-                        I18n.t(:name, scope: [:admin, :reports, @report_type])
-                      end
+      @report_title = report_title
       @rendering_options = rendering_options
       @table = @report.to_html if request.post?
       @data = Reporting::FrontendData.new(spree_current_user)

--- a/app/controllers/concerns/reports_actions.rb
+++ b/app/controllers/concerns/reports_actions.rb
@@ -39,6 +39,14 @@ module ReportsActions
     params[:report_subtype] || report_subtypes_codes.first
   end
 
+  def report_title
+    if report_subtype
+      report_subtype_title
+    else
+      I18n.t(:name, scope: [:admin, :reports, report_type])
+    end
+  end
+
   def report_subtype_title
     report_subtypes.select { |_name, key| key.to_sym == report_subtype.to_sym }.first[0]
   end

--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Renders a report and saves it to a temporary file.
+class ReportJob < ActiveJob::Base
+  def perform(report_class, user, params, format)
+    report = report_class.new(user, params, render: true)
+    result = report.render_as(format)
+    write(result)
+  end
+
+  def done?
+    @done ||= File.file?(filename)
+  end
+
+  def result
+    @result ||= read_result
+  end
+
+  private
+
+  def write(result)
+    File.write(filename, result)
+  end
+
+  def read_result
+    File.read(filename)
+  ensure
+    File.unlink(filename)
+  end
+
+  def filename
+    Rails.root.join("tmp/report-#{job_id}")
+  end
+end

--- a/app/services/job_processor.rb
+++ b/app/services/job_processor.rb
@@ -19,6 +19,7 @@ class JobProcessor
       exit # rubocop:disable Rails/Exit
     end
 
+    # Wait for all forked child processes to exit
     Process.waitall
   ensure
     # If this Puma thread is interrupted then we need to detach the child

--- a/app/services/job_processor.rb
+++ b/app/services/job_processor.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Forks into a separate process to contain memory usage and timeout errors.
+class JobProcessor
+  def self.perform_forked(job, *args)
+    fork do
+      Process.setproctitle("Job worker #{job.job_id}")
+      job.perform(*args)
+
+      # Exit is not a good idea within a Rails process but Rubocop doesn't know
+      # that we are in a forked process.
+      exit # rubocop:disable Rails/Exit
+    end
+
+    Process.waitall
+  end
+end

--- a/app/services/job_processor.rb
+++ b/app/services/job_processor.rb
@@ -3,9 +3,16 @@
 # Forks into a separate process to contain memory usage and timeout errors.
 class JobProcessor
   def self.perform_forked(job, *args)
-    fork do
+    # Reports should abort when puma threads are killed to avoid wasting
+    # resources. Nobody would be collecting the result. We still need to
+    # implement a way to email or download reports later.
+    timeout = ENV.fetch("RACK_TIMEOUT_WAIT_TIMEOUT", "30").to_i
+
+    child = fork do
       Process.setproctitle("Job worker #{job.job_id}")
-      job.perform(*args)
+      Timeout.timeout(timeout) do
+        job.perform(*args)
+      end
 
       # Exit is not a good idea within a Rails process but Rubocop doesn't know
       # that we are in a forked process.
@@ -13,5 +20,9 @@ class JobProcessor
     end
 
     Process.waitall
+  ensure
+    # If this Puma thread is interrupted then we need to detach the child
+    # process to avoid it becoming a zombie.
+    Process.detach(child)
   end
 end

--- a/app/views/admin/reports/_table.html.haml
+++ b/app/views/admin/reports/_table.html.haml
@@ -1,5 +1,3 @@
-- report ||= @report
-
 .report__table-container
   %table.report__table
     %thead

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -19,7 +19,4 @@
   - if request.post?
     %button.btn-print.icon-print{ onclick: "window.print()"}= t(:report_print)
 
-/ We don't want to render data unless search params are supplied.
-/ Compiling data can take a long time.
-- if request.post?
-  = render "table"
+= @table

--- a/lib/reporting/report_renderer.rb
+++ b/lib/reporting/report_renderer.rb
@@ -46,6 +46,14 @@ module Reporting
       public_send("to_#{target_format}")
     end
 
+    def to_html(layout: nil)
+      ApplicationController.render(
+        template: "admin/reports/_table",
+        layout: layout,
+        locals: { report: @report }
+      )
+    end
+
     def to_csv
       SpreadsheetArchitect.to_csv(headers: table_headers, data: table_rows)
     end
@@ -55,11 +63,7 @@ module Reporting
     end
 
     def to_pdf
-      html = ApplicationController.render(
-        template: "admin/reports/_table",
-        layout: "pdf",
-        locals: { report: @report }
-      )
+      html = to_html(layout: "pdf")
       WickedPdf.new.pdf_from_string(html)
     end
 

--- a/lib/reporting/report_renderer.rb
+++ b/lib/reporting/report_renderer.rb
@@ -4,7 +4,7 @@ require 'spreadsheet_architect'
 
 module Reporting
   class ReportRenderer
-    REPORT_FORMATS = [:csv, :json, :xlsx, :pdf].freeze
+    REPORT_FORMATS = [:csv, :json, :html, :xlsx, :pdf].freeze
 
     def initialize(report)
       @report = report

--- a/lib/reporting/report_template.rb
+++ b/lib/reporting/report_template.rb
@@ -14,8 +14,8 @@ module Reporting
 
     delegate :formatted_rules, :header_option?, :summary_row_option?, to: :ruler
 
-    def initialize(user, params = {}, request = nil)
-      if request.nil? || request.get?
+    def initialize(user, params = {}, render: false)
+      unless render
         params.reverse_merge!(default_params)
         params[:q] ||= {}
         params[:q].reverse_merge!(default_params[:q]) if default_params[:q].present?

--- a/lib/reporting/report_template.rb
+++ b/lib/reporting/report_template.rb
@@ -5,7 +5,7 @@ module Reporting
     include ReportsHelper
     attr_accessor :user, :params, :ransack_params
 
-    delegate :render_as, :as_json, :to_csv, :to_xlsx, :to_pdf, :to_json, to: :renderer
+    delegate :render_as, :as_json, :to_html, :to_csv, :to_xlsx, :to_pdf, :to_json, to: :renderer
     delegate :raw_render?, :html_render?, :display_header_row?, :display_summary_row?, to: :renderer
 
     delegate :rows, :table_rows, :grouped_data, to: :rows_builder

--- a/lib/reporting/reports/enterprise_fee_summary/base.rb
+++ b/lib/reporting/reports/enterprise_fee_summary/base.rb
@@ -6,8 +6,8 @@ module Reporting
       class Base < ReportTemplate
         attr_accessor :permissions, :parameters
 
-        def initialize(user, params = {}, request = nil)
-          super(user, params, request)
+        def initialize(user, params = {}, render: false)
+          super(user, params, render: render)
           p = params[:q]
           if p.present?
             p['start_at'] = p.delete('completed_at_gt')

--- a/spec/jobs/report_job_spec.rb
+++ b/spec/jobs/report_job_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ReportJob do
+  let(:report_args) { [report_class, user, params, format] }
+  let(:report_class) { Reporting::Reports::UsersAndEnterprises::Base }
+  let(:user) { enterprise.owner }
+  let(:enterprise) { create(:enterprise) }
+  let(:params) { {} }
+  let(:format) { :csv }
+
+  it "generates a report" do
+    job = ReportJob.new
+    job.perform(*report_args)
+    expect_csv_report(job)
+  end
+
+  it "enqueues a job for asynch processing" do
+    job = ReportJob.perform_later(*report_args)
+    expect(job.done?).to eq false
+
+    # This performs the job in the same process but that's good enought for
+    # testing the job code. I hope that we can rely on the job worker.
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+    job.retry_job
+
+    expect(job.done?).to eq true
+    expect_csv_report(job)
+  end
+
+  def expect_csv_report(job)
+    table = CSV.parse(job.result)
+    expect(table[0][1]).to eq "Relationship"
+    expect(table[1][1]).to eq "owns"
+  end
+end

--- a/spec/lib/reports/xero_invoices_report_spec.rb
+++ b/spec/lib/reports/xero_invoices_report_spec.rb
@@ -26,8 +26,13 @@ module Reporting
 
         describe "summary rows" do
           let(:report) {
-            Base.new user, initial_invoice_number: '', invoice_date: '', due_date: '',
-                           account_code: ''
+            Base.new(user, params)
+          }
+          let(:params) {
+            {
+              initial_invoice_number: '', invoice_date: '', due_date: '',
+              account_code: ''
+            }
           }
           let(:order) { double(:order) }
           let(:summary_rows) { report.__send__(:summary_rows_for_order, order, 1, {}) }
@@ -84,7 +89,7 @@ module Reporting
           end
 
           describe "when an initial invoice number is given" do
-            subject { Base.new user, initial_invoice_number: '123' }
+            subject { Base.new(user, { initial_invoice_number: '123' }) }
 
             it "increments the number by the index" do
               expect(subject.send(:invoice_number_for, order, 456)).to eq(579)

--- a/spec/services/job_processor_spec.rb
+++ b/spec/services/job_processor_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+class TestJob < ActiveJob::Base
+  def initialize
+    @file = Tempfile.new("test-job-result")
+    super
+  end
+
+  def perform(message)
+    @file.write(message)
+  end
+
+  def result
+    @file.rewind
+    @file.read
+  end
+end
+
+describe JobProcessor do
+  describe ".perform_forked" do
+    let(:job) { TestJob.new }
+
+    it "executes a job" do
+      JobProcessor.perform_forked(job, "hello")
+
+      expect(job.result).to eq "hello"
+    end
+  end
+end

--- a/spec/services/job_processor_spec.rb
+++ b/spec/services/job_processor_spec.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# We need to configure MiniRacer to allow forking.
+# Otherwise this spec hangs on CI.
+# https://github.com/rubyjs/mini_racer#fork-safety
+require "mini_racer"
+MiniRacer::Platform.set_flags!(:single_threaded)
+
 require 'spec_helper'
 
 class TestJob < ActiveJob::Base


### PR DESCRIPTION
#### What? Why?

- Closes #10016  <!-- Insert issue number here. -->
- Closes #10240

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

When a process ends it frees up all of its memory. So by moving the report generation into a separate, short-lived process frees up all memory afterwards. Such a process will also be most likely be killed first when the system runs out of memory which enables us to finish gracefully. The web request still times out as usual and the user will still see the Snail error message. We can work on that later. Here are my plans to keep in mind when reviewing these commits:

* Implement a report action to download a generated report. This allows us to link there when the report takes a long time. We should leave the report file on disk after reading so that it can be downloaded multiple times. We will need a cleanup task which deletes old reports for us. Maybe they expire after 3 days? That allows for kicking a report off on Friday evening and downloading it on Monday morning. We can also allow more, like 7 days which could be more convenient. #10280
* Notify user via email about a report that needed some time. The browser may have been closed or the request timed out. #10281
* Allow report processes to run for longer, for example 15 minutes (UK allows 12 minutes). We can then reduce the Puma timeout because all non-report requests should be faster. #10282

##### Disclaimer

API v0 has a reports endpoint which I didn't change. So if people use that one then there will still be higher memory use.

##### Potential problems

Forked processes share memory. They are exactly the same after the fork. Writing memory in one process doesn't overwrite the data in the other fork though. The system uses copy-on-write, meaning that any data changed in any process is isolated there. Nevertheless, network connections like the database connection and the Redis connection are shared. There's a risk of conflict here. But it seems like Rails is handling that very well:

* Luckily Rails doesn't try to disconnect from the database if the connection is shared. https://github.com/rails/rails/pull/31173
* Rails removed the advice to re-establish database connections because it's all safe now. https://github.com/rails/rails/pull/31241

Redis seems to be fork-safe, too:

* https://github.com/redis/redis-rb/pull/414

I'm wondering if we can remove the reconnect in our puma config:

```rb

  # Ensure clean Redis connections when forking
  before_fork do
    Redis.current.disconnect! if defined?(Redis)
  end

  on_refork do
    Redis.current.disconnect! if defined?(Redis)
  end
```
https://github.com/openfoodfoundation/ofn-install/blob/8095da474335d1804d880356813ad7caf5e3c432/roles/webserver/templates/puma.rb.j2#L25-L32

##### Notes for instance managers

We never created background processes in the way this pull request does. It could fail in mysterious ways and maybe only after a lot of reports were run. Deactivating the feature and restarting the server should resolve all problems though. Let's test this in phases when we can monitor error reports.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit the /admin/reports page.
- Find a report with default parameters and make sure that they are applied.
- Check that you can change the default parameters.
- Go to /admin/feature-toggle and activate background reports.
- Check that reports are still rendering on screen and for download.
- Try to run multiple (>= 5) long-running reports in parallel.
- Make sure that overloading the system with reports does not break any other requests, surfing in other tabs). Timeout is allowed, of course. But the system should always recover.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
