### PR TITLE
Update mail settings notice

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3666,7 +3666,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     choose_currency: "Choose Currency"
 
     mail_method_settings: "Mail Method Settings"
-    mail_settings_notice_html: "Some of the following settings can't be edited and are listed here just for debugging purposes. Changes can be made by updating the instance's secrets and provisioning them using <a href='https://github.com/openfoodfoundation/ofn-install'>ofn-install</a>. Reach out to the OFN global team for further details."
+    mail_settings_notice_html: "<b>Changes made here will be temporary</b> for debugging only, and may get reverted in the future. <br>Permanent changes can be made by updating the instance's secrets and provisioning them using <a href='https://github.com/openfoodfoundation/ofn-install'>ofn-install</a>. Reach out to the OFN global team for further details."
     general: "General"
     enable_mail_delivery: "Enable Mail Delivery"
     send_mails_as: "Send Mails As"


### PR DESCRIPTION
#### What? Why?
[It is confusing](https://openfoodnetwork.slack.com/archives/C2GQ45KNU/p1672896977880709) how these settings work, hopefully the new message makes it clear now:

![Screen Shot 2023-01-12 at 5 41 46 pm](https://user-images.githubusercontent.com/4188088/211996007-0e56b05b-7aa1-415e-870f-3f8f8820013a.png)


We could just disable the fields entirely, but it was chosen to allow temporary updates so that instance managers can troubleshoot mail issues (063d44fecc55f42712e98726f7b6fed925e05d7e).


#### What should we test?
- Visit /admin/mail_methods/edit
- View the updated message. Did it make sense to you?

#### Release notes

Changelog Category: Technical changes
