### PR TITLE
Fix product description style render with ng-bind-html

### DIFF
--- a/app/views/shop/products/_summary.html.haml
+++ b/app/views/shop/products/_summary.html.haml
@@ -9,7 +9,7 @@
     %h3
       %a{"ng-click" => "triggerProductModal()", href: 'javascript:void(0)'}
         %span{"ng-bind" => "::product.name"}
-    %p.product-description{ng: {bind: "::product.description", click: "triggerProductModal()", show: "product.description.length"}}
+    %p.product-description{ng: {"bind-html": "::product.description_html", click: "triggerProductModal()", show: "product.description_html.length"}}
     .product-producer
       = t :products_from
       %span


### PR DESCRIPTION
#### What? Why?

- Closes #10211

Resolved the issue of bold, italics, underline, links not properly rendering in the short product description thanks to implementation suggested by jibees. 

Didn't see any similar existing view-related tests in the spec file, so figured that was for a reason and didn't add in a test. If I should let me know, otherwise feature can be tested manually by the steps listed below.

#### What should we test?

- Log in as default user `ofn@example.com` / `ofn123` 
- Navigate to http://localhost:3000/admin/products/fuji-apple/edit and add a short description to fuji apples under the admin's product's options. Short description should include bold, italics, underline, and a link. 
- Navigate to a farm's shop which has that fruit in. So if editing fuji apples in Freddy's Farm, navigate to http://localhost:3000/freddy-s-farm-shop/shop
- The short description should look as follows, with the styles rendering properly for bold, italics, underline, and links.

![Screenshot from 2023-01-12 09-25-09](https://user-images.githubusercontent.com/43343880/212094883-e838de67-0962-43ad-93bf-8726423b17bd.png)

#### Release notes

Changelog Category: User facing changes
