### PR TITLE
On `/cart` page, if consumer adds more quantity than available, use in-app flash message instead of native alert

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/flash.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/flash.js.coffee
@@ -17,9 +17,12 @@ angular.module('Darkswarm').directive "ofnFlash", (flash, $timeout, RailsFlashLo
     
     # Callback when a new flash message is pushed to flash service
     show = (message, type)=>
-      if message
-        $scope.flashes.push({message: message, type: typePairings[type]})
-        $timeout($scope.delete, 10000)
+      return unless message
+      # if same message already exists, don't add it again
+      return if $scope.flashes.some((flash) -> flash.message == message)
+
+      $scope.flashes.push({message: message, type: typePairings[type]})
+      $timeout($scope.delete, 10000)
 
     $scope.delete = ->
       $scope.flashes.shift()

--- a/app/assets/javascripts/darkswarm/directives/on_hand.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/on_hand.js.coffee
@@ -1,4 +1,4 @@
-angular.module('Darkswarm').directive "ofnOnHand", (StockQuantity) ->
+angular.module('Darkswarm').directive "ofnOnHand", (StockQuantity, Messages) ->
   restrict: 'A'
   require: "ngModel"
   scope: true
@@ -16,7 +16,7 @@ angular.module('Darkswarm').directive "ofnOnHand", (StockQuantity) ->
     ngModel.$parsers.push (viewValue) ->
       available_quantity = scope.available_quantity()
       if parseInt(viewValue) > available_quantity
-        alert t("js.insufficient_stock", {on_hand: available_quantity})
+        Messages.flash({error: t("js.insufficient_stock", {on_hand: available_quantity})})
         viewValue = available_quantity
         ngModel.$setViewValue viewValue
         ngModel.$render()

--- a/spec/system/consumer/shopping/cart_spec.rb
+++ b/spec/system/consumer/shopping/cart_spec.rb
@@ -203,18 +203,16 @@ describe "full-page cart", js: true do
           variant2.update!(on_hand: 3, on_demand: false)
           visit main_app.cart_path
 
-          accept_alert 'Insufficient stock available, only 2 remaining' do
-            within "tr.variant-#{variant.id}" do
-              fill_in "order_line_items_attributes_0_quantity", with: '4'
-            end
+          within "tr.variant-#{variant.id}" do
+            fill_in "order_line_items_attributes_0_quantity", with: '4'
           end
+          expect(page).to have_content "Insufficient stock available, only 2 remaining"
           expect(page).to have_field "order_line_items_attributes_0_quantity", with: '2'
 
-          accept_alert 'Insufficient stock available, only 3 remaining' do
-            within "tr.variant-#{variant2.id}" do
-              fill_in "order_line_items_attributes_1_quantity", with: '4'
-            end
+          within "tr.variant-#{variant2.id}" do
+            fill_in "order_line_items_attributes_1_quantity", with: '4'
           end
+          expect(page).to have_content "Insufficient stock available, only 3 remaining"
           expect(page).to have_field "order_line_items_attributes_1_quantity", with: '3'
         end
 
@@ -225,12 +223,8 @@ describe "full-page cart", js: true do
           visit main_app.cart_path
           variant.update! on_hand: 2
 
-          accept_alert do
-            fill_in "order_line_items_attributes_0_quantity", with: '4'
-          end
+          fill_in "order_line_items_attributes_0_quantity", with: '4'
           click_button 'Update'
-
-          expect(page).to have_content "Insufficient stock available, only 2 remaining"
           expect(page).to have_field "order_line_items_attributes_0_quantity", with: '1'
         end
 


### PR DESCRIPTION
#### What? Why?

- Closes #8905


<img width="1437" alt="Capture d’écran 2023-01-16 à 11 48 52" src="https://user-images.githubusercontent.com/296452/212660707-64580d9f-4092-40fe-8dae-ac76f5c9c066.png">

+ I've added a tiny modification on flash message management. We should not be able to see same flash message (ie. with the same text inside) more than one. Previously, flash message were stacked, and it was pretty ugly.


<img width="1406" alt="Capture d’écran 2023-01-16 à 11 54 43" src="https://user-images.githubusercontent.com/296452/212661774-f6c19e1d-22f2-4c9d-9ad4-9e5aaf15a214.png">



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an hub manager, set a product with on_hand value to 3 for example
- As an customer, add this product to cart, and try to edit its quantity on `/cart` page
- You should:
  - not be able to increase quantity over the on_hand value
  - see a alert on top of the page if you try to increase
  - not see more than one flash message with the same message (true in all app actually) 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
