### PR TITLE
Split Checkout, increase input to 16px for small devices and iOS devices

### DIFF
--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -507,3 +507,15 @@
     margin-bottom: 10px;
   }
 }
+
+// For small screen or for iOS devices, increase to 16px the input font-size
+@media screen and (max-width: 700px) {
+  .checkout-input input {
+    font-size: 16px;
+  }
+}
+@supports(-webkit-overflow-scrolling: touch) {
+  .checkout-input input {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
This avoid that "zoom on input focus" on iOS devices

#### What? Why?

- Closes #10250




#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

As a consumer, check that every step of the split checkout process (details, payment and summary) is correctly handled


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
