### PR TITLE
Enable pg_stat_statements in development like prod

### DIFF
--- a/db/migrate/20230117043628_enable_stats_extension.rb
+++ b/db/migrate/20230117043628_enable_stats_extension.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class EnableStatsExtension < ActiveRecord::Migration[6.1]
+  def change
+    # Most production servers have this already. Enabling twice isn't harmful.
+    enable_extension "pg_stat_statements"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_05_000312) do
+ActiveRecord::Schema.define(version: 2023_01_17_043628) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|


### PR DESCRIPTION

#### What? Why?

We activated this database extension in production via ofn-install. But this had not been reflected in Rails' schema.rb.

This change avoids inconsistent db/schema.rb files on production servers and makes development more similar to production.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

##### Dev Test

- Deploy.
- `cd ~/apps/openfoodnetwork/current && git diff -- db/schema.rb`
- Confirm that the diff doesn't contain `pg_stat_statements`.

Unfortunately, since we don't reset the database after staging new migrations, there are some other changes in the diff. Ideally, the diff would be empty.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
