### PR TITLE
For calculator fields, do not edit currency preference

### DIFF
--- a/app/helpers/spree/admin/base_helper.rb
+++ b/app/helpers/spree/admin/base_helper.rb
@@ -110,10 +110,16 @@ module Spree
 
       # maps each preference to a hash containing the label and field html.
       # E.g. { :label => "<label>...", :field => "<select>..." }
-      def preference_fields(object, form)
+      # options[:reject_currency] - if true, the currency preference will not be included.
+      #                             Defaults to false.
+      def preference_fields(object, form, options = {})
         return unless object.respond_to?(:preferences)
 
-        object.preferences.keys.map { |key|
+        preferences_key = object.preferences.keys
+        if options.fetch(:reject_currency, false)
+          preferences_key = preferences_key.reject { |key| key == :currency }
+        end
+        preferences_key.map { |key|
           preference_label = form.label("preferred_#{key}",
                                         Spree.t(key.to_s.gsub("_from_list", "")) + ": ").html_safe
           preference_field = preference_field_for(

--- a/app/views/admin/enterprise_fees/_calculator_settings.html.haml
+++ b/app/views/admin/enterprise_fees/_calculator_settings.html.haml
@@ -7,7 +7,7 @@
       - if !enterprise_fee.new_record?
         .calculator-settings
           = f.fields_for :calculator do |calculator_form|
-            - preference_fields(enterprise_fee.calculator, calculator_form).each do |field|
+            - preference_fields(enterprise_fee.calculator, calculator_form, { reject_currency: true }).each do |field|
               %span.field
                 = field[:label]
               %p.field

--- a/app/views/spree/admin/shared/_calculator_fields.html.haml
+++ b/app/views/spree/admin/shared/_calculator_fields.html.haml
@@ -10,7 +10,7 @@
       .row
         .calculator-settings
           = f.fields_for :calculator do |calculator_form|
-            - preference_fields(@object.calculator, calculator_form).each do |field|
+            - preference_fields(@object.calculator, calculator_form, { reject_currency: true }).each do |field|
               .alpha.four.columns
                 = field[:label]
               .field.twelve.eight.columns


### PR DESCRIPTION
#### What? Why?

- Closes #10272

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
<img width="1030" alt="Capture d’écran 2023-01-18 à 16 43 22" src="https://user-images.githubusercontent.com/296452/213217594-2f8ead43-685d-49cc-bbd1-e00b8e7975dc.png">
<img width="760" alt="Capture d’écran 2023-01-18 à 16 43 57" src="https://user-images.githubusercontent.com/296452/213217749-4fbbd6d9-18bf-49d2-a6ac-042aa9738091.png">


#### What should we test?
- As an admin, when editing fees that include method, or fees that include calculator is `Amount` (flatrate, ...) you should not see `Currency` input and therefore you should be able to edit it. 


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing change
