### PR TITLE
Add Rails standard ApplicationJob for consistency

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -684,19 +684,6 @@ Rails/ApplicationController:
   Exclude:
     - 'engines/dfc_provider/app/controllers/dfc_provider/base_controller.rb'
 
-# Offense count: 6
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/ApplicationJob:
-  Exclude:
-    - 'app/jobs/bulk_invoice_job.rb'
-    - 'app/jobs/heartbeat_job.rb'
-    - 'app/jobs/order_cycle_closing_job.rb'
-    - 'app/jobs/order_cycle_notification_job.rb'
-    - 'app/jobs/report_job.rb'
-    - 'app/jobs/subscription_confirm_job.rb'
-    - 'app/jobs/subscription_placement_job.rb'
-    - 'spec/services/job_processor_spec.rb'
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/ApplicationMailer:

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Rails standard class for common job code.
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/bulk_invoice_job.rb
+++ b/app/jobs/bulk_invoice_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class BulkInvoiceJob < ActiveJob::Base
+class BulkInvoiceJob < ApplicationJob
   def perform(order_ids, filepath)
     pdf = CombinePDF.new
 

--- a/app/jobs/heartbeat_job.rb
+++ b/app/jobs/heartbeat_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HeartbeatJob < ActiveJob::Base
+class HeartbeatJob < ApplicationJob
   def perform
     Spree::Config.last_job_queue_heartbeat_at = Time.now.in_time_zone
   end

--- a/app/jobs/order_cycle_closing_job.rb
+++ b/app/jobs/order_cycle_closing_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OrderCycleClosingJob < ActiveJob::Base
+class OrderCycleClosingJob < ApplicationJob
   def perform
     return if recently_closed_order_cycles.empty?
 

--- a/app/jobs/order_cycle_notification_job.rb
+++ b/app/jobs/order_cycle_notification_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Delivers an email with a report of the order cycle to each of its suppliers
-class OrderCycleNotificationJob < ActiveJob::Base
+class OrderCycleNotificationJob < ApplicationJob
   def perform(order_cycle_id)
     order_cycle = OrderCycle.find(order_cycle_id)
     order_cycle.suppliers.each do |supplier|

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -3,7 +3,7 @@
 require 'order_management/subscriptions/summarizer'
 
 # Confirms orders of unconfirmed proxy orders in recently closed Order Cycles
-class SubscriptionConfirmJob < ActiveJob::Base
+class SubscriptionConfirmJob < ApplicationJob
   def perform
     confirm_proxy_orders!
   end

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -2,7 +2,7 @@
 
 require 'order_management/subscriptions/summarizer'
 
-class SubscriptionPlacementJob < ActiveJob::Base
+class SubscriptionPlacementJob < ApplicationJob
   def perform
     proxy_orders.each do |proxy_order|
       place_order_for(proxy_order)

--- a/spec/services/job_processor_spec.rb
+++ b/spec/services/job_processor_spec.rb
@@ -8,7 +8,7 @@ MiniRacer::Platform.set_flags!(:single_threaded)
 
 require 'spec_helper'
 
-class TestJob < ActiveJob::Base
+class TestJob < ApplicationJob
   def initialize
     @file = Tempfile.new("test-job-result")
     super


### PR DESCRIPTION

#### What? Why?

New Rails apps come with this class already, the job generator creates it for every new job and Rubocop requires it as well. Let's make our lives easier and use the same structure as other Rails projects. This class may be handy one day.

This came up in:

- https://github.com/openfoodfoundation/openfoodnetwork/pull/9687#discussion_r1048501584
- https://github.com/openfoodfoundation/openfoodnetwork/pull/10258#discussion_r1073002715

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
