### PR TITLE
fix the pending invoice print spec

### DIFF
--- a/app/helpers/tax_helper.rb
+++ b/app/helpers/tax_helper.rb
@@ -12,6 +12,16 @@ module TaxHelper
     end
   end
 
+  def display_line_items_taxes(line_item, display_zero: true)
+    if line_item.included_tax.positive?
+      Spree::Money.new(line_item.included_tax, currency: line_item.currency)
+    elsif line_item.added_tax.positive?
+      Spree::Money.new(line_item.added_tax, currency: line_item.currency)
+    elsif display_zero
+      Spree::Money.new(0.00, currency: line_item.currency)
+    end
+  end
+
   def display_total_with_tax(taxable)
     total = taxable.amount + taxable.additional_tax_total
     Spree::Money.new(total, currency: taxable.currency)

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -186,6 +186,10 @@ module Spree
       adjustments.tax.inclusive.sum(:amount)
     end
 
+    def added_tax
+      adjustments.tax.additional.sum(:amount)
+    end
+
     def tax_rates
       product.tax_category&.tax_rates || []
     end

--- a/app/views/spree/admin/orders/_invoice_table.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table.html.haml
@@ -20,7 +20,7 @@
         %td{:align => "right"}
           = item.quantity
         %td{:align => "right"}
-          = item.included_tax > 0 ? item.display_included_tax : ""
+          = display_line_items_taxes(item)
         %td{:align => "right"}
           = item.display_amount_with_adjustments
       

--- a/spec/helpers/tax_helper_spec.rb
+++ b/spec/helpers/tax_helper_spec.rb
@@ -4,17 +4,23 @@ require 'spec_helper'
 
 describe TaxHelper, type: :helper do
   let(:line_item) { create(:line_item) }
+  let(:line_item2) { create(:line_item) }
+  let(:line_item3) { create(:line_item) }
   let!(:tax_rate) { create(:tax_rate, amount: 0.1) }
   let!(:tax_rate2) { create(:tax_rate, amount: 0.2, included_in_price: false) }
   let!(:included_tax_adjustment) {
     create(:adjustment, originator: tax_rate, adjustable: line_item, state: "closed")
   }
   let!(:additional_tax_adjustment) {
-    create(:adjustment, originator: tax_rate2, adjustable: line_item, state: "closed")
+    create(:adjustment, originator: tax_rate2, adjustable: line_item2, state: "closed")
   }
   let!(:no_tax_adjustment) {
-    create(:adjustment, amount: 0, adjustable: line_item, state: "closed")
+    create(:adjustment, amount: 0, adjustable: line_item3, state: "closed")
   }
+
+  before do
+    included_tax_adjustment.update(included: true)
+  end
 
   describe "#display_taxes" do
     it "displays included tax" do
@@ -39,6 +45,26 @@ describe TaxHelper, type: :helper do
       expect(
         helper.display_taxes(no_tax_adjustment, display_zero: false)
       ).to be_nil
+    end
+  end
+
+  describe "#display_line_items_taxes" do
+    it "displays included tax" do
+      expect(
+        helper.display_line_items_taxes(line_item)
+      ).to eq Spree::Money.new(line_item.included_tax, currency: line_item.currency)
+    end
+
+    it "displays additional tax" do
+      expect(
+        helper.display_line_items_taxes(line_item2)
+      ).to eq Spree::Money.new(line_item2.added_tax, currency: line_item2.currency)
+    end
+
+    it "displays formatted 0.00 amount when amount is zero" do
+      expect(
+        helper.display_line_items_taxes(line_item3)
+      ).to eq Spree::Money.new(0.00,)
     end
   end
 

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -212,13 +212,6 @@ describe '
           expect(page).to have_content "(1g)" # display as
         end
 
-        it "displays GST for enterprise fees" do
-          pending "ii) for legend see picture on PR #9495"
-          # enterprise fee of $20.00
-          expect(page).to have_content "Whole order - #{enterprise_fee.name} fee by coordinator " \
-                                       "#{user1.enterprises.first.name} 1 $20.00 (included) $120.00"
-        end
-
         it "displays the taxes correctly" do
           # header
           expect(page).to have_content "Item Qty GST Price"
@@ -358,13 +351,6 @@ describe '
           expect(page).to have_content Spree::Product.second.name.to_s
           expect(page).to have_content "(1g)" # display as
           expect(page).to have_content "3 $300.09 $1,500.45"
-        end
-
-        it "displays GST for enterprise fees" do
-          pending "v) for legend see picture on PR #9495"
-          # enterprise fee of $24.00
-          expect(page).to have_content "Whole order - #{enterprise_fee.name} fee by coordinator " \
-                                       "#{user1.enterprises.first.name} 1 $20.00 $120.00"
         end
 
         it "displays the taxes correctly" do

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -205,11 +205,8 @@ describe '
           convert_pdf_to_page
         end
 
-        it "displays $0.0 when a line item has no tax" do
-          pending "i) for legend see picture on PR #9495"
-          # first line item, no tax
-          expect(page).to have_content "#{Spree::Product.first.name} 1 $0.0 $12.54"
-          expect(page).to have_content "(1g)" # display as
+        it "displays $0.00 when a line item has no tax" do
+          expect(page).to have_content "#{Spree::Product.first.name} (1g) 1 $0.00 $12.54"
         end
 
         it "displays the taxes correctly" do
@@ -338,16 +335,10 @@ describe '
           convert_pdf_to_page
         end
         it "displays $0.0 when a line item has no tax" do
-          pending "iii) for legend see picture on PR #9495"
-          # first line item, no tax - display $0.0
-          expect(page).to have_content Spree::Product.first.name.to_s
-          expect(page).to have_content "(1g)" # display as
-          expect(page).to have_content "1 $0.0 $12.54"
+          expect(page).to have_content "#{Spree::Product.first.name} (1g) 1 $0.00 $12.54"
         end
 
         it "displays the added tax on the GST colum" do
-          pending "closing #7983, iv) for legend see picture on PR #9495"
-          # second line item, added tax of $300.09
           expect(page).to have_content Spree::Product.second.name.to_s
           expect(page).to have_content "(1g)" # display as
           expect(page).to have_content "3 $300.09 $1,500.45"

--- a/spec/views/spree/admin/orders/invoice.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/invoice.html.haml_spec.rb
@@ -22,6 +22,7 @@ describe "spree/admin/orders/invoice.html.haml" do
   before do
     assign(:order, order)
     allow(view).to receive_messages checkout_adjustments_for: [],
+                                    display_line_items_taxes: '',
                                     display_checkout_tax_total: '10',
                                     display_checkout_total_less_tax: '8',
                                     outstanding_balance_label: 'Outstanding Balance'


### PR DESCRIPTION
#### What? Why?

- Closes #7983

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

1. Fix the pending tests on `spec/system/admin/invoice_print_spec.rb`
2. Display added taxes 
3. Show 0.00$ when there is no taxes or tax amount = 0

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

My focus was on line item taxes on Order printing as PDF when
1. added taxes are in use
2. included taxes are in use
3. no taxes

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
