### PR TITLE
Sets no-sandbox option, for CI env.; increases timeout values

### DIFF
--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -4,14 +4,17 @@ require "capybara/cuprite"
 
 headless = ActiveModel::Type::Boolean.new.cast(ENV.fetch("HEADLESS", true))
 
+browser_options = {}
+browser_options["no-sandbox"] = nil if ENV['CI']
+
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,
     **{
       window_size: [1200, 800],
-      browser_options: {},
-      process_timeout: 20,
-      timeout: 20,
+      browser_options: browser_options,
+      process_timeout: 60,
+      timeout: 60,
       # Don't load scripts from external sources, like google maps or stripe
       url_whitelist: ["http://localhost", "http://0.0.0.0", "http://127.0.0.1"],
       inspector: true,


### PR DESCRIPTION
#### What? Why?

- Relates to #10018 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This PR makes two changes to `cuprite_setup.rb`:

- it passes the `no-sandbox` option if using docker, as mentioned [in the Cuprite documentation](https://github.com/rubycdp/cuprite#install). In our case, we use it while running our CI so this PR adds this option to reflect that. 

(However, we sometime use Docker in development environment, so maybe we'll need to consider as well.)

- it increases `process_timeout` and `timeout`. These can perhaps decrease the occurrence of #10018 and related errors when running the build.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build - no browser timeouts.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
