### PR TITLE
Add required webpack package

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -24,6 +24,14 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
       - name: prettier
         uses: EPMatt/reviewdog-action-prettier@v1
         with:

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "webpack-cli": "~3"
   },
   "devDependencies": {
+    "@webpack-cli/serve": "*",
     "husky": "^8.0.0",
     "jasmine-core": "~2.4.1",
     "jest": "^27.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,6 +2027,11 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@webpack-cli/serve@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.1.tgz#34bdc31727a1889198855913db2f270ace6d7bf8"
+  integrity sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
#### What? Why?
We use webpack with our script `bin/webpack-dev-server` when running `foreman start`

But today it refused to run and tells me I need to install the new package:

> The command moved into a separate package: @webpack-cli/serve
> Would you like to install serve? (That will run yarn add -D @webpack-cli/serve) (yes/NO)

So I did :D


#### What should we test? DEV
A dev can verify that the dev server works:

- `foreman start`
- Browse the page and confirm JS loads correctly 


#### Release notes

Changelog Category: Technical changes > Dev dependency
