### PR TITLE
Ignore vi .swp files when webpack dev reloads page

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -79,7 +79,9 @@ development:
     headers:
       'Access-Control-Allow-Origin': '*'
     watch_options:
-      ignored: '**/node_modules/**'
+      ignored:
+        - '**/node_modules/**'
+        - '**/*.swp'
 
 production: &production
   <<: *default


### PR DESCRIPTION
#### What? Why?

The webpack dev server watches assets and reloads the page when files change on disk. While using vim I noticed that every save would trigger two reloads in my browser. So I'm adding vi's temporary files to the ignore list to get only one reload.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

**Dev Test**

- Start server with `foreman start`.
- Open the home page.
- Change a JS file in `app/webpacker`.
- The page in your browser should reload.
- If it reloads once, we are good and I didn't break anything.
- If it reloads twice then your editor may need ignoring, too.
- If it reloads twice and you are using vi then I failed to resolve the problem.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
