### PR TITLE
SplitCheckout: On step3, do not display payment method description if not present

### DIFF
--- a/app/views/split_checkout/_summary.html.haml
+++ b/app/views/split_checkout/_summary.html.haml
@@ -53,11 +53,12 @@
         - payment_method = last_payment_method(@order)
         = payment_method&.name
         %em.fees=payment_or_shipping_price(payment_method, @order)
-      %div
-        .summary-subtitle
-          = t("split_checkout.step3.payment_method.instructions")
+      - if payment_method&.description.present? 
         %div
-          = last_payment_method(@order)&.description
+          .summary-subtitle
+            = t("split_checkout.step3.payment_method.instructions")
+          %div
+            = last_payment_method(@order)&.description
 
 
   %div.checkout-substep


### PR DESCRIPTION


#### What? Why?

This avoid an empty section with `Instructions` title


###### Before
<img width="770" alt="Capture d’écran 2023-01-24 à 15 05 05" src="https://user-images.githubusercontent.com/296452/214315956-b2ec0e17-2c3f-4f99-8fc9-06d32d7c1ec5.png">

###### After
<img width="775" alt="Capture d’écran 2023-01-24 à 15 05 15" src="https://user-images.githubusercontent.com/296452/214315971-c25b68d9-c979-491e-9d65-db1585787150.png">


#### What should we test?


- As a hub manager, create a payment method with a description, and another one with no description
- As a customer, on step 3 check that selecting a payment method:
   -  _with_ a description display the description under the Instructions section
   -  _without_ a description do not display the Instruction section

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
