### PR TITLE
Upgrade brakeman to its latest version

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Setup Brakeman
       env:
-        BRAKEMAN_VERSION: '4.10' # SARIF support is provided in Brakeman version 4.10+
+        BRAKEMAN_VERSION: '5.4.0'
       run: |
         gem install brakeman --version $BRAKEMAN_VERSION
 


### PR DESCRIPTION
#### What? Why?

Should close issue that we sometimes have around version of loofah :

> loofah gem 2.19.1 is vulnerable (CVE-2018-8048). Upgrade to 2.2.1.

Fixed via https://github.com/presidentbeef/brakeman/releases/tag/v5.0.2


_Context by @sigmundpetersen in https://github.com/openfoodfoundation/openfoodnetwork/issues/10312#issuecomment-1402106210_
            


#### What should we test?
I guess green build is enough

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
