### PR TITLE
Display checkout error messages to user for convencience

### DIFF
--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -36,14 +36,7 @@ class SplitCheckoutController < ::BaseController
       advance_order_state
       redirect_to_step
     else
-      flash.now[:error] ||= I18n.t(
-        'split_checkout.errors.saving_failed',
-        messages: @order.errors.full_messages.to_sentence
-      )
-
-      render status: :unprocessable_entity, operations: cable_car.
-        replace("#checkout", partial("split_checkout/checkout")).
-        replace("#flashes", partial("shared/flashes", locals: { flashes: flash }))
+      render_error
     end
   rescue Spree::Core::GatewayError => e
     flash[:error] = I18n.t(:spree_gateway_error_flash_for_checkout, error: e.message)
@@ -52,6 +45,17 @@ class SplitCheckoutController < ::BaseController
   end
 
   private
+
+  def render_error
+    flash.now[:error] ||= I18n.t(
+      'split_checkout.errors.saving_failed',
+      messages: @order.errors.full_messages.to_sentence
+    )
+
+    render status: :unprocessable_entity, operations: cable_car.
+      replace("#checkout", partial("split_checkout/checkout")).
+      replace("#flashes", partial("shared/flashes", locals: { flashes: flash }))
+  end
 
   def flash_error_when_no_shipping_method_available
     flash[:error] = I18n.t('split_checkout.errors.no_shipping_methods_available')

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -36,7 +36,10 @@ class SplitCheckoutController < ::BaseController
       advance_order_state
       redirect_to_step
     else
-      flash.now[:error] ||= I18n.t('split_checkout.errors.global')
+      flash.now[:error] ||= I18n.t(
+        'split_checkout.errors.saving_failed',
+        messages: @order.errors.full_messages.to_sentence
+      )
 
       render status: :unprocessable_entity, operations: cable_car.
         replace("#checkout", partial("split_checkout/checkout")).

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,15 @@ en:
       spree/product: Product
       spree/shipping_method: Shipping Method
     attributes:
+      spree/order/ship_address:
+        address1: "Shipping address line 1"
+        address2: "Shipping address line 2"
+        city: "Shipping address suburb 1"
+        country: "Shipping address country"
+        phone: "Phone number"
+        firstname: "First name"
+        lastname: "Last name"
+        zipcode: "Shipping address postcode"
       spree/user:
         password: "Password"
         password_confirmation: "Password confirmation"
@@ -1996,7 +2005,6 @@ en:
       submit: Complete order
       cancel: Back to Payment method
     errors:
-      global: "Saving failed, please update the highlighted fields."
       saving_failed: "Saving failed, please update the highlighted fields. %{messages}"
       terms_not_accepted: Please accept Terms and Conditions
       required: Field cannot be blank

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1997,6 +1997,7 @@ en:
       cancel: Back to Payment method
     errors:
       global: "Saving failed, please update the highlighted fields."
+      saving_failed: "Saving failed, please update the highlighted fields. %{messages}"
       terms_not_accepted: Please accept Terms and Conditions
       required: Field cannot be blank
       invalid_number: "Please enter a valid phone number"

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -86,7 +86,7 @@ describe SplitCheckoutController, type: :controller do
           put :update, params: params
 
           expect(response.status).to eq 422
-          expect(flash[:error]).to eq "Saving failed, please update the highlighted fields."
+          expect(flash[:error]).to match "Saving failed, please update the highlighted fields."
           expect(order.reload.state).to eq "cart"
         end
       end
@@ -161,7 +161,7 @@ describe SplitCheckoutController, type: :controller do
           put :update, params: params
 
           expect(response.status).to eq 422
-          expect(flash[:error]).to eq "Saving failed, please update the highlighted fields."
+          expect(flash[:error]).to match "Saving failed, please update the highlighted fields."
           expect(order.reload.state).to eq "payment"
         end
       end
@@ -271,7 +271,7 @@ describe SplitCheckoutController, type: :controller do
             put :update, params: params
 
             expect(response.status).to eq 422
-            expect(flash[:error]).to eq "Saving failed, please update the highlighted fields."
+            expect(flash[:error]).to match "Saving failed, please update the highlighted fields."
             expect(order.reload.state).to eq "confirmation"
           end
         end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -8,6 +8,14 @@ describe Spree::Order do
   let(:user) { build(:user, email: "spree@example.com") }
   let(:order) { build(:order, user: user) }
 
+  describe "#errors" do
+    it "provides friendly error messages" do
+      order.ship_address = Spree::Address.new
+      order.save
+      expect(order.errors.full_messages).to include "Shipping address line 1 can't be blank"
+    end
+  end
+
   context "#products" do
     let(:order) { create(:order_with_line_items) }
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -294,6 +294,7 @@ describe "As a consumer, I want to checkout my order" do
           click_button "Next - Payment method"
 
           expect(page).to have_content "Saving failed, please update the highlighted fields."
+          expect(page).to have_content "Ship address address1 can't be blank"
           expect(page).to have_content "Shipping address same as billing address?"
           expect(page).to have_content "Save as default shipping address"
           expect(page).to have_checked_field "Shipping address same as billing address?"

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -294,7 +294,7 @@ describe "As a consumer, I want to checkout my order" do
           click_button "Next - Payment method"
 
           expect(page).to have_content "Saving failed, please update the highlighted fields."
-          expect(page).to have_content "Ship address address1 can't be blank"
+          expect(page).to have_content "Shipping address line 1 can't be blank"
           expect(page).to have_content "Shipping address same as billing address?"
           expect(page).to have_content "Save as default shipping address"
           expect(page).to have_checked_field "Shipping address same as billing address?"

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -2,7 +2,7 @@
 
 require "system_helper"
 
-describe "As a consumer, I want to checkout my order", js: true do
+describe "As a consumer, I want to checkout my order" do
   include ShopWorkflow
   include SplitCheckoutHelper
   include FileHelper


### PR DESCRIPTION
#### What? Why?

- Helps finding cause for: #9056 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I wasn't able to reproduce the above issue. But I added more information to the error message which could help us if it happens again.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit split checkout page.
- Don't fill in all shipping address fields.
- Submit the form and observe the red error message at the top.
- It should tell you where to look for missing input.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
