### PR TITLE
Remove unused currency from calculators

### DIFF
--- a/app/models/calculator/flat_rate.rb
+++ b/app/models/calculator/flat_rate.rb
@@ -7,7 +7,6 @@ module Calculator
     extend Spree::LocalizedNumber
 
     preference :amount, :decimal, default: 0
-    preference :currency, :string, default: Spree::Config[:currency]
 
     localize_number :preferred_amount
 

--- a/app/models/calculator/flexi_rate.rb
+++ b/app/models/calculator/flexi_rate.rb
@@ -9,7 +9,6 @@ module Calculator
     preference :first_item,      :decimal, default: 0.0
     preference :additional_item, :decimal, default: 0.0
     preference :max_items,       :integer, default: 0
-    preference :currency,        :string,  default: Spree::Config[:currency]
 
     localize_number :preferred_first_item,
                     :preferred_additional_item

--- a/app/models/calculator/per_item.rb
+++ b/app/models/calculator/per_item.rb
@@ -7,7 +7,6 @@ module Calculator
     extend Spree::LocalizedNumber
 
     preference :amount, :decimal, default: 0
-    preference :currency, :string, default: Spree::Config[:currency]
 
     localize_number :preferred_amount
 

--- a/app/models/calculator/price_sack.rb
+++ b/app/models/calculator/price_sack.rb
@@ -9,7 +9,6 @@ module Calculator
     preference :minimal_amount, :decimal, default: 0
     preference :normal_amount, :decimal, default: 0
     preference :discount_amount, :decimal, default: 0
-    preference :currency, :string, default: Spree::Config[:currency]
 
     localize_number :preferred_minimal_amount,
                     :preferred_normal_amount,

--- a/app/services/permitted_attributes/calculator.rb
+++ b/app/services/permitted_attributes/calculator.rb
@@ -4,7 +4,7 @@ module PermittedAttributes
   class Calculator
     def self.attributes
       [
-        :id, :preferred_currency, :preferred_amount, :preferred_flat_percent,
+        :id, :preferred_amount, :preferred_flat_percent,
         :preferred_minimal_amount, :preferred_normal_amount, :preferred_discount_amount,
         :preferred_unit_from_list, :preferred_per_unit, :preferred_first_item,
         :preferred_additional_item, :preferred_max_items

--- a/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -123,7 +123,6 @@ module Spree
               calculator_attributes: {
                 id: payment_method.calculator.id,
                 preferred_amount: 456,
-                preferred_currency: "GBP"
               }
             }
           }
@@ -138,7 +137,6 @@ module Spree
           expect(payment_method.name).to eq "Updated"
           expect(payment_method.description).to eq "Updated"
           expect(payment_method.calculator.preferred_amount).to eq 456
-          expect(payment_method.calculator.preferred_currency).to eq "GBP"
         end
 
         context "when the given payment method type does not match" do

--- a/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
@@ -20,15 +20,13 @@ describe Spree::Admin::ShippingMethodsController, type: :controller do
 
     before { controller_login_as_admin }
 
-    it "updates preferred_amount and preferred_currency of a FlatRate calculator" do
+    it "updates preferred_amount of a FlatRate calculator" do
       shipping_method.calculator = create(:calculator_flat_rate, calculable: shipping_method)
       params[:shipping_method][:calculator_attributes][:preferred_amount] = 123
-      params[:shipping_method][:calculator_attributes][:preferred_currency] = "EUR"
 
       spree_post :update, params
 
       expect(shipping_method.reload.calculator.preferred_amount).to eq 123
-      expect(shipping_method.reload.calculator.preferred_currency).to eq "EUR"
     end
 
     %i[


### PR DESCRIPTION
#### What? Why?

- Partially completes #10272
- This is an alternative solution and closes https://github.com/openfoodfoundation/openfoodnetwork/pull/10279

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
<img width="1030" alt="Capture d’écran 2023-01-18 à 16 43 22" src="https://user-images.githubusercontent.com/296452/213217594-2f8ead43-685d-49cc-bbd1-e00b8e7975dc.png">
<img width="760" alt="Capture d’écran 2023-01-18 à 16 43 57" src="https://user-images.githubusercontent.com/296452/213217749-4fbbd6d9-18bf-49d2-a6ac-042aa9738091.png">


#### What should we test?
As in https://github.com/openfoodfoundation/openfoodnetwork/issues/10272#issue-1532566910 . For example:
- As an admin, when editing fees that include method, or fees that include calculator is `Amount` (flatrate, ...) you should not see `Currency` input and therefore you should be able to edit it. 


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing change


#### Documentation updates
The user guide already doesn't mention this field (eg https://guide.openfoodnetwork.org/basic-features/shopfront/shipping-methods#fee-calculators )

However it's already a bit confusing that you have to save/update before you can access the calculator values, so I've submitted a PR to update the user guide: https://github.com/openfoodfoundation/ofn-UserGuide/pull/39
