### PR TITLE
Show new flash messages until discarded by user

### DIFF
--- a/app/webpacker/controllers/flash_controller.js
+++ b/app/webpacker/controllers/flash_controller.js
@@ -5,15 +5,6 @@ document.addEventListener("turbolinks:before-cache", () =>
 );
 
 export default class extends Controller {
-  connect() {
-    setTimeout(this.fadeout.bind(this), 3000);
-  }
-
-  fadeout() {
-    this.element.classList.add("animate-hide-500");
-    setTimeout(this.close.bind(this), 500);
-  }
-
   close() {
     this.element.remove();
   }

--- a/app/webpacker/css/darkswarm/animations.scss
+++ b/app/webpacker/css/darkswarm/animations.scss
@@ -4,17 +4,6 @@
 
 // ANIMATION FUNCTIONS
 
-@keyframes fade-out-hide {
-  0%   {opacity: 1; visibility: visible;}
-  99%  {opacity: 0; visibility: visible;}
-  100% {opacity: 0; visibility: hidden;}
-}
-
-.animate-hide-500 {
-  animation: fade-out-hide 0.5s;
-}
-
-//
 @-webkit-keyframes slideInDown {
   0% {
     opacity: 0;


### PR DESCRIPTION
#### What? Why?
We currently have two mechanisms to display flash messages. The old one through AngularJS and the new one with StimulusReflex.

The AngularJS directive showed flashes for 10 seconds. The StimulusReflex controller showed them only for 3 seconds. But any time based disappearance of error messages is problematic. There's important information in there and some error messages can be long. It's also possible that a request takes a while, the user leaves the computer and comes back later. If we hide the flash automatically then the user may have no idea what went wrong. They may even think that everything is fine and their order went through.

I removed the time-based removal of flash messages from the new StimulusReflex controller to address this problem. But I didn't touch the AngularJS directive because it will be removed anyway. There may also be many more messages that could be annoying if they didn't disappear, for example a simple "login successful".

I personally think that flash messages that are not important to keep, don't need to be shown in the first place. The best UX makes the success obvious on the page. And success should be assumed.

Relates to:

- #9056
- #10317

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit split checkout page.
- Don't fill in all shipping address fields.
- Submit the form and observe the red error message at the top.
- It should only disappear when you click the x button to close it.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
