### PR TITLE
For super admin, add pagination on `/admin/enterprises`

### DIFF
--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -14,7 +14,6 @@ module Admin
     prepend_before_action :override_owner, only: :create
     prepend_before_action :override_sells, only: :create
 
-    before_action :load_enterprise_set_on_index, only: :index
     before_action :load_countries, except: [:index, :register, :check_permalink]
     before_action :load_methods_and_fees, only: [:edit, :update]
     before_action :load_groups, only: [:new, :edit, :update, :create]
@@ -34,6 +33,8 @@ module Admin
     include OrderCyclesHelper
 
     def index
+      load_enterprise_set_on_index
+
       respond_to do |format|
         format.html
         format.json {

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -38,3 +38,5 @@
         %tr
           %td{colspan: "4"}= t(:none)
   = f.submit t(:update)
+
+  = render partial: 'admin/shared/pagy_links', locals: { pagy: @pagy }


### PR DESCRIPTION

#### What? Why?

Introducing pagination thanks to `pagy` for super admin on this page.

Also, previously, we used to use `@enterprise_set = Sets::EnterpriseSet.new(collection)` instead of creating set based on `@collection`: this leads to call the `collection` method twice, which was probably very time consuming. This commit fix also that.


- Closes #8027

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a super admin, we should this a faster page and paginated on `/admin/enterprises`. In term of performance, actually, I don't know if this could be mesurable in staging. Maybe we could compare the request time of `/admin/enterprises` URL via chrome|firefox inspector. 
- As a hub manager, nothing should change.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

