### PR TITLE
SplitCheckout, Specs: fix errors count when submitting form with errors

### DIFF
--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -489,7 +489,12 @@ describe "As a consumer, I want to checkout my order" do
               expect(page).to have_field("Address", with: "")
               expect(page).to have_field("City", with: "")
               expect(page).to have_field("Postcode", with: "")
-              expect(page).to have_content("can't be blank", count: 3)
+              within "checkout" do
+                expect(page).to have_content("can't be blank", count: 3)
+              end
+              within ".flash[type='error']" do
+                expect(page).to have_content("can't be blank", count: 3)
+              end
             end
 
             it "fills in shipping details and redirects the user to the Payment Method step,
@@ -541,7 +546,13 @@ describe "As a consumer, I want to checkout my order" do
           expect(page).to have_field("Address", with: "")
           expect(page).to have_field("City", with: "")
           expect(page).to have_field("Postcode", with: "")
-          expect(page).to have_content("can't be blank", count: 7)
+          within "checkout" do
+            expect(page).to have_content("can't be blank", count: 7)
+          end
+          within ".flash[type='error']" do
+            expect(page).to have_content("can't be blank", count: 13)
+            expect(page).to have_content("is invalid", count: 1)
+          end
           expect(page).to have_content("Select a shipping method")
         end
       end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -485,14 +485,14 @@ describe "As a consumer, I want to checkout my order" do
 
             it "displays error messages when submitting incomplete billing address" do
               click_button "Next - Payment method"
-              expect(page).to have_content "Saving failed, please update the highlighted fields."
-              expect(page).to have_field("Address", with: "")
-              expect(page).to have_field("City", with: "")
-              expect(page).to have_field("Postcode", with: "")
               within "checkout" do
+                expect(page).to have_field("Address", with: "")
+                expect(page).to have_field("City", with: "")
+                expect(page).to have_field("Postcode", with: "")
                 expect(page).to have_content("can't be blank", count: 3)
               end
               within ".flash[type='error']" do
+                expect(page).to have_content "Saving failed, please update the highlighted fields."
                 expect(page).to have_content("can't be blank", count: 3)
               end
             end
@@ -537,23 +537,23 @@ describe "As a consumer, I want to checkout my order" do
         end
         it "should display error when fields are empty" do
           click_button "Next - Payment method"
-          expect(page).to have_content("Saving failed, please update the highlighted fields")
-          expect(page).to have_field("First Name", with: "")
-          expect(page).to have_field("Last Name", with: "")
-          expect(page).to have_field("Email", with: "")
-          expect(page).to have_content("is invalid")
-          expect(page).to have_field("Phone number", with: "")
-          expect(page).to have_field("Address", with: "")
-          expect(page).to have_field("City", with: "")
-          expect(page).to have_field("Postcode", with: "")
           within "checkout" do
+            expect(page).to have_field("First Name", with: "")
+            expect(page).to have_field("Last Name", with: "")
+            expect(page).to have_field("Email", with: "")
+            expect(page).to have_content("is invalid")
+            expect(page).to have_field("Phone number", with: "")
+            expect(page).to have_field("Address", with: "")
+            expect(page).to have_field("City", with: "")
+            expect(page).to have_field("Postcode", with: "")
             expect(page).to have_content("can't be blank", count: 7)
+            expect(page).to have_content("Select a shipping method")
           end
           within ".flash[type='error']" do
+            expect(page).to have_content("Saving failed, please update the highlighted fields")
             expect(page).to have_content("can't be blank", count: 13)
             expect(page).to have_content("is invalid", count: 1)
           end
-          expect(page).to have_content("Select a shipping method")
         end
       end
 


### PR DESCRIPTION


#### What? Why?

Since https://github.com/openfoodfoundation/openfoodnetwork/pull/10317 we are displaying the error message also in the flash message. For unknown reason, build didn't fail for that PR, but, as the PR adds some error message, we need to change the spec to reflect that change.

This PR separates error in checkout page itself, and errors in flash message banner.

- Closes #10327 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
🟢 Green build. 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
![failures_r_spec_example_groups_as_a_consumer_i_want_to_checkout_my_order_as_a_logged_in_user_details_step_not_filling_out_delivery_details_should_display_error_when_fields_are_empty_561](https://user-images.githubusercontent.com/296452/214809429-4c1a3409-62c2-4707-904d-b2f664d3860f.png)
