### PR TITLE
Standardize api v1 query param handeling

### DIFF
--- a/app/models/api/v1/query_param.rb
+++ b/app/models/api/v1/query_param.rb
@@ -1,0 +1,101 @@
+# A class to standardize controller query param handeling for the api
+#
+#
+# Example:
+#
+# # Given incoming request controller params:
+#
+# params = {
+#   some_boolean: "true",
+#   some_datetime_arr, "2023-01-02T00:00:00,2023-01-02T00:00:00",
+#   ...
+# }
+#
+# # We could declare:
+#
+# query_params = Api::V1::QueryParam.new(params, {
+#   some_boolean: :boolean,  # shorthand when using default opts
+#   "some_datetime_arr[]": { type: :array, items: { type: datetime } }
+# })
+#
+# # If params invalid: render #json_response with correct message and status code
+# query_params.valid? || render query_params.json_response
+#
+# # #get returns params parsed to appropriate rails data type
+# parsed_params = query_params.get  # get all
+# some_boolean = query_params.get(:some_boolean)  # get single
+# ------------------------------------
+#
+# QueryParam type classes
+#
+# Only available type classes should be defined inside the query_params/types directory. Eg:
+# Api::V1::QueryParam::Types::DateTime < Api::V1::QueryParam::Type
+# They are then automatically made available through their location and namespace.
+#
+class Api::V1::QueryParam
+  def initialize(params, declaration)
+    @params = params
+    @declaration = declaration
+    @types = get_types
+    @opts = get_opts
+    @type_objs = get_type_objs
+    @parsed_params = {}
+    @errors = []
+    @status = :ok
+
+    combine_data
+  end
+
+  def json_response
+    { json: { errors: @errors }, status: @status }
+  end
+
+  def valid?
+    @errors.any?
+  end
+
+  def get(param = nil)
+    param ? @parsed_params[param] : @parsed_params
+  end
+
+
+  private
+
+  def get_types
+    @declaration.map do |param_name, opts|
+      type = opts.is_a?(Hash) ? opts[:type] : opts
+      raise_error(ArgumentError, "#{param_name}: type missing") if type.blank?
+
+      {"#{param_name}": type}
+    end
+  end
+
+  def get_opts
+    @declaration.map do |param_name, opts| 
+      { "#{param_name}": opts.is_a?(Hash) ? opts.except(:type) : {} }
+    end
+  end
+
+  def get_type_objs
+    @types.map do |param_name, type|
+      Api::V1::QueryParam::Type.get_object(type, @params, param_name, @opts)
+    end
+  end
+
+  def combine_data
+    combine_errors
+    combine_status
+  end
+
+  def combine_errors
+    @errors = @type_objs.map{|o| o.error}.compact
+  end
+
+  def combine_statuses
+    error_statuses = @type_objs.map{|o| o.status}.except{|s| s == :ok}
+
+    if error_statuses.any?
+      @status = Api::V1::QueryParam::Error.get_top_status(error_statuses)
+    end
+  end
+end

--- a/app/models/api/v1/query_param/error.rb
+++ b/app/models/api/v1/query_param/error.rb
@@ -1,0 +1,45 @@
+class Api::V1::QueryParam::Error
+  # When multiple errors are encountered, we chose the most generic
+  # https://jsonapi.org/format/#errors-processing
+  # List of available rails errors
+  # https://gist.github.com/mlanett/a31c340b132ddefa9cca
+  AVAILABLE_STATUSES_IN_ORDER_OF_PRIORITY = [
+    :bad_request,           # when param cannot be parsed
+    :unprocessable_entity,  # when param can be parsed but value invalid
+  ]
+  
+  def self.get_top_status(statuses)
+    statuses.sort_by(&AVAILABLE_STATUSES_IN_ORDER_OF_PRIORITY.method(:index))
+  end
+
+  attr_reader :status, :error
+
+  def initialize(param_name, status, detail)
+    @param_name=param_name
+    @status = status
+    @detail = @detail
+
+    validate_status    
+  end
+
+  # Error formatting from this standard
+  # https://jsonapi.org/format/#error-objects
+  def get
+    {
+      status: @status,
+      code: Rack::Utils::SYMBOL_TO_STATUS_CODE[@status],
+      title: "Invalid query parameter",
+      detail: @detail,
+      source: {
+        parameter: @param_name,
+      },
+    }
+  end
+
+
+  private
+
+  def validate_status
+    @status.in?(AVAILABLE_STATUSES_IN_ORDER_OF_PRIORITY)
+  end
+end

--- a/app/models/api/v1/query_param/option.rb
+++ b/app/models/api/v1/query_param/option.rb
@@ -1,0 +1,73 @@
+# Query param type options handler
+# See: Api::V1::QueryParam::Type for more info
+#
+class Api::V1::QueryParam::Option
+  SUPPORTED_OPT_PROPS = [
+    :type,     # opt type, class_name.underscore.to_sym, 
+               # :boolean also accepted although not a real ruby class
+    :default,  # opt default value
+    :required, # ensure present
+    :in,       # ensure opt value in array
+  ]
+
+
+
+  def initialize(params, param_name, type, opts, supported_options)
+    @params = params
+    @param_name = param_name
+    @type = type
+    @opts = opts
+    @supported_options = supported_options
+
+    parse
+  end
+
+  def get
+    
+  end
+
+
+  private
+
+  def parse
+    validate
+    @opts = defaults.merge(@opts)
+    convert_values
+  end
+  
+  def validate
+    @opts.each do |opt_key, opt_val|
+      validate_opt_supported(opt_key)
+      validate_opt_value_type(opt_key, opt_val)
+    end
+  end
+
+  def validate_opt_supported(opt_key)
+    unless @supported_options&.key?(opt_key)
+      raise_opt_error(opt_key, "not supported" )
+    end
+  end
+
+  def validate_opt_value_type(opt_key, opt_val)
+    return unless type = @supported_options.dig(opt_key, :type)
+    
+    if type == :boolean
+      opt_val.in?([true, false])
+    end
+    unless type.in?(TYPE_CHECKS.keys)
+      raise_opt_error(opt_key, "invalid type specified: #{type}")
+    end
+    
+    unless TYPE_CHECKS[type](opt_val)
+      raise_opt_error(opt_key, "value not of type: #{type}")
+    end
+  end
+
+  def defaults
+    @supported_options.map{|opt_key, opt_val| {"#{opt_key}": opt_val[:default]}.compact}
+  end
+ 
+  def raise_opt_error(opt_key, msg)
+    raise_error(ArgumentError, "#{@param_name}: #{@type}: #{opt_key}: #{msg}")
+  end
+end

--- a/app/models/api/v1/query_param/type.rb
+++ b/app/models/api/v1/query_param/type.rb
@@ -1,0 +1,114 @@
+# Info for QueryParam::Type classes inheriting from this Base:
+#
+# See Api::V1::QueryParam::Types::DateTime for examples
+#
+# - #parse: is your main function to derive @parsed_param given incoming @param and @opts
+# - @param: query param value
+# - @parsed_param: variable where to store the result after parsing param to rails friendly format
+# - @opts: incoming options hash.
+#
+# - TYPE_SPECIFIC_OPTIONS: Use this constant to define supported options for your type. 
+#   see Api::V1::QueryParam::Option
+#
+# - #set_error(status, msg): Set your error status and message if @param invalid 
+#   see Api::V1::QueryParam::Error
+#
+class Api::V1::QueryParam::Type
+  TYPES_PARENT_MODULE = Api::V1::QueryParam::Types.freeze
+
+  class << self
+    def get_object(type, params, param_name, opts)
+      "#{TYPES_PARENT_MODULE.to_s}::#{type.classify}".constantize.new(params, param_name, opts)
+    end
+  end
+  
+  attr_reader :error, :status
+
+  def initialize(
+    params,
+    param_name, 
+    opts,
+    param_value = nil,
+  )
+    @params = params
+    @param_name = param_name
+    @param = param_value || param_value(param_name)
+    @type = self.class.param_name.underscore.to_sym
+    @error = {}
+    @status = :ok
+    @parsed_param = nil
+    @opts = Api::V1::QueryParam::Option.new(@params, @param_name, @type, @opts, SUPPORTED_OPTS).get
+    
+    preprocess
+    valid? && parse
+  end
+
+  def valid?
+    @errors.none?
+  end
+
+  def get
+    @parsed_param
+  end
+
+
+  private
+
+  def set_error(status, detail)
+    @status = status
+    @error = Api::V1::QueryParam::Error.new(@param_name, status, title).get
+  end
+
+  def preprocess
+    if @param.blank?
+      preprocess_blank
+    elsif @param.is_a?(Hash)
+      preprocess_hash
+    end
+  end
+
+  def preprocess_blank
+    # This might be a bit strict but imagine it could help debugging and prevent unexpected responses
+    set_error(:bad_request, "Blank value received") if param_received?
+  end
+
+
+
+  # Only way to get a hash is with query params as nested members under a specified param family:
+  #
+  # 1. We define a param param_name eg param[family]
+  # 2. The request sends params with deeper nesting eg:
+  #
+  #    incoming_param="param[family][family2]=value"
+  #    params = Rack::Utils.parse_nested_query(incoming_param)
+  #       # {"param"=>{"family"=>{"family2"=>"value"}}}
+  #    specified_param = params["param"]["family"]  
+  #       # { "family2": "value"}
+  #    specified_param.is_a?(Hash)
+  #       # true
+  # 
+  def preprocess_hash
+    unless @type == :hash
+      set_error(:unprocessable_entity, "Query parameter family nested deeper than specification")
+    end
+  end
+
+  # Param can be received with null value
+  def param_received?
+    obj = @params
+
+    param_keys(@param_name).each do |key|
+      obj.key?(key) && obj = obj[key] || return false
+    end
+
+    true
+  end
+
+  def param_value(param_name)
+    @params.dig(*param_keys(param_name))
+  end
+
+  def param_keys(param_name)
+    Rack::Utils.parse_nested_query(@param_name)
+  end
+end

--- a/app/models/api/v1/query_param/types/array.rb
+++ b/app/models/api/v1/query_param/types/array.rb
@@ -1,0 +1,55 @@
+# See: Api::V1::QueryParam where this class is used internally
+# See: Api::V1::QueryParam::Type for relevant variables and methods
+#
+class Api::V1::QueryParam::Types::Array < Api::V1::QueryParam::Type 
+  SUPPORTED_OPTS = {
+    items:  { type: :hash }, # options for contained items
+    # Length is only checked if value received
+    min_items: { type: :integer, default: 1 },
+    # Support max eg: 1 full year of dates. Although there isn't technically a limit to the length of query strings
+    # Modern browsers support ca 60k chars.
+    # https://stackoverflow.com/questions/812925/what-is-the-maximum-possible-length-of-a-query-string
+    # 365 datetimes "&obj[prop][sub_prop][]=2023-01-01T00:00:00" produce ca 62050 chars
+    # For larger amounts of data it might be wise to use something other than query params
+    max_items: { type: :integer, default: 365 }, 
+    unique_items: { type: :boolean, default: false },
+  }
+  
+  # set @parsed_param given incoming @param and @opts, #set_error(status, msg) if @param invalid
+  def parse
+    validate_options
+    @item_type = @opts.dig(:items, :type)
+    convert_param
+    valid? && handle_options     
+  end
+  
+  def convert_param
+    # If request contains param= instead of param[]=, we allow it as a shorthand for single item
+    @param = [@param] if @param.is_a?(String)
+    
+    unless @param.is_a?(Array)
+      if item_type.present?
+        set_error(:unprocessable_entity, "Expected array of #{item_type}")
+      else
+        set_error(:unprocessable_entity, "Expected array")
+      end
+    end
+
+    validate_length
+    convert_items
+  end
+
+  def validate_length
+    if @param.length > @opts[:max_items]
+      set_error(:unprocessable_entity, "Array max length #{@opts[:max_items]}")
+    elsif @param.length < @opts[:min_items]
+      set_error(:unprocessable_entity, "Array min length #{@opts[:min_items]}")
+    end
+  end
+
+  def convert_items
+    @param.each do |item|
+      Api::V1::QueryParam::Type.get_object(item, @params, @name, @opts)
+    end
+  end
+end

--- a/app/models/api/v1/query_param/types/boolean.rb
+++ b/app/models/api/v1/query_param/types/boolean.rb
@@ -1,0 +1,18 @@
+class Api::V1::QueryParam::Types::Boolean < Api::V1::QueryParam::Type 
+  # set @parsed_param given incoming @param and @opts, #set_error(status, msg) if @param invalid
+  def parse
+    convert_param
+  end
+
+  private
+
+  def convert_param
+    if @param == "true"
+      @parsed_param = true 
+    elsif @param == "false"
+      @parsed_param = false 
+    else
+      set_error(:bad_request, "Expected value true or false")
+    end
+  end
+end

--- a/app/models/api/v1/query_param/types/date_time.rb
+++ b/app/models/api/v1/query_param/types/date_time.rb
@@ -1,0 +1,27 @@
+class Api::V1::QueryParam::Types::DateTime < Api::V1::QueryParam::Type
+  SUPPORTED_OPTS = {
+    no_future: { type: :boolean, default: false } # If accept future datetimes
+  }
+  
+  # set @parsed_param given incoming @param and @opts, #set_error(status, msg) if @param invalid
+  def parse
+    convert_param
+    valid? && handle_options
+  end
+
+  private 
+
+  def convert_param
+    begin
+      @parsed_param = @param.to_datetime
+    rescue
+      set_error(:unprocessable_entity, "Expected datetime. Recommended format: ISO 8601")
+    end
+  end
+
+  def handle_options
+    if @opts[:no_future] && @parsed_param.future?
+      set_error(:unprocessable_entity, "Future datetime not accepted")
+    end
+  end
+end

--- a/app/models/api/v1/query_param/types/hash.rb
+++ b/app/models/api/v1/query_param/types/hash.rb
@@ -1,0 +1,15 @@
+# See: Api::V1::QueryParam where this class is used internally
+# See: Api::V1::QueryParam::Type for relevant variables and methods
+#
+class Api::V1::QueryParam::Types::Hash < Api::V1::QueryParam::Type 
+  SUPPORTED_OPTS = {
+    # size is only checked if value received
+    min_size: { type: :integer, default: 1 },
+    max_size: { type: :integer, default: 365 }, # See array for discussion on size
+  }
+  
+  # set @parsed_param given incoming @param and @opts, #set_error(status, msg) if @param invalid
+  def parse
+
+  end
+end


### PR DESCRIPTION
#### What? Why?
**Disclaimers:** This is just a draft, the code doesn't work

I felt like we could use some more standardized query param handeling `Api::V1::QueryParam`. The work quickly outgrew the scope of the issue i was working on. And I wanted to check what you think before continuing.

Please let me know if you like this idea or have other preferred ways of working.

#### Benefits: 
- Standardized validations, error handeling, and type conversion to appropriate rails format
- Get nice overview of what query_params are expected in each action.
- Reduce need of repeated testing for controller actions. Just need to check that `QueryParam.new` has been called with correct params, then rest of tests target `QueryParam` functionality.
- Bonus. rswag like syntax so we can put a similar statement in the controller action and its corresponding spec.

#### Syntax
```RUBY
class MyController
  def index
    query_params = Api::V1::QueryParam.new(params, {
      some_boolean: :boolean,  # shorthand when using default opts
      "some_datetime_arr[]": { type: :array, items: { type: datetime } }
    })
    
    # Might be able to avoid this line if response can be rendered from within QueryParam somehow...
    query_params.valid? || render query_params.json_response
    
    parsed_params = query_params.get  # get all
    some_boolean = query_params.get(:some_boolean)  # get single
  end
end
 
```

#### Structure
```
app/models/
├── api
│   └── v1
│       ├── query_param
│       │   ├── error.rb
│       │   ├── option.rb
│       │   ├── type.rb
│       │   └── types
│       │       ├── array.rb
│       │       ├── boolean.rb
│       │       ├── date_time.rb
│       │       └── hash.rb
│       └── query_param.rb
```

