### PR TITLE
Shopfront: Allow product description with formatting and `<img />`

### DIFF
--- a/app/services/content_sanitizer.rb
+++ b/app/services/content_sanitizer.rb
@@ -5,8 +5,8 @@
 class ContentSanitizer
   include ActionView::Helpers::SanitizeHelper
 
-  ALLOWED_TAGS = ["p", "b", "strong", "em", "i", "a", "u"].freeze
-  ALLOWED_ATTRIBUTES = ["href", "target"].freeze
+  ALLOWED_TAGS = ["p", "b", "strong", "em", "i", "a", "u", "img"].freeze
+  ALLOWED_ATTRIBUTES = ["href", "target", "src", "alt"].freeze
   FILTERED_CHARACTERS = {
     "&amp;amp;" => "&",
     "&amp;" => "&",

--- a/app/services/content_sanitizer.rb
+++ b/app/services/content_sanitizer.rb
@@ -5,8 +5,6 @@
 class ContentSanitizer
   include ActionView::Helpers::SanitizeHelper
 
-  ALLOWED_TAGS = ["p", "b", "strong", "em", "i", "a", "u", "img"].freeze
-  ALLOWED_ATTRIBUTES = ["href", "target", "src", "alt"].freeze
   FILTERED_CHARACTERS = {
     "&amp;amp;" => "&",
     "&amp;" => "&",
@@ -24,7 +22,7 @@ class ContentSanitizer
   def sanitize_content(content)
     return unless content.present?
 
-    content = sanitize(content.to_s, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
+    content = sanitize(content.to_s, scrubber: ContentScrubber.new)
 
     filter_characters(content)
   end

--- a/app/services/content_scrubber.rb
+++ b/app/services/content_scrubber.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ContentScrubber < Rails::Html::PermitScrubber
+  ALLOWED_TAGS = ["p", "b", "strong", "em", "i", "a", "u", "img"].freeze
+  ALLOWED_ATTRIBUTES = ["href", "target", "src", "alt"].freeze
+
+  def initialize
+    super
+    self.tags = ALLOWED_TAGS
+    self.attributes = ALLOWED_ATTRIBUTES
+  end
+
+  def skip_node?(node)
+    node.text?
+  end
+end

--- a/app/views/shop/products/_summary.html.haml
+++ b/app/views/shop/products/_summary.html.haml
@@ -9,7 +9,7 @@
     %h3
       %a{"ng-click" => "triggerProductModal()", href: 'javascript:void(0)'}
         %span{"ng-bind" => "::product.name"}
-    %p.product-description{ng: {bind: "::product.description", click: "triggerProductModal()", show: "product.description.length"}}
+    %p.product-description{ng: {"bind-html": "::product.description_html", click: "triggerProductModal()", show: "product.description_html.length"}}
     .product-producer
       = t :products_from
       %span

--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -13,7 +13,7 @@
     = f.field_container :description do
       = f.label :description, t(:description)
       %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'textangular-unsafe-sanitizer' => true, "textangular-links-target-blank" => true, 'ta-toolbar' => "[['bold','italics','underline','clear'],['insertLink']]"}
-        = sanitize(@product.description, attributes: ["href", "target"])
+        = sanitize(@product.description, attributes: ["href", "target", "src", "alt"])
       = f.error_message_on :description
 
   .right.four.columns.omega

--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -13,7 +13,7 @@
     = f.field_container :description do
       = f.label :description, t(:description)
       %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'textangular-unsafe-sanitizer' => true, "textangular-links-target-blank" => true, 'ta-toolbar' => "[['bold','italics','underline','clear'],['insertLink']]"}
-        = sanitize(@product.description, attributes: ["href", "target", "src", "alt"])
+        = sanitize(@product.description, scrubber: ContentScrubber.new)
       = f.error_message_on :description
 
   .right.four.columns.omega

--- a/spec/system/consumer/shopping/products_spec.rb
+++ b/spec/system/consumer/shopping/products_spec.rb
@@ -42,7 +42,7 @@ describe "As a consumer I want to view products", js: true do
       end
 
       it "shows HTML product description" do
-        product.description = '<p><b>Formatted</b> product description.</p> Link to an <a href="http://google.fr" target="_blank">external site</a>'
+        product.description = '<p><b>Formatted</b> product description.</p> Link to an <a href="http://google.fr" target="_blank">external site</a><img src="https://www.openfoodnetwork.org/wp-content/uploads/2019/05/logo-ofn-global-web@2x.png" alt="open food network logo" />'
         product.save!
 
         visit shop_path

--- a/spec/system/consumer/shopping/products_spec.rb
+++ b/spec/system/consumer/shopping/products_spec.rb
@@ -56,24 +56,7 @@ describe "As a consumer I want to view products", js: true do
           expect(html).to include('<p><b>Formatted</b> product description.</p> Link to an <a href="http://google.fr" target="_blank">external site</a>')
         end
 
-        # -- edit product via admin interface
-        login_as_admin_and_visit spree.edit_admin_product_path(product)
-        expect(page.find("div[id^='taTextElement']")['innerHTML']).to include('<a href="http://google.fr" target="_blank">external site</a>')
 
-        fill_in 'product_name', with: "#{product.name}_update"
-        click_button 'Update'
-
-        # -- check back consumer product view
-        visit shop_path
-        expect(page).to have_content("#{product.name}_update")
-        click_link("#{product.name}_update")
-
-        expect(page).to have_selector '.reveal-modal'
-        modal_should_be_open_for product
-
-        within(".reveal-modal") do
-          expect(html).to include('<p><b>Formatted</b> product description.</p> Link to an <a href="http://google.fr" target="_blank">external site</a>')
-        end
       end
 
       it "does not show unsecure HTML" do

--- a/spec/system/consumer/shopping/products_spec.rb
+++ b/spec/system/consumer/shopping/products_spec.rb
@@ -47,16 +47,8 @@ describe "As a consumer I want to view products", js: true do
 
         visit shop_path
         expect(page).to have_content product.name
-        click_link product.name
 
-        expect(page).to have_selector '.reveal-modal'
-        modal_should_be_open_for product
-
-        within(".reveal-modal") do
-          expect(html).to include('<p><b>Formatted</b> product description.</p> Link to an <a href="http://google.fr" target="_blank">external site</a>')
-        end
-
-
+        expect_product_description_html_to_be_displayed(product, product.description)
       end
 
       it "does not show unsecure HTML" do
@@ -65,15 +57,8 @@ describe "As a consumer I want to view products", js: true do
 
         visit shop_path
         expect(page).to have_content product.name
-        click_link product.name
 
-        expect(page).to have_selector '.reveal-modal'
-        modal_should_be_open_for product
-
-        within(".reveal-modal") do
-          expect(html).to include("<p>Safe</p>")
-          expect(html).not_to include("<script>alert('Dangerous!');</script>")
-        end
+        expect_product_description_html_to_be_displayed(product, "<p>Safe</p>", "<script>alert('Dangerous!');</script>")
       end
     end
 
@@ -117,6 +102,23 @@ describe "As a consumer I want to view products", js: true do
           expect(page).not_to have_content variant2.name.to_s
         end
       end
+    end
+  end
+
+  def expect_product_description_html_to_be_displayed(product, html, not_include = nil)
+    # check inside list of products
+    within "#product-#{product.id} .product-description" do
+      expect(html).to include(html)
+      expect(html).not_to include(not_include) if not_include
+    end
+
+    # check in product description modal
+    click_link product.name
+    expect(page).to have_selector '.reveal-modal'
+    modal_should_be_open_for product
+    within(".reveal-modal") do
+      expect(html).to include(html)
+      expect(html).not_to include(not_include) if not_include
     end
   end
 end


### PR DESCRIPTION
#### What? Why?
This one actually closes two issues, as we are now displaying formatting and images inside the modal product and in the product description itself (inside the products list)

##### In the list
<img width="916" alt="Capture d’écran 2023-01-26 à 18 14 02" src="https://user-images.githubusercontent.com/296452/214903527-5b4cb789-7901-4b7a-85d7-6751be3df219.png">

##### In the modal
<img width="940" alt="Capture d’écran 2023-01-26 à 18 14 09" src="https://user-images.githubusercontent.com/296452/214903544-403ca6d2-0539-4199-a94c-580595591ec0.png">

- Closes #8901
- Closes #10211

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, format text of a product A.
- As a consumer, check that formatting for that product A is well displayed in the list of products of that shop _and_ in the product modal

 - As an admin, import product and adds description for that product with a valid `<img />` tag with valid `src` attribute
 - As a consumer, check that you see that image in the list of products of that shop _and_ in the product modal

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
