### PR TITLE
Clean up unused calculator currency data

### DIFF
--- a/db/migrate/20230126233821_delete_calculator_currency_from_spree_preferences.rb
+++ b/db/migrate/20230126233821_delete_calculator_currency_from_spree_preferences.rb
@@ -1,0 +1,15 @@
+class DeleteCalculatorCurrencyFromSpreePreferences < ActiveRecord::Migration[6.1]
+  class SpreePreference < ActiveRecord::Base
+  end
+
+  def up
+    # Delete all currency preferences for calculators, they are no longer used.
+    rows = SpreePreference.where("key like '/calculator%/currency/%'").delete_all
+    puts "#{rows} rows deleted."
+  end
+
+  def down
+    # Sorry, the data was deleted!
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Closes #10272

This deletes currency data that was hidden in https://github.com/openfoodfoundation/openfoodnetwork/pull/10318

#### Dev test
Run the migration and query the db to check results (see below comment)

#### What should we test?
This deletes values from the database directly, filtering for "calculator" and "currency". 

Check that other preferences are still present, particularly for calculators (eg the saved enterprise fee 'amount' still shows after deployment)

#### Release notes

Changelog Category: Technical changes

#### Dependencies
- https://github.com/openfoodfoundation/openfoodnetwork/pull/10318
- https://github.com/openfoodfoundation/openfoodnetwork/pull/10510
