### PR TITLE
Wait only for report jobs within Puma workers

### DIFF
--- a/app/services/job_processor.rb
+++ b/app/services/job_processor.rb
@@ -19,8 +19,8 @@ class JobProcessor
       exit # rubocop:disable Rails/Exit
     end
 
-    # Wait for all forked child processes to exit
-    Process.waitall
+    # Wait for the forked child process to exit.
+    Process.waitpid(child)
   ensure
     # If this Puma thread is interrupted then we need to detach the child
     # process to avoid it becoming a zombie.

--- a/spec/services/job_processor_spec.rb
+++ b/spec/services/job_processor_spec.rb
@@ -33,5 +33,25 @@ describe JobProcessor do
 
       expect(job.result).to eq "hello"
     end
+
+    describe "with other unrelated children" do
+      let(:start_time) { Time.zone.now }
+      let(:end_time) { Time.zone.now }
+
+      # We made a mistake waiting for all forked processes.
+      # Now starting an unrelated process in a similar way.
+      around do |example|
+        start_time
+        other_process = fork { sleep 10 }
+        example.run
+        Process.kill("QUIT", other_process)
+      end
+
+      it "returns as soon as the job is done" do
+        JobProcessor.perform_forked(job, "hello")
+
+        expect(end_time).to be_within(10.seconds).of start_time
+      end
+    end
   end
 end


### PR DESCRIPTION
Otherwise a root Puma worker will try to wait for its other child processes as well while they live a long time.

#### What? Why?

- Closes #10338 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Activate the Background Reports feature toggle.
- Open several tabs (at least as many as workers on the server (2 on au-staging, uk-staging, 4 on fr-staging).
- Run reports in all tabs at the same time so that all workers are used.
- All reports should complete and display the result.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
