### PR TITLE
Notify bugsnag on 404 errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,6 +4,11 @@ class ErrorsController < ApplicationController
   layout "errors"
 
   def not_found
+    Bugsnag.notify("404") do |event|
+      event.severity = "info"
+
+      event.add_metadata(:request, request.env)
+    end
     render status: :not_found
   end
 


### PR DESCRIPTION
#### What? Why?

The aim of this PR is to notify bugsnag on 404 errors. Marked severity as `info`.


<img width="1315" alt="Capture d’écran 2023-01-30 à 14 22 43" src="https://user-images.githubusercontent.com/296452/215489384-b21ecd74-4a0c-41ec-afa4-42931aec4538.png">



- Closes #9538
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Generate a 404 error (with the snail) as a consumer (going on a bad URL)
- Check that errors is notified on bugsnag by checking bugsnag dashboard

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
