### PR TITLE
Enable RSpec's status file for --next-failure

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,9 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
 
+  # You can use `rspec -n` to run only failed specs.
+  config.example_status_persistence_file_path = "tmp/rspec-status.txt"
+
   # Helpers
   config.include ViewComponent::TestHelpers, type: :component
   config.include ControllerRequestsHelper, type: :controller


### PR DESCRIPTION

#### What? Why?

With this config, we can use `rspec -n` which is shorthand for:

    rspec --only-failures --fail-fast --order defined

This is much easier than running specs by line numbers.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
