### PR TITLE
Order cycle creation, fix needless warning and add warning to prevent data loss

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
@@ -35,7 +35,11 @@ angular.module('admin.orderCycles')
       OrderCycle.removeExchangeFee(exchange, index)
       $scope.order_cycle_form.$dirty = true
 
-    $scope.setPickupTimeFieldDirty = (index) ->
+    $scope.setPickupTimeFieldDirty = (index, pickup_time) ->
+      # if the pickup_time is already set we are in edit mode, so no need to set pickup_time field as dirty
+      # to show it is required (it has a red border when set to dirty)
+      return if pickup_time
+
       $timeout ->
         pickup_time_field_name = "order_cycle_outgoing_exchange_" + index + "_pickup_time"
         $scope.order_cycle_form[pickup_time_field_name].$setDirty()

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -10,7 +10,7 @@
     %td.tags.panel-toggle.text-center{ name: "tags", ng: { if: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }
       {{ exchange.tags.length }}
     %td.collection-details
-      = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'ng-init' => 'setPickupTimeFieldDirty($index)', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'required' => 'required', 'placeholder' => t('.pickup_time_placeholder'), 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator', 'maxlength' => 35
+      = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'ng-init' => 'setPickupTimeFieldDirty($index, exchange.pickup_time)', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'required' => 'required', 'placeholder' => t('.pickup_time_placeholder'), 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator', 'maxlength' => 35
       %span.icon-question-sign{'ofn-with-tip' => t('.pickup_time_tip')}
       %br/
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', 'placeholder' => t('.pickup_instructions_placeholder'), 'ng-model' => 'exchange.pickup_instructions', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'

--- a/app/views/admin/order_cycles/checkout_options.html.haml
+++ b/app/views/admin/order_cycles/checkout_options.html.haml
@@ -4,7 +4,6 @@
   = t :edit_order_cycle
 
 = form_for [main_app, :admin, @order_cycle], html: { class: "order_cycle" , data: { controller: 'unsaved-changes', action: 'unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage', 'unsaved-changes-changed': "false" } } do |f|
-
   = render 'wizard_progress'
 
   %fieldset.no-border-bottom
@@ -26,7 +25,7 @@
               %td.text-center
                 - if distributor_shipping_methods.many?
                   %label
-                    = check_box_tag nil, nil, nil, { "data-action": "change->select-all#toggleAll change->unsaved-changes#formIsChanged", "data-select-all-target": "all" }
+                    = check_box_tag nil, nil, nil, { "data-action": "change->select-all#toggleAll", "data-select-all-target": "all" }
                     = t(".select_all")
               %td
                 %em= distributor.name
@@ -37,7 +36,7 @@
                           distributor_shipping_method.id,
                           @order_cycle.distributor_shipping_methods.include?(distributor_shipping_method),
                           id: "order_cycle_selected_distributor_shipping_method_ids_#{distributor_shipping_method.id}",
-                          data: ({ "action" => "change->select-all#toggleCheckbox change->unsaved-changes#formIsChanged", "select-all-target" => "checkbox" } if distributor_shipping_method.shipping_method.frontend?)
+                          data: ({ "action" => "change->select-all#toggleCheckbox", "select-all-target" => "checkbox" } if distributor_shipping_method.shipping_method.frontend?)
                       = distributor_shipping_method.shipping_method.name
                 - distributor.shipping_methods.backend.each do |shipping_method|
                   %label.disabled
@@ -57,7 +56,7 @@
               %td.text-center
                 - if distributor_payment_methods.many?
                   %label
-                    = check_box_tag nil, nil, nil, { "data-action": "change->select-all#toggleAll change->unsaved-changes#formIsChanged", "data-select-all-target": "all" }
+                    = check_box_tag nil, nil, nil, { "data-action": "change->select-all#toggleAll", "data-select-all-target": "all" }
                     = t(".select_all")
               %td
                 %em= distributor.name
@@ -68,7 +67,7 @@
                           distributor_payment_method.id,
                           @order_cycle.distributor_payment_methods.include?(distributor_payment_method),
                           id: "order_cycle_selected_distributor_payment_method_ids_#{distributor_payment_method.id}",
-                          data: ({ "action" => "change->select-all#toggleCheckbox change->unsaved-changes#formIsChanged", "select-all-target" => "checkbox" } if distributor_payment_method.payment_method.frontend?)
+                          data: ({ "action" => "change->select-all#toggleCheckbox", "select-all-target" => "checkbox" } if distributor_payment_method.payment_method.frontend?)
                       = distributor_payment_method.payment_method.name
                 - distributor.payment_methods.inactive_or_backend.each do |payment_method|
                   %label.disabled

--- a/app/views/admin/order_cycles/checkout_options.html.haml
+++ b/app/views/admin/order_cycles/checkout_options.html.haml
@@ -3,7 +3,7 @@
 - content_for :page_title do
   = t :edit_order_cycle
 
-= form_for [main_app, :admin, @order_cycle], html: { class: "order_cycle" } do |f|
+= form_for [main_app, :admin, @order_cycle], html: { class: "order_cycle" , data: { controller: 'unsaved-changes', action: 'beforeunload@window->unsaved-changes#leavingPage', 'unsaved-changes-changed': "false" } } do |f|
 
   = render 'wizard_progress'
 
@@ -26,7 +26,7 @@
               %td.text-center
                 - if distributor_shipping_methods.many?
                   %label
-                    = check_box_tag nil, nil, nil, { "data-action": "change->select-all#toggleAll", "data-select-all-target": "all" }
+                    = check_box_tag nil, nil, nil, { "data-action": "change->select-all#toggleAll change->unsaved-changes#formIsChanged", "data-select-all-target": "all" }
                     = t(".select_all")
               %td
                 %em= distributor.name
@@ -37,7 +37,7 @@
                           distributor_shipping_method.id,
                           @order_cycle.distributor_shipping_methods.include?(distributor_shipping_method),
                           id: "order_cycle_selected_distributor_shipping_method_ids_#{distributor_shipping_method.id}",
-                          data: ({ "action" => "change->select-all#toggleCheckbox", "select-all-target" => "checkbox" } if distributor_shipping_method.shipping_method.frontend?)
+                          data: ({ "action" => "change->select-all#toggleCheckbox change->unsaved-changes#formIsChanged", "select-all-target" => "checkbox" } if distributor_shipping_method.shipping_method.frontend?)
                       = distributor_shipping_method.shipping_method.name
                 - distributor.shipping_methods.backend.each do |shipping_method|
                   %label.disabled
@@ -57,7 +57,7 @@
               %td.text-center
                 - if distributor_payment_methods.many?
                   %label
-                    = check_box_tag nil, nil, nil, { "data-action": "change->select-all#toggleAll", "data-select-all-target": "all" }
+                    = check_box_tag nil, nil, nil, { "data-action": "change->select-all#toggleAll change->unsaved-changes#formIsChanged", "data-select-all-target": "all" }
                     = t(".select_all")
               %td
                 %em= distributor.name
@@ -68,7 +68,7 @@
                           distributor_payment_method.id,
                           @order_cycle.distributor_payment_methods.include?(distributor_payment_method),
                           id: "order_cycle_selected_distributor_payment_method_ids_#{distributor_payment_method.id}",
-                          data: ({ "action" => "change->select-all#toggleCheckbox", "select-all-target" => "checkbox" } if distributor_payment_method.payment_method.frontend?)
+                          data: ({ "action" => "change->select-all#toggleCheckbox change->unsaved-changes#formIsChanged", "select-all-target" => "checkbox" } if distributor_payment_method.payment_method.frontend?)
                       = distributor_payment_method.payment_method.name
                 - distributor.payment_methods.inactive_or_backend.each do |payment_method|
                   %label.disabled

--- a/app/views/admin/order_cycles/checkout_options.html.haml
+++ b/app/views/admin/order_cycles/checkout_options.html.haml
@@ -3,7 +3,7 @@
 - content_for :page_title do
   = t :edit_order_cycle
 
-= form_for [main_app, :admin, @order_cycle], html: { class: "order_cycle" , data: { controller: 'unsaved-changes', action: 'beforeunload@window->unsaved-changes#leavingPage', 'unsaved-changes-changed': "false" } } do |f|
+= form_for [main_app, :admin, @order_cycle], html: { class: "order_cycle" , data: { controller: 'unsaved-changes', action: 'unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage', 'unsaved-changes-changed': "false" } } do |f|
 
   = render 'wizard_progress'
 

--- a/app/views/admin/order_cycles/checkout_options.html.haml
+++ b/app/views/admin/order_cycles/checkout_options.html.haml
@@ -3,7 +3,7 @@
 - content_for :page_title do
   = t :edit_order_cycle
 
-= form_for [main_app, :admin, @order_cycle], html: { class: "order_cycle" , data: { controller: 'unsaved-changes', action: 'unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage', 'unsaved-changes-changed': "false" } } do |f|
+= form_for [main_app, :admin, @order_cycle], html: { class: "order_cycle" , data: { controller: 'unsaved-changes', action: 'beforeunload@window->unsaved-changes#leavingPage', 'unsaved-changes-changed': "false" } } do |f|
   = render 'wizard_progress'
 
   %fieldset.no-border-bottom

--- a/app/webpacker/controllers/unsaved_changes_controller.js
+++ b/app/webpacker/controllers/unsaved_changes_controller.js
@@ -4,21 +4,34 @@ import { Controller } from "stimulus";
 //
 // Usage :
 // - with beforeunload event :
-//    <form data-controller="unsaved-changes" data-action="beforeunload@window->unsaved-changes#leavingPage" data-unsaved-changes-changed="true">
-//      <input data-action="change->unsaved-changes#formIsChanged">
+//    <form
+//      data-controller="unsaved-changes"
+//      data-action="beforeunload@window->unsaved-changes#leavingPage"
+//      data-unsaved-changes-changed="true"
+//    >
+//      <input data-action="change->unsaved-changes#formIsChanged" />
 //    </form>
 //
 // - with turbolinks :
-//    <form data-controller="unsaved-changes" data-action="turbolinks:before-visit@window->unsaved-changes#leavingPage" data-unsaved-changes-changed="true">
-//      <input data-action="change->unsaved-changes#formIsChanged">
+//    <form
+//      data-controller="unsaved-changes"
+//      data-action="turbolinks:before-visit@window->unsaved-changes#leavingPage"
+//      data-unsaved-changes-changed="true"
+//    >
+//      <input data-action="change->unsaved-changes#formIsChanged" />
 //    </form>
 //
 // You can also combine the two actions
+// You also need to add 'data-action="change->unsaved-changes#formIsChanged"' on all the form element
+// that can be interacted with
+//
+// Optional, you can add 'data-unsaved-changes-changed="true"' if you want to disable all
+// submit buttons when the form hasn't been interacted with
 //
 export default class extends Controller {
   connect() {
     // disable submit button when first loading the page
-    if (!this.isFormChanged()) {
+    if (!this.isFormChanged() && this.isSubmitButtonDisabled()) {
       this.disableButtons();
     }
   }
@@ -27,7 +40,10 @@ export default class extends Controller {
     // We only do something if the form hasn't already been changed
     if (!this.isFormChanged()) {
       this.setChanged("true");
-      this.enableButtons();
+
+      if (this.isSubmitButtonDisabled()) {
+        this.enableButtons();
+      }
     }
   }
 
@@ -61,6 +77,14 @@ export default class extends Controller {
 
   isFormChanged() {
     return this.data.get("changed") == "true";
+  }
+
+  isSubmitButtonDisabled() {
+    if (this.data.has("disable-submit-button")) {
+      return this.data.get("disable-submit-button") == "true";
+    }
+
+    return false;
   }
 
   enableButtons() {

--- a/app/webpacker/controllers/unsaved_changes_controller.js
+++ b/app/webpacker/controllers/unsaved_changes_controller.js
@@ -21,20 +21,25 @@ import { Controller } from "stimulus";
 //      <input data-action="change->unsaved-changes#formIsChanged" />
 //    </form>
 //
-// You can also combine the two event trigger ie : 
+// You can also combine the two event trigger ie :
 //    <form
 //      data-controller="unsaved-changes"
 //      data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage"
 //      data-unsaved-changes-changed="true"
 //    >
-// You then need to add 'data-action="change->unsaved-changes#formIsChanged"' on all the form element
-// that can be interacted with
 //
 // Optional, you can add 'data-unsaved-changes-changed="true"' if you want to disable all
 // submit buttons when the form hasn't been interacted with
 //
 export default class extends Controller {
   connect() {
+    // add onChange event to all form element
+    this.element
+      .querySelectorAll("input, select, textarea")
+      .forEach((input) => {
+        input.addEventListener("change", this.formIsChanged.bind(this));
+      });
+
     // disable submit button when first loading the page
     if (!this.isFormChanged() && this.isSubmitButtonDisabled()) {
       this.disableButtons();
@@ -77,8 +82,8 @@ export default class extends Controller {
   }
 
   submit(event) {
-    // if we are submitting the form, we don't want to trigger a warning so set changed to false 
-    this.setChanged("false")
+    // if we are submitting the form, we don't want to trigger a warning so set changed to false
+    this.setChanged("false");
   }
 
   setChanged(changed) {

--- a/app/webpacker/controllers/unsaved_changes_controller.js
+++ b/app/webpacker/controllers/unsaved_changes_controller.js
@@ -6,7 +6,7 @@ import { Controller } from "stimulus";
 // - with beforeunload event :
 //    <form
 //      data-controller="unsaved-changes"
-//      data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage"
+//      data-action="beforeunload@window->unsaved-changes#leavingPage"
 //      data-unsaved-changes-changed="true"
 //    >
 //      <input data-action="change->unsaved-changes#formIsChanged" />
@@ -15,7 +15,7 @@ import { Controller } from "stimulus";
 // - with turbolinks :
 //    <form
 //      data-controller="unsaved-changes"
-//      data-action="unsaved-changes#submit turbolinks:before-visit@window->unsaved-changes#leavingPage"
+//      data-action="turbolinks:before-visit@window->unsaved-changes#leavingPage"
 //      data-unsaved-changes-changed="true"
 //    >
 //      <input data-action="change->unsaved-changes#formIsChanged" />
@@ -24,11 +24,11 @@ import { Controller } from "stimulus";
 // You can also combine the two event trigger ie :
 //    <form
 //      data-controller="unsaved-changes"
-//      data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage"
+//      data-action="beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage"
 //      data-unsaved-changes-changed="true"
 //    >
 //
-// Optional, you can add 'data-unsaved-changes-changed="true"' if you want to disable all
+// Optional, you can add 'data-unsaved-changes-disable-submit-button="true"' if you want to disable all
 // submit buttons when the form hasn't been interacted with
 //
 export default class extends Controller {
@@ -39,6 +39,8 @@ export default class extends Controller {
       .forEach((input) => {
         input.addEventListener("change", this.formIsChanged.bind(this));
       });
+
+    this.element.addEventListener("submit", this.handleSubmit.bind(this));
 
     // disable submit button when first loading the page
     if (!this.isFormChanged() && this.isSubmitButtonDisabled()) {
@@ -81,7 +83,7 @@ export default class extends Controller {
     }
   }
 
-  submit(event) {
+  handleSubmit(event) {
     // if we are submitting the form, we don't want to trigger a warning so set changed to false
     this.setChanged("false");
   }

--- a/app/webpacker/controllers/unsaved_changes_controller.js
+++ b/app/webpacker/controllers/unsaved_changes_controller.js
@@ -1,0 +1,54 @@
+import { Controller } from "stimulus";
+
+// UnsavedChanges allows you to promp the user about unsaved changes when trying to leave the page
+//
+// Usage :
+// - with beforeunload event :
+//    <form data-controller="unsaved-changes" data-action="beforeunload@window->unsaved-changes#leavingPage" data-unsaved-changes-changed="true">
+//      <input data-action="change->unsaved-changes#formIsChanged">
+//    </form>
+//
+// - with turbolinks :
+//    <form data-controller="unsaved-changes" data-action="turbolinks:before-visit@window->unsaved-changes#leavingPage" data-unsaved-changes-changed="true">
+//      <input data-action="change->unsaved-changes#formIsChanged">
+//    </form>
+//
+// You can also combine the two actions
+//
+export default class extends Controller {
+  formIsChanged(event) {
+    this.setChanged("true");
+  }
+
+  leavingPage(event) {
+    const LEAVING_PAGE_MESSAGE = I18n.t("admin.unsaved_confirm_leave");
+
+    if (this.isFormChanged()) {
+      if (event.type == "turbolinks:before-visit") {
+        if (!window.confirm(LEAVING_PAGE_MESSAGE)) {
+          event.preventDefault();
+        }
+      } else {
+        // We cover our bases, according to the documentation we should be able to prompt the user
+        // by calling event.preventDefault(), but it's not really supported yet.
+        // Instead we set the value of event.returnValue, and return a string, both of them
+        // should prompt the user.
+        // Note, in most modern browser a generic string not under the control of the webpage is shown
+        // instead of the returned string.
+        //
+        // More info : https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event
+        //
+        event.returnValue = LEAVING_PAGE_MESSAGE;
+        return event.returnValue;
+      }
+    }
+  }
+
+  setChanged(changed) {
+    this.data.set("changed", changed);
+  }
+
+  isFormChanged() {
+    return this.data.get("changed") == "true";
+  }
+}

--- a/app/webpacker/controllers/unsaved_changes_controller.js
+++ b/app/webpacker/controllers/unsaved_changes_controller.js
@@ -6,7 +6,7 @@ import { Controller } from "stimulus";
 // - with beforeunload event :
 //    <form
 //      data-controller="unsaved-changes"
-//      data-action="beforeunload@window->unsaved-changes#leavingPage"
+//      data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage"
 //      data-unsaved-changes-changed="true"
 //    >
 //      <input data-action="change->unsaved-changes#formIsChanged" />
@@ -15,14 +15,19 @@ import { Controller } from "stimulus";
 // - with turbolinks :
 //    <form
 //      data-controller="unsaved-changes"
-//      data-action="turbolinks:before-visit@window->unsaved-changes#leavingPage"
+//      data-action="unsaved-changes#submit turbolinks:before-visit@window->unsaved-changes#leavingPage"
 //      data-unsaved-changes-changed="true"
 //    >
 //      <input data-action="change->unsaved-changes#formIsChanged" />
 //    </form>
 //
-// You can also combine the two actions
-// You also need to add 'data-action="change->unsaved-changes#formIsChanged"' on all the form element
+// You can also combine the two event trigger ie : 
+//    <form
+//      data-controller="unsaved-changes"
+//      data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage"
+//      data-unsaved-changes-changed="true"
+//    >
+// You then need to add 'data-action="change->unsaved-changes#formIsChanged"' on all the form element
 // that can be interacted with
 //
 // Optional, you can add 'data-unsaved-changes-changed="true"' if you want to disable all
@@ -69,6 +74,11 @@ export default class extends Controller {
         return event.returnValue;
       }
     }
+  }
+
+  submit(event) {
+    // if we are submitting the form, we don't want to trigger a warning so set changed to false 
+    this.setChanged("false")
   }
 
   setChanged(changed) {

--- a/app/webpacker/controllers/unsaved_changes_controller.js
+++ b/app/webpacker/controllers/unsaved_changes_controller.js
@@ -16,8 +16,19 @@ import { Controller } from "stimulus";
 // You can also combine the two actions
 //
 export default class extends Controller {
+  connect() {
+    // disable submit button when first loading the page
+    if (!this.isFormChanged()) {
+      this.disableButtons();
+    }
+  }
+
   formIsChanged(event) {
-    this.setChanged("true");
+    // We only do something if the form hasn't already been changed
+    if (!this.isFormChanged()) {
+      this.setChanged("true");
+      this.enableButtons();
+    }
   }
 
   leavingPage(event) {
@@ -50,5 +61,21 @@ export default class extends Controller {
 
   isFormChanged() {
     return this.data.get("changed") == "true";
+  }
+
+  enableButtons() {
+    this.submitButtons().forEach((button) => {
+      button.disabled = false;
+    });
+  }
+
+  disableButtons() {
+    this.submitButtons().forEach((button) => {
+      button.disabled = true;
+    });
+  }
+
+  submitButtons() {
+    return this.element.querySelectorAll("input[type='submit']");
   }
 }

--- a/spec/javascripts/stimulus/unsaved_changes_controller_test.js
+++ b/spec/javascripts/stimulus/unsaved_changes_controller_test.js
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { Application } from "stimulus"
+import unsaved_changes_controller from "../../../app/webpacker/controllers/unsaved_changes_controller"
+
+describe("UnsavedChangesController", () => {
+  beforeAll(() => {
+    const application = Application.start()
+    application.register("unsaved-changes", unsaved_changes_controller)
+  })
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <form id="test-form" data-controller="unsaved-changes" data-action="beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" data-unsaved-changes-changed="false">
+        <input
+          id="test-checkbox"
+          type="checkbox"
+          data-action="change->unsaved-changes#formIsChanged">
+      </form>
+    `
+  })
+
+  describe("#formIsChanged", () => {
+    it("changed is set to true", () => {
+      const form = document.getElementById("test-form")
+      const checkbox = document.getElementById("test-checkbox")
+
+      checkbox.click()
+
+      expect(form.dataset.unsavedChangesChanged).toBe('true')
+
+    })
+  })
+
+  describe('#leavingPage', () => {
+    beforeEach(() => {
+      // Add a mock I18n object to
+      const mockedT = jest.fn()
+      mockedT.mockImplementation((string) => (string))
+
+      global.I18n =  {
+        t: mockedT
+      }
+    })
+
+    afterEach(() => {
+      delete global.I18n
+    })
+
+    describe('when triggering a beforeunload event', () => {
+      it("triggers leave page pop up when leaving page and form has been interacted with", () => {
+        const checkbox = document.getElementById("test-checkbox")
+
+        // interact with the form
+        checkbox.click()
+
+        // trigger beforeunload to simulate leaving the page
+        const beforeunloadEvent = new Event("beforeunload")
+        window.dispatchEvent(beforeunloadEvent)
+
+        // Test the event returnValue has been set, we don't really care about the value as
+        // the brower will ignore it 
+        expect(beforeunloadEvent.returnValue).toBeTruthy()
+      })
+    })
+
+    describe('when triggering a turbolinks:before-visit event', () => {
+      it("triggers a confirm popup up when leaving page and form has been interacted with", () => {
+        const checkbox = document.getElementById("test-checkbox")
+        const confirmSpy = jest.spyOn(window, 'confirm')
+        confirmSpy.mockImplementation((msg) => {})
+
+        // interact with the form
+        checkbox.click()
+
+        // trigger turbolinks:before-visit to simulate leaving the page
+        const turbolinkEv = new Event("turbolinks:before-visit")
+        window.dispatchEvent(turbolinkEv)
+
+        expect(confirmSpy).toHaveBeenCalled()
+
+      })
+
+      it("stays on the page if user clicks cancel on the confirm popup", () => {
+        const checkbox = document.getElementById("test-checkbox")
+        const confirmSpy = jest.spyOn(window, 'confirm')
+        // return false to simulate a user clicking on cancel
+        confirmSpy.mockImplementation((msg) => (false)) 
+
+        // interact with the form
+        checkbox.click()
+
+        // trigger turbolinks:before-visit to simulate leaving the page
+        const turbolinkEv = new Event("turbolinks:before-visit")
+        const preventDefaultSpy = jest.spyOn(turbolinkEv, 'preventDefault')
+
+        window.dispatchEvent(turbolinkEv)
+
+        expect(confirmSpy).toHaveBeenCalled()
+        expect(preventDefaultSpy).toHaveBeenCalled()
+
+        // cleanup
+        confirmSpy.mockRestore()
+      })
+    })
+  })
+})

--- a/spec/javascripts/stimulus/unsaved_changes_controller_test.js
+++ b/spec/javascripts/stimulus/unsaved_changes_controller_test.js
@@ -14,23 +14,37 @@ describe("UnsavedChangesController", () => {
   beforeEach(() => {
     document.body.innerHTML = `
       <form id="test-form" data-controller="unsaved-changes" data-action="beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" data-unsaved-changes-changed="false">
-        <input
-          id="test-checkbox"
-          type="checkbox"
-          data-action="change->unsaved-changes#formIsChanged">
+        <input id="test-checkbox" type="checkbox" data-action="change->unsaved-changes#formIsChanged"/>
+        <input id="test-submit" type="submit"/>
       </form>
     `
   })
 
+  describe("#connect", () => {
+    it("disables any submit button", () => {
+      const submit = document.getElementById("test-submit")
+
+      expect(submit.disabled).toBe(true)
+    })  
+  })
+
   describe("#formIsChanged", () => {
     it("changed is set to true", () => {
-      const form = document.getElementById("test-form")
       const checkbox = document.getElementById("test-checkbox")
+      const form = document.getElementById("test-form")
 
       checkbox.click()
 
-      expect(form.dataset.unsavedChangesChanged).toBe('true')
+      expect(form.dataset.unsavedChangesChanged).toBe("true")
+    })
 
+    it("enables any submit button", () => {
+      const checkbox = document.getElementById("test-checkbox")
+      const submit = document.getElementById("test-submit")
+
+      checkbox.click()
+
+      expect(submit.disabled).toBe(false)
     })
   })
 

--- a/spec/javascripts/stimulus/unsaved_changes_controller_test.js
+++ b/spec/javascripts/stimulus/unsaved_changes_controller_test.js
@@ -16,7 +16,7 @@ describe("UnsavedChangesController", () => {
       <form 
         id="test-form" 
         data-controller="unsaved-changes" 
-        data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
+        data-action="beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
         data-unsaved-changes-changed="false"
       >
         <input id="test-checkbox" type="checkbox" />
@@ -32,7 +32,7 @@ describe("UnsavedChangesController", () => {
           <form 
             id="test-form" 
             data-controller="unsaved-changes" 
-            data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
+            data-action="beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
             data-unsaved-changes-changed="false" 
             data-unsaved-changes-disable-submit-button="true"
           >
@@ -55,7 +55,7 @@ describe("UnsavedChangesController", () => {
           <form 
             id="test-form" 
             data-controller="unsaved-changes" 
-            data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
+            data-action="beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
             data-unsaved-changes-changed="false" 
             data-unsaved-changes-disable-submit-button="false"
           >
@@ -195,7 +195,7 @@ describe("UnsavedChangesController", () => {
     })
   })
 
-  describe('#submit', () => {
+  describe('#handleSubmit', () => {
     let checkbox
 
     beforeEach(() => {

--- a/spec/javascripts/stimulus/unsaved_changes_controller_test.js
+++ b/spec/javascripts/stimulus/unsaved_changes_controller_test.js
@@ -15,7 +15,8 @@ describe("UnsavedChangesController", () => {
     document.body.innerHTML = `
       <form 
         id="test-form" 
-        data-controller="unsaved-changes" data-action="beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
+        data-controller="unsaved-changes" 
+        data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
         data-unsaved-changes-changed="false"
       >
         <input id="test-checkbox" type="checkbox" data-action="change->unsaved-changes#formIsChanged"/>
@@ -29,8 +30,9 @@ describe("UnsavedChangesController", () => {
       beforeEach(() => {
         document.body.innerHTML = `
           <form 
-            id="test-form" data-controller="unsaved-changes" 
-            data-action="beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
+            id="test-form" 
+            data-controller="unsaved-changes" 
+            data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
             data-unsaved-changes-changed="false" 
             data-unsaved-changes-disable-submit-button="true"
           >
@@ -53,7 +55,7 @@ describe("UnsavedChangesController", () => {
           <form 
             id="test-form" 
             data-controller="unsaved-changes" 
-            data-action="beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
+            data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
             data-unsaved-changes-changed="false" 
             data-unsaved-changes-disable-submit-button="false"
           >
@@ -189,6 +191,41 @@ describe("UnsavedChangesController", () => {
 
         expect(confirmSpy).toHaveBeenCalled()
         expect(preventDefaultSpy).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('#submit', () => {
+    let checkbox
+
+    beforeEach(() => {
+      // Add a mock I18n object to
+      const mockedT = jest.fn()
+      mockedT.mockImplementation((string) => (string))
+
+      global.I18n =  {
+        t: mockedT
+      }
+
+      checkbox = document.getElementById("test-checkbox")
+    })
+
+    afterEach(() => {
+      delete global.I18n
+    })
+
+    describe('when submiting the form', () => {
+      it("changed is set to true", () => {
+        const form = document.getElementById("test-form")
+
+        // interact with the form
+        checkbox.click()
+
+        // submit the form 
+        const submitEvent = new Event("submit")
+        form.dispatchEvent(submitEvent)
+
+        expect(form.dataset.unsavedChangesChanged).toBe("false")
       })
     })
   })

--- a/spec/javascripts/stimulus/unsaved_changes_controller_test.js
+++ b/spec/javascripts/stimulus/unsaved_changes_controller_test.js
@@ -19,7 +19,7 @@ describe("UnsavedChangesController", () => {
         data-action="unsaved-changes#submit beforeunload@window->unsaved-changes#leavingPage turbolinks:before-visit@window->unsaved-changes#leavingPage" 
         data-unsaved-changes-changed="false"
       >
-        <input id="test-checkbox" type="checkbox" data-action="change->unsaved-changes#formIsChanged"/>
+        <input id="test-checkbox" type="checkbox" />
         <input id="test-submit" type="submit"/>
       </form>
     `
@@ -36,7 +36,7 @@ describe("UnsavedChangesController", () => {
             data-unsaved-changes-changed="false" 
             data-unsaved-changes-disable-submit-button="true"
           >
-            <input id="test-checkbox" type="checkbox" data-action="change->unsaved-changes#formIsChanged"/>
+            <input id="test-checkbox" type="checkbox" />
             <input id="test-submit" type="submit"/>
           </form>
         `
@@ -59,7 +59,7 @@ describe("UnsavedChangesController", () => {
             data-unsaved-changes-changed="false" 
             data-unsaved-changes-disable-submit-button="false"
           >
-            <input id="test-checkbox" type="checkbox" data-action="change->unsaved-changes#formIsChanged"/>
+            <input id="test-checkbox" type="checkbox" />
             <input id="test-submit" type="submit"/>
           </form>
         `


### PR DESCRIPTION
#### What? Why?

Closes #9874
When editing a complex order cycle, there are warning when leaving a step with unsaved data. However the behaviour is inconsistent on step 3 and 4. This PR add the expected behaviour:
* Leaving step 3 without changing any data doesn't ask to confirm to leave the page
* Leaving step 4 after changing data ask to confirm to leave the page
* On step 3, 'save' and 'save and next' buttons are not active if data hasn't been changed
~~* On step 4, 'save' and 'save and back to list' buttons are only active if data has been changed~~
This is a bit confusing when creating a new order cycle, as you would end up on the last page with no way of saving. I kept the existing behaviour of having 'save' and 'save and back to list' enable

Tech note:
* step 3 bug is an unintended side effect of this PR https://github.com/openfoodfoundation/openfoodnetwork/pull/4452


#### What should we test?

- Visit admin -> Order cycles, and 
-  create an order cycle for a hub, and proceed through all the steps
- Edit the order cycle just created
- Proceed to step 3 and don't change anything :
  - 'save' and 'save and next' buttons are disabled
  
  ![step_3](https://user-images.githubusercontent.com/40413322/215905075-b5d1a933-1806-4593-b071-15835a522b0a.png)
  
  - click on step 1,2 or 4 --> no warning shown
- Come back to step 3 and update something :
  - 'save' and 'save and next' buttons are enabled
  - click on step 1,2 or 4 --> Confirmation to leave site will be shown

  ![step_3_updated](https://user-images.githubusercontent.com/40413322/215905509-5df6ce5a-0609-4696-b05e-6ccb14ed0e00.png)

- Proceed to step 4 and don't change anything :
  - 'save' and 'save and back to list' buttons are enable ( current behaviour )

  ![step_4_no_update](https://user-images.githubusercontent.com/40413322/215933939-693867fe-1c7d-4c09-a42c-42b6b77b7796.png)

  - click on step 1,2 or 3 --> no warning shown
- Proceed to step 4 and change anything :
  - click on step 1,2 or 3 --> Confirmation to leave site will be shown

  ![step_4_warning](https://user-images.githubusercontent.com/40413322/215933622-8f4f9f79-da39-41e0-8297-fc0853994587.png)

#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.


#### Dependencies

#### Documentation updates
