### PR TITLE
Allow Dependabot to update package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,12 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    # Only specific requirements are specified in Gemfile, so don't touch it.
     versioning-strategy: lockfile-only
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
-    versioning-strategy: lockfile-only
+    # All versions are specified in package.json, so please update them.
+    versioning-strategy: increase


### PR DESCRIPTION
#### What? Why?
As per the industry standard, all version numbers are specified in package.json, so Dependabot should be allowed to suggest increases when a new version is released so we don't miss out on them. 
This is the default setting.

Discussed in https://community.openfoodnetwork.org/t/javascript-dependency-management-with-package-json/2753

- Related to https://github.com/openfoodfoundation/openfoodnetwork/pull/10291

![Screen Shot 2023-02-03 at 2 58 39 pm](https://user-images.githubusercontent.com/4188088/216509380-5edcd806-c32b-4f87-bf87-7163b96f6b0a.png)

#### What should we test?
I don't think this can be tested, because Dependabot won't look at it until it is merged. 
We could implement [validation in CI](https://github.com/marocchino/validate-dependabot), but I don't think that's necessary and it still won't test it.

The only way to really test it is to merge and then verify:
1. Dependabot should open some new PRs to bump JS dependencies. Expected ones include: 
   - various webpacker related packages
   - `webpacker-dev-server`
   - `mrujs`
   - Foundation

Most of these won't be easy upgrades, but at least they'll be logged and we can deal with them one by one.

#### Release notes

Changelog Category: Technical changes (no change to production code)

