### PR TITLE
Make webpack-cli a dev-only dependency

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -24,6 +24,14 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
       - name: prettier
         uses: EPMatt/reviewdog-action-prettier@v1
         with:

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "stimulus-flatpickr": "^1.4.0",
     "stimulus_reflex": "3.5.0-pre9",
     "tom-select": "^2.0.0",
-    "webpack": "~4",
-    "webpack-cli": "~3"
+    "webpack": "~4"
   },
   "devDependencies": {
     "husky": "^8.0.0",
@@ -51,6 +50,7 @@
     "karma-jasmine": "~0.3.8",
     "prettier": "2.7.1",
     "pretty-quick": "^3.1.3",
+    "webpack-cli": "~3",
     "webpack-dev-server": "~3"
   }
 }


### PR DESCRIPTION
#### What? Why?
We shouldn't need this in production. According to the [readme](https://www.npmjs.com/package/webpack-cli) it's only a dev dependency.

Also a change to the linter process to ensure it uses Yarn instead of NPM.

#### What should we test?
This changes what JS packages are loaded in a deployment, so 
- Check that javascript and styles load successfully, and basic dynamic functionality works (eg view cart).

#### Release notes
Changelog Category: Technical changes > development dependencies
