### PR TITLE
BOM: Ensure orders informations are loaded for each line items

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -53,18 +53,8 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     $scope.dereferenceLoadedData()
 
   $scope.loadOrders = ->
-    [formattedStartDate, formattedEndDate] = $scope.formatDates($scope.startDate, $scope.endDate)
-
     RequestMonitor.load $scope.orders = Orders.index(
-      "q[state_not_eq]": "canceled",
-      "q[shipment_state_not_eq]": "shipped",
-      "q[completed_at_not_null]": "true",
-      "q[distributor_id_eq]": $scope.distributorFilter,
-      "q[order_cycle_id_eq]": $scope.orderCycleFilter,
-      "q[completed_at_gteq]": if formattedStartDate then formattedStartDate else undefined,
-      "q[completed_at_lt]": if formattedEndDate then formattedEndDate else undefined,
-      "page": $scope.page,
-      "per_page": $scope.per_page
+      "q[id_in][]": $scope.line_items.map((line_item) -> line_item.order.id)
     )
 
   $scope.loadLineItems = ->

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -9,7 +9,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.sharedResource = false
   $scope.columns = Columns.columns
   $scope.sorting = SortOptions
-  $scope.pagination = Orders.pagination
+  $scope.pagination = LineItems.pagination
   $scope.per_page_options = [
     {id: 15, name: t('js.admin.orders.index.per_page', results: 15)},
     {id: 50, name: t('js.admin.orders.index.per_page', results: 50)},

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -44,7 +44,6 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.refreshData = ->
     return "cancel" unless $scope.confirmRefresh()
 
-    $scope.loadOrders()
     $scope.loadLineItems()
 
     unless $scope.initialized
@@ -84,13 +83,15 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     RequestMonitor.load $scope.suppliers = Enterprises.index(action: "visible", ams_prefix: "basic", "q[is_primary_producer_eq]": "true")
 
   $scope.dereferenceLoadedData = ->
-    RequestMonitor.load $q.all([$scope.orders.$promise, $scope.distributors.$promise, $scope.orderCycles.$promise, $scope.suppliers.$promise, $scope.line_items.$promise]).then ->
-      Dereferencer.dereferenceAttr $scope.orders, "distributor", Enterprises.byID
-      Dereferencer.dereferenceAttr $scope.orders, "order_cycle", OrderCycles.byID
+    RequestMonitor.load $q.all([$scope.distributors.$promise, $scope.orderCycles.$promise, $scope.suppliers.$promise, $scope.line_items.$promise]).then ->
       Dereferencer.dereferenceAttr $scope.line_items, "supplier", Enterprises.byID
-      Dereferencer.dereferenceAttr $scope.line_items, "order", Orders.byID
-      $scope.bulk_order_form.$setPristine()
-      StatusMessage.clear()
+      $scope.loadOrders()
+      RequestMonitor.load $q.all([$scope.orders.$promise]).then ->
+        Dereferencer.dereferenceAttr $scope.line_items, "order", Orders.byID  
+        Dereferencer.dereferenceAttr $scope.orders, "distributor", Enterprises.byID
+        Dereferencer.dereferenceAttr $scope.orders, "order_cycle", OrderCycles.byID
+        $scope.bulk_order_form.$setPristine()
+        StatusMessage.clear()
 
       unless $scope.initialized
         $scope.initialized = true

--- a/app/views/admin/shared/_angular_per_page_controls.html.haml
+++ b/app/views/admin/shared/_angular_per_page_controls.html.haml
@@ -1,7 +1,7 @@
 - position ||= ""
-.per-page{'ng-show' => '!RequestMonitor.loading && orders.length > 0', class: ("right" if position == "right") }
+.per-page{'ng-show' => '!RequestMonitor.loading && line_items.length > 0', class: ("right" if position == "right") }
   %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'min-search' => 999, 'ng-model' => 'per_page', 'ng-change' => 'fetchResults()'}
 
   %span.per-page-feedback
-    {{ 'spree.admin.orders.index.results_found' | t:{number: pagination.results} }}
-    {{ 'spree.admin.orders.index.viewing' | t:{start: ((pagination.page -1) * pagination.per_page) +1, end: ((pagination.page -1) * pagination.per_page) + orders.length} }}
+    {{ 'spree.admin.line_items.index.results_found' | t:{number: pagination.results} }}
+    {{ 'spree.admin.orders.index.viewing' | t:{start: ((pagination.page -1) * pagination.per_page) +1, end: ((pagination.page -1) * pagination.per_page) + line_items.length} }}

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -190,7 +190,7 @@
           %td.actions
             %a{ 'ng-click' => "deleteLineItem(line_item)", :class => "delete-line-item icon-trash no-text" }
 
-  %div{'ng-show' => "!RequestMonitor.loading && orders.length > 0" }
+  %div{'ng-show' => "!RequestMonitor.loading && line_items.length > 0" }
     = render partial: 'admin/shared/angular_pagination'
 
 = render 'spree/admin/shared/custom-confirm'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3897,6 +3897,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           authorized: "Authorized"
           received: "Received"
           canceled: "Canceled"
+      line_items:
+        index:
+          results_found: "%{number} Results found."
+          viewing: "Viewing %{start} to %{end}."
       orders:
         add_product:
           cannot_add_item_to_canceled_order: "Cannot add item to canceled order"

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -49,10 +49,10 @@ describe "LineItemsCtrl", ->
         return Promise.resolve()
       allSaved: jasmine.createSpy('allSaved').and.returnValue(true)
 
-    httpBackend.expectGET("/api/v0/orders.json?page=1&per_page=15&q%5Bcompleted_at_not_null%5D=true&q%5Bdistributor_id_eq%5D=&q%5Border_cycle_id_eq%5D=&q%5Bshipment_state_not_eq%5D=shipped&q%5Bstate_not_eq%5D=canceled").respond {orders: [order], pagination: {page: 1, pages: 1, results: 1}}
     httpBackend.expectGET("/admin/enterprises/visible.json?ams_prefix=basic&q%5Bsells_in%5D%5B%5D=own&q%5Bsells_in%5D%5B%5D=any").respond [distributor]
     httpBackend.expectGET("/admin/order_cycles.json?ams_prefix=basic&as=distributor&q%5Borders_close_at_gt%5D=SomeDate").respond [orderCycle]
     httpBackend.expectGET("/admin/enterprises/visible.json?ams_prefix=basic&q%5Bis_primary_producer_eq%5D=true").respond [supplier]
+    httpBackend.expectGET("/api/v0/orders.json?q%5Bid_in%5D%5B%5D=#{order.id}").respond { orders: [order] }
 
     scope.bulk_order_form = jasmine.createSpyObj('bulk_order_form', ['$setPristine'])
 


### PR DESCRIPTION
#### What? Why?
This PR: 
 - change pagination from `orders` to `line_items`: we display on that page `line_items` and not `orders`, pagination should reflect that.
 - Load orders that are linked to the line_items displayed in the page and not ones that match pagination, search or whatever (we could actually only link one order if this order as at list 15 line_items ; 15 is the default per_page items count)


- Closes #10363


#### What should we test?
The bug occur if, for the current admin user, there was at least one order with more that one line_items (and therefore pagination was desynchronized). Then the test is pretty simple: go to BOM, and then to page 2. Please ensure you that you could reproduce the bug before staging the PR ;)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
