### PR TITLE
Update payment (cash/EFF) state on cancelled order

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -665,6 +665,7 @@ module Spree
 
     def after_cancel
       shipments.each(&:cancel!)
+      payments.checkout.each(&:void!)
 
       OrderMailer.cancel_email(id).deliver_later if send_cancellation_email
       update(payment_state: updater.update_payment_state)

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -673,6 +673,8 @@ module Spree
 
     def after_resume
       shipments.each(&:resume!)
+      payments.void.each(&:resume!)
+
       update(payment_state: updater.update_payment_state)
     end
 

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -47,6 +47,7 @@ module Spree
     scope :with_state, ->(s) { where(state: s.to_s) }
     scope :completed, -> { with_state('completed') }
     scope :incomplete, -> { where(state: %w(checkout pending requires_authorization)) }
+    scope :checkout, -> { with_state('checkout') }
     scope :pending, -> { with_state('pending') }
     scope :failed, -> { with_state('failed') }
     scope :valid, -> { where.not(state: %w(failed invalid)) }

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -51,6 +51,7 @@ module Spree
     scope :pending, -> { with_state('pending') }
     scope :failed, -> { with_state('failed') }
     scope :valid, -> { where.not(state: %w(failed invalid)) }
+    scope :void, -> { with_state('void') }
     scope :authorization_action_required, -> { where.not(cvv_response_message: nil) }
     scope :requires_authorization, -> { with_state("requires_authorization") }
     scope :with_payment_intent, ->(code) { where(response_code: code) }

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -91,6 +91,10 @@ module Spree
       event :complete_authorization do
         transition from: [:requires_authorization], to: :completed
       end
+      event :resume do
+        transition from: [:void], to: :checkout
+      end
+
 
       after_transition to: :completed, do: :set_captured_at
     end

--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -61,7 +61,7 @@ module OrderManagement
           expect(order.shipment_state).to be_nil
         end
 
-        ["shipped", "ready", "pending"].each do |state|
+        ["shipped", "ready", "pending", "canceled"].each do |state|
           it "is #{state}" do
             allow(shipment).to receive(:state).and_return(state)
             updater.update_shipment_state

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -326,6 +326,30 @@ describe Spree::Order do
     end
   end
 
+  describe "#resume" do
+    let(:order) { create(:order_with_totals_and_distribution, :completed) }
+
+    before do
+      order.cancel!
+      order.resume!
+    end
+
+    it "should resume the order" do
+      expect(order.state).to eq 'resumed'
+    end
+
+    it "should resume the shipments" do
+      expect(order.shipments.pluck(:state)).to eq ['pending']
+    end
+
+    context "when payment is in void state" do
+      it "should change the state of the payment to checkout" do
+        order.payments.reload
+        expect(order.payments.pluck(:state)).to eq ['checkout']
+      end
+    end
+  end
+
   context "insufficient_stock_lines" do
     let(:line_item) { build(:line_item) }
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -303,6 +303,29 @@ describe Spree::Order do
     end
   end
 
+  describe "#cancel" do
+    let(:order) { create(:order_with_totals_and_distribution, :completed) }
+
+    before { order.cancel! }
+
+    it "should cancel the order" do
+      expect(order.state).to eq 'canceled'
+    end
+
+    it "should cancel the shipments" do
+      expect(order.shipments.pluck(:state)).to eq ['canceled']
+    end
+
+    context "when payment has not been taken" do
+      context "and payment is in checkout state" do
+        it "should change the state of the payment to void" do
+          order.payments.reload
+          expect(order.payments.pluck(:state)).to eq ['void']
+        end
+      end
+    end
+  end
+
   context "insufficient_stock_lines" do
     let(:line_item) { build(:line_item) }
 


### PR DESCRIPTION
#### What? Why?

- Closes [#8229](https://github.com/openfoodfoundation/openfoodnetwork/issues/8229)

An order (paid for by cash or EFFs) is cancelled - either by the food enterprise or the customer - prior to payment being captured. If order is canceled then no money is due. Payment state should be "void" and "capture payment" icon should not be present.

This issue was partially solved in [PR 8863](https://github.com/openfoodfoundation/openfoodnetwork/pull/8863) -  updates the order's payment state to cancelled.

[Here's a discussion on slack that gives a bit of context to the fix](https://openfoodnetwork.slack.com/archives/C022DJZJ1J9/p1675372423159399)

This PR: 

- On order cancellation, it updates the associated payment state to "void" (currently remains "checkout")
- On order resume, it updates the associated payment state back to "checkout" 

By updating the payment to a "void" state this also fixes:

- Capture button is not shown
- The order's shipment state is changed to cancelled 

#### What should we test?

1. place dummy order and opt to pay by cash or other non-integrated payment method
2. cancel order
3. view Listing Orders table and check the order's data:
   - The order state should be cancelled
   - The order payment state should be void
   - The order shipment state should be cancelled
   - The capture button should not be shown
   
   ![Captura de ecrã 2023-02-06, às 11 14 58](https://user-images.githubusercontent.com/27692541/216977326-78858300-cac4-4a59-ab05-cdd3974f88e2.png)
   
4. Edit the order 
   - The payment status should be "void"
![Captura de ecrã 2023-02-06, às 11 15 08](https://user-images.githubusercontent.com/27692541/216977481-9a11d130-9639-41e8-8c31-d947d45ec81b.png)

5. Resume the order
   - The order state should be "resumed"
   - The payment state should be "checkout"
   - The shipment state should be "pending"
![Captura de ecrã 2023-02-06, às 11 16 33](https://user-images.githubusercontent.com/27692541/216977841-850dd173-549c-45f0-98b7-91dfc1cddc81.png)
![Captura de ecrã 2023-02-06, às 11 16 42](https://user-images.githubusercontent.com/27692541/216977903-29e162e1-3c98-44a7-8858-870b252ad2bd.png)

#### Release notes

Changelog Category: User facing changes
