### PR TITLE
Remove `report_inverse_columns_logic` from list of feature toggle

### DIFF
--- a/db/migrate/20230206142149_remove_report_inverse_columns_logic_feature_toggle_key.rb
+++ b/db/migrate/20230206142149_remove_report_inverse_columns_logic_feature_toggle_key.rb
@@ -1,0 +1,9 @@
+class RemoveReportInverseColumnsLogicFeatureToggleKey < ActiveRecord::Migration[6.1]
+  def change
+    # Remove the feature toggle key for the report inverse columns logic
+    # since it is now enabled by default. This should have been done 
+    # in the PR #9830, but was missed.
+    execute("DELETE FROM flipper_gates WHERE feature_key = 'report_inverse_columns_logic'")
+    execute("DELETE FROM flipper_features WHERE key = 'report_inverse_columns_logic'")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_30_032659) do
+ActiveRecord::Schema.define(version: 2023_02_06_142149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"


### PR DESCRIPTION
#### What? Why?
Since #9731 we can display feature keys that have been accessed through the code automatically. 
With #9830, we removes the key `report_inverse_columns_logic` since feature has been deployed to all. 

This PR migrates data to remove `report_inverse_columns_logic` from table `flipper_features`.



#### What should we test?
- Before migrating the data, check that you have `report_inverse_columns_logic` (enabled or not) in the list of feature (`/admin/feature-toggle`):
<img width="634" alt="Capture d’écran 2023-02-06 à 15 38 07" src="https://user-images.githubusercontent.com/296452/217000776-05fc5018-439d-4e32-9fce-a95a3436ccbc.png">

- After the migration, `report_inverse_columns_logic` shouldn't appear in this interface.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
