### PR TITLE
Use .node-version in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: .node-version
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: .node-version
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -195,7 +195,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: .node-version
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -273,7 +273,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: .node-version
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -351,7 +351,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: .node-version
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -429,7 +429,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: .node-version
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -489,7 +489,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: .node-version
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: .node-version
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
#### What? Why?

This ensures that all our automated tests are using the same version. I'm not sure it matters what version Prettier runs on, but thought it should be the same.

This is a down-grade, but it's better to match the version in production. The next step will be to upgrade again for production (https://github.com/openfoodfoundation/ofn-install/issues/838)


#### What should we test?
CI pass

#### Release notes

Changelog Category:  Technical changes

