### PR TITLE
Orders page and BOM page: use the same pagination file

### DIFF
--- a/app/views/admin/shared/_angular_per_page_controls.html.haml
+++ b/app/views/admin/shared/_angular_per_page_controls.html.haml
@@ -1,7 +1,7 @@
 - position ||= ""
-.per-page{'ng-show' => '!RequestMonitor.loading && line_items.length > 0', class: ("right" if position == "right") }
+.per-page{'ng-show' => "!RequestMonitor.loading && #{model}.length > 0", class: ("right" if position == "right") }
   %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'min-search' => 999, 'ng-model' => 'per_page', 'ng-change' => 'fetchResults()'}
 
   %span.per-page-feedback
-    {{ 'spree.admin.line_items.index.results_found' | t:{number: pagination.results} }}
-    {{ 'spree.admin.orders.index.viewing' | t:{start: ((pagination.page -1) * pagination.per_page) +1, end: ((pagination.page -1) * pagination.per_page) + line_items.length} }}
+    {{ "spree.admin.#{model}.index.results_found" | t:{number: pagination.results} }}
+    {{ 'spree.admin.#{model}.index.viewing' | t:{start: ((pagination.page -1) * pagination.per_page) +1, end: ((pagination.page -1) * pagination.per_page) + #{model}.length} }}

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -106,7 +106,7 @@
       %columns-dropdown{ action: "#{controller_name}_#{action_name}" }
     %div{ style: "flex-grow: 1"}
       %div{ style: "float: right;"}
-        = render partial: 'admin/shared/angular_per_page_controls', locals: { position: "right" }
+        = render partial: 'admin/shared/angular_per_page_controls', locals: { position: "right", model: "line_items" }
  
 
   %div.sixteen.columns.alpha#loading{ 'ng-if' => 'RequestMonitor.loading' }

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -40,7 +40,7 @@
               %span.name{'ng-controller' => 'bulkCancelCtrl', 'ng-click' => 'cancelSelectedOrders()' }
                 = t('.cancel_orders')
     
-    = render partial: 'admin/shared/angular_per_page_controls', locals: { position: "right" }
+    = render partial: 'admin/shared/angular_per_page_controls', locals: { position: "right", model: "orders" }
 
 %table#listing_orders.index.responsive{width: "100%", 'ng-init' => 'initialise()', 'ng-show' => "!RequestMonitor.loading && orders.length > 0" }
   %colgroup


### PR DESCRIPTION

#### What? Why?
This fix an issue raised by #10375 that only shows pagination file for line_items context, ie. BOM page. This PR now enabled pagination widget for both contexts: orders page and BOM pages.

Partial for pagination is actually used in two different contexts: orders and line_items
Distinguish them by adding a local variable model that could either be `orders` or `line_items`

The pagination widget:
<img width="402" alt="Capture d’écran 2023-02-07 à 18 17 25" src="https://user-images.githubusercontent.com/296452/217316803-2e5790d5-9254-42e8-ae60-dbbd6fe00013.png">



- Closes #10390 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, visit `/admin/orders` and check there is the pagination widget
- As an admin, visit `/admin/orders/bulk_management` and check there is the pagination widget

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
