### PR TITLE
SplitCheckout: Fix an issue raised when first time checkout user submit form without selecting shipping method

### DIFF
--- a/app/services/default_address_updater.rb
+++ b/app/services/default_address_updater.rb
@@ -15,7 +15,7 @@ class DefaultAddressUpdater
     assign_bill_addresses
     assign_ship_addresses
 
-    customer.save
+    customer&.save
     user&.save
   end
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -284,6 +284,18 @@ describe "As a consumer, I want to checkout my order" do
       visit checkout_path
     end
 
+    context "when no selecting a shipping method" do
+      before do
+        fill_out_details
+        fill_out_billing_address
+      end
+
+      it "errors is shown to the user when submitting the form" do
+        click_button "Next - Payment method"
+        expect(page).to have_content "Select a shipping method"
+      end
+    end
+
     context "details step" do
       context "when form is submitted but invalid" do
         it "display the checkbox about shipping address same as billing address when selecting a shipping method that requires ship address" do


### PR DESCRIPTION
#### What? Why?
Customer can be nil if first time they checkout
- Closes #10402 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Pretty well explained in the original issue, but I'll add:

 - SplitCheckout: submit step1 without selecting shipping method as guest
 - SplitCheckout: submit step1 without selecting shipping method with a user who has already placed an order
 - LegacyCheckout: order as guest
 - LegacyCheckout: order as first time user
 - LegacyCheckout: order with a user who has already placed an order

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
