### PR TITLE
Bump paper_trail from 12.1.0 to 12.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem 'bootsnap', require: false
 gem 'geocoder'
 gem 'gmaps4rails'
 gem 'mimemagic', '> 0.3.5'
-gem 'paper_trail', '~> 12.1.0'
+gem 'paper_trail', '~> 12.1'
 gem 'rack-rewrite'
 gem 'roadie-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,7 @@ GEM
     orm_adapter (0.5.0)
     pagy (5.10.1)
       activesupport
-    paper_trail (12.1.0)
+    paper_trail (12.3.0)
       activerecord (>= 5.2)
       request_store (~> 1.1)
     parallel (1.22.1)
@@ -559,7 +559,7 @@ GEM
     regexp_parser (2.7.0)
     reline (0.3.2)
       io-console (~> 0.5)
-    request_store (1.5.0)
+    request_store (1.5.1)
       rack (>= 1.4)
     responders (3.1.0)
       actionpack (>= 5.2)
@@ -843,7 +843,7 @@ DEPENDENCIES
   openid_connect (~> 1.3)
   order_management!
   pagy (~> 5.1)
-  paper_trail (~> 12.1.0)
+  paper_trail (~> 12.1)
   paranoia (~> 2.4)
   paypal-sdk-merchant (= 1.117.2)
   pdf-reader


### PR DESCRIPTION

#### What? Why?

No breaking changes but Rails 7 support.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

We did dev tests before to check that paper_trail is still working but I would skip that here. The base functionality is unlikely to break and the association tracking we would like is probably still broken:

* https://github.com/openfoodfoundation/openfoodnetwork/issues/5743

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
