### PR TITLE
Remove unused suburbs table

### DIFF
--- a/db/migrate/20230213060209_drop_suburbs.rb
+++ b/db/migrate/20230213060209_drop_suburbs.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DropSuburbs < ActiveRecord::Migration[6.1]
+  def change
+    drop_table "suburbs", id: :serial, force: :cascade do |t|
+      t.string "name", limit: 255
+      t.string "postcode", limit: 255
+      t.float "latitude"
+      t.float "longitude"
+      t.integer "state_id"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_06_142149) do
+ActiveRecord::Schema.define(version: 2023_02_13_060209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -1132,14 +1132,6 @@ ActiveRecord::Schema.define(version: 2023_02_06_142149) do
     t.index ["shop_id"], name: "index_subscriptions_on_shop_id"
   end
 
-  create_table "suburbs", id: :serial, force: :cascade do |t|
-    t.string "name", limit: 255
-    t.string "postcode", limit: 255
-    t.float "latitude"
-    t.float "longitude"
-    t.integer "state_id"
-  end
-
   create_table "tag_rules", id: :serial, force: :cascade do |t|
     t.integer "enterprise_id", null: false
     t.string "type", limit: 255, null: false
@@ -1299,7 +1291,6 @@ ActiveRecord::Schema.define(version: 2023_02_06_142149) do
   add_foreign_key "subscriptions", "spree_addresses", column: "ship_address_id", name: "subscriptions_ship_address_id_fk"
   add_foreign_key "subscriptions", "spree_payment_methods", column: "payment_method_id", name: "subscriptions_payment_method_id_fk"
   add_foreign_key "subscriptions", "spree_shipping_methods", column: "shipping_method_id", name: "subscriptions_shipping_method_id_fk"
-  add_foreign_key "suburbs", "spree_states", column: "state_id", name: "suburbs_state_id_fk"
   add_foreign_key "variant_overrides", "enterprises", column: "hub_id", name: "variant_overrides_hub_id_fk"
   add_foreign_key "variant_overrides", "spree_variants", column: "variant_id", name: "variant_overrides_variant_id_fk"
 end


### PR DESCRIPTION

#### What? Why?

- Closes #8578 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Once upon a time it was used to search for enterprises in a certain suburb. But we let Google Maps do that these days and the feature was removed in 2015.

* c4fb4a8510a0b9f1082866d13bdced277717c11f


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit /shops.
- See the suburbs in the table.
- You can use the search to display shops in that suburb.
- Visit /map.
- Search for a suburb.
- The map should display enterprises in that suburb.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
