### PR TITLE
Fix flaky spec `spec/system/admin/products_spec.rb:210 #10417`

### DIFF
--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -190,24 +190,25 @@ describe '
       let!(:order) { create(:shipped_order, line_items_count: 1) }
       let!(:line_item) { order.reload.line_items.first }
 
-      before do
-        login_as_admin_and_visit spree.admin_products_path
-
-        within "#p_#{order.variants.first.product_id}" do
-          accept_alert { page.find("[data-powertip=Remove]").click }
-        end
-        visit current_path
-      end
-      it 'removes it from the product list' do
-        expect(page).to have_selector "#p_#{product1.id}"
-        expect(page).not_to have_selector "#p_#{order.variants.first.product_id}"
-      end
-
       context "a deleted line item from a shipped order" do
         before do
-          login_as_admin_and_visit spree.edit_admin_order_path(order)
+          login_as_admin_and_visit spree.admin_products_path
+
+          within "#p_#{order.variants.first.product_id}" do
+            accept_alert { page.find("[data-powertip=Remove]").click }
+          end
         end
+
+        it 'removes it from the product list' do
+          visit spree.admin_products_path
+
+          expect(page).to have_selector "#p_#{product1.id}"
+          expect(page).not_to have_selector "#p_#{order.variants.first.product_id}"
+        end
+
         it 'keeps the line item on the order (admin)' do
+          visit spree.edit_admin_order_path(order)
+
           expect(page).to have_content(line_item.product.name.to_s)
         end
       end


### PR DESCRIPTION
Actually, those two tests are in the same context

The diff is pretty hard to read, but i've put the two tests "removes it from the product list" and "keeps the line item on the order (admin)" under the same context and the same `before` block

#### What? Why?

- Closes # <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
