### PR TITLE
SplitCheckout: improve error messages in flash banner to improve user experience

### DIFF
--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -60,7 +60,6 @@ class SplitCheckoutController < ::BaseController
   def order_error_messages
     # Remove ship_address.* errors if no shipping method is not selected
     remove_ship_address_errors if @order.errors[:shipping_method].present?
-
   end
 
   def remove_ship_address_errors

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -59,10 +59,15 @@ class SplitCheckoutController < ::BaseController
 
   def order_error_messages
     # Remove ship_address.* errors if no shipping method is not selected
-    remove_ship_address_errors if @order.errors[:shipping_method].present?
+    remove_ship_address_errors if no_ship_address_needed?
+
     # Reorder errors to make sure the most important ones are shown first
     # and finally, return the error messages to sentence
     reorder_errors.map(&:full_message).to_sentence
+  end
+
+  def no_ship_address_needed?
+    @order.errors[:shipping_method].present? || params[:ship_address_same_as_billing] == "1"
   end
 
   def remove_ship_address_errors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,8 @@ en:
         firstname: "First name"
         lastname: "Last name"
         zipcode: "Shipping address postcode"
+      spree/order/bill_address:
+        phone: Customer phone
       spree/user:
         password: "Password"
         password_confirmation: "Password confirmation"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,9 +27,9 @@ en:
       spree/shipping_method: Shipping Method
     attributes:
       spree/order/ship_address:
-        address1: "Shipping address line 1"
+        address1: "Shipping address (Street + House number)"
         address2: "Shipping address line 2"
-        city: "Shipping address suburb 1"
+        city: "Shipping address city"
         country: "Shipping address country"
         phone: "Phone number"
         firstname: "First name"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
         lastname: "Last name"
         zipcode: "Shipping address postcode"
       spree/order/bill_address:
+        address1: "Bill address (Street + House number)"
+        zipcode: "Bill address postcode"
         phone: Customer phone
       spree/user:
         password: "Password"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,8 +36,12 @@ en:
         lastname: "Last name"
         zipcode: "Shipping address postcode"
       spree/order/bill_address:
-        address1: "Bill address (Street + House number)"
-        zipcode: "Bill address postcode"
+        address1: "Billing address (Street + House number)"
+        zipcode: "Billing address postcode"
+        city: "Billing address city"
+        country: "Billing address country"
+        firstname: "Billing address first name"
+        lastname: "Billing address last name"
         phone: Customer phone
       spree/user:
         password: "Password"

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Order do
     it "provides friendly error messages" do
       order.ship_address = Spree::Address.new
       order.save
-      expect(order.errors.full_messages).to include "Shipping address line 1 can't be blank"
+      expect(order.errors.full_messages).to include "Shipping address (Street + House number) can't be blank"
     end
 
     it "provides friendly error messages for bill address" do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -18,7 +18,7 @@ describe Spree::Order do
     it "provides friendly error messages for bill address" do
       order.bill_address = Spree::Address.new
       order.save
-      expect(order.errors.full_messages).to include "Bill address (Street + House number) can't be blank"
+      expect(order.errors.full_messages).to include "Billing address (Street + House number) can't be blank"
     end
   end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -14,6 +14,12 @@ describe Spree::Order do
       order.save
       expect(order.errors.full_messages).to include "Shipping address line 1 can't be blank"
     end
+
+    it "provides friendly error messages for bill address" do
+      order.bill_address = Spree::Address.new
+      order.save
+      expect(order.errors.full_messages).to include "Bill address (Street + House number) can't be blank"
+    end
   end
 
   context "#products" do

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -187,6 +187,19 @@ describe "As a consumer, I want to checkout my order" do
         click_on "Checkout as guest"
       end
 
+      context "should show proper list of errors" do
+        before do
+          click_button "Next - Payment method"
+          expect(page).to have_content "Saving failed, please update the highlighted fields."
+        end
+
+        it "should not display any shipping errors messages when shipping method is not selected" do
+          expect(page).not_to have_content "Shipping address line 1 can't be blank"
+          expect(page).not_to have_content "Shipping address suburb 1 can't be blank"
+          expect(page).not_to have_content "Shipping address postcode can't be blank"
+        end
+      end
+
       it "should allow visit '/checkout/details'" do
         expect(page).to have_current_path("/checkout/details")
       end
@@ -306,8 +319,6 @@ describe "As a consumer, I want to checkout my order" do
           click_button "Next - Payment method"
 
           expect(page).to have_content "Saving failed, please update the highlighted fields."
-          expect(page).to have_content "Shipping address line 1 can't be blank"
-          expect(page).to have_content "Shipping address same as billing address?"
           expect(page).to have_content "Save as default shipping address"
           expect(page).to have_checked_field "Shipping address same as billing address?"
         end
@@ -563,7 +574,7 @@ describe "As a consumer, I want to checkout my order" do
           end
           within ".flash[type='error']" do
             expect(page).to have_content("Saving failed, please update the highlighted fields")
-            expect(page).to have_content("can't be blank", count: 13)
+            expect(page).to have_content("can't be blank", count: 7)
             expect(page).to have_content("is invalid", count: 1)
           end
         end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -211,7 +211,7 @@ describe "As a consumer, I want to checkout my order" do
           end
 
           it "should display error message in the right order" do
-            expect(page).to have_content "Customer E-Mail can't be blank, Customer E-Mail is invalid, Customer phone can't be blank, Bill address firstname can't be blank, Bill address lastname can't be blank, Bill address (Street + House number) can't be blank, Bill address city can't be blank, Bill address postcode can't be blank, and Shipping method Select a shipping method"
+            expect(page).to have_content "Customer E-Mail can't be blank, Customer E-Mail is invalid, Customer phone can't be blank, Billing address first name can't be blank, Billing address last name can't be blank, Billing address (Street + House number) can't be blank, Billing address city can't be blank, Billing address postcode can't be blank, and Shipping method Select a shipping method"
           end
         end
       end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -203,6 +203,17 @@ describe "As a consumer, I want to checkout my order" do
           expect(page).not_to have_content "Bill address phone can't be blank"
           expect(page).to have_content "Customer phone can't be blank"
         end
+
+        context "with no email filled in" do
+          before do
+            fill_in "Email", with: ""
+            click_button "Next - Payment method"
+          end
+
+          it "should display error message in the right order" do
+            expect(page).to have_content "Customer E-Mail can't be blank, Customer E-Mail is invalid, Customer phone can't be blank, Bill address firstname can't be blank, Bill address lastname can't be blank, Bill address address1 can't be blank, Bill address city can't be blank, Bill address zipcode can't be blank, and Shipping method Select a shipping method"
+          end
+        end
       end
 
       it "should allow visit '/checkout/details'" do

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -198,6 +198,11 @@ describe "As a consumer, I want to checkout my order" do
           expect(page).not_to have_content "Shipping address suburb 1 can't be blank"
           expect(page).not_to have_content "Shipping address postcode can't be blank"
         end
+
+        it "should not display bill address phone number error message" do
+          expect(page).not_to have_content "Bill address phone can't be blank"
+          expect(page).to have_content "Customer phone can't be blank"
+        end
       end
 
       it "should allow visit '/checkout/details'" do

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -211,7 +211,7 @@ describe "As a consumer, I want to checkout my order" do
           end
 
           it "should display error message in the right order" do
-            expect(page).to have_content "Customer E-Mail can't be blank, Customer E-Mail is invalid, Customer phone can't be blank, Bill address firstname can't be blank, Bill address lastname can't be blank, Bill address address1 can't be blank, Bill address city can't be blank, Bill address zipcode can't be blank, and Shipping method Select a shipping method"
+            expect(page).to have_content "Customer E-Mail can't be blank, Customer E-Mail is invalid, Customer phone can't be blank, Bill address firstname can't be blank, Bill address lastname can't be blank, Bill address (Street + House number) can't be blank, Bill address city can't be blank, Bill address postcode can't be blank, and Shipping method Select a shipping method"
           end
         end
       end


### PR DESCRIPTION
#### What? Why?

- Closes #10384

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

<img width="1209" alt="Capture d’écran 2023-02-15 à 10 02 48" src="https://user-images.githubusercontent.com/296452/218981945-101f726d-b010-4a0d-937e-c65188dab168.png">


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- With split_checkout activated, as a shopper, visit checkout page
- Submit first step with partial or invalid data: the banner error message should be understable. For example:
  - No shipping address error should be shown if not shipping method is selected nor billing address is used for shipping
  - Error should use the same name than the input in the view
  - Order of errors should reflect the order of the input in the page


Maybe @RachL could take care of this test?


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
