### PR TITLE
Report deleted fees in Enterprise Fee Summary

### DIFF
--- a/lib/reporting/reports/enterprise_fee_summary/summarizer.rb
+++ b/lib/reporting/reports/enterprise_fee_summary/summarizer.rb
@@ -50,10 +50,6 @@ module Reporting
           data["shipping_method_name"].present?
         end
 
-        def for_enterprise_fee?
-          data["fee_name"].present?
-        end
-
         def for_coordinator_fee?
           data["placement_enterprise_role"] == "coordinator"
         end

--- a/lib/reporting/reports/enterprise_fee_summary/summarizer.rb
+++ b/lib/reporting/reports/enterprise_fee_summary/summarizer.rb
@@ -31,7 +31,7 @@ module Reporting
           return DataRepresentations::PaymentMethodFee if for_payment_method?
           return DataRepresentations::ShippingMethodFee if for_shipping_method?
 
-          enterprise_fee_adjustment_presentation_klass if for_enterprise_fee?
+          enterprise_fee_adjustment_presentation_klass
         end
 
         def enterprise_fee_adjustment_presentation_klass

--- a/spec/lib/reports/enterprise_fee_summary/summarizer_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/summarizer_spec.rb
@@ -32,8 +32,6 @@ describe Reporting::Reports::EnterpriseFeeSummary::Summarizer do
   end
 
   it "represents an enterprise fee without name" do
-    pending "Enterprise Fee Summary report fails #10395"
-
     data = row.merge(
       "fee_name" => nil,
       "placement_enterprise_role" => "coordinator",

--- a/spec/lib/reports/enterprise_fee_summary/summarizer_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/summarizer_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Reporting::Reports::EnterpriseFeeSummary::Summarizer do
+  let(:row) {
+    {
+      "total_amount" => 1, "payment_method_name" => nil,
+      "shipping_method_name" => nil, "hub_name" => "Kimchi Hub",
+      "enterprise_name" => nil, "fee_type" => nil,
+      "customer_name" => "Fermented Greens",
+      "customer_email" => "kimchi@example.com", "fee_name" => nil,
+      "tax_category_name" => nil,
+      "enterprise_fee_inherits_tax_category" => nil,
+      "product_tax_category_name" => nil,
+      "placement_enterprise_role" => nil,
+      "adjustment_adjustable_type" => nil,
+      "adjustment_source_distributor_name" => nil,
+      "incoming_exchange_enterprise_name" => nil,
+      "outgoing_exchange_enterprise_name" => nil,
+      "id" => nil
+    }
+  }
+
+  it "represents a transaction fee" do
+    data = row.merge(
+      "payment_method_name" => "cash",
+      "adjustment_adjustable_type" => "Spree::Payment",
+    )
+    summarizer = described_class.new(data)
+    expect(summarizer.fee_type).to eq "Payment Transaction"
+  end
+
+  it "represents an enterprise fee without name" do
+    pending "Enterprise Fee Summary report fails #10395"
+
+    data = row.merge(
+      "fee_name" => nil,
+      "placement_enterprise_role" => "coordinator",
+      "adjustment_adjustable_type" => "Spree::LineItem",
+    )
+    summarizer = described_class.new(data)
+    expect(summarizer.fee_type).to eq nil
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Part of #10395 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

When testing [background processing of reports](https://github.com/openfoodfoundation/openfoodnetwork/pull/10413), @drummer83 found several server errors. Some where due to the new background processing but one seemed to be a pre-existing bug.

The Enterprise Fee Summary report assumes that an SQL result row has a fee name when the adjustment came from an enterprise fee. This is true since we introduced [soft-deletion on enterprise fees](https://github.com/openfoodfoundation/openfoodnetwork/pull/6679). But fees deleted before January 2021 do not exist any more and we can't display their name, type or owner.

The old report didn't recognise adjustments from deleted enterprise fees and raised an error. I relaxed one condition in the fee type detection which means that no error is raised and they are displayed in the report with some empty fields.
![Screenshot from 2023-02-15 15-30-10](https://user-images.githubusercontent.com/3524483/218930827-078d05df-9f1a-4d10-b88a-8332917d67a5.png)


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Deactivate background report processing because it has another unrelated bug.
- Visit /admin/reports/enterprise_fee_summary on au-staging or uk-staging.
- Run the report without date restrictions.
- The report should display.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
