### PR TITLE
Remov i18nt keys from automated tests#9499

### DIFF
--- a/spec/controllers/admin/manager_invitations_controller_spec.rb
+++ b/spec/controllers/admin/manager_invitations_controller_spec.rb
@@ -23,7 +23,7 @@ module Admin
           spree_post :create, email: existing_user.email, enterprise_id: enterprise.id
 
           expect(response.status).to eq 422
-          expect(json_response['errors']).to eq I18n.t('admin.enterprises.invite_manager.user_already_exists')
+          expect(json_response['errors']).to eq 'User already exists'
         end
       end
 

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -341,7 +341,7 @@ module Admin
             spree_put :bulk_update, format: :json
           end.to change(oc, :orders_open_at).by(0)
           json_response = JSON.parse(response.body)
-          expect(json_response['errors']).to eq I18n.t('admin.order_cycles.bulk_update.no_data')
+          expect(json_response['errors']).to eq 'Hm, something went wrong. No order cycle data found.'
         end
 
         context "when a validation error occurs" do
@@ -425,7 +425,7 @@ module Admin
         it "displays an error message when we attempt to delete it" do
           get :destroy, params: { id: oc.id }
           expect(response).to redirect_to admin_order_cycles_path
-          expect(flash[:error]).to eq I18n.t('admin.order_cycles.destroy_errors.orders_present')
+          expect(flash[:error]).to eq 'That order cycle has been selected by a customer and cannot be deleted. To prevent customers from accessing it, please close it instead.'
         end
       end
 
@@ -435,7 +435,7 @@ module Admin
         it "displays an error message when we attempt to delete it" do
           get :destroy, params: { id: oc.id }
           expect(response).to redirect_to admin_order_cycles_path
-          expect(flash[:error]).to eq I18n.t('admin.order_cycles.destroy_errors.schedule_present')
+          expect(flash[:error]).to eq 'That order cycle is linked to a schedule and cannot be deleted. Please unlink or delete the schedule first.'
         end
       end
 

--- a/spec/controllers/admin/schedules_controller_spec.rb
+++ b/spec/controllers/admin/schedules_controller_spec.rb
@@ -255,7 +255,7 @@ describe Admin::SchedulesController, type: :controller do
             it "returns an error message and prevents me from deleting the schedule" do
               expect { spree_delete :destroy, params }.to_not change(Schedule, :count)
               json_response = JSON.parse(response.body)
-              expect(json_response["errors"]).to include I18n.t('admin.schedules.destroy.associated_subscriptions_error')
+              expect(json_response["errors"]).to include 'This schedule cannot be deleted because it has associated subscriptions'
             end
           end
         end

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -463,7 +463,7 @@ describe Admin::SubscriptionsController, type: :controller do
                 spree_put :cancel, params
                 expect(response.status).to be 409
                 json_response = JSON.parse(response.body)
-                expect(json_response['errors']['open_orders']).to eq I18n.t('admin.subscriptions.confirm_cancel_open_orders_msg')
+                expect(json_response['errors']['open_orders']).to eq 'Some orders for this subscription are currently open. The customer has already been notified that the order will be placed. Would you like to cancel these order(s) or keep them?'
               end
             end
 
@@ -564,7 +564,7 @@ describe Admin::SubscriptionsController, type: :controller do
                 spree_put :pause, params
                 expect(response.status).to be 409
                 json_response = JSON.parse(response.body)
-                expect(json_response['errors']['open_orders']).to eq I18n.t('admin.subscriptions.confirm_cancel_open_orders_msg')
+                expect(json_response['errors']['open_orders']).to eq 'Some orders for this subscription are currently open. The customer has already been notified that the order will be placed. Would you like to cancel these order(s) or keep them?'
               end
             end
 
@@ -685,7 +685,7 @@ describe Admin::SubscriptionsController, type: :controller do
                   spree_put :unpause, params
                   expect(response.status).to be 409
                   json_response = JSON.parse(response.body)
-                  expect(json_response['errors']['canceled_orders']).to eq I18n.t('admin.subscriptions.resume_canceled_orders_msg')
+                  expect(json_response['errors']['canceled_orders']).to eq 'Some orders for this subscription can be resumed right now. You can resume them from the orders dropdown.'
                 end
               end
 

--- a/spec/controllers/admin/terms_of_service_files_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service_files_controller_spec.rb
@@ -32,7 +32,7 @@ describe Admin::TermsOfServiceFilesController, type: :controller do
       it "redirects and show an error" do
         post :create, params: {}
         expect(response).to redirect_to admin_terms_of_service_files_path
-        expect(flash[:error]).to eq I18n.t(".admin.terms_of_service_files.create.select_file")
+        expect(flash[:error]).to eq 'Please select a file first.'
       end
     end
 

--- a/spec/controllers/api/v0/logos_controller_spec.rb
+++ b/spec/controllers/api/v0/logos_controller_spec.rb
@@ -45,7 +45,7 @@ module Api
             spree_delete :destroy, enterprise_id: enterprise
 
             expect(response.status).to eq(409)
-            expect(json_response["error"]).to eq I18n.t("api.enterprise_logo.destroy_attachment_does_not_exist")
+            expect(json_response['error']).to eq 'Logo does not exist'
           end
         end
       end

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -307,7 +307,7 @@ module Api
           it "returns an error" do
             put :capture, params: { id: order.number }
 
-            expect(json_response['error']).to eq I18n.t(:payment_processing_failed)
+            expect(json_response['error']).to eq 'Payment could not be processed, please check the details you entered'
           end
         end
       end

--- a/spec/controllers/api/v0/promo_images_controller_spec.rb
+++ b/spec/controllers/api/v0/promo_images_controller_spec.rb
@@ -45,7 +45,7 @@ module Api
             spree_delete :destroy, enterprise_id: enterprise
 
             expect(response.status).to eq(409)
-            expect(json_response["error"]).to eq I18n.t("api.enterprise_promo_image.destroy_attachment_does_not_exist")
+            expect(json_response['error']).to eq 'Promo image does not exist'
           end
         end
       end

--- a/spec/controllers/api/v0/reports/packing_report_spec.rb
+++ b/spec/controllers/api/v0/reports/packing_report_spec.rb
@@ -80,10 +80,10 @@ describe Api::V0::ReportsController, type: :controller do
   def supplier_report_row(line_item)
     {
       "hub" => line_item.order.distributor.name,
-      "customer_code" => I18n.t("hidden_field", scope: i18n_scope),
-      "first_name" => I18n.t("hidden_field", scope: i18n_scope),
-      "last_name" => I18n.t("hidden_field", scope: i18n_scope),
-      "phone" => I18n.t("hidden_field", scope: i18n_scope),
+      'customer_code' => '< Hidden >',
+      'first_name' => '< Hidden >',
+      'last_name' => '< Hidden >',
+      'phone' => '< Hidden >',
       "supplier" => line_item.product.supplier.name,
       "product" => line_item.product.name,
       "variant" => line_item.full_name,
@@ -108,9 +108,5 @@ describe Api::V0::ReportsController, type: :controller do
       "last_name" => bill_address.lastname,
       "phone" => bill_address.phone,
     }
-  end
-
-  def i18n_scope
-    "admin.reports"
   end
 end

--- a/spec/controllers/api/v0/reports_controller_spec.rb
+++ b/spec/controllers/api/v0/reports_controller_spec.rb
@@ -43,7 +43,7 @@ describe Api::V0::ReportsController, type: :controller do
         api_get :show, q: { example: 'test' }
 
         expect(response.status).to eq 422
-        expect(json_response["error"]).to eq I18n.t('errors.no_report_type', scope: i18n_scope)
+        expect(json_response["error"]).to eq 'Please specify a report type'
       end
     end
 
@@ -54,7 +54,7 @@ describe Api::V0::ReportsController, type: :controller do
         api_get :show, report_type: "xxxxxx", q: { example: 'test' }
 
         expect(response.status).to eq 422
-        expect(json_response["error"]).to eq I18n.t('errors.report_not_found', scope: i18n_scope)
+        expect(json_response["error"]).to eq 'Report not found'
       end
     end
 
@@ -64,16 +64,8 @@ describe Api::V0::ReportsController, type: :controller do
       it "returns an error" do
         api_get :show, report_type: "packing"
         expect(response.status).to eq 422
-        expect(json_response["error"]).to eq(
-          I18n.t('errors.missing_ransack_params', scope: i18n_scope)
-        )
+        expect(json_response["error"]).to eq('Please supply Ransack search params in the request')
       end
     end
-  end
-
-  private
-
-  def i18n_scope
-    "admin.reports"
   end
 end

--- a/spec/controllers/api/v0/terms_and_conditions_controller_spec.rb
+++ b/spec/controllers/api/v0/terms_and_conditions_controller_spec.rb
@@ -46,7 +46,7 @@ module Api
             spree_delete :destroy, enterprise_id: enterprise
 
             expect(response.status).to eq(409)
-            expect(json_response["error"]).to eq I18n.t("api.enterprise_terms_and_conditions.destroy_attachment_does_not_exist")
+            expect(json_response['error']).to eq 'Terms and Conditions file does not exist'
           end
         end
       end

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -36,7 +36,7 @@ describe CheckoutController, type: :controller do
     get :edit
 
     expect(response).to redirect_to shop_url
-    expect(flash[:info]).to eq I18n.t('order_cycle_closed')
+    expect(flash[:info]).to eq 'The order cycle you\'ve selected has just closed. Please try again!'
   end
 
   it "redirects home with message if hub is not ready for checkout" do
@@ -50,7 +50,7 @@ describe CheckoutController, type: :controller do
     get :edit
 
     expect(response).to redirect_to root_url
-    expect(flash[:info]).to eq(I18n.t('order_cycles_closed_for_hub'))
+    expect(flash[:info]).to eq('The hub you have selected is temporarily closed for orders. Please try again later.')
   end
 
   describe "#update" do
@@ -257,7 +257,7 @@ describe CheckoutController, type: :controller do
       spree_post :update, format: :json, order: {}
       expect(response.status).to eq(400)
       expect(response.body).to eq({ errors: {},
-                                    flash: { error: I18n.t("checkout.failed") } }.to_json)
+                                    flash: { error: 'The checkout failed. Please let us know so that we can process your order.' } }.to_json)
     end
 
     it "returns a specific error on Spree::Core::GatewayError" do
@@ -265,7 +265,7 @@ describe CheckoutController, type: :controller do
       spree_post :update, format: :json, order: {}
 
       expect(response.status).to eq(400)
-      flash_message = I18n.t(:spree_gateway_error_flash_for_checkout, error: "Gateway blow up")
+      flash_message = "There was a problem with your payment information: %s" % 'Gateway blow up'
       expect(json_response["flash"]["error"]).to eq flash_message
     end
 

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -185,7 +185,7 @@ describe EnterprisesController, type: :controller do
     end
 
     it "shows a flash message with the error" do
-      expect(request.flash[:error]).to eq(I18n.t(:enterprise_shop_show_error))
+      expect(request.flash[:error]).to eq('The shop you are looking for doesn\'t exist or is inactive on OFN. Please check other shops.')
     end
   end
 end

--- a/spec/controllers/payment_gateways/paypal_controller_spec.rb
+++ b/spec/controllers/payment_gateways/paypal_controller_spec.rb
@@ -55,7 +55,9 @@ module PaymentGateways
           expect(post(:confirm, params: { payment_method_id: payment_method.id })).
             to redirect_to checkout_path
 
-          expect(flash[:error]).to eq I18n.t(:payment_processing_failed)
+          expect(flash[:error]).to eq(
+            'Payment could not be processed, please check the details you entered'
+          )
         end
       end
     end

--- a/spec/controllers/payment_gateways/stripe_controller_spec.rb
+++ b/spec/controllers/payment_gateways/stripe_controller_spec.rb
@@ -55,7 +55,7 @@ module PaymentGateways
 
             expect(order.completed?).to be true
             expect(response).to redirect_to order_path(order, order_token: order.token)
-            expect(flash[:notice]).to eq I18n.t(:order_processed_successfully)
+            expect(flash[:notice]).to eq 'Your order has been processed successfully'
           end
         end
 
@@ -82,7 +82,8 @@ module PaymentGateways
             get :confirm, params: { payment_intent: "pi_123" }
 
             expect(response).to redirect_to shop_url
-            expect(flash[:info]).to eq I18n.t('order_cycle_closed')
+            expect(flash[:info]).to eq "The order cycle you've selected has just closed. \
+Please try again!"
           end
         end
 
@@ -107,7 +108,8 @@ module PaymentGateways
 
           expect(order.completed?).to be false
           expect(response).to redirect_to checkout_path
-          expect(flash[:error]).to eq I18n.t(:payment_processing_failed)
+          expect(flash[:error]).to eq "Payment could not be processed, \
+please check the details you entered"
         end
       end
 
@@ -119,7 +121,8 @@ module PaymentGateways
 
           expect(order.completed?).to be false
           expect(response).to redirect_to checkout_path
-          expect(flash[:error]).to eq I18n.t(:payment_processing_failed)
+          expect(flash[:error]).to eq "Payment could not be processed, \
+please check the details you entered"
         end
       end
 
@@ -136,7 +139,8 @@ module PaymentGateways
 
           expect(order.completed?).to be false
           expect(response).to redirect_to checkout_path
-          expect(flash[:error]).to eq I18n.t(:payment_processing_failed)
+          expect(flash[:error]).to eq "Payment could not be processed, \
+please check the details you entered"
         end
       end
 
@@ -171,7 +175,8 @@ module PaymentGateways
             get :confirm, params: { payment_intent: "pi_123" }
 
             expect(response).to redirect_to cart_path
-            expect(flash[:notice]).to eq I18n.t('checkout.payment_cancelled_due_to_stock')
+            expect(flash[:notice]).to eq "Payment cancelled: the checkout could not be \
+completed due to stock issues."
 
             expect(order.state).to eq "cart"
             expect(payment.state).to eq "void"
@@ -280,7 +285,7 @@ module PaymentGateways
             get :authorize, params: { order_number: order.number, payment_intent: payment_intent }
 
             expect(response).to redirect_to order_path(order)
-            expect(flash[:error]).to eq("#{I18n.t('payment_could_not_process')}. error message")
+            expect(flash[:error]).to eq("The payment could not be processed. error message")
             payment.reload
             expect(payment.cvv_response_message).to be nil
             expect(payment.state).to eq("failed")
@@ -303,7 +308,7 @@ module PaymentGateways
             get :authorize, params: { order_number: order.number, payment_intent: payment_intent }
 
             expect(response).to redirect_to order_path(order)
-            expect(flash[:error]).to eq("#{I18n.t('payment_could_not_process')}. ")
+            expect(flash[:error]).to eq("The payment could not be processed. ")
             payment.reload
             expect(payment.cvv_response_message).to eq("https://stripe.com/redirect")
             expect(payment.state).to eq("requires_authorization")

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -85,7 +85,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
           it "redirects to new payment page with flash error" do
             spree_post :create, payment: params, order_id: order.number
 
-            redirects_to_new_payment_page_with_flash_error(I18n.t('action_required'))
+            redirects_to_new_payment_page_with_flash_error('Action required')
           end
         end
 
@@ -186,7 +186,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
         spree_put :fire, params
 
-        expect(flash[:success]).to eq(I18n.t(:payment_updated))
+        expect(flash[:success]).to eq('Payment Updated')
       end
     end
 
@@ -222,7 +222,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
         spree_put :fire, params
 
-        expect(flash[:success]).to eq(I18n.t(:payment_updated))
+        expect(flash[:success]).to eq('Payment Updated')
       end
     end
 
@@ -241,7 +241,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
       it "resends the authorization email" do
         spree_put :fire, params
 
-        expect(flash[:success]).to eq(I18n.t(:payment_updated))
+        expect(flash[:success]).to eq('Payment Updated')
         expect(PaymentMailer).to have_received(:authorize_payment)
         expect(mail_mock).to have_received(:deliver_later)
       end
@@ -259,7 +259,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
         spree_put :fire, params
 
         expect(payment).to_not receive(:unrecognized_event)
-        expect(flash[:error]).to eq(I18n.t(:cannot_perform_operation))
+        expect(flash[:error]).to eq('Could not update the payment')
       end
     end
   end

--- a/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -206,7 +206,7 @@ module Spree
                 it "does not save the payment method" do
                   spree_put :update, params
                   expect(response).to render_template :edit
-                  expect(assigns(:payment_method).errors.messages[:stripe_account_owner]).to include I18n.t(:error_required)
+                  expect(assigns(:payment_method).errors.messages[:stripe_account_owner]).to include 'can\'t be blank'
                 end
               end
 
@@ -216,7 +216,7 @@ module Spree
                 it "does not save the payment method" do
                   spree_put :update, params
                   expect(response).to render_template :edit
-                  expect(assigns(:payment_method).errors.messages[:stripe_account_owner]).to include I18n.t(:error_required)
+                  expect(assigns(:payment_method).errors.messages[:stripe_account_owner]).to include 'can\'t be blank'
                 end
               end
             end

--- a/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
@@ -41,7 +41,8 @@ describe Spree::Admin::ShippingMethodsController, type: :controller do
 
         spree_post :update, params
 
-        expect(flash[:error]).to match I18n.t(:calculator_preferred_value_error)
+        expect(flash[:error]).to match "Invalid input. \
+Please use only numbers. For example: 10, 5.5, -20"
         expect(response).to redirect_to spree.edit_admin_shipping_method_path(shipping_method)
       end
     end

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -97,7 +97,7 @@ describe Spree::CreditCardsController, type: :controller do
           expect{ spree_post :new_from_token, params }.to_not change(Spree::CreditCard, :count)
 
           json_response = JSON.parse(response.body)
-          flash_message = I18n.t(:spree_gateway_error_flash_for_checkout, error: "Bup-bow...")
+          flash_message = "There was a problem with your payment information: %s" % 'Bup-bow...'
           expect(json_response["flash"]["error"]).to eq flash_message
         end
       end
@@ -111,7 +111,7 @@ describe Spree::CreditCardsController, type: :controller do
         it "renders a flash error" do
           spree_put :update, params
           json_response = JSON.parse(response.body)
-          expect(json_response['flash']['error']).to eq I18n.t(:card_could_not_be_updated)
+          expect(json_response['flash']['error']).to eq 'Card could not be updated'
         end
       end
 
@@ -143,7 +143,7 @@ describe Spree::CreditCardsController, type: :controller do
             it "renders an error" do
               spree_put :update, params
               json_response = JSON.parse(response.body)
-              expect(json_response['flash']['error']).to eq I18n.t(:card_could_not_be_updated)
+              expect(json_response['flash']['error']).to eq 'Card could not be updated'
             end
           end
 
@@ -174,7 +174,7 @@ describe Spree::CreditCardsController, type: :controller do
         it "redirects to /account with a flash error, does not request deletion with Stripe" do
           expect(controller).to_not receive(:destroy_at_stripe)
           spree_delete :destroy, params
-          expect(flash[:error]).to eq I18n.t(:card_could_not_be_removed)
+          expect(flash[:error]).to eq 'Sorry, the card could not be removed'
           expect(response.status).to eq 200
         end
       end
@@ -206,7 +206,7 @@ describe Spree::CreditCardsController, type: :controller do
 
             it "doesn't delete the card" do
               expect{ spree_delete :destroy, params }.to_not change(Spree::CreditCard, :count)
-              expect(flash[:error]).to eq I18n.t(:card_could_not_be_removed)
+              expect(flash[:error]).to eq 'Sorry, the card could not be removed'
               expect(response.status).to eq 422
             end
           end
@@ -219,8 +219,7 @@ describe Spree::CreditCardsController, type: :controller do
 
             it "deletes the card and redirects to account_path" do
               expect{ spree_delete :destroy, params }.to change(Spree::CreditCard, :count).by(-1)
-              expect(flash[:success]).to eq I18n.t(:card_has_been_removed,
-                                                   number: "x-#{card.last_digits}")
+              expect(flash[:success]).to eq "Your card has been removed (number: %s)" % "x-#{card.last_digits}"
               expect(response.status).to eq 200
             end
 

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -122,7 +122,7 @@ describe Spree::OrdersController, type: :controller do
       get :edit
 
       expect(response).to redirect_to root_url
-      expect(flash[:info]).to eq(I18n.t('order_cycles_closed_for_hub'))
+      expect(flash[:info]).to eq('The hub you have selected is temporarily closed for orders. Please try again later.')
     end
 
     describe "when an item is in the cart" do
@@ -161,7 +161,7 @@ describe Spree::OrdersController, type: :controller do
         it "displays a flash message when we view the cart" do
           get :edit
           expect(response.status).to eq 200
-          expect(flash[:error]).to eq I18n.t('spree.orders.error_flash_for_unavailable_items')
+          expect(flash[:error]).to eq 'An item in your cart has become unavailable. Please update the selected quantities.'
         end
       end
 
@@ -173,7 +173,7 @@ describe Spree::OrdersController, type: :controller do
         it "displays a flash message when we view the cart" do
           get :edit
           expect(response.status).to eq 200
-          expect(flash[:error]).to eq I18n.t('spree.orders.error_flash_for_unavailable_items')
+          expect(flash[:error]).to eq 'An item in your cart has become unavailable. Please update the selected quantities.'
         end
       end
     end
@@ -359,7 +359,7 @@ describe Spree::OrdersController, type: :controller do
 
       it "does not remove items, flash suggests cancellation" do
         spree_post :update, params
-        expect(flash[:error]).to eq I18n.t(:orders_cannot_remove_the_final_item)
+        expect(flash[:error]).to eq 'Cannot remove the final item from an order, please cancel the order instead.'
         expect(response).to redirect_to order_path(order)
         expect(order.reload.line_items.count).to eq 2
       end
@@ -460,7 +460,7 @@ describe Spree::OrdersController, type: :controller do
 
           expect(response).to have_http_status(:found)
           expect(response.body).to match(order_path(order)).and match("redirect")
-          expect(flash[:error]).to eq I18n.t(:orders_could_not_cancel)
+          expect(flash[:error]).to eq 'Sorry, the order could not be cancelled'
         end
       end
 
@@ -479,7 +479,7 @@ describe Spree::OrdersController, type: :controller do
 
           expect(response).to have_http_status(:found)
           expect(response.body).to match(order_path(order)).and match("redirect")
-          expect(flash[:success]).to eq I18n.t(:orders_your_order_has_been_cancelled)
+          expect(flash[:success]).to eq 'Your order has been cancelled'
         end
       end
     end

--- a/spec/controllers/stripe/callbacks_controller_spec.rb
+++ b/spec/controllers/stripe/callbacks_controller_spec.rb
@@ -45,7 +45,7 @@ describe Stripe::CallbacksController, type: :controller do
         it "renders a failure message" do
           allow(connector).to receive(:enterprise) { enterprise }
           spree_get :index, params
-          expect(flash[:notice]).to eq I18n.t('admin.controllers.enterprises.stripe_connect_cancelled')
+          expect(flash[:notice]).to eq 'Connection to Stripe has been cancelled'
           expect(response).to redirect_to edit_admin_enterprise_path(enterprise,
                                                                      anchor: 'payment_methods')
         end
@@ -57,7 +57,7 @@ describe Stripe::CallbacksController, type: :controller do
         it "renders a failure message" do
           allow(connector).to receive(:enterprise) { enterprise }
           spree_get :index, params
-          expect(flash[:error]).to eq I18n.t('admin.controllers.enterprises.stripe_connect_fail')
+          expect(flash[:error]).to eq 'Sorry, the connection of your Stripe account failed'
           expect(response).to redirect_to edit_admin_enterprise_path(enterprise,
                                                                      anchor: 'payment_methods')
         end
@@ -70,7 +70,7 @@ describe Stripe::CallbacksController, type: :controller do
       it "redirects to the enterprise edit path" do
         allow(connector).to receive(:enterprise) { enterprise }
         spree_get :index, params
-        expect(flash[:success]).to eq I18n.t('admin.controllers.enterprises.stripe_connect_success')
+        expect(flash[:success]).to eq 'Stripe account connected successfully'
         expect(response).to redirect_to edit_admin_enterprise_path(enterprise,
                                                                    anchor: 'payment_methods')
       end

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -67,7 +67,7 @@ describe UserConfirmationsController, type: :controller do
     it "redirects the user to login" do
       spree_post :create, spree_user: { email: unconfirmed_user.email }
       expect(response).to redirect_to login_path
-      expect(flash[:success]).to eq I18n.t('devise.user_confirmations.spree_user.confirmation_sent')
+      expect(flash[:success]).to eq 'Email confirmation sent'
     end
 
     it "sends the confirmation email" do

--- a/spec/controllers/user_passwords_controller_spec.rb
+++ b/spec/controllers/user_passwords_controller_spec.rb
@@ -16,19 +16,21 @@ describe UserPasswordsController, type: :controller do
     it "returns 404 if user is not found" do
       spree_post :create, spree_user: { email: "xxxxxxxxxx@example.com" }
       expect(response.status).to eq 404
-      expect(response.body).to match I18n.t(:email_not_found)
+      expect(response.body).to match 'Email address not found'
     end
 
     it "returns 422 if user is registered but not confirmed" do
       spree_post :create, spree_user: { email: unconfirmed_user.email }
       expect(response.status).to eq 422
-      expect(response.body).to match I18n.t(:email_unconfirmed)
+      expect(response.body).to match "You must confirm your email \
+address before you can reset your password."
     end
 
     it "returns 200 when password reset was successful" do
       spree_post :create, spree_user: { email: user.email }
       expect(response.status).to eq 200
-      expect(response.body).to match I18n.t(:password_reset_sent)
+      expect(response.body).to match "An email with instructions on resetting \
+your password has been sent!"
     end
   end
 

--- a/spec/controllers/user_registrations_controller_spec.rb
+++ b/spec/controllers/user_registrations_controller_spec.rb
@@ -39,7 +39,10 @@ describe UserRegistrationsController, type: :controller do
 
       expect(response.status).to eq(401)
       json = JSON.parse(response.body)
-      expect(json).to eq("message" => I18n.t('devise.user_registrations.spree_user.unknown_error'))
+      expect(json).to eq(
+        "message" =>
+        'Something went wrong while creating your account. Check your email address and try again.'
+      )
     end
 
     it "returns 200 when registration succeeds" do

--- a/spec/lib/reports/line_items_spec.rb
+++ b/spec/lib/reports/line_items_spec.rb
@@ -49,7 +49,7 @@ describe Reporting::LineItems do
 
     it 'returns masked data' do
       line_items = reports_line_items.list
-      expect(line_items.first.order.email).to eq(I18n.t('admin.reports.hidden'))
+      expect(line_items.first.order.email).to eq('HIDDEN')
     end
   end
 end

--- a/spec/lib/reports/packing/packing_report_spec.rb
+++ b/spec/lib/reports/packing/packing_report_spec.rb
@@ -84,7 +84,7 @@ describe "Packing Reports" do
         it "shows line items supplied by my producers, with names hidden" do
           expect(report_contents).to include line_item2.product.name
           expect(report_data.first["first_name"]).to eq(
-            I18n.t('admin.reports.hidden_field')
+            '< Hidden >'
           )
         end
 

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -11,7 +11,7 @@ describe Spree::OrderMailer do
     let(:order) { build(:order_with_totals_and_distribution) }
 
     it 'renders the shared/_payment.html.haml partial' do
-      expect(email.body).to include(I18n.t(:email_payment_summary))
+      expect(email.body).to include('Payment summary')
     end
 
     context 'when the order has outstanding balance' do
@@ -26,7 +26,7 @@ describe Spree::OrderMailer do
       before { allow(order).to receive(:new_outstanding_balance) { 0 } }
 
       it 'displays the payment status' do
-        expect(email.body).to include(I18n.t(:email_payment_not_paid))
+        expect(email.body).to include('NOT PAID')
       end
     end
 
@@ -54,7 +54,7 @@ describe Spree::OrderMailer do
     let(:order) { build(:order_with_totals_and_distribution) }
 
     it 'renders the shared/_payment.html.haml partial' do
-      expect(email.body).to include(I18n.t(:email_payment_summary))
+      expect(email.body).to include('Payment summary')
     end
 
     context 'when the order has outstanding balance' do
@@ -67,7 +67,7 @@ describe Spree::OrderMailer do
 
     context 'when the order has no outstanding balance' do
       it 'displays the payment status' do
-        expect(email.body).to include(I18n.t(:email_payment_not_paid))
+        expect(email.body).to include('NOT PAID')
       end
     end
   end

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -99,7 +99,7 @@ describe SubscriptionMailer, type: :mailer do
       before { allow(order).to receive(:new_outstanding_balance) { 0 } }
 
       it 'displays the payment status' do
-        expect(email.body).to include(I18n.t(:email_payment_not_paid))
+        expect(email.body).to include('NOT PAID')
       end
     end
   end
@@ -152,7 +152,7 @@ describe SubscriptionMailer, type: :mailer do
       before { allow(order).to receive(:new_outstanding_balance) { 0 } }
 
       it 'displays the payment status' do
-        expect(email.body).to include(I18n.t(:email_payment_not_paid))
+        expect(email.body).to include('NOT PAID')
       end
     end
   end
@@ -191,11 +191,13 @@ describe SubscriptionMailer, type: :mailer do
 
     it "sends the email" do
       body = strip_tags(SubscriptionMailer.deliveries.last.body.encoded)
-      expect(body).to include I18n.t("email_so_failed_payment_intro_html")
-      explainer = I18n.t("email_so_failed_payment_explainer_html",
-                         distributor: subscription.shop.name)
+      expect(body).to include 'We tried to process a payment, but had some problems...'
+      email_so_failed_payment_explainer_html = "The payment for your subscription with <strong>%s</strong> \
+failed because of a problem with your credit card. <strong>%s</strong> has been notified \
+of this failed payment."
+      explainer = email_so_failed_payment_explainer_html % ([subscription.shop.name] * 2)
       expect(body).to include strip_tags(explainer)
-      details = I18n.t("email_so_failed_payment_details_html", distributor: subscription.shop.name)
+      details = 'Here are the details of the failure provided by the payment gateway:'
       expect(body).to include strip_tags(details)
       expect(body).to include "This is a payment failure error"
     end
@@ -245,10 +247,10 @@ describe SubscriptionMailer, type: :mailer do
       it "sends the email, which notifies the enterprise that all orders were successfully processed" do
         SubscriptionMailer.placement_summary_email(summary).deliver_now
 
-        expect(body).to include I18n.t("#{scope}.placement_summary_email.intro", shop: shop.name)
-        expect(body).to include I18n.t("#{scope}.summary_overview.total", count: 37)
-        expect(body).to include I18n.t("#{scope}.summary_overview.success_all")
-        expect(body).to_not include I18n.t("#{scope}.summary_overview.issues")
+        expect(body).to include("Below is a summary of the subscription orders that have just been placed for %s." % shop.name)
+        expect(body).to include("A total of %d subscriptions were marked for automatic processing." % 37)
+        expect(body).to include 'All were processed successfully.'
+        expect(body).to_not include 'Details of the issues encountered are provided below.'
       end
 
       it "renders the shop's logo" do
@@ -274,12 +276,12 @@ describe SubscriptionMailer, type: :mailer do
       context "when no unrecorded issues are present" do
         it "sends the email, which notifies the enterprise that some issues were encountered" do
           SubscriptionMailer.placement_summary_email(summary).deliver_now
-          expect(body).to include I18n.t("#{scope}.placement_summary_email.intro", shop: shop.name)
-          expect(body).to include I18n.t("#{scope}.summary_overview.total", count: 37)
-          expect(body).to include I18n.t("#{scope}.summary_overview.success_some", count: 35)
-          expect(body).to include I18n.t("#{scope}.summary_overview.issues")
-          expect(body).to include I18n.t("#{scope}.summary_detail.processing.title", count: 2)
-          expect(body).to include I18n.t("#{scope}.summary_detail.processing.explainer")
+          expect(body).to include("Below is a summary of the subscription orders that have just been placed for %s." % shop.name)
+          expect(body).to include("A total of %d subscriptions were marked for automatic processing." % 37)
+          expect(body).to include('Of these, %d were processed successfully.' % 35)
+          expect(body).to include 'Details of the issues encountered are provided below.'
+          expect(body).to include('Error Encountered (%d orders)' % 2)
+          expect(body).to include 'Automatic processing of these orders failed due to an error. The error has been listed where possible.'
 
           # Lists orders for which an error was encountered
           expect(body).to include order1.number
@@ -287,7 +289,7 @@ describe SubscriptionMailer, type: :mailer do
 
           # Reports error messages provided by the summary, or default if none provided
           expect(body).to include "Some Error Message"
-          expect(body).to include I18n.t("#{scope}.summary_detail.no_message_provided")
+          expect(body).to include 'No error message provided'
         end
       end
 
@@ -302,10 +304,10 @@ describe SubscriptionMailer, type: :mailer do
         it "sends the email, which notifies the enterprise that some issues were encountered" do
           expect(summary).to receive(:orders_affected_by).with(:other) { [order3, order4] }
           SubscriptionMailer.placement_summary_email(summary).deliver_now
-          expect(body).to include I18n.t("#{scope}.summary_detail.processing.title", count: 2)
-          expect(body).to include I18n.t("#{scope}.summary_detail.processing.explainer")
-          expect(body).to include I18n.t("#{scope}.summary_detail.other.title", count: 2)
-          expect(body).to include I18n.t("#{scope}.summary_detail.other.explainer")
+          expect(body).to include("Error Encountered (%d orders)" % 2)
+          expect(body).to include 'Automatic processing of these orders failed due to an error. The error has been listed where possible.'
+          expect(body).to include("Other Failure (%d orders)" % 2)
+          expect(body).to include 'Automatic processing of these orders failed for an unknown reason. This should not occur, please contact us if you are seeing this.'
 
           # Lists orders for which no error or success was recorded
           expect(body).to include order3.number
@@ -328,19 +330,19 @@ describe SubscriptionMailer, type: :mailer do
       end
 
       it "sends the email, which notifies the enterprise that some issues were encountered" do
-        expect(body).to include I18n.t("#{scope}.placement_summary_email.intro", shop: shop.name)
-        expect(body).to include I18n.t("#{scope}.summary_overview.total", count: 2)
-        expect(body).to include I18n.t("#{scope}.summary_overview.success_zero")
-        expect(body).to include I18n.t("#{scope}.summary_overview.issues")
-        expect(body).to include I18n.t("#{scope}.summary_detail.changes.title", count: 2)
-        expect(body).to include I18n.t("#{scope}.summary_detail.changes.explainer")
+        expect(body).to include("Below is a summary of the subscription orders that have just been placed for %s" % shop.name)
+        expect(body).to include("A total of %d subscriptions were marked for automatic processing." % 2)
+        expect(body).to include 'Of these, none were processed successfully.'
+        expect(body).to include 'Details of the issues encountered are provided below.'
+        expect(body).to include("Insufficient Stock (%d orders)" % 2)
+        expect(body).to include 'These orders were processed but insufficient stock was available for some requested items'
 
         # Lists orders for which an error was encountered
         expect(body).to include order1.number
         expect(body).to include order2.number
 
         # No error messages reported when non provided
-        expect(body).to_not include I18n.t("#{scope}.summary_detail.no_message_provided")
+        expect(body).to_not include 'No error message provided'
       end
     end
   end
@@ -365,10 +367,10 @@ describe SubscriptionMailer, type: :mailer do
       end
 
       it "sends the email, which notifies the enterprise that all orders were successfully processed" do
-        expect(body).to include I18n.t("#{scope}.confirmation_summary_email.intro", shop: shop.name)
-        expect(body).to include I18n.t("#{scope}.summary_overview.total", count: 37)
-        expect(body).to include I18n.t("#{scope}.summary_overview.success_all")
-        expect(body).to_not include I18n.t("#{scope}.summary_overview.issues")
+        expect(body).to include("Below is a summary of the subscription orders that have just been finalised for %s." % shop.name)
+        expect(body).to include("A total of %d subscriptions were marked for automatic processing." % 37)
+        expect(body).to include 'All were processed successfully.'
+        expect(body).to_not include 'Details of the issues encountered are provided below.'
       end
     end
 
@@ -389,13 +391,12 @@ describe SubscriptionMailer, type: :mailer do
       context "when no unrecorded issues are present" do
         it "sends the email, which notifies the enterprise that some issues were encountered" do
           SubscriptionMailer.confirmation_summary_email(summary).deliver_now
-          expect(body).to include I18n.t("#{scope}.confirmation_summary_email.intro",
-                                         shop: shop.name)
-          expect(body).to include I18n.t("#{scope}.summary_overview.total", count: 37)
-          expect(body).to include I18n.t("#{scope}.summary_overview.success_some", count: 35)
-          expect(body).to include I18n.t("#{scope}.summary_overview.issues")
-          expect(body).to include I18n.t("#{scope}.summary_detail.failed_payment.title", count: 2)
-          expect(body).to include I18n.t("#{scope}.summary_detail.failed_payment.explainer")
+          expect(body).to include("Below is a summary of the subscription orders that have just been finalised for %s." % shop.name)
+          expect(body).to include("A total of %d subscriptions were marked for automatic processing." % 37)
+          expect(body).to include("Of these, %d were processed successfully." % 35)
+          expect(body).to include 'Details of the issues encountered are provided below.'
+          expect(body).to include("Failed Payment (%d orders)" % 2)
+          expect(body).to include 'Automatic processing of payment for these orders failed due to an error. The error has been listed where possible.'
 
           # Lists orders for which an error was encountered
           expect(body).to include order1.number
@@ -403,7 +404,7 @@ describe SubscriptionMailer, type: :mailer do
 
           # Reports error messages provided by the summary, or default if none provided
           expect(body).to include "Some Error Message"
-          expect(body).to include I18n.t("#{scope}.summary_detail.no_message_provided")
+          expect(body).to include 'No error message provided'
         end
       end
 
@@ -418,10 +419,10 @@ describe SubscriptionMailer, type: :mailer do
         it "sends the email, which notifies the enterprise that some issues were encountered" do
           expect(summary).to receive(:orders_affected_by).with(:other) { [order3, order4] }
           SubscriptionMailer.confirmation_summary_email(summary).deliver_now
-          expect(body).to include I18n.t("#{scope}.summary_detail.failed_payment.title", count: 2)
-          expect(body).to include I18n.t("#{scope}.summary_detail.failed_payment.explainer")
-          expect(body).to include I18n.t("#{scope}.summary_detail.other.title", count: 2)
-          expect(body).to include I18n.t("#{scope}.summary_detail.other.explainer")
+          expect(body).to include("Failed Payment (%d orders)" % 2)
+          expect(body).to include 'Automatic processing of payment for these orders failed due to an error. The error has been listed where possible.'
+          expect(body).to include("Other Failure (%d orders)" % 2)
+          expect(body).to include 'Automatic processing of these orders failed for an unknown reason. This should not occur, please contact us if you are seeing this.'
 
           # Lists orders for which no error or success was recorded
           expect(body).to include order3.number
@@ -444,19 +445,19 @@ describe SubscriptionMailer, type: :mailer do
       end
 
       it "sends the email, which notifies the enterprise that some issues were encountered" do
-        expect(body).to include I18n.t("#{scope}.confirmation_summary_email.intro", shop: shop.name)
-        expect(body).to include I18n.t("#{scope}.summary_overview.total", count: 2)
-        expect(body).to include I18n.t("#{scope}.summary_overview.success_zero")
-        expect(body).to include I18n.t("#{scope}.summary_overview.issues")
-        expect(body).to include I18n.t("#{scope}.summary_detail.changes.title", count: 2)
-        expect(body).to include I18n.t("#{scope}.summary_detail.changes.explainer")
+        expect(body).to include("Below is a summary of the subscription orders that have just been finalised for %s." % shop.name)
+        expect(body).to include("A total of %d subscriptions were marked for automatic processing." % 2)
+        expect(body).to include 'Of these, none were processed successfully.'
+        expect(body).to include 'Details of the issues encountered are provided below.'
+        expect(body).to include("Insufficient Stock (%d orders)" % 2)
+        expect(body).to include 'These orders were processed but insufficient stock was available for some requested items'
 
         # Lists orders for which an error was encountered
         expect(body).to include order1.number
         expect(body).to include order2.number
 
         # No error messages reported when non provided
-        expect(body).to_not include I18n.t("#{scope}.summary_detail.no_message_provided")
+        expect(body).to_not include 'No error message provided'
       end
     end
   end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -136,14 +136,14 @@ describe Enterprise do
       it "prevents duplicate names for new records" do
         e = Enterprise.new name: enterprise.name
         expect(e).to_not be_valid
-        expect(e.errors[:name].first).to include I18n.t('enterprise_name_error', email: owner.email)
+        expect(e.errors[:name].first).to include enterprise_name_error(owner.email)
       end
 
       it "prevents duplicate names for existing records" do
         e = create(:enterprise, name: 'foo')
         e.name = enterprise.name
         expect(e).to_not be_valid
-        expect(e.errors[:name].first).to include I18n.t('enterprise_name_error', email: owner.email)
+        expect(e.errors[:name].first).to include enterprise_name_error(owner.email)
       end
 
       it "does not prohibit the saving of an enterprise with no name clash" do
@@ -879,4 +879,11 @@ describe Enterprise do
       expect(expected).to include(sender)
     end
   end
+end
+
+def enterprise_name_error(owner_email)
+  "has already been taken. \
+If this is your enterprise and you would like to claim ownership, \
+or if you would like to trade with this enterprise please contact \
+the current manager of this profile at %s." % owner_email
 end

--- a/spec/models/order_balance_spec.rb
+++ b/spec/models/order_balance_spec.rb
@@ -14,7 +14,7 @@ describe OrderBalance do
       end
 
       it "returns 'balance due'" do
-        expect(order_balance.label).to eq(I18n.t(:balance_due))
+        expect(order_balance.label).to eq('Balance due')
       end
     end
 
@@ -24,7 +24,7 @@ describe OrderBalance do
       end
 
       it "returns 'credit owed'" do
-        expect(order_balance.label).to eq(I18n.t(:credit_owed))
+        expect(order_balance.label).to eq('Credit Owed')
       end
     end
 
@@ -34,7 +34,7 @@ describe OrderBalance do
       end
 
       it "returns 'balance due'" do
-        expect(order_balance.label).to eq(I18n.t(:balance_due))
+        expect(order_balance.label).to eq('Balance due')
       end
     end
   end

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -247,8 +247,8 @@ describe ProductImport::ProductImporter do
     # an unquoted \n will create a non valid line which will fail entry validation hence why we are only testing with \r
     it "should raise an unquoted field error if data include unquoted field with \r character" do
       expect(importer.errors.messages.values).to include(
-        [I18n.t('admin.product_import.model.malformed_csv',
-                error_message: "Unquoted fields do not allow new line <\"\\r\"> in line 3.")]
+        [format("Product Import encountered a malformed CSV: %s",
+                "Unquoted fields do not allow new line <\"\\r\"> in line 3.")]
       )
     end
   end
@@ -490,7 +490,7 @@ describe ProductImport::ProductImporter do
       expect(filter('invalid', entries)).to eq 2
 
       importer.entries.each do |entry|
-        expect(entry.errors.messages.values).to include [I18n.t('admin.product_import.model.not_updatable')]
+        expect(entry.errors.messages.values).to include ['cannot be updated on existing products via product import']
       end
     end
   end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1044,7 +1044,7 @@ describe Spree::Order do
 
     it "returns a validation error" do
       expect{ order.next }.to change(order.errors, :count).from(0).to(1)
-      expect(order.errors.messages[:email]).to eq [I18n.t('devise.failure.already_registered')]
+      expect(order.errors.messages[:email]).to eq ['This email address is already registered. Please log in to continue, or go back and use another email address.']
       expect(order.state).to eq 'cart'
     end
   end

--- a/spec/models/spree/payment_method_spec.rb
+++ b/spec/models/spree/payment_method_spec.rb
@@ -115,11 +115,11 @@ describe Spree::PaymentMethod do
   end
 
   it "generates a clean name for known Payment Method types" do
-    expect(Spree::PaymentMethod::Check.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.check"))
-    expect(Spree::Gateway::PayPalExpress.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.paypalexpress"))
-    expect(Spree::Gateway::StripeSCA.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.stripesca"))
-    expect(Spree::Gateway::BogusSimple.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.bogussimple"))
-    expect(Spree::Gateway::Bogus.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.bogus"))
+    expect(Spree::PaymentMethod::Check.clean_name).to eq('Cash/EFT/etc. (payments for which automatic validation is not required)')
+    expect(Spree::Gateway::PayPalExpress.clean_name).to eq('PayPal Express')
+    expect(Spree::Gateway::StripeSCA.clean_name).to eq('Stripe SCA')
+    expect(Spree::Gateway::BogusSimple.clean_name).to eq('BogusSimple')
+    expect(Spree::Gateway::Bogus.clean_name).to eq('Bogus')
   end
 
   it "computes the amount of fees" do

--- a/spec/models/spree/return_authorization_spec.rb
+++ b/spec/models/spree/return_authorization_spec.rb
@@ -86,7 +86,7 @@ describe Spree::ReturnAuthorization do
 
       expect(Spree::Adjustment).to receive(:create).with(
         amount: -20,
-        label: I18n.t('spree.rma_credit'),
+        label: 'RMA credit',
         order: order,
         adjustable: order,
         originator: return_authorization

--- a/spec/requests/checkout/failed_checkout_spec.rb
+++ b/spec/requests/checkout/failed_checkout_spec.rb
@@ -62,7 +62,7 @@ describe "checking out an order that initially fails", type: :request do
       # Checking out a BogusGateway without a source fails at :payment
       # Shipments and payments should then be cleared before rendering checkout
       expect(response.status).to be 400
-      expect(flash[:error]).to eq I18n.t(:payment_processing_failed)
+      expect(flash[:error]).to eq 'Payment could not be processed, please check the details you entered'
       order.reload
       expect(order.shipments.count).to be 0
       expect(order.payments.count).to be 0

--- a/spec/requests/checkout/stripe_sca_spec.rb
+++ b/spec/requests/checkout/stripe_sca_spec.rb
@@ -244,7 +244,8 @@ describe "checking out an order with a Stripe SCA payment method", type: :reques
           expect(response.status).to be 400
 
           expect(json_response["flash"]["error"])
-            .to eq(I18n.t(:spree_gateway_error_flash_for_checkout, error: 'customer-store-failure'))
+            .to eq(format("There was a problem with your payment information: %s",
+                          'customer-store-failure'))
           expect(order.payments.completed.count).to be 0
         end
       end

--- a/spec/services/order_data_masker_spec.rb
+++ b/spec/services/order_data_masker_spec.rb
@@ -31,18 +31,18 @@ describe OrderDataMasker do
           'state_id' => nil
         )
 
-        expect(order.email).to eq(I18n.t('admin.reports.hidden'))
+        expect(order.email).to eq('HIDDEN')
       end
 
       it 'does not mask the full name' do
         described_class.new(order).call
 
         expect(order.bill_address.attributes).not_to include(
-          firstname: I18n.t('admin.reports.hidden'),
+          firstname: 'HIDDEN',
           lastname: ''
         )
         expect(order.ship_address.attributes).not_to include(
-          firstname: I18n.t('admin.reports.hidden'),
+          firstname: 'HIDDEN',
           lastname: ''
         )
       end
@@ -72,18 +72,18 @@ describe OrderDataMasker do
           'state_id' => nil
         )
 
-        expect(order.email).to eq(I18n.t('admin.reports.hidden'))
+        expect(order.email).to eq('HIDDEN')
       end
 
       it 'masks the full name' do
         described_class.new(order).call
 
         expect(order.bill_address.attributes).to include(
-          'firstname' => I18n.t('admin.reports.hidden'),
+          'firstname' => 'HIDDEN',
           'lastname' => ''
         )
         expect(order.ship_address.attributes).to include(
-          'firstname' => I18n.t('admin.reports.hidden'),
+          'firstname' => 'HIDDEN',
           'lastname' => ''
         )
       end

--- a/spec/services/paypal_items_builder_spec.rb
+++ b/spec/services/paypal_items_builder_spec.rb
@@ -66,7 +66,7 @@ describe PaypalItemsBuilder do
     end
 
     it "lists the payment fee adjustment" do
-      payment_fee = items.find{ |i| i[:Name] == I18n.t('payment_method_fee') }
+      payment_fee = items.find{ |i| i[:Name] == 'Transaction fee' }
 
       expect(payment_fee[:Quantity]).to eq 1
       expect(payment_fee[:Amount]).to eq(currencyID: order.currency,
@@ -107,7 +107,7 @@ describe PaypalItemsBuilder do
     end
 
     it "does not list the shipping fee" do
-      shipping_fee_item = items.find{ |i| i[:Name] == I18n.t('shipping') }
+      shipping_fee_item = items.find{ |i| i[:Name] == 'Shipping' }
 
       expect(order.all_adjustments.shipping.count).to eq 1
       expect(shipping_fee_item).to be_nil

--- a/spec/services/process_payment_intent_spec.rb
+++ b/spec/services/process_payment_intent_spec.rb
@@ -174,7 +174,7 @@ describe ProcessPaymentIntent do
         result = service.call!
 
         expect(result.ok?).to eq(false)
-        expect(result.error).to eq(I18n.t("payment_could_not_complete"))
+        expect(result.error).to eq('The payment could not be completed')
       end
 
       it "does fails the payment" do

--- a/spec/support/localized_number_helper.rb
+++ b/spec/support/localized_number_helper.rb
@@ -17,7 +17,7 @@ shared_examples "a model using the LocalizedNumber module" do |attributes|
     it "creates an error if the input to #{attribute} is invalid" do
       subject.send(setter, '1.59,99')
       subject.valid?
-      expect(subject.errors[attribute]).to include(I18n.t('spree.localized_number.invalid_format'))
+      expect(subject.errors[attribute]).to include('has an invalid format. Please enter a number.')
     end
   end
 end

--- a/spec/support/matchers/date_time_validator_matchers.rb
+++ b/spec/support/matchers/date_time_validator_matchers.rb
@@ -11,7 +11,7 @@ RSpec::Matchers.define :validate_date_time_format_of do |attribute|
   match do |instance|
     @instance, @attribute = instance, attribute
 
-    invalid_format_message = I18n.t("validators.date_time_string_validator.invalid_format_error")
+    invalid_format_message = 'must be valid'
 
     allow(instance).to receive(attribute) { "Invalid Format" }
     instance.valid?

--- a/spec/support/matchers/integer_array_validator_matchers.rb
+++ b/spec/support/matchers/integer_array_validator_matchers.rb
@@ -11,7 +11,7 @@ RSpec::Matchers.define :validate_integer_array do |attribute|
   match do |instance|
     @instance, @attribute = instance, attribute
 
-    invalid_format_message = I18n.t("validators.integer_array_validator.invalid_element_error")
+    invalid_format_message = 'must contain only valid integers'
 
     allow(instance).to receive(attribute) { [1, "2", "Not Integer", 3] }
     instance.valid?

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -20,7 +20,7 @@ module ShopWorkflow
     wait_for_cart
     toggle_cart
     within '.cart-sidebar' do
-      expect(page).to have_link I18n.t('shared.menu.cart_sidebar.edit_cart')
+      expect(page).to have_link 'Edit cart'
     end
     first("a.edit-cart").click
   end

--- a/spec/system/admin/adjustments_spec.rb
+++ b/spec/system/admin/adjustments_spec.rb
@@ -104,7 +104,7 @@ describe '
       click_link 'Adjustments'
 
       expect(page).to_not have_selector('tr a.icon-edit')
-      expect(page).to_not have_selector('a.icon-plus'), text: I18n.t(:new_adjustment)
+      expect(page).to_not have_selector('a.icon-plus'), text: 'New Adjustment'
     end
   end
 end

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -136,7 +136,7 @@ describe '
 
       it "displays a column for order date" do
         expect(page).to have_selector "th.date",
-                                      text: I18n.t("admin.orders.bulk_management.order_date").upcase
+                                      text: 'Completed at'.upcase
         expect(page).to have_selector "td.date", text: o1.completed_at.strftime('%B %d, %Y')
         expect(page).to have_selector "td.date", text: o2.completed_at.strftime('%B %d, %Y')
       end
@@ -344,7 +344,7 @@ describe '
       it "displays the default selected columns" do
         expect(page).to have_selector "th", text: "NAME"
         expect(page).to have_selector "th",
-                                      text: I18n.t("admin.orders.bulk_management.order_date").upcase
+                                      text: 'Completed at'.upcase
         expect(page).to have_selector "th", text: "PRODUCER"
         expect(page).to have_selector "th", text: "PRODUCT: UNIT"
         expect(page).to have_selector "th", text: "QUANTITY"
@@ -360,7 +360,7 @@ describe '
           expect(page).to have_no_selector "th", text: "PRODUCER"
           expect(page).to have_selector "th", text: "NAME"
           expect(page).to have_selector "th",
-                                        text: I18n.t("admin.orders.bulk_management.order_date").upcase
+                                        text: 'Completed at'.upcase
           expect(page).to have_selector "th", text: "PRODUCT: UNIT"
           expect(page).to have_selector "th", text: "QUANTITY"
           expect(page).to have_selector "th", text: "MAX"

--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -183,7 +183,7 @@ describe '
       let(:hub) { create(:distributor_enterprise) }
       let!(:override) { create(:variant_override, variant: variant, hub: hub ) }
       let(:variant_overrides_tip) {
-        I18n.t('spree.admin.products.index.products_variant.variant_has_n_overrides', n: 1)
+        "This variant has %d override(s)" % 1
       }
 
       it "displays an icon indicating a variant has overrides" do

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -89,7 +89,7 @@ describe 'Customers' do
             end
           end
           expect(page).to have_selector "#info-dialog .text",
-                                        text: I18n.t('admin.customers.destroy.has_associated_subscriptions')
+                                        text: 'Delete failed: This customer has active subscriptions. Cancel them first.'
           click_button "OK"
         }.to_not change{ Customer.count }
 
@@ -191,7 +191,7 @@ describe 'Customers' do
           find(:css, "tags-input .tags input").set "awesome\n"
           expect(page).to have_css ".tag_watcher.update-pending"
         end
-        expect(page).to have_content I18n.t('admin.unsaved_changes')
+        expect(page).to have_content 'You have unsaved changes'
         click_button "Save Changes"
 
         # Every says it updated

--- a/spec/system/admin/enterprise_roles_spec.rb
+++ b/spec/system/admin/enterprise_roles_spec.rb
@@ -156,9 +156,9 @@ create(:enterprise)
 
         within '#invite-manager-modal' do
           fill_in 'invite_email', with: new_email
-          click_button I18n.t('js.admin.modals.invite')
-          expect(page).to have_content I18n.t('user_invited', email: new_email)
-          click_button I18n.t('js.admin.modals.close')
+          click_button 'Invite'
+          expect(page).to have_content "#{new_email} has been invited to manage this enterprise"
+          click_button 'Close'
         end
 
         expect(page).not_to have_selector "#invite-manager-modal"

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -117,7 +117,7 @@ describe '
     # Attempting to edit dates of an open order cycle with active subscriptions
     find("#oc#{oc1.id}_orders_open_at").click
     expect(page).to have_selector "#confirm-dialog .message",
-                                  text: I18n.t('admin.order_cycles.date_warning.msg', n: 1)
+                                  text: date_warning_msg(1)
   end
 
   describe 'listing order cycles with other locales' do
@@ -188,5 +188,9 @@ describe '
   def select_incoming_variant(supplier, exchange_no, variant)
     page.find("table.exchanges tr.supplier-#{supplier.id} td.products").click
     check "order_cycle_incoming_exchange_#{exchange_no}_variants_#{variant.id}"
+  end
+
+  def date_warning_msg(nbr = 1)
+    "This order cycle is linked to %d open subscription orders. Changing this date now will not affect any orders which have already been placed, but should be avoided if possible. Are you sure you want to proceed?" % nbr
   end
 end

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -308,7 +308,7 @@ describe '
 
           visit edit_admin_order_cycle_path(oc)
 
-          expect(page).to have_content I18n.t("admin.order_cycles.edit.re_notify_producers").upcase
+          expect(page).to have_content 'Re notify producers'.upcase
         end
 
         it "allows removing exchanges" do

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -309,7 +309,7 @@ describe '
       expect(page).to have_content "Customer Details updated"
       click_link "Order Details"
 
-      expect(page).to have_content I18n.t('spree.add_product').upcase
+      expect(page).to have_content 'Add Product'.upcase
       select2_select product.name, from: 'add_variant_id', search: true
 
       within("table.stock-levels") do
@@ -463,7 +463,7 @@ describe '
         expect(page).to have_selector "fieldset#order-total", text: order.display_total
 
         # shows the order tax adjustments
-        within('fieldset', text: I18n.t('spree.admin.orders.form.line_item_adjustments').upcase) do
+        within('fieldset', text: 'Line Item Adjustments'.upcase) do
           expect(page).to have_selector "td", match: :first, text: "Tax 1"
           expect(page).to have_selector "td.total", text: Spree::Money.new(10)
         end

--- a/spec/system/admin/payment_method_spec.rb
+++ b/spec/system/admin/payment_method_spec.rb
@@ -70,15 +70,15 @@ describe '
 
         select2_select "Missing", from: "payment_method_preferred_enterprise_id"
         expect(page).to have_selector "#stripe-account-status .alert-box.error",
-                                      text: I18n.t("spree.admin.payment_methods.stripe_connect.account_missing_msg")
-        connect_one = I18n.t("spree.admin.payment_methods.stripe_connect.connect_one")
+                                      text: 'No Stripe account exists for this enterprise.'
+        connect_one = 'Connect One'
         expect(page).to have_link connect_one,
                                   href: edit_admin_enterprise_path(missing_account_enterprise,
                                                                    anchor: "/payment_methods")
 
         select2_select "Revoked", from: "payment_method_preferred_enterprise_id"
         expect(page).to have_selector "#stripe-account-status .alert-box.error",
-                                      text: I18n.t("spree.admin.payment_methods.stripe_connect.access_revoked_msg")
+                                      text: 'Access to this Stripe account has been revoked, please reconnect your account.'
 
         select2_select "Connected", from: "payment_method_preferred_enterprise_id"
         expect(page).to have_selector "#stripe-account-status .status", text: "Status: Connected"

--- a/spec/system/admin/payments_spec.rb
+++ b/spec/system/admin/payments_spec.rb
@@ -14,7 +14,7 @@ describe '
     it "displays the order balance as the default payment amount" do
       login_as_admin_and_visit spree.new_admin_order_payment_path order
 
-      expect(page).to have_content I18n.t(:new_payment)
+      expect(page).to have_content 'New Payment'
       expect(page).to have_field(:payment_amount, with: order.outstanding_balance.to_f)
     end
   end
@@ -32,7 +32,7 @@ describe '
     it "renders the new payment page" do
       login_as_admin_and_visit spree.new_admin_order_payment_path order
 
-      expect(page).to have_content I18n.t(:new_payment)
+      expect(page).to have_content 'New Payment'
     end
   end
 

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -98,7 +98,7 @@ describe "Product Import", js: true do
 
       wait_until { page.find("a.button.view").present? }
 
-      click_link I18n.t('admin.product_import.save_results.view_products')
+      click_link 'Go To Products Page'
 
       expect(page).to have_content 'Bulk Edit Products'
       wait_until { page.find("#p_#{potatoes.id}").present? }
@@ -216,7 +216,7 @@ describe "Product Import", js: true do
       potatoes = Spree::Product.find_by(name: 'Potatoes')
       expect(potatoes.variants.first.import_date).to be_within(1.minute).of Time.zone.now
 
-      click_link I18n.t('admin.product_import.save_results.view_products')
+      click_link 'Go To Products Page'
 
       wait_until { page.find("#p_#{carrots.id}").present? }
 
@@ -321,7 +321,7 @@ describe "Product Import", js: true do
       File.write('/tmp/test.csv', csv_data)
 
       visit main_app.admin_product_import_path
-      select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
+      select 'Inventories', from: "settings_import_into"
       attach_file 'file', '/tmp/test.csv'
       click_button 'Upload'
 
@@ -357,7 +357,7 @@ describe "Product Import", js: true do
       expect(Float(cabbage_override.price)).to eq 1.50
       expect(cabbage_override.count_on_hand).to eq 2001
 
-      click_link I18n.t('admin.product_import.save_results.view_inventory')
+      click_link 'Go To Inventory Page'
       expect(page).to have_content 'Inventory'
 
       select enterprise2.name, from: "hub_id", visible: false
@@ -382,7 +382,7 @@ describe "Product Import", js: true do
       File.write('/tmp/test.csv', csv_data)
 
       visit main_app.admin_product_import_path
-      select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
+      select 'Inventories', from: "settings_import_into"
       attach_file 'file', '/tmp/test.csv'
       click_button 'Upload'
 
@@ -420,7 +420,7 @@ describe "Product Import", js: true do
 
         File.write('/tmp/test.csv', csv_data)
         visit main_app.admin_product_import_path
-        select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
+        select 'Inventories', from: "settings_import_into"
         attach_file 'file', '/tmp/test.csv'
         click_button 'Upload'
         proceed_to_validation
@@ -452,7 +452,7 @@ describe "Product Import", js: true do
 
         File.write('/tmp/test.csv', csv_data)
         visit main_app.admin_product_import_path
-        select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
+        select 'Inventories', from: "settings_import_into"
         attach_file 'file', '/tmp/test.csv'
         click_button 'Upload'
         proceed_to_validation
@@ -482,7 +482,7 @@ describe "Product Import", js: true do
       File.write('/tmp/test.csv', csv_data)
 
       visit main_app.admin_product_import_path
-      select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
+      select 'Inventories', from: "settings_import_into"
       attach_file 'file', '/tmp/test.csv'
       click_button 'Upload'
 
@@ -683,7 +683,7 @@ describe "Product Import", js: true do
       expect(page).to have_content 'Select a spreadsheet to upload'
       click_button 'Upload'
 
-      expect(flash_message).to eq I18n.t(:product_import_file_not_found_notice)
+      expect(flash_message).to eq 'File not found or could not be opened'
     end
 
     it "handles cases where no meaningful data can be read from the file" do
@@ -712,8 +712,7 @@ describe "Product Import", js: true do
       expect(page).to have_no_selector '.create-count'
       expect(page).to have_no_selector '.update-count'
       expect(page).to have_no_selector 'input[type=submit][value="Save"]'
-      expect(flash_message).to match(I18n.t('admin.product_import.model.malformed_csv',
-                                            error_message: ""))
+      expect(flash_message).to match("Product Import encountered a malformed CSV: %s" % '')
 
       File.delete('/tmp/test.csv')
     end
@@ -741,7 +740,7 @@ describe "Product Import", js: true do
 
       proceed_to_validation
 
-      expect(page).to have_content I18n.t('admin.product_import.import.validation_overview')
+      expect(page).to have_content 'Import validation overview'
       expect(page).to have_selector '.item-count', text: "2"
       expect(page).to have_selector '.invalid-count', text: "1"
       expect(page).to have_selector '.create-count', text: "1"
@@ -767,11 +766,11 @@ describe "Product Import", js: true do
       it "validates and saves all batches" do
         # Upload and validate file.
         attach_file "file", csv_file
-        click_button I18n.t("admin.product_import.index.upload")
+        click_button 'Upload'
         proceed_to_validation
 
         # Check that all rows are validated.
-        heading = I18n.t('admin.product_import.import.products_to_create')
+        heading = 'Products will be created'
         find(".header-description", text: heading).click
         expect(page).to have_content "Imported Product 10"
         expect(page).to have_content "Imported Product 60"
@@ -794,9 +793,9 @@ describe "Product Import", js: true do
 
   def proceed_to_validation
     expect(page).to have_selector 'a.button.proceed'
-    within("#content") { click_link I18n.t('admin.product_import.import.import') }
+    within("#content") { click_link 'Import' }
     expect(page).to have_selector 'form.product-import'
-    expect(page).to have_content I18n.t('admin.product_import.import.validation_overview')
+    expect(page).to have_content 'Import validation overview'
   end
 
   def save_data
@@ -807,7 +806,7 @@ describe "Product Import", js: true do
   end
 
   def proceed_with_save
-    click_link I18n.t("admin.product_import.import.save")
+    click_link 'Save'
   end
 
   def expect_import_completed

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -312,44 +312,44 @@ describe '
 
       # Link back to the bulk product update page should include the filters
       expected_admin_product_url = Regexp.new(Regexp.escape("#{spree.admin_products_path}#?#{filter.to_query}"))
-      expect(page).to have_link(I18n.t('admin.products.back_to_products_list'),
+      expect(page).to have_link('Back to products list',
                                 href: expected_admin_product_url)
-      expect(page).to have_link(I18n.t(:cancel), href: expected_admin_product_url)
+      expect(page).to have_link('Cancel', href: expected_admin_product_url)
 
       expected_product_url = Regexp.new(Regexp.escape(spree.edit_admin_product_path(
                                                         product.permalink, filter
                                                       )))
-      expect(page).to have_link(I18n.t('admin.products.tabs.product_details'),
+      expect(page).to have_link('Product Details',
                                 href: expected_product_url)
 
       expected_product_image_url = Regexp.new(Regexp.escape(spree.admin_product_images_path(
                                                               product.permalink, filter
                                                             )))
-      expect(page).to have_link(I18n.t('admin.products.tabs.images'),
+      expect(page).to have_link('Images',
                                 href: expected_product_image_url)
 
       expected_product_variant_url = Regexp.new(Regexp.escape(spree.admin_product_variants_path(
                                                                 product.permalink, filter
                                                               )))
-      expect(page).to have_link(I18n.t('admin.products.tabs.variants'),
+      expect(page).to have_link('Variants',
                                 href: expected_product_variant_url)
 
       expected_product_properties_url = Regexp.new(Regexp.escape(spree.admin_product_product_properties_path(
                                                                    product.permalink, filter
                                                                  )))
-      expect(page).to have_link(I18n.t('admin.products.tabs.product_properties'),
+      expect(page).to have_link('Product Properties',
                                 href: expected_product_properties_url)
 
       expected_product_group_buy_option_url = Regexp.new(Regexp.escape(spree.group_buy_options_admin_product_path(
                                                                          product.permalink, filter
                                                                        )))
-      expect(page).to have_link(I18n.t('admin.products.tabs.group_buy_options'),
+      expect(page).to have_link('Group Buy Options',
                                 href: expected_product_group_buy_option_url)
 
       expected_product_seo_url = Regexp.new(Regexp.escape(spree.seo_admin_product_path(
                                                             product.permalink, filter
                                                           )))
-      expect(page).to have_link(I18n.t(:search), href: expected_product_seo_url)
+      expect(page).to have_link('Search', href: expected_product_seo_url)
     end
 
     it "editing product group buy options" do
@@ -375,7 +375,7 @@ describe '
 
       expected_cancel_link = Regexp.new(Regexp.escape(spree.edit_admin_product_path(product,
                                                                                     filter)))
-      expect(page).to have_link(I18n.t(:cancel), href: expected_cancel_link)
+      expect(page).to have_link('Cancel', href: expected_cancel_link)
     end
 
     it "editing product group buy options with url filter" do
@@ -411,7 +411,7 @@ describe '
 
       expected_cancel_link = Regexp.new(Regexp.escape(spree.edit_admin_product_path(product,
                                                                                     filter)))
-      expect(page).to have_link(I18n.t(:cancel), href: expected_cancel_link)
+      expect(page).to have_link('Cancel', href: expected_cancel_link)
     end
 
     it "editing product Search with url filter" do
@@ -440,7 +440,7 @@ describe '
       expected_cancel_link = Regexp.new(Regexp.escape(spree.admin_product_product_properties_path(
                                                         product, filter
                                                       )))
-      expect(page).to have_link(I18n.t(:cancel), href: expected_cancel_link)
+      expect(page).to have_link('Cancel', href: expected_cancel_link)
     end
 
     it "deleting product properties", js: true do
@@ -526,7 +526,7 @@ describe '
 
       expected_cancel_link = Regexp.new(Regexp.escape(spree.admin_product_images_path(product,
                                                                                       filter)))
-      expect(page).to have_link(I18n.t(:cancel), href: expected_cancel_link)
+      expect(page).to have_link('Cancel', href: expected_cancel_link)
     end
 
     it "upload a new product image including url filters", js: true do
@@ -552,7 +552,7 @@ describe '
       expected_new_image_link = Regexp.new(Regexp.escape(spree.new_admin_product_image_path(
                                                            product, filter
                                                          )))
-      expect(page).to have_link(I18n.t('spree.new_image'), href: expected_new_image_link)
+      expect(page).to have_link('New Image', href: expected_new_image_link)
     end
 
     it "loading edit product image page including url filter", js: true do
@@ -571,7 +571,7 @@ describe '
 
       expected_cancel_link = Regexp.new(Regexp.escape(spree.admin_product_images_path(product,
                                                                                       filter)))
-      expect(page).to have_link(I18n.t(:cancel), href: expected_cancel_link)
+      expect(page).to have_link('Cancel', href: expected_cancel_link)
       expect(page).to have_link("Back To Images List", href: expected_cancel_link)
     end
 

--- a/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
@@ -26,7 +26,7 @@ describe "enterprise fee summaries" do
         let(:current_user) { create(:admin_user) }
 
         it "shows link and allows access to the report" do
-          click_on I18n.t("admin.reports.enterprise_fee_summary.name")
+          click_on 'Enterprise Fee Summary'
           expect(page).to have_button("Go")
         end
       end
@@ -35,7 +35,7 @@ describe "enterprise fee summaries" do
         let(:current_user) { distributor.owner }
 
         it "shows link and allows access to the report" do
-          click_on I18n.t("admin.reports.enterprise_fee_summary.name")
+          click_on 'Enterprise Fee Summary'
           expect(page).to have_button("Go")
         end
       end
@@ -44,9 +44,9 @@ describe "enterprise fee summaries" do
         let(:current_user) { create(:user) }
 
         it "does not allow access to the report" do
-          expect(page).to have_no_link(I18n.t("admin.reports.enterprise_fee_summary.name"))
+          expect(page).to have_no_link('Enterprise Fee Summary')
           visit main_app.admin_report_path(report_type: 'enterprise_fee_summary')
-          expect(page).to have_content(I18n.t("unauthorized"))
+          expect(page).to have_content('Unauthorized')
         end
       end
     end

--- a/spec/system/admin/reports/sales_tax/sales_tax_totals_by_producer_spec.rb
+++ b/spec/system/admin/reports/sales_tax/sales_tax_totals_by_producer_spec.rb
@@ -80,7 +80,7 @@ describe "Sales Tax Totals By Producer" do
     it "generates the report" do
       login_as admin
       visit admin_reports_path
-      click_on I18n.t("admin.reports.sales_tax_totals_by_producer")
+      click_on 'Sales Tax Totals By Producer'
 
       expect(page).to have_button("Go")
       click_on "Go"
@@ -141,7 +141,7 @@ describe "Sales Tax Totals By Producer" do
     it "generates the report" do
       login_as admin
       visit admin_reports_path
-      click_on I18n.t("admin.reports.sales_tax_totals_by_producer")
+      click_on 'Sales Tax Totals By Producer'
 
       expect(page).to have_button("Go")
       click_on "Go"
@@ -328,7 +328,7 @@ describe "Sales Tax Totals By Producer" do
       end
       login_as admin
       visit admin_reports_path
-      click_on I18n.t("admin.reports.sales_tax_totals_by_producer")
+      click_on 'Sales Tax Totals By Producer'
     end
 
     it "should load all the orders" do

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -104,26 +104,26 @@ describe '
       table_headers = rows.map { |r| r.all("th").map { |c| c.text.strip } }
 
       expect(table_headers).to eq([
-                                    [I18n.t("report_header_order_date"),
-                                     I18n.t("report_header_order_id"),
-                                     I18n.t("report_header_customer_name"),
-                                     I18n.t("report_header_customer_email"),
-                                     I18n.t("report_header_customer_phone"),
-                                     I18n.t("report_header_customer_city"),
-                                     I18n.t("report_header_sku"),
-                                     I18n.t("report_header_item_name"),
-                                     I18n.t("report_header_variant"),
-                                     I18n.t("report_header_quantity"),
-                                     I18n.t("report_header_max_quantity"),
-                                     I18n.t("report_header_cost"),
-                                     I18n.t("report_header_shipping_cost"),
-                                     I18n.t("report_header_payment_method"),
-                                     I18n.t("report_header_distributor"),
-                                     I18n.t("report_header_distributor_address"),
-                                     I18n.t("report_header_distributor_city"),
-                                     I18n.t("report_header_distributor_postcode"),
-                                     I18n.t("report_header_shipping_method"),
-                                     I18n.t("report_header_shipping_instructions")]
+                                    ['Order date',
+                                     'Order Id',
+                                     'Customer Name',
+                                     'Customer Email',
+                                     'Customer Phone',
+                                     'Customer City',
+                                     'SKU',
+                                     'Item name',
+                                     'Variant',
+                                     'Quantity',
+                                     'Max Quantity',
+                                     'Cost',
+                                     'Shipping Cost',
+                                     'Payment Method',
+                                     'Distributor',
+                                     'Distributor address',
+                                     'Distributor city',
+                                     'Distributor postcode',
+                                     'Shipping Method',
+                                     'Shipping instructions']
                                            .map(&:upcase)
                                   ])
 
@@ -142,10 +142,10 @@ describe '
       table_headers = rows.map { |r| r.all("th").map { |c| c.text.strip } }
 
       expect(table_headers).to eq([
-                                    [I18n.t("report_header_payment_state"),
-                                     I18n.t("report_header_distributor"),
-                                     I18n.t("report_header_payment_type"),
-                                     I18n.t("report_header_total_price", currency: currency_symbol)]
+                                    ['Payment State',
+                                     'Distributor',
+                                     'Payment Type',
+                                     "Total (%s)" % currency_symbol]
                                            .map(&:upcase)
                                   ])
 

--- a/spec/system/admin/shipping_methods_spec.rb
+++ b/spec/system/admin/shipping_methods_spec.rb
@@ -33,9 +33,9 @@ describe 'shipping methods' do
       check "shipping_method_distributor_ids_#{distributor1.id}"
       check "shipping_method_distributor_ids_#{distributor2.id}"
       check "shipping_method_shipping_categories_"
-      click_button I18n.t("actions.create")
+      click_button 'Create'
 
-      expect(page).to have_no_button I18n.t("actions.create")
+      expect(page).to have_no_button 'Create'
 
       # Then the shipping method should have its distributor set
       expect(flash_message).to include "Carrier Pidgeon", "successfully created!"

--- a/spec/system/admin/subscriptions_spec.rb
+++ b/spec/system/admin/subscriptions_spec.rb
@@ -417,7 +417,7 @@ describe 'Subscriptions' do
 
         # Can't use a Stripe payment method because customer does not allow it
         select2_select stripe_payment_method.name, from: 'payment_method_id'
-        expect(page).to have_content I18n.t('admin.subscriptions.details.charges_not_allowed')
+        expect(page).to have_content 'Charges are not allowed by this customer'
         click_button 'Save Changes'
         expect(page).to have_content 'Credit card charges are not allowed by this customer'
         select2_select payment_method.name, from: 'payment_method_id'
@@ -504,7 +504,7 @@ describe 'Subscriptions' do
           expect(page).to have_content 'Saved'
 
           expect(page).to have_selector "#order_update_issues_dialog .message",
-                                        text: I18n.t("admin.subscriptions.order_update_issues_msg")
+                                        text: 'Some orders could not be automatically updated, this is most likely because they have been manually edited. Please review the issues listed below and make any adjustments to individual orders if required.'
         end
       end
     end
@@ -732,7 +732,6 @@ describe 'Subscriptions' do
   end
 
   def variant_not_in_open_or_upcoming_order_cycle_warning
-    I18n.t("not_in_open_and_upcoming_order_cycles_warning",
-           scope: "admin.subscriptions.subscription_line_items")
+    'There are no open or upcoming order cycles for this product.'
   end
 end

--- a/spec/system/admin/variant_overrides_spec.rb
+++ b/spec/system/admin/variant_overrides_spec.rb
@@ -277,9 +277,9 @@ describe "
             expect(page).to have_input "variant-overrides-#{variant.id}-price", with: '77.77',
                                                                                 placeholder: '1.23'
             expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: "",
-                                                                                        placeholder: I18n.t("js.variants.on_demand.yes")
+                                                                                        placeholder: 'On demand'
             expect(page).to have_select "variant-overrides-#{variant.id}-on_demand",
-                                        selected: I18n.t("js.variant_overrides.on_demand.yes")
+                                        selected: 'Yes'
 
             expect(page).to have_input "variant-overrides-#{variant2.id}-count_on_hand",
                                        with: "40", placeholder: ""
@@ -306,22 +306,22 @@ describe "
 
           it "updates on_demand settings" do
             select_on_demand variant, :no
-            click_button I18n.t("save_changes")
-            expect(page).to have_content I18n.t("js.changes_saved")
+            click_button 'Save Changes'
+            expect(page).to have_content 'Changes saved.'
 
             vo.reload
             expect(vo.on_demand).to eq(false)
 
             select_on_demand variant, :yes
-            click_button I18n.t("save_changes")
-            expect(page).to have_content I18n.t("js.changes_saved")
+            click_button 'Save Changes'
+            expect(page).to have_content 'Changes saved.'
 
             vo.reload
             expect(vo.on_demand).to eq(true)
 
             select_on_demand variant, :use_producer_settings
-            click_button I18n.t("save_changes")
-            expect(page).to have_content I18n.t("js.changes_saved")
+            click_button 'Save Changes'
+            expect(page).to have_content 'Changes saved.'
 
             vo.reload
             expect(vo.on_demand).to be_nil
@@ -407,8 +407,8 @@ describe "
               expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: ""
 
               # It saves the changes.
-              click_button I18n.t("save_changes")
-              expect(page).to have_content I18n.t("js.changes_saved")
+              click_button 'Save Changes'
+              expect(page).to have_content 'Changes saved.'
               vo.reload
               expect(vo.count_on_hand).to be_nil
               expect(vo.on_demand).to be_nil
@@ -418,17 +418,17 @@ describe "
               # Successfully change stock settings.
               select_on_demand variant, :no
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "1111"
-              click_button I18n.t("save_changes")
-              expect(page).to have_content I18n.t("js.changes_saved")
+              click_button 'Save Changes'
+              expect(page).to have_content 'Changes saved.'
 
               # Make stock settings incompatible.
               select_on_demand variant, :no
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: ""
 
               # It does not save the changes.
-              click_button I18n.t("save_changes")
-              expect(page).to have_content I18n.t("activerecord.errors.models.variant_override.count_on_hand.limited_stock_but_no_count_on_hand")
-              expect(page).to have_no_content I18n.t("js.changes_saved")
+              click_button 'Save Changes'
+              expect(page).to have_content 'must be specified because forcing limited stock'
+              expect(page).to have_no_content 'Changes saved.'
 
               vo.reload
               expect(vo.count_on_hand).to eq(1111)

--- a/spec/system/admin/variants_spec.rb
+++ b/spec/system/admin/variants_spec.rb
@@ -43,7 +43,7 @@ describe '
       expected_cancel_url = Regexp.new(
         Regexp.escape(spree.admin_product_variants_path(product, filter))
       )
-      expect(page).to have_link(I18n.t('actions.cancel'), href: expected_cancel_url)
+      expect(page).to have_link('Cancel', href: expected_cancel_url)
     end
   end
 
@@ -96,7 +96,7 @@ describe '
       expected_cancel_url = Regexp.new(
         Regexp.escape(spree.admin_product_variants_path(product, filter))
       )
-      expect(page).to have_link(I18n.t('actions.cancel'), href: expected_cancel_url)
+      expect(page).to have_link('Cancel', href: expected_cancel_url)
     end
 
     it "when variant_unit is weight" do

--- a/spec/system/consumer/account/cards_spec.rb
+++ b/spec/system/consumer/account/cards_spec.rb
@@ -39,9 +39,9 @@ describe "Credit Cards", js: true do
     it "passes the smoke test" do
       visit "/account"
 
-      find("a", text: /#{I18n.t('spree.users.show.tabs.cards')}/i).click
+      find("a", text: /Credit Cards/i).click
 
-      expect(page).to have_content I18n.t(:saved_cards)
+      expect(page).to have_content 'Saved cards'
 
       # Lists saved cards
       within(".card#card#{default_card.id}") do
@@ -69,7 +69,7 @@ describe "Credit Cards", js: true do
         expect(find_field('default_card')).to be_checked
       end
 
-      expect(page).to have_content I18n.t('js.default_card_updated')
+      expect(page).to have_content 'Default Card Updated'
 
       expect(default_card.reload.is_default).to be false
       within(".card#card#{default_card.id}") do
@@ -78,17 +78,18 @@ describe "Credit Cards", js: true do
       expect(non_default_card.reload.is_default).to be true
 
       # Shows the interface for adding a card
-      click_button I18n.t(:add_a_card)
+      click_button 'Add a Card'
       expect(page).to have_field 'first_name'
       expect(page).to have_selector '#card-element.StripeElement'
 
       # Allows deletion of cards
       within(".card#card#{default_card.id}") do
-        click_button I18n.t(:delete)
+        click_button 'Delete'
       end
 
-      expect(page).to have_content I18n.t(:card_has_been_removed,
-                                          number: "x-#{default_card.last_digits}")
+      expect(page).to have_content(
+        format("Your card has been removed (number: %s)", "x-#{default_card.last_digits}")
+      )
       expect(page).to have_no_selector ".card#card#{default_card.id}"
 
       # Allows authorisation of card use by shops
@@ -96,7 +97,7 @@ describe "Credit Cards", js: true do
         expect(find_field('allow_charges')).to_not be_checked
         find_field('allow_charges').click
       end
-      expect(page).to have_content I18n.t('js.changes_saved')
+      expect(page).to have_content 'Changes saved.'
       expect(customer.reload.allow_charges).to be true
     end
 

--- a/spec/system/consumer/account/payments_spec.rb
+++ b/spec/system/consumer/account/payments_spec.rb
@@ -24,8 +24,8 @@ describe "Payments requiring action", js: true do
       it "shows a table of payments requiring authorization" do
         visit "/account"
 
-        find("a", text: /#{I18n.t('spree.users.show.tabs.transactions')}/i).click
-        expect(page).to have_content I18n.t("spree.users.transactions.authorisation_required")
+        find("a", text: /Transactions/i).click
+        expect(page).to have_content 'Authorisation Required'
       end
     end
 
@@ -37,8 +37,8 @@ describe "Payments requiring action", js: true do
       it "does not show the table of payments requiring authorization" do
         visit "/account"
 
-        find("a", text: /#{I18n.t('spree.users.show.tabs.transactions')}/i).click
-        expect(page).to_not have_content I18n.t("spree.users.transactions.authorisation_required")
+        find("a", text: /Transactions/i).click
+        expect(page).to_not have_content 'Authorisation Required'
       end
     end
   end

--- a/spec/system/consumer/account/settings_spec.rb
+++ b/spec/system/consumer/account/settings_spec.rb
@@ -18,8 +18,8 @@ describe "Account Settings", js: true do
       setup_email
       login_as user
       visit "/account"
-      find("a", text: /#{I18n.t('spree.users.show.tabs.settings')}/i).click
-      expect(page).to have_content I18n.t('spree.users.form.account_settings')
+      find("a", text: /Account Settings/i).click
+      expect(page).to have_content 'Account Settings'
     end
 
     it "allows the user to update their email address" do
@@ -27,19 +27,19 @@ describe "Account Settings", js: true do
 
       performing_deliveries do
         expect do
-          click_button I18n.t(:update)
+          click_button 'Update'
         end.to enqueue_job ActionMailer::MailDeliveryJob
       end
 
       expect(enqueued_jobs.last.to_s).to match "new@email.com"
 
-      expect(find(".alert-box.success").text.strip).to eq "#{I18n.t('spree.account_updated')}\n×"
+      expect(find(".alert-box.success").text.strip).to eq "Account updated!\n×"
       user.reload
       expect(user.email).to eq 'old@email.com'
       expect(user.unconfirmed_email).to eq 'new@email.com'
-      find("a", text: /#{I18n.t('spree.users.show.tabs.settings')}/i).click
-      expect(page).to have_content I18n.t('spree.users.show.unconfirmed_email',
-                                          unconfirmed_email: 'new@email.com')
+      find("a", text: /Account Settings/i).click
+      expect(page).to have_content "Pending email confirmation for: %s. \
+Your email address will be updated once the new email is confirmed." % 'new@email.com'
     end
 
     it "allows the user to change their password" do
@@ -48,8 +48,8 @@ describe "Account Settings", js: true do
       fill_in 'user_password', with: 'NewPassword'
       fill_in 'user_password_confirmation', with: 'NewPassword'
 
-      click_button I18n.t(:update)
-      expect(find(".alert-box.success").text.strip).to eq "#{I18n.t('spree.account_updated')}\n×"
+      click_button 'Update'
+      expect(find(".alert-box.success").text.strip).to eq "Account updated!\n×"
 
       expect(user.reload.encrypted_password).to_not eq initial_password
     end

--- a/spec/system/consumer/account_spec.rb
+++ b/spec/system/consumer/account_spec.rb
@@ -45,9 +45,9 @@ describe '
         visit "/account"
 
         # No distributors allow changes to orders
-        expect(page).to have_no_content I18n.t('spree.users.orders.open_orders')
+        expect(page).to have_no_content 'Open Orders'
 
-        expect(page).to have_content I18n.t('spree.users.orders.past_orders')
+        expect(page).to have_content 'Past Orders'
 
         # Lists all other orders
         expect(page).to have_content d1o1.number.to_s
@@ -62,7 +62,7 @@ describe '
                                   href: "#{distributor_credit.permalink}/shop", count: 1)
 
         # Viewing transaction history
-        find("a", text: /#{I18n.t('spree.users.show.tabs.transactions')}/i).click
+        find("a", text: /Transactions/i).click
 
         # It shows all hubs that have been ordered from with balance or credit
         expect(page).to have_content distributor1.name
@@ -91,15 +91,15 @@ describe '
 
         it "shows such orders in a section labelled 'Open Orders'" do
           visit '/account'
-          expect(page).to have_content I18n.t('spree.users.orders.open_orders')
+          expect(page).to have_content 'Open Orders'
 
           expect(page).to have_link 'Edit', href: order_path(d1o1)
           expect(page).to have_link 'Edit', href: order_path(d1o2)
           expect(page).to have_link(distributor1.name,
                                     href: "#{distributor1.permalink}/shop", count: 2)
-          expect(page).to have_link I18n.t('spree.users.open_orders.cancel'),
+          expect(page).to have_link 'Cancel',
                                     href: cancel_order_path(d1o1)
-          expect(page).to have_link I18n.t('spree.users.open_orders.cancel'),
+          expect(page).to have_link 'Cancel',
                                     href: cancel_order_path(d1o2)
         end
       end
@@ -108,7 +108,7 @@ describe '
     context "without any completed orders" do
       it "displays an appropriate message" do
         visit "/account"
-        expect(page).to have_content I18n.t(:you_have_no_orders_yet)
+        expect(page).to have_content 'You have no orders yet'
       end
     end
 

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -66,17 +66,17 @@ describe "Authentication", js: true do
               fill_in "Password", with: user.password
               click_login_button
 
-              expect(page).to have_content I18n.t('email_unconfirmed')
+              expect(page).to have_content 'You must confirm your email address before you can reset your password.'
               expect do
-                page.find("a", text: I18n.t('devise.confirmations.resend_confirmation_email')).click
+                page.find("a", text: 'Resend confirmation email.').click
               end.to enqueue_job ActionMailer::MailDeliveryJob
               expect(enqueued_jobs.last.to_s).to match "confirmation_instructions"
 
-              expect(page).to have_content I18n.t('devise.confirmations.send_instructions')
+              expect(page).to have_content 'You will receive an email with instructions about how to confirm your account in a few minutes.'
 
               visit spree.spree_user_confirmation_path(confirmation_token: user.confirmation_token)
               expect(user.reload.confirmed?).to be true
-              expect(page).to have_text I18n.t('devise.confirmations.confirmed')
+              expect(page).to have_text 'Thanks for confirming your email! You can now log in.'
             end
           end
         end
@@ -114,7 +114,7 @@ describe "Authentication", js: true do
 
             expect do
               click_signup_button
-              expect(page).to have_content I18n.t('devise.user_registrations.spree_user.signed_up_but_unconfirmed')
+              expect(page).to have_content 'A message with a confirmation link has been sent to your email address. Please open the link to activate your account.'
             end.to enqueue_job ActionMailer::MailDeliveryJob
           end
         end
@@ -150,13 +150,13 @@ describe "Authentication", js: true do
             it "cannot reset password before confirming email" do
               fill_in "Your email", with: email
               click_reset_password_button
-              expect(page).to have_content I18n.t('email_unconfirmed')
-              page.find("a", text: I18n.t('devise.confirmations.resend_confirmation_email')).click
-              expect(page).to have_content I18n.t('devise.confirmations.send_instructions')
+              expect(page).to have_content 'You must confirm your email address before you can reset your password.'
+              page.find("a", text: 'Resend confirmation email.').click
+              expect(page).to have_content 'You will receive an email with instructions about how to confirm your account in a few minutes.'
 
               visit spree.spree_user_confirmation_path(confirmation_token: user.confirmation_token)
               expect(user.reload.confirmed?).to be true
-              expect(page).to have_text I18n.t('devise.confirmations.confirmed')
+              expect(page).to have_text 'Thanks for confirming your email! You can now log in.'
 
               select_login_tab "Forgot Password?"
               fill_in "Your email", with: email
@@ -205,7 +205,7 @@ describe "Authentication", js: true do
       it "shows confirmed message in modal" do
         visit root_path(anchor: "/login", validation: "confirmed")
         expect(page).to have_login_modal
-        expect(page).to have_content I18n.t('devise.confirmations.confirmed')
+        expect(page).to have_content 'Thanks for confirming your email! You can now log in.'
       end
     end
 
@@ -230,7 +230,7 @@ describe "Authentication", js: true do
           fill_in_and_submit_login_form(user)
           expect_logged_in
 
-          expect(page).to have_content I18n.t(:home_shop, locale: :es).upcase
+          expect(page).to have_content 'COMPRAR AHORA'
         end
       end
 
@@ -243,7 +243,7 @@ describe "Authentication", js: true do
           fill_in_and_submit_login_form(user)
           expect_logged_in
 
-          expect(page).to have_content I18n.t(:home_shop, locale: :en).upcase
+          expect(page).to have_content 'SHOP NOW'
           expect(user.reload.locale).to eq "en"
         end
       end
@@ -259,7 +259,7 @@ describe "Authentication", js: true do
           fill_in_and_submit_login_form(user)
           expect_logged_in
 
-          expect(page).to have_content I18n.t(:home_shop, locale: :es).upcase
+          expect(page).to have_content 'COMPRAR AHORA'
           expect(user.reload.locale).to eq "es"
 
           page.driver.remove_cookie("locale")

--- a/spec/system/consumer/cookies_spec.rb
+++ b/spec/system/consumer/cookies_spec.rb
@@ -62,7 +62,7 @@ describe "Cookies", js: true do
       scenario "it is not showing" do
         Spree::Config[:cookies_consent_banner_toggle] = false
         visit root_path
-        expect(page).to have_no_content I18n.t('legal.cookies_banner.cookies_usage')
+        expect(page).to have_no_content 'This site uses cookies in order to make your navigation frictionless and secure, and to help us understand how you use it in order to improve the features we offer.'
       end
     end
   end
@@ -124,7 +124,7 @@ describe "Cookies", js: true do
   end
 
   def expect_visible_cookies_policy_page
-    expect(page).to have_content I18n.t('legal.cookies_policy.header')
+    expect(page).to have_content 'How We Use Cookies'
   end
 
   def expect_visible_cookies_banner
@@ -136,7 +136,7 @@ describe "Cookies", js: true do
   end
 
   def accept_cookies_button_text
-    I18n.t('legal.cookies_banner.cookies_accept_button')
+    'Accept Cookies'
   end
 
   def visit_root_path_and_wait
@@ -169,10 +169,10 @@ describe "Cookies", js: true do
   end
 
   def matomo_description_text
-    I18n.t('legal.cookies_policy.cookie_matomo_basics_desc')
+    'Matomo first party cookies to collect statistics.'
   end
 
   def matomo_opt_out_iframe
-    I18n.t('legal.cookies_policy.statistics_cookies_matomo_optout')
+    'Do you want to opt-out of Matomo analytics? We don’t collect any personal data, and Matomo helps us to improve our service, but we respect your choice :-)'
   end
 end

--- a/spec/system/consumer/multilingual_spec.rb
+++ b/spec/system/consumer/multilingual_spec.rb
@@ -128,9 +128,8 @@ describe 'Multilingual', js: true do
 
         find('.language-switcher').click
         within '.language-switcher .dropdown' do
-          expect(page).not_to have_link I18n.t('language_name', locale: :en), href: '/locales/en'
-          expect(page).to have_link I18n.t('language_name', locale: :es, default: 'Language Name'),
-                                    href: '/locales/es'
+          expect(page).not_to have_link 'English', href: '/locales/en'
+          expect(page).to have_link 'Español', href: '/locales/es'
 
           find('li a[href="/locales/es"]').click
         end

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -161,7 +161,7 @@ describe "Registration", js: true do
         fill_in "Email", with: user.email
         fill_in "Password", with: user.password
         click_button 'Login'
-        expect(page).to have_content I18n.t('registration.steps.limit_reached.headline')
+        expect(page).to have_content 'Oh no!'
       end
     end
   end

--- a/spec/system/consumer/shopping/cart_spec.rb
+++ b/spec/system/consumer/shopping/cart_spec.rb
@@ -239,7 +239,7 @@ describe "full-page cart", js: true do
 
             # shows a relevant Flash message
             expect(page).to have_selector ".alert-box",
-                                          text: I18n.t('spree.orders.error_flash_for_unavailable_items')
+                                          text: 'An item in your cart has become unavailable. Please update the selected quantities.'
 
             # "Continue Shopping" and "Checkout" buttons are disabled
             expect(page).to have_selector "a.continue-shopping[disabled=disabled]"
@@ -255,7 +255,7 @@ describe "full-page cart", js: true do
             expect(page).to_not have_selector "#order_line_items_attributes_0_quantity.ng-invalid-stock"
             expect(page).to have_selector "#update-button.alert"
 
-            click_button I18n.t("update")
+            click_button 'Update'
 
             # "Continue Shopping" and "Checkout" buttons are not disabled after cart is updated
             expect(page).to_not have_selector "a.continue-shopping[disabled=disabled]"
@@ -294,7 +294,7 @@ describe "full-page cart", js: true do
         expect(page).to have_no_content item1.variant.name
         expect(page).to have_no_content item2.variant.name
 
-        expect(page).to have_link I18n.t(:orders_bought_edit_button), href: spree.account_path
+        expect(page).to have_link 'Edit confirmed items', href: spree.account_path
         find("td.toggle-bought").click
 
         expect(page).to have_content item1.variant.name

--- a/spec/system/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/system/consumer/shopping/checkout_auth_spec.rb
@@ -110,7 +110,7 @@ describe "As a consumer I want to check out my cart", js: true do
         end
 
         expect(page).to have_selector 'div.login-modal'
-        expect(page).to have_content I18n.t('devise.failure.already_registered')
+        expect(page).to have_content 'This email address is already registered. Please log in to continue, or go back and use another email address.'
       end
     end
   end

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -143,7 +143,7 @@ describe "Order Management", js: true do
         expect(find("tr.variant-#{item1.variant.id}")).to have_content item1.product.name
         expect(find("tr.variant-#{item2.variant.id}")).to have_content item2.product.name
         expect(find("tr.variant-#{item3.variant.id}")).to have_content item3.product.name
-        expect(page).to have_no_button I18n.t(:save_changes)
+        expect(page).to have_no_button 'Save Changes'
       end
     end
 
@@ -158,8 +158,8 @@ describe "Order Management", js: true do
       it "allows quantity to be changed, items to be removed and the order to be cancelled" do
         visit order_path(order)
 
-        expect(page).to have_button I18n.t(:order_saved), disabled: true
-        expect(page).to have_no_button I18n.t(:save_changes)
+        expect(page).to have_button 'Order Saved', disabled: true
+        expect(page).to have_no_button 'Save Changes'
 
         # Changing the quantity of an item
         within "tr.variant-#{item1.variant.id}" do
@@ -171,14 +171,14 @@ describe "Order Management", js: true do
           fill_in 'order_line_items_attributes_0_quantity', with: 5
         end
 
-        expect(page).to have_button I18n.t(:save_changes)
+        expect(page).to have_button 'Save Changes'
 
         expect(find("tr.variant-#{item2.variant.id}")).to have_content item2.product.name
         expect(find("tr.variant-#{item3.variant.id}")).to have_content item3.product.name
         expect(find("tr.order-adjustment")).to have_content "Shipping"
         expect(find("tr.order-adjustment")).to have_content "5.00"
 
-        click_button I18n.t(:save_changes)
+        click_button 'Save Changes'
 
         expect(find(".order-total.grand-total")).to have_content "115.00"
         expect(item1.reload.quantity).to eq 5
@@ -193,9 +193,9 @@ describe "Order Management", js: true do
 
         # Cancelling the order
         accept_alert do
-          click_link(I18n.t(:cancel_order))
+          click_link('Cancel Order')
         end
-        expect(page).to have_content I18n.t(:orders_show_cancelled)
+        expect(page).to have_content 'Cancelled'
         expect(order.reload).to be_canceled
       end
     end

--- a/spec/system/consumer/shopping/shopping_spec.rb
+++ b/spec/system/consumer/shopping/shopping_spec.rb
@@ -677,7 +677,7 @@ describe "As a consumer I want to shop with a distributor", js: true do
   def expect_out_of_stock_behavior
     # Shows an "out of stock" modal, with helpful user feedback
     within(".out-of-stock-modal") do
-      expect(page).to have_content I18n.t('js.out_of_stock.out_of_stock_text').strip
+      expect(page).to have_content 'While you\'ve been shopping, the stock levels for one or more of the products in your cart have reduced. Here\'s what\'s changed:'
     end
 
     # Removes the item from the client-side cart and marks the variant as unavailable

--- a/spec/system/consumer/shopping/unit_price_spec.rb
+++ b/spec/system/consumer/shopping/unit_price_spec.rb
@@ -39,12 +39,12 @@ describe "As a consumer, I want to check unit price information for a product", 
       find('.question-mark-icon').click
       expect(page).to have_selector '.joyride-tip-guide.question-mark-tooltip'
       within '.joyride-tip-guide.question-mark-tooltip' do
-        expect(page).to have_content I18n.t('js.shopfront.unit_price_tooltip')
+        expect(page).to have_content 'This is the unit price of this product. It allows you to compare the price of products independent of packaging sizes & weights.'
       end
 
       page.find("body").click
       expect(page).not_to have_selector '.joyride-tip-guide.question-mark-tooltip'
-      expect(page).to have_no_content I18n.t('js.shopfront.unit_price_tooltip')
+      expect(page).to have_no_content 'This is the unit price of this product. It allows you to compare the price of products independent of packaging sizes & weights.'
     end
   end
 
@@ -60,11 +60,11 @@ describe "As a consumer, I want to check unit price information for a product", 
       find(".cart-content .question-mark-icon").click
       expect(page).to have_selector '.joyride-tip-guide.question-mark-tooltip'
       within '.joyride-tip-guide.question-mark-tooltip' do
-        expect(page).to have_content I18n.t('js.shopfront.unit_price_tooltip')
+        expect(page).to have_content 'This is the unit price of this product. It allows you to compare the price of products independent of packaging sizes & weights.'
       end
       page.find("body").click
       expect(page).not_to have_selector '.joyride-tip-guide.question-mark-tooltip'
-      expect(page).to have_no_content I18n.t('js.shopfront.unit_price_tooltip')
+      expect(page).to have_no_content 'This is the unit price of this product. It allows you to compare the price of products independent of packaging sizes & weights.'
     end
   end
 end

--- a/spec/system/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/system/consumer/shopping/variant_overrides_spec.rb
@@ -253,6 +253,6 @@ describe "shopping with variant overrides defined", js: true do
   def click_checkout
     toggle_cart
     wait_for_cart
-    click_link I18n.t('shared.menu.cart_sidebar.checkout')
+    click_link 'Checkout'
   end
 end

--- a/spec/system/consumer/user_password_spec.rb
+++ b/spec/system/consumer/user_password_spec.rb
@@ -20,7 +20,7 @@ describe "User password confirm/reset page" do
       visit spree.spree_user_confirmation_path(confirmation_token: user.confirmation_token)
 
       expect(user.reload.confirmed?).to be true
-      expect(page).to have_text I18n.t(:change_my_password)
+      expect(page).to have_text 'Change my password'
 
       fill_in "Password", with: "my secret"
       fill_in "Password Confirmation", with: "my secret"
@@ -34,7 +34,7 @@ describe "User password confirm/reset page" do
       visit spree.spree_user_confirmation_path(confirmation_token: user.confirmation_token)
 
       expect(user.reload.confirmed?).to be true
-      expect(page).to have_text I18n.t(:change_my_password)
+      expect(page).to have_text 'Change my password'
 
       fill_in "Password", with: ""
       fill_in "Password Confirmation", with: ""


### PR DESCRIPTION
#### What? Why?

- Closes #9499 

A few occurrences of I18n remain, due to their variable nature.


#### What should we test?
Since this PR is all about automated testing, the only test is to get every automated test passing.
There are also tests about the I18n lib itself.

