### PR TITLE
#10408/Fixes flaky admin/orders_spec:330

### DIFF
--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -12,6 +12,7 @@ module AuthenticationHelper
   def login_as_admin_and_visit(path_visit)
     login_as_admin
     visit path_visit
+    expect_logged_in # Make sure user is logged in
   end
 
   def login_to_admin_section

--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -9,10 +9,10 @@ module AuthenticationHelper
     admin_user
   end
 
-  def login_as_admin_and_visit(path_visit)
+  def login_as_admin_and_visit(path_visit, should_expect_logged_in: true)
     login_as_admin
     visit path_visit
-    expect_logged_in # Make sure user is logged in
+    expect_logged_in if should_expect_logged_in
   end
 
   def login_to_admin_section

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -45,7 +45,7 @@ describe '
 
     context "with no payment" do
       it "do not display the payment description information" do
-        login_as_admin_and_visit spree.print_admin_order_path(order)
+        login_as_admin_and_visit spree.print_admin_order_path(order), should_expect_logged_in: false
         convert_pdf_to_page
         expect(page).to have_no_content 'Payment Description at Checkout'
       end
@@ -60,7 +60,7 @@ describe '
       end
 
       it "display the payment description section" do
-        login_as_admin_and_visit spree.print_admin_order_path(order)
+        login_as_admin_and_visit spree.print_admin_order_path(order), should_expect_logged_in: false
         convert_pdf_to_page
         expect(page).to have_content 'Payment Description at Checkout'
         expect(page).to have_content 'description1'
@@ -79,7 +79,7 @@ describe '
       end
 
       it "display the payment description section and use the one from the completed payment" do
-        login_as_admin_and_visit spree.print_admin_order_path(order)
+        login_as_admin_and_visit spree.print_admin_order_path(order), should_expect_logged_in: false
         convert_pdf_to_page
         expect(page).to have_content 'Payment Description at Checkout'
         expect(page).to have_content 'description1'
@@ -99,7 +99,7 @@ describe '
       end
 
       it "display the payment description section and use the one from the last payment" do
-        login_as_admin_and_visit spree.print_admin_order_path(order)
+        login_as_admin_and_visit spree.print_admin_order_path(order), should_expect_logged_in: false
         convert_pdf_to_page
         expect(page).to have_content 'Payment Description at Checkout'
         expect(page).to have_content 'description2'
@@ -116,7 +116,8 @@ describe '
 
     before do
       allow(Spree::Config).to receive(:invoice_style2?).and_return(alternative_invoice)
-      login_as_admin_and_visit spree.print_admin_order_path(completed_order)
+      login_as_admin_and_visit spree.print_admin_order_path(completed_order),
+                               should_expect_logged_in: false
       convert_pdf_to_page
     end
 
@@ -201,7 +202,8 @@ describe '
       context "legacy invoice" do
         before do
           allow(Spree::Config).to receive(:invoice_style2?).and_return(false)
-          login_as_admin_and_visit spree.print_admin_order_path(order1)
+          login_as_admin_and_visit spree.print_admin_order_path(order1),
+                                   should_expect_logged_in: false
           convert_pdf_to_page
         end
 
@@ -231,7 +233,8 @@ describe '
       context "alternative invoice" do
         before do
           allow(Spree::Config).to receive(:invoice_style2?).and_return(true)
-          login_as_admin_and_visit spree.print_admin_order_path(order1)
+          login_as_admin_and_visit spree.print_admin_order_path(order1),
+                                   should_expect_logged_in: false
           convert_pdf_to_page
         end
 
@@ -331,7 +334,8 @@ describe '
       context "legacy invoice" do
         before do
           allow(Spree::Config).to receive(:invoice_style2?).and_return(false)
-          login_as_admin_and_visit spree.print_admin_order_path(order2)
+          login_as_admin_and_visit spree.print_admin_order_path(order2),
+                                   should_expect_logged_in: false
           convert_pdf_to_page
         end
         it "displays $0.0 when a line item has no tax" do
@@ -362,7 +366,8 @@ describe '
       context "alternative invoice" do
         before do
           allow(Spree::Config).to receive(:invoice_style2?).and_return(true)
-          login_as_admin_and_visit spree.print_admin_order_path(order2)
+          login_as_admin_and_visit spree.print_admin_order_path(order2),
+                                   should_expect_logged_in: false
           convert_pdf_to_page
         end
         it "displays the taxes correctly" do


### PR DESCRIPTION
#### What? Why?
Changes `spec/system/admin/orders_spec.rb` to ensure user is logged in.

- Closes #10408 

#### Why?

It wasn't able to login sometimes and so the test failed. Screenshot attached:

<img width="1191" alt="Screenshot 2023-02-15 at 3 38 22 PM" src="https://user-images.githubusercontent.com/13817656/219002018-04f3685a-e0e1-4264-adfb-51cec2c3d6d1.png">

I added a check to ensure that user is logged in. Ran spec around 10 times to see if failed. Before this check it failed on every 2-3rd run. Screenshot attached:

<img width="1191" alt="Screenshot 2023-02-15 at 3 44 37 PM" src="https://user-images.githubusercontent.com/13817656/219002489-26028f1a-2f4c-4835-a87c-29325a2254ca.png">

#### What should we test?
Run this spec `rspec spec/system/admin/orders_spec.rb`.

- Visit /admin/orders.
- You should see a table with header `NAME` which is can be clicked in order to sort records based on name column.

#### Release notes
Fixes flaky admin orders spec.

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
None

#### Documentation updates
Note required.
