### PR TITLE
Admin, BOM: can bulk delete line items of an order

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -151,7 +151,9 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
               Promise.all(LineItems.delete(item) for item in items).then(-> $scope.refreshData())
       , "js.admin.deleting_item_will_cancel_order")   
     else
-      Promise.all(LineItems.delete(item) for item in lineItemsToDelete).then(-> $scope.refreshData())
+      ofnDeleteLineItemsAlert(() ->
+        Promise.all(LineItems.delete(item) for item in lineItemsToDelete).then(-> $scope.refreshData())
+      , lineItemsToDelete.length)
 
   $scope.allBoxesChecked = ->
     checkedCount = $scope.filteredLineItems.reduce (count,lineItem) ->

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -150,6 +150,8 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
             else
               Promise.all(LineItems.delete(item) for item in items).then(-> $scope.refreshData())
       , "js.admin.deleting_item_will_cancel_order")   
+    else
+      Promise.all(LineItems.delete(item) for item in lineItemsToDelete).then(-> $scope.refreshData())
 
   $scope.allBoxesChecked = ->
     checkedCount = $scope.filteredLineItems.reduce (count,lineItem) ->

--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -250,6 +250,18 @@ ofnCancelOrderAlert = function(callback, i18nKey) {
   $('#custom-confirm').show();
 }
 
+ofnDeleteLineItemsAlert = function(callback, count) {
+  $('#custom-confirm .message').html(`${t("js.admin.orders.delete_line_items_html", {count: count})}`);
+  $('#custom-confirm button.confirm').click(() => {
+    $('#custom-confirm').hide();
+    callback();
+  });
+  $('#custom-confirm button.cancel').click(() => {
+    $('#custom-confirm').hide();
+  });
+  $('#custom-confirm').show();
+}
+
 ofnConfirm = function(callback) {
   $('#custom-confirm .message').html(
       ` ${t("are_you_sure")}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3236,6 +3236,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         cancel_the_order_send_cancelation_email: "Send a cancellation email to the customer"
         restock_item: "Restock Items: return this item to stock"
         restock_items: "Restock Items: return all items to stock"
+        delete_line_items_html:
+          one: "This will delete one line item from the order.<br />Are you sure you want to proceed?"
+          other: "This will delete %{count} line items from the order.<br />Are you sure you want to proceed?"
       resend_user_email_confirmation:
         resend: "Resend"
         sending: "Resend..."

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -785,7 +785,7 @@ describe '
             end.to have_enqueued_mail(Spree::OrderMailer, :cancel_email)
           end
 
-          it "deletes one line item and do not show any popup if it does not lead to order cancelation" do
+          it "deletes one line item should show modal confirmation about this line item deletion and not about order cancelation" do
             expect(page).to have_selector "tr#li_#{li1.id}"
             within("tr#li_#{li1.id} td.bulk") do
               check "bulk"
@@ -793,6 +793,11 @@ describe '
 
             find("div#bulk-actions-dropdown").click
             find("div#bulk-actions-dropdown div.menu_item", text: "Delete Selected" ).click
+
+            within ".modal" do
+              expect(page).to have_content "This will delete one line item from the order. Are you sure you want to proceed?"
+              click_on "OK"
+            end
 
             expect(page).to have_content "Loading orders"
 

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -720,6 +720,7 @@ describe '
                                         completed_at: Time.zone.now )
       }
       let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
+      let!(:li11) { create(:line_item_with_shipment, order: o1 ) }
       let!(:li2) { create(:line_item_with_shipment, order: o2 ) }
 
       before :each do
@@ -753,27 +754,36 @@ describe '
       end
 
       context "performing actions" do
-        it "deletes selected items" do
-          expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).to have_selector "tr#li_#{li2.id}"
-          within("tr#li_#{li2.id} td.bulk") do
-            check "bulk"
-          end
-
-          find("div#bulk-actions-dropdown").click
-          find("div#bulk-actions-dropdown div.menu_item", text: "Delete Selected" ).click
-
-          expect(page).to have_content "This operation will result in one or more empty orders, which will be cancelled. Do you wish to proceed?"
-
-          expect do
-            within(".modal") do
-              check("send_cancellation_email")
-              click_on("OK")
-            end
+        context "deletes selected items" do
+          it "displays a confirmation dialog when deleting one or more items leads to order cancelation" do
             expect(page).to have_selector "tr#li_#{li1.id}"
-            expect(page).to have_no_selector "tr#li_#{li2.id}"
-            expect(o2.reload.state).to eq("canceled")
-          end.to have_enqueued_mail(Spree::OrderMailer, :cancel_email)
+            expect(page).to have_selector "tr#li_#{li11.id}"
+            within("tr#li_#{li1.id} td.bulk") do
+              check "bulk"
+            end
+            within("tr#li_#{li11.id} td.bulk") do
+              check "bulk"
+            end
+
+            find("div#bulk-actions-dropdown").click
+            find("div#bulk-actions-dropdown div.menu_item", text: "Delete Selected" ).click
+
+            expect(page).to have_content "This operation will result in one or more empty orders, which will be cancelled. Do you wish to proceed?"
+
+            expect do
+              within(".modal") do
+                check("send_cancellation_email")
+                click_on("OK")
+              end
+              # order 1 should be canceled
+              expect(page).to have_no_selector "tr#li_#{li1.id}"
+              expect(page).to have_no_selector "tr#li_#{li11.id}"
+              expect(o1.reload.state).to eq("canceled")
+              # order 2 should not be canceled
+              expect(page).to have_selector "tr#li_#{li2.id}"
+              expect(o2.reload.state).to eq("complete")
+            end.to have_enqueued_mail(Spree::OrderMailer, :cancel_email)
+          end
         end
       end
 

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -784,6 +784,23 @@ describe '
               expect(o2.reload.state).to eq("complete")
             end.to have_enqueued_mail(Spree::OrderMailer, :cancel_email)
           end
+
+          it "deletes one line item and do not show any popup if it does not lead to order cancelation" do
+            expect(page).to have_selector "tr#li_#{li1.id}"
+            within("tr#li_#{li1.id} td.bulk") do
+              check "bulk"
+            end
+
+            find("div#bulk-actions-dropdown").click
+            find("div#bulk-actions-dropdown div.menu_item", text: "Delete Selected" ).click
+
+            expect(page).to have_content "Loading orders"
+
+            expect(page).to have_no_selector ".modal"
+            expect(page).to have_no_selector "tr#li_#{li1.id}"
+            expect(page).to have_selector "tr#li_#{li11.id}"
+            expect(o1.reload.state).to eq("complete")
+          end
         end
       end
 


### PR DESCRIPTION
#### What? Why?
Previously, we could only bulk delete line items if those deletions lead to an order cancellation (basically, all items of an order)
With this PR we can bulk delete line items event if deletion does not lead to an order cancellation.

- Closes #9148

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
As an admin, on BOM page:
- delete **all** line items of an order: this should show a modal about modal cancellation
- delete **not all** line items of an order: this should delete those previously selected line items


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
