### PR TITLE
Fixing Enterprise creation submit button behavior

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/registration/registration_form_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/registration/registration_form_controller.js.coffee
@@ -7,8 +7,12 @@ angular.module('Darkswarm').controller "RegistrationFormCtrl", ($scope, Registra
     form.$valid
 
   $scope.create = (form) ->
-    $scope.disableButton()
-    EnterpriseRegistrationService.create($scope.enableButton) if $scope.valid(form)
+    if ($scope.valid(form)) 
+      $scope.disableButton()
+      EnterpriseRegistrationService.create().then(() ->
+        $scope.enableButton()
+      )
+    end
 
   $scope.update = (nextStep, form) ->
     EnterpriseRegistrationService.update(nextStep) if $scope.valid(form)

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -70,6 +70,10 @@ describe "Registration", js: true do
       expect(page).to have_content 'Last step to add My Awesome Enterprise!'
 
       # Choosing a type
+      click_button "Create Profile"
+      expect(page).to have_content("Please choose one. Are you are producer?")
+      expect(page).to have_button "Create Profile", disabled: false
+
       click_link "producer-panel"
       expect(page).to have_selector '#producer-panel.selected'
 


### PR DESCRIPTION
#### What? Why?

- Closes #10009

Fixes the Submit button behavior on enterprise creation form. 
1. Keeps the button from being disabled when submit button is hit without complete form. (Shows error)
2. Disables button once hit with valid form, to avoid multiple submissions.

#### What should we test?


1. log in
2. Visit /register page.
   1. If number of enterprises are already at max for the given account, please go the admin page and delete one of the test enterprises.
4. Fill out form till step 3.

##### Disabled button fix: 
1. On step 3 of the form, without selecting the type of the enterprise, hit submit.
2. Error is displayed to select the type of the enterprise.
  1. For control - the button gets disabled, and doesn't get re-enabled even after selecting the type.
  2. For treatment - Button does not get disabled and can submit after the type is selected.
     1. Error stays until the selection is made to complete the form and keeps from submitting without type selection.

##### Multiple submission fix:
1. Refresh the page and fill out the form till step 3 again.
1. Select a type and hit Submit multiple times.
  1. For control - the success page is loaded and error alerts are shown saying that the enterprise already exist. (For the number of times the submit button was pressed -1)
  2. For treatment - the success page is displayed. The button was disabled after the first submission, to avoid multiple clicks until the first request was processed.

#### Release notes

Changelog Category: User facing changes 

