### PR TITLE
Update OCs after ER Permissions are Revoked

### DIFF
--- a/app/models/enterprise_relationship.rb
+++ b/app/models/enterprise_relationship.rb
@@ -13,6 +13,7 @@ class EnterpriseRelationship < ApplicationRecord
 
   after_save :update_permissions_of_child_variant_overrides
   before_destroy :revoke_all_child_variant_overrides
+  before_destroy :destroy_related_exchanges
 
   scope :with_enterprises, -> {
     joins("
@@ -100,6 +101,10 @@ class EnterpriseRelationship < ApplicationRecord
 
   def revoke_all_child_variant_overrides
     child_variant_overrides.update_all(permission_revoked_at: Time.zone.now)
+  end
+
+  def destroy_related_exchanges
+    Exchange.where(sender: parent, receiver: child, incoming: true).destroy_all
   end
 
   def child_variant_overrides

--- a/app/models/enterprise_relationship_permission.rb
+++ b/app/models/enterprise_relationship_permission.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
 class EnterpriseRelationshipPermission < ApplicationRecord
+  belongs_to :enterprise_relationship
   default_scope { order('name') }
+  before_destroy :destroy_related_exchanges
+
+  def destroy_related_exchanges
+    return if name != "add_to_order_cycle"
+
+    Exchange
+      .where(sender: enterprise_relationship.parent,
+             receiver: enterprise_relationship.child, incoming: true).destroy_all
+  end
 end

--- a/app/models/exchange_variant.rb
+++ b/app/models/exchange_variant.rb
@@ -3,4 +3,9 @@
 class ExchangeVariant < ApplicationRecord
   belongs_to :exchange
   belongs_to :variant, class_name: 'Spree::Variant'
+  after_destroy :destroy_related_outgoing_variants
+
+  def destroy_related_outgoing_variants
+    VariantDeleter.new.destroy_related_outgoing_variants(variant_id, exchange.order_cycle)
+  end
 end

--- a/app/services/variant_deleter.rb
+++ b/app/services/variant_deleter.rb
@@ -11,6 +11,15 @@ class VariantDeleter
     variant.destroy
   end
 
+  def destroy_related_outgoing_variants(variant_id, order_cycle)
+    internal_variants = ExchangeVariant.where(variant_id: variant_id).
+      joins(:exchange).
+      where(
+        exchanges: { order_cycle: order_cycle, incoming: false }
+      )
+    internal_variants.destroy_all
+  end
+
   private
 
   def only_variant_on_product?(variant)


### PR DESCRIPTION
#### OCs still have products from exchanges even after ER permission is revoked

- Closes #1157 

If ER permissions are revoked, users are still able to shop for variants at a distributor.

#### OC shouldn't have variant or exchange from the parent of the ER that has been revoked.

To reproduce this error, create an OC with an enterprise and add a variant. Remove the ER to add_to_order_cycle. The variant count remains the same and users can still shop for the variant on the frontend.

#### Release notes

Changelog Category: User facing changes

Update OCs after ER Permissions are Revoked

The title of the pull request will be included in the release notes.

#### Dependencies

None

#### Documentation updates

None