### PR TITLE
Sort correctly in Bulk Order Managment

### DIFF
--- a/app/serializers/api/admin/order_serializer.rb
+++ b/app/serializers/api/admin/order_serializer.rb
@@ -3,7 +3,8 @@
 module Api
   module Admin
     class OrderSerializer < ActiveModel::Serializer
-      attributes :id, :number, :user_id, :full_name, :email, :phone, :completed_at, :display_total,
+      attributes :id, :number, :user_id, :full_name, :email, :phone, :completed_at,
+                 :completed_at_utc_iso8601, :display_total,
                  :edit_path, :state, :payment_state, :shipment_state,
                  :payments_path, :ready_to_ship, :ready_to_capture, :created_at,
                  :distributor_name, :special_instructions, :display_outstanding_balance,
@@ -71,6 +72,10 @@ module Api
 
       def item_count
         object.line_items.count
+      end
+
+      def completed_at_utc_iso8601
+        object.completed_at.blank? ? "" : object.completed_at.utc.iso8601
       end
 
       private

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -138,7 +138,7 @@
               %a{ :href => '', 'ng-click' => "sorting.toggle('order.phone')" }
                 = t("admin.phone")
             %th.date{ 'ng-show' => 'columns.order_date.visible' }
-              %a{ :href => '', 'ng-click' => "sorting.toggle('order.completed_at')" }
+              %a{ :href => '', 'ng-click' => "sorting.toggle('order.completed_at_utc_iso8601')" }
                 = t("admin.orders.bulk_management.order_date")
             %th.producer{ 'ng-show' => 'columns.producer.visible' }
               %a{ :href => '', 'ng-click' => "sorting.toggle('supplier.name')" }

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -26,17 +26,27 @@ describe '
     context "displaying the list of line items" do
       let!(:o1) {
         create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
-                                        completed_at: Time.zone.now )
+                                        completed_at: Time.zone.parse('2022-05-05 15:30:45'))
       }
       let!(:o2) {
         create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
-                                        completed_at: Time.zone.now )
+                                        completed_at: Time.zone.parse('2022-04-26 15:10:45'))
+      }
+      let!(:o21) {
+        create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
+                                        completed_at: Time.zone.parse('2022-08-04 09:10:45'))
+      }
+      let!(:o22) {
+        create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
+                                        completed_at: Time.zone.parse('2022-06-07 09:10:45'))
       }
       let!(:o3) { create(:order_with_distributor, state: 'address', completed_at: nil ) }
       let!(:o4) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:o5) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:li1) { create(:line_item_with_shipment, order: o1) }
       let!(:li2) { create(:line_item_with_shipment, order: o2) }
+      let!(:li21) { create(:line_item_with_shipment, order: o21) }
+      let!(:li22) { create(:line_item_with_shipment, order: o22) }
       let!(:li3) { create(:line_item, order: o3 ) }
       let!(:li4) { create(:line_item_with_shipment, order: o4) }
       let!(:li5) { create(:line_item_with_shipment, order: o5) }
@@ -56,6 +66,13 @@ describe '
         expect(page).to have_selector "tr#li_#{li2.id}"
         expect(page).to have_no_selector "tr#li_#{li4.id}"
         expect(page).to have_no_selector "tr#li_#{li5.id}"
+      end
+
+      it "orders by completion date" do
+        find("a", text: 'COMPLETED AT').click # sets ascending ordering
+        expect(page).to have_content(/#{li2.product.name}.*#{li1.product.name}.*#{li22.product.name}.*#{li21.product.name}/m)
+        find("a", text: 'COMPLETED AT').click # sets descending ordering
+        expect(page).to have_content(/#{li21.product.name}.*#{li22.product.name}.*#{li1.product.name}.*#{li2.product.name}/m)
       end
     end
 


### PR DESCRIPTION
#### What? Why?

- Closes #9661 

Inaccurate sorting @ /admin/orders/bulk_management
Even though so some numeric representation of a Date could be used at first thought, the advantage here is also to get a utc date first then to format it to an ISO8601. No locale in a numeric representation.

Avdi Grimm has a post on it: https://avdi.codes/iso8601-dates-in-ruby/


#### What should we test?
The same procedure as stated in #9661
- Go to /admin/orders/bulk_management
- Select date range covering three or more months
- Sort by date (click on 'completed at' in the table header)

I would personally use  July, September and August
