### PR TITLE
Node install script

### DIFF
--- a/script/nodenv-install.sh
+++ b/script/nodenv-install.sh
@@ -9,8 +9,13 @@ if nodenv install --skip-existing; then
   echo "Correct Node version is installed."
 else
   echo "Upgrading node-build:"
-  # If homebrew (macOS) installed, try that first. Otherwise look in plugins directory.
-  brew upgrade node-build || git -C "$(nodenv root)"/plugins/node-build pull
+
+  if command -v brew &> /dev/null; then
+    # Installation via Homebrew is recommended on macOS.
+    brew upgrade node-build
+  else
+    git -C "$(nodenv root)"/plugins/node-build pull
+  fi
 
   nodenv install
 fi

--- a/script/nodenv-install.sh
+++ b/script/nodenv-install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Install our selected Node version defined in the .node-version file.
+#
+# If our node-build version is outdated and it can't build the version we want
+# then we try upgrading node-build and installing again.
+
+if nodenv install --skip-existing; then
+  echo "Correct Node version is installed."
+else
+  echo "Upgrading node-build:"
+  git -C "$(nodenv root)"/plugins/node-build pull
+
+  nodenv install
+fi

--- a/script/nodenv-install.sh
+++ b/script/nodenv-install.sh
@@ -9,7 +9,8 @@ if nodenv install --skip-existing; then
   echo "Correct Node version is installed."
 else
   echo "Upgrading node-build:"
-  git -C "$(nodenv root)"/plugins/node-build pull
+  # If homebrew (macOS) installed, try that first. Otherwise look in plugins directory.
+  brew upgrade node-build || git -C "$(nodenv root)"/plugins/node-build pull
 
   nodenv install
 fi


### PR DESCRIPTION
### What? Why?

- related to https://github.com/openfoodfoundation/ofn-install/issues/838

This script executes `nodenv` to ensure that the correct version of Node is installed and ready to use. It should work wherever `nodenv` is installed according to official documentation.

This could be used on a dev or server environment. But for now I didn't end up using it in 
 ofn-install this time (https://github.com/openfoodfoundation/ofn-install/pull/866).

### What should a dev test?

**1. install current version**
```
script/nodenv-install.sh
```

**2. install new version**
```
# edit .node-version with a new version number first, eg 17.9.1
script/nodenv-install.sh
```

**3. install unknown version (test node-build)**
If there's an unknown version, it will update node-build in case it's a new version it didn't know about.
```
# edit .node-version with a non-existent version, like "blah"
script/nodenv-install.sh
```

### Release notes

Changelog Category: Technical changes

The title of the pull request will be included in the release notes.


### Dependencies


### Documentation updates
The new script could be mentioned in the getting started guide.
