### PR TITLE
Report summaries in JSON (API) output

### DIFF
--- a/lib/reporting/report_renderer.rb
+++ b/lib/reporting/report_renderer.rb
@@ -12,7 +12,7 @@ module Reporting
 
     # Strip header and summary rows for these formats
     def raw_render?
-      @report.params[:report_format].in?(['json', 'csv'])
+      @report.params[:report_format].in?(['csv'])
     end
 
     # Do not format values for these output formats

--- a/lib/reporting/report_renderer.rb
+++ b/lib/reporting/report_renderer.rb
@@ -10,7 +10,13 @@ module Reporting
       @report = report
     end
 
+    # Strip header and summary rows for these formats
     def raw_render?
+      @report.params[:report_format].in?(['json', 'csv'])
+    end
+
+    # Do not format values for these output formats
+    def unformatted_render?
       @report.params[:report_format].in?(['json', 'csv'])
     end
 

--- a/lib/reporting/report_row_builder.rb
+++ b/lib/reporting/report_row_builder.rb
@@ -30,7 +30,7 @@ module Reporting
     def slice_and_format_row(row)
       result = row.to_h.select { |k, _v| k.in?(report.fields_to_show) }
 
-      unless report.raw_render?
+      unless report.unformatted_render?
         result = result.map { |k, v| [k, format_cell(v, k)] }.to_h
       end
       OpenStruct.new(result)

--- a/lib/reporting/report_row_builder.rb
+++ b/lib/reporting/report_row_builder.rb
@@ -47,11 +47,16 @@ module Reporting
 
       proc_args = [group_value, datas.map(&:item), datas.map(&:full_row)]
       row = rule[:summary_row].call(*proc_args)
+      row = add_summary_row_type(row)
       row = slice_and_format_row(OpenStruct.new(row.reverse_merge!(blank_row)))
       add_summary_row_label(row, rule, proc_args)
     end
 
     private
+
+    def add_summary_row_type(row)
+      row.reverse_merge!({ report_row_type: "summary" })
+    end
 
     def add_summary_row_label(row, rule, proc_args)
       previous_key = nil

--- a/lib/reporting/report_template.rb
+++ b/lib/reporting/report_template.rb
@@ -6,7 +6,8 @@ module Reporting
     attr_accessor :user, :params, :ransack_params
 
     delegate :render_as, :as_json, :to_html, :to_csv, :to_xlsx, :to_pdf, :to_json, to: :renderer
-    delegate :raw_render?, :html_render?, :display_header_row?, :display_summary_row?, to: :renderer
+    delegate :unformatted_render?, :html_render?, :display_header_row?, :display_summary_row?,
+             to: :renderer
 
     delegate :rows, :table_rows, :grouped_data, to: :rows_builder
     delegate :available_headers, :table_headers, :fields_to_hide, :fields_to_show,

--- a/spec/lib/reports/order_cycle_management_report_spec.rb
+++ b/spec/lib/reports/order_cycle_management_report_spec.rb
@@ -165,7 +165,7 @@ module Reporting
               end
 
               it 'returns rows with payment information' do
-                allow(subject).to receive(:raw_render?).and_return(true)
+                allow(subject).to receive(:unformatted_render?).and_return(true)
                 expect(subject.table_rows).to eq([[
                                                    order.billing_address.firstname,
                                                    order.billing_address.lastname,
@@ -192,7 +192,7 @@ module Reporting
               end
 
               it 'returns rows with delivery information' do
-                allow(subject).to receive(:raw_render?).and_return(true)
+                allow(subject).to receive(:unformatted_render?).and_return(true)
                 expect(subject.table_rows).to eq([[
                                                    order.ship_address.firstname,
                                                    order.ship_address.lastname,

--- a/spec/lib/reports/orders_and_distributors_report_spec.rb
+++ b/spec/lib/reports/orders_and_distributors_report_spec.rb
@@ -47,7 +47,7 @@ module Reporting
 
             it 'should denormalise order and distributor details for display as csv' do
               subject = Base.new create(:admin_user), {}
-              allow(subject).to receive(:raw_render?).and_return(true)
+              allow(subject).to receive(:unformatted_render?).and_return(true)
               table = subject.table_rows
 
               expect(table.size).to eq 1

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb
@@ -118,7 +118,6 @@ describe Reporting::Reports::OrdersAndFulfillment::OrderCycleCustomerTotals do
       end
 
       it "shows the correct payment fee amount for the order" do
-        allow(report).to receive(:raw_render?).and_return(true)
         expect(report.rows.last.pay_fee_price).to eq completed_payment.adjustment.amount
       end
     end

--- a/spec/lib/reports/products_and_inventory_report_spec.rb
+++ b/spec/lib/reports/products_and_inventory_report_spec.rb
@@ -49,7 +49,6 @@ module Reporting
                                                                          double(name: "taxon2")]
             allow(variant).to receive_message_chain(:product, :group_buy_unit_size).and_return(21)
             allow(subject).to receive(:query_result).and_return [variant]
-            allow(subject).to receive(:raw_render?).and_return(true)
 
             expect(subject.table_rows).to eq([[
                                                "Supplier",

--- a/spec/lib/reports/report_spec.rb
+++ b/spec/lib/reports/report_spec.rb
@@ -124,7 +124,7 @@ module Reporting
       end
 
       it "get correct data" do
-        allow(subject).to receive(:raw_render?).and_return(true)
+        allow(subject).to receive(:unformatted_render?).and_return(true)
         @expected_table_rows = [
           [5, "My Hub"],
           [12, "My Other Hub"],
@@ -156,7 +156,6 @@ module Reporting
             { group_by: :customer, header: true }
           ]
           allow(subject).to receive(:display_header_row?).and_return(true)
-          allow(subject).to receive(:raw_render?).and_return(true)
           @expected_rows = [
             { header: "Hub 1" },
             { header: "Abby" },


### PR DESCRIPTION
### What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/10508
- Also related to #6850

This change allows you to optionally enable summary rows on JSON report output, via the reports v0 API.

Example output:
http://localhost:3000/api/v0/reports/packing?authenticity_token=****&q%5Border_completed_at_gt%5D=2022-10-01+00%3A00&q%5Border_completed_at_lt%5D=2023-02-22+00%3A00&q%5Border_distributor_id_in%5D%5B%5D=&report_subtype=supplier&report_format=&display_summary_row=true&fields_to_show%5B%5D=hub&fields_to_show%5B%5D=supplier&fields_to_show%5B%5D=customer_code&fields_to_show%5B%5D=first_name&fields_to_show%5B%5D=last_name&fields_to_show%5B%5D=product&fields_to_show%5B%5D=variant&fields_to_show%5B%5D=quantity&fields_to_show%5B%5D=report_row_type
```json
{
  "data": [
    {
      "hub": "Elmore Compost and Organics",
      "supplier": "Elmore Compost and Organics",
      "customer_code": null,
      "first_name": "David",
      "last_name": "Cook",
      "product": "Biochar",
      "variant": "2L",
      "quantity": 1
    },
    {
      "hub": "",
      "supplier": "",
      "customer_code": "",
      "first_name": "",
      "last_name": "",
      "product": "",
      "variant": "Total By Customer",
      "quantity": 1,
      "report_row_type": "summary"
    },
...
```


### What should we test? 
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

#### Test to ensure no change in Admin Reports:
- column options in form dropdown
- displayed columns
- displayed header rows
- displayed summary rows

#### Test to ensure no change in API v0 reports:
- columns
- header not displayed by default
- summary not displayed by default

#### Test to enable summary rows 
* Add parameter `display_header_row=true`
* Add parameter `display_summary_row=true`

Extra rows should be output, similar to example above

#### Test to enable summary row markers
Summary rows look just like normal rows, so an additional marker can be used to differentiate them:
* Add parameter `fields_to_show[]=report_row_type`

The summary rows should have a new column/field: `"report_row_type": "summary"`

### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



### Documentation updates
Yep: https://ofn-user-guide.gitbook.io/ofn-api-handbook/ofn-api-v0-unsupported/reports
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
