### PR TITLE
limit users who can update shipping/payment method of an order cycle

### DIFF
--- a/app/services/order_cycle_form.rb
+++ b/app/services/order_cycle_form.rb
@@ -30,8 +30,10 @@ class OrderCycleForm
       order_cycle.schedule_ids = schedule_ids if parameter_specified?(:schedule_ids)
       order_cycle.save!
       apply_exchange_changes
-      attach_selected_distributor_payment_methods
-      attach_selected_distributor_shipping_methods
+      if can_update_selected_payment_or_shipping_methods?
+        attach_selected_distributor_payment_methods
+        attach_selected_distributor_shipping_methods
+      end
       sync_subscriptions
       true
     end
@@ -61,14 +63,29 @@ class OrderCycleForm
   def attach_selected_distributor_payment_methods
     return if @selected_distributor_payment_method_ids.nil?
 
-    order_cycle.selected_distributor_payment_method_ids = selected_distributor_payment_method_ids
+    if distributor_only?
+      payment_method_ids = order_cycle.selected_distributor_payment_method_ids
+      payment_method_ids -= user_distributor_payment_method_ids
+      payment_method_ids += user_only_selected_distributor_payment_method_ids
+      order_cycle.selected_distributor_payment_method_ids = payment_method_ids
+    else
+      order_cycle.selected_distributor_payment_method_ids = selected_distributor_payment_method_ids
+    end
     order_cycle.save!
   end
 
   def attach_selected_distributor_shipping_methods
     return if @selected_distributor_shipping_method_ids.nil?
 
-    order_cycle.selected_distributor_shipping_method_ids = selected_distributor_shipping_method_ids
+    if distributor_only?
+      shipping_method_ids = order_cycle.selected_distributor_shipping_method_ids
+      shipping_method_ids -= user_distributor_shipping_method_ids
+      shipping_method_ids += user_only_selected_distributor_shipping_method_ids
+      order_cycle.selected_distributor_shipping_method_ids = shipping_method_ids
+    else
+      order_cycle.selected_distributor_shipping_method_ids = selected_distributor_shipping_method_ids
+    end
+
     order_cycle.save!
   end
 
@@ -99,6 +116,10 @@ class OrderCycleForm
     @selected_distributor_payment_method_ids
   end
 
+  def user_only_selected_distributor_payment_method_ids
+    user_distributor_payment_method_ids.intersection(selected_distributor_payment_method_ids)
+  end
+
   def selected_distributor_shipping_method_ids
     @selected_distributor_shipping_method_ids = (
       attachable_distributor_shipping_method_ids &
@@ -110,6 +131,10 @@ class OrderCycleForm
     end
 
     @selected_distributor_shipping_method_ids
+  end
+
+  def user_only_selected_distributor_shipping_method_ids
+    user_distributor_shipping_method_ids.intersection(selected_distributor_shipping_method_ids)
   end
 
   def build_schedule_ids
@@ -159,5 +184,38 @@ class OrderCycleForm
 
   def new_schedule_ids
     @order_cycle.schedule_ids - existing_schedule_ids
+  end
+
+  def can_update_selected_payment_or_shipping_methods?
+    @user.admin? || coordinator? || distributor?
+  end
+
+  def coordinator?
+    @user.enterprises.include?(@order_cycle.coordinator)
+  end
+
+  def distributor?
+    !user_distributors_ids.empty?
+  end
+
+  def distributor_only?
+    distributor? && !@user.admin? && !coordinator?
+  end
+
+  def user_distributors_ids
+    @user_distributors_ids ||= @user.enterprises.pluck(:id)
+      .intersection(@order_cycle.distributors.pluck(:id))
+  end
+
+  def user_distributor_payment_method_ids
+    @user_distributor_payment_method_ids ||=
+      DistributorPaymentMethod.where(distributor_id: user_distributors_ids)
+        .pluck(:id)
+  end
+
+  def user_distributor_shipping_method_ids
+    @user_distributor_shipping_method_ids ||=
+      DistributorShippingMethod.where(distributor_id: user_distributors_ids)
+        .pluck(:id)
   end
 end

--- a/app/services/order_cycle_form.rb
+++ b/app/services/order_cycle_form.rb
@@ -78,6 +78,10 @@ class OrderCycleForm
     return if @selected_distributor_shipping_method_ids.nil?
 
     if distributor_only?
+      # A distributor can only update methods associated with their own
+      # enterprise, so we load all previously selected methods, and replace
+      # only the distributor's methods with their selection (not touching other
+      # distributor's methods).
       shipping_method_ids = order_cycle.selected_distributor_shipping_method_ids
       shipping_method_ids -= user_distributor_shipping_method_ids
       shipping_method_ids += user_only_selected_distributor_shipping_method_ids

--- a/spec/services/order_cycle_form_spec.rb
+++ b/spec/services/order_cycle_form_spec.rb
@@ -334,19 +334,21 @@ describe OrderCycleForm do
             order_cycle.coordinator.users.first
           )
 
-          expect(form.save).to be true
-          expect(order_cycle.distributor_payment_methods).to eq [distributor_payment_method_i]
+          expect{ form.save }.not_to change{
+            order_cycle.distributor_payment_methods.pluck(:id)
+          }.from([distributor_payment_method_i.id])
         end
       end
     end
 
     context "updating shipping methods" do
       context "and it's valid" do
-        let(:distributor){ create(:distributor_enterprise) }
-        let(:shipping_method){ create(:shipping_method, distributors: [distributor]) }
-        let(:shipping_method2){ create(:shipping_method, distributors: [distributor]) }
-        let(:distributor_shipping_method){ shipping_method.distributor_shipping_methods.first }
-        let(:distributor_shipping_method2){ shipping_method2.distributor_shipping_methods.first }
+        let!(:distributor){ create(:distributor_enterprise) }
+        let!(:shipping_method){ create(:shipping_method, distributors: [distributor]) }
+        let!(:shipping_method2){ create(:shipping_method, distributors: [distributor]) }
+        let!(:distributor_shipping_method){ distributor.distributor_shipping_methods.first.id }
+        let!(:distributor_shipping_method2){ distributor.distributor_shipping_methods.second.id }
+
         let(:supplier){ create(:supplier_enterprise) }
         context "the submitter is a coordinator" do
           it "saves the changes" do
@@ -354,12 +356,13 @@ describe OrderCycleForm do
 
             form = OrderCycleForm.new(
               order_cycle,
-              { selected_distributor_shipping_method_ids: [distributor_shipping_method.id] },
+              { selected_distributor_shipping_method_ids: [distributor_shipping_method] },
               order_cycle.coordinator.users.first
             )
 
-            expect(form.save).to be true
-            expect(order_cycle.distributor_shipping_methods).to eq [distributor_shipping_method]
+            expect{ form.save }.to change{ order_cycle.distributor_shipping_methods.pluck(:id) }
+              .from([distributor_shipping_method, distributor_shipping_method2])
+              .to([distributor_shipping_method])
           end
         end
         context "submitter is a supplier" do
@@ -369,14 +372,13 @@ describe OrderCycleForm do
 
             form = OrderCycleForm.new(
               order_cycle,
-              { selected_distributor_shipping_method_ids: [distributor_shipping_method.id] },
+              { selected_distributor_shipping_method_ids: [distributor_shipping_method] },
               supplier.users.first
             )
 
-            expect(form).not_to receive(:attach_selected_distributor_shipping_methods)
-            expect(order_cycle.distributor_shipping_methods).to match_array [
-              distributor_shipping_method, distributor_shipping_method2
-            ]
+            expect{ form.save }.not_to change{
+              order_cycle.distributor_shipping_methods.pluck(:id)
+            }.from([distributor_shipping_method, distributor_shipping_method2])
           end
         end
         context "submitter is an admin" do
@@ -385,12 +387,13 @@ describe OrderCycleForm do
 
             form = OrderCycleForm.new(
               order_cycle,
-              { selected_distributor_shipping_method_ids: [distributor_shipping_method.id] },
+              { selected_distributor_shipping_method_ids: [distributor_shipping_method] },
               create(:admin_user)
             )
 
-            expect(form.save).to be true
-            expect(order_cycle.distributor_shipping_methods).to eq [distributor_shipping_method]
+            expect{ form.save }.to change{ order_cycle.distributor_shipping_methods.pluck(:id) }
+              .from([distributor_shipping_method, distributor_shipping_method2])
+              .to([distributor_shipping_method])
           end
         end
         context "submitter is a distributor" do
@@ -400,29 +403,38 @@ describe OrderCycleForm do
 
               form = OrderCycleForm.new(
                 order_cycle,
-                { selected_distributor_shipping_method_ids: [distributor_shipping_method.id] },
+                { selected_distributor_shipping_method_ids: [distributor_shipping_method] },
                 distributor.users.first
               )
 
-              expect(form.save).to be true
-              expect(order_cycle.distributor_shipping_methods).to eq [distributor_shipping_method]
+              expect{ form.save }.to change{
+                order_cycle.distributor_shipping_methods.pluck(:id)
+              }.from([
+                       distributor_shipping_method, distributor_shipping_method2
+                     ]).to([distributor_shipping_method])
             end
           end
           context "can't update other distributors' shipping methods" do
-            let(:distributor2){ create(:distributor_enterprise) }
+            let!(:distributor2){ create(:distributor_enterprise) }
+            let!(:shipping_method3){ create(:shipping_method, distributors: [distributor2]) }
+            let!(:distributor_shipping_method3){
+              distributor2.distributor_shipping_methods.first.id
+            }
             it "doesn't save the changes" do
               order_cycle = create(:distributor_order_cycle,
                                    distributors: [distributor, distributor2])
 
               form = OrderCycleForm.new(
                 order_cycle,
-                { selected_distributor_shipping_method_ids: [distributor_shipping_method.id] },
+                { selected_distributor_shipping_method_ids: [distributor_shipping_method] },
                 distributor2.users.first
               )
 
-              expect(form).not_to receive(:attach_selected_distributor_shipping_methods)
-              expect(order_cycle.distributor_shipping_methods).to match_array [
-                distributor_shipping_method, distributor_shipping_method2
+              expect{ form.save }.not_to change{
+                order_cycle.distributor_shipping_methods.pluck(:id)
+              }.from [
+                distributor_shipping_method, distributor_shipping_method2,
+                distributor_shipping_method3
               ]
             end
           end

--- a/spec/services/order_cycle_form_spec.rb
+++ b/spec/services/order_cycle_form_spec.rb
@@ -331,7 +331,7 @@ describe OrderCycleForm do
           form = OrderCycleForm.new(
             order_cycle,
             { selected_distributor_payment_method_ids: [distributor_payment_method_ii.id] },
-            order_cycle.coordinator
+            order_cycle.coordinator.users.first
           )
 
           expect(form.save).to be true
@@ -447,7 +447,7 @@ describe OrderCycleForm do
           form = OrderCycleForm.new(
             order_cycle,
             { selected_distributor_shipping_method_ids: [distributor_shipping_method_ii.id] },
-            order_cycle.coordinator
+            order_cycle.coordinator.users.first
           )
 
           expect(form.save).to be true


### PR DESCRIPTION
#### What? Why?

- Closes #10462

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Some of the scenarios that I can think about:

- Access the edit order cycle => checkout options
- As an admin or coordinator, you should be able to edit the shipping methods/payment methods of any distributor
- As a distributor, 
    - you should be able to only update your shipping methods/payment methods.
    - you should not be able to edit other distributors' checkout options
- As a supplier, you should not be able to edit checkout options

Additional:
- As a coordinator and a distributor at the same time, you should be able to edit any distributor's checkout options.
- As a coordinator and a supplier at the same time, you should be able to edit any distributor's checkout options.
- As a supplier and a distributor at the same time, you should be able to edit any distributor's checkout options.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
