### PR TITLE
Fix: Customers can checkout with non-matching shipping and product categories

### DIFF
--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -54,7 +54,7 @@ module CheckoutCallbacks
   end
 
   def load_allowed_shipping_methods
-    @allowed_shipping_methods = sorted_available_shipping_methods.filter(
+    @allowed_shipping_methods ||= sorted_available_shipping_methods.filter(
       &method(:supports_all_products_shipping_categories?)
     )
   end

--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -15,7 +15,10 @@ module CheckoutCallbacks
     prepend_before_action :require_distributor_chosen
 
     before_action :load_order, :associate_user, :load_saved_addresses, :load_saved_credit_cards
-    before_action :load_shipping_methods, if: -> { params[:step] == "details" }
+    before_action :load_shipping_methods,
+                  :load_allowed_shipping_methods, if: -> {
+                                                        params[:step] == "details"
+                                                      }
 
     before_action :ensure_order_not_completed
     before_action :ensure_checkout_allowed
@@ -47,7 +50,25 @@ module CheckoutCallbacks
   end
 
   def load_shipping_methods
-    @shipping_methods = available_shipping_methods.sort { |a, b| a.name.casecmp(b.name) }
+    @shipping_methods = sorted_available_shipping_methods
+  end
+
+  def load_allowed_shipping_methods
+    @allowed_shipping_methods = sorted_available_shipping_methods.filter(
+      &method(:supports_all_products_shipping_categories?)
+    )
+  end
+
+  def sorted_available_shipping_methods
+    available_shipping_methods.sort { |a, b| a.name.casecmp(b.name) }
+  end
+
+  def supports_all_products_shipping_categories?(shipping_method)
+    (products_shipping_categories - shipping_method.shipping_categories.pluck(:id)).empty?
+  end
+
+  def products_shipping_categories
+    @products_shipping_categories ||= @order.products.pluck(:shipping_category_id).uniq
   end
 
   def redirect_to_shop?

--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -15,10 +15,9 @@ module CheckoutCallbacks
     prepend_before_action :require_distributor_chosen
 
     before_action :load_order, :associate_user, :load_saved_addresses, :load_saved_credit_cards
-    before_action :load_shipping_methods,
-                  :load_allowed_shipping_methods, if: -> {
-                                                        params[:step] == "details"
-                                                      }
+    before_action :allowed_shipping_methods, if: -> {
+                                                   params[:step] == "details"
+                                                 }
 
     before_action :ensure_order_not_completed
     before_action :ensure_checkout_allowed
@@ -49,11 +48,7 @@ module CheckoutCallbacks
     @selected_card = nil
   end
 
-  def load_shipping_methods
-    @shipping_methods = sorted_available_shipping_methods
-  end
-
-  def load_allowed_shipping_methods
+  def allowed_shipping_methods
     @allowed_shipping_methods ||= sorted_available_shipping_methods.filter(
       &method(:supports_all_products_shipping_categories?)
     )

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -24,7 +24,7 @@ class SplitCheckoutController < ::BaseController
     check_step if params[:step]
     recalculate_tax if params[:step] == "summary"
 
-    flash_error_when_no_shipping_method_available if available_shipping_methods.none?
+    flash_error_when_no_shipping_method_available if load_allowed_shipping_methods.none?
   end
 
   def update

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -24,7 +24,7 @@ class SplitCheckoutController < ::BaseController
     check_step if params[:step]
     recalculate_tax if params[:step] == "summary"
 
-    flash_error_when_no_shipping_method_available if load_allowed_shipping_methods.none?
+    flash_error_when_no_shipping_method_available if allowed_shipping_methods.none?
   end
 
   def update

--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -76,7 +76,7 @@
     - display_ship_address = false
     - ship_method_description = nil
 
-    - selected_shipping_method ||= @shipping_methods[0].id if @shipping_methods.length == 1
+    - selected_shipping_method ||= @allowed_shipping_methods[0].id if @allowed_shipping_methods.length == 1
     - @allowed_shipping_methods.each do |shipping_method|
       - ship_method_is_selected = shipping_method.id == selected_shipping_method.to_i
       %div.checkout-input.checkout-input-radio

--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -77,7 +77,7 @@
     - ship_method_description = nil
 
     - selected_shipping_method ||= @shipping_methods[0].id if @shipping_methods.length == 1
-    - @shipping_methods.each do |shipping_method|
+    - @allowed_shipping_methods.each do |shipping_method|
       - ship_method_is_selected = shipping_method.id == selected_shipping_method.to_i
       %div.checkout-input.checkout-input-radio
         = fields_for shipping_method do |shipping_method_form|


### PR DESCRIPTION

#### What? Why?

- Closes #9629

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

In addition to the scenario described on #9629
I can think about:
Scenario 1:
- An order with a product that belongs to the shipping category: A
- distributor supports multiple shipping methods and  none of them supports category A
=> an error should be raised
Scenario 2:
- An order with two products that belong to two different shipping categories: A and B  
- The distributor has
    -  one shipping method (sm1) that supports the shipping category A, 
    -  one shipping method (sm2) that supports the shipping category B, 
=> an error should be railse

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
