### PR TITLE
Stabilise flaky spec with defined enterprise order

### DIFF
--- a/spec/system/admin/enterprises/index_spec.rb
+++ b/spec/system/admin/enterprises/index_spec.rb
@@ -38,10 +38,10 @@ describe 'Enterprises Index' do
       let!(:distributor) {
         create(:distributor_enterprise, sells: 'none', name: "Adam's Market")
       }
-      let!(:mani) { create(:user, enterprise_limit: 1) }
+      let!(:manager) { create(:user, enterprise_limit: 1) }
 
       before do
-        distributor.users << mani
+        distributor.users << manager
       end
 
       context "without violating rules" do
@@ -54,14 +54,14 @@ describe 'Enterprises Index' do
             expect(page).to have_checked_field "sets_enterprise_set_collection_attributes_0_visible"
             uncheck "sets_enterprise_set_collection_attributes_0_visible"
             select 'any', from: "sets_enterprise_set_collection_attributes_0_sells"
-            select mani.email, from: 'sets_enterprise_set_collection_attributes_0_owner_id'
+            select manager.email, from: 'sets_enterprise_set_collection_attributes_0_owner_id'
           end
           click_button "Update"
           expect(flash_message).to eq('Enterprises updated successfully')
           distributor.reload
           expect(distributor.visible).to eq "hidden"
           expect(distributor.sells).to eq 'any'
-          expect(distributor.owner).to eq mani
+          expect(distributor.owner).to eq manager
         end
       end
 
@@ -73,24 +73,24 @@ describe 'Enterprises Index' do
         }
 
         before do
-          second_distributor.users << mani
+          second_distributor.users << manager
 
           login_as_admin_and_visit admin_enterprises_path
         end
 
         it "does not update the enterprises and displays errors" do
-          select_new_owner(mani, distributor)
-          select_new_owner(mani, second_distributor)
+          select_new_owner(manager, distributor)
+          select_new_owner(manager, second_distributor)
 
           expect {
             click_button "Update"
 
             expect(flash_message).to eq('Update failed')
-            expect(page).to have_content "#{mani.email} is not permitted to own any more enterprises (limit is 1)."
+            expect(page).to have_content "#{manager.email} is not permitted to own any more enterprises (limit is 1)."
             second_distributor.reload
           }.to_not change { second_distributor.owner }
 
-          expect(second_distributor.owner).to_not eq mani
+          expect(second_distributor.owner).to_not eq manager
         end
 
         def select_new_owner(user, enterprise)

--- a/spec/system/admin/enterprises/index_spec.rb
+++ b/spec/system/admin/enterprises/index_spec.rb
@@ -87,12 +87,9 @@ describe 'Enterprises Index' do
         end
 
         def select_new_owner(user, enterprise)
-          enterprise_row_number = all('tr').index { |tr| tr.text.include? enterprise.name }
-          enterprise_row_number -= 1
-
-          within("tr.enterprise-#{enterprise.id}") do
-            select user.email,
-                   from: "sets_enterprise_set_collection_attributes_#{enterprise_row_number}_owner_id"
+          # The fifth table column contains the owner field.
+          within("tr.enterprise-#{enterprise.id} td:nth-child(5)") do
+            select user.email
           end
         end
       end

--- a/spec/system/admin/enterprises/index_spec.rb
+++ b/spec/system/admin/enterprises/index_spec.rb
@@ -39,8 +39,7 @@ describe 'Enterprises Index' do
       let!(:d_manager) { create(:user, enterprise_limit: 1) }
 
       before do
-        d_manager.enterprise_roles.build(enterprise: d).save
-        expect(d.owner).to_not eq d_manager
+        d.users << d_manager
       end
 
       context "without violating rules" do
@@ -68,8 +67,7 @@ describe 'Enterprises Index' do
         let!(:second_distributor) { create(:distributor_enterprise, sells: 'none') }
 
         before do
-          d_manager.enterprise_roles.build(enterprise: second_distributor).save
-          expect(d.owner).to_not eq d_manager
+          second_distributor.users << d_manager
 
           login_as_admin_and_visit admin_enterprises_path
         end

--- a/spec/system/admin/enterprises/index_spec.rb
+++ b/spec/system/admin/enterprises/index_spec.rb
@@ -35,7 +35,6 @@ describe 'Enterprises Index' do
     end
 
     context "editing enterprises in bulk" do
-      let!(:s){ create(:supplier_enterprise) }
       let!(:d){ create(:distributor_enterprise, sells: 'none') }
       let!(:d_manager) { create(:user, enterprise_limit: 1) }
 


### PR DESCRIPTION
#### What? Why?

- Closes #10055 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This spec would fail when a certain number of enterprises were created before this spec. Enterprise names are generated continuously from Enterprise 1, Enterprise 2 etc. The second enterprise in this spec could be displayed above the first one due to the alphabetical sorting. Examples: "10, 9" or "90, 89". But the spec assumes that it's always the second enterprise which can't be assigned an owner and that assumption wasn't true when the second enterprise was updated first.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
