### PR TITLE
Fix deprecation warning when accessing model errors

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -415,8 +415,8 @@ module Spree
       # If the master cannot be saved, the Product object will get its errors
       # and will be destroyed
     rescue ActiveRecord::RecordInvalid
-      master.errors.each do |att, error|
-        errors.add(att, error)
+      master.errors.each do |error|
+        errors.add error.attribute, error.message
       end
       raise
     end


### PR DESCRIPTION
#### What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/10044

This PR fixes the deprecation warning that is raised when master variant errors are passed to the product errors. 

We are currently iterating the `errors` as a hash but from rails 6.1 `errors` is an array of Error objects.

#### What should we test?

I don't think that there is anything we can test on the UI.

The warning was being raised in the controller tests. Not showing up in this PR's build.

![Captura de ecrã 2023-02-26, às 18 14 44](https://user-images.githubusercontent.com/27692541/221437761-da9ba302-472c-4424-af90-c69599c43201.png)


#### Release notes

Technical changes
