### PR TITLE
Remove unused Spree translation checker

### DIFF
--- a/spec/lib/spree/i18n_spec.rb
+++ b/spec/lib/spree/i18n_spec.rb
@@ -2,7 +2,6 @@
 
 require 'rspec/expectations'
 require 'spree/i18n'
-require 'support/i18n_translations_checker'
 
 describe "i18n" do
   before do
@@ -28,20 +27,20 @@ describe "i18n" do
   end
 
   it "translates within the spree scope" do
-    expect(Spree.normal_t(:foo)).to eql("bar")
+    expect(Spree.t(:foo)).to eql("bar")
     expect(Spree.translate(:foo)).to eql("bar")
   end
 
   it "translates within the spree scope using a path" do
     allow(Spree).to receive(:virtual_path).and_return('bar')
 
-    expect(Spree.normal_t('.legacy_translation')).to eql("back in the day...")
+    expect(Spree.t('.legacy_translation')).to eql("back in the day...")
     expect(Spree.translate('.legacy_translation')).to eql("back in the day...")
   end
 
   it "raise error without any context when using a path" do
     expect {
-      Spree.normal_t('.legacy_translation')
+      Spree.t('.legacy_translation')
     }.to raise_error
 
     expect {
@@ -50,82 +49,18 @@ describe "i18n" do
   end
 
   it "prepends a string scope" do
-    expect(Spree.normal_t(:foo, scope: "bar")).to eql("bar within bar scope")
+    expect(Spree.t(:foo, scope: "bar")).to eql("bar within bar scope")
   end
 
   it "prepends to an array scope" do
-    expect(Spree.normal_t(:foo, scope: ["bar"])).to eql("bar within bar scope")
+    expect(Spree.t(:foo, scope: ["bar"])).to eql("bar within bar scope")
   end
 
   it "returns two translations" do
-    expect(Spree.normal_t([:foo, 'bar.foo'])).to eql(["bar", "bar within bar scope"])
+    expect(Spree.t([:foo, 'bar.foo'])).to eql(["bar", "bar within bar scope"])
   end
 
   it "returns reasonable string for missing translations" do
     expect(Spree.t(:missing_entry)).to include("<span")
-  end
-
-  context "missed + unused translations" do
-    def key_with_locale(key)
-      "#{key} (#{I18n.locale})"
-    end
-
-    before do
-      Spree.used_translations = []
-    end
-
-    context "missed translations" do
-      def assert_missing_translation(key)
-        key = key_with_locale(key)
-        message = Spree.missing_translation_messages.detect { |m| m == key }
-        expect(message).not_to(be_nil, "expected '#{key}' to be missing, but it wasn't.")
-      end
-
-      it "logs missing translations" do
-        Spree.t(:missing, scope: [:else, :where])
-        Spree.check_missing_translations
-        assert_missing_translation("else")
-        assert_missing_translation("else.where")
-        assert_missing_translation("else.where.missing")
-      end
-
-      it "does not log present translations" do
-        Spree.t(:foo)
-        Spree.check_missing_translations
-        expect(Spree.missing_translation_messages).to be_empty
-      end
-
-      it "does not break when asked for multiple translations" do
-        Spree.t [:foo, 'bar.foo']
-        Spree.check_missing_translations
-        expect(Spree.missing_translation_messages).to be_empty
-      end
-    end
-
-    context "unused translations" do
-      def assert_unused_translation(key)
-        key = key_with_locale(key)
-        message = Spree.unused_translation_messages.detect { |m| m == key }
-        expect(message).not_to(be_nil, "expected '#{key}' to be unused, but it was used.")
-      end
-
-      def assert_used_translation(key)
-        key = key_with_locale(key)
-        message = Spree.unused_translation_messages.detect { |m| m == key }
-        expect(message).to(be_nil, "expected '#{key}' to be used, but it wasn't.")
-      end
-
-      it "logs translations that aren't used" do
-        Spree.check_unused_translations
-        assert_unused_translation("bar.legacy_translation")
-        assert_unused_translation("legacy_translation")
-      end
-
-      it "does not log used translations" do
-        Spree.t(:foo)
-        Spree.check_unused_translations
-        assert_used_translation("foo")
-      end
-    end
   end
 end

--- a/spec/lib/spree/i18n_spec.rb
+++ b/spec/lib/spree/i18n_spec.rb
@@ -41,11 +41,11 @@ describe "i18n" do
   it "raise error without any context when using a path" do
     expect {
       Spree.t('.legacy_translation')
-    }.to raise_error
+    }.to raise_error RuntimeError
 
     expect {
       Spree.translate('.legacy_translation')
-    }.to raise_error
+    }.to raise_error RuntimeError
   end
 
   it "prepends a string scope" do


### PR DESCRIPTION
#### What? Why?

Trying to upgrade to Rails 7 I noticed some failing specs and started fixing them. But then I realised that the tested code is unused and not needed. If we want similar functionality, we should look at the i18n-tasks gem.

* https://github.com/openfoodfoundation/openfoodnetwork/pull/10440

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
