### PR TITLE
Reports, `background_reports` feature toggle activated: Force writing file in binary mode

### DIFF
--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -19,7 +19,7 @@ class ReportJob < ActiveJob::Base
   private
 
   def write(result)
-    File.write(filename, result)
+    File.write(filename, result, mode: "wb")
   end
 
   def read_result


### PR DESCRIPTION

Error was:

```
/app/jobs/report_job.rb:22:in `write': "\\xFE" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
from /app/jobs/report_job.rb:22:in `write'
from /app/jobs/report_job.rb:8:in `perform'
```

#### What? Why?

- Closes #10492 


#### What should we test?

- As an admin, with feature toggle `background_reports` activated, generate a report in PDF and Spreadsheet
- Check the file is valid and can be open

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
