### PR TITLE
[split checkout] Fix bug preventing user from reaching payment step

### DIFF
--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -141,6 +141,10 @@ class SplitCheckoutController < ::BaseController
   def update_order
     return if params[:confirm_order] || @order.errors.any?
 
+    # If we have "pick up" shipping method (require_ship_address is set to false), use the
+    # distributor address as shipping address
+    use_shipping_address_from_distributor if shipping_method_ship_address_not_required?
+
     @order.select_shipping_method(params[:shipping_method_id])
     @order.update(order_params)
     @order.updater.update_totals_and_states
@@ -148,6 +152,29 @@ class SplitCheckoutController < ::BaseController
     validate_current_step!
 
     @order.errors.empty?
+  end
+
+  def use_shipping_address_from_distributor
+    @order.ship_address = @order.address_from_distributor
+
+    # Add the missing data
+    bill_address = params[:order][:bill_address_attributes]
+    @order.ship_address.firstname = bill_address[:firstname]
+    @order.ship_address.lastname = bill_address[:lastname]
+    @order.ship_address.phone = bill_address[:phone]
+
+    # Remove shipping address from parameter so we don't override the address we just set
+    params[:order].delete(:ship_address_attributes)
+  end
+
+  def shipping_method_ship_address_not_required?
+    selected_shipping_method = allowed_shipping_methods&.select do |sm|
+      sm.id.to_s == params[:shipping_method_id]
+    end
+
+    return false if selected_shipping_method.empty?
+
+    selected_shipping_method.first.require_ship_address == false
   end
 
   def summary_step?

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -458,6 +458,19 @@ describe "As a consumer, I want to checkout my order" do
             fill_notes("SpEcIaL NoTeS")
             proceed_to_payment
           end
+
+          context 'when the user has no shipping address' do
+            before do
+              # Hack so we can have "Shipping address same as billing address?" unticked
+              choose free_shipping_with_required_address.name
+              uncheck "Shipping address same as billing address?"
+              choose free_shipping_without_required_address.name
+            end
+
+            it "redirects the user to the Payment Method step" do
+              proceed_to_payment
+            end
+          end
         end
 
         describe "selecting a delivery method with a shipping fee" do


### PR DESCRIPTION
When using a "pick up" shipping method, with a user who doesn't have a shipping address it was impossible to proceed to the payment step because shipping address was invalid.

To fix this, we ensure that "ship_address_same_as_billing" parameter is set to true when using a "pick up" shipping method.

#### What? Why?
- Closes #10479 

In a very specific scenario, a user can be blocked from proceeding to the payment step on checkout :
- User had no shipping address
- Shop only has a "pick up" shipping method
It this case the user will get a shipping address error when clicking on "Next - Payment Method" button as the shipping address is invalid

I am not sure how a user can end up in this scenario, I didn't get to check the affected user. As far as I can see, there is no way to delete a user/customer shipping address. I managed to reproduce the error by manually delete the customer shipping address ( see the test section below ) 
I fixed the issue by setting `ship_address_same_as_billing` to true when the selected shipping method is a "pick up" one. It's a bit hacky but it seems like the easiest solution.
Ideally we would skip validating the order's shipping address in this case, but that would mean getting rid of `accepts_nested_attributes_for :ship_address` in  `Spree::Order` which would probably cause other issue. I don't think there is a way to skip/conditionally skip validation with `accepts_nested_attributes_for`.  

Filipe did mention in this [comment](https://github.com/openfoodfoundation/openfoodnetwork/issues/9056#issuecomment-1087845901) that

>   Since we're dealing with a pick-up delivery method the hub's address should become the ship address for that order. Don't know   why this is happening

I don't if this correct or where in the code it's supposed to happen.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Create or set up a shop with only a "pick up" shipping method
- Make sure there is an order cycle open for said shop

![Shop_pick_up_shipping](https://user-images.githubusercontent.com/40413322/222051359-9f4ca543-a8ad-402d-a70e-d12cbd876c5b.png)

- Create a new user
- Place an order with the new user
- Remove user shipping address via rails console x :
  - Load placed order:  `o = Spree::Order.find_by number: 'R313071156'`
  - Load customer `c = o.customer`, it should have a `ship_address_id`
  - Remove ship_address, 
    ```
    c.ship_address = nil
    c.save!
    ```
  - Check in back office that address has been remove properly 
  - Go to customer tab, choose shop you placed an order with , you should see "Edit" under "Shipping Address" for your use:
 
    ![customer_no_shipping_address](https://user-images.githubusercontent.com/40413322/222051396-20d5af47-95d1-4c25-8d71-d0ab01808949.png)

- Start an order with the new user and go to checkout
- Click on Next - Payment method -> you should be redirected to the payment step

Alternatively,  you might be able to do the following, similar to what the system spec does, I ran out of time to test that :
- Set up a shop with two shipping methods, one requiring a shipping address, and one pick up only 
- Start an order and go to checkout
- First choose the shipping method requiring an address, untick "Shipping address same as billing address?"
- Make sure the shipping address is empty
- Then choose the pick up shipping method 
- Click on Next - Payment method -> you should be redirected to the payment step

#### Release notes

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
