### PR TITLE
SplitCheckout: Make label clickable to check/uncheck checkbox on step 2

### DIFF
--- a/app/views/split_checkout/payment/_stripe_sca.html.haml
+++ b/app/views/split_checkout/payment/_stripe_sca.html.haml
@@ -29,5 +29,5 @@
     - if spree_current_user
       .checkout-input
         = check_box_tag "order[payments_attributes][][source_attributes][save_requested_by_customer]", 1, false
-        = label :save_requested_by_customer, t('split_checkout.step2.form.stripe.save_card'), { for: "save_requested_by_customer" }
+        = label_tag :order_payments_attributes__source_attributes_save_requested_by_customer, t('split_checkout.step2.form.stripe.save_card')
       


### PR DESCRIPTION
#### What? Why?

- Closes #10495 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

![2023-03-01 08 47 57](https://user-images.githubusercontent.com/296452/222076538-58fcb367-5f7a-470c-bb0b-c4f16315f17a.gif)


#### What should we test?
Pretty well explained in the original issue:

1. Activate Split Checkout (feature toggle).
2. Make sure you have an order cycle open with a stripe payment method set up.
3. Go shopping and start the checkout process.
4. On step 2 (payment method) select the stripe payment method.
5. Select 'or enter new card details below'.
6. Try to activate the checkbbox 'Save card for later use' by clicking the label of it.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
