### PR TITLE
10272 Remove currency check on shipping methods

### DIFF
--- a/engines/order_management/app/services/order_management/stock/estimator.rb
+++ b/engines/order_management/app/services/order_management/stock/estimator.rb
@@ -54,10 +54,6 @@ module OrderManagement
         shipping_methods = package.shipping_methods
         shipping_methods.delete_if { |ship_method| !ship_method.calculator.available?(package) }
         shipping_methods.delete_if { |ship_method| !ship_method.include?(order.ship_address) }
-        shipping_methods.delete_if { |ship_method|
-          !(ship_method.calculator.preferences[:currency].nil? ||
-            ship_method.calculator.preferences[:currency] == currency)
-        }
         shipping_methods
       end
     end

--- a/engines/order_management/app/services/order_management/stock/estimator.rb
+++ b/engines/order_management/app/services/order_management/stock/estimator.rb
@@ -52,8 +52,8 @@ module OrderManagement
 
       def shipping_methods(package)
         package.shipping_methods
-          .reject { |ship_method| !ship_method.calculator.available?(package) }
-          .reject { |ship_method| !ship_method.include?(order.ship_address) }
+          .select { |ship_method| ship_method.calculator.available?(package) }
+          .select { |ship_method| ship_method.include?(order.ship_address) }
       end
     end
   end

--- a/engines/order_management/app/services/order_management/stock/estimator.rb
+++ b/engines/order_management/app/services/order_management/stock/estimator.rb
@@ -51,9 +51,9 @@ module OrderManagement
       end
 
       def shipping_methods(package)
-        package.shipping_methods
-          .select { |ship_method| ship_method.calculator.available?(package) }
-          .select { |ship_method| ship_method.include?(order.ship_address) }
+        package.shipping_methods.select { |ship_method|
+          ship_method.calculator.available?(package) && ship_method.include?(order.ship_address)
+        }
       end
     end
   end

--- a/engines/order_management/app/services/order_management/stock/estimator.rb
+++ b/engines/order_management/app/services/order_management/stock/estimator.rb
@@ -51,10 +51,9 @@ module OrderManagement
       end
 
       def shipping_methods(package)
-        shipping_methods = package.shipping_methods
-        shipping_methods.delete_if { |ship_method| !ship_method.calculator.available?(package) }
-        shipping_methods.delete_if { |ship_method| !ship_method.include?(order.ship_address) }
-        shipping_methods
+        package.shipping_methods
+          .reject { |ship_method| !ship_method.calculator.available?(package) }
+          .reject { |ship_method| !ship_method.include?(order.ship_address) }
       end
     end
   end

--- a/engines/order_management/spec/services/order_management/stock/estimator_spec.rb
+++ b/engines/order_management/spec/services/order_management/stock/estimator_spec.rb
@@ -18,9 +18,6 @@ module OrderManagement
           allow_any_instance_of(Spree::ShippingMethod).
             to receive_message_chain(:calculator, :compute).and_return(4.00)
           allow_any_instance_of(Spree::ShippingMethod).
-            to receive_message_chain(:calculator, :preferences).
-            and_return(currency: order.currency)
-          allow_any_instance_of(Spree::ShippingMethod).
             to receive_message_chain(:calculator, :marked_for_destruction?)
 
           allow(package).to receive_messages(shipping_methods: [shipping_method])
@@ -45,21 +42,6 @@ module OrderManagement
           it "does not return shipping rates from a shipping method" do
             allow_any_instance_of(Spree::ShippingMethod).
               to receive_message_chain(:calculator, :available?).and_return(false)
-            shipping_rates = subject.shipping_rates(package)
-            expect(shipping_rates).to eq []
-          end
-        end
-
-        context "the currency matches the order's currency" do
-          it "returns shipping rates from a shipping method" do
-            shipping_rates = subject.shipping_rates(package)
-            expect(shipping_rates.first.cost).to eq 4.00
-          end
-        end
-
-        context "the currency is different than the order's currency" do
-          it "does not return shipping rates from a shipping method" do
-            order.currency = "USD"
             shipping_rates = subject.shipping_rates(package)
             expect(shipping_rates).to eq []
           end


### PR DESCRIPTION
#### What? Why?

- part of #10272

We have decided that we don't need currency on calculators anymore, so silly me tried to clean it up.
Maikel pointed out this code which is still looking at any currency values that are still in the database.

**If there are any methods that currently have a calculator with a different currency applied, they would have been hidden and suddenly start showing unexpectedly.**
Hmm.. that could be bad. Should we locate and deactivate these first?

#### What should we test?
I don't know for sure all the cases that should be tested, but this seems to be related to showing all shipping rates applicable for an order. Eg checkout and updating orders.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
