### PR TITLE
Prevent saving the enterprise fee when a per order calculator is selected along with 'Inherit from product'

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -656,6 +656,7 @@ Metrics/BlockNesting:
 Metrics/ClassLength:
   Exclude:
     - 'app/components/products_table_component.rb'
+    - 'app/controllers/admin/enterprise_fees_controller.rb'
     - 'app/controllers/admin/enterprises_controller.rb'
     - 'app/controllers/admin/order_cycles_controller.rb'
     - 'app/controllers/admin/resource_controller.rb'

--- a/app/models/enterprise_fee.rb
+++ b/app/models/enterprise_fee.rb
@@ -58,6 +58,14 @@ class EnterpriseFee < ApplicationRecord
     elsif inherits_tax_category_changed?
       self.tax_category_id = nil if inherits_tax_category?
     end
+
+    if inherits_tax_category? && PER_ORDER_CALCULATORS.include?(calculator_type)
+      errors.add(:inherits_tax_category,
+                 I18n.t("activerecord.errors.models." \
+                  "enterpise_fee.cannot_inherit_from_product_when_per_order_calculator_selected"))
+      throw :abort
+    end
+
     true
   end
 end

--- a/app/models/enterprise_fee.rb
+++ b/app/models/enterprise_fee.rb
@@ -60,9 +60,7 @@ class EnterpriseFee < ApplicationRecord
     end
 
     if inherits_tax_category? && PER_ORDER_CALCULATORS.include?(calculator_type)
-      errors.add(:inherits_tax_category,
-                 I18n.t("activerecord.errors.models." \
-                  "enterpise_fee.cannot_inherit_from_product_when_per_order_calculator_selected"))
+      errors.add(:base, :inherit_tax_requires_per_item_calculator)
       throw :abort
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,8 @@ en:
         preferred_per_unit: "Calculator Per Unit:"
     errors:
       models:
+        enterprise_fee:
+          inherit_tax_requires_per_item_calculator: "Inheriting the tax categeory requires a per-item calculator."
         spree/user:
           attributes:
             email:
@@ -113,8 +115,6 @@ en:
             using_producer_stock_settings_but_count_on_hand_set: "must be blank because using producer stock settings"
             on_demand_but_count_on_hand_set: "must be blank if on demand"
             limited_stock_but_no_count_on_hand: "must be specified because forcing limited stock"
-        enterpise_fee:
-          cannot_inherit_from_product_when_per_order_calculator_selected: "You cannot select 'Inherit From Product' when a per order calculator is selected"
   # Used by active_storage_validations
   errors:
     messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,7 +113,8 @@ en:
             using_producer_stock_settings_but_count_on_hand_set: "must be blank because using producer stock settings"
             on_demand_but_count_on_hand_set: "must be blank if on demand"
             limited_stock_but_no_count_on_hand: "must be specified because forcing limited stock"
-
+        enterpise_fee:
+          cannot_inherit_from_product_when_per_order_calculator_selected: "You cannot select 'Inherit From Product' when a per order calculator is selected"
   # Used by active_storage_validations
   errors:
     messages:

--- a/db/migrate/20230316034707_disable_inherits_tax_category_from_per_order_enterprise_fees.rb
+++ b/db/migrate/20230316034707_disable_inherits_tax_category_from_per_order_enterprise_fees.rb
@@ -2,10 +2,10 @@
 
 class DisableInheritsTaxCategoryFromPerOrderEnterpriseFees < ActiveRecord::Migration[6.1]
   class EnterpriseFee < ApplicationRecord
-    has_one :calculator, as: :calculable, class_name: "Spree::Calculator", dependent: :destroy
+    has_many :calculator, class_name: "Spree::Calculator", foreign_key: :calculable_id
   end
 
-  class Spree
+  module Spree
     class Calculator < ApplicationRecord
       self.table_name = 'spree_calculators'
     end
@@ -18,7 +18,7 @@ class DisableInheritsTaxCategoryFromPerOrderEnterpriseFees < ActiveRecord::Migra
   end
 
   def calculators
-    Spree::Calculator.where(type: per_order_calculators)
+    Spree::Calculator.where(type: per_order_calculators, calculable_type: 'EnterpriseFee')
   end
 
   def per_order_calculators

--- a/db/migrate/20230316034707_disable_inherits_tax_category_from_per_order_enterprise_fees.rb
+++ b/db/migrate/20230316034707_disable_inherits_tax_category_from_per_order_enterprise_fees.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class DisableInheritsTaxCategoryFromPerOrderEnterpriseFees < ActiveRecord::Migration[6.1]
+  class EnterpriseFee < ApplicationRecord
+    has_one :calculator, as: :calculable, class_name: "Spree::Calculator", dependent: :destroy
+  end
+
+  class Spree
+    class Calculator < ApplicationRecord
+      self.table_name = 'spree_calculators'
+    end
+  end
+
+  def change
+    EnterpriseFee.joins(:calculator).merge(calculators)
+      .where(inherits_tax_category: true)
+      .update_all(inherits_tax_category: false)
+  end
+
+  def calculators
+    Spree::Calculator.where(type: per_order_calculators)
+  end
+
+  def per_order_calculators
+    ['Calculator::FlatRate',
+     'Calculator::FlexiRate',
+     'Calculator::PriceSack']
+  end
+end

--- a/spec/lib/reports/enterprise_fee_summary/enterprise_fee_summary_report_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/enterprise_fee_summary_report_spec.rb
@@ -319,9 +319,9 @@ describe Reporting::Reports::EnterpriseFeeSummary::Base do
                                             amount: 15)
       end
       let!(:coordinator_fee_inheriting_product_tax_category) do
-        create(:enterprise_fee, :flat_rate, name: "Coordinator Fee B", enterprise: coordinator,
-                                            fee_type: "admin", inherits_tax_category: true,
-                                            amount: 20)
+        create(:enterprise_fee, :per_item, name: "Coordinator Fee B", enterprise: coordinator,
+                                           fee_type: "admin", inherits_tax_category: true,
+                                           amount: 20)
       end
       let!(:coordinator_fee_without_tax) do
         create(:enterprise_fee, :flat_rate, name: "Coordinator Fee C", enterprise: coordinator,

--- a/spec/models/enterprise_fee_spec.rb
+++ b/spec/models/enterprise_fee_spec.rb
@@ -9,6 +9,19 @@ describe EnterpriseFee do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
+
+    it "requires a per-item calculator to inherit tax" do
+      subject = build(
+        :enterprise_fee,
+        inherits_tax_category: true,
+        calculator: Calculator::FlatRate.new
+      )
+
+      expect(subject.save).to eq false
+      expect(subject.errors.full_messages.first).to eq(
+        "Inheriting the tax categeory requires a per-item calculator."
+      )
+    end
   end
 
   describe "callbacks" do

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -426,7 +426,7 @@ module Spree
 
           context "when enterprise fees are taxed per-order" do
             let(:enterprise_fee) {
-              create(:enterprise_fee, enterprise: coordinator, inherits_tax_category: true,
+              create(:enterprise_fee, enterprise: coordinator, inherits_tax_category: false,
                                       calculator: ::Calculator::FlatRate.new(preferred_amount: 50.0))
             }
 


### PR DESCRIPTION

#### What? Why?

- Closes #10348

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Go to the Enterprise Fees page
- Selected an existing Enterprise Fee ( or you  can create a new one )
- select 'Inherit From Product' as the tax category
- select any 'Per Order' calculator.
- Fill in the remaining field if you're creating a new enterprise fee.

You should see an error message:
""You cannot select 'Inherit From Product' when a per order calculator is selected""
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
