### PR TITLE
SplitCheckout: Display special_instructions of the order as emphasized text if present on summary page

### DIFF
--- a/app/views/split_checkout/_summary.html.haml
+++ b/app/views/split_checkout/_summary.html.haml
@@ -34,6 +34,10 @@
           = @order.bill_address.zipcode
         %div
           = @order.bill_address.country
+        - if @order.special_instructions.present?
+          %br
+          %em
+            = @order.special_instructions
       - if @order.shipping_method.description.present?
         %div
           .summary-subtitle

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -793,6 +793,17 @@ describe "As a consumer, I want to checkout my order" do
         create(:order_ready_for_confirmation, distributor: distributor)
       }
 
+      describe "with an order with special instructions" do
+        before do
+          order.update_attribute(:special_instructions, "Please deliver on Tuesday")
+          visit checkout_step_path(:summary)
+        end
+
+        it "displays the special instructions" do
+          expect(page).to have_content "Please deliver on Tuesday"
+        end
+      end
+
       describe "completing the checkout" do
         it "keeps the distributor selected for the current user after completion" do
           visit checkout_step_path(:summary)


### PR DESCRIPTION
#### What? Why?

- Closes #10505
- 
<img width="1177" alt="Capture d’écran 2023-03-03 à 11 04 33" src="https://user-images.githubusercontent.com/296452/222692083-0f09eda2-7df2-4a0a-8b99-c328abf85d57.png">

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
(Depending when this will be tested, you will need to activate Split checkout - or not)

1. Use checkout as guest
2. Add a comment in step 1
3. See it is displayed in step 3 as the design above
4. Check backoffice as a hub to see if the comment is correctly saved


Repeat with a loggedin user.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 