### PR TITLE
Do not update `estimate_price` of a variant that is not available for the shop on OrderCycle update

### DIFF
--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -104,6 +104,9 @@ module Admin
           subscription.subscription_line_items.nil_price_estimate.each do |line_item|
             variant = OrderManagement::Subscriptions::
                 VariantsList.eligible_variants(shop).find_by(id: line_item.variant_id)
+            # If the variant is not available in the shop, the price estimate will be nil
+            next if variant.nil?
+
             price = variant.price + fee_calculator.indexed_fees_for(variant)
             line_item.update_column(:price_estimate, price)
           end

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -100,10 +100,10 @@ module Admin
       order_cycle.schedules.each do |schedule|
         Subscription.where(schedule_id: schedule.id).each do |subscription|
           shop = Enterprise.managed_by(spree_current_user).find_by(id: subscription.shop_id)
+          fee_calculator = OpenFoodNetwork::EnterpriseFeeCalculator.new(shop, order_cycle)
           subscription.subscription_line_items.nil_price_estimate.each do |line_item|
             variant = OrderManagement::Subscriptions::
                 VariantsList.eligible_variants(shop).find_by(id: line_item.variant_id)
-            fee_calculator = OpenFoodNetwork::EnterpriseFeeCalculator.new(shop, order_cycle)
             price = variant.price + fee_calculator.indexed_fees_for(variant)
             line_item.update_column(:price_estimate, price)
           end


### PR DESCRIPTION
#### What? Why?
This is a tough one, I hope the solution is good. 
- Closes #9292



#### What should we test?

The setup I used to _reproduce_ (I hope...) the issue:
 - Having a closing OC with a schedule
<img width="1391" alt="Capture d’écran 2023-03-03 à 15 09 39" src="https://user-images.githubusercontent.com/296452/222741777-5e2bc866-de84-4664-8009-2899794b39af.png">

 - Adding product to this schedule (here `Garlic 200g`)
<img width="1243" alt="Capture d’écran 2023-03-03 à 15 10 11" src="https://user-images.githubusercontent.com/296452/222741913-001fe5ed-7187-47e1-b77f-bdbd504599bf.png">

- Delete this variant
- Try to update OC. _Before_ the PR, you should see an error message ; _After_ the PR, the OC must be edited with a success message.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
