### PR TITLE
Removing 'none' from shipping categories from product edit page

### DIFF
--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -45,7 +45,7 @@
 
     = f.field_container :shipping_categories do
       = f.label :shipping_category_id, t(:shipping_categories)
-      = f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => t(:none) }, { :class => 'select2' })
+      = f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, {}, { :class => 'select2' })
       = f.error_message_on :shipping_category
 
     = f.field_container :tax_category do


### PR DESCRIPTION
- Closes #10515 

Simply removing the 'none' option from shipping categories drop down from product edit page as it cannot be saved set to none.

#### What should we test?
- Go to products under admin section
- Go to edit page of any product and see that there is no `none` as one of the options under `Shipping Categories` drop down.

#### Release notes
Changelog Category: User facing changes | Technical changes
