### PR TITLE
Voucher bare minimum backoffice

### DIFF
--- a/app/controllers/admin/vouchers_controller.rb
+++ b/app/controllers/admin/vouchers_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Admin
+  class VouchersController < ResourceController
+
+   def new
+     @enterprise = Enterprise.find_by permalink: params[:enterprise_id]
+   end
+  end
+end

--- a/app/controllers/admin/vouchers_controller.rb
+++ b/app/controllers/admin/vouchers_controller.rb
@@ -5,6 +5,7 @@ module Admin
 
    def new
      @enterprise = Enterprise.find_by permalink: params[:enterprise_id]
+     @voucher = Voucher.new
    end
   end
 end

--- a/app/controllers/admin/vouchers_controller.rb
+++ b/app/controllers/admin/vouchers_controller.rb
@@ -2,10 +2,35 @@
 
 module Admin
   class VouchersController < ResourceController
+    before_action :load_enterprise
 
-   def new
-     @enterprise = Enterprise.find_by permalink: params[:enterprise_id]
-     @voucher = Voucher.new
-   end
+    def new
+      @voucher = Voucher.new
+    end
+
+    def create
+      voucher_params = permitted_resource_params.merge(enterprise: @enterprise)
+      @voucher = Voucher.create(voucher_params)
+
+      if @voucher.save
+        redirect_to(
+          "#{edit_admin_enterprise_path(@enterprise)}#vouchers_panel",
+          flash: { success: flash_message_for(@voucher, :successfully_created) }
+        )
+      else
+        flash[:error] = @voucher.errors.full_messages.to_sentence
+        render :new
+      end
+    end
+
+    private
+
+    def load_enterprise
+      @enterprise = Enterprise.find_by permalink: params[:enterprise_id]
+    end
+
+    def permitted_resource_params
+      params.require(:voucher).permit(:code)
+    end
   end
 end

--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -14,6 +14,7 @@ module Admin
       producers.size == 1 ? producers.first.id : nil
     end
 
+    # rubocop:disable Metrics/MethodLength
     def enterprise_side_menu_items(enterprise)
       is_shop = enterprise.sells != "none"
       show_properties = !!enterprise.is_primary_producer
@@ -34,7 +35,7 @@ module Admin
         { name: 'shipping_methods', icon_class: "icon-truck", show: show_shipping_methods },
         { name: 'payment_methods',  icon_class: "icon-money", show: show_payment_methods },
         { name: 'enterprise_fees',  icon_class: "icon-tasks", show: show_enterprise_fees },
-        { name: 'vouchers',  icon_class: "icon-ticket", show: true },
+        { name: 'vouchers', icon_class: "icon-ticket", show: true },
         { name: 'enterprise_permissions', icon_class: "icon-plug", show: true,
           href: admin_enterprise_relationships_path },
         { name: 'inventory_settings', icon_class: "icon-list-ol", show: is_shop },
@@ -43,5 +44,6 @@ module Admin
         { name: 'users', icon_class: "icon-user", show: true }
       ]
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -34,6 +34,7 @@ module Admin
         { name: 'shipping_methods', icon_class: "icon-truck", show: show_shipping_methods },
         { name: 'payment_methods',  icon_class: "icon-money", show: show_payment_methods },
         { name: 'enterprise_fees',  icon_class: "icon-tasks", show: show_enterprise_fees },
+        { name: 'vouchers',  icon_class: "icon-ticket", show: true },
         { name: 'enterprise_permissions', icon_class: "icon-plug", show: true,
           href: admin_enterprise_relationships_path },
         { name: 'inventory_settings', icon_class: "icon-list-ol", show: is_shop },

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -65,6 +65,7 @@ class Enterprise < ApplicationRecord
   has_many :inventory_items
   has_many :tag_rules
   has_one :stripe_account, dependent: :destroy
+  has_many :vouchers
 
   delegate :latitude, :longitude, :city, :state_name, to: :address
 

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -179,6 +179,8 @@ module Spree
       can [:admin, :create], :manager_invitation
 
       can [:admin, :index], :oidc_setting
+
+      can [:admin, :create], Voucher
     end
 
     def add_product_management_abilities(user)

--- a/app/models/voucher.rb
+++ b/app/models/voucher.rb
@@ -4,4 +4,12 @@ class Voucher < ApplicationRecord
   belongs_to :enterprise
 
   validates :code, presence: true, uniqueness: { scope: :enterprise_id }
+
+  def value
+    10
+  end
+
+  def display_value
+    Spree::Money.new(value)
+  end
 end

--- a/app/models/voucher.rb
+++ b/app/models/voucher.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: false
+
+class Voucher < ApplicationRecord
+  belongs_to :enterprise
+
+  validates :code, presence: true, uniqueness: { scope: :enterprise_id }
+end

--- a/app/views/admin/enterprises/_form.html.haml
+++ b/app/views/admin/enterprises/_form.html.haml
@@ -9,6 +9,12 @@
     %fieldset.alpha.no-border-bottom{ id: "#{item[:name]}_panel", data: { "tabs-and-panels-target": "panel" }}
       %legend= t(".#{ item[:name] }.legend")
 
+  - when 'vouchers'
+    - if feature?(:vouchers, spree_current_user)
+      %fieldset.alpha.no-border-bottom{ id: "#{item[:name]}_panel", data: { "tabs-and-panels-target": "panel"  }}
+        %legend= t(".#{ item[:form_name] || item[:name] }.legend")
+        = render "admin/enterprises/form/#{ item[:form_name] || item[:name] }", f: f
+
   - else
     %fieldset.alpha.no-border-bottom{ id: "#{item[:name]}_panel", data: { "tabs-and-panels-target": "panel"  }}
       %legend= t(".#{ item[:form_name] || item[:name] }.legend")

--- a/app/views/admin/enterprises/form/_vouchers.html.haml
+++ b/app/views/admin/enterprises/form/_vouchers.html.haml
@@ -19,7 +19,7 @@
       - @enterprise.vouchers.each do |voucher|
         %tr
           %td= voucher.code
-          %td $10 
+          %td= voucher.display_value  
           %td
           %td
           %td

--- a/app/views/admin/enterprises/form/_vouchers.html.haml
+++ b/app/views/admin/enterprises/form/_vouchers.html.haml
@@ -9,23 +9,23 @@
       %tr
         %th= t('.voucher_code')
         %th= t('.rate')
-        %th= t('.label')
-        %th= t('.purpose')
-        %th= t('.expiry')
-        %th= t('.use_limit')
-        %th= t('.customers')
-        %th= t('.net_value')
+        /%th= t('.label')
+        /%th= t('.purpose')
+        /%th= t('.expiry')
+        /%th= t('.use_limit')
+        /%th= t('.customers')
+        /%th= t('.net_value')
     %tbody
       - @enterprise.vouchers.each do |voucher|
         %tr
           %td= voucher.code
           %td= voucher.display_value  
-          %td
-          %td
-          %td
-          %td
-          %td
-          %td
+          /%td
+          /%td
+          /%td
+          /%td
+          /%td
+          /%td
 
 - else
   %p.text-center

--- a/app/views/admin/enterprises/form/_vouchers.html.haml
+++ b/app/views/admin/enterprises/form/_vouchers.html.haml
@@ -1,0 +1,33 @@
+.text-right
+  %a.button{ href: "#{new_admin_enterprise_voucher_path(@enterprise)}"}
+    = t('.add_new')
+%br
+
+- if @enterprise.vouchers.present?
+  %table
+    %thead
+      %tr
+        %th= t('.voucher_code')
+        %th= t('.rate')
+        %th= t('.label')
+        %th= t('.purpose')
+        %th= t('.expiry')
+        %th= t('.use_limit')
+        %th= t('.customers')
+        %th= t('.net_value')
+    %tbody
+      - @enterprise.vouchers.each do |voucher|
+        %tr
+          %td= voucher.code
+          %td= voucher.rate
+          %td
+          %td
+          %td
+          %td
+          %td
+          %td
+
+- else
+  %p.text-center
+    = t('.no_voucher_yet')
+

--- a/app/views/admin/enterprises/form/_vouchers.html.haml
+++ b/app/views/admin/enterprises/form/_vouchers.html.haml
@@ -19,7 +19,7 @@
       - @enterprise.vouchers.each do |voucher|
         %tr
           %td= voucher.code
-          %td= voucher.rate
+          %td $10 
           %td
           %td
           %td

--- a/app/views/admin/shared/_side_menu.html.haml
+++ b/app/views/admin/shared/_side_menu.html.haml
@@ -1,7 +1,7 @@
 .side_menu#side_menu
   - if @enterprise
     - enterprise_side_menu_items(@enterprise).each do |item|
-    - next unless item[:show]
+    - next if !item[:show] || (item[:name] == 'vouchers' && !feature?(:vouchers, spree_current_user))
       %a.menu_item{ href: item[:href] || "##{item[:name]}_panel", id: item[:name], data: { action: "tabs-and-panels#changeActivePanel tabs-and-panels#changeActiveTab", "tabs-and-panels-target": "tab" }, class: item[:selected] }
         %i{ class: item[:icon_class] }
         %span= t(".enterprise.#{item[:name] }")

--- a/app/views/admin/vouchers/new.html.haml
+++ b/app/views/admin/vouchers/new.html.haml
@@ -19,5 +19,5 @@
           .alpha.four.columns
             = f.label :amount, t('.voucher_amount')
           .omega.eight.columns
-            $
-            = f.text_field :amount, value: 10, disabled: true
+            = Spree::Money.currency_symbol
+            = f.text_field :amount, value: @voucher.value, disabled: true

--- a/app/views/admin/vouchers/new.html.haml
+++ b/app/views/admin/vouchers/new.html.haml
@@ -1,22 +1,23 @@
-.row
-  .sixteen.columns.alpha
-    .four.columns.alpha.text-right
-      %a.button{ href: "#{edit_admin_enterprise_path(@enterprise)}#!#vouchers_panel"}
-        = t('.back')
-    .twelve.columns.omega
-      .row 
-        .eight.columns.text-center
-          %legend= t(".legend")
-        .four.columns.text-right
-          %input.red{ type: "button", value: t('.save') }
-      .row
-        .alpha.four.columns
-          = label :voucher, :code, t('.voucher_code')
-        .omega.eight.columns
-          %textarea.fullwidth{ id: 'voucher_code', name: 'voucher_code', rows: 6 }
-      .row
-        .alpha.four.columns
-          = label :voucher, :amount, t('.voucher_amount')
-        .omega.eight.columns
-          $
-          %input{ type: 'text', id: 'voucher_amount', name: 'voucher_amount', value: 10, disabled: true }
+= form_with model: @voucher, url: admin_enterprise_vouchers_path(@enterprise), html: { name: "voucher_form" } do |f|
+  .row
+    .sixteen.columns.alpha
+      .four.columns.alpha.text-right
+        %a.button{ href: "#{edit_admin_enterprise_path(@enterprise)}#!#vouchers_panel"}
+          = t('.back')
+      .twelve.columns.omega
+        .row 
+          .eight.columns.text-center
+            %legend= t(".legend")
+          .four.columns.text-right
+            = f.submit t('.save'), class: 'red'
+        .row
+          .alpha.four.columns
+            = f.label :code, t('.voucher_code')
+          .omega.eight.columns
+            = f.text_area :code, rows: 6, class: 'fullwidth' 
+        .row
+          .alpha.four.columns
+            = f.label :amount, t('.voucher_amount')
+          .omega.eight.columns
+            $
+            = f.text_field :amount, value: 10, disabled: true

--- a/app/views/admin/vouchers/new.html.haml
+++ b/app/views/admin/vouchers/new.html.haml
@@ -1,0 +1,22 @@
+.row
+  .sixteen.columns.alpha
+    .four.columns.alpha.text-right
+      %a.button{ href: "#{edit_admin_enterprise_path(@enterprise)}#!#vouchers_panel"}
+        = t('.back')
+    .twelve.columns.omega
+      .row 
+        .eight.columns.text-center
+          %legend= t(".legend")
+        .four.columns.text-right
+          %input.red{ type: "button", value: t('.save') }
+      .row
+        .alpha.four.columns
+          = label :voucher, :code, t('.voucher_code')
+        .omega.eight.columns
+          %textarea.fullwidth{ id: 'voucher_code', name: 'voucher_code', rows: 6 }
+      .row
+        .alpha.four.columns
+          = label :voucher, :amount, t('.voucher_amount')
+        .omega.eight.columns
+          $
+          %input{ type: 'text', id: 'voucher_amount', name: 'voucher_amount', value: 10, disabled: true }

--- a/app/views/spree/admin/shared/_tabs.html.haml
+++ b/app/views/spree/admin/shared/_tabs.html.haml
@@ -4,7 +4,7 @@
 = tab :orders, :subscriptions, :customer_details, :adjustments, :payments, :return_authorizations, url: admin_orders_path('q[s]' => 'completed_at desc'), icon: 'icon-shopping-cart'
 = tab :reports, url: main_app.admin_reports_path, icon: 'icon-file'
 = tab :general_settings, :mail_methods, :tax_categories, :tax_rates, :tax_settings, :zones, :countries, :states, :payment_methods, :taxonomies, :shipping_methods, :shipping_categories, :enterprise_fees, :contents, :invoice_settings, :matomo_settings, :stripe_connect_settings, label: 'configuration', icon: 'icon-wrench', url: edit_admin_general_settings_path
-= tab :enterprises, :enterprise_relationships, :oidc_settings, url: main_app.admin_enterprises_path
+= tab :enterprises, :enterprise_relationships, :vouchers, :oidc_settings, url: main_app.admin_enterprises_path
 = tab :customers, url: main_app.admin_customers_path
 = tab :enterprise_groups, url: main_app.admin_enterprise_groups_path, label: 'groups'
 - if can? :admin, Spree::User

--- a/app/webpacker/controllers/tabs_and_panels_controller.js
+++ b/app/webpacker/controllers/tabs_and_panels_controller.js
@@ -12,12 +12,33 @@ export default class extends Controller {
 
     // only display the default panel
     this.defaultTarget.style.display = "block";
+
+    // Display panel specified in url anchor
+    const anchors = window.location.toString().split("#");
+    const anchor = anchors.length > 1 ? anchors.pop() : "";
+
+    if (anchor != "") {
+      this.updateActivePanel(anchor);
+
+      // tab
+      const tab_id = anchor.split("_panel").shift();
+      this.updateActiveTab(tab_id);
+    }
   }
 
   changeActivePanel(event) {
+    this.updateActivePanel(`${event.currentTarget.id}_panel`);
+  }
+
+  updateActivePanel(panel_id) {
     const newActivePanel = this.panelTargets.find(
-      (panel) => panel.id == `${event.currentTarget.id}_panel`
+      (panel) => panel.id == panel_id
     );
+
+    if (newActivePanel === undefined) {
+      // No panel found
+      return;
+    }
 
     this.currentActivePanel.style.display = "none";
     newActivePanel.style.display = "block";
@@ -26,6 +47,18 @@ export default class extends Controller {
   changeActiveTab(event) {
     this.currentActiveTab.classList.remove(`${this.classNameValue}`);
     event.currentTarget.classList.add(`${this.classNameValue}`);
+  }
+
+  updateActiveTab(tab_id) {
+    const newActiveTab = this.tabTargets.find((tab) => tab.id == tab_id);
+
+    if (newActiveTab === undefined) {
+      // No tab found
+      return;
+    }
+
+    this.currentActiveTab.classList.remove(`${this.classNameValue}`);
+    newActiveTab.classList.add(`${this.classNameValue}`);
   }
 
   get currentActiveTab() {

--- a/app/webpacker/controllers/tabs_and_panels_controller.js
+++ b/app/webpacker/controllers/tabs_and_panels_controller.js
@@ -15,9 +15,15 @@ export default class extends Controller {
 
     // Display panel specified in url anchor
     const anchors = window.location.toString().split("#");
-    const anchor = anchors.length > 1 ? anchors.pop() : "";
+    let anchor = anchors.length > 1 ? anchors.pop() : "";
 
     if (anchor != "") {
+      // Conveniently AngularJs rewrite "example.com#panel" to "example.com#/panel" :(
+      // strip the starting / if any
+      if (anchor[0] == "/") {
+        anchor = anchor.slice(1);
+      }
+
       this.updateActivePanel(anchor);
 
       // tab

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1146,6 +1146,7 @@ en:
           email_not_confirmed: "Email not confirmed"
         vouchers:
           legend: Vouchers
+          voucher_code: Voucher Code
           rate: Rate
           label: Label
           purpose: Purpose

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1144,6 +1144,17 @@ en:
           add_unregistered_user: "Add an unregistered user"
           email_confirmed: "Email confirmed"
           email_not_confirmed: "Email not confirmed"
+        vouchers:
+          legend: Vouchers
+          rate: Rate
+          label: Label
+          purpose: Purpose
+          expiry: Expiry
+          use_limit: Use/Limit
+          customers: Customer
+          net_value: Net Value
+          add_new: Add New
+          no_voucher_yet: No Vouchers yet
       actions:
         edit_profile: Settings
         properties: Properties
@@ -1382,6 +1393,7 @@ en:
           tag_rules: "Tag Rules"
           shop_preferences: "Shop Preferences"
           users: "Users"
+          vouchers: Vouchers
         enterprise_group:
           primary_details: "Primary Details"
           users: "Users"
@@ -1590,6 +1602,13 @@ en:
     schedules:
       destroy:
         associated_subscriptions_error: This schedule cannot be deleted because it has associated subscriptions
+    vouchers:
+      new:
+        legend: New Voucher
+        back: Back
+        save: Save
+        voucher_code: Voucher Code
+        voucher_amount: Amount
 
     # Admin controllers
     controllers:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -41,8 +41,9 @@ Openfoodnetwork::Application.routes.draw do
 
       resources :tag_rules, only: [:destroy]
 
-      # TODO do we need to remove more routes
-      resources :vouchers, only: [:new, :create]
+      constraints FeatureToggleConstraint.new(:vouchers) do
+        resources :vouchers, only: [:new, :create]
+      end
     end
 
     resources :enterprise_relationships

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -40,6 +40,9 @@ Openfoodnetwork::Application.routes.draw do
       end
 
       resources :tag_rules, only: [:destroy]
+
+      # TODO do we need to remove more routes
+      resources :vouchers, only: [:new, :create]
     end
 
     resources :enterprise_relationships

--- a/db/migrate/20230215034821_create_vouchers.rb
+++ b/db/migrate/20230215034821_create_vouchers.rb
@@ -1,0 +1,12 @@
+class CreateVouchers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :vouchers do |t|
+      t.string :code, null: false, limit: 255
+      t.datetime :expiry_date
+
+      t.timestamps
+    end
+    add_reference :vouchers, :enterprise, foreign_key: true
+    add_index :vouchers, [:code, :enterprise_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1197,6 +1197,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_160135) do
     t.index ["user_id"], name: "index_webhook_endpoints_on_user_id"
   end
 
+  create_table "vouchers", force: :cascade do |t|
+    t.string "code", limit: 255, null: false
+    t.datetime "expiry_date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "enterprise_id"
+    t.index ["code", "enterprise_id"], name: "index_vouchers_on_code_and_enterprise_id", unique: true
+    t.index ["enterprise_id"], name: "index_vouchers_on_enterprise_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "adjustment_metadata", "enterprises", name: "adjustment_metadata_enterprise_id_fk"
@@ -1302,4 +1312,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_160135) do
   add_foreign_key "variant_overrides", "enterprises", column: "hub_id", name: "variant_overrides_hub_id_fk"
   add_foreign_key "variant_overrides", "spree_variants", column: "variant_id", name: "variant_overrides_variant_id_fk"
   add_foreign_key "webhook_endpoints", "spree_users", column: "user_id"
+  add_foreign_key "vouchers", "enterprises"
 end

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -37,6 +37,9 @@ module OpenFoodNetwork
       "split_checkout" => <<~DESC,
         Replace the one-page checkout with a multi-step checkout.
       DESC
+      "vouchers" => <<~DESC,
+        Add voucher functionality. Voucher can be managed via Enterprise settings.
+      DESC
     }.freeze
 
     # Move your feature entry from CURRENT_FEATURES to RETIRED_FEATURES when

--- a/spec/javascripts/stimulus/tabs_and_panels_controller_test.js
+++ b/spec/javascripts/stimulus/tabs_and_panels_controller_test.js
@@ -87,7 +87,7 @@ describe('TabsAndPanelsController', () => {
       const { location } = window;
       const mockLocationToString = (panel) => {
         // Mocking window.location.toString() 
-        const url = `http://localhost:3000/admin/enterprises/great-shop/edit#!#${panel}`
+        const url = `http://localhost:3000/admin/enterprises/great-shop/edit#/${panel}`
         const mockedToString = jest.fn()
         mockedToString.mockImplementation(() => (url))
 

--- a/spec/javascripts/stimulus/tabs_and_panels_controller_test.js
+++ b/spec/javascripts/stimulus/tabs_and_panels_controller_test.js
@@ -2,16 +2,26 @@
  * @jest-environment jsdom
  */
 
-import { Application } from "stimulus";
-import tabs_and_panels_controller from "../../../app/webpacker/controllers/tabs_and_panels_controller";
+import { Application } from 'stimulus';
+import tabs_and_panels_controller from '../../../app/webpacker/controllers/tabs_and_panels_controller';
 
-describe("EnterprisePanelController", () => {
+describe('EnterprisePanelController', () => {
   beforeAll(() => {
     const application = Application.start();
-    application.register("tabs-and-panels", tabs_and_panels_controller);
+    application.register('tabs-and-panels', tabs_and_panels_controller);
   });
 
-  describe("#tabs-and-panels", () => {
+  describe('#tabs-and-panels', () => {
+    const checkDefaultPanel = () => {
+      const peekPanel = document.getElementById('peek_panel');
+      const kaPanel = document.getElementById('ka_panel');
+      const booPanel = document.getElementById('boo_panel');
+
+      expect(peekPanel.style.display).toBe('block');
+      expect(kaPanel.style.display).toBe('none');
+      expect(booPanel.style.display).toBe('none');
+    }
+
     beforeEach(() => {
       document.body.innerHTML = `
         <div data-controller="tabs-and-panels" data-tabs-and-panels-class-name-value="selected">
@@ -26,23 +36,75 @@ describe("EnterprisePanelController", () => {
         </div>`;
     });
 
-    it("displays only the default panel", () => {
-      const peekPanel = document.getElementById("peek_panel");
-      const kaPanel = document.getElementById("ka_panel");
-      const booPanel = document.getElementById("boo_panel");
-
-      expect(peekPanel.style.display).toBe("block");
-      expect(kaPanel.style.display).toBe("none");
-      expect(booPanel.style.display).toBe("none");
+    it('displays only the default panel', () => {
+      checkDefaultPanel()
     });
 
-    it("displays appropriate panel when associated tab is clicked", () => {
-      const kaPanel = document.getElementById("ka_panel");
-      const ka = document.getElementById("ka");
+    describe('when tab is clicked', () => {
+      let ka;
 
-      expect(kaPanel.style.display).toBe("none");
-      ka.click();
-      expect(kaPanel.style.display).toBe("block");
-    });
+      beforeEach(() => {
+        ka = document.getElementById('ka');
+      })
+
+      it('displays appropriate panel', () => {
+        const kaPanel = document.getElementById('ka_panel');
+
+        expect(kaPanel.style.display).toBe('none');
+        ka.click();
+        expect(kaPanel.style.display).toBe('block');
+      });
+
+      it('selects the clicked tab', () => {
+        ka.click();
+        expect(ka.classList.contains('selected')).toBe(true);
+      });
+    })
+
+    describe('when anchor is specified in the url', () => {
+      const { location } = window;
+      const mockLocationToString = (panel) => {
+        // Mocking window.location.toString() 
+        const url = `http://localhost:3000/admin/enterprises/great-shop/edit#!#${panel}`
+        const mockedToString = jest.fn()
+        mockedToString.mockImplementation(() => (url))
+
+        delete window.location 
+        window.location = {
+          toString: mockedToString
+        } 
+      }
+
+      beforeAll(() => {
+        mockLocationToString('ka_panel')
+      })
+
+      afterAll(() => {
+        // cleaning up
+        window.location = location
+      })
+
+      it('displays the panel associated with the anchor', () => {
+        const kaPanel = document.getElementById('ka_panel');
+
+        expect(kaPanel.style.display).toBe('block');
+      })
+
+      it('selects the tab entry associated with the anchor', () => {
+        const ka = document.getElementById('ka');
+
+        expect(ka.classList.contains('selected')).toBe(true);
+      })
+
+      describe("when anchor doesn't macht any panel", () => {
+        beforeAll(() => {
+          mockLocationToString('random_panel')
+        })
+
+        it('displays the default panel', () => {
+          checkDefaultPanel()
+        })
+      })
+    })
   });
 });

--- a/spec/javascripts/stimulus/tabs_and_panels_controller_test.js
+++ b/spec/javascripts/stimulus/tabs_and_panels_controller_test.js
@@ -5,7 +5,7 @@
 import { Application } from 'stimulus';
 import tabs_and_panels_controller from '../../../app/webpacker/controllers/tabs_and_panels_controller';
 
-describe('EnterprisePanelController', () => {
+describe('TabsAndPanelsController', () => {
   beforeAll(() => {
     const application = Application.start();
     application.register('tabs-and-panels', tabs_and_panels_controller);
@@ -59,6 +59,28 @@ describe('EnterprisePanelController', () => {
         ka.click();
         expect(ka.classList.contains('selected')).toBe(true);
       });
+
+      describe("when panel doesn't exist", () => {
+        beforeEach(() => {
+          document.body.innerHTML = `
+            <div data-controller="tabs-and-panels" data-tabs-and-panels-class-name-value="selected">
+              <a id="peek" href="#" data-action="tabs-and-panels#changeActivePanel tabs-and-panels#changeActiveTab" class="selected" data-tabs-and-panels-target="tab">Peek</a>
+              <a id="ka" href="#" data-action="tabs-and-panels#changeActivePanel tabs-and-panels#changeActiveTab" data-tabs-and-panels-target="tab">Ka</a>
+              <a id="boo" href="#" data-action="tabs-and-panels#changeActivePanel tabs-and-panels#changeActiveTab" data-tabs-and-panels-target="tab">Boo</a>
+
+
+              <div id="peek_panel" data-tabs-and-panels-target="panel default">Peek me</div>
+              <div id="boo_panel" data-tabs-and-panels-target="panel">Boo three</div>
+            </div>`;
+        });
+
+        it('displays the current panel', () => {
+          const peekPanel = document.getElementById('peek_panel');
+
+          ka.click();
+          expect(peekPanel.style.display).toBe('block');
+        })
+      })
     })
 
     describe('when anchor is specified in the url', () => {

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -741,13 +741,9 @@ describe Enterprise do
     it "assigns permalink when initialized" do
       allow(Enterprise).to receive(:find_available_permalink).and_return("available_permalink")
       expect(Enterprise).to receive(:find_available_permalink).with("Name To Turn Into A Permalink")
-      expect(
-        lambda { enterprise.send(:initialize_permalink) }
-      ).to change{
-        enterprise.permalink
-      }.to(
-        "available_permalink"
-      )
+      expect do
+         enterprise.send(:initialize_permalink)
+      end.to change { enterprise.permalink }.to("available_permalink")
     end
 
     describe "finding a permalink" do

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -24,6 +24,7 @@ describe Enterprise do
     it { is_expected.to have_many(:distributed_orders) }
     it { is_expected.to belong_to(:address) }
     it { is_expected.to belong_to(:business_address) }
+    it { is_expected.to have_many(:vouchers) }
 
     it "destroys enterprise roles upon its own demise" do
       e = create(:enterprise)

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -742,7 +742,7 @@ describe Enterprise do
       allow(Enterprise).to receive(:find_available_permalink).and_return("available_permalink")
       expect(Enterprise).to receive(:find_available_permalink).with("Name To Turn Into A Permalink")
       expect do
-         enterprise.send(:initialize_permalink)
+        enterprise.send(:initialize_permalink)
       end.to change { enterprise.permalink }.to("available_permalink")
     end
 

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -788,6 +788,10 @@ describe Spree::Ability do
         is_expected.to have_ability([:admin, :known_users, :customers], for: :search)
         is_expected.not_to have_ability([:users], for: :search)
       end
+
+      it "has the ability to manage vouchers" do
+        is_expected.to have_ability([:admin, :create], for: Voucher)
+      end
     end
 
     context 'enterprise owner' do

--- a/spec/models/voucher_spec.rb
+++ b/spec/models/voucher_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Voucher do
+  describe 'associations' do
+    it { is_expected.to belong_to(:enterprise) }
+  end
+
+  describe 'validations' do
+    subject { Voucher.new(code: 'new_code', enterprise: enterprise) }
+
+    let(:enterprise) { build(:enterprise) }
+
+    it { is_expected.to validate_presence_of(:code) }
+    it { is_expected.to validate_uniqueness_of(:code).scoped_to(:enterprise_id) }
+  end
+end

--- a/spec/system/admin/vouchers_spec.rb
+++ b/spec/system/admin/vouchers_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+describe '
+    As an administrator
+    I want to manage vouchers
+' do
+  include WebHelper
+  include AuthenticationHelper
+
+  let(:enterprise) { create(:supplier_enterprise, name: 'Feedme') }
+  let(:voucher_code) { 'awesomevoucher' }
+
+  it 'lists enterprise vouchers' do
+    # Given an enterprise with vouchers
+    Voucher.create!(enterprise: enterprise, code: voucher_code)
+
+    # When I go to the enterprise voucher tab
+    login_as_admin_and_visit edit_admin_enterprise_path(enterprise)
+    click_link 'Vouchers'
+
+    # Then I see a list of vouchers
+    expect(page).to have_content voucher_code
+    expect(page).to have_content "10"
+  end
+
+  it 'creates a voucher' do
+    # Given an enterprise
+    # When I go to the new voucher page
+    login_as_admin_and_visit new_admin_enterprise_voucher_path(enterprise)
+
+    # And I fill in the fields for a new voucher click save
+    fill_in 'voucher_code', with: voucher_code
+    click_button 'Save'
+
+    # Then I should get redirect to the entreprise voucher tab and see the created voucher
+    expect(page).to have_selector '.success', text: 'Voucher has been successfully created!'
+
+    # TODO: doesn't automatically show the voucher tab
+    click_link 'Vouchers'
+
+    expect(page).to have_content voucher_code
+    expect(page).to have_content "10"
+
+    voucher = Voucher.where(enterprise: enterprise, code: voucher_code).first
+
+    expect(voucher).not_to be(nil)
+  end
+
+  context 'when entering invalid data' do
+    it 'shows an error flash message' do
+      # Given an enterprise
+      # When I go to the new voucher page
+      login_as_admin_and_visit new_admin_enterprise_voucher_path(enterprise)
+
+      # And I fill in filers with invalid data click save
+      click_button 'Save'
+
+      # Then I should see an error flash message
+      expect(page).to have_selector '.error', text: "Code can't be blank"
+
+      vouchers = Voucher.where(enterprise: enterprise)
+
+      expect(vouchers).to be_empty
+    end
+  end
+end

--- a/spec/system/admin/vouchers_spec.rb
+++ b/spec/system/admin/vouchers_spec.rb
@@ -3,7 +3,7 @@
 require 'system_helper'
 
 describe '
-    As an administrator
+    As an entreprise user
     I want to manage vouchers
 ' do
   include WebHelper
@@ -11,9 +11,13 @@ describe '
 
   let(:enterprise) { create(:supplier_enterprise, name: 'Feedme') }
   let(:voucher_code) { 'awesomevoucher' }
+  let(:enterprise_user) { create(:user, enterprise_limit: 1) }
 
   before do
     Flipper.enable(:vouchers)
+
+    enterprise_user.enterprise_roles.build(enterprise: enterprise).save
+    login_as enterprise_user
   end
 
   it 'lists enterprise vouchers' do
@@ -21,7 +25,8 @@ describe '
     Voucher.create!(enterprise: enterprise, code: voucher_code)
 
     # When I go to the enterprise voucher tab
-    login_as_admin_and_visit edit_admin_enterprise_path(enterprise)
+    visit edit_admin_enterprise_path(enterprise)
+
     click_link 'Vouchers'
 
     # Then I see a list of vouchers
@@ -32,7 +37,8 @@ describe '
   it 'creates a voucher' do
     # Given an enterprise
     # When I go to the enterprise voucher tab and click new
-    login_as_admin_and_visit edit_admin_enterprise_path(enterprise)
+    visit edit_admin_enterprise_path(enterprise)
+
     click_link 'Vouchers'
     within "#vouchers_panel" do
       click_link 'Add New'
@@ -56,7 +62,7 @@ describe '
     it 'shows an error flash message' do
       # Given an enterprise
       # When I go to the new voucher page
-      login_as_admin_and_visit new_admin_enterprise_voucher_path(enterprise)
+      visit new_admin_enterprise_voucher_path(enterprise)
 
       # And I fill in fields with invalid data and click save
       click_button 'Save'

--- a/spec/system/admin/vouchers_spec.rb
+++ b/spec/system/admin/vouchers_spec.rb
@@ -40,10 +40,6 @@ describe '
 
     # Then I should get redirect to the entreprise voucher tab and see the created voucher
     expect(page).to have_selector '.success', text: 'Voucher has been successfully created!'
-
-    # TODO: doesn't automatically show the voucher tab
-    click_link 'Vouchers'
-
     expect(page).to have_content voucher_code
     expect(page).to have_content "10"
 
@@ -58,7 +54,7 @@ describe '
       # When I go to the new voucher page
       login_as_admin_and_visit new_admin_enterprise_voucher_path(enterprise)
 
-      # And I fill in filers with invalid data click save
+      # And I fill in fields with invalid data and click save
       click_button 'Save'
 
       # Then I should see an error flash message

--- a/spec/system/admin/vouchers_spec.rb
+++ b/spec/system/admin/vouchers_spec.rb
@@ -12,6 +12,10 @@ describe '
   let(:enterprise) { create(:supplier_enterprise, name: 'Feedme') }
   let(:voucher_code) { 'awesomevoucher' }
 
+  before do
+    Flipper.enable(:vouchers)
+  end
+
   it 'lists enterprise vouchers' do
     # Given an enterprise with vouchers
     Voucher.create!(enterprise: enterprise, code: voucher_code)

--- a/spec/system/admin/vouchers_spec.rb
+++ b/spec/system/admin/vouchers_spec.rb
@@ -31,8 +31,12 @@ describe '
 
   it 'creates a voucher' do
     # Given an enterprise
-    # When I go to the new voucher page
-    login_as_admin_and_visit new_admin_enterprise_voucher_path(enterprise)
+    # When I go to the enterprise voucher tab and click new
+    login_as_admin_and_visit edit_admin_enterprise_path(enterprise)
+    click_link 'Vouchers'
+    within "#vouchers_panel" do
+      click_link 'Add New'
+    end
 
     # And I fill in the fields for a new voucher click save
     fill_in 'voucher_code', with: voucher_code


### PR DESCRIPTION
#### What? Why?

- Closes #10431 

Implement a bare minimum admin screen for vouchers. It allows you to create a voucher with a flat value of $10. Currently you can only enter one code at the time.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Enable vouchers feature 
- Visit `admin/feature-toggle/features` and enable or add `vouchers` feature

In the backoffice logged as an enterprise user:
- Visit the Enterprise tab and click on "Settings" for a shop of your choosing
- Check that 'vouchers' appears in the left menu column, and click on it 
  --> It should load a page saying "No vouchers yet" and have "Add New" button
- Click on "Add New button"
  --> It should load the New Voucher page 
- Enter a voucher code and click "Save"
 --> It should redirect you to the vouchers page on the enterprise edit page
 --> You should now see a list of vouchers with the one you just created
- Go back to the New Voucher page
- Click on Save without entering any code
  --> You should see an error message saying "Code can't be blank"  

#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
