### PR TITLE
Fixing 'unsaved' alert behaviour for order cycle edit forms

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -18,7 +18,6 @@ angular.module('admin.orderCycles')
 
     $scope.submit = ($event, destination) ->
       $event.preventDefault()
-      NavigationCheck.clear()
       StatusMessage.display 'progress', t('js.saving')
       OrderCycle.update(destination, $scope.order_cycle_form)
 

--- a/spec/system/admin/order_cycles/complex_editing_multiple_updation_spec.rb
+++ b/spec/system/admin/order_cycles/complex_editing_multiple_updation_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+describe '
+    As an administrator
+    I want to see alert for unsaved changes on order cycle edit page
+' do
+  include AuthenticationHelper
+  include WebHelper
+
+  it "Alerts for unsaved changes on general settings (/edit) page" do
+    oc = create(:order_cycle)
+    login_as_admin_and_visit edit_admin_order_cycle_path(oc)
+
+    # Expect correct values
+    expect(page).to have_field('order_cycle_name', with: oc.name)
+    expect(page).to have_content "COORDINATOR #{oc.coordinator.name}"
+    expect(page).to have_button('Save', disabled: true)
+    expect(page).to have_button('Save and Next', disabled: true)
+
+    # First change
+    fill_in 'order_cycle_name', with: 'Bonnie'
+    fill_in 'order_cycle_orders_open_at', with: '2020-01-06 06:00:00 +0000'
+    fill_in 'order_cycle_orders_close_at', with: '2020-01-07 06:00:00 +0000'
+    expect(page).to have_content('You have unsaved changes')
+    expect(page).to have_button('Save', disabled: false)
+    expect(page).to have_button('Save and Next', disabled: false)
+    expect(page).to have_button('Cancel', disabled: false)
+    expect(page).to have_button('Next', disabled: true)
+
+    # Trying to go to another page with unsaved changes
+    dismiss_confirm "" do
+      click_link 'Orders'
+    end
+
+    # Click cancel with unsaved changes
+    dismiss_confirm "" do
+      click_button 'Cancel'
+    end
+
+    # Saving first change
+    click_button 'Save'
+    expect(page).to have_content('Your order cycle has been updated.')
+    expect(page).to have_button('Save', disabled: true)
+    expect(page).to have_button('Save and Next', disabled: true)
+
+    # Second change
+    fill_in 'order_cycle_name', with: 'Clyde'
+    fill_in 'order_cycle_orders_open_at', with: '2021-01-06 06:00:00 +0000'
+    fill_in 'order_cycle_orders_close_at', with: '2021-01-07 06:00:00 +0000'
+    expect(page).to have_content('You have unsaved changes')
+    expect(page).to have_button('Save', disabled: false)
+    expect(page).to have_button('Save and Next', disabled: false)
+    expect(page).to have_button('Cancel', disabled: false)
+    expect(page).to have_button('Next', disabled: true)
+
+    # Trying to go to another page with unsaved changes
+    dismiss_confirm "" do
+      click_link 'Orders'
+    end
+
+    # Click cancel with unsaved changes
+    dismiss_confirm "" do
+      click_button 'Cancel'
+    end
+
+    # Saving Second change
+    click_button 'Save'
+    expect(page).to have_content('Your order cycle has been updated.')
+    expect(page).to have_button('Save', disabled: true)
+    expect(page).to have_button('Save and Next', disabled: true)
+
+    # Can leave without alert if no changes have been made
+    click_link 'Orders'
+
+    # Made it to orders page
+    expect(page).to have_content 'Listing Orders'
+  end
+
+  it "Alerts for unsaved changes on /incoming step" do
+    oc = create(:order_cycle)
+    oc.suppliers.first.update_attribute :name, 'farmer'
+    login_as_admin_and_visit edit_admin_order_cycle_path(oc)
+
+    # Go to incoming step
+    click_button 'Next'
+
+    # Expect details
+    expect(page).to have_selector 'td.supplier_name', text: oc.suppliers.first.name
+    expect(page).to have_button('Save', disabled: true)
+    expect(page).to have_button('Save and Next', disabled: true)
+
+    # First change
+    fill_in 'order_cycle_incoming_exchange_0_receival_instructions', with: 'its cheese'
+    expect(page).to have_content('You have unsaved changes')
+    expect(page).to have_button('Save', disabled: false)
+    expect(page).to have_button('Save and Next', disabled: false)
+    expect(page).to have_button('Cancel', disabled: false)
+    expect(page).to have_button('Next', disabled: true)
+
+    # Trying to go to another page with unsaved changes
+    dismiss_confirm "" do
+      click_link 'Orders'
+    end
+
+    # Click cancel with unsaved changes
+    dismiss_confirm "" do
+      click_button 'Cancel'
+    end
+
+    # Saving first change
+    click_button 'Save'
+    expect(page).to have_content('Your order cycle has been updated.')
+    expect(page).to have_button('Save', disabled: true)
+    expect(page).to have_button('Save and Next', disabled: true)
+
+    # Second change
+    fill_in 'order_cycle_incoming_exchange_0_receival_instructions', with: 'the blue kind'
+    expect(page).to have_content('You have unsaved changes')
+    expect(page).to have_button('Save', disabled: false)
+    expect(page).to have_button('Save and Next', disabled: false)
+    expect(page).to have_button('Cancel', disabled: false)
+    expect(page).to have_button('Next', disabled: true)
+
+    # Trying to go to another page with unsaved changes
+    dismiss_confirm "" do
+      click_link 'Orders'
+    end
+
+    # Click cancel with unsaved changes
+    dismiss_confirm "" do
+      click_button 'Cancel'
+    end
+
+    # Saving Second change
+    click_button 'Save'
+    expect(page).to have_content('Your order cycle has been updated.')
+    expect(page).to have_button('Save', disabled: true)
+    expect(page).to have_button('Save and Next', disabled: true)
+
+    # Can leave without alert if no changes have been made
+    click_link 'Orders'
+
+    # Made it to orders page
+    expect(page).to have_content 'Listing Orders'
+  end
+
+  it "Alerts for unsaved changes on /outgoing step" do
+    oc = create(:order_cycle)
+    oc.distributors.first.update_attribute :name, 'store'
+    login_as_admin_and_visit edit_admin_order_cycle_path(oc)
+
+    # Go to incoming step
+    click_button 'Next'
+
+    # Go to outgoing step
+    click_button 'Next'
+
+    # Expect details
+    expect(page).to have_selector 'td.distributor_name', text: oc.distributors.first.name
+    expect(page).to have_field 'order_cycle_outgoing_exchange_0_pickup_instructions',
+                               with: 'instructions 1'
+
+    # First change
+    fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'lift with legs'
+    expect(page).to have_content('You have unsaved changes')
+    expect(page).to have_button('Save', disabled: false)
+    expect(page).to have_button('Save and Next', disabled: false)
+    expect(page).to have_button('Cancel', disabled: false)
+    expect(page).to have_button('Next', disabled: true)
+
+    # Trying to go to another page with unsaved changes
+    dismiss_confirm "" do
+      click_link 'Orders'
+    end
+
+    # Click cancel with unsaved changes
+    dismiss_confirm "" do
+      click_button 'Cancel'
+    end
+
+    # Saving first change
+    click_button 'Save'
+    expect(page).to have_content('Your order cycle has been updated.')
+    expect(page).to have_button('Save', disabled: true)
+    expect(page).to have_button('Save and Next', disabled: true)
+
+    # Second change
+    fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'baby got back'
+    expect(page).to have_content('You have unsaved changes')
+    expect(page).to have_button('Save', disabled: false)
+    expect(page).to have_button('Save and Next', disabled: false)
+    expect(page).to have_button('Cancel', disabled: false)
+    expect(page).to have_button('Next', disabled: true)
+
+    # Trying to go to another page with unsaved changes
+    dismiss_confirm "" do
+      click_link 'Orders'
+    end
+
+    # Click cancel with unsaved changes
+    dismiss_confirm "" do
+      click_button 'Cancel'
+    end
+
+    # Saving Second change
+    click_button 'Save'
+    expect(page).to have_content('Your order cycle has been updated.')
+    expect(page).to have_button('Save', disabled: true)
+    expect(page).to have_button('Save and Next', disabled: true)
+
+    # Can leave without alert if no changes have been made
+    click_link 'Orders'
+
+    # Made it to orders page
+    expect(page).to have_content 'Listing Orders'
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Closes #10456 

Shows unsaved alert messages if trying to leave(or cancel) edit order cycle form pages (`/edit`, `/incoming`, `/outgoing`).

It would not show alert for the second unsaved changes because, the controller code for submit in `AdminEditOrderCycleCtrl` would clear the NavigationChecks and the listener (`beforeunload`) when saved after first changes.
* We did not see the issue for `/outgoing` page as it had its own overridden submit method.
https://github.com/openfoodfoundation/openfoodnetwork/blob/5dd27378118ca9626ceac0f71da972971d47a156/app/assets/javascripts/admin/order_cycles/controllers/outgoing_controller.js.coffee#L21-L24
* For `/checkout_options` , it was fixed in the previous PR (#10351)

#### What should we test?
1. Go to `/admin/order_cycles/x/edit` (or `/incoming`, `/outgoing` or `/checkout_options`).
2. Make changes.
3. Try leaving the page with unsaved changes 
   1. By clicking a link on the page.
   2. clicking cancel
4. We should see alert for unsaved changes for every time we try to leave the page with unsaved changes.
5. Repeat steps a few times and try combination of link click and cancel click.

#### Release notes

Changelog Category: User facing changes

Note: Did not update spec as to not add a test for absent code.