### PR TITLE
Enable fork-safety for mini_racer gem

### DIFF
--- a/app/services/job_processor.rb
+++ b/app/services/job_processor.rb
@@ -24,6 +24,6 @@ class JobProcessor
   ensure
     # If this Puma thread is interrupted then we need to detach the child
     # process to avoid it becoming a zombie.
-    Process.detach(child)
+    Process.detach(child) if child
   end
 end

--- a/config/initializers/mini_racer.rb
+++ b/config/initializers/mini_racer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# We need to configure MiniRacer to allow forking.
+# We do that for background jobs like reports.
+# https://github.com/rubyjs/mini_racer#fork-safety
+MiniRacer::Platform.set_flags!(:single_threaded)

--- a/spec/services/job_processor_spec.rb
+++ b/spec/services/job_processor_spec.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-# We need to configure MiniRacer to allow forking.
-# Otherwise this spec hangs on CI.
-# https://github.com/rubyjs/mini_racer#fork-safety
-require "mini_racer"
-MiniRacer::Platform.set_flags!(:single_threaded)
-
 require 'spec_helper'
 
 class TestJob < ApplicationJob

--- a/spec/services/job_processor_spec.rb
+++ b/spec/services/job_processor_spec.rb
@@ -47,5 +47,16 @@ describe JobProcessor do
         expect(end_time).to be_within(10.seconds).of start_time
       end
     end
+
+    describe "when forking fails" do
+      before do
+        # We can't make `fork` fail and choose the method call before it.
+        expect(ENV).to receive(:fetch).and_raise("Test Error")
+      end
+
+      it "raises the causing error" do
+        expect { JobProcessor.perform_forked(job) }.to raise_error "Test Error"
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Forked background report processes were not exiting.

@RachL's tests in production showed that background reports would fail with a timeout. Running the same report locally I could reproduce the error and saw a familiar warning in the console about the V8 engine being forked.

So I moved code which was needed in the related spec to an initializer to make it available for the whole app. Unfortunately, after running that, I can't reproduce the error any more, even on the master branch and stopping spring. Whatever the reason for this is, it's probably the reason why we didn't see the issue before.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Before deploy:

- Visit /admin/reports/sales_tax
- Select a date range and a distributor to show some data.
- Deploy this pull request.
- Activate background reports and reload the report.
- It should display as before.
- If you see a server error (out of memory) then restart the app first:
    ```
    cd ~/apps/openfoodnetwork/current
    sudo systemctl restart puma.service
    ```
- Deactivate background reports and reload again.
- It should display as before.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
