### PR TITLE
Shopfront: Force product description to be on one line

### DIFF
--- a/app/services/content_scrubber.rb
+++ b/app/services/content_scrubber.rb
@@ -10,6 +10,14 @@ class ContentScrubber < Rails::Html::PermitScrubber
     self.attributes = ALLOWED_ATTRIBUTES
   end
 
+  def scrub(node)
+    if node.name == 'p' && (node.children.empty? || node.text.blank?)
+      node.remove
+    else
+      super
+    end
+  end
+
   def skip_node?(node)
     node.text?
   end

--- a/app/views/shop/products/_summary.html.haml
+++ b/app/views/shop/products/_summary.html.haml
@@ -9,7 +9,7 @@
     %h3
       %a{"ng-click" => "triggerProductModal()", href: 'javascript:void(0)'}
         %span{"ng-bind" => "::product.name"}
-    %p.product-description{ng: {"bind-html": "::product.description_html", click: "triggerProductModal()", show: "product.description_html.length"}}
+    .product-description{ng: {"bind-html": "::product.description_html", click: "triggerProductModal()", show: "product.description_html.length"}}
     .product-producer
       = t :products_from
       %span

--- a/app/webpacker/css/darkswarm/_shop-product-rows.scss
+++ b/app/webpacker/css/darkswarm/_shop-product-rows.scss
@@ -149,6 +149,15 @@
             text-overflow: ellipsis;
             margin-bottom: 0.75rem;
             cursor: pointer;
+            // Force product description to be on one line
+            // and truncate with ellipsis
+            display: -webkit-box;
+            -webkit-line-clamp: 1;
+            -webkit-box-orient: vertical;
+            overflow: hidden; 
+            // line-clamp is not supported in Safari
+            line-height: 1rem;
+            height: 1.75rem;
           }
 
           .product-properties {

--- a/spec/services/content_sanitizer_spec.rb
+++ b/spec/services/content_sanitizer_spec.rb
@@ -53,5 +53,9 @@ describe ContentSanitizer do
     it "echos nil if given nil" do
       expect(service.sanitize_content(nil)).to be(nil)
     end
+
+    it "removes empty <p> tags and keeps non-empty ones" do
+      expect(service.sanitize_content("<p> </p><p></p><p><b></b><p>hello</p><p></p><p>world!</p>")).to eq("<p>hello</p><p>world!</p>")
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #10537 


<img width="903" alt="Capture d’écran 2023-03-09 à 12 07 29" src="https://user-images.githubusercontent.com/296452/224006414-d98a9af0-77b6-4f5d-a530-05f304e6602e.png">



#### What should we test?
- As an admin, edit a product description with formatting and line breaks
- As a shopper, see that product description in the shop has formatting + is only on one line
(_This should be tested in both Safari and another major browser. And on mobile phones._)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
