### PR TITLE
Adds a spec to check enterprise fees creation

### DIFF
--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -157,6 +157,23 @@ describe '
       expect(flash_message)
         .to eq('Invalid input. Please use only numbers. For example: 10, 5.5, -20')
     end
+
+    it "does not allow editing to an invalid combination" do
+      pending "10512"
+      
+      # starting with a valid tax category / calculator combination
+      expect(page).to have_select 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id',
+                                  selected: 'Inherit From Product'
+      expect(page).to have_selector "option[selected]", text: 'Flat Percent (per item)'
+      
+      # editing to an invalid combination
+      select 'Flat Rate (per order)', 
+        from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+      expect{
+        click_button 'Update'
+      }.to_not change { fee.reload.calculator_type }
+      expect(page).to have_content "Inheriting the tax categeory requires a per-item calculator."
+    end
   end
 
   it "deleting an enterprise fee" do
@@ -205,16 +222,20 @@ describe '
                    from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
             select 'Packing', from: 'sets_enterprise_fee_set_collection_attributes_0_fee_type'
             fill_in 'sets_enterprise_fee_set_collection_attributes_0_name', with: 'foo'
-            select tax_category, from: 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id'
-            select calculator, from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+            select tax_category, 
+from: 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id'
+            select calculator, 
+from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
             click_button 'Update'
 
             # The correct flash message should be displayed
             expect(page).to have_content(flash_message)
 
             # After saving, we should be redirected to the fees for our chosen enterprise
-            expect(page).not_to have_select 'sets_enterprise_fee_set_collection_attributes_1_enterprise_id',
-                                            selected: 'Second Distributor'
+            expect(page).
+              not_to have_select 'sets_enterprise_fee_set_collection_attributes_1_enterprise_id',
+            selected: 'Second Distributor'
+            
             # A new enterprise fee is created
             expect(EnterpriseFee.count).to eq(fee_count)
           end
@@ -224,7 +245,8 @@ describe '
       xcontext "an error message is displayed" do
         # pending "#10348"
         message = 'Inheriting the tax categeory requires a per-item calculator.'
-        it_behaves_like "shared example", 'Inherit From Product', 'Flat Rate (per order)', message, 0
+        it_behaves_like "shared example", 'Inherit From Product', 'Flat Rate (per order)', message, 
+0
       end
 
       context "an success message is displayed" do

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -20,14 +20,11 @@ describe '
     visit spree.edit_admin_general_settings_path
     click_link 'Enterprise Fees'
 
-    expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_enterprise_id"
-    expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_fee_type",
-                                selected: 'Packing fee'
+    expect(page).to have_select "#{prefix}_enterprise_id"
+    expect(page).to have_select "#{prefix}_fee_type", selected: 'Packing fee'
     expect(page).to have_selector "input[value='$0.50 / kg']"
-    expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_tax_category_id",
-                                selected: 'GST'
-    expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_calculator_type",
-                                selected: 'Flat Rate (per item)'
+    expect(page).to have_select "#{prefix}_tax_category_id", selected: 'GST'
+    expect(page).to have_select "#{prefix}_calculator_type", selected: 'Flat Rate (per item)'
     expect(page).to have_selector "input[value='#{amount}']"
   end
 
@@ -40,11 +37,11 @@ describe '
     visit admin_enterprise_fees_path
 
     # And I fill in the fields for a new enterprise fee and click update
-    select 'Feedme', from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
-    select 'Admin', from: 'sets_enterprise_fee_set_collection_attributes_0_fee_type'
-    fill_in 'sets_enterprise_fee_set_collection_attributes_0_name', with: 'Hello!'
-    select 'GST', from: 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id'
-    select 'Flat Percent', from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+    select 'Feedme', from: "#{prefix}_enterprise_id"
+    select 'Admin', from: "#{prefix}_fee_type"
+    fill_in "#{prefix}_name", with: 'Hello!'
+    select 'GST', from: "#{prefix}_tax_category_id"
+    select 'Flat Percent', from: "#{prefix}_calculator_type"
     click_button 'Update'
 
     # Then I should see my fee and fields for the calculator
@@ -52,12 +49,12 @@ describe '
     expect(page).to have_selector "input[value='Hello!']"
 
     # When I fill in the calculator fields and click update
-    fill_in 'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes'\
-            '_preferred_flat_percent', with: '12.34'
+    fill_in "#{prefix}_calculator_attributes"\
+            "_preferred_flat_percent", with: '12.34'
     click_button 'Update'
 
     # Then I should see the correct values in my calculator fields
-    expect(page).to have_selector("#sets_enterprise_fee_set_collection_attributes_0_calculator"\
+    expect(page).to have_selector("##{prefix}_calculator"\
                                   "_attributes_preferred_flat_percent[value='12.34']")
   end
 
@@ -70,11 +67,11 @@ describe '
     visit admin_enterprise_fees_path
 
     # And I fill in the fields for a new enterprise fee and click update
-    select 'Feedme', from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
-    select 'Admin', from: 'sets_enterprise_fee_set_collection_attributes_0_fee_type'
-    fill_in 'sets_enterprise_fee_set_collection_attributes_0_name', with: 'Hello!'
-    select 'GST', from: 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id'
-    select 'Flat Percent', from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+    select 'Feedme', from: "#{prefix}_enterprise_id"
+    select 'Admin', from: "#{prefix}_fee_type"
+    fill_in "#{prefix}_name", with: 'Hello!'
+    select 'GST', from: "#{prefix}_tax_category_id"
+    select 'Flat Percent', from: "#{prefix}_calculator_type"
     click_button 'Update'
 
     # Then I should see my fee and fields for the calculator
@@ -82,10 +79,7 @@ describe '
     expect(page).to have_selector "input[value='Hello!']"
 
     # When I fill in the calculator fields and click update
-    fill_in(
-      'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_'\
-      'preferred_flat_percent', with: "\'20.0'"
-    )
+    fill_in("#{prefix}_calculator_attributes_preferred_flat_percent", with: "\'20.0'")
     click_button 'Update'
 
     # Then I should see the flash error message
@@ -102,24 +96,21 @@ describe '
       login_as_admin
       visit admin_enterprise_fees_path
       # And I update the fields for the enterprise fee and click update
-      select 'Foo', from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
-      select 'Admin', from: 'sets_enterprise_fee_set_collection_attributes_0_fee_type'
-      fill_in 'sets_enterprise_fee_set_collection_attributes_0_name', with: 'Greetings!'
+      select 'Foo', from: "#{prefix}_enterprise_id"
+      select 'Admin', from: "#{prefix}_fee_type"
+      fill_in "#{prefix}_name", with: 'Greetings!'
       select 'Inherit From Product', 
-        from: 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id'
-      select 'Flat Percent', from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+        from: "#{prefix}_tax_category_id"
+      select 'Flat Percent', from: "#{prefix}_calculator_type"
       click_button 'Update'
     end
 
     it "handle the default cases" do
       # Then I should see the updated fields for my fee
-      expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_enterprise_id",
-                                  selected: 'Foo'
-      expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_fee_type",
-                                  selected: 'Admin fee'
+      expect(page).to have_select "#{prefix}_enterprise_id", selected: 'Foo'
+      expect(page).to have_select "#{prefix}_fee_type", selected: 'Admin fee'
       expect(page).to have_selector "input[value='Greetings!']"
-      expect(page).to have_select 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id',
-                                  selected: 'Inherit From Product'
+      expect(page).to have_select "#{prefix}_tax_category_id", selected: 'Inherit From Product'
       expect(page).to have_selector "option[selected]", text: 'Flat Percent (per item)'
 
       fee.reload
@@ -135,11 +126,11 @@ describe '
 
     it "handle when updating calculator type for Weight to Flat Rate" do
       select 'Weight (per kg or lb)', 
-        from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+        from: "#{prefix}_calculator_type"
       click_button 'Update'
 
       select 'Flat Rate (per item)', 
-        from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+        from: "#{prefix}_calculator_type"
       click_button 'Update'
 
       expect(fee.reload.calculator_type).to eq("Calculator::PerItem")
@@ -148,7 +139,7 @@ describe '
     it 'shows error flash when updating fee amount with invalid values' do
       # When I fill in the calculator fields and click update
       fill_in(
-        'sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_'\
+        "#{prefix}_calculator_attributes_"\
         'preferred_flat_percent', with: "\'20.0'"
       )
       click_button 'Update'
@@ -161,16 +152,13 @@ describe '
     it "does not allow editing to an invalid combination" do
       
       # starting with a valid tax category / calculator combination
-      expect(page).to have_select 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id',
-                                  selected: 'Inherit From Product'
+      expect(page).to have_select "#{prefix}_tax_category_id", selected: 'Inherit From Product'
       expect(page).to have_selector "option[selected]", text: 'Flat Percent (per item)'
       
       # editing to an invalid combination
       select 'Flat Rate (per order)', 
-        from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
-      expect{
-        click_button 'Update'
-      }.to_not change { fee.reload.calculator_type }
+        from: "#{prefix}_calculator_type"
+      expect{ click_button 'Update' }.to_not change { fee.reload.calculator_type }
       expect(page).to have_content "Inheriting the tax categeory requires a per-item calculator."
     end
   end
@@ -217,14 +205,11 @@ describe '
       shared_examples "shared example" do |tax_category, calculator, flash_message, fee_count|
         context "setting it up as #{tax_category}, with a #{calculator} calculator" do
           it "triggers the expected message" do
-            select distributor1.name,
-                   from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
-            select 'Packing', from: 'sets_enterprise_fee_set_collection_attributes_0_fee_type'
-            fill_in 'sets_enterprise_fee_set_collection_attributes_0_name', with: 'foo'
-            select tax_category, 
-from: 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id'
-            select calculator, 
-from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+            select distributor1.name, from: "#{prefix}_enterprise_id"
+            select 'Packing', from: "#{prefix}_fee_type"
+            fill_in "#{prefix}_name", with: 'foo'
+            select tax_category, from: "#{prefix}_tax_category_id"
+            select calculator, from: "#{prefix}_calculator_type"
             click_button 'Update'
 
             # The correct flash message should be displayed
@@ -270,18 +255,15 @@ from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
       visit edit_admin_enterprise_path(distributor1)
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Manage Enterprise Fees"
-      expect(page).to     have_field 'sets_enterprise_fee_set_collection_attributes_0_name',
-                                     with: 'One'
+      expect(page).to     have_field "#{prefix}_name", with: 'One'
       expect(page).not_to have_field 'sets_enterprise_fee_set_collection_attributes_1_name',
                                      with: 'Two'
 
       visit edit_admin_enterprise_path(distributor2)
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Manage Enterprise Fees"
-      expect(page).not_to have_field 'sets_enterprise_fee_set_collection_attributes_0_name',
-                                     with: 'One'
-      expect(page).to     have_field 'sets_enterprise_fee_set_collection_attributes_0_name',
-                                     with: 'Two'
+      expect(page).not_to have_field "#{prefix}_name", with: 'One'
+      expect(page).to     have_field "#{prefix}_name", with: 'Two'
     end
 
     it "only allows me to select enterprises I have access to" do
@@ -292,9 +274,13 @@ from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
       visit edit_admin_enterprise_path(distributor2)
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Manage Enterprise Fees"
-      expect(page).to have_select('sets_enterprise_fee_set_collection_attributes_0_enterprise_id',
+      expect(page).to have_select("#{prefix}_enterprise_id",
                                   selected: 'Second Distributor',
                                   options: ['First Distributor', 'Second Distributor'])
     end
   end
+end
+
+def prefix
+  'sets_enterprise_fee_set_collection_attributes_0'
 end

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -159,7 +159,6 @@ describe '
     end
 
     it "does not allow editing to an invalid combination" do
-      pending "10512"
       
       # starting with a valid tax category / calculator combination
       expect(page).to have_select 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id',
@@ -242,11 +241,10 @@ from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
         end
       end
 
-      xcontext "an error message is displayed" do
-        # pending "#10348"
+      context "an error message is displayed" do
         message = 'Inheriting the tax categeory requires a per-item calculator.'
-        it_behaves_like "shared example", 'Inherit From Product', 'Flat Rate (per order)', message, 
-0
+        it_behaves_like "shared example", 'Inherit From Product',
+                                          'Flat Rate (per order)', message, 0
       end
 
       context "an success message is displayed" do

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -202,8 +202,8 @@ describe '
         click_link "Create One Now"
       end
 
-      shared_examples "shared example" do |tax_category, calculator, flash_message, fee_count|
-        context "setting it up as #{tax_category}, with a #{calculator} calculator" do
+      shared_examples "setting it up" do |tax_category, calculator, flash_message, fee_count|
+        context "as #{tax_category}, with a #{calculator} calculator" do
           it "triggers the expected message" do
             select distributor1.name, from: "#{prefix}_enterprise_id"
             select 'Packing', from: "#{prefix}_fee_type"
@@ -228,23 +228,23 @@ describe '
 
       context "an error message is displayed" do
         message = 'Inheriting the tax categeory requires a per-item calculator.'
-        it_behaves_like "shared example", 'Inherit From Product',
+        it_behaves_like "setting it up", 'Inherit From Product',
                                           'Flat Rate (per order)', message, 0
       end
 
       context "an success message is displayed" do
         message = 'Your enterprise fees have been updated.'
-        it_behaves_like "shared example", 'Inherit From Product', 'Flat Rate (per item)', message, 1
+        it_behaves_like "setting it up", 'Inherit From Product', 'Flat Rate (per item)', message, 1
       end
 
       context "an success message is displayed" do
         message = 'Your enterprise fees have been updated.'
-        it_behaves_like "shared example", 'GST', 'Flat Rate (per order)', message, 1
+        it_behaves_like "setting it up", 'GST', 'Flat Rate (per order)', message, 1
       end
 
       context "an success message is displayed" do
         message = 'Your enterprise fees have been updated.'
-        it_behaves_like "shared example", 'GST', 'Flat Rate (per item)', message, 1
+        it_behaves_like "setting it up", 'GST', 'Flat Rate (per item)', message, 1
       end
     end
 


### PR DESCRIPTION
Prepares for #10348.

#### What? Why?

- Adds a spec to check enterprise fees creation and cover the cases in which we have invalid combinations of tax category and calculator

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build after merging and rebasing https://github.com/openfoodfoundation/openfoodnetwork/pull/10512 and #10348 is closed.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
