### PR TITLE
Add `$locationProvider` configuration to `utils/utils.js.coffee` to be used on `/admin/enterprises/*` pages

### DIFF
--- a/app/assets/javascripts/admin/utils/utils.js.coffee
+++ b/app/assets/javascripts/admin/utils/utils.js.coffee
@@ -1,2 +1,3 @@
-angular.module("admin.utils", ["templates", "ngSanitize"]).config ($httpProvider) ->
+angular.module("admin.utils", ["templates", "ngSanitize"]).config ($httpProvider, $locationProvider) ->
+ $locationProvider.hashPrefix('')
  $httpProvider.defaults.headers.common["Accept"] = "application/json, text/javascript, */*"


### PR DESCRIPTION
Actually the `config()` method of `admin_ofn` file did not run on `/admin/enterprises/*` pages for an unknown reason

Now those two files have the same configuration

#### What? Why?

- Closes #10541

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

- As an admin, navigate through the backoffice of the app as much as possible.
- Every links, specially the anchors ones should be fine
- You should not see `#!#` in the URL, but only _valid_ URLs ie. with only `#` (or nothing of course)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
