### PR TITLE
Enable invoices config only controls Print bulk action

### DIFF
--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -21,24 +21,24 @@
 
 .row.index-controls{'ng-show' => '!RequestMonitor.loading && orders.length > 0'}
   %div{style: "display: flex; justify-content: space-between;"}
-    - if Spree::Config[:enable_invoices?]
-      .ofn-drop-down-with-prepend
-        .ofn-drop-down-prepend{"ng-class": "selected_orders.length == 0 ? 'disabled' : ''"}
-          {{ "spree.admin.orders.index.selected" | t:{count: selected_orders.length} }}
-        .ofn-drop-down{"ng-class": "selected_orders.length == 0 ? 'disabled' : ''"}
-          %span{ :class => 'icon-reorder' }
-            ="#{t('admin.actions')}".html_safe
-          %span{ 'ng-class' => "expanded && 'icon-caret-up' || !expanded && 'icon-caret-down'" }
-          %div.menu{ 'ng-show' => "expanded" }
-            %div.menu_item
-              %span.name{ "data-controller": "modal-link", "data-action": "click->modal-link#open", "data-modal-link-target-value": "resend_confirmation" }
-                = t('.resend_confirmation')
+    .ofn-drop-down-with-prepend
+      .ofn-drop-down-prepend{"ng-class": "selected_orders.length == 0 ? 'disabled' : ''"}
+        {{ "spree.admin.orders.index.selected" | t:{count: selected_orders.length} }}
+      .ofn-drop-down{"ng-class": "selected_orders.length == 0 ? 'disabled' : ''"}
+        %span{ :class => 'icon-reorder' }
+          ="#{t('admin.actions')}".html_safe
+        %span{ 'ng-class' => "expanded && 'icon-caret-up' || !expanded && 'icon-caret-down'" }
+        %div.menu{ 'ng-show' => "expanded" }
+          %div.menu_item
+            %span.name{ "data-controller": "modal-link", "data-action": "click->modal-link#open", "data-modal-link-target-value": "resend_confirmation" }
+              = t('.resend_confirmation')
+          - if Spree::Config[:enable_invoices?]
             %div.menu_item
               %span.name.invoices-modal{'ng-controller' => 'bulkInvoiceCtrl', 'ng-click' => 'createBulkInvoice()' }
                 = t('.print_invoices')
-            %div.menu_item
-              %span.name{ "data-controller": "modal-link", "data-action": "click->modal-link#open", "data-modal-link-target-value": "cancel_orders" }
-                = t('.cancel_orders')
+          %div.menu_item
+            %span.name{ "data-controller": "modal-link", "data-action": "click->modal-link#open", "data-modal-link-target-value": "cancel_orders" }
+              = t('.cancel_orders')
     
     = render partial: 'admin/shared/angular_per_page_controls', locals: { position: "right", model: "orders" }
 

--- a/spec/views/spree/admin/orders/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/index.html.haml_spec.rb
@@ -22,21 +22,25 @@ describe "spree/admin/orders/index.html.haml" do
     allow(view).to receive_messages spree_current_user: create(:user)
   end
 
-  describe "print invoices button" do
-    it "displays button when invoices are enabled" do
+  describe "Bulk order actions" do
+    it "display all buttons when invoices are enabled" do
       Spree::Config[:enable_invoices?] = true
 
       render
 
       expect(rendered).to have_content("Print Invoices")
+      expect(rendered).to have_content("Resend Confirmation")
+      expect(rendered).to have_content("Cancel Orders")
     end
 
-    it "does not display button when invoices are disabled" do
+    it "does not display print button when invoices are disabled but others remain" do
       Spree::Config[:enable_invoices?] = false
 
       render
 
       expect(rendered).to_not have_content("Print Invoices")
+      expect(rendered).to have_content("Resend Confirmation")
+      expect(rendered).to have_content("Cancel Orders")
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #10419 

Enable invoice config only controls the visibility of "Print invoices" bulk action and the rest remain unaffected.

Modified the specs accordingly. 

#### What should we test?
- Check bulk order actions available with enable invoices enabled.
   -  The following should be available:
        - print invoices
        - Cancel orders
        - Resend confirmations
- With enable invoices disabled: 
  - Cancel orders
  - Resend confirmations

#### Release notes

Changelog Category: User facing changes
