### PR TITLE
Move `webpack-*` as dependency (not devDependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "stimulus-flatpickr": "^1.4.0",
     "stimulus_reflex": "3.5.0-pre9",
     "tom-select": "^2.0.0",
-    "webpack": "~4"
+    "webpack": "~4",
+    "webpack-cli": "~4",
+    "webpack-dev-server": "~4"
   },
   "devDependencies": {
     "husky": "^8.0.0",
@@ -49,8 +51,6 @@
     "karma-coffee-preprocessor": "~1.0.1",
     "karma-jasmine": "~0.3.8",
     "prettier": "2.8.5",
-    "pretty-quick": "^3.1.3",
-    "webpack-cli": "~4",
-    "webpack-dev-server": "~4"
+    "pretty-quick": "^3.1.3"
   }
 }


### PR DESCRIPTION
#### What? Why?

- Closes #10593 


#### What should we test?
- Green CI: ✅ 
- Building/Deployment: ✅ https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2/servers/fr-staging/deploys/970
- Testing the deployment ✅ 

<img width="1067" alt="Capture d’écran 2023-03-21 à 14 44 56" src="https://user-images.githubusercontent.com/296452/226624945-ef0ed079-f1ea-465f-8a2e-d0bd5290f36b.png">

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
