### PR TITLE
Add all feature toggles with descriptions at boot

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -2,13 +2,6 @@ require "flipper"
 require "flipper/adapters/active_record"
 require "open_food_network/feature_toggle"
 
-if Rails.env.production?
-  Flipper::UI.configure do |config|
-    config.banner_text = '⚠️ Production environment: be aware that the changes have an impact on the application. Please, read the how-to before: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Feature-toggle-with-Flipper'
-    config.banner_class = 'danger'
-  end
-end
-
 Flipper.register(:admins) { |actor| actor.respond_to?(:admin?) && actor.admin? }
 
 Flipper::UI.configure do |config|
@@ -20,6 +13,15 @@ Flipper::UI.configure do |config|
   # Defaults to false. Set to true to show feature descriptions on the list
   # page as well as the view page.
   # config.show_feature_description_in_list = true
+
+  if Rails.env.production?
+    config.banner_text = <<~TEXT
+      ⚠️ Production environment: be aware that the changes have an impact on the
+      application. Please read the how-to before:
+      https://github.com/openfoodfoundation/openfoodnetwork/wiki/Feature-toggle-with-Flipper
+    TEXT
+    config.banner_class = 'danger'
+  end
 end
 
 # Add known feature toggles. This may fail if the database isn't setup yet.

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,5 +1,6 @@
 require "flipper"
 require "flipper/adapters/active_record"
+require "open_food_network/feature_toggle"
 
 if Rails.env.production?
   Flipper::UI.configure do |config|
@@ -9,3 +10,17 @@ if Rails.env.production?
 end
 
 Flipper.register(:admins) { |actor| actor.respond_to?(:admin?) && actor.admin? }
+
+Flipper::UI.configure do |config|
+  config.descriptions_source = ->(_keys) do
+    # return has to be hash of {String key => String description}
+    OpenFoodNetwork::FeatureToggle::CURRENT_FEATURES
+  end
+
+  # Defaults to false. Set to true to show feature descriptions on the list
+  # page as well as the view page.
+  # config.show_feature_description_in_list = true
+end
+
+# Add known feature toggles. This may fail if the database isn't setup yet.
+OpenFoodNetwork::FeatureToggle.setup! rescue ActiveRecord::StatementInvalid

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -7,6 +7,58 @@ module OpenFoodNetwork
   # - http://localhost:3000/admin/feature-toggle/features
   #
   module FeatureToggle
+    # Please add your new feature here to appear in the Flipper UI.
+    # We way move this to a YAML file when it becomes too awkward.
+    CURRENT_FEATURES = {
+      "admin_style_v2" => <<~DESC,
+        Change some colour and layout in the backend to a newer version.
+      DESC
+      "api_reports" => <<~DESC,
+        An API endpoint for reports at
+        <code>/api/v0/reports/:report_type(/:report_subtype)</code>
+      DESC
+      "api_v1" => <<~DESC,
+        Enable the new API at <code>/api/v1</code>
+      DESC
+      "background_reports" => <<~DESC,
+        Generate reports in a background process to limit memory consumption.
+      DESC
+      "dfc_provider" => <<~DESC,
+        Enable the DFC compatible endpoint at <code>/api/dfc-*</code>.
+      DESC
+      "match_shipping_categories" => <<~DESC,
+        During checkout, show only shipping methods that support <em>all</em>
+        shipping categories. Activating this feature for an enterprise owner
+        will activate it for all shops of this enterprise.
+      DESC
+      "new_products_page" => <<~DESC,
+        Show the new (experimental) version of the admin products page.
+      DESC
+      "split_checkout" => <<~DESC,
+        Replace the one-page checkout with a multi-step checkout.
+      DESC
+    }.freeze
+
+    # Move your feature entry from CURRENT_FEATURES to RETIRED_FEATURES when
+    # you remove it from the code. It will then be deleted from the database.
+    #
+    # We may delete this field one day and regard all features not listed in
+    # CURRENT_FEATURES as unsupported and remove them. But until this approach
+    # is accepted we delete only the features listed here.
+    RETIRED_FEATURES = {}.freeze
+
+    def self.setup!
+      CURRENT_FEATURES.each_key do |name|
+        feature = Flipper.feature(name)
+        feature.add unless feature.exist?
+      end
+
+      RETIRED_FEATURES.each_key do |name|
+        feature = Flipper.feature(name)
+        feature.remove if feature.exist?
+      end
+    end
+
     def self.enabled?(feature_name, user = nil)
       feature = Flipper.feature(feature_name)
       feature.add unless feature.exist?

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -60,9 +60,7 @@ module OpenFoodNetwork
     end
 
     def self.enabled?(feature_name, user = nil)
-      feature = Flipper.feature(feature_name)
-      feature.add unless feature.exist?
-      feature.enabled?(user)
+      Flipper.enabled?(feature_name, user)
     end
 
     def self.disabled?(feature_name, user = nil)

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -13,13 +13,6 @@ module OpenFoodNetwork
         Flipper.enable(:foo)
         expect(FeatureToggle.enabled?(:foo)).to be true
       end
-
-      it "adds features to the database for easy admin in the UI" do
-        feature = Flipper.feature(:sparkling_new)
-
-        expect { FeatureToggle.enabled?(:sparkling_new) }.
-          to change { feature.exist? }.from(false).to(true)
-      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

We are adding feature toggles more often now and I saw an opportunity to improve the communication and simplify the removal of feature toggles. We don't need migrations for that any more. And we can add descriptions which are displayed in the admin UI:

![Screenshot from 2023-03-22 14-47-44](https://user-images.githubusercontent.com/3524483/226797196-55f72d95-f387-42bb-b2fe-b6ac41905ff8.png)


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Log in as admin.
- Visit /admin/feature-toggle/.
- All feature toggles should be there as before (or with additions).
- Delete all feature toggles.
- Restart Puma: `cd ~/apps/openfoodnetwork/current && sudo systemctl restart puma.service`
- Visit /admin/feature-toggle/.
- All current features should be listed straight away (now deactivated because they were deleted).
- Click on each feature.
- Every feature should have a description at the top.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

Update https://github.com/openfoodfoundation/openfoodnetwork/wiki/Feature-toggles