### PR TITLE
Fix load order cycles by date ranges

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycles_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycles_controller.js.coffee
@@ -33,9 +33,11 @@ angular.module("admin.orderCycles").controller "OrderCyclesCtrl", ($scope, $q, C
     StatusMessage.display 'notice', "You have unsaved changes" if newVal
 
   $scope.showMore = (days) ->
+    orderCycles = OrderCycles.index(ams_prefix: "index", 
+    "q[orders_close_at_gt]": "#{daysFromToday($scope.ordersCloseAtLimit - days)}", 
+    "q[orders_close_at_lteq]": "#{daysFromToday($scope.ordersCloseAtLimit)}"
+    )
     $scope.ordersCloseAtLimit -= days
-    existingIDs = Object.keys(OrderCycles.byID)
-    orderCycles = OrderCycles.index(ams_prefix: "index", "q[orders_close_at_gt]": "#{daysFromToday($scope.ordersCloseAtLimit)}", "q[id_not_in][]": existingIDs)
     orderCycles.$promise.then ->
       $scope.orderCycles.push(orderCycle) for orderCycle in orderCycles
       compileData()


### PR DESCRIPTION
#### What? Why?

- Closes #4544

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I detailed the problem in my comment: https://github.com/openfoodfoundation/openfoodnetwork/issues/4544#issuecomment-1473635001

In summary, the problem is not a performance issue and it's not related to the date range (6 months).
The problem occurs when there are too many order cycles loaded on the browser. When the user tries to load more, the query used to load the order cycles will become long enough to be rejected by nginx.
#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- load many order cycles.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
