### PR TITLE
Sort zones by name again, in the admin panel

### DIFF
--- a/app/controllers/spree/admin/zones_controller.rb
+++ b/app/controllers/spree/admin/zones_controller.rb
@@ -13,7 +13,7 @@ module Spree
 
       def collection
         params[:q] ||= {}
-        params[:q][:s] ||= "ascend_by_name"
+        params[:q][:s] ||= "name asc"
         @search = super.ransack(params[:q])
         @pagy, @zones = pagy(@search.result, items: Spree::Config[:orders_per_page])
         @zones

--- a/spec/system/admin/configuration/zones_spec.rb
+++ b/spec/system/admin/configuration/zones_spec.rb
@@ -8,7 +8,6 @@ describe "Zones" do
 
   before do
     login_as_admin
-    Spree::Zone.delete_all
   end
 
   it "list existing zones" do

--- a/spec/system/admin/configuration/zones_spec.rb
+++ b/spec/system/admin/configuration/zones_spec.rb
@@ -6,12 +6,8 @@ describe "Zones" do
   include AuthenticationHelper
   include WebHelper
 
-  before do
-    login_as_admin
-  end
-
   it "list existing zones" do
-    visit spree.edit_admin_general_settings_path
+    login_as_admin_and_visit spree.edit_admin_general_settings_path
     create(:zone, name: "eastern", description: "zone is eastern")
     create(:zone, name: "western", description: "cool san fran")
 
@@ -27,7 +23,7 @@ describe "Zones" do
   end
 
   it "create a new zone" do
-    visit spree.admin_zones_path
+    login_as_admin_and_visit spree.admin_zones_path
     click_link "admin_new_zone_link"
     expect(page).to have_content("New Zone")
 
@@ -40,7 +36,7 @@ describe "Zones" do
 
   it "edit existing zone" do
     zone = create(:zone_with_member)
-    visit spree.edit_admin_zone_path(zone.id)
+    login_as_admin_and_visit spree.edit_admin_zone_path(zone.id)
 
     expect(page).to have_checked_field "country_based"
 

--- a/spec/system/admin/configuration/zones_spec.rb
+++ b/spec/system/admin/configuration/zones_spec.rb
@@ -8,18 +8,21 @@ describe "Zones" do
 
   it "list existing zones" do
     login_as_admin_and_visit spree.edit_admin_general_settings_path
+    create(:zone, name: "northern", description: "middle position alphabetically")
     create(:zone, name: "eastern", description: "zone is eastern")
     create(:zone, name: "western", description: "cool san fran")
 
     click_link "Zones"
 
     within_row(1) { expect(page).to have_content("eastern") }
-    within_row(2) { expect(page).to have_content("western") }
+    within_row(2) { expect(page).to have_content("northern") }
+    within_row(3) { expect(page).to have_content("western") }
 
     click_link "zones_order_by_description_title"
 
     within_row(1) { expect(page).to have_content("western") }
-    within_row(2) { expect(page).to have_content("eastern") }
+    within_row(2) { expect(page).to have_content("northern") }
+    within_row(3) { expect(page).to have_content("eastern") }
   end
 
   it "create a new zone" do


### PR DESCRIPTION
#### What? Why?

- Closes #10499 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I just came across this flaky spec for sorting zones and it turned out that the production code wasn't sorting by default.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit Admin -> Configuration -> Zones
- By default, the zones should be sorted alphabetically.
- You can sort them by description as well.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
