### PR TITLE
Make previously generated reports available for download

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ReportsHelper
+  JOB_TIMEOUT = 10
+
   def report_order_cycle_options(order_cycles)
     order_cycles.map do |oc|
       orders_open_at = oc.orders_open_at&.to_s(:short) || 'NA'

--- a/app/views/spree/layouts/_admin_body.html.haml
+++ b/app/views/spree/layouts/_admin_body.html.haml
@@ -10,6 +10,10 @@
       .flash.notice= notice
     - if flash[:success]
       .flash.success= flash[:success]
+    - if flash[:ok_to_download]
+      .msg.success= link_to I18n.t('admin.reports.report_download_your_file_ok'), flash[:ok_to_download].url(disposition: 'attachment')
+    - if flash[:ko_to_download]
+      .msg.error= flash[:ko_to_download]
 
     = render partial: "shared/flashes"
 

--- a/app/webpacker/css/admin/components/messages.scss
+++ b/app/webpacker/css/admin/components/messages.scss
@@ -32,7 +32,7 @@
   width: 100%;
   z-index: 1000;
 
-  .flash {
+  .flash, .msg {
     padding: 18px;
     text-align: center;  
     font-size: 120%;
@@ -48,6 +48,8 @@
     &:nth-child(2) { padding: 24px; }
     &:nth-child(3) { padding: 20px; }
   }
+
+  a, a:visited { color: $color-1; }
 }
 
 .notice:not(.flash) {

--- a/app/webpacker/css/admin/openfoodnetwork.scss
+++ b/app/webpacker/css/admin/openfoodnetwork.scss
@@ -32,7 +32,7 @@ text-angular .ta-editor {
   left: 275px;
 }
 
-span.error, div.error:not(.flash) {
+span.error, div.error:not(.flash, .msg) {
   color: $warning-red;
 }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -249,5 +249,7 @@ module Openfoodnetwork
     config.active_storage.variable_content_types += ["image/svg+xml"]
 
     config.exceptions_app = self.routes
+
+    config.active_storage.service_urls_expire_in = 60.minutes
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1422,6 +1422,7 @@ en:
       pack_by_customer: Pack By Customer
       pack_by_supplier: Pack By Supplier
       pack_by_product: Pack By Product
+      report_download_your_file_ok: Please download your report
       revenues_by_hub:
         name: Revenues By Hub
         description: Revenues by hub
@@ -1457,6 +1458,8 @@ en:
         no_report_type: "Please specify a report type"
         report_not_found: "Report not found"
         missing_ransack_params: "Please supply Ransack search params in the request"
+        report_generation_timed_out: "Sorry, processing of your report have taken too much time"
+        no_file_could_be_generated: "No file could be generated"
       hidden_field: "< Hidden >"
       summary_row:
         total: "TOTAL"

--- a/lib/reporting/report_renderer.rb
+++ b/lib/reporting/report_renderer.rb
@@ -52,6 +52,15 @@ module Reporting
       public_send("to_#{target_format}")
     end
 
+    def report_from_job(format, user, report_class, params)
+      job = ReportJob.new
+      JobProcessor.perform_forked(
+        job,
+        report_class, user, params, format
+      )
+      job.result
+    end
+
     def to_html(layout: nil)
       ApplicationController.render(
         template: "admin/reports/_table",

--- a/lib/reporting/report_template.rb
+++ b/lib/reporting/report_template.rb
@@ -5,7 +5,8 @@ module Reporting
     include ReportsHelper
     attr_accessor :user, :params, :ransack_params
 
-    delegate :render_as, :as_json, :to_html, :to_csv, :to_xlsx, :to_pdf, :to_json, to: :renderer
+    delegate :render_as, :report_from_job, :as_json, :to_html, :to_csv, :to_xlsx, :to_pdf, :to_json,
+             to: :renderer
     delegate :unformatted_render?, :html_render?, :display_header_row?, :display_summary_row?,
              to: :renderer
 

--- a/spec/jobs/report_job_spec.rb
+++ b/spec/jobs/report_job_spec.rb
@@ -9,6 +9,7 @@ describe ReportJob do
   let(:enterprise) { create(:enterprise) }
   let(:params) { {} }
   let(:format) { :csv }
+  let(:configured_job) { instance_double(ActiveJob::ConfiguredJob) }
 
   it "generates a report" do
     job = ReportJob.new
@@ -20,17 +21,25 @@ describe ReportJob do
     job = ReportJob.perform_later(*report_args)
     expect(job.done?).to eq false
 
-    # This performs the job in the same process but that's good enought for
-    # testing the job code. I hope that we can rely on the job worker.
-    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-    job.retry_job
+    perform_enqueued_jobs(only: ReportJob)
 
     expect(job.done?).to eq true
     expect_csv_report(job)
   end
 
+  it 'sets a purge job on blob creation' do
+    allow(ActiveStorage::PurgeJob).to receive(:set).and_return(configured_job)
+    allow(configured_job).to receive(:perform_later)
+    job = ReportJob.new
+    job.perform(*report_args)
+    job.result
+
+    expect(ActiveStorage::PurgeJob).to have_received(:set).with(hash_including(:wait))
+  end
+
   def expect_csv_report(job)
-    table = CSV.parse(job.result)
+    blob = job.result
+    table = CSV.parse(blob.download)
     expect(table[0][1]).to eq "Relationship"
     expect(table[1][1]).to eq "owns"
   end


### PR DESCRIPTION
#### What? Why?

- Closes #10280 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit http://localhost:3000/admin/reports
- if report is configured as background job (/admin/feature-toggle/features) then a flash message should display 
  a link to a report if everything ok, or a flash message displaying an error notice.

To change the validity of the url: `config.active_storage.service_urls_expire_in` in `config/application.rb` 

Timeout generation is set to 10 second and can be changed in `app/helpers/reports_helper.rb`

#### Notes
Display when user wants to download report that is not valid no more due to time is not yet implemented(white screen).

I did not make use of Stimulus etc., but rather did it the "classical" way because too many options for the report(background or not, screen or pdf/xlsx).

