### PR TITLE
Webpack, dev. env: Fix configuration export

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -5,4 +5,4 @@ const environment = require('./environment')
 const config = environment.toWebpackConfig();
 config.output.filename = "js/[name]-[hash].js";
 
-module.exports = environment.toWebpackConfig()
+module.exports = config;


### PR DESCRIPTION
#### What? Why?
Since https://github.com/openfoodfoundation/openfoodnetwork/pull/10568 we changed a bit the configuration options for webpack in development environement. The PR was incomplete, since it does not export the right value. Change that. 


#### What should we test?
- Locally, remove `public/packs` folder
- Start your server (via `foreman start`) and check that after requesting a page, folder `public/packs` is not empty and you don't have any errors in your browser console
- Everything should be fine (can navigate, ...)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
