### PR TITLE
Fix content security policy: authorize `ENV["SITE_URL"]` as trusted domain for images

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -8,6 +8,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.default_src :self, :https
   policy.font_src :self, :https, :data, "fonts.gstatic.com"
   policy.img_src :self, :https, :data, "*.s3.amazonaws.com"
+  policy.img_src :self, :http, :data, ENV["SITE_URL"] if Rails.env.development?
   policy.object_src :none
   policy.frame_ancestors :none
   policy.script_src :self, :https, :unsafe_inline, :unsafe_eval, "*.stripe.com", "openfoodnetwork.innocraft.cloud",


### PR DESCRIPTION
#### What? Why?

Previously, we add an error in browser, and image didn't display:
```
Refused to load the image 'http://0.0.0.0:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBYlU9IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--4e6630d45966b83ed9536cf64530b7893f11a83e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDVG9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0RFpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1hnWTdCbFE2Q1dOeWIzQkpJaEF4TURCNE1UQXdLekFyTUFZN0JsUT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--c347e2bbbeea821ae3d33a49279dc7e5cc41eade/6y6ttn.jpg' because it violates the following Content Security Policy directive: "img-src 'self' https: data: *.s3.amazonaws.com".
```

#### What should we test?
- Upload an image for a shopfront (promo or logo)
- Go to the shopfront: the image should display

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
