### PR TITLE
[Hidden] Display a friendly message when a background report times out

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -11,3 +11,9 @@ OFN_REDIS_URL="redis://localhost:6379/1"
 OFN_REDIS_JOBS_URL="redis://localhost:6379/2"
 
 SITE_URL="0.0.0.0:3000"
+
+# Deactivate rack-timeout in development.
+# https://github.com/zombocom/rack-timeout#configuring
+RACK_TIMEOUT_SERVICE_TIMEOUT="0"
+RACK_TIMEOUT_WAIT_TIMEOUT="0"
+RACK_TIMEOUT_WAIT_OVERTIME="0"

--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ gem 'gmaps4rails'
 gem 'mimemagic', '> 0.3.5'
 gem 'paper_trail', '~> 12.1'
 gem 'rack-rewrite'
+gem 'rack-timeout'
 gem 'roadie-rails'
 
 gem 'hiredis'
@@ -141,7 +142,6 @@ gem "private_address_check"
 
 group :production, :staging do
   gem 'ddtrace'
-  gem 'rack-timeout'
   gem 'sd_notify' # For better Systemd process management. Used by Puma.
 end
 

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -26,6 +26,8 @@ module Admin
       else
         show_report
       end
+    rescue Rack::Timeout::RequestTimeoutException
+      render_timeout_error
     end
 
     private
@@ -36,6 +38,7 @@ module Admin
 
     def show_report
       assign_view_data
+      @table = render_report_as(:html) if render_data?
       render "show"
     end
 
@@ -45,7 +48,6 @@ module Admin
       @report_subtype = report_subtype
       @report_title = report_title
       @rendering_options = rendering_options
-      @table = render_report_as(:html) if render_data?
       @data = Reporting::FrontendData.new(spree_current_user)
     end
 
@@ -65,6 +67,12 @@ module Admin
       else
         @report.render_as(format)
       end
+    end
+
+    def render_timeout_error
+      assign_view_data
+      @error = ".report_taking_longer"
+      render "show"
     end
   end
 end

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -18,7 +18,8 @@
 .report__header.print-hidden
   - if @report.message.present?
     %p.report__message= @report.message
-  - if request.post?
+  - if request.post? && !@error
     %button.btn-print.icon-print{ onclick: "window.print()"}= t(:report_print)
 
+= t(@error) if @error
 = @table

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1438,6 +1438,11 @@ en:
       pack_by_customer: Pack By Customer
       pack_by_supplier: Pack By Supplier
       pack_by_product: Pack By Product
+      show:
+        report_taking_longer: >
+          This report is taking longer to process.
+          It may contain a lot of data or we are busy with other reports.
+          You can try again later.
       revenues_by_hub:
         name: Revenues By Hub
         description: Revenues by hub

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1440,7 +1440,7 @@ en:
       pack_by_product: Pack By Product
       show:
         report_taking_longer: >
-          This report is taking longer to process.
+          Sorry, this report took too long to process.
           It may contain a lot of data or we are busy with other reports.
           You can try again later.
       revenues_by_hub:

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -44,6 +44,19 @@ describe '
       click_button "Go"
       expect(page).to have_content "EMAIL FIRST NAME"
     end
+
+    it "displays a friendly timeout message" do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+      login_as_admin_and_visit admin_report_path(
+        report_type: :customers, report_subtype: :mailing_list
+      )
+      expect_any_instance_of(Admin::ReportsController).to receive(:sleep).
+        and_raise(Rack::Timeout::RequestTimeoutException.new(nil))
+
+      click_button "Go"
+
+      expect(page).to have_content "This report is taking longer to process."
+    end
   end
 
   describe "Can access Customers reports and generate customers report" do

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -55,7 +55,7 @@ describe '
 
       click_button "Go"
 
-      expect(page).to have_content "This report is taking longer to process."
+      expect(page).to have_content "this report took too long"
     end
   end
 

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -50,8 +50,8 @@ describe '
       login_as_admin_and_visit admin_report_path(
         report_type: :customers, report_subtype: :mailing_list
       )
-      expect_any_instance_of(Admin::ReportsController).to receive(:sleep).
-        and_raise(Rack::Timeout::RequestTimeoutException.new(nil))
+      expect(ENV).to receive(:fetch).with("RACK_TIMEOUT_SERVICE_TIMEOUT", "15")
+        .and_return("-1") # Negative values time out immediately.
 
       click_button "Go"
 


### PR DESCRIPTION
#### What? Why?

- First step towards #10280

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Activate background reports.
- Visit /admin/reports
- Choose a complex report.
- Choose parameters to make it time out. uk-staging orders_and_distributors since 2021 should time out but not run too long.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
