### PR TITLE
BOM: When selecting a specific variant, trigger a new search that avoid pagination issues

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -37,7 +37,6 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     $scope.query = ''
     $scope.startDate = undefined
     $scope.endDate = undefined
-    $scope.filterByVariantId = null
     event = new CustomEvent('flatpickr:clear')
     window.dispatchEvent(event)
 

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -183,6 +183,14 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     $scope.page = 1
     $scope.refreshData()
 
+  $scope.resetSelectedUnitsVariant = ->
+    $scope.selectedUnitsProduct = { }
+    $scope.selectedUnitsVariant = { }
+    $scope.filterByVariantId = null
+    $scope.sharedResource = false
+    $scope.page = 1
+    $scope.refreshData()
+
   $scope.getLineItemScale = (lineItem) ->
     if lineItem.units_product && lineItem.units_variant && (lineItem.units_product.variant_unit == "weight" || lineItem.units_product.variant_unit == "volume") 
       lineItem.units_product.variant_unit_scale

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -17,6 +17,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   ]
   $scope.page = 1
   $scope.per_page = $scope.per_page_options[0].id
+  $scope.filterByVariantId = null
   searchThrough = ["order_distributor_name",
     "order_bill_address_phone",
     "order_bill_address_firstname",
@@ -36,6 +37,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     $scope.query = ''
     $scope.startDate = undefined
     $scope.endDate = undefined
+    $scope.filterByVariantId = null
     event = new CustomEvent('flatpickr:clear')
     window.dispatchEvent(event)
 
@@ -68,6 +70,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
 
     RequestMonitor.load LineItems.index(
       "q[#{searchThrough}]": $scope.query,
+      "q[variant_id_eq]": $scope.filterByVariantId if $scope.filterByVariantId,
       "q[order_state_not_eq]": "canceled",
       "q[order_shipment_state_not_eq]": "shipped",
       "q[order_completed_at_not_null]": "true",
@@ -176,6 +179,9 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.setSelectedUnitsVariant = (unitsProduct,unitsVariant) ->
     $scope.selectedUnitsProduct = unitsProduct
     $scope.selectedUnitsVariant = unitsVariant
+    $scope.filterByVariantId = unitsVariant.id
+    $scope.page = 1
+    $scope.refreshData()
 
   $scope.getLineItemScale = (lineItem) ->
     if lineItem.units_product && lineItem.units_variant && (lineItem.units_product.variant_unit == "weight" || lineItem.units_product.variant_unit == "volume") 

--- a/app/assets/javascripts/admin/line_items/filters/variant_filter.js.coffee
+++ b/app/assets/javascripts/admin/line_items/filters/variant_filter.js.coffee
@@ -1,6 +1,0 @@
-angular.module("admin.lineItems").filter "variantFilter", ->
-    return (lineItems,selectedUnitsProduct,selectedUnitsVariant,sharedResource) ->
-      filtered = []
-      filtered.push lineItem for lineItem in lineItems when (angular.equals(selectedUnitsProduct,{}) ||
-        (lineItem.units_product.id == selectedUnitsProduct.id && (sharedResource || lineItem.units_variant.id == selectedUnitsVariant.id ) ) )
-      filtered

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -166,7 +166,7 @@
               = "#{t('admin.price')} (#{Spree::Money.currency_symbol})"
             %th.actions
 
-        %tr.line_item{ ng: { repeat: "line_item in filteredLineItems = ( line_items | variantFilter:selectedUnitsProduct:selectedUnitsVariant:sharedResource | orderBy:sorting.predicate:sorting.reverse )", 'class-even' => "'even'", 'class-odd' => "'odd'", attr: { id: "li_{{line_item.id}}" } } }
+        %tr.line_item{ ng: { repeat: "line_item in filteredLineItems = ( line_items | orderBy:sorting.predicate:sorting.reverse )", 'class-even' => "'even'", 'class-odd' => "'odd'", attr: { id: "li_{{line_item.id}}" } } }
           %td.bulk
             %input{ :type => "checkbox", :name => 'bulk', 'ng-model' => 'line_item.checked', 'ignore-dirty' => true }
           %td.order_no{ 'ng-show' => 'columns.order_no.visible' } {{ line_item.order.number }}

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -70,7 +70,7 @@
       %h6.text-center{ 'ng-hide' => 'sharedResource' } {{ selectedUnitsVariant.full_name }}
     .three.columns
       %h6.text-right
-        %a{ :href => '#', 'ng-click' => 'selectedUnitsVariant = {};selectedUnitsProduct = {};sharedResource=false;' }= t('admin.clear')
+        %a{ :href => '#', 'ng-click' => 'resetSelectedUnitsVariant()' }= t('admin.clear')
     %hr
     .row
       .one.columns.alpha

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -1082,6 +1082,7 @@ describe '
           expect(page).to have_no_selector "tr#li_#{li2.id}"
           expect(page).to have_selector "tr#li_#{li3.id}"
           expect(page).to have_selector "tr#li_#{li4.id}"
+          expect(page).to have_css("table#listing_orders tbody tr", count: 2)
         end
       end
 
@@ -1098,6 +1099,32 @@ describe '
           expect(page).to have_selector "tr#li_#{li2.id}"
           expect(page).to have_selector "tr#li_#{li3.id}"
           expect(page).to have_selector "tr#li_#{li4.id}"
+        end 
+      end
+
+      context "when filtering" do
+        before do
+          fill_in "quick_filter", with: li3.order.email
+          page.find('.filter-actions .button.icon-search').click
+        end
+
+        it "shows only variant filtering by email" do
+          expect(page).to have_no_selector "tr#li_#{li1.id}"
+          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).to have_selector "tr#li_#{li3.id}"
+          expect(page).to have_no_selector "tr#li_#{li4.id}"
+        end
+
+        context "clicking 'Clear Filters' button" do
+          before :each do
+            page.find('.filter-actions #clear_filters_button').click
+          end
+
+          it_behaves_like "display only group by information for selected variant"
+
+          it "but actually clears the filters" do
+            expect(page.find("input[name='quick_filter']").value).to eq("")
+          end
         end
       end
     end

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -85,13 +85,29 @@ describe '
         create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
                                         completed_at: Time.zone.now )
       }
+      let!(:o3) {
+        create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
+                                        completed_at: Time.zone.now )
+      }
+      let!(:product) {
+        create(:simple_product)
+      }
+      let!(:var1) {
+        create(:variant, product_id: product.id, display_name: "Little Fish")
+      }
+      let!(:var2) {
+        create(:variant, product_id: product.id, display_name: "Big Fish")
+      }
 
       before do
-        15.times {
-          create(:line_item_with_shipment, order: o1)
+        10.times {
+          create(:line_item_with_shipment, variant: var1, order: o2)
         }
         5.times {
-          create(:line_item_with_shipment, order: o2)
+          create(:line_item_with_shipment, variant: var2, order: o1)
+        }
+        5.times {
+          create(:line_item_with_shipment, variant: var1, order: o3)
         }
       end
 
@@ -124,6 +140,20 @@ describe '
         expect(page).to have_button("Last »", disabled: true)
         select2_select "100 per page", from: "autogen4" # should display all 20 line items
         expect(page).to have_content "20 Results found. Viewing 1 to 20."
+      end
+
+      it "clicking the product variant" do
+        visit_bulk_order_management
+        expect(page).to have_content "Little Fish", count: 10
+        expect(page).to have_content "Big Fish", count: 5
+        click_on("Little Fish") # opens BOM box
+        within "#listing_orders" do
+          expect(page).to have_content "Little Fish", count: 15
+          expect(page).not_to have_content "Big Fish"
+        end
+        find("a", text: "Clear").click # closes BOM box
+        expect(page).to have_content "Little Fish", count: 10
+        expect(page).to have_content "Big Fish", count: 5
       end
     end
 

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -1054,34 +1054,38 @@ describe '
         end
       end
 
-      it "displays group buy calc box" do
-        expect(page).to have_selector "div#group_buy_calculation"
+      shared_examples "display only group by information for selected variant" do          
+        it "displays group buy calc box" do
+          expect(page).to have_selector "div#group_buy_calculation"
 
-        within "div#group_buy_calculation" do
-          expect(page).to have_text "Group Buy Unit Size"
-          expect(page).to have_text "5000 g"
-          expect(page).to have_text "Total Quantity Ordered"
-          expect(page).to have_text "4000 g"
-          expect(page).to have_text "Max Quantity Ordered"
-          expect(page).to have_text "9000 g"
-          expect(page).to have_text "Current Fulfilled Units"
-          expect(page).to have_text "0.8"
-          expect(page).to have_text "Max Fulfilled Units"
-          expect(page).to have_text "1.8"
-          expect(page).to have_selector "div.shared_resource"
-          within "div.shared_resource" do
-            expect(page).to have_selector "span", text: "Shared Resource?"
-            expect(page).to have_selector "input#shared_resource"
+          within "div#group_buy_calculation" do
+            expect(page).to have_text "Group Buy Unit Size"
+            expect(page).to have_text "5000 g"
+            expect(page).to have_text "Total Quantity Ordered"
+            expect(page).to have_text "4000 g"
+            expect(page).to have_text "Max Quantity Ordered"
+            expect(page).to have_text "9000 g"
+            expect(page).to have_text "Current Fulfilled Units"
+            expect(page).to have_text "0.8"
+            expect(page).to have_text "Max Fulfilled Units"
+            expect(page).to have_text "1.8"
+            expect(page).to have_selector "div.shared_resource"
+            within "div.shared_resource" do
+              expect(page).to have_selector "span", text: "Shared Resource?"
+              expect(page).to have_selector "input#shared_resource"
+            end
           end
+        end
+  
+        it "all line items of the same variant" do
+          expect(page).to have_no_selector "tr#li_#{li1.id}"
+          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).to have_selector "tr#li_#{li3.id}"
+          expect(page).to have_selector "tr#li_#{li4.id}"
         end
       end
 
-      it "all line items of the same variant" do
-        expect(page).to have_no_selector "tr#li_#{li1.id}"
-        expect(page).to have_no_selector "tr#li_#{li2.id}"
-        expect(page).to have_selector "tr#li_#{li3.id}"
-        expect(page).to have_selector "tr#li_#{li4.id}"
-      end
+      it_behaves_like "display only group by information for selected variant"
 
       context "clicking 'Clear' in group buy box" do
         before :each do


### PR DESCRIPTION
This PR basically starts a new search once variant has been selected
 - Remove variant_filter
 - instantiate a new search to avoid pagination issues

#### What? Why?

- Closes #10645 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
- As an admin, go to `/admin/orders/bulk_management`
- It's better to have lots of (ie. more than one page) orders with a specific line items
- Click on a product on the column
- This should instantiate a new search, that search for that specific variant clicked, and show all orders with that variant (if many orders with that variant we must see the pagination)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
