### PR TITLE
Fix bug #10596, missing translation for editing shipping category

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3791,6 +3791,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     shipping_categories: "Shipping Categories"
     new_shipping_category: "New Shipping Category"
     back_to_shipping_categories: "Back To Shipping Categories"
+    editing_shipping_category: "Editing Shipping Category"
 
     name: "Name"
     description: "Description"

--- a/spec/system/admin/configuration/shipping_categories_spec.rb
+++ b/spec/system/admin/configuration/shipping_categories_spec.rb
@@ -4,6 +4,30 @@ require 'system_helper'
 
 describe "Shipping Categories" do
   include AuthenticationHelper
+  include WebHelper
+  let(:admin_role) { Spree::Role.find_or_create_by!(name: 'admin') }
+  let(:admin_user) { create(:user) }
+
+  context 'user visits shipping categories page' do
+    it 'header is translated' do
+      login_as_admin_and_visit spree.admin_shipping_categories_path(locale: 'es')
+      expect(get_i18n_locale).to eq 'es'
+
+      expect(get_i18n_translation('shipping_categories')).to eq 'Categorías de envío'
+      click_link "Nueva categoría de envío"
+
+      fill_in "shipping_category_name", with: "freeze"
+      check "shipping_category_temperature_controlled"
+      click_button "Crear"
+
+      expect(page).to have_content("freeze")
+      row = find('tr', text: 'freeze')
+      within row do
+        find('a', class: 'icon-edit').click
+      end
+      expect(page).to have_content "Edición de la categoría de envío"
+    end
+  end
 
   context 'user adds a new shipping category with temperature control' do
     it 'user sees new shipping category with temperature control' do

--- a/spec/system/admin/configuration/shipping_categories_spec.rb
+++ b/spec/system/admin/configuration/shipping_categories_spec.rb
@@ -10,22 +10,12 @@ describe "Shipping Categories" do
 
   context 'user visits shipping categories page' do
     it 'header is translated' do
-      login_as_admin_and_visit spree.admin_shipping_categories_path(locale: 'es')
-      expect(get_i18n_locale).to eq 'es'
+      category = create(:shipping_category)
 
-      expect(get_i18n_translation('shipping_categories')).to eq 'Categorías de envío'
-      click_link "Nueva categoría de envío"
+      login_as_admin
+      visit spree.edit_admin_shipping_category_path(category)
 
-      fill_in "shipping_category_name", with: "freeze"
-      check "shipping_category_temperature_controlled"
-      click_button "Crear"
-
-      expect(page).to have_content("freeze")
-      row = find('tr', text: 'freeze')
-      within row do
-        find('a', class: 'icon-edit').click
-      end
-      expect(page).to have_content "Edición de la categoría de envío"
+      expect(page).to have_content "Editing Shipping Category"
     end
   end
 


### PR DESCRIPTION
#### What? Why?

- Closes #10596 

- Fixes user-facing issue where header on /admin/shipping_categories/<shipping_category_id>/edit where header is not translatable. 



#### What should we test?




#### Release notes

Changelog Category: User facing changes

