### PR TITLE
Admin, Payment reports: add missing translation for payment state

### DIFF
--- a/lib/reporting/reports/payments/base.rb
+++ b/lib/reporting/reports/payments/base.rb
@@ -15,7 +15,7 @@ module Reporting
         protected
 
         def payment_state(order)
-          order.payment_state
+          I18n.t "spree.payment_states.#{order.payment_state}"
         end
       end
     end

--- a/lib/reporting/reports/payments/base.rb
+++ b/lib/reporting/reports/payments/base.rb
@@ -11,6 +11,12 @@ module Reporting
         def query_result
           search.result.group_by { |order| [order.payment_state, order.distributor] }.values
         end
+
+        protected
+
+        def payment_state(order)
+          order.payment_state
+        end
       end
     end
   end

--- a/lib/reporting/reports/payments/itemised_payment_totals.rb
+++ b/lib/reporting/reports/payments/itemised_payment_totals.rb
@@ -6,7 +6,7 @@ module Reporting
       class ItemisedPaymentTotals < Base
         def columns
           {
-            payment_state: proc { |orders| orders.first.payment_state },
+            payment_state: proc { |orders| payment_state(orders.first) },
             distributor: proc { |orders| orders.first.distributor.name },
             product_total_price: proc { |orders| orders.to_a.sum(&:item_total) },
             shipping_total_price: proc { |orders| orders.sum(&:ship_total) },

--- a/lib/reporting/reports/payments/payment_totals.rb
+++ b/lib/reporting/reports/payments/payment_totals.rb
@@ -6,7 +6,7 @@ module Reporting
       class PaymentTotals < Base
         def columns
           {
-            payment_state: proc { |orders| orders.first.payment_state },
+            payment_state: proc { |orders| payment_state(orders.first) },
             distributor: proc { |orders| orders.first.distributor.name },
             product_total_price: proc { |orders| orders.to_a.sum(&:item_total) },
             shipping_total_price: proc { |orders| orders.sum(&:ship_total) },

--- a/lib/reporting/reports/payments/payments_by_payment_type.rb
+++ b/lib/reporting/reports/payments/payments_by_payment_type.rb
@@ -15,7 +15,7 @@ module Reporting
 
         def columns
           {
-            payment_state: proc { |payments| payments.first.order.payment_state },
+            payment_state: proc { |payments| payment_state(payments.first.order) },
             distributor: proc { |payments| payments.first.order.distributor.name },
             payment_type: proc { |payments| payments.first.payment_method.name },
             total_price: proc { |payments| payments.sum(&:amount) }

--- a/spec/system/admin/reports/payments_report_spec.rb
+++ b/spec/system/admin/reports/payments_report_spec.rb
@@ -86,7 +86,7 @@ describe "Payments Reports" do
       ].join(" ").upcase)
 
       expect(page.find("table.report__table tbody tr").text).to have_content([
-        order.payment_state,
+        "credit owed",
         order.distributor.name,
         order.item_total.to_f + other_order.item_total.to_f,
         order.ship_total.to_f + other_order.ship_total.to_f,


### PR DESCRIPTION
#### What? Why?

- Closes #9723 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
- As an admin, generate the 3 payment reports
- Check that first column, payment state, is translated (ie. `balance due` instead of `balance_due` or `credit owed` instead of `credit_owed`)

<img width="611" alt="Capture d’écran 2023-04-06 à 10 03 03" src="https://user-images.githubusercontent.com/296452/230313474-626920eb-fdd9-4856-b86a-1b428e62f317.png">


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
