### PR TITLE
Show commit in CI

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Scan
       continue-on-error: true
       run: |
+        git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
         brakeman -f sarif -o output.sarif.json .
 
     # Upload the SARIF file generated in the previous step

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,6 @@ jobs:
           bundle exec rake db:schema:load
 
       - name: Run tests
-
         env:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: 864ef557d85ea8e603e086c0387d5154
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
@@ -82,8 +81,8 @@ jobs:
           # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it
           #KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/controllers/**/*_spec.rb}" 
-        
         run: |
+          git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
           bundle exec rake knapsack_pro:rspec
 
   knapsack_rspec_models:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -9,7 +9,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v1
+
       - uses: ruby/setup-ruby@v1
+
+      - run: git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
+
       - name: rubocop
         uses: reviewdog/action-rubocop@v2
         with:
@@ -31,6 +35,8 @@ jobs:
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
+
+      - run: git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
 
       - name: prettier
         uses: EPMatt/reviewdog-action-prettier@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ TL;DR:
 * Maintain a clean commit history
 * Use a style consistent with the rest of the codebase
 * Before submitting, [rebase your work][rebase] on the current master branch
+* After submitting, be sure to check the [CI test results](ci). Click on a ❌ result to view the logged results and investigate.
 
 From here, your pull request will progress through the [Review, Test, Merge & Deploy process][process].
 
@@ -71,3 +72,4 @@ From here, your pull request will progress through the [Review, Test, Merge & De
 [ofn-transifex]: https://www.transifex.com/open-food-foundation/open-food-network/
 [i18n]: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-%28i18n%29
 [welcome-dev]: https://github.com/orgs/openfoodfoundation/projects/2
+[ci]: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Continuous-Integration


### PR DESCRIPTION


#### What? Why?
https://openfoodnetwork.slack.com/archives/GK2T38QPJ/p1681180450549159

> I’ve just found two instances where CI (linting and testing) appears to be running from a rebased version of the PR branch. That is, the PR branches off an old version of master, but when running in CI it appears to include the latest changes from master.

`actions/checkout@v3` actually creates a merge commit into master, to ensure you're testing the latest as close to master as possible. That's all well and good, but quite confusing when you see errors in CI that aren't present in the actual PR branch. Hopefully this will be a clue when such confusions arise.



#### What should we test?
When viewing the CI logs for linters or specs, we should be able to see the commit ID and name (which mentions the merge)

#### Release notes

Changelog Category: Technical changes > CI


#### Documentation updates
Have already added a section here: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Continuous-Integration
