### PR TITLE
Fix admin product variants form to close issues #10579 & Wishlist: 430

### DIFF
--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -11,9 +11,7 @@
       .field
         = label_tag :unit_value_human, "#{t('admin.'+@product.variant_unit)} ({{unitName(#{@product.variant_unit_scale}, '#{@product.variant_unit}')}})"
         = hidden_field_tag 'product_variant_unit_scale', @product.variant_unit_scale
-        -# CHANGED LINE
         = number_field_tag :unit_value_human, nil, {class: "fullwidth", step: 0.01, 'ng-model' => 'unit_value_human', 'ng-change' => 'updateValue()'}
-        -# CHANGED LINE
         = f.number_field :unit_value, {hidden: true, 'ng-value' => 'unit_value'}
 
     .field

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -11,8 +11,10 @@
       .field
         = label_tag :unit_value_human, "#{t('admin.'+@product.variant_unit)} ({{unitName(#{@product.variant_unit_scale}, '#{@product.variant_unit}')}})"
         = hidden_field_tag 'product_variant_unit_scale', @product.variant_unit_scale
-        = text_field_tag :unit_value_human, nil, {class: "fullwidth", 'ng-model' => 'unit_value_human', 'ng-change' => 'updateValue()'}
-        = f.text_field :unit_value, {hidden: true, 'ng-value' => 'unit_value'}
+        -# CHANGED LINE
+        = number_field_tag :unit_value_human, nil, {class: "fullwidth", step: 0.01, 'ng-model' => 'unit_value_human', 'ng-change' => 'updateValue()'}
+        -# CHANGED LINE
+        = f.number_field :unit_value, {hidden: true, 'ng-value' => 'unit_value'}
 
     .field
       = f.label :unit_description, t(:spree_admin_unit_description)
@@ -65,8 +67,8 @@
   - if @product.variant_unit != 'weight'
     .field
       = f.label 'weight', t(:weight)+' (kg)'
-      - value = number_with_precision(@variant.weight, precision: 2)
-      = f.number_field 'weight', value: value, class: 'fullwidth', step: 0.01
+      - value = number_with_precision(@variant.weight, precision: 3)
+      = f.number_field 'weight', value: value, class: 'fullwidth', step: 0.001
 
   - [:height, :width, :depth].each do |field|
     .field

--- a/spec/system/admin/variants_spec.rb
+++ b/spec/system/admin/variants_spec.rb
@@ -256,7 +256,6 @@ describe '
     # It should allow the weight to be changed
     expect(page).to have_field "unit_value_human"
 
-
     # When I update the fields and save the variant with invalid value
     fill_in "unit_value_human", with: "1.234"
     click_button 'Update'


### PR DESCRIPTION
#### What? Why?

- Closes #10579 
- Closes https://github.com/openfoodfoundation/wishlist/issues/430

- There was no error message when the user entered an invalid weight into the admin/product/edit/variant page. The form now matches the width, and height entries, where an error appears for non-numeric values, and those that do not fit the precision limit. 
- Changed precision limit for shipping weight for products with non-weight units to 3. (Wishlist item 430)



#### What should we test?
Test weight inputs as product unit, and as shipping weight on /admin/products/<product>/variants/<#>/edit page

- Visit /admin/products/<product>/variants/<#>/edit page.

#### Release notes

Changelog Category: User facing changes

Fix admin product variants form to close issues #10579 & https://github.com/openfoodfoundation/wishlist/issues/430

