### PR TITLE
Rename Inversable Method Names

### DIFF
--- a/app/models/spree/order_inventory.rb
+++ b/app/models/spree/order_inventory.rb
@@ -63,7 +63,7 @@ module Spree
     # first unshipped that's leaving from a stock_location that stocks this variant
     def determine_target_shipment(variant)
       target_shipment = order.shipments.detect do |shipment|
-        (shipment.ready? || shipment.pending?) && shipment.include?(variant)
+        (shipment.ready? || shipment.pending?) && shipment.contains?(variant)
       end
 
       target_shipment || order.shipments.detect do |shipment|

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -246,7 +246,7 @@ module Spree
       @tracking_url ||= shipping_method.build_tracking_url(tracking)
     end
 
-    def include?(variant)
+    def contains?(variant)
       inventory_units_for(variant).present?
     end
 

--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -61,7 +61,7 @@ module Spree
     # Here we allow checkout with shipping methods without zones (see issue #3928 for details)
     #   and also checkout with addresses outside of the zones of the selected shipping method
     # This method could be used, like in Spree, to validate shipping method zones on checkout.
-    def include?(address)
+    def delivers_to?(address)
       address.present?
     end
 

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -69,7 +69,8 @@ module Spree
       return 0 unless category
 
       address ||= Address.new(country_id: DefaultCountry.id)
-      rate = category.tax_rates.detect { |tax_rate| tax_rate.zone.include? address }.try(:amount)
+      rate = category.tax_rates
+        .detect { |tax_rate| tax_rate.zone.contains_address? address }.try(:amount)
 
       rate || 0
     end

--- a/app/models/spree/zone.rb
+++ b/app/models/spree/zone.rb
@@ -24,7 +24,7 @@ module Spree
       # do nothing - just here to satisfy the form
     end
 
-    def include?(address)
+    def contains_address?(address)
       return false unless address
 
       members.any? do |zone_member|
@@ -44,7 +44,7 @@ module Spree
     def self.match(address)
       return unless matches = includes(:zone_members).
         order('zone_members_count', 'created_at').
-        select { |zone| zone.include? address }
+        select { |zone| zone.contains_address? address }
 
       ['state', 'country'].each do |zone_kind|
         if match = matches.detect { |zone| zone_kind == zone.kind }

--- a/engines/order_management/app/services/order_management/stock/estimator.rb
+++ b/engines/order_management/app/services/order_management/stock/estimator.rb
@@ -53,7 +53,7 @@ module OrderManagement
       def shipping_methods(package)
         shipping_methods = package.shipping_methods
         shipping_methods.delete_if { |ship_method| !ship_method.calculator.available?(package) }
-        shipping_methods.delete_if { |ship_method| !ship_method.include?(order.ship_address) }
+        shipping_methods.delete_if { |ship_method| !ship_method.delivers_to?(order.ship_address) }
         shipping_methods.delete_if { |ship_method|
           !(ship_method.calculator.preferences[:currency].nil? ||
             ship_method.calculator.preferences[:currency] == currency)

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -106,20 +106,20 @@ module Spree
       end
     end
 
-    describe "#include?" do
+    describe "#delivers_to?" do
       let(:shipping_method) { build_stubbed(:shipping_method) }
 
-      it "does not include a nil address" do
-        expect(shipping_method.include?(nil)).to be false
+      it "does not deliver to a nil address" do
+        expect(shipping_method.delivers_to?(nil)).to be false
       end
 
       it "includes an address that is not included in the zones of the shipping method" do
         address = create(:address)
         zone_mock = instance_double(Spree::Zone)
-        allow(zone_mock).to receive(:include?).with(address).and_return(false)
+        allow(zone_mock).to receive(:contains?).with(address).and_return(false)
         allow(shipping_method).to receive(:zones) { [zone_mock] }
 
-        expect(shipping_method.include?(address)).to be true
+        expect(shipping_method.delivers_to?(address)).to be true
       end
     end
 

--- a/spec/models/spree/zone_spec.rb
+++ b/spec/models/spree/zone_spec.rb
@@ -88,7 +88,7 @@ describe Spree::Zone do
     end
   end
 
-  context "#include?" do
+  context "#contains_address?" do
     let(:state) { create(:state) }
     let(:country) { state.country }
     let(:address) { create(:address, country: country, state: state) }
@@ -98,7 +98,7 @@ describe Spree::Zone do
       before { country_zone.members.create(zoneable: country) }
 
       it "should be true" do
-        expect(country_zone.include?(address)).to be_truthy
+        expect(country_zone.contains_address?(address)).to be_truthy
       end
     end
 
@@ -107,7 +107,7 @@ describe Spree::Zone do
       before { state_zone.members.create(zoneable: state) }
 
       it "should be true" do
-        expect(state_zone.include?(address)).to be_truthy
+        expect(state_zone.contains_address?(address)).to be_truthy
       end
     end
   end


### PR DESCRIPTION
#### Some method names were incompatible with Rubocop's InverseMethod Rule

- Closes issues that came up with #10598 

Rubocop raises offenses when positive methods are negated. The following is
an offense according to Rubocop:
```
if !collection.includes?(key):
  <do something>
```

It should be rewritten to avoid negation:
```
if collection.excludes?(key):
  <do something>
```

Some models had methods that Rubocop recognized as having inverse functions
(eg. model.includes?). These needed to be renamed in order for Rubocop to pass.

#### What should we test?

Shouldn't require extra testing.

#### Release notes

Changelog Category: Technical changes