### PR TITLE
Simplify login test helpers

### DIFF
--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -7,13 +7,9 @@ module AuthenticationHelper
     login_as create(:admin_user)
   end
 
-  def login_as_admin_and_visit(path_visit)
-    login_as_admin
-    visit path_visit
-  end
-
   def login_to_admin_section
-    login_as_admin_and_visit(spree.admin_dashboard_path)
+    login_as_admin
+    visit spree.admin_dashboard_path
   end
 
   def fill_in_and_submit_login_form(user)

--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -4,9 +4,7 @@ module AuthenticationHelper
   include Warden::Test::Helpers
 
   def login_as_admin
-    admin_user = create(:admin_user)
-    login_as admin_user
-    admin_user
+    login_as create(:admin_user)
   end
 
   def login_as_admin_and_visit(path_visit)

--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -16,11 +16,6 @@ module AuthenticationHelper
     login_as_admin_and_visit(spree.admin_dashboard_path)
   end
 
-  def login_to_admin_as(user)
-    login_as user
-    visit spree.admin_dashboard_path
-  end
-
   def fill_in_and_submit_login_form(user)
     fill_in "Email", with: user.email
     fill_in "Password", with: user.password

--- a/spec/system/admin/adjustments_spec.rb
+++ b/spec/system/admin/adjustments_spec.rb
@@ -26,7 +26,8 @@ describe '
   before do
     order.finalize!
     create(:check_payment, order: order, amount: order.total)
-    login_as_admin_and_visit spree.admin_orders_path
+    login_as_admin
+    visit spree.admin_orders_path
   end
 
   it "adding taxed adjustments to an order" do
@@ -97,7 +98,8 @@ describe '
     }
     before do
       order.cancel!
-      login_as_admin_and_visit spree.edit_admin_order_path(order)
+      login_as_admin
+      visit spree.edit_admin_order_path(order)
     end
 
     it "displays adjustments" do

--- a/spec/system/admin/bulk_order_cancellation_spec.rb
+++ b/spec/system/admin/bulk_order_cancellation_spec.rb
@@ -21,7 +21,8 @@ describe '
     }
 
     before :each do
-      login_as_admin_and_visit spree.admin_orders_path
+      login_as_admin
+      visit spree.admin_orders_path
     end
 
     it "deletes orders" do

--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -785,7 +785,7 @@ describe '
       @enterprise_user.enterprise_roles.build(enterprise: supplier_managed2).save
       @enterprise_user.enterprise_roles.build(enterprise: distributor_managed).save
 
-      login_to_admin_as @enterprise_user
+      login_as @enterprise_user
     end
 
     it "shows only products that I supply" do

--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -208,7 +208,8 @@ describe '
     shipping_category = create(:shipping_category)
     taxon = create(:taxon)
 
-    login_as_admin_and_visit spree.admin_products_path
+    login_as_admin
+    visit spree.admin_products_path
 
     find("a", text: "NEW PRODUCT").click
     expect(page).to have_content 'NEW PRODUCT'
@@ -528,7 +529,8 @@ describe '
     p1 = FactoryBot.create(:simple_product, name: "product1", supplier: s1)
     p2 = FactoryBot.create(:simple_product, name: "product2", supplier: s2)
 
-    login_as_admin_and_visit spree.admin_products_path
+    login_as_admin
+    visit spree.admin_products_path
 
     select2_select s1.name, from: "producer_filter"
     apply_filters
@@ -605,7 +607,8 @@ describe '
       let!(:v2) { p2.variants.first }
 
       before do
-        login_as_admin_and_visit spree.admin_products_path
+        login_as_admin
+        visit spree.admin_products_path
       end
 
       it "shows an edit button for products, which takes the user to the standard edit page for that product" do
@@ -678,7 +681,8 @@ describe '
         p2 = FactoryBot.create(:product, name: "P2")
         p3 = FactoryBot.create(:product, name: "P3")
 
-        login_as_admin_and_visit spree.admin_products_path
+        login_as_admin
+        visit spree.admin_products_path
 
         expect(page).to have_selector "a.clone-product", count: 3
 
@@ -702,7 +706,8 @@ describe '
     describe "using column display dropdown" do
       it "shows a column display dropdown, which shows a list of columns when clicked" do
         FactoryBot.create(:simple_product)
-        login_as_admin_and_visit spree.admin_products_path
+        login_as_admin
+        visit spree.admin_products_path
 
         toggle_columns "Available On"
 
@@ -729,7 +734,8 @@ describe '
         p1 = FactoryBot.create(:simple_product, name: "product1", supplier: s1)
         p2 = FactoryBot.create(:simple_product, name: "product2", supplier: s2)
 
-        login_as_admin_and_visit spree.admin_products_path
+        login_as_admin
+        visit spree.admin_products_path
 
         # Page shows the filter controls
         expect(page).to have_select "producer_filter", visible: false
@@ -888,7 +894,8 @@ describe '
     let!(:product) { create(:simple_product, name: "Carrots") }
 
     it "displays product images and image upload modal" do
-      login_as_admin_and_visit spree.admin_products_path
+      login_as_admin
+      visit spree.admin_products_path
 
       within "table#listing_products tr#p_#{product.id}" do
         # Displays product images

--- a/spec/system/admin/configuration/content_spec.rb
+++ b/spec/system/admin/configuration/content_spec.rb
@@ -11,7 +11,8 @@ describe "
   include WebHelper
 
   before do
-    login_as_admin_and_visit spree.edit_admin_general_settings_path
+    login_as_admin
+    visit spree.edit_admin_general_settings_path
     click_link "Content"
   end
 

--- a/spec/system/admin/configuration/general_settings_spec.rb
+++ b/spec/system/admin/configuration/general_settings_spec.rb
@@ -6,7 +6,8 @@ describe "General Settings" do
   include AuthenticationHelper
 
   before do
-    login_as_admin_and_visit spree.admin_dashboard_path
+    login_as_admin
+    visit spree.admin_dashboard_path
     click_link "Configuration"
     click_link "General Settings"
   end

--- a/spec/system/admin/configuration/mail_methods_spec.rb
+++ b/spec/system/admin/configuration/mail_methods_spec.rb
@@ -5,7 +5,10 @@ require 'system_helper'
 describe "Mail Methods" do
   include AuthenticationHelper
 
-  before { login_as_admin_and_visit spree.edit_admin_general_settings_path }
+  before do
+    login_as_admin
+    visit spree.edit_admin_general_settings_path
+  end
 
   context "edit" do
     before { click_link "Mail Method Settings" }

--- a/spec/system/admin/configuration/shipping_categories_spec.rb
+++ b/spec/system/admin/configuration/shipping_categories_spec.rb
@@ -21,7 +21,8 @@ describe "Shipping Categories" do
 
   context 'user adds a new shipping category with temperature control' do
     it 'user sees new shipping category with temperature control' do
-      login_as_admin_and_visit spree.admin_shipping_categories_path
+      login_as_admin
+      visit spree.admin_shipping_categories_path
       click_link "New Shipping Category"
 
       fill_in "shipping_category_name", with: "freeze"

--- a/spec/system/admin/configuration/tax_categories_spec.rb
+++ b/spec/system/admin/configuration/tax_categories_spec.rb
@@ -7,7 +7,8 @@ describe "Tax Categories" do
   include WebHelper
 
   before(:each) do
-    login_as_admin_and_visit spree.edit_admin_general_settings_path
+    login_as_admin
+    visit spree.edit_admin_general_settings_path
   end
 
   context "admin visiting tax categories list" do

--- a/spec/system/admin/configuration/tax_rates_spec.rb
+++ b/spec/system/admin/configuration/tax_rates_spec.rb
@@ -11,7 +11,8 @@ describe "Tax Rates" do
   let!(:tax_category) { create(:tax_category, name: "Full") }
 
   before do
-    login_as_admin_and_visit spree.edit_admin_general_settings_path
+    login_as_admin
+    visit spree.edit_admin_general_settings_path
   end
 
   # Regression test for Spree #535

--- a/spec/system/admin/configuration/taxonomies_spec.rb
+++ b/spec/system/admin/configuration/taxonomies_spec.rb
@@ -7,7 +7,8 @@ describe "Taxonomies" do
   include WebHelper
 
   before(:each) do
-    login_as_admin_and_visit spree.edit_admin_general_settings_path
+    login_as_admin
+    visit spree.edit_admin_general_settings_path
   end
 
   context "show" do

--- a/spec/system/admin/configuration/zones_spec.rb
+++ b/spec/system/admin/configuration/zones_spec.rb
@@ -7,7 +7,8 @@ describe "Zones" do
   include WebHelper
 
   it "list existing zones" do
-    login_as_admin_and_visit spree.edit_admin_general_settings_path
+    login_as_admin
+    visit spree.edit_admin_general_settings_path
     create(:zone, name: "northern", description: "middle position alphabetically")
     create(:zone, name: "eastern", description: "zone is eastern")
     create(:zone, name: "western", description: "cool san fran")
@@ -26,7 +27,8 @@ describe "Zones" do
   end
 
   it "create a new zone" do
-    login_as_admin_and_visit spree.admin_zones_path
+    login_as_admin
+    visit spree.admin_zones_path
     click_link "admin_new_zone_link"
     expect(page).to have_content("New Zone")
 
@@ -39,7 +41,8 @@ describe "Zones" do
 
   it "edit existing zone" do
     zone = create(:zone_with_member)
-    login_as_admin_and_visit spree.edit_admin_zone_path(zone.id)
+    login_as_admin
+    visit spree.edit_admin_zone_path(zone.id)
 
     expect(page).to have_checked_field "country_based"
 

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -16,7 +16,8 @@ describe '
                                   tax_category: tax_category_gst)
     amount = fee.calculator.preferred_amount
 
-    login_as_admin_and_visit spree.edit_admin_general_settings_path
+    login_as_admin
+    visit spree.edit_admin_general_settings_path
     click_link 'Enterprise Fees'
 
     expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_enterprise_id"
@@ -35,7 +36,8 @@ describe '
     e = create(:supplier_enterprise, name: 'Feedme')
 
     # When I go to the enterprise fees page
-    login_as_admin_and_visit admin_enterprise_fees_path
+    login_as_admin
+    visit admin_enterprise_fees_path
 
     # And I fill in the fields for a new enterprise fee and click update
     select 'Feedme', from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
@@ -64,7 +66,8 @@ describe '
     e = create(:supplier_enterprise, name: 'Feedme')
 
     # When I go to the enterprise fees page
-    login_as_admin_and_visit admin_enterprise_fees_path
+    login_as_admin
+    visit admin_enterprise_fees_path
 
     # And I fill in the fields for a new enterprise fee and click update
     select 'Feedme', from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
@@ -96,7 +99,8 @@ describe '
 
     before do
       # When I go to the enterprise fees page
-      login_as_admin_and_visit admin_enterprise_fees_path
+      login_as_admin
+      visit admin_enterprise_fees_path
       # And I update the fields for the enterprise fee and click update
       select 'Foo', from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
       select 'Admin', from: 'sets_enterprise_fee_set_collection_attributes_0_fee_type'
@@ -160,7 +164,8 @@ describe '
     fee = create(:enterprise_fee)
 
     # When I go to the enterprise fees page
-    login_as_admin_and_visit admin_enterprise_fees_path
+    login_as_admin
+    visit admin_enterprise_fees_path
 
     # And I click delete
     accept_alert do

--- a/spec/system/admin/enterprise_user_spec.rb
+++ b/spec/system/admin/enterprise_user_spec.rb
@@ -23,7 +23,8 @@ describe '
     context "with a limitted number of owned enterprises" do
       it "setting the enterprise ownership limit" do
         expect(user.enterprise_limit).to eq 5
-        login_as_admin_and_visit spree.admin_users_path
+        login_as_admin
+        visit spree.admin_users_path
         click_link user.email
 
         fill_in "user_enterprise_limit", with: 2

--- a/spec/system/admin/enterprises/index_spec.rb
+++ b/spec/system/admin/enterprises/index_spec.rb
@@ -11,7 +11,8 @@ describe 'Enterprises Index' do
       s = create(:supplier_enterprise)
       d = create(:distributor_enterprise)
 
-      login_as_admin_and_visit admin_enterprises_path
+      login_as_admin
+      visit admin_enterprises_path
 
       within("tr.enterprise-#{s.id}") do
         expect(page).to have_content s.name
@@ -46,7 +47,8 @@ describe 'Enterprises Index' do
 
       context "without violating rules" do
         before do
-          login_as_admin_and_visit admin_enterprises_path
+          login_as_admin
+          visit admin_enterprises_path
         end
 
         it "updates the enterprises" do
@@ -75,7 +77,8 @@ describe 'Enterprises Index' do
         before do
           second_distributor.users << manager
 
-          login_as_admin_and_visit admin_enterprises_path
+          login_as_admin
+          visit admin_enterprises_path
         end
 
         it "does not update the enterprises and displays errors" do

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -256,7 +256,8 @@ describe '
       s = create(:supplier_enterprise)
 
       # When I go to its properties page
-      login_as_admin_and_visit admin_enterprises_path
+      login_as_admin
+      visit admin_enterprises_path
       within(".enterprise-#{s.id}") { click_link 'Properties' }
 
       # And I create a property
@@ -279,7 +280,8 @@ describe '
       s.producer_properties.create! property_name: 'Certified Organic', value: 'NASAA 12345'
 
       # When I go to its properties page
-      login_as_admin_and_visit main_app.admin_enterprise_producer_properties_path(s)
+      login_as_admin
+      visit main_app.admin_enterprise_producer_properties_path(s)
 
       # And I update the property
       fill_in 'enterprise_producer_properties_attributes_0_property_name', with: "Biodynamic"
@@ -301,7 +303,8 @@ describe '
       pp = s.producer_properties.create! property_name: 'Certified Organic', value: 'NASAA 12345'
 
       # When I go to its properties page
-      login_as_admin_and_visit main_app.admin_enterprise_producer_properties_path(s)
+      login_as_admin
+      visit main_app.admin_enterprise_producer_properties_path(s)
 
       # And I remove the property
       expect(page).to have_field 'enterprise_producer_properties_attributes_0_property_name',
@@ -550,7 +553,8 @@ describe '
 
     describe "check users tab" do
       before do
-        login_as_admin_and_visit edit_admin_enterprise_path(distributor1)
+        login_as_admin
+        visit edit_admin_enterprise_path(distributor1)
         within ".side_menu" do
           click_link 'Users'
         end

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -22,6 +22,7 @@ describe '
   end
 
   it "creating a new enterprise" do
+    admin = create(:admin_user)
     eg1 = create(:enterprise_group, name: 'eg1')
     eg2 = create(:enterprise_group, name: 'eg2')
     payment_method = create(:payment_method)
@@ -29,7 +30,7 @@ describe '
     enterprise_fee = create(:enterprise_fee)
 
     # Navigating
-    admin = login_as_admin
+    login_as admin
     visit '/admin/enterprises'
     click_link 'New Enterprise'
 

--- a/spec/system/admin/flatpickr_spec.rb
+++ b/spec/system/admin/flatpickr_spec.rb
@@ -8,7 +8,8 @@ describe "Test Flatpickr" do
 
   context "orders" do
     it "opens the datepicker and closes it using the 'CLOSE' button" do
-      login_as_admin_and_visit 'admin/orders'
+      login_as_admin
+      visit 'admin/orders'
       open_datepicker('.datepicker')
       # Looks for the close button and click it
       within(".flatpickr-calendar.open") do
@@ -20,7 +21,8 @@ describe "Test Flatpickr" do
     end
     
     it "opens the datepicker and closes it by clicking outside" do
-      login_as_admin_and_visit 'admin/orders'
+      login_as_admin
+      visit 'admin/orders'
       open_datepicker('.datepicker')
       find("#admin-menu").click       
       # Should no more have opened flatpickr

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -45,7 +45,8 @@ describe '
 
     context "with no payment" do
       it "do not display the payment description information" do
-        login_as_admin_and_visit spree.print_admin_order_path(order)
+        login_as_admin
+        visit spree.print_admin_order_path(order)
         convert_pdf_to_page
         expect(page).to have_no_content 'Payment Description at Checkout'
       end
@@ -60,7 +61,8 @@ describe '
       end
 
       it "display the payment description section" do
-        login_as_admin_and_visit spree.print_admin_order_path(order)
+        login_as_admin
+        visit spree.print_admin_order_path(order)
         convert_pdf_to_page
         expect(page).to have_content 'Payment Description at Checkout'
         expect(page).to have_content 'description1'
@@ -79,7 +81,8 @@ describe '
       end
 
       it "display the payment description section and use the one from the completed payment" do
-        login_as_admin_and_visit spree.print_admin_order_path(order)
+        login_as_admin
+        visit spree.print_admin_order_path(order)
         convert_pdf_to_page
         expect(page).to have_content 'Payment Description at Checkout'
         expect(page).to have_content 'description1'
@@ -99,7 +102,8 @@ describe '
       end
 
       it "display the payment description section and use the one from the last payment" do
-        login_as_admin_and_visit spree.print_admin_order_path(order)
+        login_as_admin
+        visit spree.print_admin_order_path(order)
         convert_pdf_to_page
         expect(page).to have_content 'Payment Description at Checkout'
         expect(page).to have_content 'description2'
@@ -116,7 +120,8 @@ describe '
 
     before do
       allow(Spree::Config).to receive(:invoice_style2?).and_return(alternative_invoice)
-      login_as_admin_and_visit spree.print_admin_order_path(completed_order)
+      login_as_admin
+      visit spree.print_admin_order_path(completed_order)
       convert_pdf_to_page
     end
 
@@ -201,7 +206,8 @@ describe '
       context "legacy invoice" do
         before do
           allow(Spree::Config).to receive(:invoice_style2?).and_return(false)
-          login_as_admin_and_visit spree.print_admin_order_path(order1)
+          login_as_admin
+          visit spree.print_admin_order_path(order1)
           convert_pdf_to_page
         end
 
@@ -231,7 +237,8 @@ describe '
       context "alternative invoice" do
         before do
           allow(Spree::Config).to receive(:invoice_style2?).and_return(true)
-          login_as_admin_and_visit spree.print_admin_order_path(order1)
+          login_as_admin
+          visit spree.print_admin_order_path(order1)
           convert_pdf_to_page
         end
 
@@ -331,7 +338,8 @@ describe '
       context "legacy invoice" do
         before do
           allow(Spree::Config).to receive(:invoice_style2?).and_return(false)
-          login_as_admin_and_visit spree.print_admin_order_path(order2)
+          login_as_admin
+          visit spree.print_admin_order_path(order2)
           convert_pdf_to_page
         end
         it "displays $0.0 when a line item has no tax" do
@@ -362,7 +370,8 @@ describe '
       context "alternative invoice" do
         before do
           allow(Spree::Config).to receive(:invoice_style2?).and_return(true)
-          login_as_admin_and_visit spree.print_admin_order_path(order2)
+          login_as_admin
+          visit spree.print_admin_order_path(order2)
           convert_pdf_to_page
         end
         it "displays the taxes correctly" do

--- a/spec/system/admin/order_cycles/complex_creating_specific_time_spec.rb
+++ b/spec/system/admin/order_cycles/complex_creating_specific_time_spec.rb
@@ -52,7 +52,8 @@ describe '
   xit "creating an order cycle with full interface", retry: 3 do
     # pending issue #10042, see below
     ## CREATE
-    login_as_admin_and_visit admin_order_cycles_path
+    login_as_admin
+    visit admin_order_cycles_path
     click_link 'New Order Cycle'
 
     # Select a coordinator since there are two available

--- a/spec/system/admin/order_cycles/complex_editing_exchange_same_enterprise_spec.rb
+++ b/spec/system/admin/order_cycles/complex_editing_exchange_same_enterprise_spec.rb
@@ -20,7 +20,8 @@ describe '
     oc_outgoing = create(:simple_order_cycle, coordinator: c, distributors: [c])
 
     # When I edit the first order cycle, the exchange should appear as incoming
-    login_as_admin_and_visit admin_order_cycle_incoming_path(oc_incoming)
+    login_as_admin
+    visit admin_order_cycle_incoming_path(oc_incoming)
     expect(page).to have_selector 'table.exchanges tr.supplier'
     visit admin_order_cycle_outgoing_path(oc_incoming)
     expect(page).not_to have_selector 'table.exchanges tr.distributor'

--- a/spec/system/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
+++ b/spec/system/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
@@ -18,7 +18,8 @@ describe '
     before do
       stub_const("#{Api::V0::ExchangeProductsController}::DEFAULT_PER_PAGE", 1)
 
-      login_as_admin_and_visit admin_order_cycle_incoming_path(order_cycle)
+      login_as_admin
+      visit admin_order_cycle_incoming_path(order_cycle)
       expect(page).to have_content "1 / 2 selected"
 
       page.find("tr.supplier-#{supplier_enterprise.id} td.products").click

--- a/spec/system/admin/order_cycles/complex_editing_multiple_updation_spec.rb
+++ b/spec/system/admin/order_cycles/complex_editing_multiple_updation_spec.rb
@@ -11,7 +11,8 @@ describe '
 
   it "Alerts for unsaved changes on general settings (/edit) page" do
     oc = create(:order_cycle)
-    login_as_admin_and_visit edit_admin_order_cycle_path(oc)
+    login_as_admin
+    visit edit_admin_order_cycle_path(oc)
 
     # Expect correct values
     expect(page).to have_field('order_cycle_name', with: oc.name)
@@ -81,7 +82,8 @@ describe '
   it "Alerts for unsaved changes on /incoming step" do
     oc = create(:order_cycle)
     oc.suppliers.first.update_attribute :name, 'farmer'
-    login_as_admin_and_visit edit_admin_order_cycle_path(oc)
+    login_as_admin
+    visit edit_admin_order_cycle_path(oc)
 
     # Go to incoming step
     click_button 'Next'
@@ -149,7 +151,8 @@ describe '
   it "Alerts for unsaved changes on /outgoing step" do
     oc = create(:order_cycle)
     oc.distributors.first.update_attribute :name, 'store'
-    login_as_admin_and_visit edit_admin_order_cycle_path(oc)
+    login_as_admin
+    visit edit_admin_order_cycle_path(oc)
 
     # Go to incoming step
     click_button 'Next'

--- a/spec/system/admin/order_cycles/complex_editing_spec.rb
+++ b/spec/system/admin/order_cycles/complex_editing_spec.rb
@@ -19,7 +19,8 @@ describe '
     oc.distributors.last.update_attribute :name, 'ZZZZ'
 
     # When I edit it
-    login_as_admin_and_visit edit_admin_order_cycle_path(oc)
+    login_as_admin
+    visit edit_admin_order_cycle_path(oc)
 
     wait_for_edit_form_to_load_order_cycle(oc)
 

--- a/spec/system/admin/order_cycles/complex_updating_specific_time_spec.rb
+++ b/spec/system/admin/order_cycles/complex_updating_specific_time_spec.rb
@@ -48,7 +48,8 @@ xdescribe '
     distributor_fee2 = create(:enterprise_fee, enterprise: distributor, name: 'Distributor fee 2')
 
     # When I go to its edit page
-    login_as_admin_and_visit admin_order_cycles_path
+    login_as_admin
+    visit admin_order_cycles_path
     within "tr.order-cycle-#{oc.id}" do
       find("a.edit-order-cycle").click
     end

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -32,7 +32,8 @@ describe '
     create(:proxy_order, subscription: create(:subscription, schedule: schedule1), order_cycle: oc1)
 
     # When I go to the admin order cycles page
-    login_as_admin_and_visit admin_order_cycles_path
+    login_as_admin
+    visit admin_order_cycles_path
 
     # Then the order cycles should be ordered correctly
     expect(page).to have_selector "#listing_order_cycles tr td:first-child", count: 7
@@ -139,7 +140,8 @@ describe '
 
     context 'using datetimepickers' do
       it "correctly opens the datetimepicker and changes the date field" do
-        login_as_admin_and_visit admin_order_cycles_path
+        login_as_admin
+        visit admin_order_cycles_path
 
         within("tr.order-cycle-#{oc_pt.id}") do
           expect(find('input.datetimepicker', 
@@ -162,7 +164,8 @@ match: :first).value).to eq oc_open_at.strftime("%Y-%m-13 %H:%M")
 
       it "correctly opens the datetimepicker and closes it using the last button "\
          "(the 'Close' one)" do
-        login_as_admin_and_visit admin_order_cycles_path
+        login_as_admin
+        visit admin_order_cycles_path
         test_value = Time.zone.now
 
         # Opens a datetimepicker

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -23,7 +23,8 @@ describe '
                  orders_close_at: Time.zone.local(2041, 12, 12, 12, 12, 5))
 
     # When I go to the order cycles page
-    login_as_admin_and_visit admin_order_cycles_path
+    login_as_admin
+    visit admin_order_cycles_path
 
     ## -- OC1
     find("input#oc#{oc1.id}_name").set ""
@@ -76,7 +77,8 @@ describe '
     oc = create(:simple_order_cycle)
 
     # When I clone it
-    login_as_admin_and_visit admin_order_cycles_path
+    login_as_admin
+    visit admin_order_cycles_path
     within "tr.order-cycle-#{oc.id}" do
       find('a.clone-order-cycle').click
     end
@@ -102,7 +104,8 @@ describe '
       end
 
       it "displays a warning on the order cycles screen" do
-        login_as_admin_and_visit admin_order_cycles_path
+        login_as_admin
+        visit admin_order_cycles_path
         expect(page).to have_content(
           "The hub #{hub.name} is listed in an active order cycle, "\
           "but does not have valid shipping and payment methods. Until you set these up, "\
@@ -643,7 +646,8 @@ describe '
       ex.update! pickup_time: 'pickup time', pickup_instructions: 'pickup instructions'
 
       # When I edit it
-      login_as_admin_and_visit admin_order_cycles_path
+      login_as_admin
+      visit admin_order_cycles_path
       within "tr.order-cycle-#{oc.id}" do
         find("a.edit-order-cycle").click
       end
@@ -680,7 +684,8 @@ describe '
       ex.update! pickup_time: 'pickup time', pickup_instructions: 'pickup instructions'
 
       # When I edit it
-      login_as_admin_and_visit edit_admin_order_cycle_path oc
+      login_as_admin
+      visit edit_admin_order_cycle_path oc
 
       wait_for_edit_form_to_load_order_cycle(oc)
 
@@ -749,7 +754,8 @@ describe '
      "check that the modifications are taken into account", 
      retry: 3 do
     order_cycle = create(:simple_order_cycle, name: "Translusent Berries")
-    login_as_admin_and_visit admin_order_cycles_path
+    login_as_admin
+    visit admin_order_cycles_path
     find("#oc#{order_cycle.id}_orders_close_at").click
     datetime = Time.zone.at(Time.zone.local(2040, 10, 17, 0o6, 0o0, 0o0))
     input = find(".flatpickr-calendar.open .flatpickr-minute")
@@ -762,7 +768,8 @@ describe '
 
   it "deleting an order cycle" do
     order_cycle = create(:simple_order_cycle, name: "Translusent Berries")
-    login_as_admin_and_visit admin_order_cycles_path
+    login_as_admin
+    visit admin_order_cycles_path
     expect(page).to have_selector "tr.order-cycle-#{order_cycle.id}"
     accept_alert do
       first('a.delete-order-cycle').click

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -384,7 +384,7 @@ describe '
 
       before do
         new_user.enterprise_roles.build(enterprise: supplier_managed).save
-        login_to_admin_as new_user
+        login_as new_user
       end
 
       it "editing an order cycle" do
@@ -467,7 +467,7 @@ describe '
                                          permissions_list: [:add_to_order_cycle])
 
         new_user.enterprise_roles.build(enterprise: my_distributor).save
-        login_to_admin_as new_user
+        login_as new_user
       end
 
       it "editing an order cycle" do
@@ -555,7 +555,7 @@ describe '
 
     before do
       user.enterprise_roles.create! enterprise: enterprise
-      login_to_admin_as user
+      login_as user
     end
 
     it "shows me an index of order cycles without enterprise columns" do

--- a/spec/system/admin/order_cycles_complex_nav_check_spec.rb
+++ b/spec/system/admin/order_cycles_complex_nav_check_spec.rb
@@ -13,7 +13,8 @@ describe '
     oc = create(:order_cycle)
 
     # When I edit the form
-    login_as_admin_and_visit edit_admin_order_cycle_path(oc)
+    login_as_admin
+    visit edit_admin_order_cycle_path(oc)
 
     wait_for_edit_form_to_load_order_cycle(oc)
 

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -43,7 +43,8 @@ describe '
     distributor_disabled = create(:distributor_enterprise)
     create(:simple_order_cycle, name: 'Two')
 
-    login_as_admin_and_visit spree.admin_orders_path
+    login_as_admin
+    visit spree.admin_orders_path
     click_link 'New Order'
 
     # Distributors without an order cycle should be shown as disabled
@@ -89,7 +90,8 @@ describe '
   end
 
   it "can add a product to an existing order" do
-    login_as_admin_and_visit spree.edit_admin_order_path(order)
+    login_as_admin
+    visit spree.edit_admin_order_path(order)
 
     select2_select product.name, from: 'add_variant_id', search: true
 
@@ -114,7 +116,8 @@ describe '
     order.user = nil
     order.save
 
-    login_as_admin_and_visit spree.edit_admin_order_path(order)
+    login_as_admin
+    visit spree.edit_admin_order_path(order)
 
     expect(page).to have_select2 "order_distributor_id", with_options: [d.name]
     select2_select d.name, from: 'order_distributor_id'
@@ -128,7 +131,8 @@ describe '
   it "can't add products to an order outside the order's hub and order cycle" do
     product = create(:simple_product)
 
-    login_as_admin_and_visit spree.edit_admin_order_path(order)
+    login_as_admin
+    visit spree.edit_admin_order_path(order)
 
     expect(page).not_to have_select2 "add_variant_id", with_options: [product.name]
   end
@@ -139,7 +143,8 @@ describe '
 
       before do
         order.line_items << line_item
-        login_as_admin_and_visit spree.edit_admin_order_path(order)
+        login_as_admin
+        visit spree.edit_admin_order_path(order)
         find("a.delete-item").click
         expect(page).to have_content "Are you sure?"        
       end
@@ -168,7 +173,8 @@ describe '
       before do
         # specify that order has only one line item
         order.line_items = [order.line_items.first]
-        login_as_admin_and_visit spree.edit_admin_order_path(order)
+        login_as_admin
+        visit spree.edit_admin_order_path(order)
         find("a.delete-item").click 
       end
 
@@ -229,7 +235,8 @@ describe '
     order.state = 'cart'
     order.completed_at = nil
 
-    login_as_admin_and_visit spree.edit_admin_order_path(order)
+    login_as_admin
+    visit spree.edit_admin_order_path(order)
 
     quantity = order.line_items.first.quantity
     max_quantity = 0
@@ -257,7 +264,8 @@ describe '
     order.completed_at = nil
     order.line_items.first.variant.update_attribute(:on_demand, true)
 
-    login_as_admin_and_visit spree.edit_admin_order_path(order)
+    login_as_admin
+    visit spree.edit_admin_order_path(order)
 
     within("tr.stock-item", text: order.products.first.name) do
       find("a.edit-item").click
@@ -353,7 +361,8 @@ describe '
   end
 
   it "can't change distributor or order cycle once order has been finalized" do
-    login_as_admin_and_visit spree.edit_admin_order_path(order)
+    login_as_admin
+    visit spree.edit_admin_order_path(order)
 
     expect(page).not_to have_select2 'order_distributor_id'
     expect(page).not_to have_select2 'order_order_cycle_id'

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -539,7 +539,7 @@ distributors: [distributor4, distributor5]) }
 
       context "for a hub manager" do
         before do
-          login_to_admin_as owner2
+          login_as owner2
           visit spree.admin_orders_path
         end
 

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -94,7 +94,8 @@ distributors: [distributor4, distributor5]) }
 
     describe "filters" do
       before do
-        login_as_admin_and_visit spree.admin_orders_path
+        login_as_admin
+        visit spree.admin_orders_path
       end
 
       it "order cycles appear in descending order by close date on orders page" do
@@ -237,7 +238,8 @@ distributors: [distributor4, distributor5]) }
           order3.update!(completed_at: Time.zone.now - 3.weeks)
           order4.update!(completed_at: Time.zone.now - 4.weeks)
           order5.update!(completed_at: Time.zone.now - 5.weeks)
-          login_as_admin_and_visit spree.admin_orders_path
+          login_as_admin
+          visit spree.admin_orders_path
         end
         it "orders by completion date" do
           find("a", text: 'COMPLETED AT').click # sets ascending ordering
@@ -257,7 +259,8 @@ distributors: [distributor4, distributor5]) }
           order3.update!(number: "R444444444")
           order4.update!(number: "R333333333")
           order5.update!(number: "R222222222")
-          login_as_admin_and_visit spree.admin_orders_path
+          login_as_admin
+          visit spree.admin_orders_path
         end
 
         it "orders by order number" do
@@ -278,7 +281,8 @@ distributors: [distributor4, distributor5]) }
           order3.update!(state: "complete")
           order4.update!(state: "cart")
           order5.cancel
-          login_as_admin_and_visit spree.admin_orders_path
+          login_as_admin
+          visit spree.admin_orders_path
           uncheck 'Only show complete orders'
           page.find('.filter-actions .button.icon-search').click
         end
@@ -300,7 +304,8 @@ distributors: [distributor4, distributor5]) }
           Spree::Payment.where(order_id: order2.id).first.update!(amount: 50.0)
           Spree::Payment.where(order_id: order3.id).first.update!(amount: 100.0)
           Spree::Payment.where(order_id: order4.id).first.update!(amount: 10.0)
-          login_as_admin_and_visit spree.admin_orders_path
+          login_as_admin
+          visit spree.admin_orders_path
         end
 
         it "orders by payment state" do
@@ -317,7 +322,8 @@ distributors: [distributor4, distributor5]) }
           Spree::Payment.where(order_id: order3.id).first.update!(amount: 100.0)
           Spree::Payment.where(order_id: order4.id).first.update!(amount: 10.0)
           order2.ship
-          login_as_admin_and_visit spree.admin_orders_path
+          login_as_admin
+          visit spree.admin_orders_path
         end
 
         it "orders by shipment state" do
@@ -334,7 +340,8 @@ distributors: [distributor4, distributor5]) }
           order3.update!(email: "ghi@ghi.com")
           order4.update!(email: "def@def.com")
           order5.update!(email: "abc@abc.com")
-          login_as_admin_and_visit spree.admin_orders_path
+          login_as_admin
+          visit spree.admin_orders_path
         end
 
         it "orders by customer email" do
@@ -355,7 +362,8 @@ distributors: [distributor4, distributor5]) }
           billing_address3.update!(lastname: "Duchess")
           billing_address4.update!(lastname: "Cheshire Cat")
           billing_address5.update!(lastname: "Alice")
-          login_as_admin_and_visit spree.admin_orders_path
+          login_as_admin
+          visit spree.admin_orders_path
         end
 
         it "orders by last name" do
@@ -380,7 +388,8 @@ distributors: [distributor4, distributor5]) }
           order3.save
           order4.save
           order5.save
-          login_as_admin_and_visit spree.admin_orders_path
+          login_as_admin
+          visit spree.admin_orders_path
         end
 
         it "orders by order total" do
@@ -398,7 +407,8 @@ distributors: [distributor4, distributor5]) }
 
     context "select/unselect all orders" do
       before do
-        login_as_admin_and_visit spree.admin_orders_path
+        login_as_admin
+        visit spree.admin_orders_path
       end
 
       it "by clicking on the checkbox in the table header" do
@@ -424,7 +434,8 @@ distributors: [distributor4, distributor5]) }
     context "bulk actions" do
       context "as a super admin" do
         before do
-          login_as_admin_and_visit spree.admin_orders_path
+          login_as_admin
+          visit spree.admin_orders_path
         end
 
         context "bulk print invoices" do
@@ -579,7 +590,8 @@ distributors: [distributor4, distributor5]) }
 
     context "pagination" do
       before do
-        login_as_admin_and_visit spree.admin_orders_path
+        login_as_admin
+        visit spree.admin_orders_path
       end
 
       it "displays pagination options" do
@@ -603,7 +615,8 @@ distributors: [distributor4, distributor5]) }
       end
 
       it "capture payment" do
-        login_as_admin_and_visit spree.admin_orders_path
+        login_as_admin
+        visit spree.admin_orders_path
         expect(page).to have_current_path spree.admin_orders_path
 
         # click the 'capture' link for the order
@@ -621,7 +634,8 @@ distributors: [distributor4, distributor5]) }
 
       it "ship order from the orders index page" do
         order.payments.first.capture!
-        login_as_admin_and_visit spree.admin_orders_path
+        login_as_admin
+        visit spree.admin_orders_path
 
         page.find("[data-powertip=Ship]").click
 
@@ -638,7 +652,8 @@ distributors: [distributor4, distributor5]) }
                                                         order_cycle: order_cycle,
                                                         line_items_count: 1)
 
-      login_as_admin_and_visit spree.admin_orders_path
+      login_as_admin
+      visit spree.admin_orders_path
       uncheck 'Only show complete orders'
       page.find('a.icon-search').click
 
@@ -677,7 +692,8 @@ distributors: [distributor4, distributor5]) }
 
       empty_order = create(:order, distributor: distributor, order_cycle: order_cycle)
 
-      login_as_admin_and_visit spree.admin_orders_path
+      login_as_admin
+      visit spree.admin_orders_path
       expect(page).to have_content complete_order.number
       expect(page).to have_content empty_complete_order.number
       expect(page).to have_no_content incomplete_order.number
@@ -708,7 +724,8 @@ distributors: [distributor4, distributor5]) }
       )
     end
     before :each do
-      login_as_admin_and_visit spree.admin_orders_path
+      login_as_admin
+      visit spree.admin_orders_path
 
       # Specify each filters
       uncheck 'Only show complete orders'

--- a/spec/system/admin/payment_method_spec.rb
+++ b/spec/system/admin/payment_method_spec.rb
@@ -15,7 +15,8 @@ describe '
 
   describe "creating a payment method" do
     it "assigning a distributor to the payment method" do
-      login_as_admin_and_visit spree.edit_admin_general_settings_path
+      login_as_admin
+      visit spree.edit_admin_general_settings_path
       click_link 'Payment Methods'
       click_link 'New Payment Method'
 
@@ -95,13 +96,15 @@ describe '
 
     it "checking a single distributor is checked by default" do
       2.times.each { Enterprise.last.destroy }
-      login_as_admin_and_visit spree.new_admin_payment_method_path
+      login_as_admin
+      visit spree.new_admin_payment_method_path
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[0].id}",
                                  checked: true
     end
 
     it "checking more than a distributor displays no default choice" do
-      login_as_admin_and_visit spree.new_admin_payment_method_path
+      login_as_admin
+      visit spree.new_admin_payment_method_path
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[0].id}",
                                  checked: false
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[1].id}",
@@ -114,7 +117,8 @@ describe '
   it "updating a payment method" do
     payment_method = create(:payment_method, distributors: [@distributors[0]],
                                              calculator: build(:calculator_flat_rate))
-    login_as_admin_and_visit spree.edit_admin_payment_method_path payment_method
+    login_as_admin
+    visit spree.edit_admin_payment_method_path payment_method
 
     fill_in 'payment_method_name', with: 'New PM Name'
     find(:css, "tags-input .tags input").set "member\n"
@@ -250,7 +254,11 @@ describe '
 
   describe "Setting transaction fees" do
     let!(:payment_method) { create(:payment_method) }
-    before { login_as_admin_and_visit spree.edit_admin_payment_method_path payment_method }
+
+    before {
+      login_as_admin
+      visit spree.edit_admin_payment_method_path payment_method
+    }
 
     it "set by default 'None' as calculator" do
       expect(page).to have_select "calc_type", selected: "None"

--- a/spec/system/admin/payments_spec.rb
+++ b/spec/system/admin/payments_spec.rb
@@ -12,7 +12,8 @@ describe '
 
   describe "payments/new" do
     it "displays the order balance as the default payment amount" do
-      login_as_admin_and_visit spree.new_admin_order_payment_path order
+      login_as_admin
+      visit spree.new_admin_order_payment_path order
 
       expect(page).to have_content 'New Payment'
       expect(page).to have_field(:payment_amount, with: order.outstanding_balance.to_f)
@@ -30,7 +31,8 @@ describe '
     end
 
     it "renders the new payment page" do
-      login_as_admin_and_visit spree.new_admin_order_payment_path order
+      login_as_admin
+      visit spree.new_admin_order_payment_path order
 
       expect(page).to have_content 'New Payment'
     end
@@ -47,7 +49,8 @@ describe '
     end
 
     it "creates the payment, completes the order, and updates payment and shipping states" do
-      login_as_admin_and_visit spree.new_admin_order_payment_path order
+      login_as_admin
+      visit spree.new_admin_order_payment_path order
 
       expect(page).to have_content "New Payment"
 

--- a/spec/system/admin/payments_stripe_spec.rb
+++ b/spec/system/admin/payments_stripe_spec.rb
@@ -39,7 +39,8 @@ describe '
           before { stub_successful_capture_request order: order }
 
           it "adds a payment with state complete" do
-            login_as_admin_and_visit spree.new_admin_order_payment_path order
+            login_as_admin
+            visit spree.new_admin_order_payment_path order
 
             fill_in "payment_amount", with: order.total.to_s
             fill_in_card_details_in_backoffice
@@ -56,7 +57,8 @@ describe '
           before { stub_failed_capture_request order: order, response: { message: error_message } }
 
           it "fails to add a payment due to card error" do
-            login_as_admin_and_visit spree.new_admin_order_payment_path order
+            login_as_admin
+            visit spree.new_admin_order_payment_path order
 
             fill_in "payment_amount", with: order.total.to_s
             fill_in_card_details_in_backoffice
@@ -76,7 +78,8 @@ describe '
         end
 
         it "adds the payment and it is in the requires_authorization state" do
-          login_as_admin_and_visit spree.new_admin_order_payment_path order
+          login_as_admin
+          visit spree.new_admin_order_payment_path order
 
           fill_in "payment_amount", with: order.total.to_s
           fill_in_card_details_in_backoffice
@@ -101,7 +104,8 @@ describe '
       end
 
       it "adds a payment with state complete" do
-        login_as_admin_and_visit spree.new_admin_order_payment_path order
+        login_as_admin
+        visit spree.new_admin_order_payment_path order
 
         fill_in "payment_amount", with: order.total.to_s
         fill_in_card_details_in_backoffice
@@ -120,7 +124,8 @@ describe '
     end
 
     it "renders the payment details" do
-      login_as_admin_and_visit spree.admin_order_payments_path order
+      login_as_admin
+      visit spree.admin_order_payments_path order
 
       page.click_link("StripeSCA")
       expect(page).to have_content order.payments.last.source.last_digits
@@ -132,7 +137,8 @@ describe '
       end
 
       it "renders the payment details" do
-        login_as_admin_and_visit spree.admin_order_payments_path order
+        login_as_admin
+        visit spree.admin_order_payments_path order
 
         page.click_link("StripeSCA")
         expect(page).to have_content order.payments.last.amount
@@ -150,7 +156,8 @@ describe '
       end
 
       it "allows to refund the payment" do
-        login_as_admin_and_visit spree.admin_order_payments_path order
+        login_as_admin
+        visit spree.admin_order_payments_path order
 
         expect(page).to have_link "StripeSCA"
         expect(page).to have_content "COMPLETED"

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -118,7 +118,8 @@ describe '
     end
 
     it "creating an on-demand product" do
-      login_as_admin_and_visit spree.admin_products_path
+      login_as_admin
+      visit spree.admin_products_path
 
       click_link 'New Product'
 
@@ -144,7 +145,8 @@ describe '
     end
 
     it "creating product with empty unit value" do
-      login_as_admin_and_visit spree.admin_products_path
+      login_as_admin
+      visit spree.admin_products_path
 
       click_link 'New Product'
 
@@ -174,7 +176,8 @@ describe '
       let!(:product2) { create(:simple_product, name: 'a product to delete', supplier: @supplier) }
 
       before do
-        login_as_admin_and_visit spree.admin_products_path
+        login_as_admin
+        visit spree.admin_products_path
 
         within "#p_#{product2.id}" do
           accept_alert { page.find("[data-powertip=Remove]").click }
@@ -194,7 +197,8 @@ describe '
 
       context "a deleted line item from a shipped order" do
         before do
-          login_as_admin_and_visit spree.admin_products_path
+          login_as_admin
+          visit spree.admin_products_path
 
           within "#p_#{order.variants.first.product_id}" do
             accept_alert { page.find("[data-powertip=Remove]").click }
@@ -224,7 +228,8 @@ describe '
 
     context 'products' do
       before do
-        login_as_admin_and_visit spree.admin_products_path
+        login_as_admin
+        visit spree.admin_products_path
       end
 
       it 'creates a copy of the product' do

--- a/spec/system/admin/properties_spec.rb
+++ b/spec/system/admin/properties_spec.rb
@@ -9,7 +9,8 @@ describe '
   include AuthenticationHelper
 
   it "creating and editing a property" do
-    login_as_admin_and_visit spree.admin_properties_path
+    login_as_admin
+    visit spree.admin_properties_path
 
     click_link 'New Property'
     fill_in 'property_name', with: 'New property!'

--- a/spec/system/admin/reports/orders_and_fulfillment_spec.rb
+++ b/spec/system/admin/reports/orders_and_fulfillment_spec.rb
@@ -10,7 +10,7 @@ describe "Orders And Fulfillment" do
     let(:current_user) { create(:admin_user) }
 
     before do
-      login_to_admin_as(current_user)
+      login_as(current_user)
       visit admin_reports_path
     end
 
@@ -553,7 +553,7 @@ describe "Orders And Fulfillment" do
             click_button 'Go'
 
             logout
-            login_to_admin_as(current_user)
+            login_as(current_user)
             visit admin_reports_path
 
             click_link report_title
@@ -573,7 +573,7 @@ describe "Orders And Fulfillment" do
             click_button 'Go'
 
             logout
-            login_to_admin_as(current_user)
+            login_as(current_user)
             visit admin_reports_path
 
             click_link "Report"

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -16,8 +16,8 @@ describe '
       end
 
       it "does not show super admin only report" do
-        login_to_admin_as user
-        click_link "Reports"
+        login_as user
+        visit admin_reports_path
         expect(page).not_to have_content "Users & Enterprises"
       end
     end

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -38,7 +38,8 @@ describe '
     end
 
     it "can run the customers report" do
-      login_as_admin_and_visit admin_report_path(
+      login_as_admin
+      visit admin_report_path(
         report_type: :customers, report_subtype: :mailing_list
       )
       click_button "Go"
@@ -47,7 +48,8 @@ describe '
 
     it "displays a friendly timeout message" do
       ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
-      login_as_admin_and_visit admin_report_path(
+      login_as_admin
+      visit admin_report_path(
         report_type: :customers, report_subtype: :mailing_list
       )
       expect(ENV).to receive(:fetch).with("RACK_TIMEOUT_SERVICE_TIMEOUT", "15")
@@ -61,7 +63,8 @@ describe '
 
   describe "Can access Customers reports and generate customers report" do
     before do
-      login_as_admin_and_visit admin_reports_path
+      login_as_admin
+      visit admin_reports_path
     end
 
     it "customers report" do
@@ -90,7 +93,8 @@ describe '
 
   describe "Order cycle management report" do
     before do
-      login_as_admin_and_visit admin_reports_path
+      login_as_admin
+      visit admin_reports_path
     end
 
     it "payment method report" do
@@ -121,7 +125,8 @@ describe '
     let!(:ready_to_ship_order) { create(:order_ready_to_ship) }
 
     before do
-      login_as_admin_and_visit admin_reports_path
+      login_as_admin
+      visit admin_reports_path
     end
 
     it "generates the orders and distributors report" do
@@ -245,7 +250,8 @@ describe '
                        payment_method: create(:payment_method, distributors: [distributor1]))
       break unless order1.next! until order1.complete?
 
-      login_as_admin_and_visit admin_reports_path
+      login_as_admin
+      visit admin_reports_path
     end
 
     it "generate Tax Types reports" do
@@ -322,7 +328,8 @@ describe '
     end
 
     it "shows products and inventory report" do
-      login_as_admin_and_visit admin_reports_path
+      login_as_admin
+      visit admin_reports_path
 
       expect(page).to have_content "All products"
       expect(page).to have_content "Inventory (on hand)"
@@ -350,7 +357,8 @@ describe '
     end
 
     it "shows the LettuceShare report" do
-      login_as_admin_and_visit admin_reports_path
+      login_as_admin
+      visit admin_reports_path
       click_link 'LettuceShare'
       click_button "Go"
 
@@ -370,7 +378,8 @@ describe '
     before do
       enterprise3.enterprise_roles.build( user: enterprise1.owner ).save
 
-      login_as_admin_and_visit admin_reports_path
+      login_as_admin
+      visit admin_reports_path
 
       click_link 'Users & Enterprises'
     end
@@ -411,7 +420,8 @@ describe '
 
   describe 'bulk coop report' do
     before do
-      login_as_admin_and_visit admin_reports_path
+      login_as_admin
+      visit admin_reports_path
     end
 
     it "generating Bulk Co-op Supplier Report" do
@@ -576,7 +586,8 @@ describe '
 
       context "summary report" do
         before do
-          login_as_admin_and_visit admin_reports_path
+          login_as_admin
+          visit admin_reports_path
           click_link "Summary"
           click_button 'Go'
         end
@@ -635,13 +646,15 @@ describe '
 
       context "detailed report" do
         before do
-          login_as_admin_and_visit admin_reports_path
+          login_as_admin
+          visit admin_reports_path
           click_link "Detailed"
           click_button 'Go'
         end
 
         it "generates a detailed report" do
-          login_as_admin_and_visit admin_reports_path
+          login_as_admin
+          visit admin_reports_path
           click_link "Detailed"
           click_button 'Go'
 

--- a/spec/system/admin/subscriptions_spec.rb
+++ b/spec/system/admin/subscriptions_spec.rb
@@ -693,7 +693,8 @@ describe 'Subscriptions' do
         expect(page).to have_selector "#subscription-line-items .item", count: 4
 
         # Delete an existing product
-        login_as_admin_and_visit spree.admin_products_path
+        login_as_admin
+        visit spree.admin_products_path
         within "#p_#{shop_product2.id}" do
           accept_alert { page.find("[data-powertip=Remove]").click }
         end

--- a/spec/system/admin/tag_rules_spec.rb
+++ b/spec/system/admin/tag_rules_spec.rb
@@ -278,7 +278,8 @@ describe 'Tag Rules' do
   end
 
   def visit_tag_rules
-    login_as_admin_and_visit main_app.edit_admin_enterprise_path(enterprise)
+    login_as_admin
+    visit main_app.edit_admin_enterprise_path(enterprise)
     expect(page).to have_content "PRIMARY DETAILS"
     click_link "Tag Rules"
   end

--- a/spec/system/admin/tax_settings_spec.rb
+++ b/spec/system/admin/tax_settings_spec.rb
@@ -13,14 +13,16 @@ describe 'Account and Billing Settings' do
 
     context "as an admin user" do
       it "loads the page" do
-        login_as_admin_and_visit spree.edit_admin_general_settings_path
+        login_as_admin
+        visit spree.edit_admin_general_settings_path
         click_link "Tax Settings"
 
         expect(page).to have_unchecked_field 'preferences_products_require_tax_category'
       end
 
       it "attributes can be changed" do
-        login_as_admin_and_visit spree.edit_admin_tax_settings_path
+        login_as_admin
+        visit spree.edit_admin_tax_settings_path
 
         check 'preferences_products_require_tax_category'
 

--- a/spec/system/admin/unit_price_spec.rb
+++ b/spec/system/admin/unit_price_spec.rb
@@ -13,7 +13,8 @@ describe '
 
   describe "product" do
     it "creating a new product" do
-      login_as_admin_and_visit spree.admin_products_path
+      login_as_admin
+      visit spree.admin_products_path
       click_link 'New Product'
       select "Weight (kg)", from: 'product_variant_unit_with_scale'
       fill_in 'Value', with: '1'
@@ -26,7 +27,8 @@ describe '
   describe "variant" do
     it "creating a new variant" do
       product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
-      login_as_admin_and_visit spree.admin_product_variants_path product
+      login_as_admin
+      visit spree.admin_product_variants_path product
       click_link 'New Variant'
       fill_in 'Weight (g)', with: '1'
       fill_in 'Price', with: '1'
@@ -38,7 +40,8 @@ describe '
       product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
       variant = product.variants.first
       variant.update(price: 1.0)
-      login_as_admin_and_visit spree.edit_admin_product_variant_path(product, variant)
+      login_as_admin
+      visit spree.edit_admin_product_variant_path(product, variant)
 
       expect(find_field("Unit Price", disabled: true).value).to eq '$1,000.00 / kg'
     end
@@ -46,7 +49,8 @@ describe '
 
   describe "when admin use es as default language (and comma as decimal separator)", :debug do
     it "creating a new product with a comma separated decimal price" do
-      login_as_admin_and_visit spree.admin_dashboard_path(locale: 'es')
+      login_as_admin
+      visit spree.admin_dashboard_path(locale: 'es')
       visit spree.admin_products_path
       click_link 'Nuevo producto'
       select "Peso (kg)", from: 'product_variant_unit_with_scale'
@@ -58,7 +62,8 @@ describe '
 
     it "creating a new variant with a comma separated decimal price" do
       product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
-      login_as_admin_and_visit spree.admin_dashboard_path(locale: 'es')
+      login_as_admin
+      visit spree.admin_dashboard_path(locale: 'es')
       visit spree.admin_product_variants_path product
       click_link 'Nueva Variante'
       fill_in 'Peso (g)', with: '1'
@@ -71,7 +76,8 @@ describe '
       product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
       variant = product.variants.first
       variant.update(price: 1.5)
-      login_as_admin_and_visit spree.admin_dashboard_path(locale: 'es')
+      login_as_admin
+      visit spree.admin_dashboard_path(locale: 'es')
       visit spree.edit_admin_product_variant_path(product, variant)
 
       expect(find_field("Precio por unidad", disabled: true).value).to eq '1.500,00 $ / kg'

--- a/spec/system/admin/variant_overrides_spec.rb
+++ b/spec/system/admin/variant_overrides_spec.rb
@@ -452,7 +452,8 @@ describe "
       let(:product) { order_cycle.products.first }
 
       before do
-        login_as_admin_and_visit spree.new_admin_order_path
+        login_as_admin
+        visit spree.new_admin_order_path
         select2_select distributor.name, from: 'order_distributor_id'
         select2_select order_cycle.name, from: 'order_order_cycle_id'
         click_button 'Next'

--- a/spec/system/admin/variants_spec.rb
+++ b/spec/system/admin/variants_spec.rb
@@ -15,7 +15,8 @@ describe '
       product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
 
       # When I create a variant on the product
-      login_as_admin_and_visit spree.admin_product_variants_path product
+      login_as_admin
+      visit spree.admin_product_variants_path product
       click_link 'New Variant'
 
       fill_in 'unit_value_human', with: '1'
@@ -32,7 +33,8 @@ describe '
       filter = { producerFilter: 2 }
 
       # When I create a variant on the product
-      login_as_admin_and_visit spree.admin_product_variants_path(product, filter)
+      login_as_admin
+      visit spree.admin_product_variants_path(product, filter)
 
       click_link 'New Variant'
 
@@ -54,7 +56,8 @@ describe '
       filter = { producerFilter: 2 }
 
       # When I create a variant on the product
-      login_as_admin_and_visit spree.admin_product_variants_path(product, filter)
+      login_as_admin
+      visit spree.admin_product_variants_path(product, filter)
 
       visit spree.admin_product_variants_path(product, filter)
 
@@ -89,7 +92,8 @@ describe '
       filter = { producerFilter: 2 }
 
       # When I create a variant on the product
-      login_as_admin_and_visit spree.admin_product_variants_path(product, filter)
+      login_as_admin
+      visit spree.admin_product_variants_path(product, filter)
       page.find('table.index .icon-edit').click
 
       # Cancel link should include product filter
@@ -109,7 +113,8 @@ describe '
       product.option_types << variant.option_values.first.option_type
 
       # When I view the variant
-      login_as_admin_and_visit spree.admin_product_variants_path product
+      login_as_admin
+      visit spree.admin_product_variants_path product
       page.find('table.index .icon-edit').click
 
       # Then I should not see a traditional option value field for the unit-related option value
@@ -135,7 +140,8 @@ describe '
       variant = product.variants.first
       variant.update(unit_description: 'foo')
 
-      login_as_admin_and_visit spree.edit_admin_product_variant_path(product, variant)
+      login_as_admin
+      visit spree.edit_admin_product_variant_path(product, variant)
 
       expect(page).to_not have_field "unit_value_human"
       expect(page).to have_field "variant_unit_description", with: "foo"
@@ -192,7 +198,8 @@ describe '
     product = create(:simple_product)
     variant = create(:variant, product: product)
 
-    login_as_admin_and_visit spree.admin_product_variants_path product
+    login_as_admin
+    visit spree.admin_product_variants_path product
 
     within "tr#spree_variant_#{variant.id}" do
       accept_alert do
@@ -209,7 +216,8 @@ describe '
     variant = product.variants.first
 
     # When I view the variant
-    login_as_admin_and_visit spree.admin_product_variants_path product
+    login_as_admin
+    visit spree.admin_product_variants_path product
     page.find('table.index .icon-edit').click
 
     # It should allow the display name to be changed


### PR DESCRIPTION
#### What? Why?


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The `login_as_admin_and_visit` helper was used a lot but isn't really
shorter than:

    login_as_admin
    visit path_visit

Calling those methods separately reduces line length. It also removes
the potential impression that it may be more efficient to use the
helper. Now we have less indirection if one of the calls fails and see
the failing spec line straight away.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

This PR has lots of potential conflicts with other PRs adding specs using the removed helper. We may need to fix other PRs or master if a conflicting PR gets merged accidentally. But since it's only affecting specs, I think that this risk is tolerable and we don't need additional efforts to deprecate the method first and remove it later.

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
