### PR TITLE
Bump select2-rails (and select2) to 4.0.13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ gem 'angular_rails_csrf'
 
 gem 'jquery-rails', '4.4.0'
 gem 'jquery-ui-rails', '~> 4.2'
-gem "select2-rails", github: "openfoodfoundation/select2-rails", branch: "v349_with_thor_v1"
+gem "select2-rails", '~> 4.0.4'
 
 gem 'good_migrations'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,6 @@ GIT
       fog-core (~> 1.0)
       rails (>= 3.2.0)
 
-GIT
-  remote: https://github.com/openfoodfoundation/select2-rails.git
-  revision: fc240e85fbdf1878ff3c39d972c0cd9a312f5ed4
-  branch: v349_with_thor_v1
-  specs:
-    select2-rails (3.4.9)
-      sass-rails
-      thor (>= 0.14)
-
 PATH
   remote: engines/catalog
   specs:
@@ -641,14 +632,8 @@ GEM
     sanitize (6.0.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    sass (3.4.25)
-    sass-rails (5.0.8)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sd_notify (0.1.1)
+    select2-rails (4.0.13)
     semantic_range (3.0.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
@@ -880,7 +865,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sd_notify
-  select2-rails!
+  select2-rails (~> 4.0.4)
   shoulda-matchers
   sidekiq
   sidekiq-scheduler


### PR DESCRIPTION
#### What? Why?

Our fork is no longer necessary, [the fix](https://github.com/argerim/select2-rails/commit/51def23e3e112f3545fbe4ee0b9fce332bd6d8ec) was released in 4.0.4.

We should be able to archive https://github.com/openfoodfoundation/select2-rails

This also results in upgrading Select2 from **3.4.3 (2013)** all the way up to **4.0.13 (2020)**! I hope this is ok. I figured it wasn't worth testing intermediate releases in case there are bugs that have already been fixed.


#### What should we test?
Styled dropdown fields. Eg

* Normal  (`/admin/enterprises`)
* When an action happens after changing selection (`/admin/payment_methods/*/edit/`)
* With Angular (`/admin/products`)
* Is there multi-select anywhere?

#### Release notes

Changelog Category:  Technical changes

#### Post-release actions

We can archive https://github.com/openfoodfoundation/select2-rails
