### PR TITLE
Hide users with no completed orders from a hub's customers list

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -36,9 +36,11 @@ module Admin
     end
 
     def create
-      @customer = Customer.new(customer_params)
-      @customer.created_manually = true
+      @customer = Customer.find_or_new(customer_params[:email], customer_params[:enterprise_id])
+      @customer.assign_attributes(customer_params)
+
       if user_can_create_customer?
+        @customer.set_created_manually_flag
         if @customer.save
           tag_rule_mapping = TagRule.mapping_for(Enterprise.where(id: @customer.enterprise))
           render_as_json @customer, tag_rule_mapping: tag_rule_mapping

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -37,6 +37,7 @@ module Admin
 
     def create
       @customer = Customer.new(customer_params)
+      @customer.created_manually = true
       if user_can_create_customer?
         if @customer.save
           tag_rule_mapping = TagRule.mapping_for(Enterprise.where(id: @customer.enterprise))
@@ -83,7 +84,7 @@ module Admin
     def customers
       return @customers if @customers.present?
 
-      @customers = Customer.managed_by(spree_current_user)
+      @customers = Customer.visible.managed_by(spree_current_user)
       return @customers if params[:enterprise_id].blank?
 
       @customers = @customers.where(enterprise_id: params[:enterprise_id])

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -37,10 +37,9 @@ module Admin
 
     def create
       @customer = Customer.find_or_new(customer_params[:email], customer_params[:enterprise_id])
-      @customer.assign_attributes(customer_params)
 
       if user_can_create_customer?
-        @customer.set_created_manually_flag
+        @customer.created_manually = true
         if @customer.save
           tag_rule_mapping = TagRule.mapping_for(Enterprise.where(id: @customer.enterprise))
           render_as_json @customer, tag_rule_mapping: tag_rule_mapping

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -36,7 +36,7 @@ module Admin
     end
 
     def create
-      @customer = Customer.find_or_new(customer_params[:email], customer_params[:enterprise_id])
+      @customer = Customer.find_or_initialize_by(customer_params.slice(:email, :enterprise_id))
 
       if user_can_create_customer?
         @customer.created_manually = true

--- a/app/controllers/api/v0/customers_controller.rb
+++ b/app/controllers/api/v0/customers_controller.rb
@@ -6,7 +6,7 @@ module Api
       skip_authorization_check only: :index
 
       def index
-        @customers = current_api_user.customers
+        @customers = current_api_user.customers.visible
         render json: @customers, each_serializer: CustomerSerializer
       end
 

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -80,7 +80,7 @@ module Api
       end
 
       def visible_customers
-        Customer.managed_by(current_api_user)
+        Customer.visible.managed_by(current_api_user)
       end
 
       def customer_params
@@ -96,6 +96,7 @@ module Api
           ]
         ).to_h
 
+        attributes.merge!(created_manually: true)
         attributes.merge!(tag_list: params[:tags]) if params.key?(:tags)
 
         transform_address!(attributes, :billing_address, :bill_address)

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -29,7 +29,9 @@ module Api
 
       def create
         authorize! :update, Enterprise.find(customer_params[:enterprise_id])
-        customer = Customer.new(customer_params)
+        customer = Customer.find_or_new(customer_params[:email], customer_params[:enterprise_id])
+        customer.assign_attributes(customer_params)
+        customer.set_created_manually_flag
 
         if customer.save
           render json: Api::V1::CustomerSerializer.new(customer), status: :created

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -29,7 +29,7 @@ module Api
 
       def create
         authorize! :update, Enterprise.find(customer_params[:enterprise_id])
-        customer = Customer.find_or_new(customer_params[:email], customer_params[:enterprise_id])
+        customer = Customer.find_or_initialize_by(customer_params.slice(:email, :enterprise_id))
         customer.assign_attributes(customer_params)
 
         if customer.save

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -31,7 +31,6 @@ module Api
         authorize! :update, Enterprise.find(customer_params[:enterprise_id])
         customer = Customer.find_or_new(customer_params[:email], customer_params[:enterprise_id])
         customer.assign_attributes(customer_params)
-        customer.set_created_manually_flag
 
         if customer.save
           render json: Api::V1::CustomerSerializer.new(customer), status: :created

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -45,11 +45,6 @@ class Customer < ApplicationRecord
 
   attr_accessor :gateway_recurring_payment_client_secret, :gateway_shop_id
 
-  def self.find_or_new(email, enterprise_id)
-    Customer.find_by(email: email, enterprise_id: enterprise_id) ||
-      Customer.new(email: email, enterprise_id: enterprise_id)
-  end
-
   def full_name
     "#{first_name} #{last_name}".strip
   end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -46,8 +46,6 @@ class Customer < ApplicationRecord
   attr_accessor :gateway_recurring_payment_client_secret, :gateway_shop_id
 
   def self.find_or_new(email, enterprise_id)
-    Customer.new(email: email, enterprise_id: enterprise_id) unless email.present? && enterprise_id.present?
-
     Customer.find_by(email: email, enterprise_id: enterprise_id) ||
       Customer.new(email: email, enterprise_id: enterprise_id)
   end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -54,13 +54,6 @@ class Customer < ApplicationRecord
     "#{first_name} #{last_name}".strip
   end
 
-  def set_created_manually_flag
-    self.created_manually = true
-    return unless persisted?
-
-    update_attribute(:created_manually, true)
-  end
-
   private
 
   def downcase_email

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -38,6 +38,8 @@ class Customer < ApplicationRecord
 
   scope :of, ->(enterprise) { where(enterprise_id: enterprise) }
   scope :managed_by, ->(user) { user&.persisted? ? where(user: user).or(of(Enterprise.managed_by(user))) : none }
+  scope :created_manually, -> { where(created_manually: true) }
+  scope :visible, -> { where(id: Spree::Order.complete.select(:customer_id)).or(created_manually) }
 
   before_create :associate_user
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -45,15 +45,15 @@ class Customer < ApplicationRecord
 
   attr_accessor :gateway_recurring_payment_client_secret, :gateway_shop_id
 
-  def full_name
-    "#{first_name} #{last_name}".strip
-  end
-
   def self.find_or_new(email, enterprise_id)
     Customer.new(email: email, enterprise_id: enterprise_id) unless email.present? && enterprise_id.present?
 
     Customer.find_by(email: email, enterprise_id: enterprise_id) ||
       Customer.new(email: email, enterprise_id: enterprise_id)
+  end
+
+  def full_name
+    "#{first_name} #{last_name}".strip
   end
 
   def set_created_manually_flag

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -49,6 +49,20 @@ class Customer < ApplicationRecord
     "#{first_name} #{last_name}".strip
   end
 
+  def self.find_or_new(email, enterprise_id)
+    Customer.new(email: email, enterprise_id: enterprise_id) unless email.present? && enterprise_id.present?
+
+    Customer.find_by(email: email, enterprise_id: enterprise_id) ||
+      Customer.new(email: email, enterprise_id: enterprise_id)
+  end
+
+  def set_created_manually_flag
+    self.created_manually = true
+    return unless persisted?
+
+    update_attribute(:created_manually, true)
+  end
+
   private
 
   def downcase_email

--- a/db/migrate/20230516072511_add_created_manually_flag_to_customer.rb
+++ b/db/migrate/20230516072511_add_created_manually_flag_to_customer.rb
@@ -1,0 +1,5 @@
+class AddCreatedManuallyFlagToCustomer < ActiveRecord::Migration[7.0]
+  def change
+    add_column :customers, :created_manually, :boolean, default: false
+  end
+end

--- a/db/migrate/20230516072511_add_created_manually_flag_to_customer.rb
+++ b/db/migrate/20230516072511_add_created_manually_flag_to_customer.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 class AddCreatedManuallyFlagToCustomer < ActiveRecord::Migration[7.0]
   def change
-    add_column :customers, :created_manually, :boolean, default: false
+    add_column :customers, :created_manually, :boolean, null: false, default: false
+    add_index :customers, :created_manually
   end
 end

--- a/db/migrate/20230525081252_update_created_manually_flag_on_customers.rb
+++ b/db/migrate/20230525081252_update_created_manually_flag_on_customers.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class UpdateCreatedManuallyFlagOnCustomers < ActiveRecord::Migration[7.0]
+  class Customer < ApplicationRecord
+    has_many :orders, class_name: "Spree::Order"
+    acts_as_taggable
+  end
+
+  module Spree
+    class Order < ApplicationRecord
+      belongs_to :customer
+      self.table_name = 'spree_orders'
+    end
+  end
+
+  def change
+    # We want to set the created_manually flag to true for all customers that don't have any orders
+    Customer.where.not(id: customers_with_at_least_one_order)
+      .update_all(created_manually: true)
+  end
+
+  def customers_with_at_least_one_order
+    Spree::Order.pluck(:customer_id)
+  end
+end

--- a/db/migrate/20230525081252_update_created_manually_flag_on_customers.rb
+++ b/db/migrate/20230525081252_update_created_manually_flag_on_customers.rb
@@ -2,24 +2,18 @@
 
 class UpdateCreatedManuallyFlagOnCustomers < ActiveRecord::Migration[7.0]
   class Customer < ApplicationRecord
-    has_many :orders, class_name: "Spree::Order"
-    acts_as_taggable
+    has_many :orders
   end
 
-  module Spree
-    class Order < ApplicationRecord
-      belongs_to :customer
-      self.table_name = 'spree_orders'
-    end
+  class Order < ApplicationRecord
+    self.table_name = 'spree_orders'
   end
 
-  def change
-    # We want to set the created_manually flag to true for all customers that don't have any orders
-    Customer.where.not(id: customers_with_at_least_one_order)
-      .update_all(created_manually: true)
+  def up
+    Customer.where.missing(:orders).update_all(created_manually: true)
   end
 
-  def customers_with_at_least_one_order
-    Spree::Order.pluck(:customer_id)
+  def down
+    Customer.where(created_manually: true).update_all(created_manually: false)
   end
 end

--- a/db/migrate/20230531010957_add_index_to_customers.rb
+++ b/db/migrate/20230531010957_add_index_to_customers.rb
@@ -1,0 +1,5 @@
+class AddIndexToCustomers < ActiveRecord::Migration[7.0]
+  def change
+    add_index :customers, :created_manually
+  end
+end

--- a/db/migrate/20230531010957_add_index_to_customers.rb
+++ b/db/migrate/20230531010957_add_index_to_customers.rb
@@ -1,5 +1,0 @@
-class AddIndexToCustomers < ActiveRecord::Migration[7.0]
-  def change
-    add_index :customers, :created_manually
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_25_081252) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_31_010957) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_25_081252) do
     t.string "last_name", default: "", null: false
     t.boolean "created_manually", default: false
     t.index ["bill_address_id"], name: "index_customers_on_bill_address_id"
+    t.index ["created_manually"], name: "index_customers_on_created_manually"
     t.index ["email"], name: "index_customers_on_email"
     t.index ["enterprise_id", "code"], name: "index_customers_on_enterprise_id_and_code", unique: true
     t.index ["ship_address_id"], name: "index_customers_on_ship_address_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_22_120633) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_16_072511) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -93,6 +93,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_120633) do
     t.datetime "terms_and_conditions_accepted_at", precision: nil
     t.string "first_name", default: "", null: false
     t.string "last_name", default: "", null: false
+    t.boolean "created_manually", default: false
     t.index ["bill_address_id"], name: "index_customers_on_bill_address_id"
     t.index ["email"], name: "index_customers_on_email"
     t.index ["enterprise_id", "code"], name: "index_customers_on_enterprise_id_and_code", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_16_072511) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_25_081252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_31_010957) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_05_133804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -93,7 +93,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_010957) do
     t.datetime "terms_and_conditions_accepted_at", precision: nil
     t.string "first_name", default: "", null: false
     t.string "last_name", default: "", null: false
-    t.boolean "created_manually", default: false
+    t.boolean "created_manually", default: false, null: false
     t.index ["bill_address_id"], name: "index_customers_on_bill_address_id"
     t.index ["created_manually"], name: "index_customers_on_created_manually"
     t.index ["email"], name: "index_customers_on_email"

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -22,7 +22,7 @@ module Admin
       end
 
       context "json" do
-        let!(:customer) { create(:customer, enterprise: enterprise) }
+        let!(:customer) { create(:customer, enterprise: enterprise, created_manually: true) }
 
         context "where I manage the enterprise" do
           before do
@@ -31,7 +31,7 @@ module Admin
 
           context "and enterprise_id is given in params" do
             let(:user){ enterprise.users.first }
-            let(:customers){ Customer.managed_by(user).where(enterprise_id: enterprise.id) }
+            let(:customers){ Customer.visible.managed_by(user).where(enterprise_id: enterprise.id) }
             let(:params) { { format: :json, enterprise_id: enterprise.id } }
 
             it "scopes @collection to customers of that enterprise" do

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -205,6 +205,7 @@ module Admin
 
           it "allows me to create the customer" do
             expect { create_customer enterprise }.to change(Customer, :count).by(1)
+            expect(Customer.reorder(:id).last.created_manually).to eq true
           end
         end
 

--- a/spec/controllers/api/v0/customers_controller_spec.rb
+++ b/spec/controllers/api/v0/customers_controller_spec.rb
@@ -10,8 +10,8 @@ module Api
     let(:user) { create(:user) }
 
     describe "index" do
-      let!(:customer1) { create(:customer) }
-      let!(:customer2) { create(:customer) }
+      let!(:customer1) { create(:customer, created_manually: true) }
+      let!(:customer2) { create(:customer, created_manually: true) }
 
       before do
         user.customers << customer1

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -116,5 +116,30 @@ describe Customer, type: :model do
         expect(Customer.managed_by(guest)).to match_array []
       end
     end
+
+    context "with split checkout enabled" do
+      before do
+        Flipper.enable(:split_checkout)
+      end
+
+      context 'visible' do
+        let!(:customer) { create(:customer) }
+        let!(:customer2) { create(:customer) }
+        let!(:customer3) { create(:customer) }
+        let!(:customer4) { create(:customer) }
+        let!(:customer5) { create(:customer, created_manually: true) }
+
+        let!(:order_ready_for_details) { create(:order_ready_for_details, customer: customer) }
+        let!(:order_ready_for_payment) { create(:order_ready_for_payment, customer: customer2) }
+        let!(:order_ready_for_confirmation) {
+          create(:order_ready_for_confirmation, customer: customer3)
+        }
+        let!(:completed_order) { create(:completed_order_with_totals, customer: customer4) }
+
+        it 'returns customers with completed orders' do
+          expect(Customer.visible).to match_array [customer4, customer5]
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -11,13 +11,14 @@ describe "Customers", type: :request do
     create(
       :customer,
       enterprise: enterprise1,
+      created_manually: true,
       terms_and_conditions_accepted_at: Time.zone.parse("2000-01-01"),
       tag_list: ["long-term"],
       ship_address: create(:address),
     )
   }
-  let!(:customer2) { create(:customer, enterprise: enterprise1) }
-  let!(:customer3) { create(:customer, enterprise: enterprise2) }
+  let!(:customer2) { create(:customer, enterprise: enterprise1, created_manually: true,) }
+  let!(:customer3) { create(:customer, enterprise: enterprise2, created_manually: true,) }
 
   before do
     Flipper.enable(:api_v1)

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -190,6 +190,9 @@ describe "Customers", type: :request do
             allow_charges: false,
             terms_and_conditions_accepted_at: nil,
           )
+
+          customer = Customer.find(json_response[:data][:attributes][:id])
+          expect(customer.created_manually).to eq true
         end
       end
 

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -16,11 +16,17 @@ describe 'Customers' do
     describe "using the customers index" do
       let!(:customer1) {
         create(:customer, first_name: 'John', last_name: 'Doe', enterprise: managed_distributor1, 
-code: nil)
+code: nil, created_manually: true)
       }
-      let!(:customer2) { create(:customer, enterprise: managed_distributor1, code: nil) }
-      let!(:customer3) { create(:customer, enterprise: unmanaged_distributor) }
-      let!(:customer4) { create(:customer, enterprise: managed_distributor2) }
+      let!(:customer2) {
+        create(:customer, enterprise: managed_distributor1, created_manually: true, code: nil)
+      }
+      let!(:customer3) {
+        create(:customer, enterprise: unmanaged_distributor, created_manually: true,)
+      }
+      let!(:customer4) {
+        create(:customer, enterprise: managed_distributor2, created_manually: true,)
+      }
 
       before do
         login_as user

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -352,6 +352,7 @@ code: nil, created_manually: true)
         context "when a shop is selected" do
           before do
             select2_select managed_distributor1.name, from: "shop_id"
+            customer1.update!(created_manually: false)
           end
 
           it "creates customers when the email provided is valid" do
@@ -378,7 +379,8 @@ code: nil, created_manually: true)
               click_button 'Add Customer'
               expect(page).to have_selector "#new-customer-dialog .error",
                                             text: "Email is associated with an existing customer"
-            }.to_not change{ Customer.of(managed_distributor1).count }
+            }.to change{ customer1.reload.created_manually }.from(false).to(true)
+              .and change { Customer.of(managed_distributor1).count }.by(0)
 
             # When a new valid email is used
             expect{
@@ -386,6 +388,11 @@ code: nil, created_manually: true)
               click_button 'Add Customer'
               expect(page).not_to have_selector "#new-customer-dialog"
             }.to change{ Customer.of(managed_distributor1).count }.from(2).to(3)
+
+            expect(
+              Customer.of(managed_distributor1).reorder(:id)
+                .last.created_manually 
+            ).to be true
           end
         end
       end

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -373,26 +373,29 @@ code: nil, created_manually: true)
                                             text: "Email is invalid"
             }.to_not change{ Customer.of(managed_distributor1).count }
 
-            # When an existing email is used
-            expect{
-              fill_in 'email', with: customer1.email
-              click_button 'Add Customer'
-              expect(page).to have_selector "#new-customer-dialog .error",
-                                            text: "Email is associated with an existing customer"
-            }.to change{ customer1.reload.created_manually }.from(false).to(true)
-              .and change { Customer.of(managed_distributor1).count }.by(0)
-
             # When a new valid email is used
             expect{
               fill_in 'email', with: "new@email.com"
               click_button 'Add Customer'
               expect(page).not_to have_selector "#new-customer-dialog"
             }.to change{ Customer.of(managed_distributor1).count }.from(2).to(3)
+          end
 
-            expect(
-              Customer.of(managed_distributor1).reorder(:id)
-                .last.created_manually 
-            ).to be true
+          it "shows a hidden customer when trying to create it" do
+            click_link('New Customer')
+            fill_in 'email', with: customer1.email
+
+            expect do
+              click_button 'Add Customer'
+              expect(page).not_to have_selector "#new-customer-dialog"
+              customer1.reload
+            end
+              .to change { customer1.created_manually }.from(false).to(true)
+              .and change { Customer.count }.by(0)
+
+            expect(page).to have_content customer1.email
+            expect(page).to have_field "first_name", with: "John"
+            expect(page).to have_field "last_name", with: "Doe"
           end
         end
       end

--- a/spec/system/consumer/account/cards_spec.rb
+++ b/spec/system/consumer/account/cards_spec.rb
@@ -9,7 +9,7 @@ describe "Credit Cards" do
 
   describe "as a logged in user" do
     let(:user) { create(:user) }
-    let!(:customer) { create(:customer, user: user) }
+    let!(:customer) { create(:customer, user: user, created_manually: true) }
     let!(:default_card) {
       create(:stored_credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_AZNMJ',
                                   is_default: true)


### PR DESCRIPTION
#### What? Why?

- Closes #10624

I update the three endpoints that return customers list to only return:
1. customers created manually
2. or customers that have at least one completed order

Lists should not return customer that have started (and not completed) a checkout with split checkout.
 
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- check the customers list
- check customers list endpoints (v0 & v1)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
