### PR TITLE
Fix ShipmentMailer preview autoload path

### DIFF
--- a/spec/mailers/previews/shipment_preview.rb
+++ b/spec/mailers/previews/shipment_preview.rb
@@ -2,13 +2,11 @@
 
 require 'open_food_network/scope_variant_to_hub'
 
-module Spree
-  class ShipmentPreview < ActionMailer::Preview
-    def shipped
-      shipment =
-        Shipment.where.not(tracking: [nil, ""]).last ||
-        Shipment.last
-      ShipmentMailer.shipped_email(shipment)
-    end
+class ShipmentPreview < ActionMailer::Preview
+  def shipped
+    shipment =
+      Spree::Shipment.where.not(tracking: [nil, ""]).last ||
+      Spree::Shipment.last
+    Spree::ShipmentMailer.shipped_email(shipment, delivery: true)
   end
 end


### PR DESCRIPTION

#### What? Why?

The Zeitwerk autoloader requires class names and file names to match. In this case, the class had a Spree namespace without being in a spree folder. The preview couldn't be displayed. Now it can be displayed.

When generating a new mailer for background reports, I couldn't display the preview because Zeitwerk was missing the expected class name.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

The mailer previews are not displayed in staging, only in development and I tested that they are displayed now. I don't think it's worth a dev test but feel free to try it if you never used mailer previews.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
