### PR TITLE
Adds caching by default in development environment to avoid StimulusReflex warning

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 # Foreman Procfile. Start all dev server processes with: `foreman start`
 
-rails:      bundle exec rails s -p 3000
+rails:      DEV_CACHING=true bundle exec rails s -p 3000
 webpack:    ./bin/webpack-dev-server
-sidekiq:    bundle exec sidekiq -q mailers -q default
+sidekiq:    DEV_CACHING=true bundle exec sidekiq -q mailers -q default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,8 +13,6 @@ Openfoodnetwork::Application.configure do
 
   config.action_controller.default_url_options = {host: "localhost", port: 3000}
 
-  config.session_store :cache_store, key: "_sessions_development", compress: true, pool_size: 5, expire_after: 1.year
-
   # :file_store is used by default when no cache store is specifically configured.
   if !!ENV["PROFILE"] || !!ENV["DEV_CACHING"]
     config.cache_store = :redis_cache_store, {


### PR DESCRIPTION
#### What? Why?

- Closes #10048 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
- Dev test: you should not see the warning when starting the application via `foreman`
- Deployment on staging: you should have access to website as usual + test bulk send confirmation email on page `/admin/orders` (triggers a reflex)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
