### PR TITLE
Adds forcing of i18n exceptions

### DIFF
--- a/config/initializers/i18n_force_exceptions.rb
+++ b/config/initializers/i18n_force_exceptions.rb
@@ -1,0 +1,14 @@
+
+module I18n
+  class ForceMissingTranslationsHandler < ExceptionHandler
+    def call(exception, locale, key, options)
+      if Rails.env.test?
+        raise exception.to_exception
+      else
+        super
+      end
+    end
+  end
+end
+
+I18n.exception_handler = I18n::ForceMissingTranslationsHandler.new


### PR DESCRIPTION
Partially addresses #2626.

This code snippet seems to be necessary to enable exceptions to be raised, and specs to fail accordingly - please note this was taken from [this discussion](https://stackoverflow.com/questions/8066901/rails-how-to-raise-i18n-translation-is-missing-exceptions-in-the-testing-enviro).

This PR does not seem to improve the build on what missing JS translations is concerned.

 :orange_circle:   Maybe some things to do, within the scope of this PR:

- set an ENV variable to check for translations; we could then set a dedicated runner job in the CI to check for this only for all specs -> I've noticed that running `bundle exec rspec --dry-run ./spec` would throw the error any way - so this could be a separate job in the CI
- remove `spec/support/i18n_translations_checker.rb`, as per [this comment](https://github.com/openfoodfoundation/openfoodnetwork/pull/10728#issuecomment-1517061451).

What do you think? (added `feedback needed` label) :orange_circle: 

#### What? Why?

- Relates (maybe closes) #9500

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Ideally, we'd like to see our build failing for every Action View translation or for JS translations. This PR tries to make the former work, as the recommended setting in `config/environments/test.rb` (below) is not working:

```
# Tests should fail when translations are missing.
config.i18n.raise_on_missing_translations = false
```

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
