### PR TITLE
White Label: remove OFN banner from order confirmation emails when `hide_ofn_navigation` is activated for the shop

### DIFF
--- a/app/mailers/spree/order_mailer.rb
+++ b/app/mailers/spree/order_mailer.rb
@@ -28,6 +28,7 @@ module Spree
 
     def confirm_email_for_customer(order_or_order_id, resend = false)
       @order = find_order(order_or_order_id)
+      @hide_ofn_navigation = @order.distributor.hide_ofn_navigation
       I18n.with_locale valid_locale(@order.user) do
         subject = mail_subject(t('spree.order_mailer.confirm_email.subject'), resend)
         mail(to: @order.email,

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -11,6 +11,7 @@ class SubscriptionMailer < ApplicationMailer
   def confirmation_email(order)
     @type = 'confirmation'
     @order = order
+    @hide_ofn_navigation = @order.distributor.hide_ofn_navigation
     send_mail(order)
   end
 

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -7,19 +7,20 @@
       = Spree::Config[:site_name]
     = stylesheet_pack_tag 'mail'
   %body{:bgcolor => "#FFFFFF" }
-    %table.head-wrap{:bgcolor => "#f2f2f2"}
-      %tr
-        %td
-        %td.header.container
-          .content
-            %table{:bgcolor => "#f2f2f2"}
-              %tr
-                %td
-                  %img{src: ContentConfig.url_for(:footer_logo), width: "144", height: "50"}/
-                %td{:align => "right"}
-                  %h6.collapse
-                    = Spree::Config[:site_name]
-        %td
+    - unless @hide_ofn_navigation
+      %table.head-wrap{:bgcolor => "#f2f2f2"}
+        %tr
+          %td
+          %td.header.container
+            .content
+              %table{:bgcolor => "#f2f2f2"}
+                %tr
+                  %td
+                    %img{src: ContentConfig.url_for(:footer_logo), width: "144", height: "50"}/
+                  %td{:align => "right"}
+                    %h6.collapse
+                      = Spree::Config[:site_name]
+          %td
 
     %table.body-wrap
       %tr

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -44,6 +44,20 @@ describe Spree::OrderMailer do
         described_class.confirm_email_for_customer(order.id).deliver_now
       }.to_not raise_error
     end
+
+    it "display the OFN header by default" do
+      expect(email.body).to include(ContentConfig.url_for(:footer_logo))
+    end
+
+    context 'when hide OFN navigation is enabled for the distributor of the order' do
+      before do
+        allow(order.distributor).to receive(:hide_ofn_navigation).and_return(true)
+      end
+
+      it 'does not display the OFN navigation' do
+        expect(email.body).to_not include(ContentConfig.url_for(:footer_logo))
+      end
+    end
   end
 
   describe '#confirm_email_for_shop' do

--- a/spec/mailers/previews/order_mailer_preview.rb
+++ b/spec/mailers/previews/order_mailer_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class OrderMailerPreview < ActionMailer::Preview
+  def confirm_email_for_customer
+    Spree::OrderMailer.confirm_email_for_customer(Spree::Order.complete.last)
+  end
+end

--- a/spec/mailers/previews/subscription_mailer_preview.rb
+++ b/spec/mailers/previews/subscription_mailer_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SubscriptionMailerPreview < ActionMailer::Preview
+  def confirmation_email
+    SubscriptionMailer.confirmation_email(Spree::Order.complete.last)
+  end
+end

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -117,6 +117,10 @@ describe SubscriptionMailer, type: :mailer do
       expect(body).to include "This order was automatically placed for you"
     end
 
+    it "display the OFN header by default" do
+      expect(email.body).to include(ContentConfig.url_for(:footer_logo))
+    end
+
     describe "linking to order page" do
       let(:order_link_href) { "href=\"#{order_url(order)}\"" }
 
@@ -150,6 +154,16 @@ describe SubscriptionMailer, type: :mailer do
 
       it 'displays the payment status' do
         expect(email.body).to include('NOT PAID')
+      end
+    end
+
+    context 'when hide OFN navigation is enabled for the distributor of the order' do
+      before do
+        allow(order.distributor).to receive(:hide_ofn_navigation).and_return(true)
+      end
+
+      it 'does not display the OFN navigation' do
+        expect(email.body).to_not include(ContentConfig.url_for(:footer_logo))
       end
     end
   end


### PR DESCRIPTION
~⚠️ I did not put this feature behind the feature toggle `white_label` as we want it to be soon removed. That's why this PR should not be merge until we completely remove the `white_label` feature toggle.~

~But this is ready to be reviewed.~

#### What? Why?
- Closes #10556 

##### BEFORE
<img width="691" alt="Capture d’écran 2023-04-25 à 10 31 18" src="https://user-images.githubusercontent.com/296452/234222008-97edc027-1947-4ded-8ab9-4dd5e29643a1.png">

##### AFTER
<img width="592" alt="Capture d’écran 2023-04-25 à 10 31 29" src="https://user-images.githubusercontent.com/296452/234222046-ded30238-5600-43e6-9e8f-23a5d727a44d.png">



#### What should we test?
- ~As a super-admin, activate white_label feature toggle for the instance~
- As a super-admin, activate hide_ofn_navigation for the shop in `/admin/enterprises/ENTERPRISE_SLUG/edit#/white_label_panel`
<img width="689" alt="Capture d’écran 2023-04-25 à 10 37 08" src="https://user-images.githubusercontent.com/296452/234221848-da3667f3-d312-4268-a04b-8329329e5565.png">

- Check that order confirmation email does not contains the OFN header.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes