### PR TITLE
White Label: allow hide of groups tab in shop navigation

### DIFF
--- a/app/helpers/shop_helper.rb
+++ b/app/helpers/shop_helper.rb
@@ -24,7 +24,7 @@ module ShopHelper
       { name: 'about', title: t(:shopping_tabs_about), show: true },
       { name: 'producers', title: t(:shopping_tabs_producers), show: true },
       { name: 'contact', title: t(:shopping_tabs_contact), show: true },
-      { name: 'groups', title: t(:shopping_tabs_groups), show: current_distributor.groups.any? },
+      { name: 'groups', title: t(:shopping_tabs_groups), show: show_groups_tabs? },
     ].select{ |tab| tab[:show] }
   end
 
@@ -51,5 +51,11 @@ module ShopHelper
                     current_page?(main_app.enterprise_shop_path(current_distributor))
 
     true
+  end
+
+  private
+
+  def show_groups_tabs?
+    !current_distributor.hide_groups_tab? && current_distributor.groups.any?
   end
 end

--- a/app/services/permitted_attributes/enterprise.rb
+++ b/app/services/permitted_attributes/enterprise.rb
@@ -35,7 +35,8 @@ module PermittedAttributes
         :show_customer_names_to_suppliers, :preferred_shopfront_product_sorting_method,
         :preferred_invoice_order_by_supplier,
         :preferred_product_low_stock_display,
-        :hide_ofn_navigation, :white_label_logo, :white_label_logo_link
+        :hide_ofn_navigation, :white_label_logo, :white_label_logo_link,
+        :hide_groups_tab
       ]
     end
   end

--- a/app/views/admin/enterprises/form/_white_label.html.haml
+++ b/app/views/admin/enterprises/form/_white_label.html.haml
@@ -29,3 +29,11 @@
   = render ConfirmModalComponent.new(id: "remove_logo", confirm_reflexes: "click->WhiteLabel#remove_logo" ) do
     .margin-bottom-30
       = t('.remove_logo_confirm')
+
+// Hide groups tab boolean attribute
+
+.row
+  .three.columns.alpha
+    = f.label :hide_groups_tab, t('.hide_groups_tab')
+  .three.columns
+    = f.check_box :hide_groups_tab

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1185,6 +1185,7 @@ en:
           remove_logo_confirm: "Are you sure you want to remove this logo?"
           remove_logo_success: "Logo removed"
           white_label_logo_link_label: "Link for the logo used in shopfront"
+          hide_groups_tab: "Hide groups tab in shopfront"
       actions:
         edit_profile: Settings
         properties: Properties

--- a/db/migrate/20230425135232_add_hide_groups_tab_to_enterprises.rb
+++ b/db/migrate/20230425135232_add_hide_groups_tab_to_enterprises.rb
@@ -1,0 +1,5 @@
+class AddHideGroupsTabToEnterprises < ActiveRecord::Migration[7.0]
+  def change
+    add_column :enterprises, :hide_groups_tab, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_24_141213) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_25_135232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -226,6 +226,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_24_141213) do
     t.string "whatsapp_phone", limit: 255
     t.boolean "hide_ofn_navigation", default: false, null: false
     t.text "white_label_logo_link"
+    t.boolean "hide_groups_tab", default: false
     t.index ["address_id"], name: "index_enterprises_on_address_id"
     t.index ["is_primary_producer", "sells"], name: "index_enterprises_on_is_primary_producer_and_sells"
     t.index ["name"], name: "index_enterprises_on_name", unique: true

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -706,6 +706,25 @@ describe '
             expect(distributor1.reload.white_label_logo_link).to eq("https://www.openfoodnetwork.org")
           end
         end
+
+        it "can check/uncheck the hide_groups_tab attribute" do
+          check "Hide groups tab in shopfront"
+          click_button 'Update'
+          expect(flash_message)
+            .to eq('Enterprise "First Distributor" has been successfully updated!')
+          expect(distributor1.reload.hide_groups_tab).to be true
+
+          visit edit_admin_enterprise_path(distributor1)
+          within(".side_menu") do
+            click_link "White Label"
+          end
+
+          uncheck "Hide groups tab in shopfront"
+          click_button 'Update'
+          expect(flash_message)
+            .to eq('Enterprise "First Distributor" has been successfully updated!')
+          expect(distributor1.reload.hide_groups_tab).to be false
+        end
       end
     end
   end

--- a/spec/system/consumer/white_label_spec.rb
+++ b/spec/system/consumer/white_label_spec.rb
@@ -157,6 +157,36 @@ describe 'White label setting' do
 
       it_behaves_like "does not hide the OFN navigation"
     end
+
+    context "manage hide_groups_tab preference when distributor belongs to a group" do
+      let(:group) { create(:enterprise_group) }
+
+      before do
+        distributor.groups << group
+      end
+
+      context "when the preference is set to true" do
+        before do
+          distributor.update_attribute(:hide_groups_tab, true)
+        end
+
+        it "hides the groups tab" do
+          visit main_app.enterprise_shop_path(distributor)
+          expect(page).to have_no_selector "a[href='#groups']"
+        end
+      end
+
+      context "when the preference is set to false" do
+        before do
+          distributor.update_attribute(:hide_groups_tab, false)
+        end
+
+        it "shows the groups tab" do
+          visit main_app.enterprise_shop_path(distributor)
+          expect(page).to have_selector "a[href='#groups']"
+        end
+      end
+    end
   end
 
   context "manage the white_label_logo preference" do


### PR DESCRIPTION
~⚠️ 
As per #10744, I did not put this feature behind the feature toggle `white_label` as we want it to be soon removed. That's why this PR should not be merge until we completely remove the `white_label` feature toggle.~

~But this is ready to be reviewed.~

#### What? Why?

- Closes #10560
This simply removes the `groups` tab in a shopfront of a distributor if `Hide groups tab` has been set to true

##### `hide_groups_tab` is false
<img width="937" alt="Capture d’écran 2023-04-25 à 17 19 09" src="https://user-images.githubusercontent.com/296452/234326041-814072a0-2835-4e05-a2a1-75870a601f00.png">
<img width="1224" alt="Capture d’écran 2023-04-25 à 17 19 15" src="https://user-images.githubusercontent.com/296452/234326053-4c9dda59-444b-4ed6-8ccf-38335971a997.png">

##### `hide_groups_tab` is true
<img width="979" alt="Capture d’écran 2023-04-25 à 17 18 50" src="https://user-images.githubusercontent.com/296452/234326134-c7233c12-4abf-4873-a3d3-589a7a909089.png">
<img width="1173" alt="Capture d’écran 2023-04-25 à 17 18 43" src="https://user-images.githubusercontent.com/296452/234326148-8c27b589-01ef-4d9f-afa1-831550af0ebc.png">




#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, for a distributor that belongs to a group, check/uncheck the `HIDE GROUPS TAB IN SHOPFRONT` checkbox in `White Label` panel in enterprise settings
- With attribute checked, you _should not see_ the groups tab in the shopfront
- With attribute unchecked, you _should see_ the groups tab in the shopfront

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 