### PR TITLE
Remove unused feature to intercept emails

### DIFF
--- a/app/models/spree/app_configuration.rb
+++ b/app/models/spree/app_configuration.rb
@@ -88,7 +88,6 @@ module Spree
     # Default mail headers settings
     preference :mails_from, :string, default: 'ofn@example.com'
     preference :mail_bcc, :string, default: 'ofn@example.com'
-    preference :intercept_email, :string, default: nil
 
     # Default smtp settings
     preference :mail_host, :string, default: 'localhost'

--- a/app/services/mail_configuration.rb
+++ b/app/services/mail_configuration.rb
@@ -22,7 +22,6 @@ class MailConfiguration
       secure_connection_type: ENV.fetch('MAIL_SECURE_CONNECTION', 'None'),
       mails_from: ENV.fetch('MAILS_FROM', "no-reply@#{ENV.fetch('MAIL_DOMAIN')}"),
       mail_bcc: ENV.fetch('MAIL_BCC', ''),
-      intercept_email: ''
     }
   end
 

--- a/app/views/spree/admin/mail_methods/_form.html.haml
+++ b/app/views/spree/admin/mail_methods/_form.html.haml
@@ -18,10 +18,3 @@
         %br/
         %span.info
           = t("spree.smtp_send_copy_to_this_addresses")
-      .field
-        = label_tag :intercept_email, t("spree.intercept_email_address")
-        %br/
-        = text_field_tag :intercept_email, Spree::Config[:intercept_email], disabled: true, class: 'fullwidth'
-        %br/
-        %span.info
-          = t("spree.intercept_email_instructions")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3759,8 +3759,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     smtp_send_all_emails_as_from_following_address: "Send all mails as from the following address."
     send_copy_of_all_mails_to: "Send Copy of All Mails To"
     smtp_send_copy_to_this_addresses: "Sends a copy of all outgoing mails to this address. For multiple addresses, separate with commas."
-    intercept_email_address: "Intercept Email Address"
-    intercept_email_instructions: "Override email recipient and replace with this address."
 
     tax_categories: "Tax Categories"
     listing_tax_categories: "Listing Tax Categories"

--- a/lib/spree/core/mail_interceptor.rb
+++ b/lib/spree/core/mail_interceptor.rb
@@ -8,11 +8,6 @@ module Spree
   module Core
     class MailInterceptor
       def self.delivering_email(message)
-        if Config[:intercept_email].present?
-          message.subject = "#{message.to} #{message.subject}"
-          message.to = Config[:intercept_email]
-        end
-
         return if Config[:mail_bcc].blank?
 
         message.bcc ||= Config[:mail_bcc]

--- a/spec/lib/spree/core/mail_interceptor_spec.rb
+++ b/spec/lib/spree/core/mail_interceptor_spec.rb
@@ -34,38 +34,5 @@ describe Spree::OrderMailer do
       @email = ActionMailer::Base.deliveries.first
       expect(@email.bcc).to eq ["bcc-foo@foobar.com"]
     end
-
-    context "when intercept_email is provided" do
-      it "should strip the bcc recipients" do
-        expect(message.bcc).to be_blank
-      end
-
-      it "should strip the cc recipients" do
-        expect(message.cc).to be_blank
-      end
-
-      it "should replace the receipient with the specified address" do
-        Spree::Config[:intercept_email] = "intercept@foobar.com"
-        message.deliver_now
-        @email = ActionMailer::Base.deliveries.first
-        expect(@email.to).to eq ["intercept@foobar.com"]
-      end
-
-      it "should modify the subject to include the original email" do
-        Spree::Config[:intercept_email] = "intercept@foobar.com"
-        message.deliver_now
-        @email = ActionMailer::Base.deliveries.first
-        expect(@email.subject).to include order.distributor.contact.email
-      end
-    end
-
-    context "when intercept_mode is not provided" do
-      it "should not modify the recipient" do
-        Spree::Config[:intercept_email] = ""
-        message.deliver_now
-        @email = ActionMailer::Base.deliveries.first
-        expect(@email.to).to eq [order.distributor.contact.email]
-      end
-    end
   end
 end

--- a/spec/services/mail_configuration_spec.rb
+++ b/spec/services/mail_configuration_spec.rb
@@ -21,7 +21,6 @@ describe MailConfiguration do
       expect(Spree::Config).to have_received(:[]=).with(:secure_connection_type, "None")
       expect(Spree::Config).to have_received(:[]=).with(:mails_from, "no-reply@example.com")
       expect(Spree::Config).to have_received(:[]=).with(:mail_bcc, "")
-      expect(Spree::Config).to have_received(:[]=).with(:intercept_email, "")
     end
 
     it 'initializes the mail settings' do

--- a/spec/system/admin/configuration/mail_methods_spec.rb
+++ b/spec/system/admin/configuration/mail_methods_spec.rb
@@ -16,7 +16,6 @@ describe "Mail Methods" do
     it "only allows changing the mails_from setting" do
       fill_in 'mails_from', with: 'ofn@example.com'
       fill_in 'mail_bcc', with: 'bcc@example.com'
-      expect(page).to have_field('intercept_email', disabled: true)
 
       click_button 'Update'
       expect(page).to have_content('successfully updated!')


### PR DESCRIPTION

#### What? Why?


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This option came from Spree and we never used it. The config input field is disabled in the admin interface and I checked our managed databases.

I don't think that we will want this feature in the future either. Staging sends unmodified emails which is more realistic and we haven't had a use case to intercept those emails. There's still the BCC option if we need additional access.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Place an order.
- Check that you receive the order confirmation.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
