### PR TITLE
Admin, Add unregistered user: Fix a reflex-morph issue that lead to a HTML escaping error

### DIFF
--- a/app/views/admin/enterprises/form/_add_new_unregistered_manager.html.haml
+++ b/app/views/admin/enterprises/form/_add_new_unregistered_manager.html.haml
@@ -1,22 +1,21 @@
-%div#add_manager_modal
-  %form{ "data-reflex": "submit->InviteManager#invite", "data-reflex-serialize-form": true }
-    .margin-bottom-30.text-center
-      .text-big
-        = t('js.admin.modals.invite_title')
+%form#add_manager_modal{ 'data-reflex': 'submit->InviteManager#invite', 'data-reflex-serialize-form': true }
+  .margin-bottom-30.text-center
+    .text-big
+      = t('js.admin.modals.invite_title')
 
+  - if success
+    %p.alert-box.ok= t('user_invited', email: email)
+
+  - if error
+    %p.alert-box.error= error
+
+  = text_field_tag :email, nil, class: 'fullwidth margin-bottom-20'
+  = hidden_field_tag :enterprise_id, @enterprise&.id || enterprise.id
+
+  .modal-actions
     - if success
-      %p.alert-box.ok= t('user_invited', email: email)
-
-    - if error
-      %p.alert-box.error= error
-
-    = text_field_tag :email, nil, class: 'fullwidth margin-bottom-20'
-    = hidden_field_tag :enterprise_id, @enterprise&.id || enterprise.id
-
-    .modal-actions
-      - if success
-        %input{ class: "button icon-plus secondary", type: 'button', value: t('js.admin.modals.close'), "data-action": "click->help-modal#close" }
-      - else
-        %input{ class: "button icon-plus secondary", type: 'button', value: t('js.admin.modals.cancel'), "data-action": "click->help-modal#close" }
-        = submit_tag "#{t('js.admin.modals.invite')}"
-      
+      %input{ class: "button icon-plus secondary", type: 'button', value: t('js.admin.modals.close'), "data-action": "click->help-modal#close" }
+    - else
+      %input{ class: "button icon-plus secondary", type: 'button', value: t('js.admin.modals.cancel'), "data-action": "click->help-modal#close" }
+      = submit_tag "#{t('js.admin.modals.invite')}"
+    


### PR DESCRIPTION

#### What? Why?
Morph the form itself instead of morphing a parent DOM element, this seems to avoid HTML parsing error.
- Closes #10743 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

1. As an admin, go to `/admin/enterprises/ENTERPRISE_SLUG/edit#/users_panel`
2. Click on `Add an unregistered user` bouton, modal opens
3. In the modal, submit the form (with no email, email already registered, 
4. You should not see html `data-reflex='submit-InviteManager#invite'>` in plain text in the top of the modal
<img width="729" alt="Capture d’écran 2023-04-26 à 17 41 42" src="https://user-images.githubusercontent.com/296452/234629207-9601d9d3-7a52-4c84-a105-1181eba3c1ef.png">

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 