### PR TITLE
Preserve encoding of stored reports

### DIFF
--- a/app/models/report_blob.rb
+++ b/app/models/report_blob.rb
@@ -31,6 +31,6 @@ class ReportBlob < ActiveStorage::Blob
   end
 
   def result
-    @result ||= download
+    @result ||= download.force_encoding(Encoding::UTF_8)
   end
 end

--- a/spec/models/report_blob_spec.rb
+++ b/spec/models/report_blob_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: false
+
+require 'spec_helper'
+
+describe ReportBlob, type: :model do
+  it "preserves UTF-8 content" do
+    blob = ReportBlob.create_for_upload_later!("customers.html")
+    content = "This works. ✓"
+
+    expect do
+      blob.store(content)
+      content = blob.result
+    end.to_not change { content.encoding }.from(Encoding::UTF_8)
+  end
+end


### PR DESCRIPTION


#### What? Why?

- Closes #10758 <!-- Insert issue number here. -->

Active Storage reads stored strings as ASCII and that can clash with Rails' default UTF-8 encoding when special characters are present.
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Find a staging server that fails with master, e.g. au-staging
- Activate background reports.
- Render an On Screen report.
- It should display as normal.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
