### PR TITLE
Remove `data-hook` attributes

### DIFF
--- a/app/assets/javascripts/admin/spree/orders/shipments.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/shipments.js.erb
@@ -15,7 +15,7 @@ $(document).ready(function() {
       console.log(msg);
     });
   }
-  $('[data-hook=admin_order_edit_form] a.ship').click(handle_ship_click);
+  $('.admin-order-edit-form a.ship').click(handle_ship_click);
 
   //handle shipping method edit click
   $('a.edit-method').click(toggleMethodEdit);
@@ -37,7 +37,7 @@ $(document).ready(function() {
       console.log(msg);
     });
   }
-  $('[data-hook=admin_order_edit_form] a.save-method').click(handle_shipping_method_save);
+  $('.admin-order-edit-form a.save-method').click(handle_shipping_method_save);
 
   //handle tracking info edit/delete
 
@@ -64,8 +64,8 @@ $(document).ready(function() {
     return Spree.url( Spree.routes.orders_api + "/" + order_number + "/shipments/" + shipmentNumber + ".json");
   }
 
-  $('[data-hook=admin_order_edit_form] a.save-tracking').click(saveTrackingInfo);
-  $('[data-hook=admin_order_edit_form] a.delete-tracking').click(deleteTrackingInfo);
+  $('.admin-order-edit-form a.save-tracking').click(saveTrackingInfo);
+  $('.admin-order-edit-form a.delete-tracking').click(deleteTrackingInfo);
 
   // handle note edit/delete
 
@@ -96,8 +96,8 @@ $(document).ready(function() {
     }); 
   }
 
-  $('[data-hook=admin_order_edit_form] a.save-note').click(saveNote);
-  $('[data-hook=admin_order_edit_form] a.delete-note').click(deleteNote);
+  $('.admin-order-edit-form a.save-note').click(saveNote);
+  $('.admin-order-edit-form a.delete-note').click(deleteNote);
 
   // Makes API call for notes/tracking info
   makeApiCall = function(url, params) {

--- a/app/views/admin/contents/edit.html.haml
+++ b/app/views/admin/contents/edit.html.haml
@@ -8,6 +8,6 @@
     - @preference_sections.each do |preference_section|
       = render 'fieldset', name: preference_section[:name], preferences: preference_section[:preferences]
 
-    .form-buttons.filter-actions.actions{"data-hook" => "buttons"}
+    .form-buttons.filter-actions.actions
       = button t(:update), 'icon-refresh'
       = link_to_with_icon 'icon-remove', t(:cancel), main_app.edit_admin_contents_path, class: 'button'

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -10,7 +10,7 @@
         %col{style: "width: 18%;"}/
       %col{style: "width: 25%;"}/
     %thead
-      %tr{"data-hook" => "enterprises_header"}
+      %tr
         %th= t('.name')
         %th= t('.role')
         - if spree_current_user.admin?
@@ -32,7 +32,7 @@
           %td= enterprise_form.check_box :visible, {}, 'public', 'hidden'
           - if spree_current_user.admin?
             %td= enterprise_form.select :owner_id, enterprise.users.map{ |e| [ e.email, e.id ] }, {}, class: "select2 fullwidth"
-          %td{"data-hook" => "admin_users_index_row_actions"}
+          %td
             = render 'actions', enterprise: enterprise
       - if @enterprises.empty?
         %tr

--- a/app/views/admin/invoice_settings/edit.html.haml
+++ b/app/views/admin/invoice_settings/edit.html.haml
@@ -20,5 +20,5 @@
     = check_box_tag 'preferences[enterprise_number_required_on_invoices?]', '1',  Spree::Config[:enterprise_number_required_on_invoices?]
     = label_tag nil, t('.enterprise_number_required_on_invoices?')
 
-  .form-buttons{"data-hook" => "buttons"}
+  .form-buttons
     = button t(:update), 'icon-refresh'

--- a/app/views/admin/matomo_settings/edit.html.haml
+++ b/app/views/admin/matomo_settings/edit.html.haml
@@ -23,5 +23,5 @@
     = preference_field_tag("preferences[#{:matomo_tag_manager_url}]", Spree::Config[:matomo_tag_manager_url], type: Spree::Config.preference_type(:matomo_tag_manager_url))
     .warning.note= t('.config_instructions_tag_manager_html')
 
-  .form-buttons{"data-hook" => "buttons"}
+  .form-buttons
     = button t(:update), 'icon-refresh'

--- a/app/views/admin/producer_properties/_form.html.haml
+++ b/app/views/admin/producer_properties/_form.html.haml
@@ -1,12 +1,12 @@
 %fieldset.no-border-top
-  .add_producer_properties{"data-hook" => "add_producer_properties"}
+  .add_producer_properties
   = image_pack_tag 'spinner.gif', :plugin => 'spree', :style => 'display:none;', :id => 'busy_indicator'
-  %table.index.sortable{"data-hook" => "", "data-sortable-link" => main_app.update_positions_admin_enterprise_producer_properties_url(@enterprise)}
+  %table.index.sortable{"data-sortable-link" => main_app.update_positions_admin_enterprise_producer_properties_url(@enterprise)}
     %thead
-      %tr{"data-hook" => "producer_properties_header"}
+      %tr
         %th{colspan: "2"}= t('admin.products.properties.property_name')
         %th= t('admin.description')
         %th.actions
-    %tbody#producer_properties{"data-hook" => ""}
+    %tbody#producer_properties
       = f.fields_for :producer_properties do |pp_form|
         = render 'admin/producer_properties/producer_property_fields', f: pp_form

--- a/app/views/admin/producer_properties/_producer_property_fields.html.haml
+++ b/app/views/admin/producer_properties/_producer_property_fields.html.haml
@@ -1,5 +1,5 @@
 -# admin/admin.js.erb in spree requires id to start with "spree_" for sortable tables
-%tr.product_property.fields{"data-hook" => "producer_property", id: "spree_#{dom_id(f.object)}"}
+%tr.product_property.fields{id: "spree_#{dom_id(f.object)}"}
   %td.no-border
     %span.handle
     = f.hidden_field :id

--- a/app/views/admin/shared/_enterprises_sub_menu.html.haml
+++ b/app/views/admin/shared/_enterprises_sub_menu.html.haml
@@ -1,5 +1,5 @@
 - content_for :sub_menu do
-  %ul#sub_nav.inline-menu{"data-hook" => "admin_enterprise_sub_tabs"}
+  %ul#sub_nav.inline-menu
     = tab :enterprises, url: main_app.admin_enterprises_path
     = tab :enterprise_relationships, url: main_app.admin_enterprise_relationships_path
     - if ENV["OPENID_APP_ID"].present? && ENV["OPENID_APP_SECRET"].present?

--- a/app/views/admin/shared/_users_sub_menu.html.haml
+++ b/app/views/admin/shared/_users_sub_menu.html.haml
@@ -1,4 +1,4 @@
 - content_for :sub_menu do
-  %ul#sub_nav.inline-menu{"data-hook" => "admin_user_sub_tabs"}
+  %ul#sub_nav.inline-menu
     = tab :users, url: spree.admin_users_path
     = tab :roles, url: main_app.admin_enterprise_roles_path, match_path: '/enterprise_roles'

--- a/app/views/admin/stripe_connect_settings/edit.html.haml
+++ b/app/views/admin/stripe_connect_settings/edit.html.haml
@@ -14,7 +14,7 @@
           = f.label :stripe_connect_enabled, t('.stripe_connect_enabled')
           = f.check_box :stripe_connect_enabled, disabled: disabled
     .row
-      .twelve.columns.alpha.omega.form-buttons{"data-hook" => "buttons"}
+      .twelve.columns.alpha.omega.form-buttons
         = button t(:update), 'icon-refresh', value: "update"
 
 %fieldset.no-border-bottom

--- a/app/views/admin/subscriptions/_review.html.haml
+++ b/app/views/admin/subscriptions/_review.html.haml
@@ -77,7 +77,7 @@
               %td.price.align-center {{ item.price_estimate | localizeCurrency }}
               %td.quantity {{ item.quantity }}
               %td.total.align-center {{ (item.price_estimate * item.quantity) | localizeCurrency }}
-          %tbody#subtotal.no-border-top{"data-hook" => "admin_order_form_subtotal"}
+          %tbody#subtotal.no-border-top
             %tr#subtotal-row
               %td{:colspan => "3"}
                 %b
@@ -85,7 +85,7 @@
                   \:
               %td.total.align-center
                 %span {{ subscription.estimatedSubtotal() | localizeCurrency }}
-          %tbody#order-total.grand-total.no-border-top{"data-hook" => "admin_order_form_total"}
+          %tbody#order-total.grand-total.no-border-top
             %tr
               %td{:colspan => "3"}
                 %b

--- a/app/views/admin/subscriptions/_subscription_line_items.html.haml
+++ b/app/views/admin/subscriptions/_subscription_line_items.html.haml
@@ -25,7 +25,7 @@
       %td.total.align-center {{ (item.price_estimate * item.quantity) | localizeCurrency }}
       %td.actions
         %a.delete-item.icon-trash.no-text{ ng: { click: 'removeSubscriptionLineItem(item)'}, :href => "javascript:void(0)" }
-  %tbody#subtotal.no-border-top{"data-hook" => "admin_order_form_subtotal"}
+  %tbody#subtotal.no-border-top
     %tr#subtotal-row
       %td{:colspan => "3"}
         %b
@@ -43,7 +43,7 @@
       %td.total.align-center
         %span#order_fees {{ subscription.estimatedFees() | localizeCurrency }}
       %td.actions
-  %tbody#order-total.grand-total.no-border-top{"data-hook" => "admin_order_form_total"}
+  %tbody#order-total.grand-total.no-border-top
     %tr
       %td{:colspan => "3"}
         %b

--- a/app/views/spree/admin/adjustments/_adjustments_table.html.haml
+++ b/app/views/spree/admin/adjustments/_adjustments_table.html.haml
@@ -1,5 +1,5 @@
-%table.index{"data-hook" => "adjustments"}
-  %thead{"data-hook" => "adjustmment_head"}
+%table.index
+  %thead
     %tr
       %th= "#{t('spree.date')}/#{t('spree.time')}"
       %th= t(:description)
@@ -15,7 +15,7 @@
       - taxable = adjustment.adjustable_type == "Spree::Shipment" ? adjustment.adjustable : adjustment
       - tr_class = cycle('odd', 'even')
       - tr_id = spree_dom_id(adjustment)
-      %tr{:class => tr_class, "data-hook" => "adjustment_row", :id => tr_id}
+      %tr{:class => tr_class, :id => tr_id}
         %td.align-center.created_at
           = pretty_time(adjustment.created_at)
         %td.align-center.label

--- a/app/views/spree/admin/adjustments/_form.html.haml
+++ b/app/views/spree/admin/adjustments/_form.html.haml
@@ -1,4 +1,4 @@
-.row{"data-hook" => "admin_adjustment_form_fields"}
+.row
   - if @adjustment.new_record?
     = render 'new_form', f: f
   - else

--- a/app/views/spree/admin/adjustments/edit.html.haml
+++ b/app/views/spree/admin/adjustments/edit.html.haml
@@ -14,6 +14,6 @@
 = form_for @adjustment, :url => admin_order_adjustment_path(@order, @adjustment), :method => :put do |f|
   %fieldset.no-border-top
     = render :partial => 'form', :locals => { :f => f }
-    .filter-actions.actions{"data-hook" => "buttons"}
+    .filter-actions.actions
       = button Spree.t(:continue), 'icon-arrow-right'
       = link_to_with_icon 'icon-remove', Spree.t('actions.cancel'), admin_order_adjustments_url(@order), :class => 'button'

--- a/app/views/spree/admin/adjustments/new.html.haml
+++ b/app/views/spree/admin/adjustments/new.html.haml
@@ -13,6 +13,6 @@
 = form_for @adjustment, :url => admin_order_adjustments_path do |f|
   %fieldset.no-border-top
     = render :partial => 'form', :locals => { :f => f }
-    .filter-actions.actions{"data-hook" => "buttons"}
+    .filter-actions.actions
       = button Spree.t(:continue), 'icon-arrow-right'
       = button_link_to Spree.t('actions.cancel'), admin_order_adjustments_url(@order), :icon => 'icon-remove'

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -5,7 +5,7 @@
   = Spree.t(:general_settings)
 
 = form_tag admin_general_settings_path, :method => :put do
-  #preferences{"data-hook" => ""}
+  #preferences
 
     %fieldset.general.no-border-top
       - @preferences_general.each do |key|
@@ -85,6 +85,6 @@
                 = preference_field_tag("available_units[#{unit}]", selected, { type: :boolean, selected: selected })
                 = label_tag(unit, unit.downcase) + tag(:br)
 
-      .form-buttons.filter-actions.actions{"data-hook" => "buttons"}
+      .form-buttons.filter-actions.actions
         = button Spree.t('actions.update'), 'icon-refresh'
         = link_to_with_icon 'icon-remove', Spree.t('actions.cancel'), edit_admin_general_settings_url, :class => 'button'

--- a/app/views/spree/admin/orders/_add_product.html.haml
+++ b/app/views/spree/admin/orders/_add_product.html.haml
@@ -1,13 +1,13 @@
 = render :partial => "spree/admin/variants/autocomplete", :formats => :js
 
-#add-line-item{"data-hook" => ""}
+#add-line-item
   %fieldset.no-border-bottom
     %legend{:align => "center"}= Spree.t(:add_product)
 
     - if @order.canceled?
       = t(".cannot_add_item_to_canceled_order")
     - else
-      .field.nine.columns.alpha{"data-hook" => "add_product_name"}
+      .field.nine.columns.alpha
         = label_tag :add_variant_id, Spree.t(:name_or_sku)
         = hidden_field_tag :add_variant_id, "", :class => "variant_autocomplete fullwidth"
       .five.columns.omega

--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -1,4 +1,4 @@
-%div{"data-hook" => "admin_orders_index_search"}
+%div.admin-orders-index-search
   = form_tag spree.admin_orders_url, {name: "orders_form", "ng-submit" => "fetchResults()"} do
     .field-block.alpha.four.columns
       .date-range-filter.field

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -1,4 +1,4 @@
-%div{"data-hook" => "admin_order_form_fields"}
+%div.admin-order-form-fields
   - if @line_item.try(:errors).present?
     = render :partial => 'spree/shared/error_messages', :locals => { :target => @line_item }
 
@@ -13,7 +13,7 @@
   = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => order_adjustments_for_display(@order), :title => t(".order_adjustments")}
 
   - if order.line_items.exists?
-    %fieldset#order-total.no-border-bottom{"data-hook" => "order_details_total"}
+    %fieldset#order-total.no-border-bottom.order-details-total
       %legend{ align: 'center' }= t(".order_total")
       %span.order-total= order.display_total
 

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -1,6 +1,6 @@
 %div{ :id => "shipment_#{shipment.id}" }
   %fieldset.no-border-bottom
-    %legend.stock-location{ :align => "center", "data-hook" => "stock-location" }
+    %legend.stock-location{ :align => "center" }
       %span.shipment-number
         = shipment.number
       = "-"
@@ -10,7 +10,7 @@
         = "-"
         = link_to t(:ship), '#', :class => 'ship button icon-arrow-right', :data => { 'shipment-number' => shipment.number }
 
-  %table.stock-contents.index{ "data-hook" => "stock-contents" }
+  %table.stock-contents.index
     %colgroup
       %col{ :style => "width: 10%;" }
       %col{ :style => "width: 30%;" }
@@ -28,7 +28,7 @@
         = Spree.t(:quantity)
       %th.force-rounded-right
         = Spree.t(:total)
-      %th.orders-actions.actions{ "data-hook" => "admin_order_form_line_items_header_actions" }
+      %th.orders-actions.actions
 
     %tbody{ "data-shipment-number" => "#{shipment.number}", "data-order-number" => "#{order.number}" }
       = render 'spree/admin/orders/shipment_manifest', order: order, shipment: shipment

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -17,7 +17,7 @@
       %td.item-total.align-center
         = line_item_shipment_price(line_item, item.quantity)
 
-      %td.cart-item-delete.actions{ "data-hook" => "cart_item_delete" }
+      %td.cart-item-delete.actions
         - if shipment.can_modify? && can?(:update, shipment)
           .flex
             = link_to '', '#', :class => 'save-item icon_link icon-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => t('actions.save'), :style => 'display: none'

--- a/app/views/spree/admin/orders/customer_details/_form.html.haml
+++ b/app/views/spree/admin/orders/customer_details/_form.html.haml
@@ -1,19 +1,19 @@
-%fieldset.no-border-top{"data-hook" => "admin_customer_detail_form_fields"}
-  %fieldset.index.no-border-bottom{"data-hook" => "customer_guest"}
+%fieldset.no-border-top
+  %fieldset.index.no-border-bottom
     %legend{:align => "center"}= Spree.t(:account)
-    .row{"data-hook" => "customer_fields"}
+    .row
       .alpha.eight.columns.fullwidth
         .field
           = f.label :email, Spree.t(:email) + ':'
           = f.email_field :email, :class => 'fullwidth'
 
-  .alpha.eight.columns{"data-hook" => "bill_address_wrapper"}
+  .alpha.eight.columns
     %fieldset.no-border-bottom
       %legend{:align => "center"}= Spree.t(:billing_address)
       = f.fields_for :bill_address do |ba_form|
         = render :partial => 'address_form', :locals => { :f => ba_form, :name => Spree.t(:billing_address), :use_billing => false }
 
-  .omega.eight.columns{"data-hook" => "ship_address_wrapper"}
+  .omega.eight.columns
     %fieldset.no-border-bottom
       %legend{:align => "center"}= Spree.t(:shipping_address)
       = f.fields_for :ship_address do |sa_form|
@@ -21,7 +21,7 @@
 
   .clear
 
-  .form-buttons.filter-actions.actions{"data-hook" => "buttons"}
+  .form-buttons.filter-actions.actions
     = button Spree.t('actions.update'), 'icon-refresh'
 
   - content_for :head do

--- a/app/views/spree/admin/orders/customer_details/edit.html.haml
+++ b/app/views/spree/admin/orders/customer_details/edit.html.haml
@@ -12,7 +12,7 @@
   %li= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 
 - if @order.cart? || @order.address?
-  #select-customer{"data-hook" => ""}
+  #select-customer
     %fieldset.no-border-bottom
       %legend{:align => "center"}= Spree.t(:customer_search)
       - content_for :main_ng_app_name do

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -15,7 +15,7 @@
 = render partial: "spree/admin/shared/order_page_title"
 = render partial: "spree/admin/shared/order_tabs", locals: { current: 'Order Details' }
 
-%div{"data-hook" => "admin_order_edit_header"}
+%div
   -# Suppress errors when manually creating a new order - needs to proceed to edit page
   -# without having line items (which otherwise gives a validation error)
   - unless params["suppress_error_msg"]
@@ -31,5 +31,5 @@
       .no-objects-found
         = Spree.t(:your_order_is_empty_add_product)
 
-    %div{"data-hook" => "admin_order_edit_form"}
+    %div.admin-order-edit-form
       = render :partial => 'form', :locals => { :order => @order }

--- a/app/views/spree/admin/product_properties/_product_property_fields.html.haml
+++ b/app/views/spree/admin/product_properties/_product_property_fields.html.haml
@@ -1,4 +1,4 @@
-%tr.product_property.fields{"data-hook" => "product_property", id: "spree_#{dom_id(f.object)}"}
+%tr.product_property.fields{id: "spree_#{dom_id(f.object)}"}
   %td.no-border
     %span.handle
     = f.hidden_field :id

--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -1,4 +1,4 @@
-%div{"data-hook" => "admin_product_form_fields"}
+%div.admin-product-form-fields
   .left.twelve.columns.alpha
     = f.field_container :name do
       = f.label :name, raw(t(:name) + content_tag(:span, ' *', :class => 'required'))

--- a/app/views/spree/admin/products/_seo_form.html.haml
+++ b/app/views/spree/admin/products/_seo_form.html.haml
@@ -1,4 +1,4 @@
-.row{"data-hook" => "admin_product_meta_form"}
+.row
   .alpha.eleven.columns
     = f.field_container :meta_keywords do
       = f.label :meta_keywords, t('admin.products.seo.product_search_keywords')

--- a/app/views/spree/admin/products/index/_header.html.haml
+++ b/app/views/spree/admin/products/index/_header.html.haml
@@ -2,7 +2,7 @@
   = t('.title')
 
 - content_for :page_actions do
-  %div{ :class => "toolbar", 'data-hook' => "toolbar" }
+  %div{ :class => "toolbar" }
     %ul{ :class => "actions header-action-links inline-menu" }
       %li#new_product_link
         = button_link_to t(:new_product), new_object_url, { :icon => 'icon-plus', :id => 'admin_new_product' }

--- a/app/views/spree/admin/shipping_categories/_form.html.haml
+++ b/app/views/spree/admin/shipping_categories/_form.html.haml
@@ -1,9 +1,9 @@
-%div{"data-hook" => "admin_shipping_category_form_fields"}
-  .field.align-center{"data-hook" => "name"}
+%div
+  .field.align-center
     = label_tag Spree.t(:name)
     %br/
     = f.text_field :name
 
-  .field.align-center{"data-hook" => "name"}
+  .field.align-center
     = f.label :temperature_controlled, t(:temperature_controlled)
     = f.check_box :temperature_controlled

--- a/app/views/spree/admin/shipping_categories/index.html.haml
+++ b/app/views/spree/admin/shipping_categories/index.html.haml
@@ -12,14 +12,14 @@
     %col{:style => "width: 85%"}/
     %col{:style => "width: 15%"}/
   %thead
-    %tr{"data-hook" => "categories_header"}
+    %tr
       %th= Spree.t(:name)
       %th
         = t(:temperature_controlled)
       %th.actions
   %tbody
     - @shipping_categories.each do |shipping_category|
-      %tr{:class => "#{cycle('odd', 'even')}", "data-hook" => "category_row", :id => "#{spree_dom_id shipping_category}"}
+      %tr{:class => "#{cycle('odd', 'even')}", :id => "#{spree_dom_id shipping_category}"}
         %td{:style => "width:350px;"}= shipping_category.name
         %td.align-center
           = shipping_category.temperature_controlled ? t(:yes) : t(:no)

--- a/app/views/spree/admin/tax_categories/index.html.haml
+++ b/app/views/spree/admin/tax_categories/index.html.haml
@@ -15,7 +15,7 @@
     %col{style: "width: 15%"}/
     %col{style: "width: 15%"}/
   %thead
-    %tr{"data-hook" => "tax_header"}
+    %tr
       %th= t("spree.name")
       %th= t("spree.description")
       %th= t("spree.default")

--- a/app/views/spree/admin/tax_settings/edit.html.haml
+++ b/app/views/spree/admin/tax_settings/edit.html.haml
@@ -5,10 +5,10 @@
 
 = form_tag admin_tax_settings_path, :method => :put do
 
-  .field.align-center{ "data-hook" => "products_require_tax_category" }
+  .field.align-center
     = hidden_field_tag 'preferences[products_require_tax_category]', '0'
     = check_box_tag 'preferences[products_require_tax_category]', '1',  Spree::Config[:products_require_tax_category]
     = label_tag nil, t(:products_require_tax_category)
 
-  .form-buttons{"data-hook" => "buttons"}
+  .form-buttons
     = button t(:update), 'icon-refresh'

--- a/app/views/spree/admin/users/edit.html.haml
+++ b/app/views/spree/admin/users/edit.html.haml
@@ -3,15 +3,15 @@
 - content_for :page_actions do
   %li
     = button_link_to t(".back_to_users_list"), spree.admin_users_path, icon: "icon-arrow-left"
-%fieldset.alpha.ten.columns{"data-hook" => "admin_user_edit_general_settings"}
+%fieldset.alpha.ten.columns
   %legend= t(".general_settings")
-  %div{"data-hook" => "admin_user_edit_form_header"}
+  %div
     = render partial: "spree/shared/error_messages", locals: { target: @user }
-  %div{"data-hook" => "admin_user_edit_form"}
+  %div
     = form_for [:admin, @user] do |f|
       = render "email_confirmation" unless @user.confirmed?
       = render partial: "form", locals: { f: f }
-      %div{"data-hook" => "admin_user_edit_form_button"}
+      %div
         = render partial: "spree/admin/shared/edit_resource_links"
 
 = render partial: 'spree/admin/users/api_fields'

--- a/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -29,7 +29,7 @@
 <script type='text/template' id='variant_autocomplete_stock_template'>
   <fieldset>
     <legend align="center"><%= Spree.t(:select_stock) %></legend>
-      <table class="stock-levels" data-hook="stock-levels">
+      <table class="stock-levels">
         <colgroup>
           <col style="width: 60%;" />
           <col style="width: 30%;" />

--- a/app/views/spree/admin/variants/new.html.haml
+++ b/app/views/spree/admin/variants/new.html.haml
@@ -3,7 +3,7 @@
 = admin_inject_available_units
 
 = form_for [:admin, @product, @variant], :url => admin_product_variants_path(@product, @url_filters) do |f|
-  %fieldset{'data-hook' => "admin_variant_new_form"}
+  %fieldset
     %legend{align: "center"}= t('.new_variant')
     = render partial: 'form', locals: { f: f }
 

--- a/app/views/spree/layouts/_admin_body.html.haml
+++ b/app/views/spree/layouts/_admin_body.html.haml
@@ -2,7 +2,7 @@
 = render "layouts/i18n_script"
 = yield :stripe_js
 
-#wrapper{ data: { hook: '' } }
+#wrapper
   .flash-container
     - if flash[:error]
       .flash.error= flash[:error]
@@ -15,27 +15,27 @@
 
   = render partial: "spree/layouts/admin/progress_spinner"
 
-  %header#header{"data-hook" => ""}
+  %header#header
     .container
-      %figure.columns.five{"data-hook" => "logo-wrapper"}
+      %figure.columns.five
         = link_to image_tag(Spree::Config[:admin_interface_logo], :id => 'logo'), spree.admin_dashboard_path
-      %nav.columns.eleven{"data-hook" => "admin_login_navigation_bar"}
+      %nav.columns.eleven.admin-login-navigation-bar
         = render :partial => 'spree/layouts/admin/login_nav'
 
-  %nav#admin-menu{ data: { hook: '' }}
+  %nav#admin-menu
     .container.no-gutter
       .sixteen.columns.main-menu-wrapper
-        %ul.inline-menu{"data-hook" => "admin_tabs"}
+        %ul.inline-menu
           = render :partial => 'spree/admin/shared/tabs'
 
   - if content_for?(:sub_menu)
-    %nav#sub-menu{ data: { hook: ''} }
+    %nav#sub-menu
       .container
         .sixteen.columns
           = yield :sub_menu
 
   - if content_for?(:page_title) || content_for?(:page_actions)
-    .js-admin-section-header.admin__section-header{ data: { hook: '' } }
+    .js-admin-section-header.admin__section-header
       .container
         .sixteen.columns
           .admin__section-header__content
@@ -44,16 +44,16 @@
                 %h1.js-admin-page-title= yield :page_title
 
             - if content_for?(:page_actions)
-              %ul.admin__section-header__actions{ data: { hook: 'toolbar' } }
+              %ul.admin__section-header__actions
                 = yield :page_actions
 
   .container
     .row
       - content_class = content_for?(:sidebar) ? "with-sidebar" : ""
-      #content{:class => content_class, "data-hook" => ""}
+      #content{:class => content_class}
         - if content_for?(:table_filter)
           - table_filter_class = content_for?(:sidebar) ? 'twelve columns' : 'sixteen columns'
-          #table-filter{:class => table_filter_class, "data-hook" => ""}
+          #table-filter{:class => table_filter_class}
             %fieldset
               %legend{:align => "center"}= yield :table_filter_title
               = yield :table_filter
@@ -61,13 +61,11 @@
         %div{:class => div_class}
           = yield
         - if content_for?(:sidebar)
-          %aside#sidebar.four.columns{"data-hook" => ""}
+          %aside#sidebar.four.columns
             - if content_for?(:sidebar_title)
               %h5.sidebar-title
                 %span= yield :sidebar_title
             = yield :sidebar
-
-%div{"data-hook" => "admin_footer_scripts"}
 
 %script
   = raw "Spree.api_key = \"#{spree_current_user.try(:spree_api_key).to_s}\";"

--- a/app/views/spree/layouts/admin.html.haml
+++ b/app/views/spree/layouts/admin.html.haml
@@ -1,6 +1,6 @@
 !!!
 %html{:lang => "en", "ng-csp": "no-unsafe-eval" }
-  %head{"data-hook" => "admin_inside_head"}
+  %head
     = render :partial => 'spree/admin/shared/head'
 
   %body.admin{ "class": ("admin-v2" if feature?(:admin_style_v2, spree_current_user)) }

--- a/app/views/spree/layouts/admin/_login_nav.html.haml
+++ b/app/views/spree/layouts/admin/_login_nav.html.haml
@@ -1,14 +1,14 @@
 - if spree_current_user
   %ul#login-nav.inline-menu
-    %li{"data-hook" => "user-logged-in-as"}
+    %li.user-logged-in-as
       = t(:logged_in_as)
       \: #{spree_current_user.email}
-    %li{"data-hook" => "user-account-link"}
+    %li
       %i.icon-user
       = link_to t(:account), account_path
-    %li{"data-hook" => "user-logout-link"}
+    %li
       %i.icon-signout
       = link_to t(:logout), logout_path
-    %li{"data-hook" => "store-frontend-link"}
+    %li
       %i.icon-external-link
       = link_to t(".header.store"), main_app.root_path, target: "_blank"

--- a/app/views/spree/layouts/bare_admin.html.haml
+++ b/app/views/spree/layouts/bare_admin.html.haml
@@ -1,7 +1,7 @@
 %html{ lang: "en", "ng-csp": "no-unsafe-eval" }
-  %head{"data-hook" => "admin_inside_head"}= render :partial => 'spree/admin/shared/head'
+  %head= render :partial => 'spree/admin/shared/head'
   %body.admin{"data-ajax-root-path" => main_app.root_path}
-    #wrapper{"data-hook" => ""}
+    #wrapper
       - if flash[:error]
         .flash.error= flash[:error]
       - if notice
@@ -10,16 +10,16 @@
         .flash.success= flash[:success]
       = render partial: "spree/layouts/admin/progress_spinner"
 
-      %header#header{"data-hook" => ""}
+      %header#header
         .container
-          %figure.columns.five{"data-hook" => "logo-wrapper"}
+          %figure.columns.five
             = link_to image_tag(Spree::Config[:admin_interface_logo], id: 'logo'), spree.admin_dashboard_path
-          %nav.columns.eleven{"data-hook" => "admin_login_navigation_bar"}
+          %nav.columns.eleven.admin-login-navigation-bar
             = render partial: "spree/layouts/admin/login_nav"
 
       .container
         .row
-          #content{"data-hook" => ""}
+          #content
             %div{:class => "sixteen columns"}
               = yield
-    %div{"data-hook" => "admin_footer_scripts"}
+    %div

--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -2,21 +2,21 @@
 
 .row
   .columns.large-12
-    %table#cart-detail{"data-hook" => ""}
+    %table#cart-detail
       %col{halign: "left", valign: "middle", width: "60%"}/
       %col{halign: "left", valign: "middle", width: "15%"}/
       %col{halign: "center", valign: "middle", width: "10%"}/
       %col{halign: "center", valign: "middle", width: "10%"}/
       %col{halign: "center", valign: "middle", width: "5%"}/
       %thead
-        %tr{"data-hook" => "cart_items_headers"}
+        %tr
           %th.cart-item-description-header= t(:item)
           %th.cart-item-price-header.text-right= t(:price)
           %th.text-center.cart-item-quantity-header= t(:qty)
           %th.cart-item-total-header.text-right= t(:total)
           %th.cart-item-delete-header
 
-      %tbody#line_items{"data-hook" => ""}
+      %tbody#line_items
         = render partial: 'line_item', collection: order_form.object.line_items, locals: {order_form: order_form}
 
       = render 'bought' if show_bought_items? && !@order.complete?

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -1,9 +1,9 @@
 - variant = line_item.variant
 = order_form.fields_for :line_items, line_item do |item_form|
   %tr.line-item{class: "variant-#{variant.id}"}
-    %td.cart-item-description{'data-hook' => "cart_item_description"}
+    %td.cart-item-description
 
-      %div.item-thumb-image{"data-hook" => "cart_item_image"}
+      %div.item-thumb-image
         = render 'spree/shared/variant_thumbnail', variant: variant
 
       = render 'spree/shared/line_item_name', line_item: line_item
@@ -18,21 +18,21 @@
           = t(".unavailable_item")
           %br/
 
-    %td.text-right.cart-item-price{"data-hook" => "cart_item_price"}
+    %td.text-right.cart-item-price
       = line_item.single_display_amount_with_adjustments.to_html
       %br
       %span.unit-price
         = line_item.unit_price_price_and_unit
-    %td.text-center.cart-item-quantity{"data-hook" => "cart_item_quantity"}
+    %td.text-center.cart-item-quantity
       - finalized_quantity = @order.completed? ? line_item.quantity : 0
       = item_form.number_field :quantity,
         :min => 0, "ofn-on-hand" => "#{variant.on_demand && 9999 || variant.on_hand}",
         "finalizedquantity" => finalized_quantity, :class => "line_item_quantity", :size => 5,
         "ng-model" => "line_item_#{line_item.id}",
         "validate-stock-quantity" => true
-    %td.cart-item-total.text-right{"data-hook" => "cart_item_total"}
+    %td.cart-item-total.text-right
       = line_item.display_amount_with_adjustments.to_html unless line_item.quantity.nil?
 
-    %td.cart-item-delete.text-center{"data-hook" => "cart_item_delete"}
+    %td.cart-item-delete.text-center
       %a.delete{href: "#", id: "delete_#{dom_id(line_item)}"}
         %i.delete.ofn-i_026-trash

--- a/app/views/spree/orders/_summary.html.haml
+++ b/app/views/spree/orders/_summary.html.haml
@@ -1,31 +1,30 @@
 - display_footer = true if display_footer.nil?
 
-%table#line-items{"data-hook" => "order_details"}
+%table#line-items
   %col{valign: "middle"}/
   %col{halign: "center", valign: "middle", width: "5%"}/
   %col{halign: "center", valign: "middle", width: "5%"}/
   %col{halign: "center", valign: "middle", width: "5%"}/
-  %thead{"data-hook" => ""}
-    %tr{"data-hook" => "order_details_line_items_headers"}
+  %thead
+    %tr
       %th= t(:item)
       %th.price= t(:price)
       %th.text-center.qty= t(:qty)
       %th.text-right.total
         %span= t(:total)
-  %tbody{"data-hook" => ""}
+  %tbody
     - order.line_items.sorted_by_name_and_unit_value.each do |item|
-      %tr.line_item{"data-hook" => "order_details_line_item_row", class: "variant-#{item.variant.id}" }
-        %td(data-hook = "order_item_description")
-
-          %div.item-thumb-image{"data-hook" => "order_item_image"}
+      %tr.line_item{ class: "variant-#{item.variant.id}" }
+        %td
+          %div.item-thumb-image
             = render 'spree/shared/variant_thumbnail', variant: item.variant
 
           = render 'spree/shared/line_item_name', line_item: item
 
-        %td.text-right.price{"data-hook" => "order_item_price"}
+        %td.text-right.price
           %span= item.single_display_amount_with_adjustments.to_html
-        %td.text-center{"data-hook" => "order_item_qty"}= item.quantity
-        %td.text-right.total{"data-hook" => "order_item_total"}
+        %td.text-center= item.quantity
+        %td.text-right.total
           %span= item.display_amount_with_adjustments.to_html
 
   = render partial: "spree/orders/totals_footer", locals: { order: order } if display_footer

--- a/app/views/spree/orders/_totals_footer.html.haml
+++ b/app/views/spree/orders/_totals_footer.html.haml
@@ -1,5 +1,5 @@
 %tfoot
-  #subtotal{"data-hook" => "order_details_subtotal"}
+  #subtotal
     %tr#subtotal-row.total
       %td.text-right{colspan: "3"}
         %strong
@@ -7,7 +7,7 @@
       %td.text-right.total
         %span= display_checkout_subtotal(order)
 
-  #order-charges{"data-hook" => "order_details_adjustments"}
+  #order-charges
     - checkout_adjustments_for(order, exclude: [:line_item]).reverse_each do |adjustment|
       %tr.total
         %td.text-right{:colspan => "3"}
@@ -16,7 +16,7 @@
         %td.text-right.total
           %span= adjustment.display_amount.to_html
 
-  #order-total{"data-hook" => "order_details_total"}
+  #order-total.order-details-total
     %tr.total
       %td.text-right{colspan: "3"}
         %h5
@@ -25,7 +25,7 @@
         %h5#order_total= order.display_total.to_html
 
   - if order.total_tax > 0
-    #tax{"data-hook" => "order_details_tax"}
+    #tax
       %tr#tax-row.total
         %td.text-right{colspan: "3"}
           = t :order_includes_tax

--- a/app/views/spree/orders/edit.html.haml
+++ b/app/views/spree/orders/edit.html.haml
@@ -27,16 +27,16 @@
 
   #cart-container
     - if @order.line_items.empty?
-      %div.row{"data-hook" => "empty_cart"}
+      %div.row
         %p= t(:your_cart_is_empty)
         %p= link_to t(:continue_shopping), current_shop_products_path, :class => 'button continue'
 
     - else
-      %div{"data-hook" => "outside_cart_form"}
+      %div
         = form_for @order, :url => main_app.update_cart_path,
           :html => {id: 'update-cart', name: "form", "ng-controller"=> 'CartFormCtrl'} do |order_form|
-          %div{"data-hook" => "inside_cart_form"}
-            %div{"data-hook" => "cart_items"}
+          %div
+            %div
               .row
                 = render :partial => 'form', :locals => { :order_form => order_form }
 

--- a/app/views/spree/orders/form/_cart_actions_row.html.haml
+++ b/app/views/spree/orders/form/_cart_actions_row.html.haml
@@ -6,5 +6,5 @@
       = t(:orders_form_update_cart)
   %td
   %td#empty-cart.text-center
-    %span#clear_cart_link{"data-hook" => ""}
+    %span#clear_cart_link
       = link_to t(:orders_form_empty_cart), main_app.empty_cart_path, method: :put, :class => 'not-bold small'

--- a/app/views/spree/orders/form/_cart_links.html.haml
+++ b/app/views/spree/orders/form/_cart_links.html.haml
@@ -1,4 +1,4 @@
-.row.links{'data-hook' => "cart_buttons"}
+.row.links
   %a.continue-shopping.button.secondary{href: current_shop_products_path, "ng-disabled" => "#{@insufficient_stock_lines.any?}", "disable-dynamically" => true}
     = t :orders_edit_continue
   %a#checkout-link.button.primary.right{href: main_app.checkout_path, "ng-disabled" => "#{@insufficient_stock_lines.any?}", "disable-dynamically" => true}

--- a/app/views/spree/orders/show.html.haml
+++ b/app/views/spree/orders/show.html.haml
@@ -7,7 +7,7 @@
 .darkswarm
   = render "shopping_shared/header" if current_distributor.present?
 
-  %fieldset#order_summary.footer-pad{"data-hook" => ""}
+  %fieldset#order_summary.footer-pad
     .row
       .columns.large-12.text-center
         %h2
@@ -21,7 +21,7 @@
               = t(:orders_show_confirmed)
               %i.ofn-i_051-check-big
 
-    #order{"data-hook" => ""}
+    #order
       - if params.has_key? :checkout_complete
         %h1= t(:thank_you_for_your_order)
 

--- a/app/views/spree/users/show.html.haml
+++ b/app/views/spree/users/show.html.haml
@@ -13,7 +13,7 @@
     .small-12.columns.pad-top
       %h2
         = accurate_title
-        %span.account-summary{"data-hook" => "account_summary"}
+        %span.account-summary
           = @user.email
 
     = render 'orders'

--- a/app/webpacker/css/admin/components/navigation.scss
+++ b/app/webpacker/css/admin/components/navigation.scss
@@ -35,7 +35,7 @@ nav.menu {
   }
 }
 
-[data-hook="admin_login_navigation_bar"] {
+.admin-login-navigation-bar {
   ul {
     text-align: right;
 
@@ -46,7 +46,7 @@ nav.menu {
       color: $color-link;
       margin-top: 8px;
 
-      &[data-hook="user-logged-in-as"] {
+      &.user-logged-in-as {
         width: 50%;
         color: $color-body-text;
       }

--- a/app/webpacker/css/admin/sections/orders.scss
+++ b/app/webpacker/css/admin/sections/orders.scss
@@ -1,5 +1,5 @@
 // Customize orders filter
-[data-hook="admin_orders_index_search"] {
+.admin-orders-index-search {
   select[data-placeholder="Status"] {
     width: 100%;
   }
@@ -10,7 +10,7 @@
 }
 
 // Order-total
-[data-hook="order_details_total"]{
+.order-details-total {
   text-align: center;
 
   .order-total {
@@ -20,7 +20,7 @@
   }
 }
 
-[data-hook="admin_order_form_fields"] {
+.admin-order-form-fields {
   legend.stock-location {
     color: $color-body-text;
 

--- a/app/webpacker/css/admin/sections/products.scss
+++ b/app/webpacker/css/admin/sections/products.scss
@@ -1,4 +1,4 @@
-[data-hook="admin_product_form_fields"] {
+.admin-product-form-fields {
   label {
     display: inline-block;
   }

--- a/app/webpacker/css/admin/shared/layout.scss
+++ b/app/webpacker/css/admin/shared/layout.scss
@@ -83,8 +83,6 @@
 
 #logo { height: 40px }
 
-[data-hook="admin-title"] { font-size: 14px }
-
 .page-title {
   i {
     color: $color-2;

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -81,9 +81,7 @@ describe '
     select2_select product.name, from: 'add_variant_id', search: true
     find('button.add_variant').click
     # Wait for JS
-    page.has_selector?(
-      "table.index tbody[data-hook='admin_order_form_line_items'] tr"
-    )
+    page.has_selector?("table.index tbody tr")
     expect(page).to have_selector 'td', text: product.name
 
     click_button 'Update'
@@ -153,9 +151,7 @@ describe '
 
     find('button.add_variant').click
     # Wait for JS
-    page.has_selector?(
-      "table.index tbody[data-hook='admin_order_form_line_items'] tr"
-    )
+    page.has_selector?("table.index tbody tr td")
     expect(page).to have_selector 'td', text: product.name
     expect(order.line_items.reload.map(&:product)).to include product
   end
@@ -465,7 +461,7 @@ describe '
 
     select2_select product.name, from: 'add_variant_id', search: true
     find('button.add_variant').click
-    page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr" # Wait for JS
+    page.has_selector? "table.index tbody tr" # Wait for JS
   end
 
   context "as an enterprise manager" do
@@ -849,7 +845,7 @@ different_shipping_method_for_distributor1]
       select2_select product.name, from: 'add_variant_id', search: true
 
       find('button.add_variant').click
-      page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr"
+      page.has_selector? "table.index tbody tr"
       expect(page).to have_selector 'td', text: product.name
 
       expect(page).to have_select2 'order_distributor_id', with_options: [distributor1.name]

--- a/spec/system/admin/variants_spec.rb
+++ b/spec/system/admin/variants_spec.rb
@@ -136,9 +136,6 @@ describe '
 
       page.find('table.index .icon-edit').click
 
-      # Then I should not see a traditional option value field for the unit-related option value
-      expect(page).to have_no_selector "div[data-hook='presentation'] input"
-
       # And I should see unit value and description fields for the unit-related option value
       expect(page).to have_field "unit_value_human", with: "1"
       expect(page).to have_field "variant_unit_description", with: "foo"


### PR DESCRIPTION
#### What? Why?

Removes 130 or so `data-hook` attributes scattered all over the view layer. These were used for "overrides" in the old Spree templating system that no longer exists in the codebase.

:broom: 


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

