### PR TITLE
Improve query logging in development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,6 +5,8 @@
 #
 #     cp .env.development .env.local
 
+VERBOSE_QUERY_LOGS=true
+
 SECRET_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 OFN_REDIS_URL="redis://localhost:6379/1"

--- a/Gemfile
+++ b/Gemfile
@@ -178,6 +178,7 @@ group :development do
   gem 'foreman'
   gem 'listen'
   gem 'pry', '~> 0.13.0'
+  gem 'query_count'
   gem 'rails-erd'
   gem 'rubocop'
   gem 'rubocop-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -487,6 +487,9 @@ GEM
     public_suffix (5.0.1)
     puma (6.2.2)
       nio4r (~> 2.0)
+    query_count (1.1.1)
+      activerecord (>= 4.2)
+      railties (>= 4.2)
     raabro (1.4.0)
     racc (1.6.2)
     rack (2.2.7)
@@ -857,6 +860,7 @@ DEPENDENCIES
   private_address_check
   pry (~> 0.13.0)
   puma
+  query_count
   rack-mini-profiler (< 3.0.0)
   rack-rewrite
   rack-timeout

--- a/config/application.rb
+++ b/config/application.rb
@@ -221,6 +221,9 @@ module Openfoodnetwork
     config.assets.precompile += ['shared/*']
     config.assets.precompile += ['*.jpg', '*.jpeg', '*.png', '*.gif' '*.svg']
 
+    # Highlight code that triggered database queries in logs.
+    config.active_record.verbose_query_logs = ENV.fetch("VERBOSE_QUERY_LOGS", false)
+
     # Apply framework defaults. New recommended defaults are successively added with each Rails version and
     # include the defaults from previous versions. For more info see:
     # https://guides.rubyonrails.org/configuring.html#results-of-config-load-defaults


### PR DESCRIPTION
#### What? Why?

A little PR that introduces a couple of small changes to logging output (in `development` only).

`verbose_query_logging` is a new Rails 7 feature which tells you which line of code is responsible for each database query. It looks like this:

![Screenshot from 2023-04-28 14-38-56](https://user-images.githubusercontent.com/9029026/235164307-23c3ba73-ba8d-4d15-841f-93f35539aa39.png)

`query_count` is a gem that adds a summary of how many queries and cached queries were executed over the course of each request, it looks like this:

![Screenshot from 2023-04-28 14-32-50](https://user-images.githubusercontent.com/9029026/235164636-6ebe583e-3a61-4b6d-9fd2-0e3dda2036ac.png)

These additions don't really add any overhead, but they're incredibly useful for debugging and performance work. :muscle: 

Could be enabled in `staging` environments as well, if that's useful for testers?

#### What should we test?

Have a look at the logs in dev :)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
