### PR TITLE
Improve `Permissions::Order#visible_line_items` querying

### DIFF
--- a/app/services/permissions/order.rb
+++ b/app/services/permissions/order.rb
@@ -31,9 +31,7 @@ module Permissions
     end
 
     def visible_line_items
-      Spree::LineItem
-        .where(id: editable_line_items.select(:id))
-        .or(Spree::LineItem.where(id: produced_line_items.select("spree_line_items.id")))
+      editable_line_items.or(produced_line_items)
     end
 
     # Any line items that I can edit

--- a/app/services/permissions/order.rb
+++ b/app/services/permissions/order.rb
@@ -31,9 +31,9 @@ module Permissions
     end
 
     def visible_line_items
-      Spree::LineItem.where(id:
-        editable_line_items.select(:id) |
-        produced_line_items.select("spree_line_items.id"))
+      Spree::LineItem
+        .where(id: editable_line_items.select(:id))
+        .or(Spree::LineItem.where(id: produced_line_items.select("spree_line_items.id")))
     end
 
     # Any line items that I can edit


### PR DESCRIPTION
#### What? Why?

Converts `Permissions::Order#visible_line_items` to a nicer `ActiveRecord::Relation` with an `or` query.

Notes:

This change looks insignificant but the result of converting this into a nice relation instead of two queries stuck together with the pipe operator (`|`) can make a huge difference when chaining this into other subqueries. The final result set is ultimately the same, but the queries can be built without first returning all the ids and then sticking those ids in an array. This can have a significant positive impact in cases where `#editable_line_items` or `#produced_line_items` are large sets, both in terms of speed and memory allocations.

#### What should we test?

Not sure there's any manual testing required, I think the entire test suite will explode if this method is not working 100% correctly.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
