### PR TITLE
Delay adding taxes on enterprise fees until checkout

### DIFF
--- a/app/services/order_fees_handler.rb
+++ b/app/services/order_fees_handler.rb
@@ -21,7 +21,7 @@ class OrderFeesHandler
       create_order_fees!
     end
 
-    tax_enterprise_fees!
+    tax_enterprise_fees! unless order.state.in?(["cart", "address", "delivery"])
     order.update_order!
   end
 

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -355,6 +355,7 @@ module Spree
 
         context "when enterprise fees have a fixed tax_category" do
           before do
+            order.update(state: "payment")
             order.recreate_all_fees!
           end
 
@@ -440,6 +441,11 @@ module Spree
                                       calculator: ::Calculator::FlatRate.new(preferred_amount: 50.0))
             }
 
+            before do
+              order.update(state: "payment")
+              order.create_tax_charge!
+            end
+
             describe "when the tax rate includes the tax in the price" do
               it "records no tax on the enterprise fee adjustments" do
                 # EnterpriseFee tax category is nil and inheritance only applies to per item fees
@@ -453,7 +459,7 @@ module Spree
             describe "when the tax rate does not include the tax in the price" do
               before do
                 product_tax_rate.update_attribute :included_in_price, false
-                order.reload.recreate_all_fees!
+                order.recreate_all_fees!
               end
 
               it "records the no tax on TaxRate adjustment on the order" do
@@ -470,6 +476,11 @@ module Spree
               create(:enterprise_fee, enterprise: coordinator, inherits_tax_category: true,
                                       calculator: ::Calculator::PerItem.new(preferred_amount: 50.0))
             }
+
+            before do
+              order.update(state: "payment")
+              order.create_tax_charge!
+            end
 
             describe "when the tax rate includes the tax in the price" do
               it "records the correct amount in a tax adjustment" do

--- a/spec/system/consumer/shopping/cart_spec.rb
+++ b/spec/system/consumer/shopping/cart_spec.rb
@@ -174,18 +174,6 @@ describe "full-page cart" do
       end
     end
 
-    describe "tax" do
-      before do
-        add_enterprise_fee enterprise_fee
-        add_product_to_cart order, product_with_tax
-        visit main_app.cart_path
-      end
-
-      it "shows the total tax for the order, including product tax and tax on fees" do
-        expect(page).to have_selector '.tax-total', text: '11.00' # 10 + 1
-      end
-    end
-
     describe "updating quantities" do
       let(:li) { order.line_items.reload.last }
       let(:variant) { product_with_tax.variants.first }


### PR DESCRIPTION
#### What? Why?

Defers calculating taxes on enterprise fees for items in the cart until checkout. This change was waiting for split checkout to be merged. It improves the performance and response times on the `CartController#populate` endpoint, which is in the top 5 endpoints that use the most processing power by CPU/volume. In most cases is should be almost twice as fast.


#### What should we test?


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
