### PR TITLE
Allow the order total to be equal to 0

### DIFF
--- a/spec/models/spree/order/checkout_spec.rb
+++ b/spec/models/spree/order/checkout_spec.rb
@@ -34,7 +34,7 @@ describe Spree::Order::Checkout do
 
     context "#checkout_steps" do
       context "when payment not required" do
-        before { allow(order).to receive_messages payment_required?: false }
+        before { allow(order).to receive_messages skip_payment_for_subscription?: true }
         specify do
           expect(order.checkout_steps).to eq %w(address delivery complete)
         end
@@ -109,7 +109,7 @@ describe Spree::Order::Checkout do
 
       context "without payment required" do
         before do
-          allow(order).to receive_messages payment_required?: false
+          allow(order).to receive_messages skip_payment_for_subscription?: true
         end
 
         it "transitions to complete" do


### PR DESCRIPTION
#### What? Why?
The aim of this PR is to not check the total of an order before going to `payment` state for an order. This is a side effect of the split checkout: order with total equals to 0 can't go to next step (from `details` to `payment`)


- Closes #10787 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
- As a producer, sells product at 0
- As a consumer, add this product to cart
- Check that you can order product (with different payment methods), even if total order is equal to 0

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
