### PR TITLE
BOM: when deleting the last item of order that leads to order cancellation, take into account the restock items checkbox

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -121,16 +121,16 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     else
       StatusMessage.display 'failure', t "unsaved_changes_error"
 
-  $scope.cancelOrder = (order, sendEmailCancellation) ->
+  $scope.cancelOrder = (order, sendEmailCancellation, restock_items) ->
     return $http(
       method: 'GET'
-      url: "/admin/orders/#{order.number}/fire?e=cancel&send_cancellation_email=#{sendEmailCancellation}")
+      url: "/admin/orders/#{order.number}/fire?e=cancel&send_cancellation_email=#{sendEmailCancellation}&restock_items=#{restock_items}")
   
   $scope.deleteLineItem = (lineItem) ->
     if lineItem.order.item_count == 1
-      ofnCancelOrderAlert((confirm, sendEmailCancellation) ->
+      ofnCancelOrderAlert((confirm, sendEmailCancellation, restock_items) ->
         if confirm
-          $scope.cancelOrder(lineItem.order, sendEmailCancellation).then(->
+          $scope.cancelOrder(lineItem.order, sendEmailCancellation, restock_items).then(->
             $scope.refreshData()
           )
         else
@@ -152,11 +152,11 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
       willCancelOrders = true if (order.item_count == itemsPerOrder.get(order).length)
 
     if willCancelOrders
-      ofnCancelOrderAlert((confirm, sendEmailCancellation) ->
+      ofnCancelOrderAlert((confirm, sendEmailCancellation, restock_items) ->
         if confirm
           itemsPerOrder.forEach (items, order) =>
             if order.item_count == items.length
-              $scope.cancelOrder(order, sendEmailCancellation).then(-> $scope.refreshData())
+              $scope.cancelOrder(order, sendEmailCancellation, restock_items).then(-> $scope.refreshData())
             else
               Promise.all(LineItems.delete(item) for item in items).then(-> $scope.refreshData())
       , "js.admin.deleting_item_will_cancel_order")   

--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -100,6 +100,7 @@ adjustItems = function(shipment_number, variant_id, quantity, restock_item){
         doAdjustItems(shipment_number, variant_id, quantity, inventory_units, restock_item, () => {
           var redirectTo = new URL(Spree.routes.cancel_order.toString());
           redirectTo.searchParams.append("send_cancellation_email", sendEmailCancellation);
+          redirectTo.searchParams.append("restock_item", restock_item);
           window.location.href = redirectTo.toString();
         });
       }


### PR DESCRIPTION

#### What? Why?

- Closes #10770

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Well explained in the linked issues:

1. On BOM page delete a line item which is the last remaining one of an order.
2. On the popup de-select the option to restock the items.
3. Check the 'on stock' amount of that product and see that it has increased by the number of items which have been cancelled.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes