### PR TITLE
Remove unknown (deleted) feature toggles at boot

### DIFF
--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -9,6 +9,7 @@ module OpenFoodNetwork
   module FeatureToggle
     # Please add your new feature here to appear in the Flipper UI.
     # We way move this to a YAML file when it becomes too awkward.
+    # **WARNING:** Features not in this list will be removed.
     CURRENT_FEATURES = {
       "admin_style_v2" => <<~DESC,
         Change some colour and layout in the backend to a newer version.
@@ -45,23 +46,14 @@ module OpenFoodNetwork
       DESC
     }.freeze
 
-    # Move your feature entry from CURRENT_FEATURES to RETIRED_FEATURES when
-    # you remove it from the code. It will then be deleted from the database.
-    #
-    # We may delete this field one day and regard all features not listed in
-    # CURRENT_FEATURES as unsupported and remove them. But until this approach
-    # is accepted we delete only the features listed here.
-    RETIRED_FEATURES = {}.freeze
-
     def self.setup!
       CURRENT_FEATURES.each_key do |name|
         feature = Flipper.feature(name)
         feature.add unless feature.exist?
       end
 
-      RETIRED_FEATURES.each_key do |name|
-        feature = Flipper.feature(name)
-        feature.remove if feature.exist?
+      Flipper.features.each do |feature|
+        feature.remove unless CURRENT_FEATURES.key?(feature.name)
       end
     end
 

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -2,17 +2,17 @@
 
 require 'spec_helper'
 
-module OpenFoodNetwork
-  describe FeatureToggle do
-    context 'when users are not specified' do
-      it "returns false when feature is undefined" do
-        expect(FeatureToggle.enabled?(:foo)).to be false
-      end
+describe OpenFoodNetwork::FeatureToggle do
+  subject(:feature_toggle) { OpenFoodNetwork::FeatureToggle }
 
-      it "uses Flipper configuration" do
-        Flipper.enable(:foo)
-        expect(FeatureToggle.enabled?(:foo)).to be true
-      end
+  context 'when users are not specified' do
+    it "returns false when feature is undefined" do
+      expect(feature_toggle.enabled?(:foo)).to be false
+    end
+
+    it "uses Flipper configuration" do
+      Flipper.enable(:foo)
+      expect(feature_toggle.enabled?(:foo)).to be true
     end
   end
 end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -15,4 +15,21 @@ describe OpenFoodNetwork::FeatureToggle do
       expect(feature_toggle.enabled?(:foo)).to be true
     end
   end
+
+  describe ".setup!" do
+    it "created all current features at boot time" do
+      expect(Flipper.features.count)
+        .to eq feature_toggle::CURRENT_FEATURES.count
+    end
+
+    it "adds any missing features" do
+      pending "We don't have features to test with at the moment." if Flipper.features.empty?
+
+      feature = Flipper.features.first
+      feature.remove
+
+      expect { feature_toggle.setup! }
+        .to change { Flipper.features }.by([feature])
+    end
+  end
 end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -31,5 +31,14 @@ describe OpenFoodNetwork::FeatureToggle do
       expect { feature_toggle.setup! }
         .to change { Flipper.features }.by([feature])
     end
+
+    it "removes unknown features" do
+      feature = Flipper.feature(:foo)
+      feature.enable
+
+      expect { feature_toggle.setup! }
+        .to change { Flipper.features.count }.by(-1)
+        .and change { feature.exist? }.to(false)
+    end
   end
 end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -18,8 +18,8 @@ describe OpenFoodNetwork::FeatureToggle do
 
   describe ".setup!" do
     it "created all current features at boot time" do
-      expect(Flipper.features.count)
-        .to eq feature_toggle::CURRENT_FEATURES.count
+      expect(Flipper.features.map(&:name))
+        .to match_array feature_toggle::CURRENT_FEATURES.keys
     end
 
     it "adds any missing features" do


### PR DESCRIPTION
#### What? Why?

This came up in:
- https://github.com/openfoodfoundation/openfoodnetwork/pull/10779#discussion_r1183194816

##### Introducing auto-cleaning to feature toggles

When we removed feature toggles in the past, we needed a database migration to remove it from the admin interface. But since all current features are listed in the code, we can assume that all features not listed are old or temporary and can be removed safely.
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

**Before deploy:**

- Visit /admin/feature-toggle/features
- Delete some features.
- Add some fictional features.
- **Deploy this pull request.**
- Visit /admin/feature-toggle/features
- The list should reflect all the current features without additions or deletions.

:bell: **Notice for testers:** From now on, if a branch contains a new feature toggle, it will be added when you stage that branch but it will be removed when you stage another branch. So any special configuration of that toggle, for examples for which users it's activated for, will be lost when deploying another branch. We briefly discussed that in a Delivery Circle meeting and the consensus was that this is actually desired behaviour.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

The following PR assumes that we have auto-deletion already:

* #10779

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
