### PR TITLE
Use the default webpack configuration for dev env

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -2,7 +2,4 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
 const environment = require('./environment')
 
-const config = environment.toWebpackConfig();
-config.output.filename = "js/[name]-[hash].js";
-
 module.exports = environment.toWebpackConfig()


### PR DESCRIPTION
#### What? Why?
We used to override the output filename but this was a misunderstanding of an error (due to webpacke(r) incompatibles versions)
 - https://medium.com/@web_developer/hash-vs-chunkhash-vs-contenthash-e94d38a32208
 - https://github.com/webpack/webpack.js.org/issues/2096


_Context: https://github.com/openfoodfoundation/openfoodnetwork/pull/10631#pullrequestreview-1410083331_


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Dev test: start servers, change js/css files, check that everything's fine

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
