### PR TITLE
Also remove localized number logic from weight calculator

### DIFF
--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-require 'spree/localized_number'
-
 module Calculator
   class Weight < Spree::Calculator
-    extend Spree::LocalizedNumber
     preference :unit_from_list, :string, default: "kg"
     preference :per_unit, :decimal, default: 0.0
-
-    localize_number :preferred_per_unit
 
     def self.description
       I18n.t('spree.weight')

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -3,8 +3,6 @@
 require 'spec_helper'
 
 describe Calculator::Weight do
-  it_behaves_like "a model using the LocalizedNumber module", [:preferred_per_unit]
-
   it "computes shipping cost for an order by total weight" do
     variant1 = build_stubbed(:variant, unit_value: 10_000)
     variant2 = build_stubbed(:variant, unit_value: 20_000)


### PR DESCRIPTION
#### What? Why?
Addresses comment:
* https://github.com/openfoodfoundation/openfoodnetwork/pull/10329#issuecomment-1533099993

> * We do have the additional 'weight' calculator. This is the only one which is still interpreting the dot as a thousands separator if there are three or more decimals. ➡️ Should be a separate issue.

(I missed this file in the last PR..)

#### What should we test?
As per above comment. I suggest @drummer83 tests this.

#### Release notes

Changelog Category: User facing changes 

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
- https://github.com/openfoodfoundation/openfoodnetwork/pull/10329



#### Documentation updates
I [don't think this is documented](https://guide.openfoodnetwork.org/?q=international+thousand%2Fdecimal+separator+logic) already, so no changes needed.
