### PR TITLE
Admin, Edit customer details for an order: when changing to another customer, update `customer_id` as well

### DIFF
--- a/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -65,6 +65,7 @@ module Spree
           params.require(:order).permit(
             :email,
             :use_billing,
+            :customer_id,
             bill_address_attributes: ::PermittedAttributes::Address.attributes,
             ship_address_attributes: ::PermittedAttributes::Address.attributes
           )

--- a/app/views/spree/admin/orders/customer_details/edit.html.haml
+++ b/app/views/spree/admin/orders/customer_details/edit.html.haml
@@ -24,3 +24,4 @@
 
 = form_for @order, :url => admin_order_customer_url(@order) do |f|
   = render 'form', :f => f
+  = f.hidden_field :customer_id, value: @order.customer_id, id: "customer_id"

--- a/app/webpacker/controllers/select_customer_controller.js
+++ b/app/webpacker/controllers/select_customer_controller.js
@@ -53,6 +53,7 @@ export default class extends TomSelectController {
     });
     $("#order_email").val(customer.email);
     $("#user_id").val(customer.user_id);
+    $("#customer_id").val(customer.id);
   }
 
   setValueOnTomSelectController = (element, value) => {


### PR DESCRIPTION
#### What? Why?

- Closes #10717 

Submitting the customer_id params in the request makes the customer_id to be updated by the controller. 

I'm not sure about the consequences of that change. 


#### What should we test?
From original issue:

1 go to the admin dashboard -> order -> new order
2. select distributor and order cycle
3. click on next
4. select a customer, C1 for example
5. Notice that the email and the addresses will be loaded
6. completed the missing data
7. click on update
8. Select another customer: C2 for example
9. Notice that the email and the addresses will be updated
10. click on update
11. The email and the addresses will be updated, but the customer id will not be replaced! the order will always refer to C1 on the database.

I'm not sure, but maybe it's fine to test https://github.com/openfoodfoundation/openfoodnetwork/pull/9710 also... (I've seen some code responsible to find associate customer to order modified in this PR ; it might be worth testing again...)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
