### PR TITLE
Scope orders before bulk actions

### DIFF
--- a/app/reflexes/bulk_actions_in_orders_list_reflex.rb
+++ b/app/reflexes/bulk_actions_in_orders_list_reflex.rb
@@ -2,7 +2,7 @@
 
 class BulkActionsInOrdersListReflex < ApplicationReflex
   def resend_confirmation_email(order_ids)
-    orders(order_ids).find_each do |o|
+    editable_orders.where(id: order_ids).find_each do |o|
       Spree::OrderMailer.confirm_email_for_customer(o.id, true).deliver_later if can? :resend, o
     end
 
@@ -11,7 +11,7 @@ class BulkActionsInOrdersListReflex < ApplicationReflex
 
   def send_invoice(order_ids)
     count = 0
-    orders(order_ids).find_each do |o|
+    editable_orders.where(id: order_ids).find_each do |o|
       next unless o.distributor.can_invoice? && (o.resumed? || o.complete?)
 
       Spree::OrderMailer.invoice_email(o.id).deliver_later
@@ -29,7 +29,7 @@ class BulkActionsInOrdersListReflex < ApplicationReflex
     morph "#flashes", render(partial: "shared/flashes", locals: { flashes: flash })
   end
 
-  def orders(order_ids)
-    Spree::Order.where(id: order_ids)
+  def editable_orders
+    Permissions::Order.new(current_user).editable_orders
   end
 end

--- a/app/reflexes/cancel_orders_reflex.rb
+++ b/app/reflexes/cancel_orders_reflex.rb
@@ -2,7 +2,7 @@
 
 class CancelOrdersReflex < ApplicationReflex
   def confirm(params)
-    OrdersBulkCancelService.new(params).call
+    OrdersBulkCancelService.new(params, current_user).call
     cable_ready.dispatch_event(name: "modal:close")
     # flash[:success] = Spree.t(:order_updated)
   end

--- a/app/services/orders_bulk_cancel_service.rb
+++ b/app/services/orders_bulk_cancel_service.rb
@@ -1,17 +1,24 @@
 # frozen_string_literal: true
 
 class OrdersBulkCancelService
-  def initialize(params)
+  def initialize(params, current_user)
     @order_ids = params[:order_ids]
+    @current_user = current_user
     @send_cancellation_email = params[:send_cancellation_email]
     @restock_items = params[:restock_items]
   end
 
   def call
-    Spree::Order.where(id: @order_ids).find_each do |order|
+    editable_orders.where(id: @order_ids).find_each do |order|
       order.send_cancellation_email = @send_cancellation_email
       order.restock_items = @restock_items
       order.cancel
     end
+  end
+
+  private
+
+  def editable_orders
+    Permissions::Order.new(@current_user).editable_orders
   end
 end


### PR DESCRIPTION
#### What? Why?

The orders in these actions need to be scoped a bit more carefully... :eyes:

#### What should we test?

As an admin, in the orders page check that you can still: cancel order, resend confirmation email and print invoice in bulk (ie. selecting order(s) with checkbox) mode

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.