### PR TITLE
Fixup order of statements in db schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1190,22 +1190,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_24_141213) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  create_table "vouchers", force: :cascade do |t|
+    t.string "code", limit: 255, null: false
+    t.datetime "expiry_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "enterprise_id"
+    t.index ["code", "enterprise_id"], name: "index_vouchers_on_code_and_enterprise_id", unique: true
+    t.index ["enterprise_id"], name: "index_vouchers_on_enterprise_id"
+  end
+
   create_table "webhook_endpoints", force: :cascade do |t|
     t.string "url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", default: 0, null: false
     t.index ["user_id"], name: "index_webhook_endpoints_on_user_id"
-  end
-
-  create_table "vouchers", force: :cascade do |t|
-    t.string "code", limit: 255, null: false
-    t.datetime "expiry_date"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.bigint "enterprise_id"
-    t.index ["code", "enterprise_id"], name: "index_vouchers_on_code_and_enterprise_id", unique: true
-    t.index ["enterprise_id"], name: "index_vouchers_on_enterprise_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
@@ -1312,6 +1312,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_24_141213) do
   add_foreign_key "subscriptions", "spree_shipping_methods", column: "shipping_method_id", name: "subscriptions_shipping_method_id_fk"
   add_foreign_key "variant_overrides", "enterprises", column: "hub_id", name: "variant_overrides_hub_id_fk"
   add_foreign_key "variant_overrides", "spree_variants", column: "variant_id", name: "variant_overrides_variant_id_fk"
-  add_foreign_key "webhook_endpoints", "spree_users", column: "user_id"
   add_foreign_key "vouchers", "enterprises"
+  add_foreign_key "webhook_endpoints", "spree_users", column: "user_id"
 end


### PR DESCRIPTION

#### What? Why?

- Found while reviewing #10761
- Originally introduced in #10523

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

It looks like the resolution of a merge conflict introduced the wrong ordering of schema statements. Rails wants to sort tables alphabetically and running `./bin/rails db:migrate` on a fresh database altered the schema.rb file. This should be fixed here.

Rails also omits the default setting of `precision: 6` since Rails 7. The vouchers feature was developed during the upgrade to Rails 7.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test. File automatically generated by Rails.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
