### PR TITLE
[Vouchers] Percentage rate

### DIFF
--- a/app/controllers/admin/vouchers_controller.rb
+++ b/app/controllers/admin/vouchers_controller.rb
@@ -9,6 +9,8 @@ module Admin
     end
 
     def create
+      # The use of "safe_constantize" here will trigger a Brakeman error, it can safely be ignored
+      # as it's a false positive : https://github.com/openfoodfoundation/openfoodnetwork/pull/10821
       voucher_type = params[:vouchers_flat_rate][:voucher_type]
       if Voucher::TYPES.include?(voucher_type)
         @voucher = voucher_type.safe_constantize.create(

--- a/app/controllers/admin/vouchers_controller.rb
+++ b/app/controllers/admin/vouchers_controller.rb
@@ -9,13 +9,11 @@ module Admin
     end
 
     def create
-      case params[:vouchers_flat_rate][:voucher_type]
-      when "Vouchers::FlatRate"
-        @voucher =
-          Vouchers::FlatRate.create(permitted_resource_params.merge(enterprise: @enterprise))
-      when "Vouchers::PercentageRate"
-        @voucher =
-          Vouchers::PercentageRate.create(permitted_resource_params.merge(enterprise: @enterprise))
+      voucher_type = params[:vouchers_flat_rate][:voucher_type]
+      if Voucher::TYPES.include?(voucher_type)
+        @voucher = voucher_type.safe_constantize.create(
+          permitted_resource_params.merge(enterprise: @enterprise)
+        )
       else
         @voucher.errors.add(:type)
         return render_error

--- a/app/controllers/admin/vouchers_controller.rb
+++ b/app/controllers/admin/vouchers_controller.rb
@@ -30,7 +30,7 @@ module Admin
     end
 
     def permitted_resource_params
-      params.require(:voucher).permit(:code, :amount)
+      params.require(:voucher).permit(:code, :amount, :voucher_type)
     end
   end
 end

--- a/app/controllers/admin/vouchers_controller.rb
+++ b/app/controllers/admin/vouchers_controller.rb
@@ -9,18 +9,32 @@ module Admin
     end
 
     def create
-      @voucher = Voucher.create(permitted_resource_params.merge(enterprise: @enterprise))
+      case params[:vouchers_flat_rate][:voucher_type]
+      when "Vouchers::FlatRate"
+        @voucher =
+          Vouchers::FlatRate.create(permitted_resource_params.merge(enterprise: @enterprise))
+      when "Vouchers::PercentageRate"
+        @voucher =
+          Vouchers::PercentageRate.create(permitted_resource_params.merge(enterprise: @enterprise))
+      else
+        @voucher.errors.add(:type)
+        return render_error
+      end
 
       if @voucher.save
-        flash[:success] = flash_message_for(@voucher, :successfully_created)
+        flash[:success] = I18n.t(:successfully_created, resource: "Voucher")
         redirect_to edit_admin_enterprise_path(@enterprise, anchor: :vouchers_panel)
       else
-        flash[:error] = @voucher.errors.full_messages.to_sentence
-        render :new
+        render_error
       end
     end
 
     private
+
+    def render_error
+      flash[:error] = @voucher.errors.full_messages.to_sentence
+      render :new
+    end
 
     def load_enterprise
       @enterprise = OpenFoodNetwork::Permissions
@@ -30,7 +44,7 @@ module Admin
     end
 
     def permitted_resource_params
-      params.require(:voucher).permit(:code, :amount, :voucher_type)
+      params.require(:vouchers_flat_rate).permit(:code, :amount)
     end
   end
 end

--- a/app/models/voucher.rb
+++ b/app/models/voucher.rb
@@ -46,4 +46,8 @@ class Voucher < ApplicationRecord
   def compute_amount(_order)
     raise NotImplementedError, 'please use concrete voucher'
   end
+
+  def rate(_order)
+    raise NotImplementedError, 'please use concrete voucher'
+  end
 end

--- a/app/models/voucher.rb
+++ b/app/models/voucher.rb
@@ -31,7 +31,12 @@ class Voucher < ApplicationRecord
   end
 
   def display_value
-    Spree::Money.new(amount)
+    case voucher_type
+    when FLAT_RATE
+      Spree::Money.new(amount)
+    when PERCENTAGE_RATE
+      I18n.t(:voucher_percentage, amount: amount)
+    end
   end
 
   # Ideally we would use `include CalculatedAdjustments` to be consistent with other adjustments,

--- a/app/models/voucher.rb
+++ b/app/models/voucher.rb
@@ -62,6 +62,9 @@ class Voucher < ApplicationRecord
   # We limit adjustment to the maximum amount needed to cover the order, ie if the voucher
   # covers more than the order.total we only need to create an adjustment covering the order.total
   def compute_amount(order)
-    -amount.clamp(0, order.pre_discount_total)
+    return -amount.clamp(0, order.pre_discount_total) if voucher_type == FLAT_RATE
+
+    percentage = amount / 100
+    -percentage * order.pre_discount_total
   end
 end

--- a/app/models/voucher.rb
+++ b/app/models/voucher.rb
@@ -11,32 +11,11 @@ class Voucher < ApplicationRecord
            dependent: :nullify
 
   validates :code, presence: true, uniqueness: { scope: :enterprise_id }
-  validates :amount,
-            presence: true,
-            numericality: { greater_than: 0 },
-            if: ->(v) { v.voucher_type == FLAT_RATE }
-  validates :amount,
-            presence: true,
-            numericality: { greater_than: 0, less_than_or_equal_to: 100 },
-            if: ->(v) { v.voucher_type == PERCENTAGE_RATE }
 
-  FLAT_RATE = 'flat'.freeze
-  PERCENTAGE_RATE = 'percentage'.freeze
-  TYPES = [FLAT_RATE, PERCENTAGE_RATE].freeze
-
-  validates :voucher_type, inclusion: TYPES
+  TYPES = ["Vouchers::FlatRate", "Vouchers::PercentageRate"].freeze
 
   def code=(value)
     super(value.to_s.strip)
-  end
-
-  def display_value
-    case voucher_type
-    when FLAT_RATE
-      Spree::Money.new(amount)
-    when PERCENTAGE_RATE
-      I18n.t(:voucher_percentage, amount: amount)
-    end
   end
 
   # Ideally we would use `include CalculatedAdjustments` to be consistent with other adjustments,
@@ -59,12 +38,12 @@ class Voucher < ApplicationRecord
     order.adjustments.create(adjustment_attributes)
   end
 
-  # We limit adjustment to the maximum amount needed to cover the order, ie if the voucher
-  # covers more than the order.total we only need to create an adjustment covering the order.total
-  def compute_amount(order)
-    return -amount.clamp(0, order.pre_discount_total) if voucher_type == FLAT_RATE
+  # The following method must be overriden in a concrete voucher.
+  def display_value
+    raise NotImplementedError, 'please use concrete voucher'
+  end
 
-    percentage = amount / 100
-    -percentage * order.pre_discount_total
+  def compute_amount(_order)
+    raise NotImplementedError, 'please use concrete voucher'
   end
 end

--- a/app/models/voucher.rb
+++ b/app/models/voucher.rb
@@ -11,7 +11,20 @@ class Voucher < ApplicationRecord
            dependent: :nullify
 
   validates :code, presence: true, uniqueness: { scope: :enterprise_id }
-  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :amount,
+            presence: true,
+            numericality: { greater_than: 0 },
+            if: ->(v) { v.voucher_type == FLAT_RATE }
+  validates :amount,
+            presence: true,
+            numericality: { greater_than: 0, less_than_or_equal_to: 100 },
+            if: ->(v) { v.voucher_type == PERCENTAGE_RATE }
+
+  FLAT_RATE = 'flat'.freeze
+  PERCENTAGE_RATE = 'percentage'.freeze
+  TYPES = [FLAT_RATE, PERCENTAGE_RATE].freeze
+
+  validates :voucher_type, inclusion: TYPES
 
   def code=(value)
     super(value.to_s.strip)

--- a/app/models/vouchers/flat_rate.rb
+++ b/app/models/vouchers/flat_rate.rb
@@ -15,5 +15,11 @@ module Vouchers
     def compute_amount(order)
       -amount.clamp(0, order.pre_discount_total)
     end
+
+    def rate(order)
+      amount = compute_amount(order)
+
+      amount / order.pre_discount_total
+    end
   end
 end

--- a/app/models/vouchers/flat_rate.rb
+++ b/app/models/vouchers/flat_rate.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: false
+
+module Vouchers
+  class FlatRate < Voucher
+    validates :amount,
+              presence: true,
+              numericality: { greater_than: 0 }
+
+    def display_value
+      Spree::Money.new(amount)
+    end
+
+    # We limit adjustment to the maximum amount needed to cover the order, ie if the voucher
+    # covers more than the order.total we only need to create an adjustment covering the order.total
+    def compute_amount(order)
+      -amount.clamp(0, order.pre_discount_total)
+    end
+  end
+end

--- a/app/models/vouchers/percentage_rate.rb
+++ b/app/models/vouchers/percentage_rate.rb
@@ -11,8 +11,11 @@ module Vouchers
     end
 
     def compute_amount(order)
-      percentage = amount / 100
-      -percentage * order.pre_discount_total
+      rate(order) * order.pre_discount_total
+    end
+
+    def rate(_order)
+      -amount / 100
     end
   end
 end

--- a/app/models/vouchers/percentage_rate.rb
+++ b/app/models/vouchers/percentage_rate.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: false
+
+module Vouchers
+  class PercentageRate < Voucher
+    validates :amount,
+              presence: true,
+              numericality: { greater_than: 0, less_than_or_equal_to: 100 }
+
+    def display_value
+      ActionController::Base.helpers.number_to_percentage(amount, precision: 2)
+    end
+
+    def compute_amount(order)
+      percentage = amount / 100
+      -percentage * order.pre_discount_total
+    end
+  end
+end

--- a/app/views/admin/vouchers/new.html.haml
+++ b/app/views/admin/vouchers/new.html.haml
@@ -17,7 +17,11 @@
             = f.text_field :code, class: 'fullwidth'
         .row
           .alpha.four.columns
+            = f.label :voucher_type, t('.voucher_type')
+          .omega.eight.columns
+            = f.select :voucher_type, options_for_select(Voucher::TYPES.map { |type| [t(".#{type}"), type] }, @voucher.voucher_type)
+        .row
+          .alpha.four.columns
             = f.label :amount, t('.voucher_amount')
           .omega.eight.columns
-            = Spree::Money.currency_symbol
             = f.text_field :amount, value: @voucher.amount

--- a/app/views/admin/vouchers/new.html.haml
+++ b/app/views/admin/vouchers/new.html.haml
@@ -19,7 +19,7 @@
           .alpha.four.columns
             = f.label :voucher_type, t('.voucher_type')
           .omega.eight.columns
-            = f.select :voucher_type, options_for_select(Voucher::TYPES.map { |type| [t(".#{type}"), type] }, @voucher.voucher_type)
+            = f.select :voucher_type, options_for_select(Voucher::TYPES.map { |type| [t(".#{type.demodulize.underscore}"), type] }, @voucher.class.to_s)
         .row
           .alpha.four.columns
             = f.label :amount, t('.voucher_amount')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1712,6 +1712,9 @@ en:
         save: Save
         voucher_code: Voucher Code
         voucher_amount: Amount
+        voucher_type: Voucher Type 
+        flat: Flat 
+        percentage: Percentage (%) 
 
     # Admin controllers
     controllers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1713,8 +1713,8 @@ en:
         voucher_code: Voucher Code
         voucher_amount: Amount
         voucher_type: Voucher Type 
-        flat: Flat 
-        percentage: Percentage (%) 
+        flat_rate: Flat 
+        percentage_rate: Percentage (%) 
 
     # Admin controllers
     controllers:

--- a/db/migrate/20230508035306_add_type_to_vouchers.rb
+++ b/db/migrate/20230508035306_add_type_to_vouchers.rb
@@ -1,5 +1,10 @@
 class AddTypeToVouchers < ActiveRecord::Migration[7.0]
-  def change
-    add_column :vouchers, :voucher_type, :string, limit: 255
+  def up
+    # It will set all the vouchers till now to Vouchers::FlatRate
+    add_column :vouchers, :type, :string, limit: 255, null: false, default: "Vouchers::FlatRate"
+  end
+
+  def down
+    remove_column :vouchers, :type
   end
 end

--- a/db/migrate/20230508035306_add_type_to_vouchers.rb
+++ b/db/migrate/20230508035306_add_type_to_vouchers.rb
@@ -1,0 +1,5 @@
+class AddTypeToVouchers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :vouchers, :voucher_type, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1081,6 +1081,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_201542) do
     t.bigint "enterprise_id"
     t.datetime "deleted_at", precision: nil
     t.decimal "amount", precision: 10, scale: 2, default: "0.0", null: false
+    t.string "voucher_type", limit: 255
     t.index ["code", "enterprise_id"], name: "index_vouchers_on_code_and_enterprise_id", unique: true
     t.index ["deleted_at"], name: "index_vouchers_on_deleted_at"
     t.index ["enterprise_id"], name: "index_vouchers_on_enterprise_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,7 +93,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_201542) do
     t.datetime "terms_and_conditions_accepted_at", precision: nil
     t.string "first_name", default: "", null: false
     t.string "last_name", default: "", null: false
-    t.boolean "created_manually", default: false, null: false
+    t.boolean "created_manually", default: false
     t.index ["bill_address_id"], name: "index_customers_on_bill_address_id"
     t.index ["created_manually"], name: "index_customers_on_created_manually"
     t.index ["email"], name: "index_customers_on_email"
@@ -1075,13 +1075,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_201542) do
 
   create_table "vouchers", force: :cascade do |t|
     t.string "code", limit: 255, null: false
-    t.datetime "expiry_date", precision: nil
+    t.datetime "expiry_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "enterprise_id"
     t.datetime "deleted_at", precision: nil
     t.decimal "amount", precision: 10, scale: 2, default: "0.0", null: false
-    t.string "voucher_type", limit: 255
+    t.string "type", limit: 255, default: "Vouchers::FlatRate", null: false
     t.index ["code", "enterprise_id"], name: "index_vouchers_on_code_and_enterprise_id", unique: true
     t.index ["deleted_at"], name: "index_vouchers_on_deleted_at"
     t.index ["enterprise_id"], name: "index_vouchers_on_enterprise_id"

--- a/spec/factories/voucher_factory.rb
+++ b/spec/factories/voucher_factory.rb
@@ -9,4 +9,8 @@ FactoryBot.define do
   factory :voucher_flat_rate, parent: :voucher, class: Vouchers::FlatRate do
     amount { 15 }
   end
+
+  factory :voucher_percentage_rate, parent: :voucher, class: Vouchers::PercentageRate do
+    amount { rand(1..100) }
+  end
 end

--- a/spec/factories/voucher_factory.rb
+++ b/spec/factories/voucher_factory.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :voucher_flat_rate, class: Voucher do
+  factory :voucher, class: Voucher do
     enterprise { build(:distributor_enterprise) }
-    voucher_type { Voucher::FLAT_RATE }
-    amount { 15 }
+    amount { 10 }
   end
 
   factory :voucher_percentage, class: Voucher do

--- a/spec/factories/voucher_factory.rb
+++ b/spec/factories/voucher_factory.rb
@@ -6,9 +6,7 @@ FactoryBot.define do
     amount { 10 }
   end
 
-  factory :voucher_percentage, class: Voucher do
-    enterprise { build(:distributor_enterprise) }
-    voucher_type { Voucher::PERCENTAGE_RATE }
-    amount { rand(1..100) }
+  factory :voucher_flat_rate, parent: :voucher, class: Vouchers::FlatRate do
+    amount { 15 }
   end
 end

--- a/spec/factories/voucher_factory.rb
+++ b/spec/factories/voucher_factory.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :voucher, class: Voucher do
+    code { "new_code" }
     enterprise { build(:distributor_enterprise) }
     amount { 10 }
   end

--- a/spec/factories/voucher_factory.rb
+++ b/spec/factories/voucher_factory.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :voucher do
+  factory :voucher_flat_rate, class: Voucher do
     enterprise { build(:distributor_enterprise) }
+    voucher_type { Voucher::FLAT_RATE }
     amount { 15 }
+  end
+
+  factory :voucher_percentage, class: Voucher do
+    enterprise { build(:distributor_enterprise) }
+    voucher_type { Voucher::PERCENTAGE_RATE }
+    amount { rand(1..100) }
   end
 end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1466,7 +1466,7 @@ describe Spree::Order do
   describe "#voucher_adjustments" do
     let(:distributor) { create(:distributor_enterprise) }
     let(:order) { create(:order, user: user, distributor: distributor) }
-    let(:voucher) { create(:voucher, code: 'new_code', enterprise: order.distributor) }
+    let(:voucher) { create(:voucher_flat_rate, code: 'new_code', enterprise: order.distributor) }
 
     context "when no voucher adjustment" do
       it 'returns an empty array' do

--- a/spec/models/voucher_spec.rb
+++ b/spec/models/voucher_spec.rb
@@ -68,4 +68,13 @@ describe Voucher do
       expect(adjustment.state).to eq("open")
     end
   end
+
+  describe '#rate' do
+    subject(:voucher) { Vouchers::TestVoucher.new(code: 'new_code', enterprise: enterprise) }
+
+    it "raises not implemented error" do
+      expect{ voucher.rate(nil) }
+        .to raise_error(NotImplementedError, 'please use concrete voucher')
+    end
+  end
 end

--- a/spec/models/voucher_spec.rb
+++ b/spec/models/voucher_spec.rb
@@ -2,6 +2,11 @@
 
 require 'spec_helper'
 
+# This is used to test non implemented methods
+module Vouchers
+  class TestVoucher < Voucher; end
+end
+
 describe Voucher do
   let(:enterprise) { build(:enterprise) }
 
@@ -23,51 +28,23 @@ describe Voucher do
 
     it { is_expected.to validate_presence_of(:code) }
     it { is_expected.to validate_uniqueness_of(:code).scoped_to(:enterprise_id) }
-    it { is_expected.to validate_presence_of(:amount) }
-    it { is_expected.to validate_inclusion_of(:voucher_type).in_array(Voucher::TYPES) }
+  end
 
-    context "when voucher_type is flat rate" do
-      it { is_expected.to validate_numericality_of(:amount).is_greater_than(0) }
-    end
+  describe '#display_value' do
+    subject(:voucher) { Vouchers::TestVoucher.new(code: 'new_code', enterprise: enterprise) }
 
-    context "when voucher_type is percentage rate" do
-      subject { build(:voucher_percentage, code: 'new_code', enterprise: enterprise) }
-
-      it do
-        is_expected.to validate_numericality_of(:amount)
-          .is_greater_than(0)
-          .is_less_than_or_equal_to(100)
-      end
+    it "raises not implemented error" do
+      expect{ voucher.display_value }
+        .to raise_error(NotImplementedError, 'please use concrete voucher')
     end
   end
 
   describe '#compute_amount' do
-    let(:order) { create(:order_with_totals) }
+    subject(:voucher) { Vouchers::TestVoucher.new(code: 'new_code', enterprise: enterprise) }
 
-    context 'when order total is more than the voucher' do
-      subject { create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 5) }
-
-      it 'uses the voucher total' do
-        expect(subject.compute_amount(order).to_f).to eq(-5)
-      end
-    end
-
-    context 'when order total is less than the voucher' do
-      subject { create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 20) }
-
-      it 'matches the order total' do
-        expect(subject.compute_amount(order).to_f).to eq(-10)
-      end
-    end
-
-    context "with percentage rate voucher" do
-      subject { create(:voucher_percentage, code: 'new_code', enterprise: enterprise, amount: 10) }
-
-      it 'returns calculated anount based on the percentage' do
-        # -0.1 (10%)  * $10 = $1
-        expected_amount = -0.1 * order.total
-        expect(subject.compute_amount(order).to_f).to eq(expected_amount.to_f)
-      end
+    it "raises not implemented error" do
+      expect{ voucher.compute_amount(nil) }
+        .to raise_error(NotImplementedError, 'please use concrete voucher')
     end
   end
 

--- a/spec/models/voucher_spec.rb
+++ b/spec/models/voucher_spec.rb
@@ -42,12 +42,10 @@ describe Voucher do
   end
 
   describe '#compute_amount' do
-    subject { create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 10) }
-
     let(:order) { create(:order_with_totals) }
 
     context 'when order total is more than the voucher' do
-      subject { create(:voucher, code: 'new_code', enterprise: enterprise, amount: 5) }
+      subject { create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 5) }
 
       it 'uses the voucher total' do
         expect(subject.compute_amount(order).to_f).to eq(-5)
@@ -55,10 +53,20 @@ describe Voucher do
     end
 
     context 'when order total is less than the voucher' do
-      subject { create(:voucher, code: 'new_code', enterprise: enterprise, amount: 20) }
+      subject { create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 20) }
 
       it 'matches the order total' do
         expect(subject.compute_amount(order).to_f).to eq(-10)
+      end
+    end
+
+    context "with percentage rate voucher" do
+      subject { create(:voucher_percentage, code: 'new_code', enterprise: enterprise, amount: 10) }
+
+      it 'returns calculated anount based on the percentage' do
+        # -0.1 (10%)  * $10 = $1
+        expected_amount = -0.1 * order.total
+        expect(subject.compute_amount(order).to_f).to eq(expected_amount.to_f)
       end
     end
   end

--- a/spec/models/vouchers/flat_rate_spec.rb
+++ b/spec/models/vouchers/flat_rate_spec.rb
@@ -3,10 +3,8 @@
 require 'spec_helper'
 
 describe Vouchers::FlatRate do
-  let(:enterprise) { build(:enterprise) }
-
   describe 'validations' do
-    subject { build(:voucher_flat_rate, code: 'new_code', enterprise:) }
+    subject { build(:voucher_flat_rate) }
 
     it { is_expected.to validate_presence_of(:amount) }
     it { is_expected.to validate_numericality_of(:amount).is_greater_than(0) }
@@ -15,8 +13,12 @@ describe Vouchers::FlatRate do
   describe '#compute_amount' do
     let(:order) { create(:order_with_totals) }
 
+    before do
+      order.update_columns(item_total: 15)
+    end
+
     context 'when order total is more than the voucher' do
-      subject { create(:voucher_flat_rate, code: 'new_code', enterprise:, amount: 5) }
+      subject { create(:voucher_flat_rate, amount: 5) }
 
       it 'uses the voucher total' do
         expect(subject.compute_amount(order).to_f).to eq(-5)
@@ -24,19 +26,23 @@ describe Vouchers::FlatRate do
     end
 
     context 'when order total is less than the voucher' do
-      subject { create(:voucher_flat_rate, code: 'new_code', enterprise:, amount: 20) }
+      subject { create(:voucher_flat_rate, amount: 20) }
 
       it 'matches the order total' do
-        expect(subject.compute_amount(order).to_f).to eq(-10)
+        expect(subject.compute_amount(order).to_f).to eq(-15)
       end
     end
   end
 
   describe "#rate" do
     subject do
-      create(:voucher_flat_rate, code: 'new_code', enterprise:, amount: 5)
+      create(:voucher_flat_rate, code: 'new_code', amount: 5)
     end
     let(:order) { create(:order_with_totals) }
+
+    before do
+      order.update_columns(item_total: 10)
+    end
 
     it "returns the voucher rate" do
       # rate = -voucher_amount / order.pre_discount_total

--- a/spec/models/vouchers/flat_rate_spec.rb
+++ b/spec/models/vouchers/flat_rate_spec.rb
@@ -31,4 +31,17 @@ describe Vouchers::FlatRate do
       end
     end
   end
+
+  describe "#rate" do
+    subject do
+      create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 5)
+    end
+    let(:order) { create(:order_with_totals) }
+
+    it "returns the voucher rate" do
+      # rate = -voucher_amount / order.pre_discount_total
+      # -5 / 10 = -0.5
+      expect(subject.rate(order).to_f).to eq(-0.5)
+    end
+  end
 end

--- a/spec/models/vouchers/flat_rate_spec.rb
+++ b/spec/models/vouchers/flat_rate_spec.rb
@@ -6,7 +6,7 @@ describe Vouchers::FlatRate do
   let(:enterprise) { build(:enterprise) }
 
   describe 'validations' do
-    subject { build(:voucher_flat_rate, code: 'new_code', enterprise: enterprise) }
+    subject { build(:voucher_flat_rate, code: 'new_code', enterprise:) }
 
     it { is_expected.to validate_presence_of(:amount) }
     it { is_expected.to validate_numericality_of(:amount).is_greater_than(0) }
@@ -16,7 +16,7 @@ describe Vouchers::FlatRate do
     let(:order) { create(:order_with_totals) }
 
     context 'when order total is more than the voucher' do
-      subject { create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 5) }
+      subject { create(:voucher_flat_rate, code: 'new_code', enterprise:, amount: 5) }
 
       it 'uses the voucher total' do
         expect(subject.compute_amount(order).to_f).to eq(-5)
@@ -24,7 +24,7 @@ describe Vouchers::FlatRate do
     end
 
     context 'when order total is less than the voucher' do
-      subject { create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 20) }
+      subject { create(:voucher_flat_rate, code: 'new_code', enterprise:, amount: 20) }
 
       it 'matches the order total' do
         expect(subject.compute_amount(order).to_f).to eq(-10)
@@ -34,7 +34,7 @@ describe Vouchers::FlatRate do
 
   describe "#rate" do
     subject do
-      create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 5)
+      create(:voucher_flat_rate, code: 'new_code', enterprise:, amount: 5)
     end
     let(:order) { create(:order_with_totals) }
 

--- a/spec/models/vouchers/flat_rate_spec.rb
+++ b/spec/models/vouchers/flat_rate_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Vouchers::FlatRate do
+  let(:enterprise) { build(:enterprise) }
+
+  describe 'validations' do
+    subject { build(:voucher_flat_rate, code: 'new_code', enterprise: enterprise) }
+
+    it { is_expected.to validate_presence_of(:amount) }
+    it { is_expected.to validate_numericality_of(:amount).is_greater_than(0) }
+  end
+
+  describe '#compute_amount' do
+    let(:order) { create(:order_with_totals) }
+
+    context 'when order total is more than the voucher' do
+      subject { create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 5) }
+
+      it 'uses the voucher total' do
+        expect(subject.compute_amount(order).to_f).to eq(-5)
+      end
+    end
+
+    context 'when order total is less than the voucher' do
+      subject { create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 20) }
+
+      it 'matches the order total' do
+        expect(subject.compute_amount(order).to_f).to eq(-10)
+      end
+    end
+  end
+end

--- a/spec/models/vouchers/percentage_rate_spec.rb
+++ b/spec/models/vouchers/percentage_rate_spec.rb
@@ -6,7 +6,7 @@ describe Vouchers::PercentageRate do
   let(:enterprise) { build(:enterprise) }
 
   describe 'validations' do
-    subject { build(:voucher_percentage_rate, code: 'new_code', enterprise: enterprise) }
+    subject { build(:voucher_percentage_rate, code: 'new_code', enterprise:) }
 
     it { is_expected.to validate_presence_of(:amount) }
     it do
@@ -18,7 +18,7 @@ describe Vouchers::PercentageRate do
 
   describe '#compute_amount' do
     subject do
-      create(:voucher_percentage_rate, code: 'new_code', enterprise: enterprise, amount: 10)
+      create(:voucher_percentage_rate, code: 'new_code', enterprise:, amount: 10)
     end
     let(:order) { create(:order_with_totals) }
 
@@ -29,7 +29,7 @@ describe Vouchers::PercentageRate do
 
   describe "#rate" do
     subject do
-      create(:voucher_percentage_rate, code: 'new_code', enterprise: enterprise, amount: 50)
+      create(:voucher_percentage_rate, code: 'new_code', enterprise:, amount: 50)
     end
 
     it "returns the voucher percentage rate" do

--- a/spec/models/vouchers/percentage_rate_spec.rb
+++ b/spec/models/vouchers/percentage_rate_spec.rb
@@ -3,10 +3,8 @@
 require 'spec_helper'
 
 describe Vouchers::PercentageRate do
-  let(:enterprise) { build(:enterprise) }
-
   describe 'validations' do
-    subject { build(:voucher_percentage_rate, code: 'new_code', enterprise:) }
+    subject { build(:voucher_percentage_rate) }
 
     it { is_expected.to validate_presence_of(:amount) }
     it do
@@ -18,18 +16,22 @@ describe Vouchers::PercentageRate do
 
   describe '#compute_amount' do
     subject do
-      create(:voucher_percentage_rate, code: 'new_code', enterprise:, amount: 10)
+      create(:voucher_percentage_rate, amount: 10)
     end
     let(:order) { create(:order_with_totals) }
 
+    before do
+      order.update_columns(item_total: 15)
+    end
+
     it 'returns percentage of the order total' do
-      expect(subject.compute_amount(order)).to eq(-order.pre_discount_total * 0.1)
+      expect(subject.compute_amount(order)).to eq(-1.5)
     end
   end
 
   describe "#rate" do
     subject do
-      create(:voucher_percentage_rate, code: 'new_code', enterprise:, amount: 50)
+      create(:voucher_percentage_rate, amount: 50)
     end
 
     it "returns the voucher percentage rate" do

--- a/spec/models/vouchers/percentage_rate_spec.rb
+++ b/spec/models/vouchers/percentage_rate_spec.rb
@@ -26,4 +26,14 @@ describe Vouchers::PercentageRate do
       expect(subject.compute_amount(order)).to eq(-order.pre_discount_total * 0.1)
     end
   end
+
+  describe "#rate" do
+    subject do
+      create(:voucher_percentage_rate, code: 'new_code', enterprise: enterprise, amount: 50)
+    end
+
+    it "returns the voucher percentage rate" do
+      expect(subject.rate(nil)).to eq(-0.5)
+    end
+  end
 end

--- a/spec/models/vouchers/percentage_rate_spec.rb
+++ b/spec/models/vouchers/percentage_rate_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Vouchers::PercentageRate do
+  let(:enterprise) { build(:enterprise) }
+
+  describe 'validations' do
+    subject { build(:voucher_percentage_rate, code: 'new_code', enterprise: enterprise) }
+
+    it { is_expected.to validate_presence_of(:amount) }
+    it do
+      is_expected.to validate_numericality_of(:amount)
+        .is_greater_than(0)
+        .is_less_than_or_equal_to(100)
+    end
+  end
+
+  describe '#compute_amount' do
+    subject do
+      create(:voucher_percentage_rate, code: 'new_code', enterprise: enterprise, amount: 10)
+    end
+    let(:order) { create(:order_with_totals) }
+
+    it 'returns percentage of the order total' do
+      expect(subject.compute_amount(order)).to eq(-order.pre_discount_total * 0.1)
+    end
+  end
+end

--- a/spec/requests/admin/vouchers_controller_spec.rb
+++ b/spec/requests/admin/vouchers_controller_spec.rb
@@ -26,7 +26,7 @@ describe Admin::VouchersController, type: :request do
 
     let(:params) do
       {
-        voucher: {
+        vouchers_flat_rate: {
           code: code,
           amount: amount,
           voucher_type: type
@@ -35,15 +35,41 @@ describe Admin::VouchersController, type: :request do
     end
     let(:code) { "new_code" }
     let(:amount) { 15 }
-    let(:type) { "percentage" }
+    let(:type) { "Vouchers::PercentageRate" }
 
-    it "creates a new voucher" do
-      expect { create_voucher }.to change(Voucher, :count).by(1)
+    context "with a flat rate voucher" do
+      let(:type) { "Vouchers::FlatRate" }
 
-      voucher = Voucher.last
-      expect(voucher.code).to eq(code)
-      expect(voucher.amount).to eq(amount)
-      expect(voucher.voucher_type).to eq(type)
+      it "creates a new voucher" do
+        expect { create_voucher }.to change(Vouchers::FlatRate, :count).by(1)
+
+        voucher = Vouchers::FlatRate.last
+        expect(voucher.code).to eq(code)
+        expect(voucher.amount).to eq(amount)
+      end
+    end
+
+    context "with a percentage rate voucher" do
+      let(:type) { "Vouchers::PercentageRate" }
+
+      it "creates a new voucher" do
+        expect { create_voucher }.to change(Vouchers::PercentageRate, :count).by(1)
+
+        voucher = Vouchers::PercentageRate.last
+        expect(voucher.code).to eq(code)
+        expect(voucher.amount).to eq(amount)
+      end
+    end
+
+    context "with a wrong type" do
+      let(:type) { "Random" }
+
+      it "render the new page with an error" do
+        create_voucher
+
+        expect(response).to render_template("admin/vouchers/new")
+        expect(flash[:error]).to eq("Type is invalid")
+      end
     end
 
     it "redirects to admin enterprise setting page, voucher panel" do

--- a/spec/requests/admin/vouchers_controller_spec.rb
+++ b/spec/requests/admin/vouchers_controller_spec.rb
@@ -28,12 +28,14 @@ describe Admin::VouchersController, type: :request do
       {
         voucher: {
           code: code,
-          amount: amount
+          amount: amount,
+          voucher_type: type
         }
       }
     end
     let(:code) { "new_code" }
     let(:amount) { 15 }
+    let(:type) { "percentage" }
 
     it "creates a new voucher" do
       expect { create_voucher }.to change(Voucher, :count).by(1)
@@ -41,6 +43,7 @@ describe Admin::VouchersController, type: :request do
       voucher = Voucher.last
       expect(voucher.code).to eq(code)
       expect(voucher.amount).to eq(amount)
+      expect(voucher.voucher_type).to eq(type)
     end
 
     it "redirects to admin enterprise setting page, voucher panel" do

--- a/spec/requests/voucher_adjustments_spec.rb
+++ b/spec/requests/voucher_adjustments_spec.rb
@@ -19,7 +19,7 @@ describe VoucherAdjustmentsController, type: :request do
     )
   end
   let(:shipping_method) { distributor.shipping_methods.first }
-  let(:voucher) { create(:voucher, code: 'some_code', enterprise: distributor) }
+  let(:voucher) { create(:voucher_flat_rate, code: 'some_code', enterprise: distributor) }
 
   before do
     order.update!(created_by: user)

--- a/spec/services/voucher_adjustments_service_spec.rb
+++ b/spec/services/voucher_adjustments_service_spec.rb
@@ -117,6 +117,8 @@ describe VoucherAdjustmentsService do
           order.create_tax_charge!
           order.update_shipping_fees!
           order.update_order!
+
+          VoucherAdjustmentsService.new(order).update
         end
 
         it 'includes amount without tax' do
@@ -206,7 +208,7 @@ describe VoucherAdjustmentsService do
             ship_address: create(:address),
             product_price: 110,
             tax_rate_amount: 0.10,
-            included_in_price: false,
+            included_in_price: true,
             tax_rate_name: "Tax 1"
           )
         end

--- a/spec/services/voucher_adjustments_service_spec.rb
+++ b/spec/services/voucher_adjustments_service_spec.rb
@@ -5,164 +5,275 @@ require 'spec_helper'
 describe VoucherAdjustmentsService do
   describe '#update' do
     let(:enterprise) { build(:enterprise) }
-    let(:voucher) { create(:voucher, code: 'new_code', enterprise: enterprise, amount: 10) }
 
-    context 'when voucher covers the order total' do
-      subject { order.voucher_adjustments.first }
-
-      let(:order) { create(:order_with_totals) }
-
-      it 'updates the adjustment amount to -order.total' do
-        voucher.create_adjustment(voucher.code, order)
-        order.update_columns(item_total: 6)
-
-        VoucherAdjustmentsService.new(order).update
-
-        expect(subject.amount.to_f).to eq(-6.0)
-      end
-    end
-
-    context 'with tax included in order price' do
-      subject { order.voucher_adjustments.first }
-
-      let(:order) do
-        create(
-          :order_with_taxes,
-          distributor: enterprise,
-          ship_address: create(:address),
-          product_price: 110,
-          tax_rate_amount: 0.10,
-          included_in_price: true,
-          tax_rate_name: "Tax 1"
-        )
+    context 'with a flat rate voucher' do
+      let(:voucher) do
+        create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 10)
       end
 
-      before do
-        # create adjustment before tax are set
-        voucher.create_adjustment(voucher.code, order)
+      context 'when voucher covers the order total' do
+        subject { order.voucher_adjustments.first }
 
-        # Update taxes
-        order.create_tax_charge!
-        order.update_shipping_fees!
-        order.update_order!
+        let(:order) { create(:order_with_totals) }
 
-        VoucherAdjustmentsService.new(order).update
+        it 'updates the adjustment amount to -order.total' do
+          voucher.create_adjustment(voucher.code, order)
+          order.update_columns(item_total: 6)
+
+          VoucherAdjustmentsService.new(order).update
+
+          expect(subject.amount.to_f).to eq(-6.0)
+        end
       end
 
-      it 'updates the adjustment included_tax' do
-        # voucher_rate = amount / order.total
-        # -10 / 160 = -0.0625
-        # included_tax = voucher_rate * order.included_tax_total
-        # -0.0625 * 10 = -0.625
-        expect(subject.included_tax.to_f).to eq(-0.63)
-      end
+      context 'with tax included in order price' do
+        subject { order.voucher_adjustments.first }
 
-      context "when re calculating" do
-        it "does not update the adjustment amount" do
-          expect do
-            VoucherAdjustmentsService.new(order).update
-          end.not_to change { subject.reload.amount }
+        let(:order) do
+          create(
+            :order_with_taxes,
+            distributor: enterprise,
+            ship_address: create(:address),
+            product_price: 110,
+            tax_rate_amount: 0.10,
+            included_in_price: true,
+            tax_rate_name: "Tax 1"
+          )
         end
 
-        it "does not update the tax adjustment" do
-          expect do
-            VoucherAdjustmentsService.new(order).update
-          end.not_to change { subject.reload.included_tax }
+        before do
+          # create adjustment before tax are set
+          voucher.create_adjustment(voucher.code, order)
+
+          # Update taxes
+          order.create_tax_charge!
+          order.update_shipping_fees!
+          order.update_order!
+
+          VoucherAdjustmentsService.new(order).update
         end
 
-        context "when the order changed" do
-          before do
-            order.update_columns(item_total: 200)
-          end
+        it 'updates the adjustment included_tax' do
+          # voucher_rate = amount / order.total
+          # -10 / 160 = -0.0625
+          # included_tax = voucher_rate * order.included_tax_total
+          # -0.625 * 10 = -0.63
+          expect(subject.included_tax.to_f).to eq(-0.63)
+        end
 
-          it "does update the adjustment amount" do
+        context "when re calculating" do
+          it "does not update the adjustment amount" do
             expect do
               VoucherAdjustmentsService.new(order).update
             end.not_to change { subject.reload.amount }
           end
 
-          it "updates the tax adjustment" do
+          it "does not update the tax adjustment" do
             expect do
               VoucherAdjustmentsService.new(order).update
-            end.to change { subject.reload.included_tax }
+            end.not_to change { subject.reload.included_tax }
+          end
+
+          context "when the order changed" do
+            before do
+              order.update_columns(item_total: 200)
+            end
+
+            it "does update the adjustment amount" do
+              expect do
+                VoucherAdjustmentsService.new(order).update
+              end.not_to change { subject.reload.amount }
+            end
+
+            it "updates the tax adjustment" do
+              expect do
+                VoucherAdjustmentsService.new(order).update
+              end.to change { subject.reload.included_tax }
+            end
+          end
+        end
+      end
+
+      context 'with tax not included in order price' do
+        let(:order) do
+          create(
+            :order_with_taxes,
+            distributor: enterprise,
+            ship_address: create(:address),
+            product_price: 110,
+            tax_rate_amount: 0.10,
+            included_in_price: false,
+            tax_rate_name: "Tax 1"
+          )
+        end
+        let(:adjustment) { order.voucher_adjustments.first }
+        let(:tax_adjustment) { order.voucher_adjustments.second }
+
+        before do
+          # create adjustment before tax are set
+          voucher.create_adjustment(voucher.code, order)
+
+          # Update taxes
+          order.create_tax_charge!
+          order.update_shipping_fees!
+          order.update_order!
+        end
+
+        it 'includes amount without tax' do
+          # voucher_rate = amount / order.total
+          # -10 / 171 = -0.058479532
+          # amount = voucher_rate * (order.total - order.additional_tax_total)
+          # -0.058479532 * (171 -11) = -9.36
+          expect(adjustment.amount.to_f).to eq(-9.36)
+        end
+
+        it 'creates a tax adjustment' do
+          # voucher_rate = amount / order.total
+          # -10 / 171 = -0.058479532
+          # amount = voucher_rate * order.additional_tax_total
+          # -0.058479532 * 11 = -0.64
+          expect(tax_adjustment.amount.to_f).to eq(-0.64)
+          expect(tax_adjustment.label).to match("Tax")
+        end
+
+        context "when re calculating" do
+          it "does not update the adjustment amount" do
+            expect do
+              VoucherAdjustmentsService.new(order).update
+            end.not_to change { adjustment.reload.amount }
+          end
+
+          it "does not update the tax adjustment" do
+            expect do
+              VoucherAdjustmentsService.new(order).update
+            end.not_to change { tax_adjustment.reload.amount }
+          end
+
+          context "when the order changed" do
+            before do
+              order.update_columns(item_total: 200)
+            end
+
+            it "updates the adjustment amount" do
+              expect do
+                VoucherAdjustmentsService.new(order).update
+              end.to change { adjustment.reload.amount }
+            end
+
+            it "updates the tax adjustment" do
+              expect do
+                VoucherAdjustmentsService.new(order).update
+              end.to change { tax_adjustment.reload.amount }
+            end
           end
         end
       end
     end
 
-    context 'with tax not included in order price' do
-      let(:order) do
-        create(
-          :order_with_taxes,
-          distributor: enterprise,
-          ship_address: create(:address),
-          product_price: 110,
-          tax_rate_amount: 0.10,
-          included_in_price: false,
-          tax_rate_name: "Tax 1"
-        )
+    context 'with a percentage rate voucher' do
+      let(:voucher) do
+        create(:voucher_percentage_rate, code: 'new_code', enterprise: enterprise, amount: 10)
       end
       let(:adjustment) { order.voucher_adjustments.first }
       let(:tax_adjustment) { order.voucher_adjustments.second }
 
-      before do
-        # create adjustment before tax are set
-        voucher.create_adjustment(voucher.code, order)
+      context 'when voucher covers the order total' do
+        subject { order.voucher_adjustments.first }
 
-        # Update taxes
-        order.create_tax_charge!
-        order.update_shipping_fees!
-        order.update_order!
+        let(:voucher) do
+          create(:voucher_percentage_rate, code: 'new_code', enterprise: enterprise, amount: 100)
+        end
+        let(:order) { create(:order_with_totals) }
 
-        VoucherAdjustmentsService.new(order).update
+        it 'updates the adjustment amount to -order.total' do
+          voucher.create_adjustment(voucher.code, order)
+
+          order.update_columns(item_total: 150)
+
+          VoucherAdjustmentsService.new(order).update
+
+          expect(subject.amount.to_f).to eq(-150.0)
+        end
       end
 
-      it 'includes amount without tax' do
-        # voucher_rate = amount / order.total
-        # -10 / 171 = -0.058479532
-        # amount = voucher_rate * (order.total - order.additional_tax_total)
-        # -0.058479532 * (171 -11) = -9.36
-        expect(adjustment.amount.to_f).to eq(-9.36)
-      end
+      context 'with tax included in order price' do
+        subject { order.voucher_adjustments.first }
 
-      it 'creates a tax adjustment' do
-        # voucher_rate = amount / order.total
-        # -10 / 171 = -0.058479532
-        # amount = voucher_rate * order.additional_tax_total
-        # -0.058479532 * 11 = -0.64
-        expect(tax_adjustment.amount.to_f).to eq(-0.64)
-        expect(tax_adjustment.label).to match("Tax")
-      end
-
-      context "when re calculating" do
-        it "does not update the adjustment amount" do
-          expect do
-            VoucherAdjustmentsService.new(order).update
-          end.not_to change { adjustment.reload.amount }
+        let(:order) do
+          create(
+            :order_with_taxes,
+            distributor: enterprise,
+            ship_address: create(:address),
+            product_price: 110,
+            tax_rate_amount: 0.10,
+            included_in_price: false,
+            tax_rate_name: "Tax 1"
+          )
         end
 
-        it "does not update the tax adjustment" do
-          expect do
-            VoucherAdjustmentsService.new(order).update
-          end.not_to change { tax_adjustment.reload.amount }
+        before do
+          # create adjustment before tax are set
+          voucher.create_adjustment(voucher.code, order)
+
+          # Update taxes
+          order.create_tax_charge!
+          order.update_shipping_fees!
+          order.update_order!
+
+          VoucherAdjustmentsService.new(order).update
         end
 
-        context "when the order changed" do
-          before do
-            order.update_columns(item_total: 200)
-          end
+        it 'updates the adjustment included_tax' do
+          # voucher_rate = voucher.amount / 100
+          # 10 / 100 = 0.1
+          # included_tax = -voucher_rate * included_tax_total
+          # -0.1 * 10 = -1
+          expect(subject.included_tax.to_f).to eq(-1)
+        end
+      end
 
-          it "updates the adjustment amount" do
-            expect do
-              VoucherAdjustmentsService.new(order).update
-            end.to change { adjustment.reload.amount }
-          end
+      context 'with tax not included in order price' do
+        let(:order) do
+          create(
+            :order_with_taxes,
+            distributor: enterprise,
+            ship_address: create(:address),
+            product_price: 110,
+            tax_rate_amount: 0.10,
+            included_in_price: false,
+            tax_rate_name: "Tax 1"
+          )
+        end
 
-          it "updates the tax adjustment" do
-            expect do
-              VoucherAdjustmentsService.new(order).update
-            end.to change { tax_adjustment.reload.amount }
-          end
+        before do
+          # create adjustment before tax are set
+          voucher.create_adjustment(voucher.code, order)
+
+          # Update taxes
+          order.create_tax_charge!
+          order.update_shipping_fees!
+          order.update_order!
+
+          VoucherAdjustmentsService.new(order).update
+        end
+
+        it 'includes amount without tax' do
+          adjustment = order.voucher_adjustments.first
+          # voucher_rate = voucher.amount / 100
+          # 10 / 100 = 0.1
+          # amount = -voucher_rate * (order.total - order.additional_tax_total)
+          # -0.1 * (171 -11) = -16.0
+          expect(adjustment.amount.to_f).to eq(-16.0)
+        end
+
+        it 'creates a tax adjustment' do
+          # voucher_rate = voucher.amount / 100
+          # 10 / 100 = 0.1
+          # amount = -voucher_rate * order.additional_tax_total
+          # -0.1 * 11 = -1.1
+          tax_adjustment = order.voucher_adjustments.second
+          expect(tax_adjustment.amount.to_f).to eq(-1.1)
+          expect(tax_adjustment.label).to match("Tax")
         end
       end
     end

--- a/spec/system/admin/vouchers_spec.rb
+++ b/spec/system/admin/vouchers_spec.rb
@@ -50,9 +50,9 @@ describe '
     context "with a flat rate voucher" do
       it 'creates a voucher' do
         # And I fill in the fields for a new voucher click save
-        fill_in 'voucher_code', with: voucher_code
-        select "Flat", from: "voucher_voucher_type"
-        fill_in 'voucher_amount', with: amount
+        fill_in 'vouchers_flat_rate_code', with: voucher_code
+        select "Flat", from: "vouchers_flat_rate_voucher_type"
+        fill_in 'vouchers_flat_rate_amount', with: amount
         click_button 'Save'
 
         # Then I should get redirect to the entreprise voucher tab and see the created voucher
@@ -64,9 +64,9 @@ describe '
     context "with a percentage rate voucher" do
       it 'creates a voucher' do
         # And I fill in the fields for a new voucher click save
-        fill_in 'voucher_code', with: voucher_code
-        select "Percentage (%)", from:  "voucher_voucher_type"
-        fill_in 'voucher_amount', with: amount
+        fill_in 'vouchers_flat_rate_code', with: voucher_code
+        select "Percentage (%)", from: "vouchers_flat_rate_voucher_type"
+        fill_in 'vouchers_flat_rate_amount', with: amount
         click_button 'Save'
 
         # Then I should get redirect to the entreprise voucher tab and see the created voucher

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -696,7 +696,7 @@ describe "As a consumer, I want to checkout my order" do
 
         context "with voucher available" do
           let!(:voucher) do
-            create(:voucher, code: 'some_code', enterprise: distributor, amount: 15)
+            create(:voucher_flat_rate, code: 'some_code', enterprise: distributor, amount: 15)
           end
 
           it "shows voucher input" do
@@ -1150,7 +1150,9 @@ describe "As a consumer, I want to checkout my order" do
       end
 
       describe "vouchers" do
-        let(:voucher) { create(:voucher, code: 'some_code', enterprise: distributor, amount: 6) }
+        let(:voucher) do
+          create(:voucher_flat_rate, code: 'some_code', enterprise: distributor, amount: 6)
+        end
 
         before do
           add_voucher_to_order(voucher, order)

--- a/spec/system/consumer/split_checkout_tax_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_incl_spec.rb
@@ -146,7 +146,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
           assert_db_voucher_adjustment(-10.00, -1.15)
         end
 
-        describe "moving between summary to summary via edit cart" do
+        describe "updating voucher adjustment after editing order" do
           let!(:voucher) do
             create(:voucher_flat_rate, code: 'good_code', enterprise: distributor, amount: 15)
           end

--- a/spec/system/consumer/split_checkout_tax_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_incl_spec.rb
@@ -112,7 +112,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
         before { Flipper.enable :vouchers }
 
         let!(:voucher) do
-          create(:voucher, code: 'some_code', enterprise: distributor, amount: 10)
+          create(:voucher_flat_rate, code: 'some_code', enterprise: distributor, amount: 10)
         end
 
         it "will include a tax included amount on the voucher adjustment" do
@@ -148,7 +148,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
         describe "moving between summary to summary via edit cart" do
           let!(:voucher) do
-            create(:voucher, code: 'good_code', enterprise: distributor, amount: 15)
+            create(:voucher_flat_rate, code: 'good_code', enterprise: distributor, amount: 15)
           end
 
           it "recalculate the tax component properly" do

--- a/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
@@ -151,10 +151,6 @@ describe "As a consumer, I want to see adjustment breakdown" do
           end
 
           # DB check
-          #order_within_zone.reload
-          #voucher_adjustment = order_within_zone.voucher_adjustments.first
-          #voucher_tax_adjustment = order_within_zone.voucher_adjustments.second
-
           assert_db_voucher_adjustment(-8.85, -1.15)
         end
 

--- a/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
@@ -118,7 +118,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
       context "when using a voucher" do
         let!(:voucher) do
-          create(:voucher, code: 'some_code', enterprise: distributor, amount: 10)
+          create(:voucher_flat_rate, code: 'some_code', enterprise: distributor, amount: 10)
         end
 
         it "will include a tax included amount on the voucher adjustment" do
@@ -151,12 +151,71 @@ describe "As a consumer, I want to see adjustment breakdown" do
           end
 
           # DB check
-          order_within_zone.reload
-          voucher_adjustment = order_within_zone.voucher_adjustments.first
-          voucher_tax_adjustment = order_within_zone.voucher_adjustments.second
+          #order_within_zone.reload
+          #voucher_adjustment = order_within_zone.voucher_adjustments.first
+          #voucher_tax_adjustment = order_within_zone.voucher_adjustments.second
 
-          expect(voucher_adjustment.amount.to_f).to eq(-8.85)
-          expect(voucher_tax_adjustment.amount.to_f).to eq(-1.15)
+          assert_db_voucher_adjustment(-8.85, -1.15)
+        end
+
+        describe "moving between summary to summary via edit cart" do
+          let!(:voucher) do
+            create(:voucher_percentage, code: 'good_code', enterprise: distributor, amount: 20)
+          end
+
+          it "recalculate the tax component properly" do
+            visit checkout_step_path(:details)
+            proceed_to_payment
+
+            # add Voucher
+            fill_in "Enter voucher code", with: voucher.code
+            click_button("Apply")
+
+            #pause
+            proceed_to_summary
+            assert_db_voucher_adjustment(-2.00, -0.26)
+
+            # Click on edit link
+            within "div", text: /Order details/ do
+              # It's a bit brittle, but the scoping doesn't seem to work
+              all(".summary-edit").last.click
+            end
+
+            # Update quantity
+            within ".cart-item-quantity" do
+              input = find(".line_item_quantity")
+              input.send_keys :up
+            end
+
+            click_button("Update")
+
+            # Check adjustment has been recalculated
+            assert_db_voucher_adjustment(-4.00, -0.52)
+
+            within "#cart-container" do
+              click_link("Checkout")
+            end
+
+            # Go back to payment step
+            proceed_to_payment
+
+            # Check voucher is still there
+            expect(page).to have_content("20.0 % Voucher")
+
+            # Go to summary
+            proceed_to_summary
+
+            # Check voucher value
+            within ".summary-right" do
+              expect(page).to have_content "good_code"
+              expect(page).to have_content "-4"
+              expect(page).to have_content "Tax good_code"
+              expect(page).to have_content "-0.52"
+            end
+
+            # Check adjustment has been recalculated, we are not expecting any changes here
+            assert_db_voucher_adjustment(-4.00, -0.52)
+          end
         end
       end
     end
@@ -232,5 +291,14 @@ describe "As a consumer, I want to see adjustment breakdown" do
         end
       end
     end
+  end
+
+  private
+
+  def assert_db_voucher_adjustment(amount, tax_amount)
+    adjustment = order_within_zone.voucher_adjustments.first
+    tax_adjustment = order_within_zone.voucher_adjustments.second
+    expect(adjustment.amount.to_f).to eq(amount)
+    expect(tax_adjustment.amount.to_f).to eq(tax_amount)
   end
 end

--- a/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
@@ -160,7 +160,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
         describe "moving between summary to summary via edit cart" do
           let!(:voucher) do
-            create(:voucher_percentage, code: 'good_code', enterprise: distributor, amount: 20)
+            create(:voucher_percentage_rate, code: 'good_code', enterprise: distributor, amount: 20)
           end
 
           it "recalculate the tax component properly" do
@@ -171,7 +171,6 @@ describe "As a consumer, I want to see adjustment breakdown" do
             fill_in "Enter voucher code", with: voucher.code
             click_button("Apply")
 
-            #pause
             proceed_to_summary
             assert_db_voucher_adjustment(-2.00, -0.26)
 
@@ -200,7 +199,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
             proceed_to_payment
 
             # Check voucher is still there
-            expect(page).to have_content("20.0 % Voucher")
+            expect(page).to have_content("20.00% Voucher")
 
             # Go to summary
             proceed_to_summary


### PR DESCRIPTION
:information_source: Please track code review under the project **`##10430 Vouchers - Aus Pt 2 (UK)`**.

#### What? Why?

- Last part of  #10727 

Add the ability to have a percentage based voucher. It supports tax included in price and tax excluded from price to same extend that flat rate voucher ie. we can't have order which mix tax included and tax exclude from price.

See calculation reference here : https://github.com/openfoodfoundation/openfoodnetwork/issues/10432#issuecomment-1439402476

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

* Enable vouchers feature
* Visit admin/feature-toggle/features and enable or add vouchers feature

In the backoffice logged as an enterprise user:

* Visit the Enterprise tab and click on "Settings" for a shop of your choosing, and click on the "vouchers" in left hand side menu
* Click on "Add New button" --> New Voucher page should now have a "Voucher type" and an "Amount" input
* Enter a voucher code, an amount and choose "Percentage(%)" type , and click "Save"
    --> It should redirect you to the vouchers page on the enterprise edit page
    --> You should now see a list of vouchers with the one you just created, included the entered percentage rate

On the website logged as a customer :

* Add one or more product in your cart from the shop above
* Proceed to checkout
* Enter details and shipping info, click on "Next - Payment method"
* Enter the voucher code and click "Apply"
    --> You should see a "xx % Voucher" box where xx is the amount you entered when creating a voucher
* choose a payment method and click on "Next - Order summary"
    --> you should see the voucher applied to the order in the order summary column, with the correct amount
* Click on "Complete order"
    --> you should see the voucher applied to the order in the order summary with the correct amount

Repeat the above scenario with tax included in price and tax excluded from price

##### Payment fees and voucher 
Payment fees are calculated based on the item total, and are recalculated when confirming the order. Vouchers are calculated based on the order total. The main thing to check here, is to make sure : 
* voucher calculation include the payment fee 
* when using a percentage based payment fee, the payment fee shouldn't change when confirming an order with a voucher
* when a voucher cover the order total or more, -> No payment required, so the payment fee shouldn't apply

See this https://github.com/openfoodfoundation/openfoodnetwork/pull/11117#discussion_r1251505213 for more background 


#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.

#### Dependencies
This is base on this PR #11117, ~~which depends on #11135~~. They will need to be merged first.


#### Documentation updates

