### PR TITLE
Adds test case for logging out

### DIFF
--- a/spec/system/admin/authentication_spec.rb
+++ b/spec/system/admin/authentication_spec.rb
@@ -26,4 +26,18 @@ describe "Authentication" do
     click_link "Account"
     expect(page).to have_current_path spree.account_path
   end
+
+  context "logged in" do
+    before do
+      login_as user
+      visit root_path
+    end
+
+    it "logs out" do
+      page.find("li", class: "user-menu").click
+      click_on "Logout"
+      expect(page).to have_content "Signed out successfully."
+      expect(page).to have_content "Login"
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

- Relates to #10772

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

PR #10772 introduced a regression, at some point, in which the session was always kept and logging out was not possible. This spec tries to cover for the latter.

It does so by adding a test case in the UI in `spec/system/admin/authentication_spec.rb`.

Note:
I think we could also consider adding to `spec/controllers/spree/user_sessions_controller_spec.rb`, in the `destroy` scenario - but I'm not sure what assertion we'd need, to catch the aforementioned regression.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
