### PR TITLE
Splits assertions to allow JS table populate

### DIFF
--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -179,9 +179,9 @@ describe '
     visit spree.edit_admin_order_path(order)
 
     select2_select product.name, from: 'add_variant_id', search: true
-
     find('button.add_variant').click
     # Wait for JS
+    sleep(1)
     page.has_selector?("table.index tbody tr td")
     expect(page).to have_selector 'td', text: product.name
     expect(order.line_items.reload.map(&:product)).to include product


### PR DESCRIPTION
#### What? Why?

- Closes #10799 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The assertion was looking for content within the table: the table was found, very often it was not yet populated with the line item names - instead a cryptic `<<ERROR>>` was "seen" by Capybara.

This PR splits the assertions into three bits, preceded by a `sleep(1)`:
1) the table
2) the content
3) the content within the table
4) check the order now has a new line item appended

The `sleep(1)` is not ideal, but seems to work... I've explored different variations, but I could not prevent this spec from timeout this way. It now passes `100 of 100 passed (100%)`; before it took longer (~20 secs) and failed several times already within the first 10 runs...

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- :green_circle: build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
