### PR TITLE
Clone all ExchangeVariant objects in bulk

### DIFF
--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -86,9 +86,9 @@ class Exchange < ApplicationRecord
     exchange = dup
     exchange.order_cycle = new_order_cycle
     exchange.enterprise_fee_ids = enterprise_fee_ids
-    exchange.variant_ids = variant_ids
     exchange.tag_ids = tag_ids
     exchange.save!
+    clone_all_exchange_variants(exchange.id)
     exchange
   end
 
@@ -104,5 +104,15 @@ class Exchange < ApplicationRecord
     return unless receiver&.persisted?
 
     receiver.touch_later
+  end
+
+  private
+
+  def clone_all_exchange_variants(exchange_id)
+    return unless variant_ids.any?
+
+    ExchangeVariant.insert_all(
+      variant_ids.map{ |variant_id| { variant_id: variant_id, exchange_id: exchange_id } }
+    )
   end
 end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -108,10 +108,13 @@ class Exchange < ApplicationRecord
 
   private
 
+  # An Order Cycle can have thousands of ExchangeVariants.
+  # It's a simple association without any callbacks on creation. So we can
+  # insert in bulk and improve the performance tenfold for large order cycles.
   def clone_all_exchange_variants(exchange_id)
     return unless variant_ids.any?
 
-    ExchangeVariant.insert_all(
+    ExchangeVariant.insert_all( # rubocop:disable Rails/SkipsModelValidations
       variant_ids.map{ |variant_id| { variant_id: variant_id, exchange_id: exchange_id } }
     )
   end


### PR DESCRIPTION
#### What? Why?

Fixes server-melting performance issues when cloning large order cycles :point_right: https://github.com/openfoodfoundation/ofn-install/pull/873#issuecomment-1542614696

#### Review Notes

An `ExchangeVariant` is a simple representation of a join table between `Exchange` and `Variant`. Previously this code was triggering an additional `INSERT` query for every variant associated to the newly cloned exchange. Some exchanges have ~3000 variants! The code now associates them in bulk in a single `INSERT` statement. When cloning large order cycles this can radically improve the performance.

Hot tip: using the `ActiveRecord` `#insert_all` method is not advised on any objects that have _callbacks_, as it skips them. `ExchangeVariant` has no callbacks :+1:

**Before, production data and cloning an order cycle with ~180 variants and multiple exchanges:**

![Screenshot from 2023-05-11 20-23-46](https://github.com/openfoodfoundation/openfoodnetwork/assets/9029026/d1dde0a0-288b-4824-a6b7-c34b7ff90bf9)

2.8 seconds, 1176 queries, ~2 billion memory allocations!

**After, cloning the same order cycle with the same data:**

![Screenshot from 2023-05-11 20-22-30](https://github.com/openfoodfoundation/openfoodnetwork/assets/9029026/0744b0a8-122b-4371-9dfb-0f338cfdbe5f)

0.2 seconds, 56 queries, ~127 thousand memory allocations.


#### What should we test?

Cloning order cycles. Make sure all the variants are there in the exchanges for the newly cloned OC as expected.

#### Release notes


Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
