### PR TITLE
Fix bad indentation (and hierarchy) of DOM elements causing bad rendering on small width screens

### DIFF
--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -12,15 +12,15 @@
           - else
             %img{src: ContentConfig.url_for(:logo_mobile), srcset: ContentConfig.url_for(:logo_mobile_svg), width: "75", height: "26"}
 
-      %section.right{"ng-cloak" => true}
-        %span.cart-span{"ng-class" => "{ dirty: Cart.dirty || Cart.empty(), 'pure-dirty': Cart.dirty }"}
-          %a.icon{ng: {click: 'toggleCartSidebar()'}}
+    %section.right{"ng-cloak" => true}
+      %span.cart-span{"ng-class" => "{ dirty: Cart.dirty || Cart.empty(), 'pure-dirty': Cart.dirty }"}
+        %a.icon{ng: {click: 'toggleCartSidebar()'}}
+          %span
+            = t '.cart'
+          %span.count
+            = image_pack_tag "menu/icn-cart.svg"
             %span
-              = t '.cart'
-            %span.count
-              = image_pack_tag "menu/icn-cart.svg"
-              %span
-                {{ Cart.total_item_count() }}
+              {{ Cart.total_item_count() }}
 
       %a{href: main_app.shop_path}
         {{ CurrentHub.hub.name }}


### PR DESCRIPTION

#### What? Why?
`%section` must be siblings each others
introduced by https://github.com/openfoodfoundation/openfoodnetwork/pull/10772

- Closes #10835 
<img width="622" alt="Capture d’écran 2023-05-12 à 09 38 02" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/4d1b61f7-4b22-412d-817f-9698acf40511">



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a shopper, visit any page (`/`, `/shops`, ...) with a small width screen ( < 1024)
- Check that the `cart` element is well placed



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
