### PR TITLE
Adds minus sign to validation criteria

### DIFF
--- a/lib/spree/localized_number.rb
+++ b/lib/spree/localized_number.rb
@@ -45,7 +45,7 @@ module Spree
     def self.valid_localizable_number?(number)
       return true unless number.is_a?(String) || number.respond_to?(:to_d)
       # Invalid if only two digits between dividers, or if any non-number characters
-      return false if number.to_s =~ /[.,]\d{2}[.,]/ || number.to_s =~ /[^0-9,.]+/
+      return false if number.to_s =~ /[.,]\d{2}[.,]/ || number.to_s =~ /[^0-9,.-]+/
 
       true
     end

--- a/lib/spree/localized_number.rb
+++ b/lib/spree/localized_number.rb
@@ -45,7 +45,7 @@ module Spree
     def self.valid_localizable_number?(number)
       return true unless number.is_a?(String) || number.respond_to?(:to_d)
       # Invalid if only two digits between dividers, or if any non-number characters
-      return false if number.to_s =~ /[.,]\d{2}[.,]/ || number.to_s =~ /[^0-9,.-]+/
+      return false if number.to_s =~ /[.,]\d{2}[.,]/ || number.to_s =~ /[^-0-9,.]+/
 
       true
     end

--- a/spec/lib/spree/localized_number_spec.rb
+++ b/spec/lib/spree/localized_number_spec.rb
@@ -58,6 +58,12 @@ describe Spree::LocalizedNumber do
       it "returns true" do
         expect(described_class.valid_localizable_number?(1599.99)).to eql true
       end
+
+      context "with a negative number" do
+        it "returns true" do
+          expect(described_class.valid_localizable_number?(-1599.99)).to eql true
+        end
+      end
     end
 
     context "with letters" do

--- a/spec/system/admin/adjustments_spec.rb
+++ b/spec/system/admin/adjustments_spec.rb
@@ -165,8 +165,8 @@ describe '
     it "displays adjustments" do
       click_link 'Adjustments'
 
-      expect(page).to_not have_selector('tr a.icon-edit')
-      expect(page).to_not have_selector('a.icon-plus'), text: 'New Adjustment'
+      expect(page).to_not have_selector 'tr a.icon-edit'
+      expect(page).to_not have_selector 'a.icon-plus', text: 'New Adjustment'
     end
   end
 end

--- a/spec/system/admin/adjustments_spec.rb
+++ b/spec/system/admin/adjustments_spec.rb
@@ -63,23 +63,17 @@ describe '
 
     context "included tax" do
       context "adding negative, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "TVA 20%", "$0.33", "$-1.67" do
-          before { pending("#10837") }
-        end
+        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "TVA 20%", "$0.33", "$-1.67"
       end
 
       context "adding positive, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Late fee", "100", "TVA 20%", "$-16.67", "$83.33" do
-          before { pending("#10837") }
-        end
+        it_behaves_like "when the enable_localized_number preference", "Late fee", "100", "TVA 20%", "$-16.67", "$83.33"
       end
     end
 
     context "added tax" do
       context "adding negative, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "GST", "$10.00", "$8.00" do
-          before { pending("#10837") }
-        end
+        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "GST", "$10.00", "$8.00"
       end
 
       context "adding positive, taxed adjustments to an order" do

--- a/spec/system/admin/adjustments_spec.rb
+++ b/spec/system/admin/adjustments_spec.rb
@@ -23,6 +23,10 @@ describe '
                       zone: create(:zone_with_member), tax_category: tax_category)
   }
 
+  let!(:tax_category_included) { create(:tax_category, name: 'TVA 20%', is_default: true) }
+  let!(:default_tax_zone) { create(:zone, default_tax: true) }
+  let!(:tax_rate2) { create(:tax_rate, name: "TVA 20%", amount: 0.2, zone: default_tax_zone, included_in_price: true, tax_category: tax_category_included, calculator: Calculator::DefaultTax.new ) }
+
   before do
     order.finalize!
     create(:check_payment, order: order, amount: order.total)
@@ -30,22 +34,84 @@ describe '
     visit spree.admin_orders_path
   end
 
-  it "adding taxed adjustments to an order" do
-    # When I go to the adjustments page for the order
-    page.find('td.actions a.icon-edit').click
-    click_link 'Adjustments'
+  shared_examples "when the enable_localized_number preference" do |adjustment_label, adjustment_amount, tax_category, tax, tax_total|
+    it "creates the adjustment and calculates taxes" do
+      # When I go to the adjustments page for the order
+      page.find('td.actions a.icon-edit').click
+      click_link 'Adjustments'
 
-    # And I create a new adjustment with tax
-    click_link 'New Adjustment'
-    fill_in 'adjustment_amount', with: 110
-    fill_in 'adjustment_label', with: 'Late fee'
-    select 'GST', from: 'adjustment_tax_category_id'
-    click_button 'Continue'
+      # And I create a new adjustment with tax
+      click_link 'New Adjustment'
+      fill_in 'adjustment_amount', with: adjustment_amount
+      fill_in 'adjustment_label', with: adjustment_label
+      select tax_category.to_s, from: 'adjustment_tax_category_id'
+      click_button 'Continue'
 
-    # Then I should see the adjustment, with the correct tax
-    expect(page).to have_selector 'td.label', text: 'Late fee'
-    expect(page).to have_selector 'td.amount', text: '110.00'
-    expect(page).to have_selector 'td.tax', text: '10.00'
+      # Then I should see the adjustment, with tax included in the amount
+      expect(page).to have_selector 'td.label', text: adjustment_label.to_s
+      expect(page).to have_selector 'td.amount', text: adjustment_amount.to_s
+      expect(page).to have_selector 'td.tax-category', text: tax_category.to_s
+      expect(page).to have_selector 'td.tax', text: tax.to_s
+      expect(page).to have_selector 'td.total', text: tax_total.to_s
+    end
+  end
+
+  context "is active" do
+    before do
+      allow(Spree::Config).to receive(:enable_localized_number?).and_return(true)
+    end
+
+    context "included tax" do
+      context "adding negative, taxed adjustments to an order" do
+        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "TVA 20%", "$0.33", "$-1.67" do
+          before { pending("#10837") }
+        end
+      end
+
+      context "adding positive, taxed adjustments to an order" do
+        it_behaves_like "when the enable_localized_number preference", "Late fee", "100", "TVA 20%", "$-16.67", "$83.33" do
+          before { pending("#10837") }
+        end
+      end
+    end
+
+    context "added tax" do
+      context "adding negative, taxed adjustments to an order" do
+        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "GST", "$10.00", "$8.00" do
+          before { pending("#10837") }
+        end
+      end
+
+      context "adding positive, taxed adjustments to an order" do
+        it_behaves_like "when the enable_localized_number preference", "Late fee", "110", "GST", "$10.00", "$120"
+      end
+    end
+  end
+
+  context "is not active" do
+    before do
+      allow(Spree::Config).to receive(:enable_localized_number?).and_return(false)
+    end
+
+    context "included tax" do
+      context "adding negative, taxed adjustments to an order" do
+        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "TVA 20%", "$0.33", "$-1.67"
+      end
+
+      context "adding positive, taxed adjustments to an order" do
+        it_behaves_like "when the enable_localized_number preference", "Late fee", "100", "TVA 20%", "$-16.67", "$83.33"
+      end
+    end
+
+    context "added tax" do
+      context "adding negative, taxed adjustments to an order" do
+        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "GST", "$10.00", "$8.00"
+      end
+
+      context "adding positive, taxed adjustments to an order" do
+        it_behaves_like "when the enable_localized_number preference", "Late fee", "110", "GST", "$10.00", "$120"
+      end
+    end
   end
 
   it "modifying taxed adjustments on an order" do


### PR DESCRIPTION

#### What? Why?

- Closes #10837

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

On 7af26e65795aa34898eec899275946c20a4ee358, PR #10329 introduced an additional input validation, with number localization enabled. However, it did not include the minus sign, which prevented negative adjustments from being created.

This PR includes the minus sign on the regular expression for validation and adds the spec proposed [here](https://github.com/openfoodfoundation/openfoodnetwork/issues/10837#issuecomment-1545976570).

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Log in as super admin
- Under `Configuration` enable the localization option

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/49817236/8a9fef5f-52ef-47ea-a15a-0ba6d7d5f712)

- Log in as a Hub
- On an existing order, go to the Adjustments section
- Create a negative adjustment
- Verify it is subtracted from the order total

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
