### PR TITLE
Validate user's email address

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -51,7 +51,10 @@ module Spree
     validates :email, 'valid_email_2/email': { mx: true }, if: :email_changed?
     validate :limit_owned_enterprises
     validates :uid, uniqueness: true, if: lambda { uid.present? }
-    validates_email :uid, if: lambda { uid.present? }
+
+    # Same validation as in the openid_connect gem.
+    # This validator is totally outdated but we indirectly depend on it.
+    validates :uid, email: true, if: lambda { uid.present? }
 
     class DestroyWithOrdersError < StandardError; end
 

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -48,6 +48,7 @@ module Spree
 
     after_create :associate_customers, :associate_orders
 
+    validates :email, 'valid_email_2/email': true, if: :email_changed?
     validate :limit_owned_enterprises
     validates :uid, uniqueness: true, if: lambda { uid.present? }
     validates_email :uid, if: lambda { uid.present? }

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -48,7 +48,7 @@ module Spree
 
     after_create :associate_customers, :associate_orders
 
-    validates :email, 'valid_email_2/email': true, if: :email_changed?
+    validates :email, 'valid_email_2/email': { mx: true }, if: :email_changed?
     validate :limit_owned_enterprises
     validates :uid, uniqueness: true, if: lambda { uid.present? }
     validates_email :uid, if: lambda { uid.present? }

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -127,6 +127,15 @@ RSpec.configure do |config|
     end
   end
 
+  # Don't validate our invalid test data with expensive network requests.
+  config.before(:each) do
+    allow_any_instance_of(ValidEmail2::Address).to receive_messages(
+      valid_mx?: true,
+      valid_strict_mx?: true,
+      mx_server_is_in?: false
+    )
+  end
+
   # Webmock raises errors that inherit directly from Exception (not StandardError).
   # The messages contain useful information for debugging stubbed requests to external
   # services (in tests), but they normally don't appear in the test output.

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -102,7 +102,10 @@ describe Spree::User do
       expect(user).to be_valid
     end
 
-    pending "detects typos in the domain" do
+    it "detects typos in the domain" do
+      # We mock this validation in all other tests because our test data is not
+      # valid, the network requests slow down tests and could make them flaky.
+      expect_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?).and_call_original
       user.email = "example@ho020tmail.com"
       expect(user).to_not be_valid
     end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -92,7 +92,7 @@ describe Spree::User do
       expect(user.errors.messages[:email]).to include "is invalid"
     end
 
-    pending "detects backslashes at the end" do
+    it "detects backslashes at the end" do
       user.email = "example@gmail.com\\\\"
       expect(user).to_not be_valid
     end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -80,6 +80,34 @@ describe Spree::User do
     end
   end
 
+  describe "validations" do
+    subject(:user) { build(:user) }
+
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
+
+    it "detects emails without @" do
+      user.email = "examplemail.com"
+      expect(user).to_not be_valid
+      expect(user.errors.messages[:email]).to include "is invalid"
+    end
+
+    pending "detects backslashes at the end" do
+      user.email = "example@gmail.com\\\\"
+      expect(user).to_not be_valid
+    end
+
+    it "is okay with numbers before the @" do
+      user.email = "example.42@posteo.de"
+      expect(user).to be_valid
+    end
+
+    pending "detects typos in the domain" do
+      user.email = "example@ho020tmail.com"
+      expect(user).to_not be_valid
+    end
+  end
+
   context "#create" do
     it "should send a confirmation email" do
       expect do


### PR DESCRIPTION
#### What? Why?

- Closes #10808 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We didn't really validate email addresses, only presence, uniqueness and that it contains an `@`. Now we validate the syntax and even the validity of the domain.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Creating a user with an invalid email address shouldn't be possible. You should see an error instead.
- Sign up as user with a domain which doesn't exist, like me@example.com.
- Invite an enterprise manager and add backslashes `\\` at the end of the address.
- Create a user as admin with an invalid address.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
