### PR TITLE
Fix error on summarising total_units in Order Cycle Supplier Totals report

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals.rb
@@ -25,9 +25,15 @@ module Reporting
               group_by: :producer,
               header: true,
               summary_row: proc do |_key, _items, rows|
+                total_units = rows.map(&:total_units)
+                summary_total_units = if total_units.all?(&:present?)
+                                        rows.sum(&:total_units)
+                                      else
+                                        " "
+                                      end
                 {
                   quantity: rows.sum(&:quantity),
-                  total_units: rows.sum(&:total_units),
+                  total_units: summary_total_units,
                   total_cost: rows.sum(&:total_cost)
                 }
               end

--- a/spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb
@@ -2,101 +2,97 @@
 
 require 'spec_helper'
 
-module Reporting
-  module Reports
-    module OrdersAndFulfillment
-      describe OrderCycleSupplierTotals do
-        let!(:distributor) { create(:distributor_enterprise) }
+describe Reporting::Reports::OrdersAndFulfillment::OrderCycleSupplierTotals do
+  let!(:distributor) { create(:distributor_enterprise) }
 
-        let!(:order) do
-          create(:completed_order_with_totals, line_items_count: 1, distributor: distributor)
-        end
-        let!(:supplier) do
-          order.line_items.first.variant.product.supplier
-        end
-        let(:current_user) { distributor.owner }
-        let(:params) { { display_summary_row: false, fields_to_hide: [] } }
-        let(:report) do
-          OrderCycleSupplierTotals.new(current_user, params)
-        end
+  let!(:order) do
+    create(:completed_order_with_totals, line_items_count: 1, distributor: distributor)
+  end
+  let!(:supplier) do
+    order.line_items.first.variant.product.supplier
+  end
+  let(:current_user) { distributor.owner }
+  let(:params) { { display_summary_row: false, fields_to_hide: [] } }
+  let(:report) do
+    described_class.new(current_user, params)
+  end
 
-        let(:table_headers) do
-          report.table_headers
-        end
+  let(:table_headers) do
+    report.table_headers
+  end
 
-        let(:report_table) do
-          report.table_rows
-        end
+  let(:report_table) do
+    report.table_rows
+  end
 
-        it "generates the report" do
-          expect(report_table.length).to eq(1)
-        end
-        context "with a VAT/GST-free supplier" do
-          before(:each) do
-            supplier.update(charges_sales_tax: false)
-          end
+  it "generates the report" do
+    expect(report_table.length).to eq(1)
+  end
 
-          it "has a variant row when product belongs to a tax category" do
-            product_tax_category_name = order.line_items.first.variant.product.tax_category.name
-
-            supplier_name_field = report_table.first[0]
-            supplier_vat_status_field = report_table.first[-2]
-            product_tax_category_field = report_table.first[-1]
-
-            expect(supplier_name_field).to eq supplier.name
-            expect(supplier_vat_status_field).to eq "No"
-            expect(product_tax_category_field).to eq product_tax_category_name
-          end
-
-          it "has a variant row when product doesn't belong to a tax category" do
-            order.line_items.first.variant.product.update(tax_category_id: nil)
-            supplier_name_field = report_table.first[0]
-            supplier_vat_status_field = report_table.first[-2]
-            product_tax_category_field = report_table.first[-1]
-
-            expect(supplier_name_field).to eq supplier.name
-            expect(supplier_vat_status_field).to eq "No"
-            expect(product_tax_category_field).to eq "none"
-          end
-        end
-        context "with a VAT/GST-enabled supplier" do
-          before(:each) do
-            supplier.update(charges_sales_tax: true)
-          end
-
-          it "has a variant row when product belongs to a tax category" do
-            product_tax_category_name = order.line_items.first.variant.product.tax_category.name
-
-            supplier_name_field = report_table.first[0]
-            supplier_vat_status_field = report_table.first[-2]
-            product_tax_category_field = report_table.first[-1]
-
-            expect(supplier_name_field).to eq supplier.name
-            expect(supplier_vat_status_field).to eq "Yes"
-            expect(product_tax_category_field).to eq product_tax_category_name
-          end
-
-          it "has a variant row when product doesn't belong to a tax category" do
-            order.line_items.first.variant.product.update(tax_category_id: nil)
-            supplier_name_field = report_table.first[0]
-            supplier_vat_status_field = report_table.first[-2]
-            product_tax_category_field = report_table.first[-1]
-
-            expect(supplier_name_field).to eq supplier.name
-            expect(supplier_vat_status_field).to eq "Yes"
-            expect(product_tax_category_field).to eq "none"
-          end
-        end
-
-        it "includes sku column" do
-          variant_sku = order.line_items.first.variant.sku
-          last_column_title = table_headers[-3]
-          first_row_last_column_value = report_table.first[-3]
-
-          expect(last_column_title).to eq "SKU"
-          expect(first_row_last_column_value).to eq variant_sku
-        end
-      end
+  context "with a VAT/GST-free supplier" do
+    before(:each) do
+      supplier.update(charges_sales_tax: false)
     end
+
+    it "has a variant row when product belongs to a tax category" do
+      product_tax_category_name = order.line_items.first.variant.product.tax_category.name
+
+      supplier_name_field = report_table.first[0]
+      supplier_vat_status_field = report_table.first[-2]
+      product_tax_category_field = report_table.first[-1]
+
+      expect(supplier_name_field).to eq supplier.name
+      expect(supplier_vat_status_field).to eq "No"
+      expect(product_tax_category_field).to eq product_tax_category_name
+    end
+
+    it "has a variant row when product doesn't belong to a tax category" do
+      order.line_items.first.variant.product.update(tax_category_id: nil)
+      supplier_name_field = report_table.first[0]
+      supplier_vat_status_field = report_table.first[-2]
+      product_tax_category_field = report_table.first[-1]
+
+      expect(supplier_name_field).to eq supplier.name
+      expect(supplier_vat_status_field).to eq "No"
+      expect(product_tax_category_field).to eq "none"
+    end
+  end
+
+  context "with a VAT/GST-enabled supplier" do
+    before(:each) do
+      supplier.update(charges_sales_tax: true)
+    end
+
+    it "has a variant row when product belongs to a tax category" do
+      product_tax_category_name = order.line_items.first.variant.product.tax_category.name
+
+      supplier_name_field = report_table.first[0]
+      supplier_vat_status_field = report_table.first[-2]
+      product_tax_category_field = report_table.first[-1]
+
+      expect(supplier_name_field).to eq supplier.name
+      expect(supplier_vat_status_field).to eq "Yes"
+      expect(product_tax_category_field).to eq product_tax_category_name
+    end
+
+    it "has a variant row when product doesn't belong to a tax category" do
+      order.line_items.first.variant.product.update(tax_category_id: nil)
+      supplier_name_field = report_table.first[0]
+      supplier_vat_status_field = report_table.first[-2]
+      product_tax_category_field = report_table.first[-1]
+
+      expect(supplier_name_field).to eq supplier.name
+      expect(supplier_vat_status_field).to eq "Yes"
+      expect(product_tax_category_field).to eq "none"
+    end
+  end
+
+  it "includes sku column" do
+    variant_sku = order.line_items.first.variant.sku
+    last_column_title = table_headers[-3]
+    first_row_last_column_value = report_table.first[-3]
+
+    expect(last_column_title).to eq "SKU"
+    expect(first_row_last_column_value).to eq variant_sku
   end
 end

--- a/spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb
@@ -29,6 +29,81 @@ describe Reporting::Reports::OrdersAndFulfillment::OrderCycleSupplierTotals do
     expect(report_table.length).to eq(1)
   end
 
+  describe "total_units column" do
+    let(:item) { order.line_items.first }
+    let(:variant) { item.variant }
+
+    it "contains a sum of total items" do
+      variant.product.update!(variant_unit: "items", variant_unit_name: "bottle")
+      variant.update!(unit_value: 6) # six-pack
+      item.update!(final_weight_volume: nil) # reset unit information
+      item.update!(quantity: 3)
+
+      expect(table_headers[4]).to eq "Total Units"
+      expect(report_table[0][4]).to eq 18 # = 3 * 6, three six-packs
+    end
+
+    it "contains a sum of total weight" do
+      variant.product.update!(variant_unit: "weight")
+      variant.update!(unit_value: 200) # grams
+      item.update!(final_weight_volume: nil) # reset unit information
+      item.update!(quantity: 3)
+
+      expect(table_headers[4]).to eq "Total Units"
+      expect(report_table[0][4]).to eq 0.6 # kg (= 3 * 0.2kg)
+    end
+
+    it "is blank when line items miss a unit" do
+      # This is not possible with the current code but was possible years ago.
+      # So I'm using `update_columns` to save invalid data.
+      # We still have lots of that data in our databases though.
+      variant.product.update(variant_unit: "items", variant_unit_name: "container")
+      variant.update_columns(unit_value: nil, unit_description: "vacuum")
+      item.update!(final_weight_volume: nil) # reset unit information
+
+      expect(table_headers[4]).to eq "Total Units"
+      expect(report_table[0][4]).to eq " "
+    end
+
+    it "is summarised" do
+      expect(report).to receive(:display_summary_row?).and_return(true)
+
+      variant.product.update!(variant_unit: "weight")
+      variant.update!(unit_value: 200) # grams
+      item.update!(final_weight_volume: nil) # reset unit information
+      item.update!(quantity: 3)
+
+      # And a second item to add up with:
+      item2 = create(:line_item, order: order)
+
+      expect(table_headers[4]).to eq "Total Units"
+      expect(report_table[0][4]).to eq 0.6 # kg (= 3 * 0.2kg)
+      expect(report_table[1][4]).to eq 0.001 # 1 gram default value
+      expect(report_table[2][4]).to eq 0.601 # summary
+    end
+
+    pending "is blank in summary when one line item misses a unit and another not" do
+      expect(report).to receive(:display_summary_row?).and_return(true)
+
+      # This is not possible with the current code but was possible years ago.
+      # So I'm using `update_columns` to save invalid data.
+      # We still have lots of that data in our databases though.
+      variant.product.update(variant_unit: "items", variant_unit_name: "container")
+      variant.update_columns(unit_value: nil, unit_description: "vacuum")
+      item.update!(final_weight_volume: nil) # reset unit information
+
+      # This second line item will have a default a bigint value.
+      order.line_items << create(:line_item)
+
+      # Generating the report used to raise:
+      # > TypeError: no implicit conversion of BigDecimal into String
+      expect(table_headers[4]).to eq "Total Units"
+      expect(report_table[0][4]).to eq " "
+      expect(report_table[1][4]).to eq 0.001 # 1 gram default value
+      expect(report_table[2][4]).to eq " " # summary
+    end
+  end
+
   context "with a VAT/GST-free supplier" do
     before(:each) do
       supplier.update(charges_sales_tax: false)

--- a/spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb
@@ -82,7 +82,7 @@ describe Reporting::Reports::OrdersAndFulfillment::OrderCycleSupplierTotals do
       expect(report_table[2][4]).to eq 0.601 # summary
     end
 
-    pending "is blank in summary when one line item misses a unit and another not" do
+    it "is blank in summary when one line item misses a unit and another not" do
       expect(report).to receive(:display_summary_row?).and_return(true)
 
       # This is not possible with the current code but was possible years ago.


### PR DESCRIPTION
#### What? Why?

- Closes #10847 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Deploy to UK staging or FR staging, both seem to have old, invalid data.
- Visit Order Cycle Supplier Totals report.
- Set the start date to the beginning of 2020 or earlier.
- Choose to display summary rows and don't download CSV (which doesn't have summaries).
- The report should display without error.
- The summary for Total Units should be empty if one of the rows has an empty value. Then you covered the previously failing scenario.
- The summary for Total Units should be the correct sum of the columns above if they all contain numbers (different date range).

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
