### PR TITLE
Show "loading" screen for background reports and display when ready

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -44,6 +44,9 @@ Metrics/BlockLength:
     "xdescribe",
   ]
 
+Metrics/ParameterLists:
+  CountKeywordArgs: false
+
 Rails/ApplicationRecord:
   Exclude:
     # Migrations should not contain application code:

--- a/app/assets/javascripts/admin/all.js
+++ b/app/assets/javascripts/admin/all.js
@@ -68,25 +68,6 @@
 //= require textAngular.min.js
 //= require i18n/translations
 //= require darkswarm/i18n.translate.js
-//= require moment/min/moment.min.js
-//= require moment/locale/ar.js
-//= require moment/locale/ca.js
-//= require moment/locale/de.js
-//= require moment/locale/en-gb.js
-//= require moment/locale/es.js
-//= require moment/locale/fil.js
-//= require moment/locale/fr.js
-//= require moment/locale/it.js
-//= require moment/locale/nb.js
-//= require moment/locale/nl-be.js
-//= require moment/locale/pt-br.js
-//= require moment/locale/pt.js
-//= require moment/locale/ru.js
-//= require moment/locale/sv.js
-//= require moment/locale/tr.js
-//= require moment/locale/pl.js
-
-//= require js-big-decimal/dist/web/js-big-decimal.min.js
 
 // foundation
 //= require ../shared/mm-foundation-tpls-0.9.0-20180826174721.min.js

--- a/app/assets/javascripts/admin_minimal.js
+++ b/app/assets/javascripts/admin_minimal.js
@@ -11,24 +11,5 @@
 
 //= require i18n/translations
 //= require darkswarm/i18n.translate.js
-//= require moment/min/moment.min.js
-//= require moment/locale/ar.js
-//= require moment/locale/ca.js
-//= require moment/locale/de.js
-//= require moment/locale/en-gb.js
-//= require moment/locale/es.js
-//= require moment/locale/fil.js
-//= require moment/locale/fr.js
-//= require moment/locale/it.js
-//= require moment/locale/nb.js
-//= require moment/locale/nl-be.js
-//= require moment/locale/pt-br.js
-//= require moment/locale/pt.js
-//= require moment/locale/ru.js
-//= require moment/locale/sv.js
-//= require moment/locale/tr.js
-//= require moment/locale/pl.js
-
-//= require js-big-decimal/dist/web/js-big-decimal.min.js
 
 window.angular = { module: function(noop){ return { value: function(){} } } }

--- a/app/assets/javascripts/darkswarm/all.js.coffee
+++ b/app/assets/javascripts/darkswarm/all.js.coffee
@@ -29,24 +29,6 @@
 #
 #= require angular-flash.min.js
 #
-#= require moment/min/moment.min.js
-#= require moment/locale/ar.js
-#= require moment/locale/ca.js
-#= require moment/locale/de.js
-#= require moment/locale/en-gb.js
-#= require moment/locale/es.js
-#= require moment/locale/fil.js
-#= require moment/locale/fr.js
-#= require moment/locale/it.js
-#= require moment/locale/nb.js
-#= require moment/locale/nl-be.js
-#= require moment/locale/pt-br.js
-#= require moment/locale/pt.js
-#= require moment/locale/ru.js
-#= require moment/locale/sv.js
-#= require moment/locale/tr.js
-#= require moment/locale/pl.js
-#
 #= require modernizr
 #
 #= require foundation-sites/js/foundation.js

--- a/app/channels/scoped_channel.rb
+++ b/app/channels/scoped_channel.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ScopedChannel < ApplicationCable::Channel
+  class << self
+    def for_id(id)
+      "ScopedChannel:#{id}"
+    end
+  end
+
+  def subscribed
+    stream_from "ScopedChannel:#{params[:id]}"
+  end
+end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -67,7 +67,7 @@ module Admin
       @blob = ReportBlob.create_for_upload_later!(report_filename)
 
       ReportJob.perform_later(
-        report_class, spree_current_user, params, format, @blob, SessionChannel.for_request(request)
+        report_class, spree_current_user, params, format, @blob, ScopedChannel.for_id(params[:uuid])
       )
 
       render cable_ready: cable_car.

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -62,6 +62,15 @@ module Admin
     end
 
     def background(format)
+      cable_ready[ScopedChannel.for_id(params[:uuid])]
+        .inner_html(
+          selector: "#report-table",
+          html: render_to_string(partial: "admin/reports/loading")
+        ).scroll_into_view(
+          selector: "#report-table",
+          block: "start"
+        ).broadcast
+
       blob = ReportBlob.create_for_upload_later!(report_filename)
 
       ReportJob.perform_later(
@@ -69,14 +78,7 @@ module Admin
         format: format, blob: blob, channel: ScopedChannel.for_id(params[:uuid]),
       )
 
-      render cable_ready: cable_car.
-        inner_html(
-          selector: "#report-table",
-          html: render_to_string(partial: "admin/reports/loading")
-        ).scroll_into_view(
-          selector: "#report-table",
-          block: "start"
-        )
+      head :no_content
     end
   end
 end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -34,8 +34,6 @@ module Admin
       else
         show_report
       end
-    rescue Timeout::Error
-      render_timeout_error
     end
 
     private
@@ -64,10 +62,10 @@ module Admin
     end
 
     def background(format)
-      @blob = ReportBlob.create_for_upload_later!(report_filename)
+      blob = ReportBlob.create_for_upload_later!(report_filename)
 
       ReportJob.perform_later(
-        report_class, spree_current_user, params, format, @blob, ScopedChannel.for_id(params[:uuid])
+        report_class, spree_current_user, params, format, blob, ScopedChannel.for_id(params[:uuid])
       )
 
       render cable_ready: cable_car.
@@ -78,18 +76,6 @@ module Admin
           selector: "#report-table",
           block: "start"
         )
-    end
-
-    def render_timeout_error
-      assign_view_data
-      if @blob
-        @error = ".report_taking_longer_html"
-        @error_url = @blob.expiring_service_url
-      else
-        @error = ".report_taking_longer"
-        @error_url = ""
-      end
-      render "show"
     end
   end
 end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -23,7 +23,7 @@ module Admin
       @report = report_class.new(spree_current_user, params, render: render_data?)
 
       @background_reports = OpenFoodNetwork::FeatureToggle
-                              .enabled?(:background_reports, spree_current_user)
+        .enabled?(:background_reports, spree_current_user)
 
       if @background_reports && request.post?
         return background(report_format)

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -65,7 +65,8 @@ module Admin
       blob = ReportBlob.create_for_upload_later!(report_filename)
 
       ReportJob.perform_later(
-        report_class, spree_current_user, params, format, blob, ScopedChannel.for_id(params[:uuid])
+        report_class: report_class, user: spree_current_user, params: params,
+        format: format, blob: blob, channel: ScopedChannel.for_id(params[:uuid]),
       )
 
       render cable_ready: cable_car.

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,4 +7,11 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
+
+  private
+
+  def enable_active_storage_urls
+    ActiveStorage::Current.url_options ||=
+      Rails.application.config.action_controller.default_url_options
+  end
 end

--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -9,7 +9,7 @@ class ReportJob < ApplicationJob
 
   NOTIFICATION_TIME = 5.seconds
 
-  def perform(report_class, user, params, format, blob, channel = nil)
+  def perform(report_class:, user:, params:, format:, blob:, channel: nil)
     start_time = Time.zone.now
 
     report = report_class.new(user, params, render: true)

--- a/app/views/admin/reports/_download.html.haml
+++ b/app/views/admin/reports/_download.html.haml
@@ -1,0 +1,2 @@
+.download
+  = link_to t("admin.reports.download.button"), file_url, target: "_blank", class: "button icon icon-file"

--- a/app/views/admin/reports/_loading.html.haml
+++ b/app/views/admin/reports/_loading.html.haml
@@ -1,0 +1,2 @@
+.loading
+  = render partial: "components/admin_spinner"

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -1,6 +1,8 @@
 - content_for :page_title do
   = @report_title
 
+- content_for :minimal_js, true if @background_reports
+
 = form_for @report.search, :url => url_for do |f|
   %fieldset.no-border-bottom.print-hidden
     %legend{ align: 'center'}= t(:report_filters)

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -3,7 +3,9 @@
 
 - content_for :minimal_js, true if @background_reports
 
-= form_for @report.search, :url => url_for do |f|
+- options = @background_reports ? { data: { remote: "true" } } : {}
+
+= form_for @report.search, { url: url_for }.merge(options) do |f|
   %fieldset.no-border-bottom.print-hidden
     %legend{ align: 'center'}= t(:report_filters)
     = render partial: "admin/reports/filters/#{@report_type}", locals: { f: f }
@@ -24,4 +26,6 @@
     %button.btn-print.icon-print{ onclick: "window.print()"}= t(:report_print)
 
 = t(@error, link: link_to(t(".report_link_label"), @error_url)) if @error
-= @table
+
+#report-table
+  = @table

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -6,6 +6,8 @@
 - options = @background_reports ? { data: { remote: "true" } } : {}
 
 = form_for @report.search, { url: url_for }.merge(options) do |f|
+  = hidden_field_tag "uuid", request.uuid
+
   %fieldset.no-border-bottom.print-hidden
     %legend{ align: 'center'}= t(:report_filters)
     = render partial: "admin/reports/filters/#{@report_type}", locals: { f: f }
@@ -27,5 +29,5 @@
 
 = t(@error, link: link_to(t(".report_link_label"), @error_url)) if @error
 
-#report-table
+#report-table{ data: { controller: "scoped-channel", "scoped-channel-id-value": request.uuid } }
   = @table

--- a/app/webpacker/controllers/scoped_channel_controller.js
+++ b/app/webpacker/controllers/scoped_channel_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "stimulus";
+import consumer from "../channels/consumer";
+import CableReady from "cable_ready";
+
+export default class extends Controller {
+  static values = { id: String };
+
+  connect() {
+    this.subscription = consumer.subscriptions.create(
+      { channel: "ScopedChannel", id: this.idValue },
+      {
+        received(data) {
+          if (data.cableReady) CableReady.perform(data.operations);
+        },
+      }
+    );
+  }
+
+  disconnect() {
+    consumer.subscriptions.remove(this.subscription);
+  }
+}

--- a/app/webpacker/css/admin/reports.scss
+++ b/app/webpacker/css/admin/reports.scss
@@ -60,3 +60,24 @@ table.report__table {
   margin: 0 !important;
   width: 120px;
 }
+
+#report-table {
+  margin-bottom: 4em;
+
+  .loading, .download {
+    text-align: center;
+    height: 2em;
+    padding: 4em;
+    width: 100%;
+
+    .spinner {
+      font-size: 4em;
+      color: $spree-blue;
+      opacity: 0.3;
+    }
+
+    .button {
+      font-size: 1.25em;
+    }
+  }
+}

--- a/app/webpacker/js/moment.js
+++ b/app/webpacker/js/moment.js
@@ -1,0 +1,19 @@
+import moment from "moment";
+window.moment = moment;
+
+import "moment/locale/ar";
+import "moment/locale/ca";
+import "moment/locale/de";
+import "moment/locale/en-gb";
+import "moment/locale/es";
+import "moment/locale/fil";
+import "moment/locale/fr";
+import "moment/locale/it";
+import "moment/locale/nb";
+import "moment/locale/nl-be";
+import "moment/locale/pt-br";
+import "moment/locale/pt";
+import "moment/locale/ru";
+import "moment/locale/sv";
+import "moment/locale/tr";
+import "moment/locale/pl";

--- a/app/webpacker/packs/admin.js
+++ b/app/webpacker/packs/admin.js
@@ -2,6 +2,10 @@ import "controllers";
 import "channels";
 import "@hotwired/turbo";
 import "../js/mrujs";
+import "../js/moment";
+
+import bigDecimal from "js-big-decimal";
+window.bigDecimal = bigDecimal;
 
 import debounced from "debounced";
 debounced.initialize({ input: { wait: 300 } });

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,6 +1,7 @@
 import "controllers";
 import "@hotwired/turbo";
 import "../js/mrujs";
+import "../js/moment";
 
 require.context("../fonts", true);
 const images = require.context("../images", true);

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1469,6 +1469,8 @@ en:
       pack_by_customer: Pack By Customer
       pack_by_supplier: Pack By Supplier
       pack_by_product: Pack By Product
+      download:
+        button: "Download Report"
       show:
         report_taking_longer: >
           Sorry, this report took too long to process.

--- a/spec/jobs/report_job_spec.rb
+++ b/spec/jobs/report_job_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe ReportJob do
-  let(:report_args) { [report_class, user, params, format, blob] }
+  let(:report_args) {
+    { report_class: report_class, user: user, params: params, format: format,
+      blob: blob }
+  }
   let(:report_class) { Reporting::Reports::UsersAndEnterprises::Base }
   let(:user) { enterprise.owner }
   let(:enterprise) { create(:enterprise) }
@@ -13,13 +16,13 @@ describe ReportJob do
 
   it "generates a report" do
     job = perform_enqueued_jobs(only: ReportJob) do
-      ReportJob.perform_later(*report_args)
+      ReportJob.perform_later(**report_args)
     end
     expect_csv_report
   end
 
   it "enqueues a job for async processing" do
-    job = ReportJob.perform_later(*report_args)
+    job = ReportJob.perform_later(**report_args)
     expect(blob.content_stored?).to eq false
 
     perform_enqueued_jobs(only: ReportJob)
@@ -29,12 +32,16 @@ describe ReportJob do
   end
 
   it "triggers an email when the report is done" do
+    # Setup test data which also triggers emails:
+    report_args
+
     # Send emails for quick jobs as well:
     stub_const("ReportJob::NOTIFICATION_TIME", 0)
 
-    ReportJob.perform_later(*report_args)
-
     expect {
+      # We need to create this job within the block because of a bug in
+      # rspec-rails: https://github.com/rspec/rspec-rails/issues/2668
+      ReportJob.perform_later(**report_args)
       perform_enqueued_jobs(only: ReportJob)
     }.to enqueue_mail(ReportMailer, :report_ready).with(
       params: {
@@ -46,9 +53,13 @@ describe ReportJob do
   end
 
   it "triggers no email when the report is done quickly" do
-    ReportJob.perform_later(*report_args)
+    # Setup test data which also triggers emails:
+    report_args
 
     expect {
+      # We need to create this job within the block because of a bug in
+      # rspec-rails: https://github.com/rspec/rspec-rails/issues/2668
+      ReportJob.perform_later(**report_args)
       perform_enqueued_jobs(only: ReportJob)
     }.to_not enqueue_mail
   end

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -110,7 +110,7 @@ describe '
       end
     end
 
-    pending "allows the report to finish before the loading screen is rendered" do
+    it "allows the report to finish before the loading screen is rendered" do
       login_as_admin
       visit admin_report_path(
         report_type: :customers, report_subtype: :mailing_list

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -77,14 +77,9 @@ describe '
       visit admin_report_path(
         report_type: :customers, report_subtype: :mailing_list
       )
-      allow(ENV).to receive(:fetch).and_call_original
-      expect(ENV).to receive(:fetch).with("RACK_TIMEOUT_SERVICE_TIMEOUT", "15")
-        .and_return("-1") # Negative values time out immediately.
       stub_const("ReportJob::NOTIFICATION_TIME", 0)
 
       click_button "Go"
-
-      expect(page).to have_content "report is taking longer"
 
       perform_enqueued_jobs(only: ReportJob)
 

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -43,6 +43,8 @@ describe '
         report_type: :customers, report_subtype: :mailing_list
       )
       click_button "Go"
+
+      expect(page).to have_selector "#report-table"
       expect(page).to have_content "EMAIL FIRST NAME"
     end
 
@@ -695,13 +697,6 @@ describe '
       end
 
       context "detailed report" do
-        before do
-          login_as_admin
-          visit admin_reports_path
-          click_link "Detailed"
-          click_button 'Go'
-        end
-
         it "generates a detailed report" do
           login_as_admin
           visit admin_reports_path


### PR DESCRIPTION
#### What? Why?

- Closes #10752 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Originally opened by @Matt-Yorkley against one of my pull requests:

* https://github.com/mkllnk/openfoodnetwork/pull/1

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit a reports page.
- Compile a report and it should display as usual.
- Activate background reports.
- When you now compile a report, you see a loading screen until the report is ready. It then displays on screen or offers a download link.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

