### PR TITLE
Require belongs_to associations - part 1

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -681,6 +681,7 @@ Metrics/ClassLength:
     - 'app/models/spree/payment.rb'
     - 'app/models/spree/product.rb'
     - 'app/models/spree/shipment.rb'
+    - 'app/models/spree/shipping_method.rb'
     - 'app/models/spree/user.rb'
     - 'app/models/spree/variant.rb'
     - 'app/models/spree/zone.rb'

--- a/app/models/adjustment_metadata.rb
+++ b/app/models/adjustment_metadata.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AdjustmentMetadata < ApplicationRecord
+  self.belongs_to_required_by_default = true
+
   belongs_to :adjustment, class_name: 'Spree::Adjustment'
   belongs_to :enterprise
 end

--- a/app/models/column_preference.rb
+++ b/app/models/column_preference.rb
@@ -5,6 +5,8 @@ require 'open_food_network/column_preference_defaults'
 class ColumnPreference < ApplicationRecord
   extend OpenFoodNetwork::ColumnPreferenceDefaults
 
+  self.belongs_to_required_by_default = true
+
   # Non-persisted attributes that only have one
   # setting (ie. the default) for a given column
   attr_accessor :name

--- a/app/models/coordinator_fee.rb
+++ b/app/models/coordinator_fee.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CoordinatorFee < ApplicationRecord
+  self.belongs_to_required_by_default = true
+
   belongs_to :order_cycle
   belongs_to :enterprise_fee
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -10,20 +10,22 @@
 class Customer < ApplicationRecord
   include SetUnusedAddressFields
 
+  self.belongs_to_required_by_default = true
+
   acts_as_taggable
 
   searchable_attributes :first_name, :last_name, :email, :code
 
-  belongs_to :enterprise, optional: false
-  belongs_to :user, class_name: "Spree::User"
+  belongs_to :enterprise
+  belongs_to :user, class_name: "Spree::User", optional: true
   has_many :orders, class_name: "Spree::Order"
   before_destroy :update_orders_and_delete_canceled_subscriptions
 
-  belongs_to :bill_address, class_name: "Spree::Address"
+  belongs_to :bill_address, class_name: "Spree::Address", optional: true
   alias_attribute :billing_address, :bill_address
   accepts_nested_attributes_for :bill_address
 
-  belongs_to :ship_address, class_name: "Spree::Address"
+  belongs_to :ship_address, class_name: "Spree::Address", optional: true
   alias_attribute :shipping_address, :ship_address
   accepts_nested_attributes_for :ship_address
 

--- a/app/models/distributor_payment_method.rb
+++ b/app/models/distributor_payment_method.rb
@@ -2,6 +2,8 @@
 
 class DistributorPaymentMethod < ApplicationRecord
   self.table_name = "distributors_payment_methods"
+  self.belongs_to_required_by_default = true
+
   belongs_to :payment_method, class_name: "Spree::PaymentMethod", touch: true
   belongs_to :distributor, class_name: "Enterprise", touch: true
 end

--- a/app/models/distributor_shipping_method.rb
+++ b/app/models/distributor_shipping_method.rb
@@ -2,6 +2,8 @@
 
 class DistributorShippingMethod < ApplicationRecord
   self.table_name = "distributors_shipping_methods"
+  self.belongs_to_required_by_default = true
+
   belongs_to :shipping_method, class_name: "Spree::ShippingMethod", touch: true
   belongs_to :distributor, class_name: "Enterprise", touch: true
 end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -61,7 +61,8 @@ class Enterprise < ApplicationRecord
   has_many :users, through: :enterprise_roles
   belongs_to :owner, class_name: 'Spree::User',
                      inverse_of: :owned_enterprises
-  has_many :distributor_payment_methods, foreign_key: :distributor_id
+  has_many :distributor_payment_methods,
+    inverse_of: :distributor, foreign_key: :distributor_id
   has_many :distributor_shipping_methods, foreign_key: :distributor_id
   has_many :payment_methods, through: :distributor_payment_methods
   has_many :shipping_methods, through: :distributor_shipping_methods

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -63,7 +63,8 @@ class Enterprise < ApplicationRecord
                      inverse_of: :owned_enterprises
   has_many :distributor_payment_methods,
     inverse_of: :distributor, foreign_key: :distributor_id
-  has_many :distributor_shipping_methods, foreign_key: :distributor_id
+  has_many :distributor_shipping_methods,
+    inverse_of: :distributor, foreign_key: :distributor_id
   has_many :payment_methods, through: :distributor_payment_methods
   has_many :shipping_methods, through: :distributor_shipping_methods
   has_many :customers

--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -8,6 +8,8 @@ module Spree
       back_end: "back_end"
     }.freeze
 
+    self.belongs_to_required_by_default = true
+
     acts_as_paranoid
     acts_as_taggable
 
@@ -25,7 +27,7 @@ module Spree
     has_and_belongs_to_many :zones, join_table: 'spree_shipping_methods_zones',
                                     class_name: 'Spree::Zone'
 
-    belongs_to :tax_category, class_name: 'Spree::TaxCategory'
+    belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
 
     validates :name, presence: true
     validate :distributor_validation

--- a/db/migrate/20230503060530_require_adjustment_and_enterprise_on_adjustment_metadata.rb
+++ b/db/migrate/20230503060530_require_adjustment_and_enterprise_on_adjustment_metadata.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RequireAdjustmentAndEnterpriseOnAdjustmentMetadata < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :adjustment_metadata, :adjustment_id, false
+    change_column_null :adjustment_metadata, :enterprise_id, false
+  end
+end

--- a/db/migrate/20230516052547_require_order_cycle_and_enterprise_fee_on_coordinator_fees.rb
+++ b/db/migrate/20230516052547_require_order_cycle_and_enterprise_fee_on_coordinator_fees.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RequireOrderCycleAndEnterpriseFeeOnCoordinatorFees < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :coordinator_fees, :order_cycle_id, false
+    change_column_null :coordinator_fees, :enterprise_fee_id, false
+  end
+end

--- a/db/migrate/20230516054204_require_payment_method_and_distributor_on_distributor_payment_methods.rb
+++ b/db/migrate/20230516054204_require_payment_method_and_distributor_on_distributor_payment_methods.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RequirePaymentMethodAndDistributorOnDistributorPaymentMethods < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :distributors_payment_methods, :payment_method_id, false
+    change_column_null :distributors_payment_methods, :distributor_id, false
+  end
+end

--- a/db/migrate/20230516054745_require_shipping_method_and_distributor_on_distributor_shipping_methods.rb
+++ b/db/migrate/20230516054745_require_shipping_method_and_distributor_on_distributor_shipping_methods.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RequireShippingMethodAndDistributorOnDistributorShippingMethods < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :distributors_shipping_methods, :shipping_method_id, false
+    change_column_null :distributors_shipping_methods, :distributor_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -116,8 +116,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_120633) do
   end
 
   create_table "distributors_payment_methods", force: :cascade do |t|
-    t.integer "distributor_id"
-    t.integer "payment_method_id"
+    t.integer "distributor_id", null: false
+    t.integer "payment_method_id", null: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["distributor_id"], name: "index_distributors_payment_methods_on_distributor_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,8 +64,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_120633) do
   end
 
   create_table "coordinator_fees", id: :serial, force: :cascade do |t|
-    t.integer "order_cycle_id"
-    t.integer "enterprise_fee_id"
+    t.integer "order_cycle_id", null: false
+    t.integer "enterprise_fee_id", null: false
     t.index ["enterprise_fee_id"], name: "index_coordinator_fees_on_enterprise_fee_id"
     t.index ["order_cycle_id"], name: "index_coordinator_fees_on_order_cycle_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,8 +44,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_120633) do
   end
 
   create_table "adjustment_metadata", id: :serial, force: :cascade do |t|
-    t.integer "adjustment_id"
-    t.integer "enterprise_id"
+    t.integer "adjustment_id", null: false
+    t.integer "enterprise_id", null: false
     t.string "fee_name", limit: 255
     t.string "fee_type", limit: 255
     t.string "enterprise_role", limit: 255

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -125,8 +125,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_120633) do
   end
 
   create_table "distributors_shipping_methods", id: :serial, force: :cascade do |t|
-    t.integer "distributor_id"
-    t.integer "shipping_method_id"
+    t.integer "distributor_id", null: false
+    t.integer "shipping_method_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["distributor_id"], name: "index_distributors_shipping_methods_on_distributor_id"

--- a/spec/models/adjustment_metadata_spec.rb
+++ b/spec/models/adjustment_metadata_spec.rb
@@ -3,6 +3,9 @@
 require 'spec_helper'
 
 describe AdjustmentMetadata do
+  it { is_expected.to belong_to(:adjustment).required }
+  it { is_expected.to belong_to(:enterprise).required }
+
   it "is valid when built from factory" do
     adjustment_metadata = build(:adjustment_metadata)
     expect(adjustment_metadata).to be_valid

--- a/spec/models/column_preference_spec.rb
+++ b/spec/models/column_preference_spec.rb
@@ -3,19 +3,27 @@
 require 'spec_helper'
 
 describe ColumnPreference, type: :model do
+  subject {
+    ColumnPreference.new(
+      user: user, action_name: :customers_index, column_name: :email
+    )
+  }
+  let(:user) { build(:user) }
+
+  it { is_expected.to belong_to(:user).required }
+
   describe "finding stored preferences for a user and action" do
     before do
       allow(ColumnPreference).to receive(:known_actions) { ['some_action'] }
       allow(ColumnPreference).to receive(:valid_columns_for) { ['col1', 'col2', 'col3'] }
     end
 
-    let(:user) { create(:user) }
     let!(:col1_pref) {
-      ColumnPreference.create(user_id: user.id, action_name: 'some_action', column_name: 'col1',
+      ColumnPreference.create(user: user, action_name: 'some_action', column_name: 'col1',
                               visible: true)
     }
     let!(:col2_pref) {
-      ColumnPreference.create(user_id: user.id, action_name: 'some_action', column_name: 'col2',
+      ColumnPreference.create(user: user, action_name: 'some_action', column_name: 'col2',
                               visible: false)
     }
     let(:defaults) {

--- a/spec/models/coordinator_fee_spec.rb
+++ b/spec/models/coordinator_fee_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CoordinatorFee do
+  it { is_expected.to belong_to(:order_cycle).required }
+  it { is_expected.to belong_to(:enterprise_fee).required }
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -3,6 +3,11 @@
 require 'spec_helper'
 
 describe Customer, type: :model do
+  it { is_expected.to belong_to(:enterprise).required }
+  it { is_expected.to belong_to(:user).optional }
+  it { is_expected.to belong_to(:bill_address).optional }
+  it { is_expected.to belong_to(:ship_address).optional }
+
   describe 'an existing customer' do
     let(:customer) { create(:customer) }
 


### PR DESCRIPTION
#### What? Why?

- Starts #10778 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

In a recent code review I noticed that developers assume that `belongs_to` associations are required by default. And Rails has been doing that for a while but we still work with an old default, making the associations optional. So I embarked on the journey on changing this default for our 60 models that use the association. :ship: It's a slow journey and I'm planning to submit it in chunks.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Create an order cycle with a selection of shipping and payment methods.
- Check out using that order cycle.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
