### PR TITLE
[Vouchers] Updates warning_forfeit_remaining_amount default message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2069,7 +2069,7 @@ en:
         placeholder: Enter voucher code
         remove_code: Remove code
         confirm_delete: Are you sure you want to remove the voucher?
-        warning_forfeit_remaining_amount: Your voucher value is more than your order. By using this voucher you are forfeiting the remaining value.
+        warning_forfeit_remaining_amount: "Note: if your order total is less than your voucher you may not be able to spend the remaining value."
     step3:
       delivery_details:
         title: Delivery details

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -758,8 +758,8 @@ describe "As a consumer, I want to checkout my order" do
                 click_button("Apply")
 
                 expect(page).to have_content(
-                  "Your voucher value is more than your order. " \
-                  "By using this voucher you are forfeiting the remaining value."
+                  "Note: if your order total is less than your voucher " \
+                  "you may not be able to spend the remaining value." 
                 )
               end
             end


### PR DESCRIPTION
#### What? Why?

Changes the default message when adding a voucher, on possibly forfeiting the remaining amount.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Context [here](https://openfoodnetwork.slack.com/archives/C04KJ61B63B/p1684236068536829).

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an enterprise, create a voucher.
- As a customer, visit the shop, add some items to the cart (value should be below 10)
- On the payment step, add a voucher
- The warning should read: `Note: if your order total is less than your voucher you may not be able to spend the remaining value.`

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/49817236/5be4966d-3120-42ea-9d4a-1fc81bf31808)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
