### PR TITLE
Delete exchange variants in bulk when deleting an order cycle

### DIFF
--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -122,6 +122,8 @@ class Exchange < ApplicationRecord
   end
 
   def delete_related_exchange_variants
+    return unless incoming?
+
     ExchangeVariant.where(variant_id: variant_ids).
       joins(:exchange).
       where(exchanges: { order_cycle: order_cycle, incoming: false }).

--- a/app/models/exchange_variant.rb
+++ b/app/models/exchange_variant.rb
@@ -3,9 +3,13 @@
 class ExchangeVariant < ApplicationRecord
   belongs_to :exchange
   belongs_to :variant, class_name: 'Spree::Variant'
-  after_destroy :destroy_related_outgoing_variants
 
-  def destroy_related_outgoing_variants
-    VariantDeleter.new.destroy_related_outgoing_variants(variant_id, exchange.order_cycle)
+  after_destroy :delete_related_outgoing_variants
+
+  def delete_related_outgoing_variants
+    ExchangeVariant.where(variant_id: variant_id).
+      joins(:exchange).
+      where(exchanges: { order_cycle: exchange.order_cycle, incoming: false }).
+      delete_all
   end
 end

--- a/app/models/exchange_variant.rb
+++ b/app/models/exchange_variant.rb
@@ -7,6 +7,8 @@ class ExchangeVariant < ApplicationRecord
   after_destroy :delete_related_outgoing_variants
 
   def delete_related_outgoing_variants
+    return unless exchange.incoming?
+
     ExchangeVariant.where(variant_id: variant_id).
       joins(:exchange).
       where(exchanges: { order_cycle: exchange.order_cycle, incoming: false }).

--- a/app/services/variant_deleter.rb
+++ b/app/services/variant_deleter.rb
@@ -11,15 +11,6 @@ class VariantDeleter
     variant.destroy
   end
 
-  def destroy_related_outgoing_variants(variant_id, order_cycle)
-    internal_variants = ExchangeVariant.where(variant_id: variant_id).
-      joins(:exchange).
-      where(
-        exchanges: { order_cycle: order_cycle, incoming: false }
-      )
-    internal_variants.destroy_all
-  end
-
   private
 
   def only_variant_on_product?(variant)


### PR DESCRIPTION
#### What? Why?

Follow up from testing comment https://github.com/openfoodfoundation/openfoodnetwork/pull/10832#issuecomment-1552984226 in PR https://github.com/openfoodfoundation/openfoodnetwork/pull/10832

Deletes exchange variants in bulk when deleting and order cycle.

**Before, order cycle with 180 variants and multiple exchanges (incoming and outgoing)**

![Screenshot from 2023-05-18 15-21-23](https://github.com/openfoodfoundation/openfoodnetwork/assets/9029026/2e43d2b7-29fe-46ee-9195-16222dc48779)

1.9 seconds, 1100 queries, 1.2 million memory allocations :warning: 

**After, same data**

![Screenshot from 2023-05-18 15-22-51](https://github.com/openfoodfoundation/openfoodnetwork/assets/9029026/7c0a372d-e7ac-49fa-945b-e7ce3729ab67)

0.1 seconds, 38 queries, ~60k memory allocations :heavy_check_mark: 

#### What should we test?

Deleting a large order cycle should not be incredibly slow...

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
