### PR TITLE
Do not show cookies banner once user accept it

### DIFF
--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -96,7 +96,7 @@
           %hr.hr-light
           %br
 
-    = cache_with_locale [ContentConfig.cache_key, TermsOfServiceFile.current_url, Spree::Config.privacy_policy_url] do
+    = cache_with_locale [ContentConfig.cache_key, TermsOfServiceFile.current_url, Spree::Config.privacy_policy_url, Spree::Config.cookies_consent_banner_toggle, Web::CookiesConsent.new(cookies, request.host)] do
       .row.legal
         .small-12.medium-3.medium-offset-2.columns.text-left
           %a{href: main_app.root_path}

--- a/spec/system/consumer/cookies_spec.rb
+++ b/spec/system/consumer/cookies_spec.rb
@@ -2,7 +2,7 @@
 
 require 'system_helper'
 
-describe "Cookies" do
+describe "Cookies", caching: true do
   describe "banner" do
     # keeps banner toggle config unchanged
     around do |example|


### PR DESCRIPTION
Once the user accept the cookie, we should not show the cookie banner element. This is handled via `app/helpers/footer_links_helper.rb#cookies_policy_link` and boolean:

```
!Web::CookiesConsent.new(cookies, request.host).exists? && Spree::Config.cookies_consent_banner_toggle
```

As far as I know, this could not be revealed by automatic specs since we don't use cache in test env.

https://github.com/openfoodfoundation/openfoodnetwork/blob/3cd53cbd41267883721039fe405e431d9e1322a5/spec/system/consumer/cookies_spec.rb#L20-L26

#### What? Why?
Closes #10882

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
0. Delete all cookies, or use a private session
1. Navigate between different pages in the shopfront.
2. Accept the cookies.
3. Note that the banner will be shown again and again.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes