### PR TITLE
[White Label] Small width screens: Hide OFN logo and use the customized logo if activated

### DIFF
--- a/app/views/shared/menu/_offcanvas_menu.html.haml
+++ b/app/views/shared/menu/_offcanvas_menu.html.haml
@@ -1,9 +1,12 @@
 %aside.left-off-canvas-menu.show-for-medium-down{ ng: { controller: "OffcanvasCtrl" } }
   %ul.off-canvas-list
-    = cache_with_locale ContentConfig.cache_key do
+    = cache_with_locale [ContentConfig.cache_key, @white_label_logo] do
       %li.ofn-logo
         %a{href: main_app.root_path}
-          %img{src: ContentConfig.url_for(:logo_mobile), srcset: ContentConfig.url_for(:logo_mobile_svg), width: "75", height: "26"}
+          - if @white_label_logo&.variable?
+            = image_tag @white_label_distributor.white_label_logo_url(:mobile)
+          - else
+            %img{src: ContentConfig.url_for(:logo_mobile), srcset: ContentConfig.url_for(:logo_mobile_svg), width: "75", height: "26"}
       - [*1..7].each do |menu_number|
         - menu_name = "menu_#{menu_number}"
         - if ContentConfig[menu_name].present?


### PR DESCRIPTION
#### What? Why?

- Closes #10853 
###### Before
<img width="608" alt="Capture d’écran 2023-05-25 à 14 30 31" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/08646625-37d5-40e4-be35-55df68136b38">

###### After
<img width="593" alt="Capture d’écran 2023-05-25 à 14 33 56" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/55227977-53b8-4107-83a0-78ede2c852a7">



<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a shop manager, activate customized logo under White label preferences for your shop
- As a consumer, with a small width screen, check that you cannot see the OFN logo in the menu (accessible via the hamburger icon)
- As a shop manager, deactivate the feature
- As a consumer, with a small width screen, check that you see the OFN logo

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
