### PR TITLE
Fix flaky spec: Prefer using `match_array` over `eq` to compare array

### DIFF
--- a/spec/controllers/api/v0/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/v0/order_cycles_controller_spec.rb
@@ -91,7 +91,7 @@ module Api
                                q: { with_properties: [supplier_property.id] }
 
             expect(response.status).to eq 200
-            expect(product_ids).to eq [product1.id, product2.id]
+            expect(product_ids).to match_array [product1.id, product2.id]
             expect(product_ids).to_not include product3.id
           end
         end


### PR DESCRIPTION
As we don't need order: https://rubydoc.info/github/rspec/rspec-expectations/RSpec%2FMatchers:match_array

#### What? Why?

- Closes #10894 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
