### PR TITLE
BOM: Sort by order completed at desc for line items by default

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -9,6 +9,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.sharedResource = false
   $scope.columns = Columns.columns
   $scope.sorting = SortOptions
+  $scope.sorting.toggle("order_date")
   $scope.pagination = LineItems.pagination
   $scope.per_page_options = [
     {id: 15, name: t('js.admin.orders.index.per_page', results: 15)},
@@ -79,6 +80,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
       "q[order_order_cycle_id_eq]": $scope.orderCycleFilter,
       "q[order_completed_at_gteq]": if formattedStartDate then formattedStartDate else undefined,
       "q[order_completed_at_lt]": if formattedEndDate then formattedEndDate else undefined,
+      "q[s]": "order_completed_at desc",
       "page": $scope.page,
       "per_page": $scope.per_page
     )

--- a/app/controllers/admin/bulk_line_items_controller.rb
+++ b/app/controllers/admin/bulk_line_items_controller.rb
@@ -12,8 +12,7 @@ module Admin
       @line_items = order_permissions.
         editable_line_items.where(order_id: orders).
         includes(:variant).
-        ransack(params[:q]).result.
-        reorder('spree_line_items.order_id ASC, spree_line_items.id ASC')
+        ransack(params[:q]).result
 
       @pagy, @line_items = pagy(@line_items) if pagination_required?
 

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -76,7 +76,7 @@ describe Admin::BulkLineItemsController, type: :controller do
         end
 
         it "retrives a list of line items which match the criteria" do
-          expect(line_item_ids).to eq [line_item2.id, line_item3.id]
+          expect(line_item_ids).to match_array [line_item2.id, line_item3.id]
         end
       end
 

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -83,11 +83,11 @@ describe '
       }
       let!(:o2) {
         create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
-                                        completed_at: Time.zone.now )
+                                        completed_at: Time.zone.yesterday )
       }
       let!(:o3) {
         create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
-                                        completed_at: Time.zone.now )
+                                        completed_at: Time.zone.yesterday - 1.day )
       }
       let!(:product) {
         create(:simple_product)


### PR DESCRIPTION

#### What? Why?

- Closes #10571


#### What should we test?
- Log in as admin of a hub with plenty of complete orders and visit /admin/orders/bulk_management
- Click "Completed at" header; take notice of the order range/ordering
- Move to another pagination index number.
- You might not have orders which should have been displayed on the first page

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
