### PR TITLE
Admin, Create an order, Select a product: translate some messages in the product selection search box

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/variant_autocomplete.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/variant_autocomplete.js.coffee
@@ -10,6 +10,12 @@ angular.module("admin.utils").directive "variantAutocomplete", ($timeout) ->
         element.select2
           placeholder: t('admin.orders.select_variant')
           minimumInputLength: 3
+          formatInputTooShort: ->
+            t('admin.select2.minimal_search_length', count: 3)
+          formatSearching: ->
+            t('admin.select2.searching')
+          formatNoMatches: ->
+            t('admin.select2.no_matches')
           ajax:
             url: Spree.routes.variants_search
             datatype: "json"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1402,6 +1402,10 @@ en:
       resume:
         could_not_resume_the_order: Could not resume the order
 
+    select2:
+      minimal_search_length: Please enter %{count} or more characters
+      searching: Searching...
+      no_matches: No matches found
     shared:
       user_guide_link:
         user_guide: User Guide


### PR DESCRIPTION
#### What? Why?
This is a quick and (not so) dirty fix to add some i18n messages to the old select2 component used to search/select a production in the order creation/edition in the backoffice.
Next step is to remplace select2 with tom-select
<img width="675" alt="Capture d’écran 2023-05-29 à 15 24 36" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/369a6039-0246-4296-bfa4-45a3bb67399e">
<img width="729" alt="Capture d’écran 2023-05-29 à 15 24 29" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/2e54250e-d5b8-427a-836d-69e6be4d755e">


- Closes #3041 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, check that the 3 messages are translated when using this component: "Please enter %{count} or more characters", "Searching..." & "No matches found"

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes




#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
