### PR TITLE
Changes date through keystrokes; removes Retry option

### DIFF
--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -751,15 +751,13 @@ describe '
   end
 
   it "modify the minute of a order cycle with the keyboard, "\
-     "check that the modifications are taken into account", 
-     retry: 3 do
+     "check that the modifications are taken into account" do
     order_cycle = create(:simple_order_cycle, name: "Translusent Berries")
     login_as_admin
     visit admin_order_cycles_path
     find("#oc#{order_cycle.id}_orders_close_at").click
-    datetime = Time.zone.at(Time.zone.local(2040, 10, 17, 0o6, 0o0, 0o0))
     input = find(".flatpickr-calendar.open .flatpickr-minute")
-    input.send_keys datetime.strftime("%M").to_s.strip
+    input.send_keys :up
     input.send_keys :enter
     within "#save-bar" do
       expect(page).to have_content "You have unsaved changes"


### PR DESCRIPTION
#### What? Why?

- Closes #10302 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Before, the spec was setting a given date in the future, retrieving the `minutes` from that date, and inserting the minutes entry on the flatpickr minute section. This did not introduce any change, if the mocked time coincided with the minutes from the actual time, which led the spec to fail (could not find the `You have unsaved changes` message).

This PR changes introduces a change in the calendar by sending an `arrow-up` keystroke, which should always introduce a change, and fix flakyness :crossed_fingers: 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
