### PR TITLE
[White Label] Make logo url link more tolerant in terms of format

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -317,6 +317,14 @@ class Enterprise < ApplicationRecord
     )
   end
 
+  def white_label_logo_link
+    return nil if self[:white_label_logo_link].blank?  
+
+    return self[:white_label_logo_link] if self[:white_label_logo_link].start_with?('http')
+
+    "http://#{self[:white_label_logo_link]}"
+  end
+
   def website
     strip_url self[:website]
   end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -460,6 +460,7 @@ class Enterprise < ApplicationRecord
 
     return if white_label_logo_link.blank?
 
+    white_label_logo_link.strip!
     uri = URI(white_label_logo_link)
     self.white_label_logo_link = "http://#{white_label_logo_link}" if uri.scheme.nil?
   rescue URI::InvalidURIError

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -332,6 +332,12 @@ describe Enterprise do
         expect(e.white_label_logo_link).to eq "http://www.example.com"
       end
 
+      it "ignores whitespace around the URL form copying and pasting" do
+        e = build(:enterprise, white_label_logo_link: ' www.example.com ')
+        expect(e).to be_valid
+        expect(e.white_label_logo_link).to eq "http://www.example.com"
+      end
+
       it "does not validate if URL is invalid and can't be infered" do
         e = build(:enterprise, white_label_logo_link: 'with spaces')
         expect(e).to be_invalid

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -313,6 +313,30 @@ describe Enterprise do
         expect(enterprise).to be_invalid
       end
     end
+
+    describe "white label logo link" do
+      before do
+        # validate white_label_logo_link only if white_label_logo is present
+        allow_any_instance_of(Enterprise).to receive(:white_label_logo).and_return(true)
+      end
+
+      it "validates the white_label_logo_link attribute" do
+        e = build(:enterprise, white_label_logo_link: 'http://www.example.com')
+        expect(e).to be_valid
+        expect(e.white_label_logo_link).to eq "http://www.example.com"
+      end
+
+      it "adds http:// to the white_label_logo_link attribute if it is missing" do
+        e = build(:enterprise, white_label_logo_link: 'www.example.com')
+        expect(e).to be_valid
+        expect(e.white_label_logo_link).to eq "http://www.example.com"
+      end
+
+      it "does not validate if URL is invalid and can't be infered" do
+        e = build(:enterprise, white_label_logo_link: 'with spaces')
+        expect(e).to be_invalid
+      end
+    end
   end
 
   describe "callbacks" do

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -710,6 +710,8 @@ describe '
 
           context "can edit white label logo link" do
             it_behaves_like "edit link with", "https://www.openfoodnetwork.org", "https://www.openfoodnetwork.org"
+            it_behaves_like "edit link with", "www.openfoodnetwork.org", "http://www.openfoodnetwork.org"
+            it_behaves_like "edit link with", "openfoodnetwork.org", "http://openfoodnetwork.org"
           end
         end
 

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -698,12 +698,18 @@ describe '
             expect(distributor1.white_label_logo).to_not be_attached
           end
 
-          it "can edit the text field white_label_logo_link" do
-            fill_in "enterprise_white_label_logo_link", with: "https://www.openfoodnetwork.org"
-            click_button 'Update'
-            expect(flash_message)
-              .to eq('Enterprise "First Distributor" has been successfully updated!')
-            expect(distributor1.reload.white_label_logo_link).to eq("https://www.openfoodnetwork.org")
+          shared_examples "edit link with" do |url, result|
+            it "url: #{url}" do
+              fill_in "enterprise_white_label_logo_link", with: url
+              click_button 'Update'
+              expect(flash_message)
+                .to eq('Enterprise "First Distributor" has been successfully updated!')
+              expect(distributor1.reload.white_label_logo_link).to eq(result)
+            end
+          end
+
+          context "can edit white label logo link" do
+            it_behaves_like "edit link with", "https://www.openfoodnetwork.org", "https://www.openfoodnetwork.org"
           end
         end
 


### PR DESCRIPTION
#### What? Why?

- Closes #10903


Makes URLs used in `LINK FOR THE LOGO USED IN SHOPFRONT` under the white label section, absolutized. 
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a shop manager, edit the `LINK FOR THE LOGO USED IN SHOPFRONT` value. 
- Check that entering an URL without `http` or `https`, create actually an URL with a `http://` added
- Check that entering an URL starting with `http`, doesn't change the value of the URL

Therefor we do have an absolute URL.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
