### PR TITLE
Set retry count to 2 on system tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,7 @@ jobs:
       - name: Run tests
 
         env:
+          RSPEC_RETRY_RETRY_COUNT: 2
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ff2456e64c9f2aa5157eb0daf711d3c3
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
@@ -285,6 +286,7 @@ jobs:
       - name: Run tests
 
         env:
+          RSPEC_RETRY_RETRY_COUNT: 2
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: e52bd4390c853e6c5bdfe4d0334586c1
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}


### PR DESCRIPTION
#### What? Why?

Discussed in a previous meeting; sets retry count to 2 so we can avoid a few flaky specs and save some time.

#### What should we test?

-

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
