### PR TITLE
Fix ProcessPaymentIntent service

### DIFF
--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -56,8 +56,9 @@ class ProcessPaymentIntent
   attr_reader :order, :payment_intent, :payment
 
   def process_payment
-    OrderWorkflow.new(order).next if order.state == "payment"
-    order.process_payments!
+    return unless order.process_payments! && order.state == "confirmation"
+
+    OrderWorkflow.new(order).next
   end
 
   def ready_for_capture?

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -56,9 +56,9 @@ class ProcessPaymentIntent
   attr_reader :order, :payment_intent, :payment
 
   def process_payment
-    return unless order.process_payments! && order.state == "confirmation"
+    return unless order.process_payments!
 
-    OrderWorkflow.new(order).next
+    OrderWorkflow.new(order).complete
   end
 
   def ready_for_capture?

--- a/spec/controllers/payment_gateways/stripe_controller_spec.rb
+++ b/spec/controllers/payment_gateways/stripe_controller_spec.rb
@@ -46,21 +46,6 @@ module PaymentGateways
           order.payments << payment
         end
 
-        shared_examples "successful order completion" do
-          it "completes the order and redirects to the order confirmation page" do
-            expect(controller).to receive(:processing_succeeded).and_call_original
-            expect(controller).to receive(:order_completion_reset).and_call_original
-
-            get :confirm, params: { payment_intent: "pi_123" }
-
-            expect(order.completed?).to be true
-            expect(response).to redirect_to order_path(order, order_token: order.token)
-            expect(flash[:notice]).to eq 'Your order has been processed successfully'
-          end
-        end
-
-        include_examples "successful order completion"
-
         it "creates a customer record" do
           order.update_columns(customer_id: nil)
           Customer.delete_all
@@ -94,7 +79,16 @@ Please try again!"
             order.update_attribute :state, "confirmation"
           end
 
-          include_examples "successful order completion"
+          it "completes the order and redirects to the order confirmation page" do
+            expect(controller).to receive(:processing_succeeded).and_call_original
+            expect(controller).to receive(:order_completion_reset).and_call_original
+
+            get :confirm, params: { payment_intent: "pi_123" }
+
+            expect(order.completed?).to be true
+            expect(response).to redirect_to order_path(order, order_token: order.token)
+            expect(flash[:notice]).to eq 'Your order has been processed successfully'
+          end
         end
       end
 

--- a/spec/controllers/payment_gateways/stripe_controller_spec.rb
+++ b/spec/controllers/payment_gateways/stripe_controller_spec.rb
@@ -230,6 +230,16 @@ completed due to stock issues."
               expect(payment.state).to eq("completed")
               expect(payment.cvv_response_message).to be nil
             end
+
+            it "moves the order state to completed" do
+              expect(order).to receive(:process_payments!) do
+                payment.complete!
+              end
+
+              get :authorize, params: { order_number: order.number, payment_intent: payment_intent }
+
+              expect(order.reload.state).to eq "complete"
+            end
           end
 
           context "when the order is already completed" do

--- a/spec/services/process_payment_intent_spec.rb
+++ b/spec/services/process_payment_intent_spec.rb
@@ -9,7 +9,7 @@ describe ProcessPaymentIntent do
     let(:customer) { create(:customer) }
     let(:order) {
       create(:order_with_totals, customer: customer, distributor: customer.enterprise,
-                                 state: "payment")
+                                 state: "confirmation")
     }
     let(:payment_method) { create(:stripe_sca_payment_method) }
 


### PR DESCRIPTION
#### What? Why?

Related to #10924 

Fixes issue with `ProcessPaymentIntent` service not transitioning the order to `complete` state.

Note: this commit is also included in #10913 but we can test this change in isolation here and merge them separately.

#### What should we test?

Placing an order with Stripe that requires 3DS / additional authentication.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
