### PR TITLE
[White Label] Remove ofn navigation for small width screens as well when option is activated

### DIFF
--- a/app/views/shared/menu/_offcanvas_menu.html.haml
+++ b/app/views/shared/menu/_offcanvas_menu.html.haml
@@ -7,14 +7,15 @@
             = image_tag @white_label_distributor.white_label_logo_url(:mobile)
           - else
             %img{src: ContentConfig.url_for(:logo_mobile), srcset: ContentConfig.url_for(:logo_mobile_svg), width: "75", height: "26"}
-      - [*1..7].each do |menu_number|
-        - menu_name = "menu_#{menu_number}"
-        - if ContentConfig[menu_name].present?
-          %li.li-menu
-            %a{href: t("#{menu_name}_url") }
-              %span.nav-primary
-                %i{class: ContentConfig["#{menu_name}_icon_name"]}
-                = t "#{menu_name}_title"
+      - unless @hide_ofn_navigation
+        - [*1..7].each do |menu_number|
+          - menu_name = "menu_#{menu_number}"
+          - if ContentConfig[menu_name].present?
+            %li.li-menu
+              %a{href: t("#{menu_name}_url") }
+                %span.nav-primary
+                  %i{class: ContentConfig["#{menu_name}_icon_name"]}
+                  = t "#{menu_name}_title"
 
     - if OpenFoodNetwork::I18nConfig.selectable_locales.count > 1
       %li.language-switcher.li-menu

--- a/spec/support/request/ui_component_helper.rb
+++ b/spec/support/request/ui_component_helper.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 module UIComponentHelper
+  def browser_as_small
+    Capybara.current_session.current_window
+      .resize_to(640, 480)
+  end
+
   def browse_as_medium
     Capybara.current_session.current_window
       .resize_to(1024, 768)
+  end
+
+  def browse_as_default
+    Capybara.current_session.current_window
+      .resize_to(1200, 800)
   end
 
   def browse_as_large

--- a/spec/support/request/ui_component_helper.rb
+++ b/spec/support/request/ui_component_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module UIComponentHelper
-  def browser_as_small
+  def browse_as_small
     Capybara.current_session.current_window
       .resize_to(640, 480)
   end

--- a/spec/support/request/ui_component_helper.rb
+++ b/spec/support/request/ui_component_helper.rb
@@ -1,24 +1,30 @@
 # frozen_string_literal: true
 
 module UIComponentHelper
-  def browse_as_small
-    Capybara.current_session.current_window
-      .resize_to(640, 480)
+  def browse_as_small(&block)
+    browse_with_window_size(640, 480, &block)
   end
 
-  def browse_as_medium
-    Capybara.current_session.current_window
-      .resize_to(1024, 768)
+  def browse_as_medium(&block)
+    browse_with_window_size(1024, 768, &block)
   end
 
-  def browse_as_default
-    Capybara.current_session.current_window
-      .resize_to(1200, 800)
+  def browse_as_default(&block)
+    browse_with_window_size(1200, 800)
+    block&.call
   end
 
-  def browse_as_large
+  def browse_as_large(&block)
+    browse_with_window_size(1280, 800, &block)
+  end
+
+  def browse_with_window_size(width, height, &block)
     Capybara.current_session.current_window
-      .resize_to(1280, 800)
+      .resize_to(width, height)
+    return unless block
+
+    block.call
+    browse_as_default
   end
 
   def click_login_button

--- a/spec/support/request/ui_component_helper.rb
+++ b/spec/support/request/ui_component_helper.rb
@@ -10,12 +10,8 @@ module UIComponentHelper
   end
 
   def browse_as_default(&block)
-    browse_with_window_size(1200, 800)
+    browse_with_window_size(1280, 800)
     block&.call
-  end
-
-  def browse_as_large(&block)
-    browse_with_window_size(1280, 800, &block)
   end
 
   def browse_with_window_size(width, height, &block)

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -24,9 +24,7 @@ describe "Authentication" do
       before do
         visit root_path
       end
-      describe "as large" do
-        around { |example| browse_as_large { example.run } }
-
+      describe "with default large screen" do
         before do
           open_login_modal
         end

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -25,8 +25,9 @@ describe "Authentication" do
         visit root_path
       end
       describe "as large" do
+        around { |example| browse_as_large { example.run } }
+
         before do
-          browse_as_large
           open_login_modal
         end
 
@@ -173,12 +174,8 @@ describe "Authentication" do
       end
 
       describe "as medium" do
-        before do
-          browse_as_medium
-        end
-        after do
-          browse_as_large
-        end
+        around { |example| browse_as_medium { example.run } }
+
         it "showing login" do
           open_off_canvas
           open_login_modal

--- a/spec/system/consumer/multilingual_spec.rb
+++ b/spec/system/consumer/multilingual_spec.rb
@@ -100,8 +100,6 @@ describe 'Multilingual' do
   end
 
   describe "using the language switcher UI" do
-    around { |example| browse_as_large { example.run } }
-
     context "when there is only one language available" do
       before do
         allow(ENV).to receive(:[]).and_call_original

--- a/spec/system/consumer/multilingual_spec.rb
+++ b/spec/system/consumer/multilingual_spec.rb
@@ -100,7 +100,8 @@ describe 'Multilingual' do
   end
 
   describe "using the language switcher UI" do
-    before { browse_as_large }
+    around { |example| browse_as_large { example.run } }
+
     context "when there is only one language available" do
       before do
         allow(ENV).to receive(:[]).and_call_original

--- a/spec/system/consumer/white_label_spec.rb
+++ b/spec/system/consumer/white_label_spec.rb
@@ -30,19 +30,34 @@ describe 'White label setting' do
   let(:ofn_navigation) { 'ul.nav-main-menu' }
 
   shared_examples "does not hide the OFN navigation" do
-    it "does not hide the OFN navigation when visiting the shop" do
-      visit main_app.enterprise_shop_path(distributor)
-      expect(page).to have_selector ofn_navigation
+    context "for shop path" do
+      before do
+        visit main_app.enterprise_shop_path(distributor)
+      end
+
+      it "does not hide the OFN navigation" do
+        expect(page).to have_selector ofn_navigation
+      end
     end
 
-    it "does not hide the OFN navigation when visiting root path" do
-      visit main_app.root_path
-      expect(page).to have_selector ofn_navigation
+    context "for cart path" do
+      before do
+        visit main_app.cart_path
+      end
+
+      it "does not hide the OFN navigation" do
+        expect(page).to have_selector ofn_navigation
+      end
     end
 
-    it "does not hide the OFN navigation when visiting cart path" do
-      visit main_app.cart_path
-      expect(page).to have_selector ofn_navigation
+    context "for root path" do
+      before do
+        visit main_app.root_path
+      end
+
+      it "does not hide the OFN navigation" do
+        expect(page).to have_selector ofn_navigation
+      end
     end
   end
 

--- a/spec/system/consumer/white_label_spec.rb
+++ b/spec/system/consumer/white_label_spec.rb
@@ -30,6 +30,29 @@ describe 'White label setting' do
 
   let(:ofn_navigation) { 'ul.nav-main-menu' }
 
+  shared_examples "hides the OFN navigation for mobile view as well" do
+    context "mobile view" do
+      before do
+        browser_as_small
+      end
+
+      after do
+        browse_as_default
+      end
+
+      it "hides OFN navigation" do
+        find("a.left-off-canvas-toggle").click
+        within "aside.left-off-canvas-menu" do
+          expect(page).not_to have_selector "a[href='#{main_app.shops_path}']"
+          expect(page).not_to have_selector "a[href='#{main_app.map_path}']"
+          expect(page).not_to have_selector "a[href='#{main_app.producers_path}']"
+          expect(page).not_to have_selector "a[href='#{main_app.groups_path}']"
+          expect(page).not_to have_selector "a[href='#{I18n.t('.menu_5_url')}']"
+        end
+      end
+    end
+  end
+
   shared_examples "does not hides the OFN navigation for mobile view as well" do
     context "mobile view" do
       before do
@@ -106,6 +129,8 @@ describe 'White label setting' do
           it "hides the OFN navigation" do
             expect(page).to have_no_selector ofn_navigation
           end
+
+          it_behaves_like "hides the OFN navigation for mobile view as well"
         end
 
         context "for root path" do
@@ -116,6 +141,8 @@ describe 'White label setting' do
           it "does not hide the OFN navigation when visiting root path" do
             expect(page).to have_selector ofn_navigation
           end
+
+          it_behaves_like "does not hides the OFN navigation for mobile view as well"
         end
       end
 
@@ -141,6 +168,8 @@ describe 'White label setting' do
             it "hides the OFN navigation" do
               expect(page).to have_no_selector ofn_navigation
             end
+
+            it_behaves_like "hides the OFN navigation for mobile view as well"
           end
 
           context "for checkout path" do
@@ -153,6 +182,8 @@ describe 'White label setting' do
               expect(page).to have_content "Order ready for "
               expect(page).to have_no_selector ofn_navigation
             end
+
+            it_behaves_like "hides the OFN navigation for mobile view as well"
           end
         end
 

--- a/spec/system/consumer/white_label_spec.rb
+++ b/spec/system/consumer/white_label_spec.rb
@@ -98,14 +98,24 @@ describe 'White label setting' do
       end
 
       shared_examples "hides the OFN navigation when needed only" do
-        it "hides the OFN navigation when visiting the shop" do
-          visit main_app.enterprise_shop_path(distributor)
-          expect(page).to have_no_selector ofn_navigation
+        context "for shop path" do
+          before do
+            visit main_app.enterprise_shop_path(distributor)
+          end
+
+          it "hides the OFN navigation" do
+            expect(page).to have_no_selector ofn_navigation
+          end
         end
 
-        it "does not hide the OFN navigation when visiting root path" do
-          visit main_app.root_path
-          expect(page).to have_selector ofn_navigation
+        context "for root path" do
+          before do
+            visit main_app.root_path
+          end
+
+          it "does not hide the OFN navigation when visiting root path" do
+            expect(page).to have_selector ofn_navigation
+          end
         end
       end
 
@@ -123,16 +133,26 @@ describe 'White label setting' do
         shared_examples "hides the OFN navigation when needed only for the checkout" do
           it_behaves_like "hides the OFN navigation when needed only"
 
-          it "hides the OFN navigation when visiting cart path" do
-            visit main_app.cart_path
-            expect(page).to have_no_selector ofn_navigation
+          context "for cart path" do
+            before do
+              visit main_app.cart_path
+            end
+
+            it "hides the OFN navigation" do
+              expect(page).to have_no_selector ofn_navigation
+            end
           end
 
-          it "hides the OFN navigation when visiting checkout path" do
-            visit checkout_path
-            expect(page).to have_content "Checkout now"
-            expect(page).to have_content "Order ready for "
-            expect(page).to have_no_selector ofn_navigation
+          context "for checkout path" do
+            before do
+              visit checkout_path
+            end
+
+            it "hides the OFN navigation" do
+              expect(page).to have_content "Checkout now"
+              expect(page).to have_content "Order ready for "
+              expect(page).to have_no_selector ofn_navigation
+            end
           end
         end
 
@@ -155,9 +175,14 @@ describe 'White label setting' do
         end
 
         shared_examples "hides the OFN navigation when needed only for the order confirmation" do
-          it "hides" do
-            visit order_path(complete_order, order_token: complete_order.token)
-            expect(page).to have_no_selector ofn_navigation
+          context "for order confirmation path" do
+            before do
+              visit order_path(complete_order, order_token: complete_order.token)
+            end
+
+            it "hides the OFN navigation" do
+              expect(page).to have_no_selector ofn_navigation
+            end
           end
         end
 

--- a/spec/system/consumer/white_label_spec.rb
+++ b/spec/system/consumer/white_label_spec.rb
@@ -6,6 +6,7 @@ describe 'White label setting' do
   include AuthenticationHelper
   include ShopWorkflow
   include FileHelper
+  include UIComponentHelper
 
   let!(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
   let!(:shipping_method) { create(:shipping_method, distributors: [distributor]) }
@@ -29,6 +30,29 @@ describe 'White label setting' do
 
   let(:ofn_navigation) { 'ul.nav-main-menu' }
 
+  shared_examples "does not hides the OFN navigation for mobile view as well" do
+    context "mobile view" do
+      before do
+        browser_as_small
+      end
+
+      after do
+        browse_as_default
+      end
+
+      it "does not hide OFN navigation" do
+        find("a.left-off-canvas-toggle").click
+        within "aside.left-off-canvas-menu" do
+          expect(page).to have_selector "a[href='#{main_app.shops_path}']"
+          expect(page).to have_selector "a[href='#{main_app.map_path}']"
+          expect(page).to have_selector "a[href='#{main_app.producers_path}']"
+          expect(page).to have_selector "a[href='#{main_app.groups_path}']"
+          expect(page).to have_selector "a[href='#{I18n.t('.menu_5_url')}']"
+        end
+      end
+    end
+  end
+
   shared_examples "does not hide the OFN navigation" do
     context "for shop path" do
       before do
@@ -38,6 +62,8 @@ describe 'White label setting' do
       it "does not hide the OFN navigation" do
         expect(page).to have_selector ofn_navigation
       end
+
+      it_behaves_like "does not hides the OFN navigation for mobile view as well"
     end
 
     context "for cart path" do
@@ -48,6 +74,8 @@ describe 'White label setting' do
       it "does not hide the OFN navigation" do
         expect(page).to have_selector ofn_navigation
       end
+
+      it_behaves_like "does not hides the OFN navigation for mobile view as well"
     end
 
     context "for root path" do
@@ -58,6 +86,8 @@ describe 'White label setting' do
       it "does not hide the OFN navigation" do
         expect(page).to have_selector ofn_navigation
       end
+
+      it_behaves_like "does not hides the OFN navigation for mobile view as well"
     end
   end
 

--- a/spec/system/consumer/white_label_spec.rb
+++ b/spec/system/consumer/white_label_spec.rb
@@ -32,13 +32,7 @@ describe 'White label setting' do
 
   shared_examples "hides the OFN navigation for mobile view as well" do
     context "mobile view" do
-      before do
-        browse_as_small
-      end
-
-      after do
-        browse_as_default
-      end
+      around { |example| browse_as_small { example.run } }
 
       it "hides OFN navigation" do
         find("a.left-off-canvas-toggle").click
@@ -55,13 +49,7 @@ describe 'White label setting' do
 
   shared_examples "does not hide the OFN navigation for mobile view as well" do
     context "mobile view" do
-      before do
-        browse_as_small
-      end
-
-      after do
-        browse_as_default
-      end
+      around { |example| browse_as_small { example.run } }
 
       it "does not hide OFN navigation" do
         find("a.left-off-canvas-toggle").click

--- a/spec/system/consumer/white_label_spec.rb
+++ b/spec/system/consumer/white_label_spec.rb
@@ -33,7 +33,7 @@ describe 'White label setting' do
   shared_examples "hides the OFN navigation for mobile view as well" do
     context "mobile view" do
       before do
-        browser_as_small
+        browse_as_small
       end
 
       after do
@@ -53,10 +53,10 @@ describe 'White label setting' do
     end
   end
 
-  shared_examples "does not hides the OFN navigation for mobile view as well" do
+  shared_examples "does not hide the OFN navigation for mobile view as well" do
     context "mobile view" do
       before do
-        browser_as_small
+        browse_as_small
       end
 
       after do
@@ -86,7 +86,7 @@ describe 'White label setting' do
         expect(page).to have_selector ofn_navigation
       end
 
-      it_behaves_like "does not hides the OFN navigation for mobile view as well"
+      it_behaves_like "does not hide the OFN navigation for mobile view as well"
     end
 
     context "for cart path" do
@@ -98,7 +98,7 @@ describe 'White label setting' do
         expect(page).to have_selector ofn_navigation
       end
 
-      it_behaves_like "does not hides the OFN navigation for mobile view as well"
+      it_behaves_like "does not hide the OFN navigation for mobile view as well"
     end
 
     context "for root path" do
@@ -110,7 +110,7 @@ describe 'White label setting' do
         expect(page).to have_selector ofn_navigation
       end
 
-      it_behaves_like "does not hides the OFN navigation for mobile view as well"
+      it_behaves_like "does not hide the OFN navigation for mobile view as well"
     end
   end
 
@@ -142,7 +142,7 @@ describe 'White label setting' do
             expect(page).to have_selector ofn_navigation
           end
 
-          it_behaves_like "does not hides the OFN navigation for mobile view as well"
+          it_behaves_like "does not hide the OFN navigation for mobile view as well"
         end
       end
 

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -11,7 +11,7 @@ Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,
     **{
-      window_size: [1200, 800],
+      window_size: [1280, 800],
       browser_options: browser_options,
       process_timeout: 60,
       timeout: 60,


### PR DESCRIPTION
#### What? Why?

- Closes #10900 
##### Before
<img width="617" alt="Capture d’écran 2023-06-05 à 14 49 01" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/0fd09ee4-f81c-4554-b60a-70b6a51b69c2">

##### After
<img width="609" alt="Capture d’écran 2023-06-05 à 14 46 27" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/fe0d9775-4fea-4804-8adf-9ce3f78c4bc9">

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a shop manager, hide OFN navigation for you enterprise under white label settings
- As a consumer, with a small width screen, check that you cannot see the OFN navigation on the right pages (shop, cart, checkout, order confirmation for the shop)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
