### PR TITLE
Order class tidyup

### DIFF
--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -32,7 +32,7 @@ module Api
         @shipment.fee_adjustment.fire_events(:open)
 
         if @shipment.update(shipment_params)
-          @order.updater.update_totals_and_states
+          @order.update_totals_and_states
         end
 
         @shipment.fee_adjustment.close

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -115,7 +115,7 @@ class CheckoutController < ::BaseController
   end
 
   def update_payment_total
-    @order.updater.update_totals
+    @order.update_totals
     @order.updater.update_pending_payment
   end
 

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -172,7 +172,7 @@ class SplitCheckoutController < ::BaseController
 
     @order.select_shipping_method(params[:shipping_method_id])
     @order.update(order_params)
-    @order.updater.update_totals_and_states
+    @order.update_totals_and_states
 
     validate_current_step!
 

--- a/app/controllers/spree/admin/adjustments_controller.rb
+++ b/app/controllers/spree/admin/adjustments_controller.rb
@@ -14,7 +14,7 @@ module Spree
 
       def update_order
         @order.reload
-        @order.updater.update_totals_and_states
+        @order.update_totals_and_states
       end
 
       def collection

--- a/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -58,7 +58,7 @@ module Spree
           @order.create_tax_charge!
           Spree::TaxRate.adjust(@order, @order.adjustments.admin)
 
-          @order.updater.update_totals_and_states
+          @order.update_totals_and_states
         end
 
         def order_params

--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -129,7 +129,8 @@ module Spree
                             @payment_methods.first
                           end
 
-        @previous_cards = @order.credit_cards.with_payment_profile
+        credit_card_ids = @order.payments.from_credit_card.pluck(:source_id).uniq
+        @previous_cards = CreditCard.where(id: credit_card_ids).with_payment_profile
       end
 
       # At this point admin should have passed through Customer Details step

--- a/app/models/concerns/order_validations.rb
+++ b/app/models/concerns/order_validations.rb
@@ -16,7 +16,7 @@ module OrderValidations
   # Check that line_items in the current order are available from a newly selected distribution
   def products_available_from_new_distribution
     return if OrderCycleDistributedVariants.new(order_cycle, distributor)
-                                           .distributes_order_variants?(self)
+      .distributes_order_variants?(self)
 
     errors.add(:base, I18n.t(:spree_order_availability_error))
   end

--- a/app/models/concerns/order_validations.rb
+++ b/app/models/concerns/order_validations.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+module OrderValidations
+  extend ActiveSupport::Concern
+
+  private
+
+  def disallow_guest_order
+    return unless using_guest_checkout? && registered_email?
+
+    errors.add(:email, I18n.t('devise.failure.already_registered'))
+  end
+
+  # Check that line_items in the current order are available from a newly selected distribution
+  def products_available_from_new_distribution
+    return if OrderCycleDistributedVariants.new(order_cycle, distributor)
+                                           .distributes_order_variants?(self)
+
+    errors.add(:base, I18n.t(:spree_order_availability_error))
+  end
+
+  # Determine if email is required (we don't want validation errors before we hit the checkout)
+  def require_email
+    true unless (new_record? || cart?) && !checkout_processing
+  end
+
+  def ensure_line_items_present
+    return if line_items.present?
+
+    errors.add(:base, Spree.t(:there_are_no_items_for_this_order))
+    false
+  end
+
+  def ensure_available_shipping_rates
+    return unless shipments.empty? || shipments.any? { |shipment| shipment.shipping_rates.blank? }
+
+    errors.add(:base, Spree.t(:items_cannot_be_shipped))
+    false
+  end
+end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -365,13 +365,6 @@ module Spree
       )
     end
 
-    def deliver_order_confirmation_email
-      return if subscription.present?
-
-      Spree::OrderMailer.confirm_email_for_customer(id).deliver_later(wait: 10.seconds)
-      Spree::OrderMailer.confirm_email_for_shop(id).deliver_later(wait: 10.seconds)
-    end
-
     # Helper methods for checkout steps
     def paid?
       payment_state == 'paid' || payment_state == 'credit_owed'
@@ -617,6 +610,13 @@ module Spree
     end
 
     private
+
+    def deliver_order_confirmation_email
+      return if subscription.present?
+
+      Spree::OrderMailer.confirm_email_for_customer(id).deliver_later(wait: 10.seconds)
+      Spree::OrderMailer.confirm_email_for_shop(id).deliver_later(wait: 10.seconds)
+    end
 
     def fee_handler
       @fee_handler ||= OrderFeesHandler.new(self)

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -301,10 +301,6 @@ module Spree
       number
     end
 
-    def shipped_shipments
-      shipments.shipped
-    end
-
     def contains?(variant)
       find_line_item_by_variant(variant).present?
     end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -426,19 +426,6 @@ module Spree
       restart_checkout_flow if state.in?(["payment", "confirmation"])
     end
 
-    def state_changed(name)
-      state = "#{name}_state"
-      return unless persisted?
-
-      old_state = __send__("#{state}_was")
-      state_changes.create(
-        previous_state: old_state,
-        next_state: __send__(state),
-        name: name,
-        user_id: user_id
-      )
-    end
-
     def shipped?
       %w(partial shipped).include?(shipment_state)
     end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -571,10 +571,6 @@ module Spree
       save!
     end
 
-    def distribution_set?
-      distributor && order_cycle
-    end
-
     def shipping_tax
       shipment_adjustments.reload.tax.sum(:amount)
     end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -337,11 +337,6 @@ module Spree
       complete? || resumed? || awaiting_return? || returned?
     end
 
-    def credit_cards
-      credit_card_ids = payments.from_credit_card.pluck(:source_id).uniq
-      CreditCard.where(id: credit_card_ids)
-    end
-
     # Finalizes an in progress order after checkout is complete.
     # Called after transition to complete state when payments will have been processed
     def finalize!

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -613,21 +613,6 @@ module Spree
       self.email = user.email if user
     end
 
-    def after_cancel
-      shipments.each(&:cancel!)
-      payments.checkout.each(&:void!)
-
-      OrderMailer.cancel_email(id).deliver_later if send_cancellation_email
-      update(payment_state: updater.update_payment_state)
-    end
-
-    def after_resume
-      shipments.each(&:resume!)
-      payments.void.each(&:resume!)
-
-      update(payment_state: updater.update_payment_state)
-    end
-
     def use_billing?
       @use_billing == true || @use_billing == 'true' || @use_billing == '1'
     end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -504,12 +504,6 @@ module Spree
       errors.add(:base, I18n.t(:spree_order_availability_error))
     end
 
-    def disallow_guest_order
-      return unless using_guest_checkout? && registered_email?
-
-      errors.add(:email, I18n.t('devise.failure.already_registered'))
-    end
-
     # After changing line items of a completed order
     def update_shipping_fees!
       shipments.each do |shipment|
@@ -606,6 +600,12 @@ module Spree
     end
 
     private
+
+    def disallow_guest_order
+      return unless using_guest_checkout? && registered_email?
+
+      errors.add(:email, I18n.t('devise.failure.already_registered'))
+    end
 
     def deliver_order_confirmation_email
       return if subscription.present?

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -83,7 +83,7 @@ module Spree
     accepts_nested_attributes_for :shipments
 
     delegate :admin_and_handling_total, :payment_fee, :ship_total, to: :adjustments_fetcher
-    delegate :update_totals, to: :updater
+    delegate :update_totals, :update_totals_and_states, to: :updater
     delegate :create_line_item_fees!, :create_order_fees!, :update_order_fees!,
              :update_line_item_fees!, :recreate_all_fees!, to: :fee_handler
 
@@ -712,7 +712,7 @@ module Spree
       return if adjustment.finalized?
 
       adjustment.update_adjustment!(force: true)
-      updater.update_totals_and_states
+      update_totals_and_states
     end
   end
 end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -492,10 +492,6 @@ module Spree
       end
     end
 
-    def refresh_shipment_rates
-      shipments.map(&:refresh_rates)
-    end
-
     # After changing line items of a completed order
     def update_shipping_fees!
       shipments.each do |shipment|

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -496,14 +496,6 @@ module Spree
       shipments.map(&:refresh_rates)
     end
 
-    # Check that line_items in the current order are available from a newly selected distribution
-    def products_available_from_new_distribution
-      return if OrderCycleDistributedVariants.new(order_cycle, distributor)
-        .distributes_order_variants?(self)
-
-      errors.add(:base, I18n.t(:spree_order_availability_error))
-    end
-
     # After changing line items of a completed order
     def update_shipping_fees!
       shipments.each do |shipment|
@@ -605,6 +597,14 @@ module Spree
       return unless using_guest_checkout? && registered_email?
 
       errors.add(:email, I18n.t('devise.failure.already_registered'))
+    end
+
+    # Check that line_items in the current order are available from a newly selected distribution
+    def products_available_from_new_distribution
+      return if OrderCycleDistributedVariants.new(order_cycle, distributor)
+        .distributes_order_variants?(self)
+
+      errors.add(:base, I18n.t(:spree_order_availability_error))
     end
 
     def deliver_order_confirmation_email

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -151,6 +151,21 @@ module Spree
 
           private
 
+          def after_cancel
+            shipments.each(&:cancel!)
+            payments.checkout.each(&:void!)
+
+            OrderMailer.cancel_email(id).deliver_later if send_cancellation_email
+            update(payment_state: updater.update_payment_state)
+          end
+
+          def after_resume
+            shipments.each(&:resume!)
+            payments.void.each(&:resume!)
+
+            update(payment_state: updater.update_payment_state)
+          end
+
           def validate_payment_method!
             return unless checkout_processing
             return if payments.any?

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -136,6 +136,19 @@ module Spree
             )
           end
 
+          def state_changed(name)
+            state = "#{name}_state"
+            return unless persisted?
+
+            old_state = __send__("#{state}_was")
+            state_changes.create(
+              previous_state: old_state,
+              next_state: __send__(state),
+              name: name,
+              user_id: user_id
+            )
+          end
+
           private
 
           def validate_payment_method!

--- a/app/models/spree/return_authorization.rb
+++ b/app/models/spree/return_authorization.rb
@@ -63,7 +63,7 @@ module Spree
     end
 
     def returnable_inventory
-      order.shipped_shipments.collect{ |s| s.inventory_units.to_a }.flatten
+      order.shipments.shipped.collect{ |s| s.inventory_units.to_a }.flatten
     end
 
     # Used when Adjustment#update_adjustment! wants to update the related adjustment
@@ -74,7 +74,7 @@ module Spree
     private
 
     def must_have_shipped_units
-      return unless order.nil? || order.shipped_shipments.none?
+      return unless order.nil? || order.shipments.shipped.none?
 
       errors.add(:order, Spree.t(:has_no_shipped_units))
     end

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -42,7 +42,7 @@
         %dd#date_complete
           = pretty_time(@order.completed_at)
 
-  - if @order.distribution_set?
+  - if @order.distributor && @order.order_cycle
     %nav.menu
       %ul
         - customer_details_classes = "active" if current == "Customer Details"

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -377,7 +377,7 @@ describe Admin::BulkLineItemsController, type: :controller do
       line_item1.product.update_columns(tax_category_id: tax_cat5.id)
       line_item2.product.update_columns(tax_category_id: tax_cat10.id)
 
-      order.refresh_shipment_rates
+      order.shipments.map(&:refresh_rates)
       order.select_shipping_method(shipping_method.id)
       order.finalize!
       order.recreate_all_fees!

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -76,7 +76,7 @@ FactoryBot.define do
 
         distributor { create(:distributor_enterprise) }
 
-        after(:create, &:refresh_shipment_rates)
+        after(:create) { |order, _evaluator| order.shipments.map(&:refresh_rates) }
 
         factory :order_ready_to_ship do
           payment_state { 'paid' }

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
 
       after(:create) do |order|
         order.line_items << build(:line_item, order: order)
-        order.updater.update_totals_and_states
+        order.update_totals_and_states
 
         order.order_cycle.exchanges.outgoing.first.variants << order.line_items.first.variant
       end
@@ -49,7 +49,7 @@ FactoryBot.define do
       after(:create) do |order|
         create(:line_item, order: order)
         order.line_items.reload # to ensure order.line_items is accessible after
-        order.updater.update_totals_and_states
+        order.update_totals_and_states
       end
     end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -935,7 +935,7 @@ describe Spree::Order do
       expect(Spree::OrderMailer).to receive(:confirm_email_for_customer).and_return(mailer)
       expect(Spree::OrderMailer).to receive(:confirm_email_for_shop).and_return(mailer)
 
-      order.deliver_order_confirmation_email
+      order.__send__(:deliver_order_confirmation_email)
     end
 
     it "does not send confirmation emails when the order belongs to a subscription" do
@@ -944,7 +944,7 @@ describe Spree::Order do
       expect(Spree::OrderMailer).not_to receive(:confirm_email_for_customer)
       expect(Spree::OrderMailer).not_to receive(:confirm_email_for_shop)
 
-      order.deliver_order_confirmation_email
+      order.__send__(:deliver_order_confirmation_email)
     end
   end
 

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -120,7 +120,7 @@ describe "Order Management" do
 
     before do
       order.shipment.shipping_method.calculator.update(preferred_amount: 5.0)
-      order.refresh_shipment_rates
+      order.shipments.map(&:refresh_rates)
       order.save
       order.reload
 


### PR DESCRIPTION
#### What? Why?

A little refactor pushing back slightly against the `Order` class drifting towards being a [God Object](https://en.wikipedia.org/wiki/God_object).

Trims down the public interface of the `Order` class a bit and reduces the class's overall size. Removes some superfluous methods, moves some out into other modules, and makes some methods private that don't need to be public.

There's probably a bit more we could do in this direction to put this class on a diet and remove some responsibilities, maybe extracting some of it's methods into services (`process_payments!`, `process_payments_offline!` and `process_each_payment` all feel like they could go to a service, `create_proposed_shipments` feels like it's not the `Order`'s job either, and `create_tax_charge!` and `clear_legacy_taxes!` feel like they could be extracted to a service). Anyway, this seems like a good step (and relatively small in scope). 

#### What should we test?

Green build should be enough.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
