### PR TITLE
[admin_v3] New products_v3 table

### DIFF
--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -6,18 +6,35 @@ module Admin
 
     def index; end
 
+    # copied from ProductsTableComponent
     def fetch_products
-      # product_query = OpenFoodNetwork::Permissions.new(spree_current_user).editable_products.merge(product_scope)
-      product_query = Spree::Product.limit(10)
-      @products = product_query
+      product_query = OpenFoodNetwork::Permissions.new(spree_current_user)
+        .editable_products.merge(product_scope)
+      @products = product_query.order(:name).limit(50)
     end
 
     def product_scope
-      scope = if spree_current_user.has_spree_role?("admin") || spree_current_user.enterprises.present?
+      scope = if spree_current_user.has_spree_role?("admin") ||
+                 spree_current_user.enterprises.present?
                 Spree::Product
               else
                 Spree::Product.active
               end
+
+      scope.includes(product_query_includes)
+    end
+
+    def product_query_includes
+      # TODO: add other fielsd used in columns? (eg supplier: [:name])
+      [
+        master: [:images],
+        variants: [
+          :default_price,
+          :stock_locations,
+          :stock_items,
+          :variant_overrides
+        ]
+      ]
     end
   end
 end

--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Admin
+  class ProductsV3Controller < Spree::Admin::BaseController
+    before_action :fetch_products
+
+    def index; end
+
+    def fetch_products
+      # product_query = OpenFoodNetwork::Permissions.new(spree_current_user).editable_products.merge(product_scope)
+      product_query = Spree::Product.limit(10)
+      @products = product_query
+    end
+
+    def product_scope
+      scope = if spree_current_user.has_spree_role?("admin") || spree_current_user.enterprises.present?
+                Spree::Product
+              else
+                Spree::Product.active
+              end
+    end
+  end
+end

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -5,3 +5,42 @@
 = render partial: 'spree/admin/shared/product_sub_menu'
 
 #products_v3_page
+  %table
+    %col{ style: "min-width: 15em;" }
+    %col{ style: "min-width: 5em;" }
+    %col{ style: "min-width: 5em;" }
+    %col{ style: "min-width: 5em;" }
+    - # producer
+    %col{ style: "min-width: 10em;" }
+    %col{ style: "min-width: 10em;" }
+    %col{ style: "min-width: 5em;" }
+    %col{ style: "min-width: 5em;" }
+    %col{ style: "min-width: 8em;" }
+    %col{ style: "min-width: 8em;" }
+    %thead
+      %tr
+        %th.align-left= t('admin.product.name')
+        %th.align-right= t('admin.sku')
+        %th.align-right= t('admin.unit')
+        %th.align-right= t('admin.on_hand')
+        %th.align-left= t('admin.producer')
+        %th.align-left= t('admin.category')
+        %th.align-left= t('admin.tax_category')
+        %th.align-left= t('admin.inherits_properties')
+        %th.align-right= t('admin.available_on')
+        %th.align-right= t('admin.import_date')
+    %tbody
+      - @products.each do |product|
+        %tr
+          %th.align-left=  product.name
+          %td.align-right= product.sku
+          %td.align-right= "#{product.unit_value&.round(3)} #{product.variant_unit}"
+          %td.align-right= product.on_hand || 0
+          %td.align-left=  product.supplier.name
+          %td.align-left=  product.taxons.map(&:name).join(', ')
+          %td.align-left=  product.tax_category&.name
+          %td.align-left=  product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values
+          %td.align-right= product.available_on&.strftime('%F')
+          %td.align-right= product.import_date&.strftime('%F')
+
+  Limited to first 50 rows

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -1,0 +1,7 @@
+
+- content_for :page_title do
+  = t('.title')
+
+= render partial: 'spree/admin/shared/product_sub_menu'
+
+#products_v3_page

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -16,8 +16,8 @@
     %col{ width:"10%" }
     %col{ width:"5%" }
     %col{ width:"5%", style: "max-width:5em" }
-    %col{ width:"8%", style: "max-width:8em" }
-    %col{ width:"8%", style: "max-width:8em" }
+    / %col{ width:"8%", style: "max-width:8em" }
+    / %col{ width:"8%", style: "max-width:8em" }
     %thead
       %tr
         %th.align-left= t('admin.product.name')
@@ -28,8 +28,8 @@
         %th.align-left= t('admin.category')
         %th.align-left= t('admin.tax_category')
         %th.align-left= t('admin.inherits_properties')
-        %th.align-right= t('admin.available_on')
-        %th.align-right= t('admin.import_date')
+        / %th.align-right= t('admin.available_on')
+        / %th.align-right= t('admin.import_date')
     %tbody
       - @products.each do |product|
         %tr
@@ -50,9 +50,9 @@
             .line-clamp-1=  product.tax_category&.name
           %td.align-left
             .line-clamp-1=  product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values
-          %td.align-right
-            .line-clamp-1= product.available_on&.strftime('%F')
-          %td.align-right
-            .line-clamp-1= product.import_date&.strftime('%F')
+          / %td.align-right
+          /   .line-clamp-1= product.available_on&.strftime('%F')
+          / %td.align-right
+          /   .line-clamp-1= product.import_date&.strftime('%F')
 
   Limited to first 50 rows

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -1,4 +1,5 @@
-
+- content_for :body_class do
+  products_v3_page
 - content_for :page_title do
   = t('.title')
 

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -6,18 +6,18 @@
 = render partial: 'spree/admin/shared/product_sub_menu'
 
 #products_v3_page
-  %table
-    %col{ style: "min-width: 15em;" }
-    %col{ style: "min-width: 5em;" }
-    %col{ style: "min-width: 5em;" }
-    %col{ style: "min-width: 5em;" }
+  %table.products
+    %col{ width:"15%" }
+    %col{ width:"5%", style: "max-width:5em" }
+    %col{ width:"5%", style: "max-width:5em" }
+    %col{ width:"5%", style: "max-width:5em"}
     - # producer
-    %col{ style: "min-width: 10em;" }
-    %col{ style: "min-width: 10em;" }
-    %col{ style: "min-width: 5em;" }
-    %col{ style: "min-width: 5em;" }
-    %col{ style: "min-width: 8em;" }
-    %col{ style: "min-width: 8em;" }
+    %col{ width:"10%" }
+    %col{ width:"10%" }
+    %col{ width:"5%" }
+    %col{ width:"5%", style: "max-width:5em" }
+    %col{ width:"8%", style: "max-width:8em" }
+    %col{ width:"8%", style: "max-width:8em" }
     %thead
       %tr
         %th.align-left= t('admin.product.name')

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -34,15 +34,25 @@
       - @products.each do |product|
         %tr
           %td.align-left
-            %b=  product.name
-          %td.align-right= product.sku
-          %td.align-right= "#{product.unit_value&.round(3)} #{product.variant_unit}"
-          %td.align-right= product.on_hand || 0
-          %td.align-left=  product.supplier.name
-          %td.align-left=  product.taxons.map(&:name).join(', ')
-          %td.align-left=  product.tax_category&.name
-          %td.align-left=  product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values
-          %td.align-right= product.available_on&.strftime('%F')
-          %td.align-right= product.import_date&.strftime('%F')
+            .line-clamp-1
+              %b=  product.name
+          %td.align-right
+            .line-clamp-1= product.sku
+          %td.align-right
+            .line-clamp-1= "#{product.unit_value&.round(3)} #{product.variant_unit}"
+          %td.align-right
+            .line-clamp-1= product.on_hand || 0
+          %td.align-left
+            .line-clamp-1=  product.supplier.name
+          %td.align-left
+            .line-clamp-1=  product.taxons.map(&:name).join(', ')
+          %td.align-left
+            .line-clamp-1=  product.tax_category&.name
+          %td.align-left
+            .line-clamp-1=  product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values
+          %td.align-right
+            .line-clamp-1= product.available_on&.strftime('%F')
+          %td.align-right
+            .line-clamp-1= product.import_date&.strftime('%F')
 
   Limited to first 50 rows

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -32,7 +32,8 @@
     %tbody
       - @products.each do |product|
         %tr
-          %th.align-left=  product.name
+          %td.align-left
+            %b=  product.name
           %td.align-right= product.sku
           %td.align-right= "#{product.unit_value&.round(3)} #{product.variant_unit}"
           %td.align-right= product.on_hand || 0

--- a/app/views/spree/layouts/_admin_body.html.haml
+++ b/app/views/spree/layouts/_admin_body.html.haml
@@ -40,10 +40,10 @@
               %ul.admin__section-header__actions
                 = yield :page_actions
 
-  .container
+  - content_class = content_for?(:sidebar) ? "with-sidebar" : ""
+  #content{class: content_class}
     .row
-      - content_class = content_for?(:sidebar) ? "with-sidebar" : ""
-      #content{:class => content_class}
+      .container
         - if content_for?(:table_filter)
           - table_filter_class = content_for?(:sidebar) ? 'twelve columns' : 'sixteen columns'
           #table-filter{:class => table_filter_class}

--- a/app/views/spree/layouts/admin.html.haml
+++ b/app/views/spree/layouts/admin.html.haml
@@ -3,7 +3,7 @@
   %head
     = render :partial => 'spree/admin/shared/head'
 
-  %body.admin{ "data-turbo": "false" }
+  %body.admin{ "data-turbo": "false", class: yield(:body_class) }
     - if content_for?(:main_ng_app_name)
       - if content_for?(:main_ng_ctrl_name)
         %div{ "ng-app" => yield(:main_ng_app_name).strip.html_safe, "ng-controller" => yield(:main_ng_ctrl_name).strip.html_safe }

--- a/app/views/spree/layouts/bare_admin.html.haml
+++ b/app/views/spree/layouts/bare_admin.html.haml
@@ -13,9 +13,9 @@
           %nav.columns.eleven.admin-login-navigation-bar
             = render partial: "spree/layouts/admin/login_nav"
 
-      .container
+      #content
         .row
-          #content
+          .container
             %div{:class => "sixteen columns"}
               = yield
     %div

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -1,0 +1,8 @@
+.products_v3_page {
+  #content .container {
+    // Allow table to extend to full width of available screen space
+    // TODO: move this to a generic rule, eg body.full-width{}. Then it can be included on any page.
+    //       or even better, create a switch that allows you to yield the page content without the surrounding content class. then you still have control to add the .content div where needed.
+    max-width: none;
+  }
+}

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -7,21 +7,24 @@
   }
 
   table.products {
-    table-layout: fixed; // Column widths are based solely on col definitions (not content)
+    table-layout: fixed; // Column widths are based solely on col definitions (not content). This allows more efficient rendering.
 
-    // Clip long content
-    th,
-    td {
+    th {
+      // Clip long content in headers, but allow wrapping
       overflow: hidden;
-      text-overflow: ellipsis;
+      text-overflow: clip; // If colums are so small that headers are clipping, ellipsis are more of a hindrance
     }
 
-    tbody {
-      // Don't allow wrapping in most cells (but it's ok in the thead)
-      th
-      td, {
-        white-space: nowrap;
-      }
+    // This could probably be a global utility class
+    .line-clamp-1 {
+      // Clip content instead of wrapping to new line
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      display: -webkit-box;
+      -webkit-line-clamp: 1; /* number of lines to show */
+      line-clamp: 1;
+      -webkit-box-orient: vertical;
     }
   }
 }

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -5,4 +5,23 @@
     //       or even better, create a switch that allows you to yield the page content without the surrounding content class. then you still have control to add the .content div where needed.
     max-width: none;
   }
+
+  table.products {
+    table-layout: fixed; // Column widths are based solely on col definitions (not content)
+
+    // Clip long content
+    th,
+    td {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    tbody {
+      // Don't allow wrapping in most cells (but it's ok in the thead)
+      th
+      td, {
+        white-space: nowrap;
+      }
+    }
+  }
 }

--- a/app/webpacker/css/admin_v3/all.scss
+++ b/app/webpacker/css/admin_v3/all.scss
@@ -105,6 +105,7 @@
 @import "../admin/orders";
 @import "../admin/product_import";
 @import "../admin/products";
+@import "../admin/products_v3";
 @import "../admin/question-mark-tooltip";
 @import "../admin/relationships";
 @import "../admin/reports";

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -72,6 +72,9 @@ Openfoodnetwork::Application.routes.draw do
     constraints FeatureToggleConstraint.new(:new_products_page) do
       get '/new_products', to: 'products#index'
     end
+    constraints FeatureToggleConstraint.new(:admin_style_v3) do
+      get '/products_v3', to: 'products_v3#index'
+    end
 
     resources :variant_overrides do
       post :bulk_update, on: :collection


### PR DESCRIPTION
#### What? Why?

- #10694

Creating a new admin products page from scratch, for the purpose of evaluating horizontal-scrolling tables. 

#### Changes made:
1. **Allow full-width content for this page.** Normally, admin pages are constricted to 1400px wide, and remain in the centre. I relaxed this restriction for the products_v3 page
2. ~~**Enable table horizontal scrolling**. This allows the table to stretch as far as its widest content, and side scrolling can be done with a scrollbar (appears at very bottom of page) or with swiping. But some product names are very long~~ 
4. **Clip long cell content with ellipsis**. I've set a relative size for each column, so the table will always stretch to fill the full screen width. Some columns have max widths and won't grow because their content will never be bigger (eg dates and IDs).

See [screenshots below](https://github.com/openfoodfoundation/openfoodnetwork/pull/10942#issuecomment-1581989306).

To review: 
1. Enable  feature toggle: http://localhost:3000/admin/feature-toggle/features/admin_style_v3
6. Go to `/admin/products_v3` (it's not in the menu yet)
7. Preview the table in different screen sizes.

#### What should we test?
This is a new hidden table so doesn't need testing. We plan to continue developing it.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Feature toggle 😎 

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
This has been based upon #10948 in order to show the visual styles at the same time.



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
