### PR TITLE
[`admin_style_v3`] As an enterprise user i can see the back office with new brand colours

### DIFF
--- a/app/helpers/spree/admin/navigation_helper.rb
+++ b/app/helpers/spree/admin/navigation_helper.rb
@@ -30,7 +30,7 @@ module Spree
 
         css_classes = []
 
-        if options[:icon]
+        if options[:icon] && !feature?(:admin_style_v3, spree_current_user)
           link = link_to_with_icon(options[:icon], titleized_label, destination_url)
           css_classes << 'tab-with-icon'
         else

--- a/app/helpers/spree/admin/navigation_helper.rb
+++ b/app/helpers/spree/admin/navigation_helper.rb
@@ -26,7 +26,7 @@ module Spree
         destination_url = options[:url] || spree.public_send("#{options[:route]}_path")
         titleized_label = Spree.t(options[:label],
                                   default: options[:label],
-                                  scope: [:admin, :tab]).titleize
+                                  scope: [:admin, :tab]).capitalize
 
         css_classes = []
 

--- a/app/webpacker/css/admin_v3/all.scss
+++ b/app/webpacker/css/admin_v3/all.scss
@@ -56,7 +56,7 @@
 @import "../admin/components/input";
 @import "../admin/components/jquery_dialog";
 @import "../admin/components/messages";
-@import "../admin/components/navigation";
+@import "components/navigation"; // admin_v3
 @import "../admin/components/ng-cloak";
 @import "../admin/components/page_actions";
 @import "../admin/components/pagination";

--- a/app/webpacker/css/admin_v3/all.scss
+++ b/app/webpacker/css/admin_v3/all.scss
@@ -32,7 +32,7 @@
 @import "../admin/shared/tables";
 @import "../admin/shared/icons";
 @import "../admin/shared/forms";
-@import "../admin/shared/layout";
+@import "shared/layout"; // admin_v3
 @import "../admin/shared/scroll_bar";
 
 @import "../admin/plugins/flatpickr-customization";

--- a/app/webpacker/css/admin_v3/components/navigation.scss
+++ b/app/webpacker/css/admin_v3/components/navigation.scss
@@ -1,0 +1,174 @@
+// Navigation
+//---------------------------------------------------
+.inline-menu {
+  margin: 0;
+  -webkit-margin-before: 0;
+  -webkit-padding-start: 0;
+}
+
+nav.menu {
+  ul {
+    list-style: none;
+
+    li {
+      a {
+        padding: 10px 0;
+        display: block;
+        position: relative;
+        text-align: left;
+        border: 1px solid transparent;
+        text-transform: uppercase;
+        font-weight: 600;
+        font-size: 90%;
+      }
+
+      &.active a {
+        color: $color-2;
+        border-left-width: 0;
+        border-bottom-color: $color-2;
+      }
+
+      &:hover a {
+        color: $color-2;
+      }
+    }
+  }
+}
+
+.admin-login-navigation-bar {
+  ul {
+    text-align: right;
+
+    li {
+      padding: 5px 0 5px 10px;
+      text-align: right;
+      font-size: 90%;
+      color: $color-link;
+      margin-top: 8px;
+
+      &.user-logged-in-as {
+        width: 50%;
+        color: $color-body-text;
+      }
+
+      &:hover {
+        i {
+          color: $color-2;
+        }
+      }
+    }
+  }
+}
+
+#admin-menu {
+  background-color: $color-3;
+
+  ul {
+    display: flex;
+  }
+
+  li {
+    min-width: 90px;
+    flex-grow: 1;
+
+    a {
+      display: block;
+      padding: 25px 5px;
+      color: $color-1 !important;
+      text-transform: uppercase;
+      position: relative;
+      text-align: center;
+      font-weight: 600;
+
+      i {
+        display: inline;
+      }
+
+      &:hover {
+        background-color: $color-2;
+
+        &:after {
+          content: "";
+          position: absolute;
+          border-left: 10px solid transparent;
+          border-right: 10px solid transparent;
+          border-top: 5px solid $color-2;
+          bottom: 0px;
+          margin-bottom: -5px;
+          left: 50%;
+          margin-left: -10px;
+          z-index: 1;
+        }
+      }
+
+      span.text {
+        font-weight: 600;
+      }
+    }
+
+    a::before {
+      font-weight: normal;
+      padding-top: 0;
+    }
+
+    .dropdown {
+      width: 300px;
+      background-color: $color-3;
+      width: 200px;
+      z-index: 100000;
+
+      > li {
+        width: 200px !important;
+
+        a:after {
+          display: none;
+        }
+      }
+    }
+
+    &.selected a {
+      @extend a, :hover;
+    }
+  }
+}
+
+#sub-menu {
+  background-color: $color-2;
+  padding-bottom: 0;
+
+  li {
+    a {
+      display: block;
+      padding: 12px 20px;
+      color: $color-1;
+      text-align: center;
+      text-transform: uppercase;
+      position: relative;
+      font-size: 85%;
+    }
+
+    &.selected a,
+    a:hover {
+      &:after {
+        content: "";
+        position: absolute;
+        border-left: 10px solid transparent;
+        border-right: 10px solid transparent;
+        border-top: 5px solid $color-2;
+        bottom: 0px;
+        margin-bottom: -5px;
+        left: 50%;
+        margin-left: -10px;
+        z-index: 0;
+      }
+    }
+  }
+}
+
+#header figure {
+  margin: 0.25em 0;
+}
+
+#login-nav {
+  line-height: 1.75em;
+}

--- a/app/webpacker/css/admin_v3/components/navigation.scss
+++ b/app/webpacker/css/admin_v3/components/navigation.scss
@@ -77,10 +77,6 @@ nav.menu {
       display: block;
       padding: 25px 5px;
       color: $color-9 !important;
-      text-transform: lowercase;
-      &::first-letter {
-        text-transform: uppercase;
-      }
       position: relative;
       text-align: center;
       font-weight: 600;
@@ -136,10 +132,6 @@ nav.menu {
       padding: 12px 20px;
       color: $color-9;
       text-align: center;
-      text-transform: lowercase;
-      &::first-letter {
-        text-transform: uppercase;
-      }
       position: relative;
       font-size: 14px;
     }

--- a/app/webpacker/css/admin_v3/components/navigation.scss
+++ b/app/webpacker/css/admin_v3/components/navigation.scss
@@ -87,6 +87,7 @@ nav.menu {
       }
 
       &:hover {
+        color: $color-5 !important;
         &:after {
           content: "";
           position: absolute;
@@ -151,6 +152,7 @@ nav.menu {
 
     &.selected a,
     a:hover {
+      color: $color-5;
       &:after {
         content: "";
         position: absolute;

--- a/app/webpacker/css/admin_v3/components/navigation.scss
+++ b/app/webpacker/css/admin_v3/components/navigation.scss
@@ -61,8 +61,6 @@ nav.menu {
 }
 
 #admin-menu {
-  background-color: $color-3;
-
   ul {
     display: flex;
   }
@@ -88,8 +86,6 @@ nav.menu {
       }
 
       &:hover {
-        background-color: $color-2;
-
         &:after {
           content: "";
           position: absolute;
@@ -136,7 +132,6 @@ nav.menu {
 }
 
 #sub-menu {
-  background-color: $color-2;
   padding-bottom: 0;
 
   li {

--- a/app/webpacker/css/admin_v3/components/navigation.scss
+++ b/app/webpacker/css/admin_v3/components/navigation.scss
@@ -75,7 +75,10 @@ nav.menu {
       display: block;
       padding: 25px 5px;
       color: $color-1 !important;
-      text-transform: uppercase;
+      text-transform: lowercase;
+      &::first-letter {
+        text-transform: uppercase;
+      }
       position: relative;
       text-align: center;
       font-weight: 600;
@@ -142,7 +145,10 @@ nav.menu {
       padding: 12px 20px;
       color: $color-1;
       text-align: center;
-      text-transform: uppercase;
+      text-transform: lowercase;
+      &::first-letter {
+        text-transform: uppercase;
+      }
       position: relative;
       font-size: 85%;
     }

--- a/app/webpacker/css/admin_v3/components/navigation.scss
+++ b/app/webpacker/css/admin_v3/components/navigation.scss
@@ -61,6 +61,8 @@ nav.menu {
 }
 
 #admin-menu {
+  box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.05), 0px 2px 2px rgba(0, 0, 0, 0.07);
+
   ul {
     display: flex;
   }
@@ -135,6 +137,7 @@ nav.menu {
 
 #sub-menu {
   padding-bottom: 0;
+  box-shadow: 0px 1px 0px $color-7;
 
   li {
     a {

--- a/app/webpacker/css/admin_v3/components/navigation.scss
+++ b/app/webpacker/css/admin_v3/components/navigation.scss
@@ -72,7 +72,7 @@ nav.menu {
     a {
       display: block;
       padding: 25px 5px;
-      color: $color-1 !important;
+      color: $color-9 !important;
       text-transform: lowercase;
       &::first-letter {
         text-transform: uppercase;
@@ -138,7 +138,7 @@ nav.menu {
     a {
       display: block;
       padding: 12px 20px;
-      color: $color-1;
+      color: $color-9;
       text-align: center;
       text-transform: lowercase;
       &::first-letter {

--- a/app/webpacker/css/admin_v3/components/navigation.scss
+++ b/app/webpacker/css/admin_v3/components/navigation.scss
@@ -19,7 +19,7 @@ nav.menu {
         border: 1px solid transparent;
         text-transform: uppercase;
         font-weight: 600;
-        font-size: 90%;
+        font-size: 16px;
       }
 
       &.active a {
@@ -80,6 +80,7 @@ nav.menu {
       position: relative;
       text-align: center;
       font-weight: 600;
+      font-size: 16px;
 
       i {
         display: inline;
@@ -145,7 +146,7 @@ nav.menu {
         text-transform: uppercase;
       }
       position: relative;
-      font-size: 85%;
+      font-size: 14px;
     }
 
     &.selected a,

--- a/app/webpacker/css/admin_v3/components/navigation.scss
+++ b/app/webpacker/css/admin_v3/components/navigation.scss
@@ -70,6 +70,8 @@ nav.menu {
   li {
     min-width: 90px;
     flex-grow: 1;
+    padding-left: 2px;
+    padding-right: 2px;
 
     a {
       display: block;
@@ -90,18 +92,7 @@ nav.menu {
 
       &:hover {
         color: $color-5 !important;
-        &:after {
-          content: "";
-          position: absolute;
-          border-left: 10px solid transparent;
-          border-right: 10px solid transparent;
-          border-top: 5px solid $color-2;
-          bottom: 0px;
-          margin-bottom: -5px;
-          left: 50%;
-          margin-left: -10px;
-          z-index: 1;
-        }
+        border-bottom: 2px solid $color-5;
       }
 
       span.text {
@@ -156,18 +147,7 @@ nav.menu {
     &.selected a,
     a:hover {
       color: $color-5;
-      &:after {
-        content: "";
-        position: absolute;
-        border-left: 10px solid transparent;
-        border-right: 10px solid transparent;
-        border-top: 5px solid $color-2;
-        bottom: 0px;
-        margin-bottom: -5px;
-        left: 50%;
-        margin-left: -10px;
-        z-index: 0;
-      }
+      border-bottom: 2px solid $color-5;
     }
   }
 }

--- a/app/webpacker/css/admin_v3/globals/palette.scss
+++ b/app/webpacker/css/admin_v3/globals/palette.scss
@@ -5,3 +5,4 @@ $color-3: #008397 !default; // Teal (Allports)
 $color-4: #6788a2 !default; // Dark Blue
 $color-5: #c85136 !default; // Red/Orange (Mojo)
 $color-6: #ff9300 !default; // Yellow
+$color-9: #2e3132 !default; // Dark Grey

--- a/app/webpacker/css/admin_v3/globals/palette.scss
+++ b/app/webpacker/css/admin_v3/globals/palette.scss
@@ -6,4 +6,5 @@ $color-4: #6788a2 !default; // Dark Blue
 $color-5: #c85136 !default; // Red/Orange (Mojo)
 $color-6: #ff9300 !default; // Yellow
 $color-7: #eff1f2 !default; // Light grey
+$color-8: #191c1d !default; // Near-black
 $color-9: #2e3132 !default; // Dark Grey

--- a/app/webpacker/css/admin_v3/globals/palette.scss
+++ b/app/webpacker/css/admin_v3/globals/palette.scss
@@ -1,7 +1,7 @@
 // Basic color palette for admin styles v3
-$color-1:                        #FFFFFF !default;    // White
-$color-2:                        #9FC820 !default;    // Green
-$color-3:                        #008397 !default;    // Teal (Allports)
-$color-4:                        #6788A2 !default;    // Dark Blue
-$color-5:                        #C85136 !default;    // Red/Orange (Mojo)
-$color-6:                        #FF9300 !default;    // Yellow
+$color-1: #ffffff !default; // White
+$color-2: #9fc820 !default; // Green
+$color-3: #008397 !default; // Teal (Allports)
+$color-4: #6788a2 !default; // Dark Blue
+$color-5: #c85136 !default; // Red/Orange (Mojo)
+$color-6: #ff9300 !default; // Yellow

--- a/app/webpacker/css/admin_v3/globals/palette.scss
+++ b/app/webpacker/css/admin_v3/globals/palette.scss
@@ -5,4 +5,5 @@ $color-3: #008397 !default; // Teal (Allports)
 $color-4: #6788a2 !default; // Dark Blue
 $color-5: #c85136 !default; // Red/Orange (Mojo)
 $color-6: #ff9300 !default; // Yellow
+$color-7: #eff1f2 !default; // Light grey
 $color-9: #2e3132 !default; // Dark Grey

--- a/app/webpacker/css/admin_v3/shared/layout.scss
+++ b/app/webpacker/css/admin_v3/shared/layout.scss
@@ -1,0 +1,134 @@
+// Basics
+//---------------------------------------------------
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.admin {
+  &__section-header {
+    padding: 15px 0;
+    background-color: very-light($color-3, 4);
+    border-bottom: 1px solid $color-border;
+
+    .ofn-drop-down {
+      border: 0;
+      background-color: $spree-blue;
+      color: $color-1;
+      float: none;
+      margin-left: 3px;
+      &:hover,
+      &.expanded {
+        border: 0;
+        color: $color-1;
+      }
+    }
+
+    &__content {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      @media all and (min-width: $tablet_breakpoint) {
+        flex-wrap: nowrap;
+      }
+    }
+
+    &__title {
+      width: 100%;
+      margin-bottom: 10px;
+      @media all and (min-width: $tablet_breakpoint) {
+        margin-bottom: 0;
+      }
+    }
+
+    &__actions {
+      display: flex;
+      flex: 1 0 auto;
+      align-items: center;
+      list-style: none;
+      @media all and (min-width: $tablet_breakpoint) {
+        justify-content: flex-end;
+      }
+      > li {
+        display: flex;
+        margin-right: 10px;
+        &:empty {
+          display: none;
+        }
+        &:last-child {
+          margin-right: 0;
+        }
+      }
+    }
+  }
+}
+
+.hidden {
+  display: none;
+}
+
+.float-right {
+  float: right;
+}
+
+.float-left {
+  float: left;
+}
+
+.mr-0 {
+  margin-right: 0 !important;
+}
+
+.ml-0 {
+  margin-left: 0 !important;
+}
+
+@media print {
+  .print-hidden {
+    display: none !important;
+  }
+}
+
+// Header
+//---------------------------------------------------
+#header {
+  background-color: $color-1;
+  padding: 5px 0;
+}
+
+#logo {
+  height: 40px;
+}
+
+.page-title {
+  i {
+    color: $color-2;
+  }
+}
+
+// Content
+//---------------------------------------------------
+#content {
+  background-color: $color-1;
+  position: relative;
+  z-index: 0;
+  padding: 0;
+  margin-top: 15px;
+}
+
+// Footer
+//---------------------------------------------------
+#footer {
+  margin-top: 15px;
+  border-top: 1px solid $color-border;
+  padding: 10px 0;
+}
+
+@media print {
+  header,
+  nav {
+    display: none;
+  }
+}

--- a/app/webpacker/css/admin_v3/shared/layout.scss
+++ b/app/webpacker/css/admin_v3/shared/layout.scss
@@ -11,6 +11,10 @@
     padding: 15px 0;
     margin-top: 25px;
 
+    h1 {
+      color: $color-8;
+    }
+
     .ofn-drop-down {
       border: 0;
       background-color: $spree-blue;

--- a/app/webpacker/css/admin_v3/shared/layout.scss
+++ b/app/webpacker/css/admin_v3/shared/layout.scss
@@ -9,8 +9,7 @@
 .admin {
   &__section-header {
     padding: 15px 0;
-    background-color: very-light($color-3, 4);
-    border-bottom: 1px solid $color-border;
+    margin-top: 25px;
 
     .ofn-drop-down {
       border: 0;

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -1195,8 +1195,8 @@ describe '
 
     it "displays a Bulk Management Tab under the Orders item" do
       visit '/admin/orders'
-      expect(page).to have_link "Bulk Order Management"
-      click_link "Bulk Order Management"
+      expect(page).to have_link "Bulk order management"
+      click_link "Bulk order management"
       expect(page).to have_selector "h1.page-title", text: "Bulk Order Management"
     end
 

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -203,7 +203,7 @@ describe '
                                                         name: 'Order Cycle 2' )
 
         visit spree.admin_dashboard_path
-        click_link "Order Cycles"
+        click_link "Order cycles"
 
         # I should see only the order cycle I am coordinating
         expect(page).to have_selector "tr.order-cycle-#{oc_user_coordinating.id}"

--- a/spec/system/admin/schedules_spec.rb
+++ b/spec/system/admin/schedules_spec.rb
@@ -30,7 +30,7 @@ describe 'Schedules' do
     describe "Adding a new Schedule" do
       it "immediately shows the schedule in the order cycle list once created" do
         visit spree.admin_dashboard_path
-        click_link 'Order Cycles'
+        click_link 'Order cycles'
         expect(page).to have_selector ".order-cycle-#{oc1.id}"
         find('a', text: 'NEW SCHEDULE').click
 


### PR DESCRIPTION
#### What? Why?

- Closes #10630

**TODO:**

- [x]  remove icons from primary navigation
- [x]  change to Sentence case
- [x]  change colours and add shadows to containers (both primary and secondary nav)
- [x]  add underline to active page (both primary and secondary nav)

<img width="1418" alt="Capture d’écran 2023-06-07 à 16 23 19" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/3c9dbecb-2a46-49bf-8be7-0e00a5047ccb">

![2023-06-07 16 25 50](https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/62e8991c-2327-45ee-a0b2-08b6899203ee)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, activate `admin_style_v3`
- As a shop manager, see that you can see the new style for the menu
- As an admin, desactivate `admin_style_v3`
- As a shop manager, see that you cannot see the new style, and everything should be equivalent to master

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
