### PR TITLE
Improve nil-safety in variant naming methods

### DIFF
--- a/app/services/variant_units/variant_and_line_item_naming.rb
+++ b/app/services/variant_units/variant_and_line_item_naming.rb
@@ -22,7 +22,8 @@ module VariantUnits
     end
 
     def product_and_full_name
-      return "#{product.name} - #{full_name}" unless full_name.start_with? product.name
+      return product.name if full_name.blank?
+      return "#{product.name} - #{full_name}" unless full_name.start_with?(product.name)
 
       full_name
     end
@@ -51,7 +52,7 @@ module VariantUnits
       return display_as if has_attribute?(:display_as) && display_as.present?
       return variant.display_as if variant_display_as?
 
-      options_text
+      options_text.to_s
     end
 
     def assign_units

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -432,6 +432,20 @@ describe Spree::Variant do
         expect(variant.product_and_full_name).to eq "Apple - Pink Lady"
       end
     end
+
+    context "when related naming values are nil" do
+      before do
+        product.name = "Apples"
+        product.display_as = nil
+        variant.display_as = nil
+        variant.unit_presentation = nil
+      end
+
+      it "returns empty string or product name" do
+        expect(variant.full_name).to eq ""
+        expect(variant.product_and_full_name).to eq product.name
+      end
+    end
   end
 
   describe "calculating the price with enterprise fees" do

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -433,17 +433,28 @@ describe Spree::Variant do
       end
     end
 
-    context "when related naming values are nil" do
-      before do
-        product.name = "Apples"
+    context "handling nil values for related naming attributes" do
+      it "returns empty string or product name" do
+        product.name = "Apple"
+        product.variant_unit = "items"
+        product.display_as = nil
+        variant.display_as = nil
+        variant.display_name = nil
+
+        expect(variant.full_name).to eq ""
+        expect(variant.product_and_full_name).to eq product.name
+      end
+
+      it "uses the display name correctly" do
+        product.name = "Apple"
+        product.variant_unit = "items"
         product.display_as = nil
         variant.display_as = nil
         variant.unit_presentation = nil
-      end
+        variant.display_name = "Green"
 
-      it "returns empty string or product name" do
-        expect(variant.full_name).to eq ""
-        expect(variant.product_and_full_name).to eq product.name
+        expect(variant.full_name).to eq "Green"
+        expect(variant.product_and_full_name).to eq "Apple - Green"
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

- Closes #10950

#### What should we test?

I'm not sure how to manually recreate this bug and it obviously wasn't triggered by any of the normal ways we create products and variants in the test suite. I wrote a test that triggered it, using a product with `display_as = nil`, a variant with `display_as = nil` and `unit_presentation = nil`. I think a variant will always have a `unit_presentation` value if it's using `weight` or `volume`, so I guess it has to be created with `items` and have it's associated `display_name` and other attributes as `nil`... and then try to load it in a report?

The underlying issue should be fixed anyway, it was trying to call a string method `.downcase` on the name in some cases where the value was `nil`, but now it should safely deal with that situation whenever it occurs.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes


