### PR TITLE
Ensure directory exists before saving invoices pdf

### DIFF
--- a/app/jobs/bulk_invoice_job.rb
+++ b/app/jobs/bulk_invoice_job.rb
@@ -13,6 +13,8 @@ class BulkInvoiceJob < ApplicationJob
       pdf << CombinePDF.parse(invoice)
     end
 
+    ensure_directory_exists filepath
+
     pdf.save filepath
 
     broadcast(filepath, options[:channel]) if options[:channel]
@@ -40,5 +42,11 @@ class BulkInvoiceJob < ApplicationJob
                      locals: { invoice_url: "/admin/orders/invoices/#{file_id}" })
       ).
       broadcast
+  end
+
+  def ensure_directory_exists(filepath)
+    return unless File.exist?(File.dirname(filepath))
+
+    FileUtils.mkdir_p(File.dirname(filepath))
   end
 end

--- a/app/jobs/bulk_invoice_job.rb
+++ b/app/jobs/bulk_invoice_job.rb
@@ -45,8 +45,6 @@ class BulkInvoiceJob < ApplicationJob
   end
 
   def ensure_directory_exists(filepath)
-    return unless File.exist?(File.dirname(filepath))
-
     FileUtils.mkdir_p(File.dirname(filepath))
   end
 end


### PR DESCRIPTION
These directories can get wiped during deployments so before writing to them we should make sure they are created/recreated.

#### What? Why?

- Closes #8080

#### What should we test?

Printing bulk invoices after a fresh deployment

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
