### PR TITLE
[WhiteLabel] Add some margin to custom tab content for a shop

### DIFF
--- a/app/views/shopping_shared/tabs/_custom.html.haml
+++ b/app/views/shopping_shared/tabs/_custom.html.haml
@@ -1,3 +1,4 @@
 .content
   .row
-    = sanitize(@distributor.custom_tab&.content, scrubber: TrixScrubber.new)
+    .columns
+      = sanitize(@distributor.custom_tab&.content, scrubber: TrixScrubber.new)


### PR DESCRIPTION
#### What? Why?

- Closes #10945 

##### Before
<img width="793" alt="Capture d’écran 2023-06-08 à 11 35 26" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/067cd86c-0a09-454d-97d9-36ba37db8ff2">

##### After
<img width="783" alt="Capture d’écran 2023-06-08 à 11 35 41" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/dc47d524-ea6f-467b-baca-451eb762c2c3">


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a shop manager, create a custom tab
- As a customer, check that, with a small width screen, you can see margin for the custom tab content

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
