### PR TITLE
Admin, Orders list: add tooltip on Edit action icon + capitalize tooltip (instead of uppercasing)

### DIFF
--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -41,7 +41,7 @@
     %div.row-loading-icons
       - if local_assigns[:success]
         %i.success.icon-ok-sign{"data-controller": "ephemeral"}
-    %a.icon_link.with-tip.icon-edit.no-text{href: edit_admin_order_path(order), 'ofn-with-tip' => t('spree.admin.orders.index.edit')}
+    %a.icon_link.with-tip.icon-edit.no-text{href: edit_admin_order_path(order), "data-controller": "tooltip", "data-tooltip-tip-value": t('spree.admin.orders.index.edit'), "data-tooltip-target": "element"}
     - if order.ready_to_ship?
       %div{ "data-controller": "tooltip", "data-tooltip-tip-value": t('spree.admin.orders.index.ship') }
         %button.icon-road.icon_link.with-tip.no-text{"data-reflex": "click->Admin::OrdersReflex#ship", "data-id": order.id.to_s,

--- a/app/webpacker/css/admin/components/tooltip.scss
+++ b/app/webpacker/css/admin/components/tooltip.scss
@@ -16,6 +16,7 @@
   color: #fff;
   max-width: 240px;
   white-space: normal;
+  text-transform: capitalize;
 }
 
 .arrow {

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -697,8 +697,6 @@ distributors: [distributor4, distributor5]) }
         end
 
         it "displays Edit tooltip" do
-          pending("issue #10956")
-
           within "tr#order_#{order.id}" do
             # checks shipment state
             expect(page).to have_content "PENDING"

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -683,7 +683,7 @@ distributors: [distributor4, distributor5]) }
 
             # mouse-hovers and finds tooltip
             find(".icon-road").hover
-            expect(page).to have_content "SHIP"
+            expect(page).to have_content "Ship"
           end
 
           within "tr#order_#{order.id}" do
@@ -692,7 +692,7 @@ distributors: [distributor4, distributor5]) }
 
             # mouse-hovers and finds tooltip
             find(".icon-capture").hover
-            expect(page).to have_content "CAPTURE"
+            expect(page).to have_content "Capture"
           end
         end
 
@@ -703,7 +703,7 @@ distributors: [distributor4, distributor5]) }
 
             # mouse-hovers and finds tooltip
             find(".icon-edit").hover
-            expect(page).to have_content "EDIT"
+            expect(page).to have_content "Edit"
           end
         end
       end


### PR DESCRIPTION
#### What? Why?

- Closes #10956

##### Before
###### No tooltip
<img width="65" alt="Capture d’écran 2023-06-08 à 14 35 48" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/407676fb-dc66-4b05-bbd0-e6be5712024e">

###### Uppercase
<img width="139" alt="Capture d’écran 2023-06-08 à 14 36 26" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/6f0be437-db14-4eab-91bf-931af40b2d16">


##### After
###### With tooltip
<img width="319" alt="Capture d’écran 2023-06-08 à 14 20 36" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/d8ade10c-266b-4844-be74-974909b7852d">

###### Capitalize
<img width="118" alt="Capture d’écran 2023-06-08 à 14 36 57" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/ef17b5a8-2a17-462a-a9bf-5e4dc40ee7cc">

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a shop manager, go to the orders list page
- Check that you can see tooltip for Edit action icon
- Check that tooltip are capitalized (not uppercase)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes