### PR TITLE
Adds spec for tooltips on orders page

### DIFF
--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -669,6 +669,46 @@ distributors: [distributor4, distributor5]) }
         expect(order.reload.shipments.any?(&:shipped?)).to be true
         expect(order.shipment_state).to eq("shipped")
       end
+
+      context "mouse-hovering" do
+        before do
+          login_as_admin
+          visit spree.admin_orders_path
+        end
+
+        it "displays Ship and Capture tooltips" do
+          within "tr#order_#{order2.id}" do
+            # checks shipment state
+            expect(page).to have_content "READY"
+
+            # mouse-hovers and finds tooltip
+            find(".icon-road").hover
+            expect(page).to have_content "SHIP"
+          end
+
+          within "tr#order_#{order.id}" do
+            # checks shipment state
+            expect(page).to have_content "PENDING"
+
+            # mouse-hovers and finds tooltip
+            find(".icon-capture").hover
+            expect(page).to have_content "CAPTURE"
+          end
+        end
+
+        it "displays Edit tooltip" do
+          pending("issue #10956")
+
+          within "tr#order_#{order.id}" do
+            # checks shipment state
+            expect(page).to have_content "PENDING"
+
+            # mouse-hovers and finds tooltip
+            find(".icon-edit").hover
+            expect(page).to have_content "EDIT"
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
#### What? Why?

- Relates to #10956

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- Adds specs to test tooltips, by mouse-hovering :mouse: :flying_saucer: 
- Reproduces #10956 with a pending example

To be cherry-picked :cherries: or rebased/updated after #10956 is closed.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

 #10956

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->