### PR TITLE
Ignore leading and trailing whitespace when importing products via a spreadsheet

### DIFF
--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -233,6 +233,8 @@ module ProductImport
     def rows
       return [] unless @sheet&.last_row
 
+      @sheet.parse(clean: true)
+
       (2..@sheet.last_row).map do |i|
         @sheet.row(i)
       end


### PR DESCRIPTION
#### What? Why?

- Closes #10612

This uses the `clean` option in https://github.com/roo-rb/roo to strip control characters and surrounding white space.

#### What should we test?

See #10612

#### Release notes

Changelog Category: Technical changes