### PR TITLE
Require localized_number in Payment class

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "spree/localized_number"
+
 module Spree
   class Payment < ApplicationRecord
     include Spree::Payment::Processing


### PR DESCRIPTION
#### What? Why?

- Closes #10973 

There seems to be some contexts (jobs for subscriptions) where the `Payment` class loads but `LocalizedNumber` is an undefined constant. It lives in the `/lib` directory so it's not auto-loaded. I think some of the places where it gets `require`'d have changed around recently.

#### What should we test?

Subscriptions placement should work.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

