### PR TITLE
[OIDC] Translate 'Enterprises' > 'OIDC Settings' tab title

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3959,6 +3959,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         enterprise_relationships: "Permissions"
         customers: "Customers"
         groups: "Groups"
+        oidc_settings: "OIDC Settings"
       product_properties:
         index:
           inherits_properties_checkbox_hint: "Inherit properties from %{supplier}? (unless overridden above)"


### PR DESCRIPTION
#### What? Why?

- Closes #10982

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

<img width="395" alt="Capture d’écran 2023-06-12 à 09 16 49" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/da466375-c52b-49be-a396-ea5ecc5252a2">


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Check that OIDC Settings in sub tab menu (under Enterprises main menu) is well translated (without `_`)
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
