### PR TITLE
[White Label] Custom tab content editor: order and unordered list should have a margin-left set

### DIFF
--- a/app/webpacker/css/admin/trix.scss
+++ b/app/webpacker/css/admin/trix.scss
@@ -2,6 +2,13 @@ trix-toolbar [data-trix-button-group="file-tools"] {
   display: none;
 }
 
+trix-editor {
+  ol,
+  ul {
+    margin-left: 1.5em;
+  }
+}
+
 trix-toolbar .trix-button {
   background-color: transparent;
 


### PR DESCRIPTION
#### What? Why?

- Closes #10980
###### Before
<img width="620" alt="Capture d’écran 2023-06-12 à 16 56 35" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/4ced6b19-0ad1-4c48-964c-025d0cc7b3d5">

###### After
<img width="358" alt="Capture d’écran 2023-06-12 à 16 56 16" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/1651d214-8212-487c-8d09-847cf5d1d0ac">


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a shop manager, create a custom tab under white label section and check that both ordered and unordered list have margin and can be indented.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes