### PR TITLE
Fix BOM order loading issue

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -62,6 +62,8 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     $scope.dereferenceLoadedData()
 
   $scope.loadOrders = ->
+    return $scope.orders = [] unless $scope.line_items.length
+
     RequestMonitor.load $scope.orders = Orders.index(
       "q[id_in][]": $scope.line_items.map((line_item) -> line_item.order.id)
     )


### PR DESCRIPTION
#### What? Why?

Closes #10990 

Initial diagnosis notes here: https://github.com/openfoodfoundation/openfoodnetwork/issues/10990#issuecomment-1589351715

There were a couple of edge cases here where the code was trying to load orders when the number of `line_items` with the current filters applied is zero, or for some reason the current Angular scope does not have line items. This ends up sending a request to the V0 orders endpoint with _no filters and no search params_, which then tries to load every order in the entire database that the current user can see (for all enterprises, for all time). If the user is **superadmin** or they manage a number of large enterprises with a lot of historic order data it will blow up :boom:

#### What should we test?

- Play around with the filters on the BOM page as **superadmin** on a server with **a lot of data**, and particularly with requests where the selected filters would return **no results**, like filter a producer and order cycle that aren't related, or a product that doesn't exist, where the result of the search would show: "No orders found".
- It was blowing up before in some cases, and now it should be fine. If the server you're testing doesn't have production-level amounts of data on it you might just find that the response is slow instead of completely timing out and failing (which is what was happening in UK production)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
