### PR TITLE
Show current version at bottom of admin dashboard

### DIFF
--- a/app/views/spree/admin/overview/_version.html.haml
+++ b/app/views/spree/admin/overview/_version.html.haml
@@ -1,0 +1,3 @@
+%a{href:"https://github.com/openfoodfoundation/openfoodnetwork/releases", target: "_blank", title: t('.view_all_releases')}
+  =# Show the latest tag. If there are commits since the tag, show number of commits and an identifier. If the working tree is dirty, show 'modified'.
+  = `git describe --tags --dirty=-modified`

--- a/app/views/spree/admin/overview/multi_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/multi_enterprise_dashboard.html.haml
@@ -22,3 +22,5 @@
       = render partial: "order_cycles"
 
     = render partial: "enterprises"
+
+  = render partial: "version"

--- a/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
@@ -81,3 +81,5 @@
         %a.button.bottom{href: main_app.admin_order_cycles_path}
           = t "manage_order_cycles"
           %span.icon-arrow-right
+
+  = render partial: "version"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4096,6 +4096,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             many: "You have %{count} active order cycles."
             other: "You have %{count} active order cycles."
           manage_order_cycles: "MANAGE ORDER CYCLES"
+        version:
+          view_all_releases: View all releases
       shipping_methods:
         index:
           shipping_methods: "Shipping Methods"


### PR DESCRIPTION
With generic link to the [releases page](https://github.com/openfoodfoundation/openfoodnetwork/releases). We could provide a link to latest tag with `git describe --tags --abbrev=0`. But I thought it better to keep things simple.

This is visible to any admins.

I considered using view caching, but concluded that it wasn't worth it. When a deployment is made, I'm not sure that the cache is cleared. So we'd need to add a cache key based on the git reference. Which requires another system call to retrieve, which defeats the point of caching.

#### What? Why?
Most people don't have access to check this on the server, so this allows them to confirm at any time.

Also, sometimes a lot of time can be lost debugging an issue, without realising the platform is running on an older version where the but has been fixed (like yesterday!)


![Screen Shot 2023-06-14 at 9 42 21 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/d1f7d25e-f2ee-4ecd-a5fd-4d70143cb9de)
![Screen Shot 2023-06-14 at 9 44 40 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/f3433112-f7b3-4186-8815-16531f63ed4d)
![Screen Shot 2023-06-14 at 9 47 53 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/5d08ae39-c17c-4073-a2ba-364b865f6d18)
![Screen Shot 2023-06-14 at 9 48 30 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/310c24f3-8e42-4202-964c-3a06c3708b8c)


#### What should we test?
- Go to the dashboard for a single or multi enterprise user.
- view the version at the bottom
  - on production, this would show something like "v4.3.12-modified"
  - on staging where we've deployed a PR, it would look like "v4.3.11-182-g61baabb1f-modified"
- click on the version, to open up the releases page in a new tab.

#### Release notes

Changelog Category: 👀 User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


