### PR TITLE
Prototype: Import products via DFC Connector

### DIFF
--- a/engines/dfc_provider/README.md
+++ b/engines/dfc_provider/README.md
@@ -1,12 +1,41 @@
-# DfcProvider
+# Data Food Consortium API for the Open Food Network app (OFN DFC API)
 
-This engine is implementing the Data Food Consortium specifications in order to serve semantic data.
-You can find more details about this on https://github.com/datafoodconsortium.
+This engine implements the [Data Food Consortium] specifications. It serves and
+reads semantic data encoded in JSON-LD.
 
-Basically, it allows an OFN user linked to an enterprise:
-* to serve his Products Catalog through a dedicated API using JSON-LD format, structured by the DFC Ontology
-* to be authenticated thanks to an Access Token from DFC Authorization server (using an OIDC implementation)
+[Data Food Consortium]: https://github.com/datafoodconsortium
 
-The API endpoint for the catalog is `/api/dfc_provider/enterprise/prodcuts.json` and you need to pass the token inside an authentication header (`Authentication: Bearer 123mytoken456`).
+## Authentication
 
-This feature is still under active development.
+The DFC uses OpenID Connect (OIDC) to authenticate requests. You need an
+account with a trusted OIDC provider. Currently these are:
+
+* https://login.lescommuns.org/auth/
+
+But you can also authenticate with your OFN user login (session cookie) through
+your browser.
+
+## API endpoints
+
+The API is under development and this list may be out of date.
+
+```
+/api/dfc-v1.7/persons/:id
+ * show: firstName, lastName, affiliatedOrganizations
+
+/api/dfc-v1.7/enterprises/:id
+ * show: name, suppliedProducts, catalogItems
+
+/api/dfc-v1.7/enterprises/:enterprise_id/supplied_products (index)
+
+/api/dfc-v1.7/enterprises/:enterprise_id/supplied_products/:id
+ * create: name, description, quantity
+ * show: name, description, productType, quantity
+ * update: description
+
+/api/dfc-v1.7/enterprises/:enterprise_id/catalog_items (index)
+
+/api/dfc-v1.7/enterprises/:enterprise_id/catalog_items/:id
+ * show: product, sku, stockLimitation, offers (price, stockLimitation)
+ * update: sku, stockLimitation
+```

--- a/engines/dfc_provider/app/controllers/dfc_provider/supplied_products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/supplied_products_controller.rb
@@ -7,7 +7,7 @@ module DfcProvider
     before_action :check_enterprise
 
     def show
-      product = DfcBuilder.supplied_product(variant)
+      product = SuppliedProductBuilder.supplied_product(variant)
       render json: DfcLoader.connector.export(product)
     end
 

--- a/engines/dfc_provider/app/controllers/dfc_provider/supplied_products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/supplied_products_controller.rb
@@ -1,10 +1,22 @@
 # frozen_string_literal: true
 
+require "data_food_consortium/connector/connector"
+
 # Controller used to provide the SuppliedProducts API for the DFC application
 # SuppliedProducts are products that are managed by an enterprise.
 module DfcProvider
   class SuppliedProductsController < DfcProvider::BaseController
     before_action :check_enterprise
+    rescue_from JSON::LD::JsonLdError::LoadingDocumentFailed, with: -> do
+      head :bad_request
+    end
+
+    def create
+      supplied_product = import.first
+      product = SuppliedProductBuilder.import(supplied_product)
+      product.supplier = current_enterprise
+      product.save!
+    end
 
     def show
       product = SuppliedProductBuilder.supplied_product(variant)
@@ -26,6 +38,10 @@ module DfcProvider
     end
 
     private
+
+    def import
+      DfcLoader.connector.import(request.body)
+    end
 
     def variant
       @variant ||=

--- a/engines/dfc_provider/app/services/dfc_builder.rb
+++ b/engines/dfc_provider/app/services/dfc_builder.rb
@@ -6,28 +6,13 @@ class DfcBuilder
       enterprise_id: variant.product.supplier_id,
       id: variant.id,
     )
-    product = supplied_product(variant)
+    product = SuppliedProductBuilder.supplied_product(variant)
 
     DataFoodConsortium::Connector::CatalogItem.new(
       id, product: product,
           sku: variant.sku,
           stockLimitation: stock_limitation(variant),
           offers: [offer(variant)],
-    )
-  end
-
-  def self.supplied_product(variant)
-    id = urls.enterprise_supplied_product_url(
-      enterprise_id: variant.product.supplier_id,
-      id: variant.id,
-    )
-
-    DataFoodConsortium::Connector::SuppliedProduct.new(
-      id,
-      name: variant.name_to_display,
-      description: variant.description,
-      productType: product_type,
-      quantity: QuantitativeValueBuilder.quantity(variant),
     )
   end
 

--- a/engines/dfc_provider/app/services/enterprise_builder.rb
+++ b/engines/dfc_provider/app/services/enterprise_builder.rb
@@ -3,8 +3,8 @@
 class EnterpriseBuilder < DfcBuilder
   def self.enterprise(enterprise)
     variants = VariantFetcher.new(enterprise).scope.to_a
-    supplied_products = variants.map(&method(:supplied_product))
     catalog_items = variants.map(&method(:catalog_item))
+    supplied_products = catalog_items.map(&:product)
 
     DataFoodConsortium::Connector::Enterprise.new(
       enterprise.name

--- a/engines/dfc_provider/app/services/quantitative_value_builder.rb
+++ b/engines/dfc_provider/app/services/quantitative_value_builder.rb
@@ -26,4 +26,19 @@ class QuantitativeValueBuilder < DfcBuilder
       DfcLoader.connector.MEASURES.UNIT.QUANTITYUNIT.PIECE
     end
   end
+
+  def self.apply(quantity, product)
+    product.variant_unit, product.variant_unit_name =
+      case quantity.unit
+      when DfcLoader.connector.MEASURES.UNIT.QUANTITYUNIT.LITRE
+        ["volume", "liter"]
+      when DfcLoader.connector.MEASURES.UNIT.QUANTITYUNIT.GRAM
+        ["weight", "gram"]
+      else
+        ["items", "items"]
+      end
+
+    product.variant_unit_scale = 1
+    product.unit_value = quantity.value
+  end
 end

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -15,4 +15,16 @@ class SuppliedProductBuilder < DfcBuilder
       quantity: QuantitativeValueBuilder.quantity(variant),
     )
   end
+
+  def self.import(supplied_product)
+    Spree::Product.new(
+      name: supplied_product.name,
+      description: supplied_product.description,
+      price: 0, # will be in DFC Offer
+      primary_taxon: Spree::Taxon.first, # dummy value until we have a mapping
+      shipping_category: DefaultShippingCategory.find_or_create,
+    ).tap do |product|
+      QuantitativeValueBuilder.apply(supplied_product.quantity, product)
+    end
+  end
 end

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class SuppliedProductBuilder < DfcBuilder
+  def self.supplied_product(variant)
+    id = urls.enterprise_supplied_product_url(
+      enterprise_id: variant.product.supplier_id,
+      id: variant.id,
+    )
+
+    DataFoodConsortium::Connector::SuppliedProduct.new(
+      id,
+      name: variant.name_to_display,
+      description: variant.description,
+      productType: product_type,
+      quantity: QuantitativeValueBuilder.quantity(variant),
+    )
+  end
+end

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -3,7 +3,7 @@
 DfcProvider::Engine.routes.draw do
   resources :enterprises, only: [:show] do
     resources :catalog_items, only: [:index, :show, :update]
-    resources :supplied_products, only: [:show, :update]
+    resources :supplied_products, only: [:create, :show, :update]
   end
   resources :persons, only: [:show]
 end

--- a/engines/dfc_provider/spec/services/enterprise_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/enterprise_builder_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require DfcProvider::Engine.root.join("spec/spec_helper")
+
+describe EnterpriseBuilder do
+  subject(:builder) { described_class }
+  let(:enterprise) { variant.product.supplier }
+  let(:variant) { create(:product, name: "Apple").variants.first }
+
+  describe ".enterprise" do
+    it "assigns a semantic id" do
+      result = builder.enterprise(enterprise)
+
+      expect(result.semanticId).to eq(
+        "http://test.host/api/dfc-v1.7/enterprises/#{enterprise.id}"
+      )
+    end
+
+    it "assignes products" do
+      result = builder.enterprise(enterprise)
+
+      expect(result.suppliedProducts.count).to eq 1
+      expect(result.suppliedProducts[0].name).to eq "Apple"
+    end
+  end
+end

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -2,14 +2,15 @@
 
 require DfcProvider::Engine.root.join("spec/spec_helper")
 
-describe DfcBuilder do
+describe SuppliedProductBuilder do
+  subject(:builder) { described_class }
   let(:variant) {
     build(:variant, id: 5).tap { |v| v.product.supplier_id = 7 }
   }
 
   describe ".supplied_product" do
     it "assigns a semantic id" do
-      product = DfcBuilder.supplied_product(variant)
+      product = builder.supplied_product(variant)
 
       expect(product.semanticId).to eq(
         "http://test.host/api/dfc-v1.7/enterprises/7/supplied_products/5"
@@ -17,7 +18,7 @@ describe DfcBuilder do
     end
 
     it "assigns a quantity" do
-      product = DfcBuilder.supplied_product(variant)
+      product = builder.supplied_product(variant)
 
       expect(product.quantity.value).to eq 1.0
       expect(product.quantity.unit.semanticId).to eq "dfc-m:Gram"
@@ -25,7 +26,7 @@ describe DfcBuilder do
 
     it "assigns the product name by default" do
       variant.product.name = "Apple"
-      product = DfcBuilder.supplied_product(variant)
+      product = builder.supplied_product(variant)
 
       expect(product.name).to eq "Apple"
     end
@@ -33,13 +34,13 @@ describe DfcBuilder do
     it "assigns the variant name if present" do
       variant.product.name = "Apple"
       variant.display_name = "Granny Smith"
-      product = DfcBuilder.supplied_product(variant)
+      product = builder.supplied_product(variant)
 
       expect(product.name).to eq "Granny Smith"
     end
 
     it "assigns a product type" do
-      product = DfcBuilder.supplied_product(variant)
+      product = builder.supplied_product(variant)
       vegetable = DfcLoader.connector.PRODUCT_TYPES.VEGETABLE.NON_LOCAL_VEGETABLE
 
       expect(product.productType).to eq vegetable

--- a/engines/dfc_provider/spec/spec_helper.rb
+++ b/engines/dfc_provider/spec/spec_helper.rb
@@ -8,11 +8,4 @@ RSpec.configure do |config|
   config.include AuthorizationHelper, type: :request
   config.include DfcProvider::Engine.routes.url_helpers, type: :request
   config.include Warden::Test::Helpers, type: :request
-
-  config.around(:each) do |example|
-    # The DFC Connector fetches the context when loaded.
-    VCR.use_cassette("dfc-context") do
-      example.run
-    end
-  end
 end

--- a/lib/data_food_consortium/connector/connector.rb
+++ b/lib/data_food_consortium/connector/connector.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "importer"
+
+module DataFoodConsortium
+  module Connector
+    class Connector
+      def import(json_string)
+        Importer.new.import(json_string)
+      end
+    end
+  end
+end

--- a/lib/data_food_consortium/connector/connector.rb
+++ b/lib/data_food_consortium/connector/connector.rb
@@ -5,8 +5,8 @@ require_relative "importer"
 module DataFoodConsortium
   module Connector
     class Connector
-      def import(json_string)
-        Importer.new.import(json_string)
+      def import(json_string_or_io)
+        Importer.new.import(json_string_or_io)
       end
     end
   end

--- a/lib/data_food_consortium/connector/importer.rb
+++ b/lib/data_food_consortium/connector/importer.rb
@@ -75,13 +75,11 @@ module DataFoodConsortium
 
         property = subject.__send__(:findSemanticProperty, property_id)
 
-        # Some properties have a one-to-one match to the method name.
-        setter_name = "#{statement.predicate.fragment}="
-
         if property.value.is_a?(Enumerable)
           property.value << value
-        elsif subject.respond_to?(setter_name)
-          subject.public_send(setter_name, value)
+        else
+          setter = guess_setter_name(statement.predicate)
+          subject.try(setter, value) if setter
         end
       end
 
@@ -91,6 +89,16 @@ module DataFoodConsortium
 
       def resolve_object(object)
         @subjects[object] || object.object
+      end
+
+      def guess_setter_name(predicate)
+        fragment = predicate.fragment
+
+        # Some predicates are named like `hasQuantity`
+        # but the attribute name would be `quantity`.
+        name = fragment.sub(/^has/, "").camelize(:lower)
+
+        "#{name}="
       end
     end
   end

--- a/lib/data_food_consortium/connector/importer.rb
+++ b/lib/data_food_consortium/connector/importer.rb
@@ -19,10 +19,10 @@ module DataFoodConsortium
         end
       end
 
-      def import(json_string)
+      def import(json_string_or_io)
         @subjects = {}
 
-        graph = parse_rdf(json_string)
+        graph = parse_rdf(json_string_or_io)
         build_subjects(graph)
         apply_statements(graph)
 
@@ -35,9 +35,10 @@ module DataFoodConsortium
 
       private
 
-      def parse_rdf(json_string)
-        json_file = StringIO.new(json_string)
-        RDF::Graph.new << JSON::LD::API.toRdf(json_file)
+      # The `io` parameter can be a String or an IO instance.
+      def parse_rdf(io)
+        io = StringIO.new(io) if io.is_a?(String)
+        RDF::Graph.new << JSON::LD::API.toRdf(io)
       end
 
       def build_subjects(graph)

--- a/lib/data_food_consortium/connector/importer.rb
+++ b/lib/data_food_consortium/connector/importer.rb
@@ -20,11 +20,16 @@ module DataFoodConsortium
       end
 
       def import(json_string)
+        @subjects = {}
+
         graph = parse_rdf(json_string)
-        head, *tail = graph.to_a
-        subject = build_subject(head)
-        apply_statements(subject, tail)
-        subject
+        apply_statements(graph)
+
+        if @subjects.size > 1
+          @subjects.values
+        else
+          @subjects.values.first
+        end
       end
 
       private
@@ -42,13 +47,15 @@ module DataFoodConsortium
         clazz.new(id)
       end
 
-      def apply_statements(subject, statements)
+      def apply_statements(statements)
         statements.each do |statement|
-          apply_statement(subject, statement)
+          apply_statement(statement)
         end
       end
 
-      def apply_statement(subject, statement)
+      def apply_statement(statement)
+        subject = subject_of(statement)
+
         return unless subject.hasSemanticProperty?(statement.predicate.value)
 
         prop_name = statement.predicate.fragment
@@ -58,6 +65,10 @@ module DataFoodConsortium
 
         value = statement.object.object
         subject.public_send(setter_name, value)
+      end
+
+      def subject_of(statement)
+        @subjects[statement.subject] ||= build_subject(statement)
       end
     end
   end

--- a/lib/data_food_consortium/connector/importer.rb
+++ b/lib/data_food_consortium/connector/importer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "skos_parser"
+
 module DataFoodConsortium
   module Connector
     class Importer
@@ -88,7 +90,16 @@ module DataFoodConsortium
       end
 
       def resolve_object(object)
-        @subjects[object] || object.object
+        @subjects[object] || skos_concept(object) || object.object
+      end
+
+      def skos_concept(object)
+        return unless object.uri?
+
+        id = object.value.sub(
+          "http://static.datafoodconsortium.org/data/measures.rdf#", "dfc-m:"
+        )
+        SKOSParser.concepts[id]
       end
 
       def guess_setter_name(predicate)

--- a/lib/data_food_consortium/connector/importer.rb
+++ b/lib/data_food_consortium/connector/importer.rb
@@ -55,16 +55,21 @@ module DataFoodConsortium
 
       def apply_statement(statement)
         subject = subject_of(statement)
-
-        return unless subject.hasSemanticProperty?(statement.predicate.value)
-
-        prop_name = statement.predicate.fragment
-        setter_name = "#{prop_name}="
-
-        return unless subject.respond_to?(setter_name)
-
+        property_id = statement.predicate.value
         value = statement.object.object
-        subject.public_send(setter_name, value)
+
+        return unless subject.hasSemanticProperty?(property_id)
+
+        property = subject.__send__(:findSemanticProperty, property_id)
+
+        # Some properties have a one-to-one match to the method name.
+        setter_name = "#{statement.predicate.fragment}="
+
+        if property.value.is_a?(Enumerable)
+          property.value << value
+        elsif subject.respond_to?(setter_name)
+          subject.public_send(setter_name, value)
+        end
       end
 
       def subject_of(statement)

--- a/lib/data_food_consortium/connector/importer.rb
+++ b/lib/data_food_consortium/connector/importer.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module DataFoodConsortium
+  module Connector
+    class Importer
+      TYPES = [
+        DataFoodConsortium::Connector::CatalogItem,
+        DataFoodConsortium::Connector::Enterprise,
+        DataFoodConsortium::Connector::Offer,
+        DataFoodConsortium::Connector::Person,
+        DataFoodConsortium::Connector::QuantitativeValue,
+        DataFoodConsortium::Connector::SuppliedProduct,
+      ].freeze
+
+      def self.type_map
+        @type_map ||= TYPES.each_with_object({}) do |clazz, result|
+          type_uri = clazz.new(nil).semanticType
+          result[type_uri] = clazz
+        end
+      end
+
+      def import(json_string)
+        graph = parse_rdf(json_string)
+        head, *tail = graph.to_a
+        subject = build_subject(head)
+        apply_statements(subject, tail)
+        subject
+      end
+
+      private
+
+      def parse_rdf(json_string)
+        json_file = StringIO.new(json_string)
+        RDF::Graph.new << JSON::LD::API.toRdf(json_file)
+      end
+
+      def build_subject(type_statement)
+        id = type_statement.subject.value
+        type = type_statement.object.value
+        clazz = self.class.type_map[type]
+
+        clazz.new(id)
+      end
+
+      def apply_statements(subject, statements)
+        statements.each do |statement|
+          apply_statement(subject, statement)
+        end
+      end
+
+      def apply_statement(subject, statement)
+        return unless subject.hasSemanticProperty?(statement.predicate.value)
+
+        prop_name = statement.predicate.fragment
+        setter_name = "#{prop_name}="
+
+        return unless subject.respond_to?(setter_name)
+
+        value = statement.object.object
+        subject.public_send(setter_name, value)
+      end
+    end
+  end
+end

--- a/lib/data_food_consortium/connector/skos_parser.rb
+++ b/lib/data_food_consortium/connector/skos_parser.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Overriding the current implementation to store all parsed concepts for
+# lookup later. Otherwise the importer can't associate these.
+# This is just a workaround and needs to be solved upstream.
+module DataFoodConsortium
+  module Connector
+    class SKOSParser
+      def self.concepts
+        @concepts ||= {}
+      end
+
+      protected
+
+      def createSKOSConcept(element) # rubocop:disable Naming/MethodName
+        concept = DataFoodConsortium::Connector::SKOSConcept.new
+        concept.semanticId = element.id
+        concept.semanticType = element.type
+        self.class.concepts[element.id] = concept
+        concept
+      end
+    end
+  end
+end

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -91,6 +91,13 @@ RSpec.configure do |config|
     expectations.syntax = :expect
   end
 
+  config.around(:each) do |example|
+    # The DFC Connector fetches the context when loaded.
+    VCR.use_cassette("dfc-context") do
+      example.run
+    end
+  end
+
   # Enable caching in any specs tagged with `caching: true`.
   config.around(:each, :caching) do |example|
     caching = ActionController::Base.perform_caching

--- a/spec/lib/data_food_consortium/connector/connector_spec.rb
+++ b/spec/lib/data_food_consortium/connector/connector_spec.rb
@@ -26,4 +26,15 @@ describe DataFoodConsortium::Connector::Connector, vcr: true do
     expect(result.semanticId).to eq "https://example.net/tomato"
     expect(result.name).to eq "Tomato"
   end
+
+  it "imports from IO like Rails supplies it" do
+    json = connector.export(product)
+    io = StringIO.new(json)
+    result = connector.import(io)
+
+    expect(result.class).to eq product.class
+    expect(result.semanticType).to eq product.semanticType
+    expect(result.semanticId).to eq "https://example.net/tomato"
+    expect(result.name).to eq "Tomato"
+  end
 end

--- a/spec/lib/data_food_consortium/connector/connector_spec.rb
+++ b/spec/lib/data_food_consortium/connector/connector_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require Rails.root.join('lib/data_food_consortium/connector/connector')
+
+describe DataFoodConsortium::Connector::Connector, vcr: true do
+  subject(:connector) { described_class.instance }
+  let(:product) do
+    DataFoodConsortium::Connector::SuppliedProduct.new(
+      "https://example.net/tomato",
+      name: "Tomato",
+      description: "Awesome tomato"
+    )
+  end
+
+  it "exports" do
+    json = connector.export(product)
+    expect(json).to match '"dfc-b:name":"Tomato"'
+  end
+
+  it "imports" do
+    json = connector.export(product)
+    result = connector.import(json)
+    expect(result.class).to eq product.class
+    expect(result.semanticType).to eq product.semanticType
+    expect(result.semanticId).to eq "https://example.net/tomato"
+    expect(result.name).to eq "Tomato"
+  end
+end

--- a/spec/lib/data_food_consortium/connector/importer_spec.rb
+++ b/spec/lib/data_food_consortium/connector/importer_spec.rb
@@ -5,6 +5,12 @@ require Rails.root.join('lib/data_food_consortium/connector/connector')
 
 describe DataFoodConsortium::Connector::Importer, vcr: true do
   let(:connector) { DataFoodConsortium::Connector::Connector.instance }
+  let(:catalog_item) do
+    DataFoodConsortium::Connector::CatalogItem.new(
+      "https://example.net/tomatoItem",
+      product:,
+    )
+  end
   let(:product) do
     DataFoodConsortium::Connector::SuppliedProduct.new(
       "https://example.net/tomato",
@@ -23,6 +29,22 @@ describe DataFoodConsortium::Connector::Importer, vcr: true do
     expect(result.name).to eq "Tomato"
     expect(result.description).to eq "Awesome tomato"
     expect(result.totalTheoreticalStock).to eq 3
+  end
+
+  it "imports a graph with multiple objects" do
+    result = import(catalog_item, product)
+
+    expect(result).to be_a Array
+    expect(result.size).to eq 2
+
+    item, tomato = result
+
+    expect(item.class).to eq catalog_item.class
+    expect(item.semanticType).to eq catalog_item.semanticType
+    expect(item.semanticId).to eq "https://example.net/tomatoItem"
+    expect(tomato.name).to eq "Tomato"
+    expect(tomato.description).to eq "Awesome tomato"
+    expect(tomato.totalTheoreticalStock).to eq 3
   end
 
   def import(*args)

--- a/spec/lib/data_food_consortium/connector/importer_spec.rb
+++ b/spec/lib/data_food_consortium/connector/importer_spec.rb
@@ -77,7 +77,9 @@ describe DataFoodConsortium::Connector::Importer, vcr: true do
     tomato, items = import(product)
 
     expect(tomato.name).to eq "Tomato"
+    expect(tomato.quantity).to eq items
     expect(items.value).to eq 5
+    expect(items.unit[:fragment]).to eq "Piece"
 
     # Pending matching concepts:
     #expect(items.unit).to eq piece

--- a/spec/lib/data_food_consortium/connector/importer_spec.rb
+++ b/spec/lib/data_food_consortium/connector/importer_spec.rb
@@ -66,12 +66,7 @@ describe DataFoodConsortium::Connector::Importer, vcr: true do
 
     enterprise, tomato, ocra = result
 
-    # Work in progress, we get only the URLs as hashes:
-    expect(enterprise.suppliedProducts[0][:path]).to eq "/tomato"
-    expect(enterprise.suppliedProducts[1][:path]).to eq "/ocra"
-
-    # We would actually like to resolve the objects:
-    #expect(enterprise.suppliedProducts).to eq [tomato, ocra]
+    expect(enterprise.suppliedProducts).to eq [tomato, ocra]
   end
 
   def import(*args)

--- a/spec/lib/data_food_consortium/connector/importer_spec.rb
+++ b/spec/lib/data_food_consortium/connector/importer_spec.rb
@@ -79,10 +79,7 @@ describe DataFoodConsortium::Connector::Importer, vcr: true do
     expect(tomato.name).to eq "Tomato"
     expect(tomato.quantity).to eq items
     expect(items.value).to eq 5
-    expect(items.unit[:fragment]).to eq "Piece"
-
-    # Pending matching concepts:
-    #expect(items.unit).to eq piece
+    expect(items.unit).to eq piece
   end
 
   it "imports properties with lists" do

--- a/spec/lib/data_food_consortium/connector/importer_spec.rb
+++ b/spec/lib/data_food_consortium/connector/importer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require Rails.root.join('lib/data_food_consortium/connector/connector')
+
+describe DataFoodConsortium::Connector::Importer, vcr: true do
+  let(:connector) { DataFoodConsortium::Connector::Connector.instance }
+  let(:product) do
+    DataFoodConsortium::Connector::SuppliedProduct.new(
+      "https://example.net/tomato",
+      name: "Tomato",
+      description: "Awesome tomato",
+      totalTheoreticalStock: 3,
+    )
+  end
+
+  it "imports a single object with simple properties" do
+    result = import(product)
+
+    expect(result.class).to eq product.class
+    expect(result.semanticType).to eq product.semanticType
+    expect(result.semanticId).to eq "https://example.net/tomato"
+    expect(result.name).to eq "Tomato"
+    expect(result.description).to eq "Awesome tomato"
+    expect(result.totalTheoreticalStock).to eq 3
+  end
+
+  def import(*args)
+    json = connector.export(*args)
+    connector.import(json)
+  end
+end

--- a/spec/lib/data_food_consortium/connector/importer_spec.rb
+++ b/spec/lib/data_food_consortium/connector/importer_spec.rb
@@ -5,6 +5,12 @@ require Rails.root.join('lib/data_food_consortium/connector/connector')
 
 describe DataFoodConsortium::Connector::Importer, vcr: true do
   let(:connector) { DataFoodConsortium::Connector::Connector.instance }
+  let(:enterprise) do
+    DataFoodConsortium::Connector::Enterprise.new(
+      "https://example.net/foo-food-inc",
+      suppliedProducts: [product, second_product],
+    )
+  end
   let(:catalog_item) do
     DataFoodConsortium::Connector::CatalogItem.new(
       "https://example.net/tomatoItem",
@@ -17,6 +23,12 @@ describe DataFoodConsortium::Connector::Importer, vcr: true do
       name: "Tomato",
       description: "Awesome tomato",
       totalTheoreticalStock: 3,
+    )
+  end
+  let(:second_product) do
+    DataFoodConsortium::Connector::SuppliedProduct.new(
+      "https://example.net/ocra",
+      name: "Ocra",
     )
   end
 
@@ -45,6 +57,21 @@ describe DataFoodConsortium::Connector::Importer, vcr: true do
     expect(tomato.name).to eq "Tomato"
     expect(tomato.description).to eq "Awesome tomato"
     expect(tomato.totalTheoreticalStock).to eq 3
+  end
+
+  it "imports properties with lists" do
+    result = import(enterprise, product, second_product)
+
+    expect(result.size).to eq 3
+
+    enterprise, tomato, ocra = result
+
+    # Work in progress, we get only the URLs as hashes:
+    expect(enterprise.suppliedProducts[0][:path]).to eq "/tomato"
+    expect(enterprise.suppliedProducts[1][:path]).to eq "/ocra"
+
+    # We would actually like to resolve the objects:
+    #expect(enterprise.suppliedProducts).to eq [tomato, ocra]
   end
 
   def import(*args)


### PR DESCRIPTION
#### What? Why?

- Part of #10826

This is a technical demonstration that we can import product data via the DFC Connector. It contains monkey-patches of the DFC Connector to add the import function. These parts are in the process to become part of the DFC Connector code itself but that may take a while. The author is rewriting a core component at the moment and we need to wait for the changes before we can add our import function.

Imported products take the name, description and quantity (variant_unit, unit_value) from the DFC data but everything else is set to dummy default values at this point. It's just to demonstrate that we can import from DFC while we don't actually have any way to test this. The DFC Prototype doesn't support storing new objects yet.


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Nothing. We don't have another app sending product data and therefore we can't test this. I just wanted to share the code so that we can base future work on top of this.
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
