### PR TITLE
Restore line item ordering

### DIFF
--- a/app/controllers/admin/bulk_line_items_controller.rb
+++ b/app/controllers/admin/bulk_line_items_controller.rb
@@ -12,7 +12,7 @@ module Admin
       @line_items = order_permissions.
         editable_line_items.where(order_id: orders).
         includes(:variant).
-        ransack(params[:q]).result
+        ransack(params[:q]).result.order(:id)
 
       @pagy, @line_items = pagy(@line_items) if pagination_required?
 


### PR DESCRIPTION

#### What? Why?

The line item sorting by id has been replaced by sorting by completed_at time: ccb183d60b12e3f69364d12aae949348a021042a

While that's a good idea, the query param to order was only defined in the client Javascript and there was no default ordering. Line items also get their completed_at date from the order. So it's the same for all items of the same order and the ordering with that group of line items was random. Several specs became flaky.

Now we are sorting by id in addition. Items are first sorted by date and then by id if there's any ambiguity.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Log in as admin of a hub with plenty of complete orders and visit /admin/orders/bulk_management
- Click "Completed at" header; take notice of the order range/ordering
- Move to another pagination index number.
- You might not have orders which should have been displayed on the first page

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
