### PR TITLE
Clears cache around examples

### DIFF
--- a/spec/system/consumer/caching/darkswarm_caching_spec.rb
+++ b/spec/system/consumer/caching/darkswarm_caching_spec.rb
@@ -19,6 +19,11 @@ describe "Darkswarm data caching", caching: true do
   }
   let(:exchange) { order_cycle.exchanges.outgoing.where(receiver_id: distributor.id).first }
 
+  around do |example|
+    Rails.cache.clear
+    example.run
+  end
+
   before do
     exchange.variants << product.variants.first
   end

--- a/spec/system/consumer/caching/shops_caching_spec.rb
+++ b/spec/system/consumer/caching/shops_caching_spec.rb
@@ -13,6 +13,11 @@ describe "Shops caching", caching: true do
     create(:open_order_cycle, distributors: [distributor], coordinator: distributor)
   }
 
+  around do |example|
+    Rails.cache.clear
+    example.run
+  end
+
   describe "caching enterprises AMS data" do
     it "caches data for all enterprises, with the provided options" do
       visit shops_path


### PR DESCRIPTION
for specs testing cache

#### What? Why?

- Closes #11010

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I think cached values were leaking from `spec/system/consumer/caching/darkswarm_caching_spec.rb` to `spec/system/consumer/caching/shops_caching_spec.rb`;

This PR clears cache around these specs, making them independent of each other.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
