### PR TITLE
Revert "Fix `redis` and `hiredis-client` version requirements "

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,9 +96,9 @@ gem 'rack-rewrite'
 gem 'rack-timeout'
 gem 'roadie-rails'
 
-gem "hiredis-client"
+gem 'hiredis'
 gem 'puma'
-gem 'redis'
+gem 'redis', '>= 4.0', require: ['redis', 'redis/connection/hiredis']
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,8 +337,7 @@ GEM
     hashery (2.1.2)
     hashie (5.0.0)
     highline (2.0.3)
-    hiredis-client (0.14.1)
-      redis-client (= 0.14.1)
+    hiredis (0.6.3)
     htmlentities (4.3.4)
     httpclient (2.8.3)
     i18n (1.14.1)
@@ -571,8 +570,7 @@ GEM
     rdf (3.2.9)
       link_header (~> 0.0, >= 0.0.8)
     redcarpet (3.6.0)
-    redis (5.0.6)
-      redis-client (>= 0.9.0)
+    redis (4.8.1)
     redis-client (0.14.1)
       connection_pool
     regexp_parser (2.8.1)
@@ -844,7 +842,7 @@ DEPENDENCIES
   good_migrations
   haml
   highline (= 2.0.3)
-  hiredis-client
+  hiredis
   i18n
   i18n-js (~> 3.9.0)
   image_processing
@@ -887,7 +885,7 @@ DEPENDENCIES
   rails_safe_tasks (~> 1.0)
   ransack (~> 2.6.0)
   redcarpet
-  redis
+  redis (>= 4.0)
   responders
   rexml
   roadie-rails
@@ -930,4 +928,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.4.5
+   2.4.3


### PR DESCRIPTION
Reverts openfoodfoundation/openfoodnetwork#10455

We got some new errors relating to an open issue on the redis gem:

* https://github.com/openfoodfoundation/openfoodnetwork/pull/10455#issuecomment-1594026324

We also got some caching spec failures which I don't think are related but could be.