### PR TITLE
Use lazy lookup for translations

### DIFF
--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -48,9 +48,9 @@
           /   .line-clamp-1= product.import_date&.strftime('%F')
 - else
   #no-products
-    = t('admin.products_v3.no_products_found')
+    = t('.no_products_found')
     #no-products-actions
       %a{ href: "/admin/products/new", class: "button icon-plus", icon: "icon-plus" } 
         = t(:new_product)
       %a{ href: "/admin/products/import", class: "button icon-upload secondary", icon: "icon-upload" } 
-        = t("admin.products_v3.import_products")
+        = t(".import_products")

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -1,7 +1,7 @@
 - content_for :body_class do
   products_v3_page
 - content_for :page_title do
-  = t('spree.admin.products.index.header.title')
+  = t('.header.title')
 - content_for :page_actions do
   %div{ :class => "toolbar" }
     %ul{ :class => "actions header-action-links inline-menu" }
@@ -14,5 +14,5 @@
 #products_v3_page{"data-controller": "productsV3"}
   #loading-spinner.spinner-container{"data-productsV3-target": "loading"}
     .spinner
-    = t('admin.products_v3.loading')
+    = t('.loading')
   #products-table

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -765,9 +765,13 @@ en:
         variants: "Variants"
         product_properties: "Product Properties"
     products_v3:
-      loading: Loading your products
-      no_products_found: No products found
-      import_products: Import multiple products
+      index:
+        header:
+          title: Bulk Edit Products
+        loading: Loading your products
+      table:
+        no_products_found: No products found
+        import_products: Import multiple products
     product_import:
       title: Product Import
       file_not_found: File not found or could not be opened


### PR DESCRIPTION
This helps enforce the conventions to make the translations easier to navigate. As per our guide: https://github.com/openfoodfoundation/openfoodnetwork/wiki//Internationalisation-(i18n)#development
