### PR TITLE
Add an OFN UID column to the Users & Enterprises report

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2870,6 +2870,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   report_filters: Report Filters
   report_print: Print Report
   report_render_options: Rendering Options
+  report_header_ofn_uid: OFN UID
   report_header_order_cycle: Order Cycle
   report_header_user: User
   report_header_email: Email

--- a/lib/reporting/reports/users_and_enterprises/base.rb
+++ b/lib/reporting/reports/users_and_enterprises/base.rb
@@ -16,7 +16,8 @@ module Reporting
             is_producer: proc { |x| x.is_primary_producer },
             sells: proc { |x| x.sells },
             visible: proc { |x| x.visible },
-            confirmation_date: proc { |x| x.created_at }
+            confirmation_date: proc { |x| x.created_at },
+            ofn_uid: proc { |x| x.ofn_uid }
           }
         end
 
@@ -46,7 +47,8 @@ module Reporting
 
         def query_helper(query, email_user, relationship_type)
           query.order("enterprises.created_at DESC")
-            .select(["enterprises.name",
+            .select(["enterprises.id AS ofn_uid",
+                     "enterprises.name",
                      "enterprises.sells",
                      "enterprises.visible",
                      "enterprises.is_primary_producer",

--- a/spec/system/admin/reports/users_and_enterprises_spec.rb
+++ b/spec/system/admin/reports/users_and_enterprises_spec.rb
@@ -13,7 +13,7 @@ describe "Users & Enterprises reports" do
   end
 
   it "displays the report" do
-    find("[type='submit']").click
+    click_button 'Go'
 
     expect(page.find("table.report__table thead tr").text).to have_content([
       "USER",

--- a/spec/system/admin/reports/users_and_enterprises_spec.rb
+++ b/spec/system/admin/reports/users_and_enterprises_spec.rb
@@ -5,14 +5,14 @@ require 'system_helper'
 describe "Users & Enterprises reports" do
   include AuthenticationHelper
 
-  let!(:enterprise) { create(:supplier_enterprise) }
-
   before do
     login_as_admin
     visit main_app.admin_report_path(report_type: 'users_and_enterprises')
   end
 
   it "displays the report" do
+    enterprise = create(:supplier_enterprise)
+
     click_button 'Go'
 
     expect(page.find("table.report__table thead tr").text).to have_content([

--- a/spec/system/admin/reports/users_and_enterprises_spec.rb
+++ b/spec/system/admin/reports/users_and_enterprises_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+describe "Users & Enterprises reports" do
+  include AuthenticationHelper
+
+  let!(:enterprise) { create(:supplier_enterprise) }
+
+  before do
+    login_as_admin
+    visit main_app.admin_report_path(report_type: 'users_and_enterprises')
+  end
+
+  it "displays the report" do
+    find("[type='submit']").click
+
+    expect(page.find("table.report__table thead tr").text).to have_content([
+      "USER",
+      "RELATIONSHIP",
+      "ENTERPRISE",
+      "PRODUCER?",
+      "SELLS",
+      "VISIBLE",
+      "CONFIRMATION DATE",
+      "OFN UID"
+    ].join(" "))
+
+    row_i, row_ii = page.all("table.report__table tbody tr").map(&:text)
+
+    expect(row_i).to have_content([
+      enterprise.owner.email,
+      "owns",
+      enterprise.name,
+      "Yes",
+      "none",
+      "public",
+      enterprise.created_at.strftime("%Y-%m-%d %H:%M"),
+      enterprise.id
+    ].compact.join(" "))
+
+    expect(row_ii).to have_content([
+      enterprise.owner.email,
+      "manages",
+      enterprise.name,
+      "Yes",
+      "none",
+      "public",
+      enterprise.created_at.strftime("%Y-%m-%d %H:%M"),
+      enterprise.id
+    ].compact.join(" "))
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Closes #10545

https://github.com/openfoodfoundation/openfoodnetwork/assets/101088/6cb3e84b-7991-4970-9d60-f50c6c1aa524

Here is what the extra column looks like in the .pdf version of the report....

![export-ofn-uid-pdf](https://github.com/openfoodfoundation/openfoodnetwork/assets/101088/763d5090-0a8f-4cd2-a413-dece8ee55ab4)

Note, `SELECT enterprises.id AS ofn_uid, ...` is used instead of just `SELECT enterprises.id, ...`. This is because if you do the latter, then the translation key in `config/locales/en.yml` is `report_header_id` which is vague and not as clear as `report_header_ofn_uid`.

#### What should we test?

See testing steps in #10545.

#### Release notes

Changelog Category: User facing changes