### PR TITLE
Use Redis for caching in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,7 +14,11 @@ Openfoodnetwork::Application.configure do
   config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Separate cache stores when running in parallel
-  config.cache_store = :file_store, Rails.root.join("tmp", "cache", "paralleltests#{ENV['TEST_ENV_NUMBER']}")
+  config.cache_store = :redis_cache_store, {
+    driver: :hiredis,
+    url: ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/1"),
+    reconnect_attempts: 1
+  }
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,7 +16,8 @@ Openfoodnetwork::Application.configure do
   # Separate cache stores when running in parallel
   config.cache_store = :redis_cache_store, {
     driver: :hiredis,
-    url: ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/1"),
+     # Unique database number to avoid conflict with others
+    url: ENV.fetch("OFN_REDIS_TEST_URL", "redis://localhost:6379/3"),
     reconnect_attempts: 1
   }
 


### PR DESCRIPTION

#### What? Why?

All other environments use it. Tests will be more realistic when using Redis for caching. We are also more likely to see bugs in redis-related gems.

This came up when looking into flaky specs but it doesn't actually solve any current issue. Still thought it would be nice to have.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No manual test. This affects only CI and local test environments.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
