### PR TITLE
Fix bulk order cancellation test

### DIFF
--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -554,8 +554,7 @@ distributors: [distributor4, distributor5]) }
           expect(page).to have_content "This will cancel the current order."
 
           within ".reveal-modal" do
-            # Untick SEND A CANCELLATION EMAIL TO THE CUSTOMER
-            page.find("input[id='send_cancellation_email']").click
+            uncheck "Send a cancellation email to the customer"
             expect {
               find_button("Cancel").click # Cancels the cancel action
             }.to_not enqueue_job(ActionMailer::MailDeliveryJob).exactly(:twice)

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -554,6 +554,8 @@ distributors: [distributor4, distributor5]) }
           expect(page).to have_content "This will cancel the current order."
 
           within ".reveal-modal" do
+            # Untick SEND A CANCELLATION EMAIL TO THE CUSTOMER
+            page.find("input[id='send_cancellation_email']").click
             expect {
               find_button("Cancel").click # Cancels the cancel action
             }.to_not enqueue_job(ActionMailer::MailDeliveryJob).exactly(:twice)


### PR DESCRIPTION


#### What? Why?

- Related to #11015   

One of the test was wrong, this a fix for it.
Add unticking of "send cancellation email to customer" to match the current test expectation

#### What should we test?
No test needed, we just need CI to pass

#### Release notes


Changelog Category:  Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


