### PR TITLE
Sets up a spec for #11085

### DIFF
--- a/spec/system/admin/variants_spec.rb
+++ b/spec/system/admin/variants_spec.rb
@@ -166,6 +166,81 @@ describe '
       expect(page).to have_content %(Variant "#{product.name}" has been successfully updated!)
       expect(variant.reload.unit_description).to eq('bar')
     end
+
+    context "with ES as a locale" do
+      let(:product) { create(:simple_product, variant_unit: "weight", variant_unit_scale: "1") }
+      let(:variant) { product.variants.first }
+
+      before do
+        # sets the locale into ES
+        I18n.default_locale = 'es'
+
+        variant.update( unit_value: 1, unit_description: 'foo' )
+
+        # When I view the variant
+        login_as_admin
+        visit spree.admin_product_variants_path product
+      end
+
+      context "with localization disabled" do
+        before do
+          allow(Spree::Config).to receive(:enable_localized_number?).and_return false
+
+          Spree::Config[:currency_decimal_mark] = "."
+          Spree::Config[:currency_thousands_separator] = ","
+        end
+
+        it "when variant_unit is weight" do
+          expect(Spree::Price.second.amount).to eq(19.99)
+
+          # Given a product with unit-related option types, with a variant
+          page.find('table.index .icon-edit').click
+
+          # assert on the price field
+          expect(page).to have_field "variant_price", with: "19,99 "
+
+          # When I update the fields and save the variant
+          fill_in "variant_price", with: "12,50 "
+
+          click_button 'Actualizar'
+          expect(page).to have_content %(Variant "#{product.name}" ha sido actualizado exitosamente)
+
+          # Then the variant price should have been updated
+          expect(Spree::Price.second.amount).to eq(12.50)
+        end
+      end
+
+      context "with localization enabled" do
+        before do
+          allow(Spree::Config).to receive(:enable_localized_number?).and_return true
+
+          Spree::Config[:currency_decimal_mark] = ","
+          Spree::Config[:currency_thousands_separator] = "."
+
+          login_as_admin
+          visit spree.admin_product_variants_path product
+        end
+
+        it "when variant_unit is weight" do
+          pending("#11085")
+          expect(Spree::Price.second.amount).to eq(19.99)
+
+          # Given a product with unit-related option types, with a variant
+          page.find('table.index .icon-edit').click
+
+          # assert on the Price field
+          expect(page).to have_field "variant_price", with: "19,99 "
+
+          # When I update the fields and save the variant
+          fill_in "variant_price", with: "12,50 "
+          click_button 'Actualizar'
+          expect(page).to have_content %(Variant "#{product.name}" ha sido actualizado exitosamente)
+
+          # Then the variant price should have been updated
+          expect(Spree::Price.second.amount).to eq(12.50)
+        end
+      end
+    end
   end
 
   describe "editing on hand and on demand values" do
@@ -211,7 +286,7 @@ describe '
 
   it "soft-deletes variants" do
     product = create(:simple_product)
-    variant = create(:variant, product: product)
+    variant = create(:variant, product:)
 
     login_as_admin
     visit spree.admin_product_variants_path product


### PR DESCRIPTION
#### What? Why?

- Reproduces #11085

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

If localization is enabled, saving a price with the value `10,00 ` will fail. A pending spec is added for this case.

In real life, the situation arises from the conversion of a number like `10.00` into a string like `10,00 ` (empty space in the end), which is displayed it in this way, on the `Price` field. Often, a user changes only one character, and ends up submitting values with empty spaces in it, without being aware:

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/49817236/d2f5aec2-00fc-4818-ad98-910194097a9a)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
