### PR TITLE
Add Sentry for monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,6 +143,8 @@ gem "private_address_check"
 group :production, :staging do
   gem 'ddtrace'
   gem 'sd_notify' # For better Systemd process management. Used by Puma.
+  gem 'sentry-rails'
+  gem 'sentry-ruby'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -665,6 +665,11 @@ GEM
       tilt (>= 1.1, < 3)
     sd_notify (0.1.1)
     semantic_range (3.0.0)
+    sentry-rails (5.9.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.9.0)
+    sentry-ruby (5.9.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     sidekiq (7.1.2)
@@ -899,6 +904,8 @@ DEPENDENCIES
   rubocop-rails
   sd_notify
   select2-rails!
+  sentry-rails
+  sentry-ruby
   shoulda-matchers
   sidekiq
   sidekiq-scheduler

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,12 @@
+if ENV["SENTRY_ENDPOINT"]
+  Sentry.init do |config|
+    config.dsn = ENV["SENTRY_ENDPOINT"]
+    config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+    config.send_default_pii = true
+
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production.
+    config.traces_sample_rate = ENV.fetch("SENTRY_SAMPLE_RATE", 1.0).to_f
+  end
+end


### PR DESCRIPTION
#### What? Why?

Related to #10997. Adds sentry gems and config. 

It's activated via an ENV var and an initializer, so it only starts up if the ENV vars have been added to the instance in question (not enabled by default).

#### What should we test?

-

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
