### PR TITLE
Fix requestSubmit issues in Safari

### DIFF
--- a/app/webpacker/controllers/search_controller.js
+++ b/app/webpacker/controllers/search_controller.js
@@ -29,7 +29,7 @@ export default class extends Controller {
   }
 
   submitSearch() {
-    this.form.requestSubmit();
+    this.form.requestSubmit(this.form.querySelector("[type='submit']"));
   }
 
   reset() {


### PR DESCRIPTION
#### What? Why?

Closes #10998

Adjusts the use of `requestSubmit()` for older Safari browsers in iOS.

#### What should we test?

Needs to be tested on an old-ish iPhone. See issue for details.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

