### PR TITLE
Revert "Fix json v1.8.6 common.rb warning"

### DIFF
--- a/config/initializers/json.rb
+++ b/config/initializers/json.rb
@@ -1,7 +1,0 @@
-module JSON
-  module_function
-
-  def parse(source, opts = {})
-    Parser.new(source, **opts).parse
-  end
-end


### PR DESCRIPTION

#### What? Why?

This reverts commit 21b80db0ee29c853ead0fb58cd004c04b6185c51.

This fix was needed for an old version of the JSON module with a newer version of Ruby. But we updated the json gem since and don't need this any more.

Context:

* https://github.com/openfoodfoundation/openfoodnetwork/pull/7737

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test. This is only used in specs and in the DFC engine. Specs pass, low risk.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
