### PR TITLE
Checkout summary: avoid carriage return on price

### DIFF
--- a/lib/spree/money.rb
+++ b/lib/spree/money.rb
@@ -28,7 +28,8 @@ module Spree
     end
 
     def to_html(options = { html_wrap: true })
-      @money.format(@options.merge(options)).html_safe
+      "<span style='white-space: nowrap;'>#{@money.format(@options.merge(options))}</span>"
+        .html_safe
     end
 
     def format(options = {})

--- a/spec/lib/spree/money_spec.rb
+++ b/spec/lib/spree/money_spec.rb
@@ -123,7 +123,7 @@ describe Spree::Money do
       money = Spree::Money.new(10)
       # The HTMLified version of the euro sign
       expect(money.to_html).to eq(
-        "<span class=\"money-whole\">10</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">00</span> <span class=\"money-currency-symbol\">&#x20AC;</span>"
+        "<span style='white-space: nowrap;'><span class=\"money-whole\">10</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">00</span> <span class=\"money-currency-symbol\">&#x20AC;</span></span>"
       )
     end
     # rubocop:enable Layout/LineLength


### PR DESCRIPTION
<img width="773" alt="Capture d’écran 2023-06-22 à 12 25 40" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/f8096ff7-a5ce-48c9-adb3-5a9952e4e4cb">

#### What? Why?

- Closes #11098 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- In shopfront, check that when a price with currency is displayed, it should display without carriage return

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
