### PR TITLE
Fix image presence checks

### DIFF
--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -22,10 +22,10 @@
     %header
       .row
         .small-12.columns
-          = image_tag @group.promo_image.variant(resize_to_limit: [1200, 260]) if @group.promo_image.variable?
+          = image_tag @group.promo_image.variant(resize_to_limit: [1200, 260]) if @group.promo_image.attached?
       .row
         .small-12.columns.group-header.pad-top
-          - if @group.logo.variable?
+          - if @group.logo.attached?
             = image_tag @group.logo.variant(resize_to_limit: [100, 100]), class: "group-logo"
           - else
             = image_tag "/noimage/group.png", class: "group-logo"

--- a/app/views/shared/menu/_large_menu.html.haml
+++ b/app/views/shared/menu/_large_menu.html.haml
@@ -4,7 +4,7 @@
       = cache_with_locale [@white_label_distributor, ContentConfig.cache_key] do
         %li.ofn-logo
           %a{href: main_logo_link(@white_label_distributor)}
-            - if @white_label_logo&.variable?
+            - if @white_label_logo&.attached?
               = image_tag @white_label_distributor.white_label_logo_url(:default)
             - else
               %img{src: ContentConfig.url_for(:logo)}

--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -7,7 +7,7 @@
     %section.left
       .ofn-logo
         %a{href: main_logo_link(@white_label_distributor)}
-          - if @white_label_logo&.variable?
+          - if @white_label_logo&.attached?
             = image_tag @white_label_distributor.white_label_logo_url(:mobile)
           - else
             %img{src: ContentConfig.url_for(:logo_mobile), srcset: ContentConfig.url_for(:logo_mobile_svg), width: "75", height: "26"}

--- a/app/views/shared/menu/_offcanvas_menu.html.haml
+++ b/app/views/shared/menu/_offcanvas_menu.html.haml
@@ -3,7 +3,7 @@
     = cache_with_locale [ContentConfig.cache_key, @white_label_logo] do
       %li.ofn-logo
         %a{href: main_logo_link(@white_label_distributor)}
-          - if @white_label_logo&.variable?
+          - if @white_label_logo&.attached?
             = image_tag @white_label_distributor.white_label_logo_url(:mobile)
           - else
             %img{src: ContentConfig.url_for(:logo_mobile), srcset: ContentConfig.url_for(:logo_mobile_svg), width: "75", height: "26"}

--- a/app/views/shopping_shared/_header.html.haml
+++ b/app/views/shopping_shared/_header.html.haml
@@ -4,7 +4,7 @@
   %distributor.details.row
     .small-12.medium-12.large-8.columns
       #distributor_title
-        - if distributor.logo.variable?
+        - if distributor.logo.attached?
           = image_tag distributor.logo_url(:thumb), class: "left"
         = render DistributorTitleComponent.new(name: distributor.name)
         %location= distributor.address.city

--- a/app/views/spree/admin/orders/invoice2.html.haml
+++ b/app/views/spree/admin/orders/invoice2.html.haml
@@ -6,7 +6,7 @@
       %td{ :align => "left" }
         %h4
           = t :tax_invoice
-      - if @order.distributor.display_invoice_logo? && @order.distributor.logo.variable?
+      - if @order.distributor.display_invoice_logo? && @order.distributor.logo.attached?
         %td{ :align => "right", rowspan: 2 }
           = wicked_pdf_image_tag @order.distributor.logo_url(:small)
     %tr{ valign: "top" }

--- a/app/views/spree/order_mailer/cancel_email.html.haml
+++ b/app/views/spree/order_mailer/cancel_email.html.haml
@@ -6,7 +6,7 @@
           = t(".customer_greeting", name: @order.bill_address.firstname)
         %h4
           = t(".instructions_html", distributor: @order.distributor.name )
-        - if @order.distributor.logo.variable?
+        - if @order.distributor.logo.attached?
           = image_tag @order.distributor.logo_url(:medium)
 
 %p.callout

--- a/app/views/spree/order_mailer/confirm_email_for_customer.html.haml
+++ b/app/views/spree/order_mailer/confirm_email_for_customer.html.haml
@@ -11,7 +11,7 @@
       %table.column{:align => "left"}
         %tr
           %td{:align => "right"}
-            - if @order.distributor.logo.variable?
+            - if @order.distributor.logo.attached?
               = image_tag @order.distributor.logo_url(:medium), class: "float-right"
       %span.clear
 

--- a/app/views/spree/order_mailer/confirm_email_for_shop.html.haml
+++ b/app/views/spree/order_mailer/confirm_email_for_shop.html.haml
@@ -11,7 +11,7 @@
       %table.column{:align => "left"}
         %tr
           %td{:align => "right"}
-            - if @order.distributor.logo.variable?
+            - if @order.distributor.logo.attached?
               = image_tag @order.distributor.logo_url(:medium), class: "float-right"
       %span.clear
 

--- a/app/views/subscription_mailer/_header.html.haml
+++ b/app/views/subscription_mailer/_header.html.haml
@@ -11,6 +11,6 @@
       %table.column{:align => "left"}
         %tr
           %td{:align => "right"}
-            - if @order.distributor.logo.variable?
+            - if @order.distributor.logo.attached?
               = image_tag @order.distributor.logo_url(:medium), class: "float-right"
       %span.clear

--- a/app/views/subscription_mailer/confirmation_summary_email.html.haml
+++ b/app/views/subscription_mailer/confirmation_summary_email.html.haml
@@ -11,7 +11,7 @@
       %table.column{:align => "left"}
         %tr
           %td{:align => "right"}
-            - if @shop.logo.variable?
+            - if @shop.logo.attached?
               = image_tag @shop.logo_url(:medium), class: "float-right"
       %span.clear
 

--- a/app/views/subscription_mailer/placement_summary_email.html.haml
+++ b/app/views/subscription_mailer/placement_summary_email.html.haml
@@ -11,7 +11,7 @@
       %table.column{:align => "left"}
         %tr
           %td{:align => "right"}
-            - if @shop.logo.variable?
+            - if @shop.logo.attached?
               = image_tag @shop.logo_url(:medium), class: "float-right"
       %span.clear
 


### PR DESCRIPTION
#### What? Why?

Closes #11099

Passing a potential `nil` value to the `image_tag` helper causes a fatal error. Before doing that, we should check the image attachment exists using `attached?`.

#### What should we test?



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
