### PR TITLE
Admin, Edit variant: remove unwanted extra space on price (added in certain specific conditions)

### DIFF
--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -23,7 +23,7 @@
       = f.text_field :sku, class: 'fullwidth'
     .field
       = f.label :price, t('.price')
-      = f.text_field :price, class: 'fullwidth', "ng-model" => "variant.price", "ng-init" => "variant.price = '#{number_to_currency(@variant.price, unit: '')}'"
+      = f.text_field :price, class: 'fullwidth', "ng-model" => "variant.price", "ng-init" => "variant.price = '#{number_to_currency(@variant.price, unit: '').strip}'"
     .field
       = hidden_field_tag 'product_variant_unit', @product.variant_unit
       = hidden_field_tag 'product_variant_unit_name', @product.variant_unit_name

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -23,7 +23,7 @@
       = f.text_field :sku, class: 'fullwidth'
     .field
       = f.label :price, t('.price')
-      = f.text_field :price, class: 'fullwidth', "ng-model" => "variant.price", "ng-init" => "variant.price = '#{number_to_currency(@variant.price, unit: '').strip}'"
+      = f.text_field :price, class: 'fullwidth', "ng-model" => "variant.price", "ng-init" => "variant.price = '#{number_to_currency(@variant.price, unit: '')&.strip}'"
     .field
       = hidden_field_tag 'product_variant_unit', @product.variant_unit
       = hidden_field_tag 'product_variant_unit_name', @product.variant_unit_name

--- a/spec/system/admin/variants_spec.rb
+++ b/spec/system/admin/variants_spec.rb
@@ -208,10 +208,10 @@ describe '
             page.find('table.index .icon-edit').click
 
             # assert on the price field
-            expect(page).to have_field "variant_price", with: "19,99 "
+            expect(page).to have_field "variant_price", with: "19,99"
 
             # When I update the fields and save the variant
-            fill_in "variant_price", with: "12,50 "
+            fill_in "variant_price", with: "12,50"
             click_button 'Actualizar'
             expect(page).to have_content \
               %(Variant "#{product.name}" ha sido actualizado exitosamente)
@@ -231,13 +231,9 @@ describe '
       end
 
       it_behaves_like "with localization", false, ".", ","
-      it_behaves_like "with localization", true, ".", "," do
-        before { pending("#11085") }
-      end
+      it_behaves_like "with localization", true, ".", ","
       it_behaves_like "with localization", false, ",", "."
-      it_behaves_like "with localization", true, ",", "." do
-        before { pending("#11085") }
-      end
+      it_behaves_like "with localization", true, ",", "."
     end
   end
 

--- a/spec/system/admin/variants_spec.rb
+++ b/spec/system/admin/variants_spec.rb
@@ -182,10 +182,13 @@ describe '
       let(:product) { create(:simple_product, variant_unit: "weight", variant_unit_scale: "1") }
       let(:variant) { product.variants.first }
 
-      before do
-        # sets the locale into ES
-        I18n.default_locale = 'es'
+      around do |example|
+        I18n.default_locale = :es
+        example.run
+        I18n.default_locale = :en
+      end
 
+      before do
         variant.update( unit_value: 1, unit_description: 'foo' )
 
         # When I view the variant
@@ -219,14 +222,6 @@ describe '
             # Then the variant price should have been updated
             expect(Spree::Price.second.amount).to eq(12.50)
           end
-        end
-
-        after do
-          # sets the locale back to EN
-          I18n.default_locale = 'en'
-
-          # disables localization to prevent leaking between specs
-          allow(Spree::Config).to receive(:enable_localized_number?).and_return false
         end
       end
 

--- a/spec/system/admin/variants_spec.rb
+++ b/spec/system/admin/variants_spec.rb
@@ -205,7 +205,7 @@ describe '
           end
 
           it "when variant_unit is weight" do
-            expect(Spree::Price.second.amount).to eq(19.99)
+            expect(variant.price).to eq(19.99)
 
             # Given a product with unit-related option types, with a variant
             page.find('table.index .icon-edit').click
@@ -220,7 +220,7 @@ describe '
               %(Variant "#{product.name}" ha sido actualizado exitosamente)
 
             # Then the variant price should have been updated
-            expect(Spree::Price.second.amount).to eq(12.50)
+            expect(variant.reload.price).to eq(12.50)
           end
         end
       end

--- a/spec/system/admin/variants_spec.rb
+++ b/spec/system/admin/variants_spec.rb
@@ -90,8 +90,6 @@ describe '
       login_as_admin
       visit spree.admin_product_variants_path(product, filter)
 
-      visit spree.admin_product_variants_path(product, filter)
-
       expected_new_url = Regexp.new(
         Regexp.escape(spree.new_admin_product_variant_path(product, filter))
       )
@@ -195,63 +193,50 @@ describe '
         visit spree.admin_product_variants_path product
       end
 
-      context "with localization disabled" do
-        before do
-          allow(Spree::Config).to receive(:enable_localized_number?).and_return false
+      shared_examples "with localization" do |localized, decimal_mark, thousands_separator|
+        context "set to #{localized}" do
+          before do
+            allow(Spree::Config).to receive(:enable_localized_number?).and_return localized
+            Spree::Config[:currency_decimal_mark] = decimal_mark
+            Spree::Config[:currency_thousands_separator] = thousands_separator
+          end
 
-          Spree::Config[:currency_decimal_mark] = "."
-          Spree::Config[:currency_thousands_separator] = ","
+          it "when variant_unit is weight" do
+            expect(Spree::Price.second.amount).to eq(19.99)
+
+            # Given a product with unit-related option types, with a variant
+            page.find('table.index .icon-edit').click
+
+            # assert on the price field
+            expect(page).to have_field "variant_price", with: "19,99 "
+
+            # When I update the fields and save the variant
+            fill_in "variant_price", with: "12,50 "
+            click_button 'Actualizar'
+            expect(page).to have_content \
+              %(Variant "#{product.name}" ha sido actualizado exitosamente)
+
+            # Then the variant price should have been updated
+            expect(Spree::Price.second.amount).to eq(12.50)
+          end
         end
 
-        it "when variant_unit is weight" do
-          expect(Spree::Price.second.amount).to eq(19.99)
+        after do
+          # sets the locale back to EN
+          I18n.default_locale = 'en'
 
-          # Given a product with unit-related option types, with a variant
-          page.find('table.index .icon-edit').click
-
-          # assert on the price field
-          expect(page).to have_field "variant_price", with: "19,99 "
-
-          # When I update the fields and save the variant
-          fill_in "variant_price", with: "12,50 "
-
-          click_button 'Actualizar'
-          expect(page).to have_content %(Variant "#{product.name}" ha sido actualizado exitosamente)
-
-          # Then the variant price should have been updated
-          expect(Spree::Price.second.amount).to eq(12.50)
+          # disables localization to prevent leaking between specs
+          allow(Spree::Config).to receive(:enable_localized_number?).and_return false
         end
       end
 
-      context "with localization enabled" do
-        before do
-          allow(Spree::Config).to receive(:enable_localized_number?).and_return true
-
-          Spree::Config[:currency_decimal_mark] = ","
-          Spree::Config[:currency_thousands_separator] = "."
-
-          login_as_admin
-          visit spree.admin_product_variants_path product
-        end
-
-        it "when variant_unit is weight" do
-          pending("#11085")
-          expect(Spree::Price.second.amount).to eq(19.99)
-
-          # Given a product with unit-related option types, with a variant
-          page.find('table.index .icon-edit').click
-
-          # assert on the Price field
-          expect(page).to have_field "variant_price", with: "19,99 "
-
-          # When I update the fields and save the variant
-          fill_in "variant_price", with: "12,50 "
-          click_button 'Actualizar'
-          expect(page).to have_content %(Variant "#{product.name}" ha sido actualizado exitosamente)
-
-          # Then the variant price should have been updated
-          expect(Spree::Price.second.amount).to eq(12.50)
-        end
+      it_behaves_like "with localization", false, ".", ","
+      it_behaves_like "with localization", true, ".", "," do
+        before { pending("#11085") }
+      end
+      it_behaves_like "with localization", false, ",", "."
+      it_behaves_like "with localization", true, ",", "." do
+        before { pending("#11085") }
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

- Closes #11085

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Copy/pasted from original issue.
###### As super admin:
Set the localization preferences as:
 - localization is enabled
- commas are used as decimal separators
###### As a hub:

 - Log in and select a locale like FR or EN
 - On the products page, click the edit product icon
 - Click Variants
 - Click the edit icon, for a given variant -> you should be redirected to 
`admin/products/<product_name>/variants/<variant_id>/edit`
 - Change the price value; click Update -> see changes did not take effect

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes