### PR TITLE
Gracefully deal with missing S3 config

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -15,6 +15,16 @@ class ApplicationRecord < ActiveRecord::Base
     ENV["S3_BUCKET"].present? ? :amazon_public : :local
   end
 
+  # We might have a development environment without S3 but with a database
+  # dump pointing to S3 images. Accessing the service fails then.
+  def image_variant_url_for(variant)
+    if ENV["S3_BUCKET"].present? && variant.service.public?
+      variant.processed.url
+    else
+      url_for(variant)
+    end
+  end
+
   def url_for(*args)
     Rails.application.routes.url_helpers.url_for(*args)
   end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -459,9 +459,8 @@ class Enterprise < ApplicationRecord
 
   def image_url_for(image, name)
     return unless image.variable?
-    return image.variant(name).processed.url if image.attachment.service.name == :amazon_public
 
-    url_for(image.variant(name))
+    image_variant_url_for(image.variant(name))
   rescue ActiveStorage::Error => e
     Bugsnag.notify "Enterprise ##{id} #{image.try(:name)} error: #{e.message}"
     Rails.logger.error(e.message)

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -31,9 +31,8 @@ module Spree
 
     def url(size)
       return self.class.default_image_url(size) unless attachment.attached?
-      return variant(size).processed.url if attachment.service.name == :amazon_public
 
-      url_for(variant(size))
+      image_variant_url_for(variant(size))
     rescue ActiveStorage::Error => e
       Bugsnag.notify "Product ##{viewable_id} Image ##{id} error: #{e.message}"
       Rails.logger.error(e.message)

--- a/spec/models/spree/image_spec.rb
+++ b/spec/models/spree/image_spec.rb
@@ -55,9 +55,14 @@ module Spree
 
       context "when using public images" do
         it "returns the direct URL for the processed image" do
+          allow(ENV).to receive(:[])
+          expect(ENV).to receive(:[]).with("S3_BUCKET").and_return("present")
+
+          variant = double(:variant)
           allow(subject).to receive_message_chain(:attachment, :attached?) { true }
-          expect(subject).to receive_message_chain(:attachment, :service, :name) { :amazon_public }
-          expect(subject).to receive_message_chain(:variant, :processed, :url) { "https://ofn-s3/123.png" }
+          expect(subject).to receive(:variant) { variant }
+          expect(variant).to receive_message_chain(:service, :public?) { true }
+          expect(variant).to receive_message_chain(:processed, :url) { "https://ofn-s3/123.png" }
 
           expect(subject.url(:small)).to eq "https://ofn-s3/123.png"
         end


### PR DESCRIPTION
#### What? Why?

I could have split this into several commits:

* Rename private method to re-use previous name for new method.
* DRY direct linking to images.
* Check S3 config before direct linking.
* Just check if service is public instead of relying on name.

Developers may copy a staging or production database or experiment with S3 storage. But when the S3 config is missing then calling `service` raises an ArgumentError due to a missing name.

Now we only try to call `service` if the S3 config is present.



<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit shops page.
- Open a producer modal and check that images are displayed.
- Visit a shop page.
- Check that product images are displayed.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
