### PR TITLE
Not paid order confirmations resemble paid orders 7603

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -188,6 +188,9 @@ module Spree
       Spree::Money.new(total, currency: currency)
     end
 
+    def display_payment_total
+       Spree::Money.new(self.payment_total, currency: currency)
+    end
     def to_param
       number.to_s.parameterize.upcase
     end

--- a/app/views/spree/orders/_totals_footer.html.haml
+++ b/app/views/spree/orders/_totals_footer.html.haml
@@ -30,7 +30,7 @@
       %td.text-right.total
         %strong
           = order.display_payment_total.to_html
-  - if order.outstanding_balance?
+  - if order.outstanding_balance? && order.outstanding_balance > 0
     %tr.total
       %td.text-right{colspan: "3"}
         %h5.not-paid
@@ -38,6 +38,15 @@
       %td.text-right.total.not-paid
         %h5.not-paid
           = order.display_outstanding_balance.to_html
+  - else
+    %tr.total
+      %td.text-right{colspan: "3"}
+        %h5
+          = t :credit_owed
+      %td.text-right.total.not-paid
+        %h5
+          = order.display_outstanding_balance.to_html
+
 
 
   - if order.total_tax > 0

--- a/app/views/spree/orders/_totals_footer.html.haml
+++ b/app/views/spree/orders/_totals_footer.html.haml
@@ -25,18 +25,18 @@
         %h5#order_total= order.display_total.to_html
     %tr.total
       %td.text-right{colspan: "3"}
-        %h5
+        %strong
           = t :order_amount_paid
       %td.text-right.total
-        %h5
-          = order.payment_total
+        %strong
+          = order.display_payment_total.to_html
   - if order.outstanding_balance?
     %tr.total
       %td.text-right{colspan: "3"}
         %h5.not-paid
           = t :order_balance_due
       %td.text-right.total.not-paid
-        %h5.not-paid#balance_due
+        %h5.not-paid
           = order.display_outstanding_balance.to_html
 
 

--- a/app/views/spree/orders/_totals_footer.html.haml
+++ b/app/views/spree/orders/_totals_footer.html.haml
@@ -43,11 +43,9 @@
       %td.text-right{colspan: "3"}
         %h5
           = t :credit_owed
-      %td.text-right.total.not-paid
+      %td.text-right.total
         %h5
           = order.display_outstanding_balance.to_html
-
-
 
   - if order.total_tax > 0
     #tax

--- a/app/views/spree/orders/_totals_footer.html.haml
+++ b/app/views/spree/orders/_totals_footer.html.haml
@@ -30,6 +30,7 @@
       %td.text-right.total
         %h5
           = order.payment_total
+  - if order.outstanding_balance?
     %tr.total
       %td.text-right{colspan: "3"}
         %h5.not-paid

--- a/app/views/spree/orders/_totals_footer.html.haml
+++ b/app/views/spree/orders/_totals_footer.html.haml
@@ -23,6 +23,13 @@
           = t :order_total_price
       %td.text-right.total
         %h5#order_total= order.display_total.to_html
+    %tr.total
+      %td.text-right{colspan: "3"}
+        %h5.not-paid
+          = t :order_balance_due
+      %td.text-right.total.not-paid
+        %h5#order_balance
+
 
   - if order.total_tax > 0
     #tax

--- a/app/views/spree/orders/_totals_footer.html.haml
+++ b/app/views/spree/orders/_totals_footer.html.haml
@@ -25,10 +25,18 @@
         %h5#order_total= order.display_total.to_html
     %tr.total
       %td.text-right{colspan: "3"}
+        %h5
+          = t :order_amount_paid
+      %td.text-right.total
+        %h5
+          = order.payment_total
+    %tr.total
+      %td.text-right{colspan: "3"}
         %h5.not-paid
           = t :order_balance_due
       %td.text-right.total.not-paid
-        %h5#order_balance
+        %h5.not-paid#balance_due
+          = order.display_outstanding_balance.to_html
 
 
   - if order.total_tax > 0

--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -2,7 +2,7 @@
   .columns.large-6
     .order-summary.text-small
       - if order.paid?
-        .right.paid
+        .right
           = t :order_paid
       - else
         .right.not-paid

--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -1,10 +1,11 @@
 .row
   .columns.large-6
     .order-summary.text-small
-      .right.not-paid
-        - if order.paid?
+      - if order.paid?
+        .right.paid
           = t :order_paid
-        - else
+      - else
+        .right.not-paid
           = t :order_not_paid
       %span
         = t :order_total

--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -1,7 +1,7 @@
 .row
   .columns.large-6
     .order-summary.text-small
-      .right
+      .right.not-paid
         - if order.paid?
           = t :order_paid
         - else

--- a/app/webpacker/css/darkswarm/checkout.scss
+++ b/app/webpacker/css/darkswarm/checkout.scss
@@ -113,3 +113,8 @@ checkout {
   color: #f40f0f;
   font-weight: 700;
 }
+
+.paid {
+  color: black;
+  font-weight: 400;
+}

--- a/app/webpacker/css/darkswarm/checkout.scss
+++ b/app/webpacker/css/darkswarm/checkout.scss
@@ -108,3 +108,8 @@ checkout {
     }
   }
 }
+
+.not-paid {
+  color: #f40f0f;
+  font-weight: 700;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2125,7 +2125,9 @@ en:
   order_pickup_time: Ready for collection
   order_pickup_instructions: Collection Instructions
   order_produce: Produce
+  order_amount_paid: Amount Paid
   order_total_price: Total
+  order_balance_due: Balance Due
   order_includes_tax: (includes tax)
   order_payment_paypal_successful: Your payment via PayPal has been processed successfully.
   order_hub_info: Hub Info


### PR DESCRIPTION
#### What? Why?

- Closes #7603

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
The order confirmations for the 'not paid' and 'paid' orders look similar.  The change will allow customers to identity the differences in the order confirmations and quickly see pending payments. 



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Log in as admin
- Click Shops
- Choose a shop
- Add items to cart
- Checkout items
- View order confirmation screen

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->
No other dependencies


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
No other documents to update
