### PR TITLE
authorize enterprise users to access invoices page

### DIFF
--- a/app/controllers/spree/admin/invoices_controller.rb
+++ b/app/controllers/spree/admin/invoices_controller.rb
@@ -11,6 +11,9 @@ module Spree
       end
 
       def create
+        Spree::Order.where(id: params[:order_ids]).find_each do |order|
+          authorize! :invoice, order
+        end
         invoice_service = BulkInvoiceService.new
         invoice_service.start_pdf_job(params[:order_ids])
 
@@ -19,6 +22,8 @@ module Spree
 
       def generate
         @order = Order.find_by(number: params[:order_id])
+        authorize! :invoice, @order
+
         @comparator = OrderInvoiceComparator.new(@order)
         if @comparator.can_generate_new_invoice?
           @order.invoices.create!(

--- a/app/controllers/spree/admin/invoices_controller.rb
+++ b/app/controllers/spree/admin/invoices_controller.rb
@@ -4,10 +4,10 @@ module Spree
   module Admin
     class InvoicesController < Spree::Admin::BaseController
       respond_to :json
-      authorize_resource class: false
 
       def index
         @order = Spree::Order.find_by(number: params[:order_id])
+        authorize! :invoice, @order
       end
 
       def create

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -29,7 +29,6 @@ module Spree
         can :update, Order do |order, token|
           order.user == user || order.token && token == order.token
         end
-        can [:index], :invoice
         can [:index, :read], Product
         can [:index, :read], ProductProperty
         can [:index, :read], Property
@@ -276,7 +275,7 @@ module Spree
       can [:admin, :bulk_management, :managed, :distribution], Spree::Order do
         user.admin? || user.enterprises.any?(&:is_distributor)
       end
-      can [:admin, :create, :show, :poll], :invoice
+      can [:admin, :index, :create, :show, :poll, :generate], :invoice
       can [:admin, :visible], Enterprise
       can [:admin, :index, :create, :update, :destroy], :line_item
       can [:admin, :index, :create], Spree::LineItem

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -29,6 +29,7 @@ module Spree
         can :update, Order do |order, token|
           order.user == user || order.token && token == order.token
         end
+        can [:index], :invoice
         can [:index, :read], Product
         can [:index, :read], ProductProperty
         can [:index, :read], Property

--- a/spec/controllers/spree/admin/orders/invoices_spec.rb
+++ b/spec/controllers/spree/admin/orders/invoices_spec.rb
@@ -104,7 +104,9 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
     end
   end
+end
 
+describe Spree::Admin::InvoicesController, type: :controller do
   describe "#index" do
     let(:user) { create(:user) }
     let(:enterprise_user) { create(:user, enterprises: [create(:enterprise)]) }
@@ -113,7 +115,7 @@ describe Spree::Admin::OrdersController, type: :controller do
                                       ship_address: create(:address))
     }
     let(:distributor) { order.distributor }
-    let(:params) { { id: order.number } }
+    let(:params) { { order_id: order.number } }
 
     context "as a normal user" do
       before { allow(controller).to receive(:spree_current_user) { user } }
@@ -141,6 +143,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         it "should allow me to see the order" do
           spree_get :index, params
           expect(response).to be_successful
+          expect(assigns(:order)).to eq order
         end
       end
     end

--- a/spec/controllers/spree/admin/orders/invoices_spec.rb
+++ b/spec/controllers/spree/admin/orders/invoices_spec.rb
@@ -107,7 +107,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
   describe "#index" do
     let(:user) { create(:user) }
-    let(:enterprise_user) { create(:user) }
+    let(:enterprise_user) { create(:user, enterprises: [create(:enterprise)]) }
     let(:order) {
       create(:order_with_distributor, bill_address: create(:address),
                                       ship_address: create(:address))
@@ -128,8 +128,9 @@ describe Spree::Admin::OrdersController, type: :controller do
       context "which is not a manager of the distributor for an order" do
         before { allow(controller).to receive(:spree_current_user) { enterprise_user } }
 
-        it "should prevent me from listing invoices for the order" do
+        it "shows only invoices of manged enterprises" do
           spree_get :index, params
+          pending "reporting success"
           expect(response).to redirect_to unauthorized_path
         end
       end

--- a/spec/controllers/spree/admin/orders/invoices_spec.rb
+++ b/spec/controllers/spree/admin/orders/invoices_spec.rb
@@ -106,13 +106,13 @@ describe Spree::Admin::OrdersController, type: :controller do
   end
 
   describe "#index" do
-    let!(:user) { create(:user) }
-    let!(:enterprise_user) { create(:user) }
-    let!(:order) {
+    let(:user) { create(:user) }
+    let(:enterprise_user) { create(:user) }
+    let(:order) {
       create(:order_with_distributor, bill_address: create(:address),
                                       ship_address: create(:address))
     }
-    let!(:distributor) { order.distributor }
+    let(:distributor) { order.distributor }
     let(:params) { { id: order.number } }
 
     context "as a normal user" do
@@ -133,6 +133,7 @@ describe Spree::Admin::OrdersController, type: :controller do
           expect(response).to redirect_to unauthorized_path
         end
       end
+
       context 'which is a manager of the distributor for an order' do
         before { allow(controller).to receive(:spree_current_user) { distributor.owner } }
 

--- a/spec/controllers/spree/admin/orders/invoices_spec.rb
+++ b/spec/controllers/spree/admin/orders/invoices_spec.rb
@@ -132,7 +132,6 @@ describe Spree::Admin::InvoicesController, type: :controller do
 
         it "shows only invoices of manged enterprises" do
           spree_get :index, params
-          pending "reporting success"
           expect(response).to redirect_to unauthorized_path
         end
       end
@@ -142,7 +141,7 @@ describe Spree::Admin::InvoicesController, type: :controller do
 
         it "should allow me to see the order" do
           spree_get :index, params
-          expect(response).to be_successful
+          expect(response).to have_http_status :success
           expect(assigns(:order)).to eq order
         end
       end

--- a/spec/controllers/spree/admin/orders/invoices_spec.rb
+++ b/spec/controllers/spree/admin/orders/invoices_spec.rb
@@ -104,4 +104,43 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
     end
   end
+
+  describe "#index" do
+    let!(:user) { create(:user) }
+    let!(:enterprise_user) { create(:user) }
+    let!(:order) {
+      create(:order_with_distributor, bill_address: create(:address),
+                                      ship_address: create(:address))
+    }
+    let!(:distributor) { order.distributor }
+    let(:params) { { id: order.number } }
+
+    context "as a normal user" do
+      before { allow(controller).to receive(:spree_current_user) { user } }
+
+      it "should prevent me from listing invoices for the order" do
+        spree_get :index, params
+        expect(response).to redirect_to unauthorized_path
+      end
+    end
+
+    context "as an enterprise user" do
+      context "which is not a manager of the distributor for an order" do
+        before { allow(controller).to receive(:spree_current_user) { enterprise_user } }
+
+        it "should prevent me from listing invoices for the order" do
+          spree_get :index, params
+          expect(response).to redirect_to unauthorized_path
+        end
+      end
+      context 'which is a manager of the distributor for an order' do
+        before { allow(controller).to receive(:spree_current_user) { distributor.owner } }
+
+        it "should allow me to see the order" do
+          spree_get :index, params
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #11048

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- described on: #11048
- relevant tests, try to access the invoices page for an order as: 
1. admin
2. enterprise user (the owner of the distributor of the order)
3. enterprise user (not the owner of distributor of the order) 
4. normal user

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
