### PR TITLE
Cart state orders not appearing orders page

### DIFF
--- a/spec/requests/api/orders_spec.rb
+++ b/spec/requests/api/orders_spec.rb
@@ -51,10 +51,6 @@ describe 'api/v0/orders', swagger_doc: 'v0/swagger.yaml', type: :request do
           }
           let!(:li4) { create(:line_item_with_shipment, order: order_dist_1_credit_owed) }
 
-          let!(:order_empty) {
-            create(:order_with_line_items, line_items_count: 0)
-          }
-
           let(:user) { order_dist_1.distributor.owner }
           let(:'X-Spree-Token') do
             user.generate_api_key
@@ -151,6 +147,28 @@ describe 'api/v0/orders', swagger_doc: 'v0/swagger.yaml', type: :request do
               orders = data["orders"]
               expect(orders.size).to eq 1
               expect(orders.first["id"]).to eq order_dist_2.id
+            end
+          end
+
+          context "and queried by cart state" do
+            let!(:order_empty) {
+              create(:order_with_line_items, line_items_count: 0)
+            }
+
+            let!(:order_not_empty) {
+              create(:order_with_line_items, line_items_count: 1)
+            }
+
+            let!(:order_not_empty_no_address) {
+              create(:order_with_line_items, line_items_count: 1, bill_address_id: nil, ship_address_id: nil)
+            }
+
+            let(:'q[state_eq]') { "cart" }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              orders = data["orders"]
+              expect(orders.size).to eq 3
             end
           end
         end

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -242,6 +242,46 @@ distributors: [distributor4, distributor5]) }
       end
     end
 
+    context "cart orders" do
+      let!(:order_empty) {
+        create(:order_with_line_items, user: customer2, distributor: distributor2,
+        line_items_count: 0)
+      }
+
+      let!(:order_not_empty) {
+        create(:order_with_line_items, user: customer2, distributor: distributor2,
+        line_items_count: 1)
+      }
+
+      let!(:order_not_empty_no_address) {
+        create(:order_with_line_items, line_items_count: 1, user: customer2,
+        distributor: distributor2, bill_address_id: nil, ship_address_id: nil)
+      }
+
+      before do
+        login_as_admin
+        visit spree.admin_orders_path
+        uncheck 'Only show complete orders'
+        tomselect_search_and_select "cart", from: 'q[state_eq]'
+        page.find('.filter-actions .button[type=submit]').click
+      end
+
+      it "displays non-empty cart orders" do
+        pending "issue #11120"
+
+        # empty cart order does not appear in the results
+        expect(page).not_to have_content order_empty.number
+
+        # non-empty cart order, with bill- and ship-address appear in the results
+        expect(page).to have_content order_not_empty.number
+
+        # non-empty cart order, with no with bill- and ship-address appear in the results
+
+        # pending issue #11120
+        expect(page).to have_content order_not_empty_no_address.number
+      end
+    end
+
     describe "ordering" do
       context "orders with different completion dates" do
         before do


### PR DESCRIPTION
#### What? Why?

- Adds regression tests to #11120

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- Adds a pending system spec (`/orders` page)
- Adds a request spec, documenting the current behavior: it seems all cart orders can be fetched by the API request. 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
