### PR TITLE
OFN DFC API documenation in OpenAPI format generated with Rswag

### DIFF
--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -10,6 +10,7 @@ Rswag::Ui.configure do |config|
   # correspond to the relative paths for those endpoints.
 
   config.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+  config.swagger_endpoint '/api-docs/dfc-v1.7/swagger.yaml', 'OFN DFC API Docs'
 
   # Add Basic Auth in case your API is private
   # config.basic_auth_enabled = true

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -1,8 +1,6 @@
 Openfoodnetwork::Application.routes.draw do
-  unless Rails.env.production?
-    mount Rswag::Ui::Engine => '/api-docs'
-    mount Rswag::Api::Engine => '/api-docs'
-  end
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
 
   namespace :api do
 

--- a/engines/dfc_provider/spec/requests/catalog_items_spec.rb
+++ b/engines/dfc_provider/spec/requests/catalog_items_spec.rb
@@ -1,115 +1,128 @@
 # frozen_string_literal: true
 
+require "swagger_helper"
 require DfcProvider::Engine.root.join("spec/spec_helper")
 
-describe "CatalogItems", type: :request do
-  let(:user) { create(:oidc_user) }
-  let(:enterprise) { create(:distributor_enterprise, owner: user) }
-  let(:product) { create(:simple_product, supplier: enterprise ) }
-  let(:variant) { product.variants.first }
+describe "CatalogItems", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml",
+                         rswag_autodoc: true do
+  let(:user) { create(:oidc_user, id: 12_345) }
+  let(:enterprise) { create(:distributor_enterprise, id: 10_000, owner: user) }
+  let(:product) {
+    create(
+      :base_product,
+      supplier: enterprise, name: "Apple", description: "Red",
+      variants: [variant],
+    )
+  }
+  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "AR") }
 
-  describe :index do
-    it "returns not_found without enterprise" do
-      items_path = enterprise_catalog_items_path(enterprise_id: "default")
+  before { login_as user }
 
-      get items_path, headers: auth_header(user.uid)
+  path "/api/dfc-v1.7/enterprises/{enterprise_id}/catalog_items" do
+    parameter name: :enterprise_id, in: :path, type: :string
 
-      expect(response).to have_http_status :not_found
-    end
+    get "List CatalogItems" do
+      produces "application/json"
 
-    context "with existing variant" do
-      before { variant }
-      it "lists catalog items with offers of default enterprise" do
-        items_path = enterprise_catalog_items_path(enterprise_id: "default")
+      response "404", "not found" do
+        context "without enterprises" do
+          let(:enterprise_id) { "default" }
 
-        get items_path, headers: auth_header(user.uid)
+          run_test!
+        end
 
-        expect(response).to have_http_status :ok
-        expect(response.body).to include variant.name
-        expect(response.body).to include variant.sku
-        expect(response.body).to include "offers/#{variant.id}"
+        context "with unrelated enterprise" do
+          let(:enterprise_id) { create(:enterprise).id }
+
+          run_test!
+        end
       end
 
-      it "lists catalog items with offers of requested enterprise" do
-        items_path = enterprise_catalog_items_path(enterprise_id: enterprise.id)
+      response "200", "success" do
+        before { product }
 
-        get items_path, headers: auth_header(user.uid)
+        context "with default enterprise id" do
+          let(:enterprise_id) { "default" }
 
-        expect(response).to have_http_status :ok
-        expect(response.body).to include variant.name
-        expect(response.body).to include variant.sku
-        expect(response.body).to include "offers/#{variant.id}"
+          run_test! do
+            expect(response.body).to include "Apple"
+            expect(response.body).to include "AR"
+            expect(response.body).to include "offers/10001"
+          end
+        end
+
+        context "with given enterprise id" do
+          let(:enterprise_id) { 10_000 }
+
+          run_test! do
+            expect(response.body).to include "Apple"
+            expect(response.body).to include "AR"
+            expect(response.body).to include "offers/10001"
+          end
+        end
       end
 
-      it "returns not_found for unrelated enterprises" do
-        other_enterprise = create(:enterprise)
-        items_path = enterprise_catalog_items_path(enterprise_id: other_enterprise.id)
+      response "401", "unauthorized" do
+        let(:enterprise_id) { "default" }
 
-        get items_path, headers: auth_header(user.uid)
+        before { login_as nil }
 
-        expect(response).to have_http_status :not_found
+        run_test!
       end
-
-      it "returns unauthorized for unauthenticated users" do
-        items_path = enterprise_catalog_items_path(enterprise_id: "default")
-
-        get items_path, headers: {}
-
-        expect(response).to have_http_status :unauthorized
-      end
-
-      it "recognises app user sessions as logins" do
-        items_path = enterprise_catalog_items_path(enterprise_id: "default")
-        login_as user
-
-        get items_path, headers: {}
-
-        expect(response).to have_http_status :ok
-      end
-    end
-  end
-
-  describe :show do
-    it "returns a catalog item with offer" do
-      item_path = enterprise_catalog_item_path(
-        variant,
-        enterprise_id: enterprise.id
-      )
-
-      get item_path, headers: auth_header(user.uid)
-
-      expect(response).to have_http_status :ok
-      expect(response.body).to include "dfc-b:CatalogItem"
-      expect(response.body).to include "offers/#{variant.id}"
-    end
-
-    it "returns not_found for unrelated variant" do
-      item_path = enterprise_catalog_item_path(
-        create(:variant),
-        enterprise_id: enterprise.id
-      )
-
-      get item_path, headers: auth_header(user.uid)
-
-      expect(response).to have_http_status :not_found
     end
   end
 
-  describe :update do
-    it "updates a variant's attributes" do
-      params = { enterprise_id: enterprise.id, id: variant.id }
-      request_body = DfcProvider::Engine.root.join("spec/support/patch_catalog_item.json").read
+  path "/api/dfc-v1.7/enterprises/{enterprise_id}/catalog_items/{id}" do
+    parameter name: :enterprise_id, in: :path, type: :string
+    parameter name: :id, in: :path, type: :string
 
-      expect {
-        put(
-          enterprise_catalog_item_path(params),
-          params: request_body,
-          headers: auth_header(user.uid)
-        )
-        expect(response).to have_http_status :success
-        variant.reload
-      }.to change { variant.on_hand }.to(3)
-        .and change { variant.sku }.to("new-sku")
+    get "Show CatalogItem" do
+      produces "application/json"
+
+      before { product }
+
+      response "200", "success" do
+        let(:enterprise_id) { 10_000 }
+        let(:id) { 10_001 }
+
+        run_test! do
+          expect(response.body).to include "dfc-b:CatalogItem"
+          expect(response.body).to include "offers/10001"
+        end
+      end
+
+      response "404", "not found" do
+        let(:enterprise_id) { 10_000 }
+        let(:id) { create(:variant).id }
+
+        run_test!
+      end
+    end
+
+    put "Update CatalogItem" do
+      consumes "application/json"
+
+      parameter name: :catalog_item, in: :body, schema: {
+        example: JSON.parse(DfcProvider::Engine.root.join("spec/support/patch_catalog_item.json").read)
+      }
+
+      before { product }
+
+      response "204", "no content" do
+        let(:enterprise_id) { 10_000 }
+        let(:id) { 10_001 }
+        let(:catalog_item) do |example|
+          example.metadata[:operation][:parameters].first[:schema][:example]
+        end
+
+        it "updates a variant" do |example|
+          expect {
+            submit_request(example.metadata)
+            variant.reload
+          }.to change { variant.on_hand }.to(3)
+            .and change { variant.sku }.to("new-sku")
+        end
+      end
     end
   end
 end

--- a/engines/dfc_provider/spec/requests/catalog_items_spec.rb
+++ b/engines/dfc_provider/spec/requests/catalog_items_spec.rb
@@ -103,7 +103,7 @@ describe "CatalogItems", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml",
       consumes "application/json"
 
       parameter name: :catalog_item, in: :body, schema: {
-        example: JSON.parse(DfcProvider::Engine.root.join("spec/support/patch_catalog_item.json").read)
+        example: ExampleJson.read("patch_catalog_item")
       }
 
       before { product }

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -1,35 +1,48 @@
 # frozen_string_literal: true
 
+require "swagger_helper"
 require DfcProvider::Engine.root.join("spec/spec_helper")
 
-describe "Enterprises", type: :request do
+describe "Enterprises", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml" do
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) { create(:distributor_enterprise, owner: user) }
   let!(:product) { create(:simple_product, supplier: enterprise ) }
 
-  describe :show do
-    it "returns the default enterprise" do
-      get enterprise_path("default"), headers: auth_header(user.uid)
+  before { login_as user }
 
-      expect(response).to have_http_status :ok
-      expect(response.body).to include(product.name)
-      expect(response.body).to include(product.variants.first.sku)
-      expect(response.body).to include("offers/#{product.variants.first.id}")
-    end
+  path "/api/dfc-v1.7/enterprises/{id}" do
+    get "Show enterprise" do
+      parameter name: :id, in: :path, type: :string
+      produces "application/json"
 
-    it "returns the requested enterprise" do
-      get enterprise_path(enterprise.id), headers: auth_header(user.uid)
+      response "200", "successful" do
+        context "without enterprise id" do
+          let(:id) { "default" }
 
-      expect(response).to have_http_status :ok
-      expect(response.body).to include(product.name)
-    end
+          run_test! do
+            expect(response.body).to include(product.name)
+            expect(response.body).to include(product.variants.first.sku)
+            expect(response.body).to include("offers/#{product.variants.first.id}")
+          end
+        end
 
-    it "returns not found for unrelated enterprise" do
-      other_enterprise = create(:distributor_enterprise)
-      get enterprise_path(other_enterprise.id), headers: auth_header(user.uid)
+        context "given an enterprise id" do
+          let(:id) { enterprise.id }
 
-      expect(response).to have_http_status :not_found
-      expect(response.body).to_not include(product.name)
+          run_test! do
+            expect(response.body).to include(product.name)
+          end
+        end
+      end
+
+      response "404", "not found" do
+        let(:id) { other_enterprise.id }
+        let(:other_enterprise) { create(:distributor_enterprise) }
+
+        run_test! do
+          expect(response.body).to_not include(product.name)
+        end
+      end
     end
   end
 end

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -5,8 +5,15 @@ require DfcProvider::Engine.root.join("spec/spec_helper")
 
 describe "Enterprises", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rswag_autodoc: true do
   let!(:user) { create(:oidc_user) }
-  let!(:enterprise) { create(:distributor_enterprise, owner: user) }
-  let!(:product) { create(:simple_product, supplier: enterprise ) }
+  let!(:enterprise) { create(:distributor_enterprise, id: 10_000, owner: user) }
+  let!(:product) {
+    create(
+      :base_product,
+      supplier: enterprise, name: "Apple", description: "Round",
+      variants: [variant],
+    )
+  }
+  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "APP") }
 
   before { login_as user }
 
@@ -20,9 +27,9 @@ describe "Enterprises", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rs
           let(:id) { "default" }
 
           run_test! do
-            expect(response.body).to include(product.name)
-            expect(response.body).to include(product.variants.first.sku)
-            expect(response.body).to include("offers/#{product.variants.first.id}")
+            expect(response.body).to include("Apple")
+            expect(response.body).to include("APP")
+            expect(response.body).to include("offers/10001")
           end
         end
 
@@ -30,7 +37,7 @@ describe "Enterprises", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rs
           let(:id) { enterprise.id }
 
           run_test! do
-            expect(response.body).to include(product.name)
+            expect(response.body).to include "Apple"
           end
         end
       end
@@ -40,7 +47,7 @@ describe "Enterprises", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rs
         let(:other_enterprise) { create(:distributor_enterprise) }
 
         run_test! do
-          expect(response.body).to_not include(product.name)
+          expect(response.body).to_not include "Apple"
         end
       end
     end

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -3,7 +3,7 @@
 require "swagger_helper"
 require DfcProvider::Engine.root.join("spec/spec_helper")
 
-describe "Enterprises", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml" do
+describe "Enterprises", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rswag_autodoc: true do
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) { create(:distributor_enterprise, owner: user) }
   let!(:product) { create(:simple_product, supplier: enterprise ) }

--- a/engines/dfc_provider/spec/requests/persons_spec.rb
+++ b/engines/dfc_provider/spec/requests/persons_spec.rb
@@ -3,7 +3,7 @@
 require "swagger_helper"
 require DfcProvider::Engine.root.join("spec/spec_helper")
 
-describe "Persons", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml" do
+describe "Persons", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rswag_autodoc: true do
   let(:user) { create(:oidc_user) }
   let(:other_user) { create(:oidc_user) }
 

--- a/engines/dfc_provider/spec/requests/persons_spec.rb
+++ b/engines/dfc_provider/spec/requests/persons_spec.rb
@@ -1,23 +1,35 @@
 # frozen_string_literal: true
 
+require "swagger_helper"
 require DfcProvider::Engine.root.join("spec/spec_helper")
 
-describe "Persons", type: :request do
+describe "Persons", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml" do
   let(:user) { create(:oidc_user) }
   let(:other_user) { create(:oidc_user) }
 
-  describe :show do
-    it "returns the authenticated user" do
-      get person_path(user), headers: auth_header(user.uid)
-      expect(response).to have_http_status :ok
-      expect(response.body).to include "dfc-b:Person"
-      expect(response.body).to include "persons/#{user.id}"
-    end
+  before { login_as user }
 
-    it "doesn't find another user" do
-      get person_path(other_user), headers: auth_header(user.uid)
-      expect(response).to have_http_status :not_found
-      expect(response.body).to_not include "dfc-b:Person"
+  path "/api/dfc-v1.7/persons/{id}" do
+    get "Show person" do
+      parameter name: :id, in: :path, type: :string
+      produces "application/json"
+
+      response "200", "successful" do
+        let(:id) { user.id }
+
+        run_test! do
+          expect(response.body).to include "dfc-b:Person"
+          expect(response.body).to include "persons/#{user.id}"
+        end
+      end
+
+      response "404", "not found" do
+        let(:id) { other_user.id }
+
+        run_test! do
+          expect(response.body).to_not include "dfc-b:Person"
+        end
+      end
     end
   end
 end

--- a/engines/dfc_provider/spec/requests/persons_spec.rb
+++ b/engines/dfc_provider/spec/requests/persons_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 require DfcProvider::Engine.root.join("spec/spec_helper")
 
 describe "Persons", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rswag_autodoc: true do
-  let(:user) { create(:oidc_user) }
+  let(:user) { create(:oidc_user, id: 10_000) }
   let(:other_user) { create(:oidc_user) }
 
   before { login_as user }
@@ -19,7 +19,7 @@ describe "Persons", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rswag_
 
         run_test! do
           expect(response.body).to include "dfc-b:Person"
-          expect(response.body).to include "persons/#{user.id}"
+          expect(response.body).to include "persons/10000"
         end
       end
 

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -3,7 +3,7 @@
 require "swagger_helper"
 require DfcProvider::Engine.root.join("spec/spec_helper")
 
-describe "SuppliedProducts", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml" do
+describe "SuppliedProducts", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rswag_autodoc: true do
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) { create(:distributor_enterprise, owner: user) }
   let!(:product) { create(:simple_product, supplier: enterprise ) }

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -3,7 +3,8 @@
 require "swagger_helper"
 require DfcProvider::Engine.root.join("spec/spec_helper")
 
-describe "SuppliedProducts", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rswag_autodoc: true do
+describe "SuppliedProducts", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml",
+                             rswag_autodoc: true do
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) { create(:distributor_enterprise, owner: user) }
   let!(:product) { create(:simple_product, supplier: enterprise ) }
@@ -22,27 +23,33 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml
 
       # This parameter is required but I want to write a spec which doesn't
       # supply it. I couldn't do it with rswag when requiring it.
-      parameter name: :supplied_product, in: :body, schema: {}, required: false
+      parameter name: :supplied_product, in: :body, required: false, schema: {
+        example: {
+          '@context': "http://static.datafoodconsortium.org/ontologies/context.json",
+          '@id': "http://test.host/api/dfc-v1.7/enterprises/6201/supplied_products/0",
+          '@type': "dfc-b:SuppliedProduct",
+          'dfc-b:name': "Apple",
+          'dfc-b:description': "A delicious heritage apple",
+          'dfc-b:hasType': "dfc-pt:non-local-vegetable",
+          'dfc-b:hasQuantity': {
+            '@type': "dfc-b:QuantitativeValue",
+            'dfc-b:hasUnit': "dfc-m:Gram",
+            'dfc-b:value': 3.0
+          },
+          'dfc-b:alcoholPercentage': 0.0,
+          'dfc-b:lifetime': "",
+          'dfc-b:usageOrStorageCondition': "",
+          'dfc-b:totalTheoreticalStock': 0.0
+        }
+      }
 
       response "400", "bad request" do
         run_test!
       end
 
       response "204", "success" do
-        let(:supplied_product) do
-          {
-            "@context": "http://static.datafoodconsortium.org/ontologies/context.json",
-            "@id": "http://test.host/api/dfc-v1.7/enterprises/6201/supplied_products/0",
-            "@type": "dfc-b:SuppliedProduct",
-            "dfc-b:name": "Apple",
-            "dfc-b:description": "A delicious heritage apple",
-            "dfc-b:hasType":"dfc-pt:non-local-vegetable",
-            "dfc-b:hasQuantity":{"@type":"dfc-b:QuantitativeValue","dfc-b:hasUnit":"dfc-m:Gram","dfc-b:value":3.0},
-            "dfc-b:alcoholPercentage":0.0,
-            "dfc-b:lifetime":"",
-            "dfc-b:usageOrStorageCondition":"",
-            "dfc-b:totalTheoreticalStock":0.0
-          }
+        let(:supplied_product) do |example|
+          example.metadata[:operation][:parameters].first[:schema][:example]
         end
 
         it "creates a variant" do |example|

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -1,91 +1,112 @@
 # frozen_string_literal: true
 
+require "swagger_helper"
 require DfcProvider::Engine.root.join("spec/spec_helper")
 
-describe "SuppliedProducts", type: :request do
+describe "SuppliedProducts", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml" do
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) { create(:distributor_enterprise, owner: user) }
   let!(:product) { create(:simple_product, supplier: enterprise ) }
   let!(:variant) { product.variants.first }
 
-  describe :create do
-    let(:endpoint) do
-      enterprise_supplied_products_path(enterprise_id: enterprise.id)
-    end
-    let(:supplied_product) do
-      SuppliedProductBuilder.supplied_product(new_variant)
-    end
-    let(:new_variant) do
-      # We need an id to generate a URL as semantic id when exporting.
-      build(:variant, id: 0, name: "Apple", unit_value: 3)
-    end
+  before { login_as user }
 
-    it "flags a bad request" do
-      post endpoint, headers: auth_header(user.uid)
+  path "/api/dfc-v1.7/enterprises/{enterprise_id}/supplied_products" do
+    parameter name: :enterprise_id, in: :path, type: :string
 
-      expect(response).to have_http_status :bad_request
-    end
+    let(:enterprise_id) { enterprise.id }
 
-    it "creates a variant" do
-      request_body = DfcLoader.connector.export(supplied_product)
+    post "Create SuppliedProduct" do
+      consumes "application/json"
+      produces "application/json"
 
-      expect do
-        post endpoint,
-             params: request_body,
-             headers: auth_header(user.uid)
+      # This parameter is required but I want to write a spec which doesn't
+      # supply it. I couldn't do it with rswag when requiring it.
+      parameter name: :supplied_product, in: :body, schema: {}, required: false
+
+      response "400", "bad request" do
+        run_test!
       end
-        .to change { enterprise.supplied_products.count }.by(1)
 
-      variant = Spree::Variant.last
-      expect(variant.name).to eq "Apple"
-      expect(variant.unit_value).to eq 3
+      response "204", "success" do
+        let(:supplied_product) do
+          {
+            "@context": "http://static.datafoodconsortium.org/ontologies/context.json",
+            "@id": "http://test.host/api/dfc-v1.7/enterprises/6201/supplied_products/0",
+            "@type": "dfc-b:SuppliedProduct",
+            "dfc-b:name": "Apple",
+            "dfc-b:description": "A delicious heritage apple",
+            "dfc-b:hasType":"dfc-pt:non-local-vegetable",
+            "dfc-b:hasQuantity":{"@type":"dfc-b:QuantitativeValue","dfc-b:hasUnit":"dfc-m:Gram","dfc-b:value":3.0},
+            "dfc-b:alcoholPercentage":0.0,
+            "dfc-b:lifetime":"",
+            "dfc-b:usageOrStorageCondition":"",
+            "dfc-b:totalTheoreticalStock":0.0
+          }
+        end
+
+        it "creates a variant" do |example|
+          expect { submit_request(example.metadata) }
+            .to change { enterprise.supplied_products.count }.by(1)
+
+          variant = Spree::Variant.last
+          expect(variant.name).to eq "Apple"
+          expect(variant.unit_value).to eq 3
+        end
+      end
     end
   end
 
-  describe :show do
-    it "returns variants" do
-      get enterprise_supplied_product_path(
-        variant.id, enterprise_id: enterprise.id
-      ), headers: auth_header(user.uid)
+  path "/api/dfc-v1.7/enterprises/{enterprise_id}/supplied_products/{id}" do
+    parameter name: :enterprise_id, in: :path, type: :string
+    parameter name: :id, in: :path, type: :string
 
-      expect(response).to have_http_status :ok
-      expect(response.body).to include variant.name
+    let(:enterprise_id) { enterprise.id }
+
+    get "Show SuppliedProduct" do
+      produces "application/json"
+
+      response "200", "success" do
+        let(:id) { variant.id }
+
+        run_test! do
+          expect(response.body).to include variant.name
+        end
+      end
+
+      response "404", "not found" do
+        let(:id) { other_variant.id }
+        let(:other_variant) { create(:variant) }
+
+        run_test!
+      end
     end
 
-    it "doesn't find unrelated variants" do
-      other_variant = create(:variant)
+    put "Update SuppliedProduct" do
+      consumes "application/json"
 
-      get enterprise_supplied_product_path(
-        other_variant.id, enterprise_id: enterprise.id
-      ), headers: auth_header(user.uid)
+      parameter name: :supplied_product, in: :body, schema: {}
 
-      expect(response).to have_http_status :not_found
-    end
-  end
+      let(:id) { variant.id }
+      let(:supplied_product) do
+        JSON.parse(DfcProvider::Engine.root.join("spec/support/patch_supplied_product.json").read)
+      end
 
-  describe :update do
-    it "requires authorisation" do
-      put enterprise_supplied_product_path(
-        variant.id, enterprise_id: enterprise.id
-      ), headers: {}
+      response "401", "unauthorized" do
+        before { login_as nil }
 
-      expect(response).to have_http_status :unauthorized
-    end
+        run_test!
+      end
 
-    it "updates a variant's attributes" do
-      params = { enterprise_id: enterprise.id, id: variant.id }
-      request_body = DfcProvider::Engine.root.join("spec/support/patch_supplied_product.json").read
-
-      expect {
-        put(
-          enterprise_supplied_product_path(params),
-          params: request_body,
-          headers: auth_header(user.uid)
-        )
-        expect(response).to have_http_status :success
-        variant.reload
-      }.to change { variant.description }.to("DFC-Pesto updated")
-        .and change { variant.unit_value }.to(17)
+      response "204", "success" do
+        it "updates a variant" do |example|
+          expect {
+            submit_request(example.metadata)
+            variant.reload
+          }.to change { variant.description }.to("DFC-Pesto updated")
+            .and change { variant.unit_value }.to(17)
+        end
+      end
     end
   end
 end

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -103,9 +103,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml
       parameter name: :supplied_product, in: :body, schema: {}
 
       let(:id) { variant.id }
-      let(:supplied_product) do
-        JSON.parse(DfcProvider::Engine.root.join("spec/support/patch_supplied_product.json").read)
-      end
+      let(:supplied_product) { ExampleJson.read("patch_supplied_product") }
 
       response "401", "unauthorized" do
         before { login_as nil }

--- a/engines/dfc_provider/spec/support/example_json.rb
+++ b/engines/dfc_provider/spec/support/example_json.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ExampleJson
+  def self.read(name)
+    pathname = DfcProvider::Engine.root.join("spec/support/#{name}.json")
+    JSON.parse(pathname.read)
+  end
+end

--- a/script/rswag
+++ b/script/rswag
@@ -2,5 +2,16 @@
 
 # Generate the API documentation based on our specs.
 #
-# The PATTERN argument is adding engines to the search path.
-exec ./bin/rake rswag PATTERN="spec/requests/api/**/*_spec.rb,engines/dfc_provider/spec/requests/**/*_spec.rb"
+# The standard way to generate the documentation is `rake rswag` which calls
+# rspec under the hood. We have a few customisations to the rspec call though
+# which only work when calling rspec ourselves.
+#
+# - We actually run the specs to generate examples instead of a dry run.
+#   While rswag has an RSWAG_DRY_RUN switch, it doesn't work with our setup.
+# - We add relevant engines to the pattern.
+# - We run only tagged swagger specs instead of all matching the pattern.
+exec ./bin/rspec\
+  --pattern "spec/requests/api/**/*_spec.rb,engines/dfc_provider/spec/requests/**/*_spec.rb"\
+  --tag "swagger_doc"\
+  --format "Rswag::Specs::SwaggerFormatter"\
+  --order "defined"

--- a/script/rswag
+++ b/script/rswag
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+# Generate the API documentation based on our specs.
+#
+# The PATTERN argument is adding engines to the search path.
+exec ./bin/rake rswag PATTERN="spec/requests/api/**/*_spec.rb,engines/dfc_provider/spec/requests/**/*_spec.rb"

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -106,6 +106,25 @@ RSpec.configure do |config|
     ActionController::Base.perform_caching = caching
   end
 
+  # Take example responses from Rswag specs for API documentation.
+  # https://github.com/rswag/rswag#enable-auto-generation-examples-from-responses
+  config.after(:each, :rswag_autodoc) do |example|
+    next if response&.body.blank?
+
+    example.metadata[:response][:content] ||= {}
+    example.metadata[:response][:content].deep_merge!(
+      {
+        "application/json" => {
+          examples: {
+            test_example: {
+              value: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        }
+      }
+    )
+  end
+
   # Show javascript errors in test output with `js_debug: true`
   config.after(:each, :js_debug) do
     errors = page.driver.browser.manage.logs.get(:browser)

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "Customers", type: :request do
+describe "Customers", type: :request, swagger_doc: "v1/swagger.yaml" do
   let!(:enterprise1) { create(:enterprise, name: "The Farm") }
   let!(:enterprise2) { create(:enterprise) }
   let!(:enterprise3) { create(:enterprise) }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -18,6 +18,44 @@ RSpec.configure do |config|
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
   config.swagger_docs = {
+    'dfc-v1.7/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'OFN DFC API',
+        version: 'v0.1.7'
+      },
+      components: {
+        securitySchemes: {
+          oidc_token: {
+            type: :http,
+            scheme: :bearer,
+            bearerFormat: "JWT",
+            description: "OpenID Connect token from a trusted platform"
+          },
+          ofn_api_token: {
+            type: :apiKey,
+            in: :header,
+            name: 'X-Api-Token',
+            description: "API token of an authorized OFN user"
+          },
+          ofn_session: {
+            type: :apiKey,
+            in: :cookie,
+            name: '_ofn_session',
+            description: "Session cookie of a logged in OFN user"
+          },
+        }
+      },
+      security: [
+        { oidc_token: [] },
+        { ofn_api_token: [] },
+        { ofn_session: [] },
+      ],
+      paths: {},
+      servers: [
+        { url: "/" },
+      ]
+    },
     'v1/swagger.yaml' => {
       openapi: '3.0.1',
       info: {

--- a/swagger/dfc-v1.7/swagger.yaml
+++ b/swagger/dfc-v1.7/swagger.yaml
@@ -25,6 +25,168 @@ security:
 - ofn_api_token: []
 - ofn_session: []
 paths:
+  "/api/dfc-v1.7/enterprises/{enterprise_id}/catalog_items":
+    parameters:
+    - name: enterprise_id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: List CatalogItems
+      responses:
+        '404':
+          description: not found
+        '200':
+          description: success
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@context": http://static.datafoodconsortium.org/ontologies/context.json
+                    "@graph":
+                    - "@id": http://test.host/api/dfc-v1.7/persons/12345
+                      "@type": dfc-b:Person
+                      dfc-b:affiliates: http://test.host/api/dfc-v1.7/enterprises/10000
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/10000
+                      "@type": dfc-b:Enterprise
+                      dfc-b:hasName: ''
+                      dfc-b:hasDescription: ''
+                      dfc-b:VATnumber: ''
+                      dfc-b:supplies: http://test.host/api/dfc-v1.7/enterprises/10000/supplied_products/10001
+                      dfc-b:manages: http://test.host/api/dfc-v1.7/enterprises/10000/catalog_items/10001
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/10000/catalog_items/10001
+                      "@type": dfc-b:CatalogItem
+                      dfc-b:references: http://test.host/api/dfc-v1.7/enterprises/10000/supplied_products/10001
+                      dfc-b:sku: AR
+                      dfc-b:stockLimitation: 0
+                      dfc-b:offeredThrough: http://test.host/api/dfc-v1.7/enterprises/10000/offers/10001
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/10000/supplied_products/10001
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: Apple
+                      dfc-b:description: Red
+                      dfc-b:hasType: dfc-pt:non-local-vegetable
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:alcoholPercentage: 0.0
+                      dfc-b:lifetime: ''
+                      dfc-b:usageOrStorageCondition: ''
+                      dfc-b:totalTheoreticalStock: 0.0
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/10000/offers/10001
+                      "@type": dfc-b:Offer
+                      dfc-b:price: 19.99
+                      dfc-b:stockLimitation: 0
+        '401':
+          description: unauthorized
+  "/api/dfc-v1.7/enterprises/{enterprise_id}/catalog_items/{id}":
+    parameters:
+    - name: enterprise_id
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Show CatalogItem
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@context": http://static.datafoodconsortium.org/ontologies/context.json
+                    "@graph":
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/10000/catalog_items/10001
+                      "@type": dfc-b:CatalogItem
+                      dfc-b:references: http://test.host/api/dfc-v1.7/enterprises/10000/supplied_products/10001
+                      dfc-b:sku: AR
+                      dfc-b:stockLimitation: 0
+                      dfc-b:offeredThrough: http://test.host/api/dfc-v1.7/enterprises/10000/offers/10001
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/10000/offers/10001
+                      "@type": dfc-b:Offer
+                      dfc-b:price: 19.99
+                      dfc-b:stockLimitation: 0
+        '404':
+          description: not found
+    put:
+      summary: Update CatalogItem
+      parameters: []
+      responses:
+        '204':
+          description: no content
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                "@context":
+                  rdfs: http://www.w3.org/2000/01/rdf-schema#
+                  skos: http://www.w3.org/2004/02/skos/core#
+                  dfc: http://static.datafoodconsortium.org/ontologies/DFC_FullModel.owl#
+                  dc: http://purl.org/dc/elements/1.1/#
+                  dfc-b: http://static.datafoodconsortium.org/ontologies/DFC_BusinessOntology.owl#
+                  dfc-p: http://static.datafoodconsortium.org/ontologies/DFC_ProductOntology.owl#
+                  dfc-t: http://static.datafoodconsortium.org/ontologies/DFC_TechnicalOntology.owl#
+                  dfc-m: http://static.datafoodconsortium.org/data/measures.rdf#
+                  dfc-pt: http://static.datafoodconsortium.org/data/productTypes.rdf#
+                  dfc-f: http://static.datafoodconsortium.org/data/facets.rdf#
+                  dfc-p:hasUnit:
+                    "@type": "@id"
+                  dfc-b:hasUnit:
+                    "@type": "@id"
+                  dfc-b:hasQuantity:
+                    "@type": "@id"
+                  dfc-p:hasType:
+                    "@type": "@id"
+                  dfc-b:hasType:
+                    "@type": "@id"
+                  dfc-b:references:
+                    "@type": "@id"
+                  dfc-b:referencedBy:
+                    "@type": "@id"
+                  dfc-b:offeres:
+                    "@type": "@id"
+                  dfc-b:supplies:
+                    "@type": "@id"
+                  dfc-b:defines:
+                    "@type": "@id"
+                  dfc-b:affiliates:
+                    "@type": "@id"
+                  dfc-b:manages:
+                    "@type": "@id"
+                  dfc-b:offeredThrough:
+                    "@type": "@id"
+                  dfc-b:hasBrand:
+                    "@type": "@id"
+                  dfc-b:hasGeographicalOrigin:
+                    "@type": "@id"
+                  dfc-b:hasClaim:
+                    "@type": "@id"
+                  dfc-b:hasAllergenDimension:
+                    "@type": "@id"
+                  dfc-b:hasNutrimentDimension:
+                    "@type": "@id"
+                  dfc-b:hasPhysicalDimension:
+                    "@type": "@id"
+                  dfc:owner:
+                    "@type": "@id"
+                  dfc-t:hostedBy:
+                    "@type": "@id"
+                  dfc-t:hasPivot:
+                    "@type": "@id"
+                  dfc-t:represent:
+                    "@type": "@id"
+                dfc-b:stockLimitation: '3'
+                dfc-b:sku: new-sku
   "/api/dfc-v1.7/enterprises/{id}":
     get:
       summary: Show enterprise

--- a/swagger/dfc-v1.7/swagger.yaml
+++ b/swagger/dfc-v1.7/swagger.yaml
@@ -116,7 +116,22 @@ paths:
       requestBody:
         content:
           application/json:
-            schema: {}
+            schema:
+              example:
+                "@context": http://static.datafoodconsortium.org/ontologies/context.json
+                "@id": http://test.host/api/dfc-v1.7/enterprises/6201/supplied_products/0
+                "@type": dfc-b:SuppliedProduct
+                dfc-b:name: Apple
+                dfc-b:description: A delicious heritage apple
+                dfc-b:hasType: dfc-pt:non-local-vegetable
+                dfc-b:hasQuantity:
+                  "@type": dfc-b:QuantitativeValue
+                  dfc-b:hasUnit: dfc-m:Gram
+                  dfc-b:value: 3.0
+                dfc-b:alcoholPercentage: 0.0
+                dfc-b:lifetime: ''
+                dfc-b:usageOrStorageCondition: ''
+                dfc-b:totalTheoreticalStock: 0.0
   "/api/dfc-v1.7/enterprises/{enterprise_id}/supplied_products/{id}":
     parameters:
     - name: enterprise_id

--- a/swagger/dfc-v1.7/swagger.yaml
+++ b/swagger/dfc-v1.7/swagger.yaml
@@ -37,6 +37,43 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@context": http://static.datafoodconsortium.org/ontologies/context.json
+                    "@graph":
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/473
+                      "@type": dfc-b:Enterprise
+                      dfc-b:hasName: ''
+                      dfc-b:hasDescription: ''
+                      dfc-b:VATnumber: ''
+                      dfc-b:supplies: http://test.host/api/dfc-v1.7/enterprises/473/supplied_products/298
+                      dfc-b:manages: http://test.host/api/dfc-v1.7/enterprises/473/catalog_items/298
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/473/supplied_products/298
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #2 - 8569'
+                      dfc-b:description: |-
+                        Voluptatem sequi hic expedita reprehenderit ad veniam recusandae explicabo. Occaecati eum cumque exercitationem culpa dolor. Velit accusamus blanditiis quia laboriosam fuga corrupti maiores ut.
+                        Consectetur illo necessitatibus porro eveniet. Similique est error labore inventore exercitationem. Similique nulla iusto tenetur reiciendis.
+                        Quis laborum saepe illo magnam dolorem distinctio sed eligendi. Suscipit et iure vitae facilis nam quia placeat. Vero ea accusantium corrupti possimus error ad. Repellendus tenetur atque minima architecto. Optio cum magni quisquam aliquid rerum.
+                        Laborum quae tempora iure accusamus sed blanditiis enim. Debitis earum omnis voluptate accusantium deserunt nisi nemo ad. Ea nihil architecto eius odit illo aut. Totam corporis error illum voluptatem. Repellendus eius adipisci eaque amet porro occaecati.
+                      dfc-b:hasType: dfc-pt:non-local-vegetable
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:alcoholPercentage: 0.0
+                      dfc-b:lifetime: ''
+                      dfc-b:usageOrStorageCondition: ''
+                      dfc-b:totalTheoreticalStock: 0.0
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/473/catalog_items/298
+                      "@type": dfc-b:CatalogItem
+                      dfc-b:references: http://test.host/api/dfc-v1.7/enterprises/473/supplied_products/298
+                      dfc-b:sku: ''
+                      dfc-b:stockLimitation: 5
+                      dfc-b:offeredThrough: http://test.host/api/dfc-v1.7/enterprises/473/offers/298
         '404':
           description: not found
   "/api/dfc-v1.7/persons/{id}":
@@ -51,6 +88,14 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@context": http://static.datafoodconsortium.org/ontologies/context.json
+                    "@id": http://test.host/api/dfc-v1.7/persons/910
+                    "@type": dfc-b:Person
         '404':
           description: not found
   "/api/dfc-v1.7/enterprises/{enterprise_id}/supplied_products":
@@ -89,6 +134,28 @@ paths:
       responses:
         '200':
           description: success
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@context": http://static.datafoodconsortium.org/ontologies/context.json
+                    "@id": http://test.host/api/dfc-v1.7/enterprises/478/supplied_products/303
+                    "@type": dfc-b:SuppliedProduct
+                    dfc-b:name: 'Product #6 - 8953'
+                    dfc-b:description: Magni nemo enim saepe harum corporis nobis
+                      facilis. Nostrum facilis molestiae at quaerat exercitationem
+                      itaque veritatis. Incidunt eaque asperiores assumenda eveniet
+                      doloribus qui voluptatibus quidem.
+                    dfc-b:hasType: dfc-pt:non-local-vegetable
+                    dfc-b:hasQuantity:
+                      "@type": dfc-b:QuantitativeValue
+                      dfc-b:hasUnit: dfc-m:Gram
+                      dfc-b:value: 1.0
+                    dfc-b:alcoholPercentage: 0.0
+                    dfc-b:lifetime: ''
+                    dfc-b:usageOrStorageCondition: ''
+                    dfc-b:totalTheoreticalStock: 0.0
         '404':
           description: not found
     put:

--- a/swagger/dfc-v1.7/swagger.yaml
+++ b/swagger/dfc-v1.7/swagger.yaml
@@ -53,5 +53,55 @@ paths:
           description: successful
         '404':
           description: not found
+  "/api/dfc-v1.7/enterprises/{enterprise_id}/supplied_products":
+    parameters:
+    - name: enterprise_id
+      in: path
+      required: true
+      schema:
+        type: string
+    post:
+      summary: Create SuppliedProduct
+      parameters: []
+      responses:
+        '400':
+          description: bad request
+        '204':
+          description: success
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+  "/api/dfc-v1.7/enterprises/{enterprise_id}/supplied_products/{id}":
+    parameters:
+    - name: enterprise_id
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Show SuppliedProduct
+      responses:
+        '200':
+          description: success
+        '404':
+          description: not found
+    put:
+      summary: Update SuppliedProduct
+      parameters: []
+      responses:
+        '401':
+          description: unauthorized
+        '204':
+          description: success
+      requestBody:
+        content:
+          application/json:
+            schema: {}
 servers:
 - url: "/"

--- a/swagger/dfc-v1.7/swagger.yaml
+++ b/swagger/dfc-v1.7/swagger.yaml
@@ -1,0 +1,29 @@
+---
+openapi: 3.0.1
+info:
+  title: OFN DFC API
+  version: v0.1.7
+components:
+  securitySchemes:
+    oidc_token:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: OpenID Connect token from a trusted platform
+    ofn_api_token:
+      type: apiKey
+      in: header
+      name: X-Api-Token
+      description: API token of an authorized OFN user
+    ofn_session:
+      type: apiKey
+      in: cookie
+      name: _ofn_session
+      description: Session cookie of a logged in OFN user
+security:
+- oidc_token: []
+- ofn_api_token: []
+- ofn_session: []
+paths: {}
+servers:
+- url: "/"

--- a/swagger/dfc-v1.7/swagger.yaml
+++ b/swagger/dfc-v1.7/swagger.yaml
@@ -44,21 +44,17 @@ paths:
                   value:
                     "@context": http://static.datafoodconsortium.org/ontologies/context.json
                     "@graph":
-                    - "@id": http://test.host/api/dfc-v1.7/enterprises/473
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/10000
                       "@type": dfc-b:Enterprise
                       dfc-b:hasName: ''
                       dfc-b:hasDescription: ''
                       dfc-b:VATnumber: ''
-                      dfc-b:supplies: http://test.host/api/dfc-v1.7/enterprises/473/supplied_products/298
-                      dfc-b:manages: http://test.host/api/dfc-v1.7/enterprises/473/catalog_items/298
-                    - "@id": http://test.host/api/dfc-v1.7/enterprises/473/supplied_products/298
+                      dfc-b:supplies: http://test.host/api/dfc-v1.7/enterprises/10000/supplied_products/10001
+                      dfc-b:manages: http://test.host/api/dfc-v1.7/enterprises/10000/catalog_items/10001
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/10000/supplied_products/10001
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #2 - 8569'
-                      dfc-b:description: |-
-                        Voluptatem sequi hic expedita reprehenderit ad veniam recusandae explicabo. Occaecati eum cumque exercitationem culpa dolor. Velit accusamus blanditiis quia laboriosam fuga corrupti maiores ut.
-                        Consectetur illo necessitatibus porro eveniet. Similique est error labore inventore exercitationem. Similique nulla iusto tenetur reiciendis.
-                        Quis laborum saepe illo magnam dolorem distinctio sed eligendi. Suscipit et iure vitae facilis nam quia placeat. Vero ea accusantium corrupti possimus error ad. Repellendus tenetur atque minima architecto. Optio cum magni quisquam aliquid rerum.
-                        Laborum quae tempora iure accusamus sed blanditiis enim. Debitis earum omnis voluptate accusantium deserunt nisi nemo ad. Ea nihil architecto eius odit illo aut. Totam corporis error illum voluptatem. Repellendus eius adipisci eaque amet porro occaecati.
+                      dfc-b:name: Apple
+                      dfc-b:description: Round
                       dfc-b:hasType: dfc-pt:non-local-vegetable
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
@@ -68,12 +64,12 @@ paths:
                       dfc-b:lifetime: ''
                       dfc-b:usageOrStorageCondition: ''
                       dfc-b:totalTheoreticalStock: 0.0
-                    - "@id": http://test.host/api/dfc-v1.7/enterprises/473/catalog_items/298
+                    - "@id": http://test.host/api/dfc-v1.7/enterprises/10000/catalog_items/10001
                       "@type": dfc-b:CatalogItem
-                      dfc-b:references: http://test.host/api/dfc-v1.7/enterprises/473/supplied_products/298
-                      dfc-b:sku: ''
-                      dfc-b:stockLimitation: 5
-                      dfc-b:offeredThrough: http://test.host/api/dfc-v1.7/enterprises/473/offers/298
+                      dfc-b:references: http://test.host/api/dfc-v1.7/enterprises/10000/supplied_products/10001
+                      dfc-b:sku: APP
+                      dfc-b:stockLimitation: 0
+                      dfc-b:offeredThrough: http://test.host/api/dfc-v1.7/enterprises/10000/offers/10001
         '404':
           description: not found
   "/api/dfc-v1.7/persons/{id}":
@@ -94,7 +90,7 @@ paths:
                 test_example:
                   value:
                     "@context": http://static.datafoodconsortium.org/ontologies/context.json
-                    "@id": http://test.host/api/dfc-v1.7/persons/910
+                    "@id": http://test.host/api/dfc-v1.7/persons/10000
                     "@type": dfc-b:Person
         '404':
           description: not found
@@ -155,13 +151,10 @@ paths:
                 test_example:
                   value:
                     "@context": http://static.datafoodconsortium.org/ontologies/context.json
-                    "@id": http://test.host/api/dfc-v1.7/enterprises/478/supplied_products/303
+                    "@id": http://test.host/api/dfc-v1.7/enterprises/10000/supplied_products/10001
                     "@type": dfc-b:SuppliedProduct
-                    dfc-b:name: 'Product #6 - 8953'
-                    dfc-b:description: Magni nemo enim saepe harum corporis nobis
-                      facilis. Nostrum facilis molestiae at quaerat exercitationem
-                      itaque veritatis. Incidunt eaque asperiores assumenda eveniet
-                      doloribus qui voluptatibus quidem.
+                    dfc-b:name: Pesto
+                    dfc-b:description: Basil Pesto
                     dfc-b:hasType: dfc-pt:non-local-vegetable
                     dfc-b:hasQuantity:
                       "@type": dfc-b:QuantitativeValue

--- a/swagger/dfc-v1.7/swagger.yaml
+++ b/swagger/dfc-v1.7/swagger.yaml
@@ -25,6 +25,20 @@ security:
 - ofn_api_token: []
 - ofn_session: []
 paths:
+  "/api/dfc-v1.7/enterprises/{id}":
+    get:
+      summary: Show enterprise
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+        '404':
+          description: not found
   "/api/dfc-v1.7/persons/{id}":
     get:
       summary: Show person

--- a/swagger/dfc-v1.7/swagger.yaml
+++ b/swagger/dfc-v1.7/swagger.yaml
@@ -24,6 +24,20 @@ security:
 - oidc_token: []
 - ofn_api_token: []
 - ofn_session: []
-paths: {}
+paths:
+  "/api/dfc-v1.7/persons/{id}":
+    get:
+      summary: Show person
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+        '404':
+          description: not found
 servers:
 - url: "/"

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -77,7 +77,7 @@ components:
                 billing_address:
                   type: object
                   nullable: true
-                  example: 
+                  example:
                 shipping_address:
                   type: object
                   nullable: true
@@ -190,7 +190,7 @@ components:
                   billing_address:
                     type: object
                     nullable: true
-                    example: 
+                    example:
                   shipping_address:
                     type: object
                     nullable: true
@@ -375,7 +375,7 @@ paths:
                 billing_address:
                   type: object
                   nullable: true
-                  example: 
+                  example:
                 shipping_address:
                   type: object
                   nullable: true
@@ -468,7 +468,7 @@ paths:
                           billing_address:
                             type: object
                             nullable: true
-                            example: 
+                            example:
                           shipping_address:
                             type: object
                             nullable: true
@@ -598,7 +598,7 @@ paths:
                 billing_address:
                   type: object
                   nullable: true
-                  example: 
+                  example:
                 shipping_address:
                   type: object
                   nullable: true


### PR DESCRIPTION
#### What? Why?

Related to:

- #9170

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

While I'm developing the DFC API, people ask me what it can and can't do. So it's time for some documentation to be open and save time in the end. I haven't actually seen any DFC app being documented in this standardised way. The next best thing is the [DFC documentation](https://datafoodconsortium.gitbook.io/dfc-standard-documentation/appendixes/practical-examples/version-1.8) which has only read examples, no update or create. And I don't know of any documentation which show the HTTP interaction with the API.

I noticed some shortcomings of the current API, which is still in development, but didn't fix them in this PR. For example:

- The SuppliedProducts#create action responds without content. It should respond with the created object, I guess. Otherwise you can't know its id.

But at least this setup of Rswag documents the *actual* behaviour instead of the expected behaviour. Rswag is usually supplied with JSON-Schema to specify what the API looks like and it can test the application against that. But I omitted that here because the DFC Connector is already enforcing that we use the right format and I didn't want to repeat the DFC ontology in a different format. Maybe we'll find a way to generate it automatically which could be helpful for the documentation.

![Screen Shot 2023-06-28 at 14 38 55](https://github.com/openfoodfoundation/openfoodnetwork/assets/3524483/0cccb3b2-15bd-4af5-845b-1368df780f16)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit `/api-docs` and have a browse.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

The documentation assumes that authentication via API token is possible already:

* https://github.com/openfoodfoundation/openfoodnetwork/pull/11101

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

This is the documentation update. We could mention it somewhere but I don't know yet where people will be looking for it.