### PR TITLE
Add timestamps to variants table

### DIFF
--- a/db/migrate/20230628144825_variant_timestamps.rb
+++ b/db/migrate/20230628144825_variant_timestamps.rb
@@ -1,0 +1,5 @@
+class VariantTimestamps < ActiveRecord::Migration[7.0]
+  def change
+    add_timestamps :spree_variants, null: false, default: -> { "NOW()" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_28_131123) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_28_144825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -1088,6 +1088,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_28_131123) do
     t.datetime "import_date", precision: nil
     t.string "variant_unit"
     t.string "unit_presentation"
+    t.datetime "created_at", default: -> { "now()" }, null: false
+    t.datetime "updated_at", default: -> { "now()" }, null: false
     t.index ["product_id"], name: "index_variants_on_product_id"
     t.index ["sku"], name: "index_spree_variants_on_sku"
     t.check_constraint "unit_value > 0::double precision", name: "positive_unit_value"


### PR DESCRIPTION
#### What? Why?

Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/9069. Adds timestamps to variants table.

#### What should we test?

Maybe dev-test? Variants should have timestamps and the default times should be set to whenever the columns were added. `ActiveRecord` takes care of the rest.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
