### PR TITLE
Fix split checkout Metrics/ClassSize

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Gemspec/RequiredRubyVersion:
     - 'engines/order_management/order_management.gemspec'
     - 'engines/web/web.gemspec'
 
-# Offense count: 31
+# Offense count: 35
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, IndentationWidth.
 # SupportedStyles: with_first_argument, with_fixed_indentation
@@ -25,6 +25,7 @@ Layout/ArgumentAlignment:
     - 'app/controllers/spree/users_controller.rb'
     - 'app/controllers/user_confirmations_controller.rb'
     - 'app/models/enterprise.rb'
+    - 'spec/lib/open_food_network/enterprise_fee_calculator_spec.rb'
     - 'spec/lib/reports/packing/packing_report_spec.rb'
     - 'spec/migrations/migrate_customer_names_spec.rb'
     - 'spec/services/products_renderer_spec.rb'
@@ -97,7 +98,7 @@ Layout/FirstHashElementIndentation:
   Exclude:
     - 'spec/services/products_renderer_spec.rb'
 
-# Offense count: 10
+# Offense count: 14
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowMultipleStyles, EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle.
 # SupportedHashRocketStyles: key, separator, table
@@ -106,6 +107,7 @@ Layout/FirstHashElementIndentation:
 Layout/HashAlignment:
   Exclude:
     - 'app/controllers/spree/users_controller.rb'
+    - 'spec/lib/open_food_network/enterprise_fee_calculator_spec.rb'
     - 'spec/migrations/migrate_customer_names_spec.rb'
     - 'spec/models/enterprise_spec.rb'
     - 'spec/system/admin/customers_spec.rb'
@@ -187,7 +189,7 @@ Layout/LineEndStringConcatenationIndentation:
     - 'spec/system/consumer/cookies_spec.rb'
     - 'spec/system/consumer/shopping/cart_spec.rb'
 
-# Offense count: 482
+# Offense count: 500
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
 # URISchemes: http, https
@@ -206,7 +208,6 @@ Layout/LineLength:
     - 'spec/controllers/api/v0/exchange_products_controller_spec.rb'
     - 'spec/controllers/api/v0/order_cycles_controller_spec.rb'
     - 'spec/controllers/api/v0/orders_controller_spec.rb'
-    - 'spec/controllers/api/v0/products_controller_spec.rb'
     - 'spec/controllers/cart_controller_spec.rb'
     - 'spec/controllers/enterprises_controller_spec.rb'
     - 'spec/controllers/line_items_controller_spec.rb'
@@ -528,7 +529,7 @@ Metrics/AbcSize:
     - 'lib/tasks/enterprises.rake'
     - 'spec/services/order_checkout_restart_spec.rb'
 
-# Offense count: 49
+# Offense count: 48
 # Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
 # AllowedMethods: refine
 Metrics/BlockLength:
@@ -570,7 +571,7 @@ Metrics/BlockNesting:
   Exclude:
     - 'app/models/spree/payment/processing.rb'
 
-# Offense count: 49
+# Offense count: 48
 # Configuration parameters: CountComments, Max, CountAsOne.
 Metrics/ClassLength:
   Exclude:
@@ -585,7 +586,6 @@ Metrics/ClassLength:
     - 'app/controllers/api/v0/products_controller.rb'
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/payment_gateways/paypal_controller.rb'
-    - 'app/controllers/split_checkout_controller.rb'
     - 'app/controllers/spree/admin/orders_controller.rb'
     - 'app/controllers/spree/admin/payment_methods_controller.rb'
     - 'app/controllers/spree/admin/payments_controller.rb'
@@ -624,7 +624,7 @@ Metrics/ClassLength:
     - 'lib/reporting/reports/enterprise_fee_summary/scope.rb'
     - 'lib/reporting/reports/xero_invoices/base.rb'
 
-# Offense count: 35
+# Offense count: 34
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/CyclomaticComplexity:
   Exclude:
@@ -644,7 +644,6 @@ Metrics/CyclomaticComplexity:
     - 'app/models/spree/preference.rb'
     - 'app/models/spree/preferences/preferable.rb'
     - 'app/models/spree/preferences/preferable_class_methods.rb'
-    - 'app/models/spree/product.rb'
     - 'app/models/spree/return_authorization.rb'
     - 'app/models/spree/tax_rate.rb'
     - 'app/models/spree/variant.rb'
@@ -733,11 +732,10 @@ Metrics/ModuleLength:
     - 'spec/support/request/shop_workflow.rb'
     - 'spec/support/request/stripe_stubs.rb'
 
-# Offense count: 8
+# Offense count: 7
 # Configuration parameters: Max, CountKeywordArgs, MaxOptionalParameters.
 Metrics/ParameterLists:
   Exclude:
-    - 'app/components/confirm_modal_component.rb'
     - 'app/helpers/angular_form_builder.rb'
     - 'app/models/product_import/entry_processor.rb'
     - 'lib/reporting/reports/xero_invoices/base.rb'
@@ -845,7 +843,7 @@ Rails/ActionOrder:
     - 'app/controllers/spree/admin/variants_controller.rb'
     - 'app/controllers/user_confirmations_controller.rb'
 
-# Offense count: 13
+# Offense count: 12
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb
@@ -949,7 +947,7 @@ Rails/HasAndBelongsToMany:
     - 'app/models/spree/user.rb'
     - 'app/models/spree/zone.rb'
 
-# Offense count: 48
+# Offense count: 47
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb
 Rails/HasManyOrHasOneDependent:
@@ -964,7 +962,6 @@ Rails/HasManyOrHasOneDependent:
     - 'app/models/spree/order.rb'
     - 'app/models/spree/payment.rb'
     - 'app/models/spree/payment_method.rb'
-    - 'app/models/spree/product.rb'
     - 'app/models/spree/property.rb'
     - 'app/models/spree/return_authorization.rb'
     - 'app/models/spree/shipment.rb'
@@ -1013,7 +1010,13 @@ Rails/I18nLocaleTexts:
   Exclude:
     - 'app/controllers/admin/stripe_accounts_controller.rb'
 
-# Offense count: 24
+# Offense count: 1
+# This cop supports unsafe autocorrection (--autocorrect-all).
+Rails/IgnoredColumnsAssignment:
+  Exclude:
+    - 'app/models/spree/variant.rb'
+
+# Offense count: 22
 # Configuration parameters: IgnoreScopes, Include.
 # Include: app/models/**/*.rb
 Rails/InverseOf:
@@ -1459,6 +1462,14 @@ Style/GuardClause:
     - 'spec/support/request/shop_workflow.rb'
     - 'spec/system/support/precompile_assets.rb'
 
+# Offense count: 1
+# This cop supports safe autocorrection (--autocorrect).
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: braces, no_braces
+Style/HashAsLastArrayItem:
+  Exclude:
+    - 'app/components/products_table_component.rb'
+
 # Offense count: 12
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowSplatArgument.
@@ -1481,7 +1492,7 @@ Style/HashLikeCase:
   Exclude:
     - 'app/models/enterprise.rb'
 
-# Offense count: 1764
+# Offense count: 1780
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
 # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
@@ -1497,6 +1508,7 @@ Style/HashSyntax:
     - 'app/controllers/admin/enterprise_groups_controller.rb'
     - 'app/controllers/admin/enterprises_controller.rb'
     - 'app/controllers/admin/order_cycles_controller.rb'
+    - 'app/controllers/admin/reports_controller.rb'
     - 'app/controllers/admin/resource_controller.rb'
     - 'app/controllers/admin/stripe_connect_settings_controller.rb'
     - 'app/controllers/api/v0/enterprise_attachment_controller.rb'
@@ -1713,6 +1725,7 @@ Style/HashSyntax:
     - 'spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb'
     - 'spec/lib/reports/packing/packing_report_spec.rb'
     - 'spec/lib/reports/products_and_inventory_report_spec.rb'
+    - 'spec/lib/spree/core/product_duplicator_spec.rb'
     - 'spec/lib/stripe/account_connector_spec.rb'
     - 'spec/lib/tasks/data/remove_transient_data_spec.rb'
     - 'spec/lib/tasks/data/truncate_data_spec.rb'

--- a/app/controllers/concerns/order_error_handling.rb
+++ b/app/controllers/concerns/order_error_handling.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module OrderErrorHandling
+  extend ActiveSupport::Concern
+
+  private
+
+  def render_error
+    flash.now[:error] ||= I18n.t(
+      'split_checkout.errors.saving_failed',
+      messages: order_error_messages
+    )
+
+    render status: :unprocessable_entity, cable_ready: cable_car.
+      replace("#checkout", partial("split_checkout/checkout")).
+      replace("#flashes", partial("shared/flashes", locals: { flashes: flash }))
+  end
+
+  def order_error_messages
+    # Remove ship_address.* errors if no shipping method is not selected
+    remove_ship_address_errors if no_ship_address_needed?
+
+    # Reorder errors to make sure the most important ones are shown first
+    # and finally, return the error messages to sentence
+    reorder_errors.map(&:full_message).to_sentence
+  end
+
+  def reorder_errors
+    @order.errors.sort_by do |e|
+      case e.attribute
+      when /email/i then 0
+      when /phone/i then 1
+      when /bill_address/i then 2 + bill_address_error_order(e)
+      else 20
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/order_shipping.rb
+++ b/app/controllers/concerns/order_shipping.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module OrderShipping
+  extend ActiveSupport::Concern
+
+  private
+
+  def no_ship_address_needed?
+    @order.errors[:shipping_method].present? || params[:ship_address_same_as_billing] == "1"
+  end
+
+  def remove_ship_address_errors
+    @order.errors.delete("ship_address.firstname")
+    @order.errors.delete("ship_address.address1")
+    @order.errors.delete("ship_address.city")
+    @order.errors.delete("ship_address.phone")
+    @order.errors.delete("ship_address.lastname")
+    @order.errors.delete("ship_address.zipcode")
+  end
+
+  def bill_address_error_order(error)
+    case error.attribute
+    when /firstname/i then 0
+    when /lastname/i then 1
+    when /address1/i then 2
+    when /city/i then 3
+    when /zipcode/i then 4
+    else 5
+    end
+  end
+
+  def flash_error_when_no_shipping_method_available
+    flash[:error] = I18n.t('split_checkout.errors.no_shipping_methods_available')
+  end
+
+  def use_shipping_address_from_distributor
+    @order.ship_address = @order.address_from_distributor
+
+    # Add the missing data
+    bill_address = params[:order][:bill_address_attributes]
+    @order.ship_address.firstname = bill_address[:firstname]
+    @order.ship_address.lastname = bill_address[:lastname]
+    @order.ship_address.phone = bill_address[:phone]
+
+    # Remove shipping address from parameter so we don't override the address we just set
+    params[:order].delete(:ship_address_attributes)
+  end
+
+  def shipping_method_ship_address_not_required?
+    selected_shipping_method = available_shipping_methods&.select do |sm|
+      sm.id.to_s == params[:shipping_method_id]
+    end
+
+    return false if selected_shipping_method.empty?
+
+    selected_shipping_method.first.require_ship_address == false
+  end
+end

--- a/app/controllers/concerns/order_steps.rb
+++ b/app/controllers/concerns/order_steps.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module OrderSteps
+  extend ActiveSupport::Concern
+
+  private
+
+  def summary_step?
+    params[:step] == "summary"
+  end
+
+  def payment_step?
+    params[:step] == "payment"
+  end
+
+  def advance_order_state
+    return if @order.complete?
+
+    OrderWorkflow.new(@order).advance_checkout(raw_params.slice(:shipping_method_id))
+  end
+
+  def redirect_to_step_based_on_order
+    case @order.state
+    when "cart", "address", "delivery"
+      redirect_to checkout_step_path(:details)
+    when "payment"
+      redirect_to checkout_step_path(:payment)
+    when "confirmation"
+      redirect_to checkout_step_path(:summary)
+    else
+      redirect_to order_path(@order, order_token: @order.token)
+    end
+  end
+
+  def redirect_to_step
+    case params[:step]
+    when "details"
+      return redirect_to checkout_step_path(:payment)
+    when "payment"
+      return redirect_to checkout_step_path(:summary)
+    end
+    redirect_to_step_based_on_order
+  end
+
+  def check_step
+    case @order.state
+    when "cart", "address", "delivery"
+      redirect_to checkout_step_path(:details) unless params[:step] == "details"
+    when "payment"
+      redirect_to checkout_step_path(:payment) if params[:step] == "summary"
+    end
+  end
+end

--- a/app/controllers/concerns/order_vouchers.rb
+++ b/app/controllers/concerns/order_vouchers.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module OrderVouchers
+  extend ActiveSupport::Concern
+
+  private
+
+  def render_voucher_section_or_redirect
+    respond_to do |format|
+      format.cable_ready { render_voucher_section }
+      format.html { redirect_to checkout_step_path(:payment) }
+    end
+  end
+
+  # Using the power of cable_car we replace only the #voucher_section instead of reloading the page
+  def render_voucher_section
+    render(
+      status: :ok,
+      cable_ready: cable_car.replace(
+        "#voucher-section",
+        partial(
+          "split_checkout/voucher_section",
+          locals: { order: @order, voucher_adjustment: @order.voucher_adjustments.first }
+        )
+      )
+    )
+  end
+
+  def process_voucher
+    if add_voucher
+      VoucherAdjustmentsService.calculate(@order)
+      render_voucher_section_or_redirect
+    elsif @order.errors.present?
+      render_error
+    end
+  end
+
+  def add_voucher
+    if params.dig(:order, :voucher_code).blank?
+      @order.errors.add(:voucher, I18n.t('split_checkout.errors.voucher_not_found'))
+      return false
+    end
+
+    # Fetch Voucher
+    voucher = Voucher.find_by(code: params[:order][:voucher_code], enterprise: @order.distributor)
+
+    if voucher.nil?
+      @order.errors.add(:voucher, I18n.t('split_checkout.errors.voucher_not_found'))
+      return false
+    end
+
+    adjustment = voucher.create_adjustment(voucher.code, @order)
+
+    unless adjustment.valid?
+      @order.errors.add(:voucher, I18n.t('split_checkout.errors.add_voucher_error'))
+      adjustment.errors.each { |error| @order.errors.import(error) }
+      return false
+    end
+
+    true
+  end
+end

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -11,6 +11,10 @@ class SplitCheckoutController < ::BaseController
   include OrderCompletion
   include CablecarResponses
   include WhiteLabel
+  include OrderErrorHandling
+  include OrderShipping
+  include OrderSteps
+  include OrderVouchers
 
   helper 'terms_and_conditions'
   helper 'checkout'
@@ -48,86 +52,6 @@ class SplitCheckoutController < ::BaseController
   end
 
   private
-
-  def render_error
-    flash.now[:error] ||= I18n.t(
-      'split_checkout.errors.saving_failed',
-      messages: order_error_messages
-    )
-
-    render status: :unprocessable_entity, cable_ready: cable_car.
-      replace("#checkout", partial("split_checkout/checkout")).
-      replace("#flashes", partial("shared/flashes", locals: { flashes: flash }))
-  end
-
-  def render_voucher_section_or_redirect
-    respond_to do |format|
-      format.cable_ready { render_voucher_section }
-      format.html { redirect_to checkout_step_path(:payment) }
-    end
-  end
-
-  # Using the power of cable_car we replace only the #voucher_section instead of reloading the page
-  def render_voucher_section
-    render(
-      status: :ok,
-      cable_ready: cable_car.replace(
-        "#voucher-section",
-        partial(
-          "split_checkout/voucher_section",
-          locals: { order: @order, voucher_adjustment: @order.voucher_adjustments.first }
-        )
-      )
-    )
-  end
-
-  def order_error_messages
-    # Remove ship_address.* errors if no shipping method is not selected
-    remove_ship_address_errors if no_ship_address_needed?
-
-    # Reorder errors to make sure the most important ones are shown first
-    # and finally, return the error messages to sentence
-    reorder_errors.map(&:full_message).to_sentence
-  end
-
-  def no_ship_address_needed?
-    @order.errors[:shipping_method].present? || params[:ship_address_same_as_billing] == "1"
-  end
-
-  def remove_ship_address_errors
-    @order.errors.delete("ship_address.firstname")
-    @order.errors.delete("ship_address.address1")
-    @order.errors.delete("ship_address.city")
-    @order.errors.delete("ship_address.phone")
-    @order.errors.delete("ship_address.lastname")
-    @order.errors.delete("ship_address.zipcode")
-  end
-
-  def reorder_errors
-    @order.errors.sort_by do |e|
-      case e.attribute
-      when /email/i then 0
-      when /phone/i then 1
-      when /bill_address/i then 2 + bill_address_error_order(e)
-      else 20
-      end
-    end
-  end
-
-  def bill_address_error_order(error)
-    case error.attribute
-    when /firstname/i then 0
-    when /lastname/i then 1
-    when /address1/i then 2
-    when /city/i then 3
-    when /zipcode/i then 4
-    else 5
-    end
-  end
-
-  def flash_error_when_no_shipping_method_available
-    flash[:error] = I18n.t('split_checkout.errors.no_shipping_methods_available')
-  end
 
   def check_payments_adjustments
     @order.payments.each(&:ensure_correct_adjustment)
@@ -178,77 +102,6 @@ class SplitCheckoutController < ::BaseController
     @order.errors.empty?
   end
 
-  def use_shipping_address_from_distributor
-    @order.ship_address = @order.address_from_distributor
-
-    # Add the missing data
-    bill_address = params[:order][:bill_address_attributes]
-    @order.ship_address.firstname = bill_address[:firstname]
-    @order.ship_address.lastname = bill_address[:lastname]
-    @order.ship_address.phone = bill_address[:phone]
-
-    # Remove shipping address from parameter so we don't override the address we just set
-    params[:order].delete(:ship_address_attributes)
-  end
-
-  def shipping_method_ship_address_not_required?
-    selected_shipping_method = available_shipping_methods&.select do |sm|
-      sm.id.to_s == params[:shipping_method_id]
-    end
-
-    return false if selected_shipping_method.empty?
-
-    selected_shipping_method.first.require_ship_address == false
-  end
-
-  def process_voucher
-    if add_voucher
-      VoucherAdjustmentsService.calculate(@order)
-      render_voucher_section_or_redirect
-    elsif @order.errors.present?
-      render_error
-    end
-  end
-
-  def add_voucher
-    if params.dig(:order, :voucher_code).blank?
-      @order.errors.add(:voucher, I18n.t('split_checkout.errors.voucher_not_found'))
-      return false
-    end
-
-    # Fetch Voucher
-    voucher = Voucher.find_by(code: params[:order][:voucher_code], enterprise: @order.distributor)
-
-    if voucher.nil?
-      @order.errors.add(:voucher, I18n.t('split_checkout.errors.voucher_not_found'))
-      return false
-    end
-
-    adjustment = voucher.create_adjustment(voucher.code, @order)
-
-    unless adjustment.valid?
-      @order.errors.add(:voucher, I18n.t('split_checkout.errors.add_voucher_error'))
-      adjustment.errors.each { |error| @order.errors.import(error) }
-      return false
-    end
-
-    true
-  end
-
-  def summary_step?
-    params[:step] == "summary"
-  end
-
-  def payment_step?
-    params[:step] == "payment"
-  end
-
-  def advance_order_state
-    return if @order.complete?
-
-    OrderWorkflow.new(@order).advance_checkout(raw_params.slice(:shipping_method_id))
-  end
-
   def validate_current_step!
     step = ([params[:step]] & ["details", "payment", "summary"]).first
     send("validate_#{step}!")
@@ -275,37 +128,5 @@ class SplitCheckoutController < ::BaseController
 
   def order_params
     @order_params ||= Checkout::Params.new(@order, params, spree_current_user).call
-  end
-
-  def redirect_to_step_based_on_order
-    case @order.state
-    when "cart", "address", "delivery"
-      redirect_to checkout_step_path(:details)
-    when "payment"
-      redirect_to checkout_step_path(:payment)
-    when "confirmation"
-      redirect_to checkout_step_path(:summary)
-    else
-      redirect_to order_path(@order, order_token: @order.token)
-    end
-  end
-
-  def redirect_to_step
-    case params[:step]
-    when "details"
-      return redirect_to checkout_step_path(:payment)
-    when "payment"
-      return redirect_to checkout_step_path(:summary)
-    end
-    redirect_to_step_based_on_order
-  end
-
-  def check_step
-    case @order.state
-    when "cart", "address", "delivery"
-      redirect_to checkout_step_path(:details) unless params[:step] == "details"
-    when "payment"
-      redirect_to checkout_step_path(:payment) if params[:step] == "summary"
-    end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #8942 

Large class sizes make code less readable. 

#### What should we test?

#### Release notes

Changelog Category: Technical changes

Reduced the size of split_checkout_controller.rb

#### Dependencies

Should wait for #10966 to rebase `.rubocop_todo.yml`

#### Documentation updates
