### PR TITLE
Remove split checkout from feature toggle

### DIFF
--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -32,9 +32,6 @@ module OpenFoodNetwork
       "new_products_page" => <<~DESC,
         Show the new (experimental) version of the admin products page.
       DESC
-      "split_checkout" => <<~DESC,
-        Replace the one-page checkout with a multi-step checkout.
-      DESC
       "vouchers" => <<~DESC,
         Add voucher functionality. Voucher can be managed via Enterprise settings.
       DESC

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -117,28 +117,22 @@ describe Customer, type: :model do
       end
     end
 
-    context "with split checkout enabled" do
-      before do
-        Flipper.enable(:split_checkout)
-      end
+    context 'visible' do
+      let!(:customer) { create(:customer) }
+      let!(:customer2) { create(:customer) }
+      let!(:customer3) { create(:customer) }
+      let!(:customer4) { create(:customer) }
+      let!(:customer5) { create(:customer, created_manually: true) }
 
-      context 'visible' do
-        let!(:customer) { create(:customer) }
-        let!(:customer2) { create(:customer) }
-        let!(:customer3) { create(:customer) }
-        let!(:customer4) { create(:customer) }
-        let!(:customer5) { create(:customer, created_manually: true) }
+      let!(:order_ready_for_details) { create(:order_ready_for_details, customer: customer) }
+      let!(:order_ready_for_payment) { create(:order_ready_for_payment, customer: customer2) }
+      let!(:order_ready_for_confirmation) {
+        create(:order_ready_for_confirmation, customer: customer3)
+      }
+      let!(:completed_order) { create(:completed_order_with_totals, customer: customer4) }
 
-        let!(:order_ready_for_details) { create(:order_ready_for_details, customer: customer) }
-        let!(:order_ready_for_payment) { create(:order_ready_for_payment, customer: customer2) }
-        let!(:order_ready_for_confirmation) {
-          create(:order_ready_for_confirmation, customer: customer3)
-        }
-        let!(:completed_order) { create(:completed_order_with_totals, customer: customer4) }
-
-        it 'returns customers with completed orders' do
-          expect(Customer.visible).to match_array [customer4, customer5]
-        end
+      it 'returns customers with completed orders' do
+        expect(Customer.visible).to match_array [customer4, customer5]
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

This is after the [comment](https://github.com/openfoodfoundation/openfoodnetwork/pull/10913#issuecomment-1621729422) 

It looks like the split checkout was not removed from the feature toggle list on [PR](https://github.com/openfoodfoundation/openfoodnetwork/pull/10913).
 
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Check if the split checkout is removed from the Feature toggle list.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
