### PR TITLE
Drop unused Spree Promotion Tables

### DIFF
--- a/db/migrate/20230706033212_drop_spree_promotion_tables.rb
+++ b/db/migrate/20230706033212_drop_spree_promotion_tables.rb
@@ -1,0 +1,9 @@
+class DropSpreePromotionTables < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :spree_products_promotion_rules
+    drop_table :spree_promotion_action_line_items
+    drop_table :spree_promotion_actions
+    drop_table :spree_promotion_rules
+    drop_table :spree_promotion_rules_users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_28_144825) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_06_033212) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -763,48 +763,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_28_144825) do
     t.index ["supplier_id"], name: "index_spree_products_on_supplier_id"
   end
 
-  create_table "spree_products_promotion_rules", id: false, force: :cascade do |t|
-    t.integer "product_id"
-    t.integer "promotion_rule_id"
-    t.index ["product_id"], name: "index_products_promotion_rules_on_product_id"
-    t.index ["promotion_rule_id"], name: "index_products_promotion_rules_on_promotion_rule_id"
-  end
-
   create_table "spree_products_taxons", id: :serial, force: :cascade do |t|
     t.integer "product_id"
     t.integer "taxon_id"
     t.index ["product_id"], name: "index_products_taxons_on_product_id"
     t.index ["taxon_id"], name: "index_products_taxons_on_taxon_id"
-  end
-
-  create_table "spree_promotion_action_line_items", id: :serial, force: :cascade do |t|
-    t.integer "promotion_action_id"
-    t.integer "variant_id"
-    t.integer "quantity", default: 1
-  end
-
-  create_table "spree_promotion_actions", id: :serial, force: :cascade do |t|
-    t.integer "activator_id"
-    t.integer "position"
-    t.string "type", limit: 255
-  end
-
-  create_table "spree_promotion_rules", id: :serial, force: :cascade do |t|
-    t.integer "activator_id"
-    t.integer "user_id"
-    t.integer "product_group_id"
-    t.string "type", limit: 255
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.index ["product_group_id"], name: "index_promotion_rules_on_product_group_id"
-    t.index ["user_id"], name: "index_promotion_rules_on_user_id"
-  end
-
-  create_table "spree_promotion_rules_users", id: false, force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "promotion_rule_id"
-    t.index ["promotion_rule_id"], name: "index_promotion_rules_users_on_promotion_rule_id"
-    t.index ["user_id"], name: "index_promotion_rules_users_on_user_id"
   end
 
   create_table "spree_properties", id: :serial, force: :cascade do |t|
@@ -1307,14 +1270,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_28_144825) do
   add_foreign_key "spree_products", "spree_shipping_categories", column: "shipping_category_id", name: "spree_products_shipping_category_id_fk"
   add_foreign_key "spree_products", "spree_tax_categories", column: "tax_category_id", name: "spree_products_tax_category_id_fk"
   add_foreign_key "spree_products", "spree_taxons", column: "primary_taxon_id", name: "spree_products_primary_taxon_id_fk"
-  add_foreign_key "spree_products_promotion_rules", "spree_products", column: "product_id", name: "spree_products_promotion_rules_product_id_fk"
-  add_foreign_key "spree_products_promotion_rules", "spree_promotion_rules", column: "promotion_rule_id", name: "spree_products_promotion_rules_promotion_rule_id_fk"
   add_foreign_key "spree_products_taxons", "spree_products", column: "product_id", name: "spree_products_taxons_product_id_fk", on_delete: :cascade
   add_foreign_key "spree_products_taxons", "spree_taxons", column: "taxon_id", name: "spree_products_taxons_taxon_id_fk", on_delete: :cascade
-  add_foreign_key "spree_promotion_action_line_items", "spree_promotion_actions", column: "promotion_action_id", name: "spree_promotion_action_line_items_promotion_action_id_fk"
-  add_foreign_key "spree_promotion_action_line_items", "spree_variants", column: "variant_id", name: "spree_promotion_action_line_items_variant_id_fk"
-  add_foreign_key "spree_promotion_actions", "spree_activators", column: "activator_id", name: "spree_promotion_actions_activator_id_fk"
-  add_foreign_key "spree_promotion_rules", "spree_activators", column: "activator_id", name: "spree_promotion_rules_activator_id_fk"
   add_foreign_key "spree_return_authorizations", "spree_orders", column: "order_id", name: "spree_return_authorizations_order_id_fk"
   add_foreign_key "spree_roles_users", "spree_roles", column: "role_id", name: "spree_roles_users_role_id_fk"
   add_foreign_key "spree_roles_users", "spree_users", column: "user_id", name: "spree_roles_users_user_id_fk"


### PR DESCRIPTION
#### What? Why?

We found some tables that aren't in use. We don't have models for these, and probably never used them.

I took a look at the au-prod database and found a small handful of records in a couple of tables, that don't seem to amount to anything (they weren't linked to any products). The timestamp was from 2013.


#### What should we test?
No application code has changed so I don't think we need to test anything.

#### Release notes

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

