### PR TITLE
Checkout, Summary step: Display the ship/delivery address (instead of the billing one)

### DIFF
--- a/app/views/split_checkout/_summary.html.haml
+++ b/app/views/split_checkout/_summary.html.haml
@@ -15,26 +15,26 @@
           .summary-subtitle
             = t("split_checkout.step3.delivery_details.address")
           %span
-            = @order.bill_address.firstname
-            = @order.bill_address.lastname
+            = @order.ship_address.firstname
+            = @order.ship_address.lastname
           %div
-            = @order.bill_address.phone
+            = @order.ship_address.phone
           %div
             = @order.user.email if @order.user
           %br
           %div
-            = @order.bill_address.address1
-          - unless @order.bill_address.address2.blank?
+            = @order.ship_address.address1
+          - unless @order.ship_address.address2.blank?
             %div
-              = @order.bill_address.address2
+              = @order.ship_address.address2
           %div
-            = @order.bill_address.city
+            = @order.ship_address.city
           %div
-            = @order.bill_address.state
+            = @order.ship_address.state
           %div
-            = @order.bill_address.zipcode
+            = @order.ship_address.zipcode
           %div
-            = @order.bill_address.country
+            = @order.ship_address.country
           - if @order.special_instructions.present?
             %br
             %em

--- a/spec/factories/address_factory.rb
+++ b/spec/factories/address_factory.rb
@@ -27,6 +27,8 @@ FactoryBot.define do
       address1 { FFaker::Address.street_address }
       address2 { nil }
       phone { FFaker::PhoneNumber.phone_number }
+      city { FFaker::Address.city }
+      zipcode { FFaker::AddressUS.zip_code }
     end
   end
 end

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -293,7 +293,9 @@ describe OrderSyncer do
             create(:address, firstname: original_bill_address.firstname,
                              lastname: original_bill_address.lastname,
                              address1: distributor_address.address1,
-                             phone: original_bill_address.phone)
+                             phone: original_bill_address.phone,
+                             city: distributor_address.city,
+                             zipcode: distributor_address.zipcode)
           end
           let(:subscription) do
             create(:subscription, shop: distributor, bill_address: original_bill_address,

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -917,6 +917,32 @@ describe "As a consumer, I want to checkout my order" do
         create(:order_ready_for_confirmation, distributor: distributor)
       }
 
+      describe "display the delivery address and not the ship address" do
+        let(:ship_address) { create(:address, :randomized) }
+        let(:bill_address) { create(:address, :randomized) }
+
+        before do
+          order.update_attribute(:ship_address, ship_address)
+          order.update_attribute(:bill_address, bill_address)
+          visit checkout_step_path(:summary)
+        end
+
+        it "displays the ship address" do
+          expect(page).to have_content "Delivery address"
+          expect(page).to have_content order.ship_address.address1
+          expect(page).to have_content order.ship_address.city
+          expect(page).to have_content order.ship_address.zipcode
+          expect(page).to have_content order.ship_address.phone
+        end
+
+        it "and not the billing address" do
+          expect(page).not_to have_content order.bill_address.address1
+          expect(page).not_to have_content order.bill_address.city
+          expect(page).not_to have_content order.bill_address.zipcode
+          expect(page).not_to have_content order.bill_address.phone
+        end
+      end
+
       describe "with an order with special instructions" do
         before do
           order.update_attribute(:special_instructions, "Please deliver on Tuesday")


### PR DESCRIPTION
#### What? Why?

- Closes #11171 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Well described in the linked issue:
- Put items in your cart and proceed to checkout.
 - On step 1 of checkout select a 'delivery' shipping method and type a different delivery address than the bill address.
 - Proceed to step 3 of checkout.
 - Look at the address displayed under 'delivery address', this should be the delivery address

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes