### PR TITLE
Adds spec for profile change

### DIFF
--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -847,7 +847,7 @@ describe '
 
         # Producer hub option is selected
         page.find('a', class: 'selected', text: "PRODUCER HUB")
-        expect(enterprise.is_primary_producer).to eq true
+        expect(enterprise.reload.is_primary_producer).to eq true
         expect(enterprise.reload.sells).to eq('any')
 
         # Displays the correct dashboard sections
@@ -863,7 +863,7 @@ describe '
         click_button "Change Package"
 
         page.find('a', class: 'selected', text: "PRODUCER SHOP")
-        expect(enterprise.is_primary_producer).to eq true
+        expect(enterprise.reload.is_primary_producer).to eq true
         expect(enterprise.reload.sells).to eq('own')
 
         # Displays the correct dashboard sections
@@ -879,8 +879,17 @@ describe '
         click_button "Change Package"
 
         page.find('a', class: 'selected', text: "PRODUCER PROFILE")
-        expect(enterprise.is_primary_producer).to eq true
+
+        # a primary producer:
+        expect(enterprise.reload.is_primary_producer).to eq true
+
+        # which is not selling:
         expect(enterprise.reload.sells).to eq('none')
+
+        # then, this should imply
+        # producer_profile_only to be true
+        # this probably relates to issue #7835
+        expect(enterprise.reload.producer_profile_only).to eq false
 
         # Displays the correct dashboard sections
         assert_supplier_menu
@@ -923,7 +932,7 @@ describe '
 
         page.find('a', class: 'selected', text: "PROFILE ONLY")
         expect(enterprise.reload.is_primary_producer).to eq false
-        expect(enterprise.reload.producer_profile_only).to eq false # this should be true?
+        expect(enterprise.reload.producer_profile_only).to eq false
 
         # Displays the correct dashboard sections
         assert_profile
@@ -980,8 +989,17 @@ describe '
 
         # Displays the correct dashboard sections
         assert_supplier_menu
-        expect(enterprise.reload.sells).to eq('none')
+
+        # a primary producer:
         expect(enterprise.reload.is_primary_producer).to eq true
+
+        # which is not selling:
+        expect(enterprise.reload.sells).to eq('none')
+
+        # then, this should imply
+        # producer_profile_only to be true
+        # this probably relates to issue #7835
+        expect(enterprise.reload.producer_profile_only).to eq false
       end
     end
 


### PR DESCRIPTION
#### What? Why?

- Relates to https://github.com/openfoodfoundation/openfoodnetwork/issues/7835 -> it seems this field is ~~only updated when the package is changed via `/enterprises` page~~ never updated
- Relates [release test automation] -> Removes item in the weekly test template: `Enterprise/Change package`

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

There are two distinct places in the app, in which the user can change package:
- via `/admin` -> dashboarad
- via `/enterprises` page

This PR adds specs to both. Once this is merged we can stop testing it manually, on the weekly release testing routine.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
