### PR TITLE
[vouchers] fix delete voucher when tax excluded from price

### DIFF
--- a/app/controllers/voucher_adjustments_controller.rb
+++ b/app/controllers/voucher_adjustments_controller.rb
@@ -15,7 +15,11 @@ class VoucherAdjustmentsController < BaseController
   end
 
   def destroy
-    @order.voucher_adjustments.find_by(id: params[:id])&.destroy
+    # An order can have more than one adjustment linked to one voucher
+    adjustment = @order.voucher_adjustments.find_by(id: params[:id])
+    if adjustment.present?
+      @order.voucher_adjustments.where(originator_id: adjustment.originator_id)&.destroy_all
+    end
 
     update_payment_section
   end

--- a/spec/requests/voucher_adjustments_spec.rb
+++ b/spec/requests/voucher_adjustments_spec.rb
@@ -96,5 +96,26 @@ describe VoucherAdjustmentsController, type: :request do
         expect(response).to be_successful
       end
     end
+
+    context "when tax excluded from price" do
+      it "deletes all voucher adjustment" do
+        # Add a tax adjustment
+        adjustment_attributes = {
+          amount: 2.00,
+          originator: adjustment.originator,
+          order: order,
+          label: "Tax #{adjustment.label}",
+          mandatory: false,
+          state: 'closed',
+          tax_category: nil,
+          included_tax: 0
+        }
+        order.adjustments.create(adjustment_attributes)
+
+        delete "/voucher_adjustments/#{adjustment.id}"
+
+        expect(order.voucher_adjustments.reload.length).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #11183 

Fix deleting a vouchers when used with a tax excluded from price


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Assuming you have voucher enabled, have an enterprise set up with a voucher and have set up a tax excluded from price 
- Add something to the cart, and proceed to checkout
- Proceed to payment step
- Add a voucher
- Delete voucher by clicking on the "remove code"
- Voucher should be deleted and "Enter voucher code" input should be visible

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
This PR #11135 will need to merged first
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

