### PR TITLE
Admin, White Label: check the custom tab checkbox if any errors on custom tab (ie. title is blank)

### DIFF
--- a/app/views/admin/enterprises/form/_white_label.html.haml
+++ b/app/views/admin/enterprises/form/_white_label.html.haml
@@ -46,7 +46,8 @@
     = label_tag :custom_tab, t('.create_custom_tab')
   .thirteen.columns
     = hidden_field_tag :custom_tab, "false" # submit `true` if checkbox is checked, `false` otherwise
-    = check_box_tag :custom_tab, "true", @object.custom_tab&.title.present?, { "data-controller": "checkbox-display", "data-checkbox-display-target-id-value": "custom_tab_form" }
+    - checked = @object.custom_tab&.title.present? || @object.errors["custom_tab.title"].present?
+    = check_box_tag :custom_tab, "true", checked, { "data-controller": "checkbox-display", "data-checkbox-display-target-id-value": "custom_tab_form" }
 
 %div{id: "custom_tab_form"}
   = f.fields_for :custom_tab, @object.custom_tab do |custom_tab_form|  

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -760,6 +760,11 @@ describe '
               click_button 'Update'
               expect(page).to have_content("Custom tab title can't be blank")
               expect(distributor1.reload.custom_tab).to be_nil
+
+              within(".side_menu") do
+                click_link "White Label"
+              end
+              expect(page).to have_checked_field "Create custom tab in shopfront"
             end
 
             it "can't save custom tab fields if title is too long" do


### PR DESCRIPTION
#### What? Why?

- Closes #10975 


<img width="1392" alt="Capture d’écran 2023-07-10 à 16 31 48" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/d1bba7ba-7b2a-4c7c-aa0f-09fe51a506fa">



#### What should we test?
Well explained in the linked issue, nothing to add. 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes