### PR TITLE
Admin, products page: avoid js error in console

### DIFF
--- a/app/views/spree/admin/products/index/_products_product.html.haml
+++ b/app/views/spree/admin/products/index/_products_product.html.haml
@@ -16,7 +16,7 @@
     %input{ 'ng-model' => 'product.master.unit_value_with_description', :name => 'master_unit_value_with_description', 'ofn-track-master' => 'unit_value_with_description', :type => 'text', :placeholder => 'value', 'ng-show' => "!hasVariants(product) && hasUnit(product)", 'ofn-maintain-unit-scale' => true }
     %input{ 'ng-model' => 'product.variant_unit_name', :name => 'variant_unit_name', 'ofn-track-product' => 'variant_unit_name', :placeholder => 'unit', 'ng-show' => "product.variant_unit_with_scale == 'items'", :type => 'text' }
   %td.display_as{ 'ng-show' => 'columns.unit.visible' }
-    %input{ 'ofn-display-as' => 'product.master', name: 'display_as', 'ofn-track-master' => 'display_as', type: 'text', placeholder: '{{ placeholder_text }}', ng: { hide: 'hasVariants(product)', model: 'product.master.display_as' } }
+    %input{ 'ofn-display-as' => 'product.variants[0]', name: 'display_as', 'ofn-track-master' => 'display_as', type: 'text', placeholder: '{{ placeholder_text }}', ng: { hide: 'hasVariants(product)', model: 'product.master.display_as' } }
   %td.price{ 'ng-show' => 'columns.price.visible' }
     %input{ 'ng-model' => 'product.price', 'ofn-decimal' => :true, :name => 'price', 'ofn-track-product' => 'price', :type => 'text', 'ng-hide' => 'hasVariants(product)' }
   %td.on_hand{ 'ng-show' => 'columns.on_hand.visible' }


### PR DESCRIPTION
This probably needs some more thoughts : 

 - `product.master` has been removed some time ago, but i can see 69 results in 8 files (in `js.coffee` files and `haml` files)
 - I only changed for the particular issue we had on `/admin/products`, but maybe there are more?
 - We probably could solve the issue by creating a _fake_ `master` attribute in `admin/services/bulk_products.js.coffee` (this is a bit hacky)

```diff
diff --git a/app/assets/javascripts/admin/services/bulk_products.js.coffee b/app/assets/javascripts/admin/services/bulk_products.js.coffee
index e8b8bb6c3d..e4401bcfc8 100644
--- a/app/assets/javascripts/admin/services/bulk_products.js.coffee
+++ b/app/assets/javascripts/admin/services/bulk_products.js.coffee
@@ -38,6 +38,7 @@ angular.module("ofn.admin").factory "BulkProducts", (ProductResource, dataFetche
       @products.splice(index + 1, 0, newProduct)
 
     unpackProduct: (product) ->
+      product.master = product.variants[0]
       #$scope.matchProducer product
       @loadVariantUnit product
 ```

#### What? Why?

- Closes #11195 



#### What should we test?
- As an admin, check page `/admin/products`
- Notice that no js errors are in console

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 