### PR TITLE
Show vouchers panel only if enterprise sells products (own or any)

### DIFF
--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -42,7 +42,7 @@ module Admin
         { name: 'shipping_methods', icon_class: "icon-truck", show: show_shipping_methods },
         { name: 'payment_methods',  icon_class: "icon-money", show: show_payment_methods },
         { name: 'enterprise_fees',  icon_class: "icon-tasks", show: show_enterprise_fees },
-        { name: 'vouchers', icon_class: "icon-ticket", show: true },
+        { name: 'vouchers', icon_class: "icon-ticket", show: is_shop },
         { name: 'enterprise_permissions', icon_class: "icon-plug", show: true,
           href: admin_enterprise_relationships_path },
         { name: 'inventory_settings', icon_class: "icon-list-ol", show: is_shop },

--- a/spec/system/admin/vouchers_spec.rb
+++ b/spec/system/admin/vouchers_spec.rb
@@ -9,7 +9,7 @@ describe '
   include WebHelper
   include AuthenticationHelper
 
-  let(:enterprise) { create(:supplier_enterprise, name: 'Feedme') }
+  let(:enterprise) { create(:supplier_enterprise, name: 'Feedme', sells: 'own') }
   let(:voucher_code) { 'awesomevoucher' }
   let(:amount) { 25 }
   let(:enterprise_user) { create(:user, enterprise_limit: 1) }


### PR DESCRIPTION
#### What? Why?

- Closes #10867 

<img width="997" alt="Capture d’écran 2023-07-19 à 15 48 32" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/cb828760-6ca5-45f5-a9df-a6913e5692d5">

<img width="1065" alt="Capture d’écran 2023-07-19 à 15 49 07" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/3f25dee9-3100-456b-af1a-7680ea8d02d4">

<img width="972" alt="Capture d’écran 2023-07-19 à 15 49 30" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/69b1c79f-8da6-4a20-be99-7a8b335ef002">

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- With `vouchers` feature enabled, on `/admin/enterprises/[ENTERPRISE_SLUG]/edit` page, `Vouchers` panel should be show only if enterprise sells own or any products
- With `vouchers` feature not enabled, on `/admin/enterprises/[ENTERPRISE_SLUG]/edit` page, `Vouchers` panel should not be shown

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes