### PR TITLE
Shopfront: On non-shop tab, when changing OC, switch to shop tab and hides non-shop tab content

### DIFF
--- a/app/webpacker/controllers/tabs_and_panels_controller.js
+++ b/app/webpacker/controllers/tabs_and_panels_controller.js
@@ -49,9 +49,7 @@ export default class extends Controller {
   }
 
   updateActivePanel(panel_id) {
-    const newActivePanel = this.panelTargets.find(
-      (panel) => panel.id == panel_id
-    );
+    const newActivePanel = this.panelTargets.find((panel) => panel.id == panel_id);
 
     if (newActivePanel === undefined) {
       // No panel found
@@ -84,8 +82,6 @@ export default class extends Controller {
   }
 
   get currentActivePanel() {
-    return this.panelTargets.find(
-      (panel) => panel.id == `${this.currentActiveTab.id}_panel`
-    );
+    return this.panelTargets.find((panel) => panel.id == `${this.currentActiveTab.id}_panel`);
   }
 }

--- a/app/webpacker/controllers/tabs_and_panels_controller.js
+++ b/app/webpacker/controllers/tabs_and_panels_controller.js
@@ -40,8 +40,8 @@ export default class extends Controller {
   }
 
   simulateClick(tab, panel) {
-    this.updateActiveTab(tab);
     this.updateActivePanel(panel);
+    this.updateActiveTab(tab);
   }
 
   changeActivePanel(event) {


### PR DESCRIPTION
#### What? Why?

- Closes #11223 

The title of the PR is pretty cryptic, but it's well explained in the linked issue, and you can see the result here:

![2023-07-19 16 28 56](https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/c21fb58c-d402-4b8f-883d-58c8c711cd94)



#### What should we test?
- Go to a shop with multiple open order cycles
- Switch to a different tab (could be the white labelled one)
- Select an order cycle
- Check that we are _redirected_ to shop tab/panel
- Check that content from the previous tab is hidden

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes