### PR TITLE
Adds assertion on the Out of Stock message

### DIFF
--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -910,6 +910,8 @@ different_shipping_method_for_distributor1]
 
           visit spree.edit_admin_order_path(incomplete_order)
 
+          expect(page).to have_content "Out of Stock".upcase
+
           within ".insufficient-stock-items" do
             expect(page).to have_content incomplete_order.products.first.name
             accept_alert 'Are you sure?' do
@@ -917,6 +919,10 @@ different_shipping_method_for_distributor1]
             end
             expect(page).to_not have_content incomplete_order.products.first.name
           end
+          
+          # updates the order and verifies the warning disappears
+          click_button 'Update And Recalculate Fees'
+          expect(page).to_not have_content "Out of Stock".upcase
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

A minor spec change regarding a Out of Stock warning displayed in the backoffice, while editing an order with line items which are out of stock. I feel it's useful to document this behavior, and assure we keep it - since it is a visible message to the user.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- Asserts the message Out of Stock:

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/49817236/411704fc-f4b8-4516-aaa6-83bb1c249746)

- Asserts the message is not visible after removing the line item which is out of stock

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
