### PR TITLE
Fixes missing translation on Invoices tab

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3642,6 +3642,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   customer_details: "Customer Details"
   adjustments: "Adjustments"
   payments: "Payments"
+  invoices: "Invoices"
   return_authorizations: "Return Authorizations"
   credit_owed: "Credit Owed"
   new_adjustment: "New Adjustment"


### PR DESCRIPTION
#### What? Why?

- Closes #11237 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds the necessary key to `en.yml`.

This was triggering an error when running the build, and blocking specs:
```

  1) 
    As an administrator
    I want to create and edit orders
 Legal Invoices complete, resumed, cancelled orders displays the invoice tab
     Failure/Error: = link_to_with_icon 'icon-cogs', t(:invoices), spree.admin_order_invoices_url(@order)
     
     ActionView::Template::Error:
       Translation missing: en.invoices
```

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
