### PR TITLE
Add Ruby version to engines for Rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,16 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 4
-# Configuration parameters: Severity, Include.
-# Include: **/*.gemspec
-Gemspec/RequiredRubyVersion:
-  Exclude:
-    - 'engines/catalog/catalog.gemspec'
-    - 'engines/dfc_provider/dfc_provider.gemspec'
-    - 'engines/order_management/order_management.gemspec'
-    - 'engines/web/web.gemspec'
-
 # Offense count: 9
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowMultipleStyles, EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,9 +26,6 @@ PATH
   remote: engines/dfc_provider
   specs:
     dfc_provider (0.0.1)
-      active_model_serializers (~> 0.8.4)
-      jwt (~> 2.2)
-      rspec (~> 3.9)
 
 PATH
   remote: engines/order_management

--- a/engines/catalog/catalog.gemspec
+++ b/engines/catalog/catalog.gemspec
@@ -10,6 +10,8 @@ Gem::Specification.new do |s|
   s.authors     = ["developers@ofn"]
   s.summary     = "Catalog domain of the OFN solution."
 
+  s.required_ruby_version = File.read(File.expand_path("../../.ruby-version", __dir__)).chomp
+
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE.txt", "Rakefile", "README.rdoc"]
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/engines/dfc_provider/dfc_provider.gemspec
+++ b/engines/dfc_provider/dfc_provider.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.summary     = 'Provides an API stack implementing DFC semantic ' \
                      'specifications'
 
+  spec.required_ruby_version = File.read(File.expand_path("../../.ruby-version", __dir__)).chomp
+
   spec.files = Dir["{app,config,lib}/**/*"] + ['README.md']
 
   spec.add_dependency 'active_model_serializers', '~> 0.8.4'

--- a/engines/dfc_provider/dfc_provider.gemspec
+++ b/engines/dfc_provider/dfc_provider.gemspec
@@ -17,8 +17,5 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,lib}/**/*"] + ['README.md']
 
-  spec.add_dependency 'active_model_serializers', '~> 0.8.4'
-  spec.add_dependency 'jwt', '~> 2.2'
-  spec.add_dependency 'rspec', '~> 3.9'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/engines/order_management/order_management.gemspec
+++ b/engines/order_management/order_management.gemspec
@@ -10,6 +10,8 @@ Gem::Specification.new do |s|
   s.authors     = ["developers@ofn"]
   s.summary     = "Order Management domain of the OFN solution."
 
+  s.required_ruby_version = File.read(File.expand_path("../../.ruby-version", __dir__)).chomp
+
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE.txt", "Rakefile", "README.rdoc"]
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/engines/web/web.gemspec
+++ b/engines/web/web.gemspec
@@ -10,6 +10,8 @@ Gem::Specification.new do |s|
   s.authors     = ["developers@ofn"]
   s.summary     = "Web domain of the OFN solution."
 
+  s.required_ruby_version = File.read(File.expand_path("../../.ruby-version", __dir__)).chomp
+
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE.txt", "Rakefile", "README.rdoc"]
   s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION

#### What? Why?

- Closes #11245 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

> This ensures that RuboCop is using the same Ruby version as the gem.

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Gemspec/RequiredRubyVersion


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
