### PR TITLE
Admin, Enterprise creation : set visibility to "Hidden" by default

### DIFF
--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -92,7 +92,7 @@ module Admin
         return render :welcome, layout: "spree/layouts/bare_admin"
       end
 
-      attributes = { sells: register_params[:sells], visible: true }
+      attributes = { sells: register_params[:sells], visible: "only_through_links" }
 
       if @enterprise.update(attributes)
         flash[:success] = I18n.t(:enterprise_register_success_notice, enterprise: @enterprise.name)

--- a/app/controllers/api/v0/enterprises_controller.rb
+++ b/app/controllers/api/v0/enterprises_controller.rb
@@ -74,7 +74,7 @@ module Api
       end
 
       def override_visible
-        enterprise_params[:visible] = false
+        enterprise_params[:visible] = "only_through_links"
       end
 
       def enterprise_params

--- a/db/migrate/20230720080504_change_defaultvalue_for_visible_enterprise.rb
+++ b/db/migrate/20230720080504_change_defaultvalue_for_visible_enterprise.rb
@@ -1,0 +1,9 @@
+class ChangeDefaultvalueForVisibleEnterprise < ActiveRecord::Migration[7.0]
+  def up
+    change_column :enterprises, :visible, :string, default: "only_through_links"
+  end
+
+  def down
+    change_column :enterprises, :visible, :string, default: "public"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_06_033212) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_20_080504) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -233,7 +233,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_06_033212) do
     t.boolean "enable_subscriptions", default: false, null: false
     t.integer "business_address_id"
     t.boolean "show_customer_names_to_suppliers", default: false, null: false
-    t.string "visible", limit: 255, default: "public", null: false
+    t.string "visible", default: "only_through_links", null: false
     t.string "whatsapp_phone", limit: 255
     t.boolean "hide_ofn_navigation", default: false, null: false
     t.text "white_label_logo_link"

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -453,6 +453,11 @@ describe Admin::EnterprisesController, type: :controller do
           expect(flash[:error]).to eq "Please select a package"
         end
       end
+
+      it "set visibility to 'only_through_links' by default" do
+        spree_post :register, id: enterprise, sells: 'none'
+        expect(enterprise.reload.visible).to eq 'only_through_links'
+      end
     end
   end
 

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -47,6 +47,15 @@ describe Admin::EnterprisesController, type: :controller do
       expect(distributor_manager.enterprise_roles.where(enterprise_id: enterprise).first).to be
     end
 
+    it "set the `visible` attribute to `hidden`" do
+      allow(controller).to receive_messages spree_current_user: distributor_manager
+      enterprise_params[:enterprise][:owner_id] = distributor_manager
+
+      spree_put :create, enterprise_params
+      enterprise = Enterprise.find_by name: 'zzz'
+      expect(enterprise.visible).to eq 'only_through_links'
+    end
+
     context "when I already own a hub" do
       before { distributor }
 

--- a/spec/controllers/api/v0/enterprises_controller_spec.rb
+++ b/spec/controllers/api/v0/enterprises_controller_spec.rb
@@ -37,6 +37,14 @@ describe Api::V0::EnterprisesController, type: :controller do
         expect(enterprise.sells).to eq('any')
       end
 
+      it "creates a visible=hidden enterprise" do
+        api_post :create, { enterprise: new_enterprise_params }
+        expect(response.status).to eq 201
+
+        enterprise = Enterprise.last
+        expect(enterprise.visible).to eq("only_through_links")
+      end
+
       it "saves all user ids submitted" do
         manager1 = create(:user)
         manager2 = create(:user)

--- a/spec/factories/enterprise_factory.rb
+++ b/spec/factories/enterprise_factory.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     description { 'enterprise' }
     long_description { '<p>Hello, world!</p><p>This is a paragraph.</p>' }
     address
+    visible { 'public' }
 
     after(:create) do |enterprise, proxy|
       proxy.users.each do |user|

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -63,6 +63,9 @@ describe '
 
     click_button 'Create'
     expect(flash_message).to eq('Enterprise "Eaterprises" has been successfully created!')
+
+    # `Visible in search` radio button should be set to `Hide all references` by default
+    expect(page).to have_checked_field "enterprise_visible_only_through_links"
   end
 
   it "editing an existing enterprise" do

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -155,6 +155,8 @@ describe "Registration" do
       page.find('.full_hub h3').click
       click_button "Select and Continue"
       expect(page).to have_content "Your profile live"
+      click_link "Manage My Awesome Enterprise"
+      expect(page).to have_checked_field "enterprise_visible_only_through_links"
     end
 
     context "when the user has no more remaining enterprises" do


### PR DESCRIPTION
#### What? Why?

- Closes #9123


<img width="1105" alt="Capture d’écran 2023-07-20 à 11 20 24" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/e2a4c07c-f26e-4375-bc8d-41d8eb07f7c9">



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
###### As an admin
- As a admin, create an enterprise
- Check that its visibility is set to `only_through_links` (ie. "Hidden" in the UI) by default
###### As a user
- As a user, create an enterprise
- Check that its visibility is set to `only_through_links` (ie. "Hidden" in the UI) by default

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes