### PR TITLE
Admin, Products & Inventory reports: add `on_hand` and `on_demand?` columns by default ; mark `Inventory (on hand)` report as deprecated

### DIFF
--- a/app/views/admin/reports/_report_subtype.html.haml
+++ b/app/views/admin/reports/_report_subtype.html.haml
@@ -2,4 +2,7 @@
   - report_subtypes.each do |report_subtype|
     %li
       - url = main_app.admin_report_path(report_type: report_type, report_subtype: report_subtype[1])
-      = link_to report_subtype[0], url
+      - if report_subtype.dig(2, :deprecated)
+        %strike= link_to report_subtype[0], url, title: t('admin.reports.deprecated')
+      - else
+        = link_to report_subtype[0], url

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1453,6 +1453,7 @@ en:
       email_confirmation: "Email confirmation is pending. We've sent a confirmation email to %{email}."
       not_visible: "%{enterprise} is not visible and so cannot be found on the map or in searches"
     reports:
+      deprecated: "This report is deprecated and will be removed in a future release."
       hidden: HIDDEN
       unitsize: UNITSIZE
       total: TOTAL

--- a/lib/reporting/reports/list.rb
+++ b/lib/reporting/reports/list.rb
@@ -40,7 +40,7 @@ module Reporting
       def products_and_inventory_report_types
         [
           [i18n_translate("all_products"), :all_products],
-          [i18n_translate("inventory"), :inventory],
+          [i18n_translate("inventory"), :inventory, { deprecated: true }],
           [i18n_translate("lettuce_share"), :lettuce_share]
         ]
       end

--- a/lib/reporting/reports/products_and_inventory/all_products.rb
+++ b/lib/reporting/reports/products_and_inventory/all_products.rb
@@ -4,10 +4,6 @@ module Reporting
   module Reports
     module ProductsAndInventory
       class AllProducts < Base
-        def default_params
-          { fields_to_hide: [:on_demand, :on_hand] }
-        end
-
         def message
           I18n.t("spree.admin.reports.products_and_inventory.all_products.message")
         end

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -423,22 +423,23 @@ describe '
       expect(page).to have_content "Supplier"
       expect(page).to have_table_row ["Supplier", "Producer Suburb", "Product",
                                       "Product Properties", "Taxons", "Variant Value", "Price",
-                                      "Group Buy Unit Quantity", "Amount", "SKU"].map(&:upcase)
+                                      "Group Buy Unit Quantity", "Amount", "SKU",
+                                      "On demand?", "On hand"].map(&:upcase)
       expect(page).to have_table_row [product1.supplier.name, product1.supplier.address.city,
                                       "Product Name",
                                       product1.properties.map(&:presentation).join(", "),
                                       product1.primary_taxon.name, "1g", "100.0",
-                                      "none", "", "sku1"]
+                                      "none", "", "sku1", "No", "10"]
       expect(page).to have_table_row [product1.supplier.name, product1.supplier.address.city,
                                       "Product Name",
                                       product1.properties.map(&:presentation).join(", "),
                                       product1.primary_taxon.name, "1g", "80.0",
-                                      "none", "", "sku2"]
+                                      "none", "", "sku2", "No", "20"]
       expect(page).to have_table_row [product2.supplier.name, product1.supplier.address.city,
                                       "Product 2",
                                       product1.properties.map(&:presentation).join(", "),
                                       product2.primary_taxon.name, "100g", "99.0",
-                                      "none", "", "product_sku"]
+                                      "none", "", "product_sku", "No", "9"]
     end
 
     it "shows the LettuceShare report" do


### PR DESCRIPTION
#### What? Why?

- Closes #11207 

Linked issue has been updated and description is a bit ouf of date, see comment: https://github.com/openfoodfoundation/openfoodnetwork/issues/11207#issuecomment-1643737108

So, this PR:

 - Set `on_demand?` and `on_hand` columns as default ones (not hidden) for the `All products` report
 
<img width="440" alt="Capture d’écran 2023-07-20 à 15 35 34" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/f0f9672b-59c2-4255-aaae-200330e38daf">

 - Mark `Inventory (on hand)` report as deprecated
###### By default
<img width="725" alt="Capture d’écran 2023-07-20 à 15 30 58" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/c5c6bfd0-5248-4bd0-8ec7-dac8aca1b44b">

###### When hovering
<img width="841" alt="Capture d’écran 2023-07-20 à 15 30 54" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/f1ca5101-e8d3-4fa3-ac5a-9488106ea08f">


#### What should we test?

- As an admin, you should see `Inventory (on hand)` deprecated (but clickable)
- As an admin, going to `All products` report should display `on_demand?` and `on_hand` columns by default. ⚠️ You should have cleaned your saved rendering options preferences by running
```
DELETE FROM report_rendering_options WHERE user_id = YOUR_USER_ID 
```

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes