### PR TITLE
Adds missing key

### DIFF
--- a/app/views/spree/admin/invoices/_invoices_table.html.haml
+++ b/app/views/spree/admin/invoices/_invoices_table.html.haml
@@ -5,7 +5,7 @@
       %th= t(:invoice_number)
       %th= t(:amount)
       %th= t(:status)
-      %th= t(:file)
+      %th= t(:invoice_file)
   %tbody
     - @order.invoices.each do |invoice|
       - tr_class = cycle('odd', 'even')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3138,6 +3138,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   date_completed: "Date Completed"
   amount: "Amount"
   invoice_number: "Invoice Number"
+  invoice_file: "File"
   state_names:
     ready: Ready
     pending: Pending


### PR DESCRIPTION
#### What? Why?

- Closes #11250

- Adds the key to the `File` string on `en.yml`
- Renames it of the respective view -> I've found `invoices_file:` to be more descriptive than just `file:` -> I've found this [list of best practices](https://www.transifex.com/blog/2015/naming-string-identifiers-best-practices for naming keys/).

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

These are the only changes in the PR (marked yellow, below). It seems only one additional key on `en.yml` was needed to close #11250, the others were really just missing translations from the other locales - I've "tested" this PR locally, and could change all strings on the `es.yml` locale:

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/49817236/09372805-87cf-4083-a66e-b0fae88c92d3)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
