### PR TITLE
Add new relic gem

### DIFF
--- a/.env
+++ b/.env
@@ -62,6 +62,8 @@ SMTP_PASSWORD="f00d"
 # STRIPE_CLIENT_ID="ca_xxxx" # This can be a development ID or a production ID
 # STRIPE_ENDPOINT_SECRET="whsec_xxxx"
 
+# New relic settings
 # see: https://one.eu.newrelic.com/admin-portal/, Administration > API keys to get the license key
+# NEW_RELIC_AGENT_ENABLED=true
 # NEW_RELIC_APP_NAME="Open Food Network"
 # NEW_RELIC_LICENSE_KEY="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/.env
+++ b/.env
@@ -61,3 +61,7 @@ SMTP_PASSWORD="f00d"
 # STRIPE_INSTANCE_PUBLISHABLE_KEY="pk_test_xxxx" # This can be a test key or a live key
 # STRIPE_CLIENT_ID="ca_xxxx" # This can be a development ID or a production ID
 # STRIPE_ENDPOINT_SECRET="whsec_xxxx"
+
+# see: https://one.eu.newrelic.com/admin-portal/, Administration > API keys to get the license key
+# NEW_RELIC_APP_NAME="Open Food Network"
+# NEW_RELIC_LICENSE_KEY="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/Gemfile
+++ b/Gemfile
@@ -139,6 +139,7 @@ gem "faraday"
 gem "private_address_check"
 
 group :production, :staging do
+  gem 'newrelic_rpm'
   gem 'sd_notify' # For better Systemd process management. Used by Puma.
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -138,8 +138,9 @@ gem 'mini_portile2', '~> 2.8'
 gem "faraday"
 gem "private_address_check"
 
+gem 'newrelic_rpm'
+
 group :production, :staging do
-  gem 'newrelic_rpm'
   gem 'sd_notify' # For better Systemd process management. Used by Puma.
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,6 +422,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    newrelic_rpm (9.3.1)
     nio4r (2.5.9)
     nokogiri (1.15.3)
       mini_portile2 (~> 2.8.2)
@@ -847,6 +848,7 @@ DEPENDENCIES
   mimemagic (> 0.3.5)
   mini_portile2 (~> 2.8)
   monetize (~> 1.11)
+  newrelic_rpm
   oauth2 (~> 1.4.7)
   omniauth-rails_csrf_protection
   omniauth_openid_connect

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,67 @@
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python, Node, and Go applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated October 28, 2022
+#
+# This configuration file is custom generated for NewRelic Administration
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  # Use NEW_RELIC_APP_NAME env variable to specify the license key
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  # Use NEW_RELIC_APP_NAME env variable to customize the application name
+  app_name: "Open Food Network"
+
+  distributed_tracing:
+    enabled: true
+
+  # To disable the agent regardless of other settings, uncomment the following:
+
+  # agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+  application_logging:
+    # If `true`, all logging-related features for the agent can be enabled or disabled
+    # independently. If `false`, all logging-related features are disabled.
+    enabled: true
+    forwarding:
+      # If `true`, the agent captures log records emitted by this application.
+      enabled: true
+      # Defines the maximum number of log records to buffer in memory at a time.
+      max_samples_stored: 10000
+    metrics:
+      # If `true`, the agent captures metrics related to logging for this application.
+      enabled: true
+    local_decorating:
+      # If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.
+      # This requires a log forwarder to send your log files to New Relic.
+      # This should not be used when forwarding is enabled.
+      enabled: false
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: 'Open Food Network (Development)'
+  monitor_mode: false
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: 'Open Food Network (Staging)'
+
+production:
+  <<: *default_settings

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -11,7 +11,7 @@
 
 common: &default_settings
   # Required license key associated with your New Relic account.
-  # Use NEW_RELIC_APP_NAME env variable to specify the license key
+  # Use NEW_RELIC_LICENSE_KEY env variable to specify the license key
 
   # Your application name. Renaming here affects where data displays in New
   # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
@@ -22,8 +22,8 @@ common: &default_settings
     enabled: true
 
   # To disable the agent regardless of other settings, uncomment the following:
-
-  # agent_enabled: false
+  # Agent is disabled by default, to enable set NEW_RELIC_AGENT_ENABLE env variable to true
+  agent_enabled: false
 
   # Logging level for log/newrelic_agent.log
   log_level: info
@@ -52,7 +52,6 @@ common: &default_settings
 development:
   <<: *default_settings
   app_name: 'Open Food Network (Development)'
-  monitor_mode: false
 
 test:
   <<: *default_settings


### PR DESCRIPTION
#### What? Why?
Related to #10997

It uses the following env varirable to enable new relic agent, setup the licence key and customise application name: 
* NEW_RELIC_AGENT_ENABLED
* NEW_RELIC_LICENSE_KEY
* NEW_RELIC_APP_NAME

The agent is disable by default so we can enable new relic for the production server that needs it.
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

* Set up the license key and application name 
* Stage the application
* Play around a little bit with the website
* Check that data is being sent to New Relic

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
