### PR TITLE
Fix Rubocop Layout violations - 2

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,21 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 9
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowMultipleStyles, EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle.
-# SupportedHashRocketStyles: key, separator, table
-# SupportedColonStyles: key, separator, table
-# SupportedLastArgumentHashStyles: always_inspect, always_ignore, ignore_implicit, ignore_explicit
-Layout/HashAlignment:
-  Exclude:
-    - 'app/controllers/spree/users_controller.rb'
-    - 'spec/models/enterprise_spec.rb'
-    - 'spec/system/admin/customers_spec.rb'
-    - 'spec/system/admin/order_spec.rb'
-    - 'spec/system/admin/orders_spec.rb'
-    - 'spec/system/admin/tag_rules_spec.rb'
-
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,16 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 4
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: normal, indented_internal_methods
-Layout/IndentationConsistency:
-  Exclude:
-    - 'spec/system/admin/order_cycles/complex_updating_specific_time_spec.rb'
-    - 'spec/system/admin/order_cycles/simple_spec.rb'
-    - 'spec/system/admin/product_import_spec.rb'
-
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowDoxygenCommentStyle, AllowGemfileRubyComment.
@@ -32,7 +22,7 @@ Layout/LineContinuationSpacing:
     - 'spec/system/admin/enterprise_fees_spec.rb'
     - 'spec/system/admin/order_spec.rb'
 
-# Offense count: 92
+# Offense count: 94
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
 # URISchemes: http, https
@@ -40,6 +30,7 @@ Layout/LineLength:
   Exclude:
     - 'app/components/confirm_modal_component.rb'
     - 'app/controllers/admin/product_import_controller.rb'
+    - 'app/controllers/spree/users_controller.rb'
     - 'app/models/customer.rb'
     - 'app/models/spree/line_item.rb'
     - 'spec/controllers/admin/order_cycles_controller_spec.rb'
@@ -63,6 +54,7 @@ Layout/LineLength:
     - 'spec/system/admin/customers_spec.rb'
     - 'spec/system/admin/order_cycles/simple_spec.rb'
     - 'spec/system/admin/order_spec.rb'
+    - 'spec/system/admin/orders_spec.rb'
     - 'spec/system/admin/product_import_spec.rb'
     - 'spec/system/consumer/shopping/cart_spec.rb'
     - 'spec/system/consumer/shopping/products_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowDoxygenCommentStyle, AllowGemfileRubyComment.
-Layout/LeadingCommentSpace:
-  Exclude:
-    - 'spec/system/admin/enterprises_spec.rb'
-
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,15 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 4
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/LineContinuationSpacing:
-  Exclude:
-    - 'spec/system/admin/enterprise_fees_spec.rb'
-    - 'spec/system/admin/order_spec.rb'
-
 # Offense count: 94
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,38 +6,29 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 94
+# Offense count: 67
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
 # URISchemes: http, https
 Layout/LineLength:
   Exclude:
-    - 'app/components/confirm_modal_component.rb'
-    - 'app/controllers/admin/product_import_controller.rb'
     - 'app/controllers/spree/users_controller.rb'
     - 'app/models/customer.rb'
     - 'app/models/spree/line_item.rb'
     - 'spec/controllers/admin/order_cycles_controller_spec.rb'
-    - 'spec/controllers/api/v0/order_cycles_controller_spec.rb'
     - 'spec/controllers/spree/admin/orders_controller_spec.rb'
     - 'spec/lib/reports/customers_report_spec.rb'
     - 'spec/migrations/migrate_customer_names_spec.rb'
-    - 'spec/models/enterprise_spec.rb'
     - 'spec/models/order_cycle_spec.rb'
     - 'spec/models/product_importer_spec.rb'
-    - 'spec/models/spree/ability_spec.rb'
     - 'spec/models/spree/adjustment_spec.rb'
     - 'spec/models/spree/line_item_spec.rb'
-    - 'spec/models/spree/product_spec.rb'
     - 'spec/models/spree/variant_spec.rb'
-    - 'spec/requests/api/orders_spec.rb'
     - 'spec/services/products_renderer_spec.rb'
-    - 'spec/support/request/web_helper.rb'
     - 'spec/system/admin/adjustments_spec.rb'
     - 'spec/system/admin/bulk_order_management_spec.rb'
     - 'spec/system/admin/customers_spec.rb'
     - 'spec/system/admin/order_cycles/simple_spec.rb'
-    - 'spec/system/admin/order_spec.rb'
     - 'spec/system/admin/orders_spec.rb'
     - 'spec/system/admin/product_import_spec.rb'
     - 'spec/system/consumer/shopping/cart_spec.rb'
@@ -78,7 +69,7 @@ Layout/TrailingEmptyLines:
   Exclude:
     - 'Rakefile'
 
-# Offense count: 77
+# Offense count: 80
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowInHeredoc.
 Layout/TrailingWhitespace:

--- a/app/components/confirm_modal_component.rb
+++ b/app/components/confirm_modal_component.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ConfirmModalComponent < ModalComponent
-  def initialize(id:, confirm_actions: nil, reflex: nil, controller: nil, message: nil, confirm_reflexes: nil)
+  def initialize(id:, confirm_actions: nil, reflex: nil, controller: nil, message: nil,
+                 confirm_reflexes: nil)
     super(id: id, close_button: true)
     @confirm_actions = confirm_actions
     @reflex = reflex

--- a/app/controllers/admin/product_import_controller.rb
+++ b/app/controllers/admin/product_import_controller.rb
@@ -139,7 +139,8 @@ module Admin
     end
 
     def raise_invalid_file_path
-      redirect_to '/admin/product_import', notice: I18n.t(:product_import_no_data_in_spreadsheet_notice)
+      redirect_to '/admin/product_import',
+                  notice: I18n.t(:product_import_no_data_in_spreadsheet_notice)
       raise 'Invalid File Path'
     end
     TEMP_FILE_PATH_REGEX = %r{^/tmp/product_import[A-Za-z0-9-]*/import\.csv$}

--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -50,7 +50,7 @@ module Spree
           "#signup-feedback",
           partial("layouts/alert", 
                   locals: { type: "success",
-                  message: t('devise.user_registrations.spree_user.signed_up_but_unconfirmed') })
+                            message: t('devise.user_registrations.spree_user.signed_up_but_unconfirmed') })
         )
       else
         render status: :unprocessable_entity, cable_ready: cable_car.morph(

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -40,7 +40,9 @@ class Customer < ApplicationRecord
                     }
 
   scope :of, ->(enterprise) { where(enterprise_id: enterprise) }
-  scope :managed_by, ->(user) { user&.persisted? ? where(user: user).or(of(Enterprise.managed_by(user))) : none }
+  scope :managed_by, ->(user) {
+                       user&.persisted? ? where(user: user).or(of(Enterprise.managed_by(user))) : none
+                     }
   scope :created_manually, -> { where(created_manually: true) }
   scope :visible, -> { where(id: Spree::Order.complete.select(:customer_id)).or(created_manually) }
 

--- a/spec/controllers/api/v0/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/v0/order_cycles_controller_spec.rb
@@ -13,8 +13,12 @@ module Api
     let!(:property1) { create(:property, presentation: 'Organic') }
     let!(:property2) { create(:property, presentation: 'Dairy-Free') }
     let!(:property3) { create(:property, presentation: 'May Contain Nuts') }
-    let!(:product1) { create(:product, name: "Kangaroo", primary_taxon: taxon1, properties: [property1]) }
-    let!(:product2) { create(:product, name: "Parsnips", primary_taxon: taxon2, properties: [property2]) }
+    let!(:product1) {
+      create(:product, name: "Kangaroo", primary_taxon: taxon1, properties: [property1])
+    }
+    let!(:product2) {
+      create(:product, name: "Parsnips", primary_taxon: taxon2, properties: [property2])
+    }
     let!(:product3) { create(:product, primary_taxon: taxon2) }
     let!(:product4) { create(:product, primary_taxon: taxon3, properties: [property3]) }
     let!(:user) { create(:user) }

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -229,7 +229,9 @@ describe Spree::Admin::OrdersController, type: :controller do
       context "with line items" do
         let!(:distributor){ create(:distributor_enterprise) }
         let!(:shipment){ create(:shipment) }
-        let!(:order_cycle){ create(:simple_order_cycle, distributors: [distributor], variants: [line_item.variant]) }
+        let!(:order_cycle){
+          create(:simple_order_cycle, distributors: [distributor], variants: [line_item.variant])
+        }
 
         before do
           line_item.product.supplier = distributor

--- a/spec/lib/reports/customers_report_spec.rb
+++ b/spec/lib/reports/customers_report_spec.rb
@@ -90,10 +90,12 @@ module Reporting
               let!(:d){ create(:distributor_enterprise) }
               let!(:sm) { create(:shipping_method, distributors: [d]) }
               let!(:o1) {
-                create(:order_with_totals_and_distribution, :completed, distributor: d, bill_address: a, shipping_method: sm)
+                create(:order_with_totals_and_distribution, :completed, distributor: d,
+                                                                        bill_address: a, shipping_method: sm)
               }
               let!(:o2) {
-                create(:order_with_totals_and_distribution, :completed, distributor: d, bill_address: a, shipping_method: sm)
+                create(:order_with_totals_and_distribution, :completed, distributor: d,
+                                                                        bill_address: a, shipping_method: sm)
               }
               before do
                 [o1, o2].each do |order|
@@ -117,7 +119,8 @@ module Reporting
                 let!(:d2) { create(:distributor_enterprise) }
                 let!(:sm2) { create(:shipping_method, distributors: [d2]) }
                 let!(:o2) {
-                  create(:order_with_totals_and_distribution, :completed, distributor: d2, bill_address: a, shipping_method: sm2)
+                  create(:order_with_totals_and_distribution, :completed, distributor: d2,
+                                                                          bill_address: a, shipping_method: sm2)
                 }
 
                 it "returns one row per customer per hub" do
@@ -142,7 +145,8 @@ module Reporting
               context "orders with different shipping methods" do
                 let!(:sm2) { create(:shipping_method, distributors: [d], name: "Bike") }
                 let!(:o2) {
-                  create(:order_with_totals_and_distribution, :completed, distributor: d, bill_address: a, shipping_method: sm2)
+                  create(:order_with_totals_and_distribution, :completed, distributor: d,
+                                                                          bill_address: a, shipping_method: sm2)
                 }
                 before do
                   o2.select_shipping_method(sm2.id)

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -518,7 +518,8 @@ describe Enterprise do
         p1 = create(:simple_product, supplier: s1)
         p2 = create(:simple_product, supplier: s2)
 
-        expect(Enterprise.supplying_variant_in([p1.variants.first, p2.variants.first])).to match_array [s1, s2]
+        expect(Enterprise.supplying_variant_in([p1.variants.first, 
+                                                p2.variants.first])).to match_array [s1, s2]
       end
 
       it "does not return duplicates" do

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -903,7 +903,7 @@ describe Enterprise do
       distributor = create(:distributor_enterprise, is_primary_producer: false)
       permission = EnterpriseRelationshipPermission.create(name: "add_to_order_cycle")
       create(:enterprise_relationship, parent: distributor, child: supplier, 
-permissions: [permission])
+                                       permissions: [permission])
       product = create(:product)
       order_cycle = create(
         :simple_order_cycle,

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -337,7 +337,8 @@ describe Spree::Ability do
         is_expected.to have_ability([:admin, :read, :update, :bulk_update, :clone, :destroy],
                                     for: p1)
         is_expected.to have_ability(
-          [:admin, :index, :read, :edit, :update, :search, :destroy, :delete], for: p1.variants.first
+          [:admin, :index, :read, :edit, :update, :search, :destroy,
+           :delete], for: p1.variants.first
         )
       end
 
@@ -347,7 +348,8 @@ describe Spree::Ability do
         is_expected.to have_ability([:admin, :read, :update, :bulk_update, :clone, :destroy],
                                     for: p_related)
         is_expected.to have_ability(
-          [:admin, :index, :read, :edit, :update, :search, :destroy, :delete], for: p_related.variants.first
+          [:admin, :index, :read, :edit, :update, :search, :destroy,
+           :delete], for: p_related.variants.first
         )
       end
 
@@ -376,7 +378,8 @@ describe Spree::Ability do
 
       it "should not be able to read/write other enterprises' product variants" do
         is_expected.not_to have_ability(
-          [:admin, :index, :read, :create, :edit, :search, :update, :destroy], for: p2.variants.first
+          [:admin, :index, :read, :create, :edit, :search, :update,
+           :destroy], for: p2.variants.first
         )
       end
 

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -406,8 +406,10 @@ module Spree
           d2 = create(:distributor_enterprise)
           p1 = create(:product)
           p2 = create(:product)
-          create(:simple_order_cycle, suppliers: [s], distributors: [d1], variants: [p1.variants.first])
-          create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [p2.variants.first])
+          create(:simple_order_cycle, suppliers: [s], distributors: [d1],
+                                      variants: [p1.variants.first])
+          create(:simple_order_cycle, suppliers: [s], distributors: [d2],
+                                      variants: [p2.variants.first])
           expect(Product.in_distributor(d1)).to eq([p1])
         end
 
@@ -483,8 +485,10 @@ module Spree
           d2 = create(:distributor_enterprise)
           p1 = create(:product)
           p2 = create(:product)
-          create(:simple_order_cycle, suppliers: [s], distributors: [d1], variants: [p1.variants.first])
-          create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [p2.variants.first])
+          create(:simple_order_cycle, suppliers: [s], distributors: [d1],
+                                      variants: [p1.variants.first])
+          create(:simple_order_cycle, suppliers: [s], distributors: [d2],
+                                      variants: [p2.variants.first])
           expect(Product.in_supplier_or_distributor(d1)).to eq([p1])
         end
 
@@ -492,7 +496,8 @@ module Spree
           s = create(:supplier_enterprise)
           d = create(:distributor_enterprise)
           p = create(:product, supplier: s)
-          create(:simple_order_cycle, suppliers: [s], distributors: [d], variants: [p.variants.first])
+          create(:simple_order_cycle, suppliers: [s], distributors: [d],
+                                      variants: [p.variants.first])
           [s, d].each { |e| expect(Product.in_supplier_or_distributor(e)).to eq([p]) }
         end
       end

--- a/spec/requests/api/orders_spec.rb
+++ b/spec/requests/api/orders_spec.rb
@@ -164,7 +164,8 @@ describe 'api/v0/orders', swagger_doc: 'v0/swagger.yaml', type: :request do
             }
 
             let!(:order_not_empty_no_address) {
-              create(:order_with_line_items, line_items_count: 1, bill_address_id: nil, ship_address_id: nil)
+              create(:order_with_line_items, line_items_count: 1, bill_address_id: nil,
+                                             ship_address_id: nil)
             }
 
             let(:'q[state_eq]') { "cart" }

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -93,7 +93,8 @@ module WebHelper
   def tomselect_multiselect(value, options)
     tomselect_wrapper = page.find("[name='#{options[:from]}']").sibling(".ts-wrapper")
     tomselect_wrapper.find(".ts-control").click
-    tomselect_wrapper.find(:css, '.ts-dropdown.multi .ts-dropdown-content .option', text: value).click
+    tomselect_wrapper.find(:css, '.ts-dropdown.multi .ts-dropdown-content .option',
+                           text: value).click
   end
 
   def tomselect_search_and_select(value, options)

--- a/spec/system/admin/adjustments_spec.rb
+++ b/spec/system/admin/adjustments_spec.rb
@@ -26,7 +26,10 @@ describe '
 
   let!(:tax_category_included) { create(:tax_category, name: 'TVA 20%', is_default: true) }
   let!(:default_tax_zone) { create(:zone, default_tax: true) }
-  let!(:tax_rate2) { create(:tax_rate, name: "TVA 20%", amount: 0.2, zone: default_tax_zone, included_in_price: true, tax_category: tax_category_included, calculator: Calculator::DefaultTax.new ) }
+  let!(:tax_rate2) {
+    create(:tax_rate, name: "TVA 20%", amount: 0.2, zone: default_tax_zone, included_in_price: true,
+                      tax_category: tax_category_included, calculator: Calculator::DefaultTax.new )
+  }
 
   before do
     order.finalize!
@@ -64,21 +67,25 @@ describe '
 
     context "included tax" do
       context "adding negative, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "TVA 20%", "$0.33", "$-1.67"
+        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "TVA 20%",
+                        "$0.33", "$-1.67"
       end
 
       context "adding positive, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Late fee", "100", "TVA 20%", "$-16.67", "$83.33"
+        it_behaves_like "when the enable_localized_number preference", "Late fee", "100",
+                        "TVA 20%", "$-16.67", "$83.33"
       end
     end
 
     context "added tax" do
       context "adding negative, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "GST", "$10.00", "$8.00"
+        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "GST",
+                        "$10.00", "$8.00"
       end
 
       context "adding positive, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Late fee", "110", "GST", "$10.00", "$120"
+        it_behaves_like "when the enable_localized_number preference", "Late fee", "110", "GST",
+                        "$10.00", "$120"
       end
     end
   end
@@ -90,21 +97,25 @@ describe '
 
     context "included tax" do
       context "adding negative, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "TVA 20%", "$0.33", "$-1.67"
+        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "TVA 20%",
+                        "$0.33", "$-1.67"
       end
 
       context "adding positive, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Late fee", "100", "TVA 20%", "$-16.67", "$83.33"
+        it_behaves_like "when the enable_localized_number preference", "Late fee", "100",
+                        "TVA 20%", "$-16.67", "$83.33"
       end
     end
 
     context "added tax" do
       context "adding negative, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "GST", "$10.00", "$8.00"
+        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "GST",
+                        "$10.00", "$8.00"
       end
 
       context "adding positive, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Late fee", "110", "GST", "$10.00", "$120"
+        it_behaves_like "when the enable_localized_number preference", "Late fee", "110", "GST",
+                        "$10.00", "$120"
       end
     end
   end

--- a/spec/system/admin/adjustments_spec.rb
+++ b/spec/system/admin/adjustments_spec.rb
@@ -67,25 +67,25 @@ describe '
 
     context "included tax" do
       context "adding negative, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "TVA 20%",
-                        "$0.33", "$-1.67"
+        it_behaves_like "when the enable_localized_number preference",
+                        "Discount", "-2", "TVA 20%", "$0.33", "$-1.67"
       end
 
       context "adding positive, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Late fee", "100",
-                        "TVA 20%", "$-16.67", "$83.33"
+        it_behaves_like "when the enable_localized_number preference",
+                        "Late fee", "100", "TVA 20%", "$-16.67", "$83.33"
       end
     end
 
     context "added tax" do
       context "adding negative, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "GST",
-                        "$10.00", "$8.00"
+        it_behaves_like "when the enable_localized_number preference",
+                        "Discount", "-2", "GST", "$10.00", "$8.00"
       end
 
       context "adding positive, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Late fee", "110", "GST",
-                        "$10.00", "$120"
+        it_behaves_like "when the enable_localized_number preference",
+                        "Late fee", "110", "GST", "$10.00", "$120"
       end
     end
   end
@@ -97,25 +97,25 @@ describe '
 
     context "included tax" do
       context "adding negative, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "TVA 20%",
-                        "$0.33", "$-1.67"
+        it_behaves_like "when the enable_localized_number preference",
+                        "Discount", "-2", "TVA 20%", "$0.33", "$-1.67"
       end
 
       context "adding positive, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Late fee", "100",
-                        "TVA 20%", "$-16.67", "$83.33"
+        it_behaves_like "when the enable_localized_number preference",
+                        "Late fee", "100", "TVA 20%", "$-16.67", "$83.33"
       end
     end
 
     context "added tax" do
       context "adding negative, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Discount", "-2", "GST",
-                        "$10.00", "$8.00"
+        it_behaves_like "when the enable_localized_number preference",
+                        "Discount", "-2", "GST", "$10.00", "$8.00"
       end
 
       context "adding positive, taxed adjustments to an order" do
-        it_behaves_like "when the enable_localized_number preference", "Late fee", "110", "GST",
-                        "$10.00", "$120"
+        it_behaves_like "when the enable_localized_number preference",
+                        "Late fee", "110", "GST", "$10.00", "$120"
       end
     end
   end

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -16,7 +16,7 @@ describe 'Customers' do
     describe "using the customers index" do
       let!(:customer1) {
         create(:customer, first_name: 'John', last_name: 'Doe', enterprise: managed_distributor1, 
-code: nil, created_manually: true)
+                          code: nil, created_manually: true)
       }
       let!(:customer2) {
         create(:customer, enterprise: managed_distributor1, created_manually: true, code: nil)

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -49,12 +49,12 @@ describe '
     expect(page).to have_selector "input[value='Hello!']"
 
     # When I fill in the calculator fields and click update
-    fill_in "#{prefix}_calculator_attributes"\
+    fill_in "#{prefix}_calculator_attributes" \
             "_preferred_flat_percent", with: '12.34'
     click_button 'Update'
 
     # Then I should see the correct values in my calculator fields
-    expect(page).to have_selector("##{prefix}_calculator"\
+    expect(page).to have_selector("##{prefix}_calculator" \
                                   "_attributes_preferred_flat_percent[value='12.34']")
   end
 
@@ -139,7 +139,7 @@ describe '
     it 'shows error flash when updating fee amount with invalid values' do
       # When I fill in the calculator fields and click update
       fill_in(
-        "#{prefix}_calculator_attributes_"\
+        "#{prefix}_calculator_attributes_" \
         'preferred_flat_percent', with: "\'20.0'"
       )
       click_button 'Update'

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -201,7 +201,7 @@ describe '
     shop_message_input.native.send_keys('This is my shopfront message.')
     expect(page)
       .to have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_close_at"
-    #using "find" as fields outside of the screen and are not visible
+    # using "find" as fields outside of the screen and are not visible
     find(:xpath, '//*[@id="enterprise_preferred_shopfront_order_cycle_order_orders_open_at"]')
       .trigger("click")
     find(:xpath, '//*[@id="enterprise_enable_subscriptions_true"]').trigger("click")

--- a/spec/system/admin/order_cycles/complex_updating_specific_time_spec.rb
+++ b/spec/system/admin/order_cycles/complex_updating_specific_time_spec.rb
@@ -81,7 +81,7 @@ xdescribe '
     open_all_exchange_product_tabs
 
     expect(page).to have_selector
-      "#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}"
+    "#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}"
     # uncheck (with visible:true filter)
     page.find("#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}").click
     check "order_cycle_incoming_exchange_2_variants_#{v1.id}"

--- a/spec/system/admin/order_cycles/complex_updating_specific_time_spec.rb
+++ b/spec/system/admin/order_cycles/complex_updating_specific_time_spec.rb
@@ -80,8 +80,9 @@ xdescribe '
 
     open_all_exchange_product_tabs
 
-    expect(page).to have_selector
-    "#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}"
+    expect(page).to have_selector(
+      "#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}"
+    )
     # uncheck (with visible:true filter)
     page.find("#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}").click
     check "order_cycle_incoming_exchange_2_variants_#{v1.id}"

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -780,15 +780,17 @@ describe '
 
   def expect_payment_methods_to_be_checked_for(distributor)
     distributor.distributor_payment_method_ids.each do |distributor_payment_method_id|
-      expect(page).to have_checked_field
-      "order_cycle_selected_distributor_payment_method_ids_#{distributor_payment_method_id}"
+      expect(page).to have_checked_field(
+        "order_cycle_selected_distributor_payment_method_ids_#{distributor_payment_method_id}"
+      )
     end
   end
 
   def expect_shipping_methods_to_be_checked_for(distributor)
     distributor.distributor_shipping_method_ids.each do |distributor_shipping_method_id|
-      expect(page).to have_checked_field
-      "order_cycle_selected_distributor_shipping_method_ids_#{distributor_shipping_method_id}"
+      expect(page).to have_checked_field(
+        "order_cycle_selected_distributor_shipping_method_ids_#{distributor_shipping_method_id}"
+      )
     end
   end
 

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -781,14 +781,14 @@ describe '
   def expect_payment_methods_to_be_checked_for(distributor)
     distributor.distributor_payment_method_ids.each do |distributor_payment_method_id|
       expect(page).to have_checked_field
-        "order_cycle_selected_distributor_payment_method_ids_#{distributor_payment_method_id}"
+      "order_cycle_selected_distributor_payment_method_ids_#{distributor_payment_method_id}"
     end
   end
 
   def expect_shipping_methods_to_be_checked_for(distributor)
     distributor.distributor_shipping_method_ids.each do |distributor_shipping_method_id|
       expect(page).to have_checked_field
-        "order_cycle_selected_distributor_shipping_method_ids_#{distributor_shipping_method_id}"
+      "order_cycle_selected_distributor_shipping_method_ids_#{distributor_shipping_method_id}"
     end
   end
 

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -595,7 +595,8 @@ describe '
         end
 
         it "shows the link" do
-          expect(page).to have_link "Resend Confirmation", href: spree.resend_admin_order_path(order)
+          expect(page).to have_link "Resend Confirmation", 
+                                    href: spree.resend_admin_order_path(order)
         end
 
         it "resends the confirmation email" do
@@ -613,7 +614,8 @@ describe '
         end
 
         it "shows the link" do
-          expect(page).to have_link "Cancel Order", href: spree.fire_admin_order_path(order, e: 'cancel')
+          expect(page).to have_link "Cancel Order", 
+                                    href: spree.fire_admin_order_path(order, e: 'cancel')
         end
 
         it "cancels the order" do

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -705,7 +705,7 @@ describe '
       context "with different shipping methods" do
         let!(:different_shipping_method_for_distributor1) do
           create(:shipping_method_with, :flat_rate, name: "Different", amount: 15,
-distributors: [distributor1])
+                                                    distributors: [distributor1])
         end
         let!(:shipping_method_for_distributor2) do
           create(:shipping_method, name: "Other", distributors: [distributor2])

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -643,7 +643,7 @@ describe '
           end
 
           it 'can send invoices' do
-            accept_alert "An invoice for this order will be sent to the customer. "\
+            accept_alert "An invoice for this order will be sent to the customer. " \
                          "Are you sure you want to continue?" do
               click_link "Send Invoice"
             end

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -42,7 +42,7 @@ describe '
   }
   let!(:shipping_method2) {
     create(:shipping_method_with, :pickup, name: "delivery",
-   distributors: [distributor4, distributor5])
+                                           distributors: [distributor4, distributor5])
   }
   let(:order_cycle) do
     create(:simple_order_cycle, name: 'One', distributors: [distributor, distributor2,
@@ -246,17 +246,17 @@ describe '
     context "cart orders" do
       let!(:order_empty) {
         create(:order_with_line_items, user: customer2, distributor: distributor2,
-        line_items_count: 0)
+                                       line_items_count: 0)
       }
 
       let!(:order_not_empty) {
         create(:order_with_line_items, user: customer2, distributor: distributor2,
-        line_items_count: 1)
+                                       line_items_count: 1)
       }
 
       let!(:order_not_empty_no_address) {
         create(:order_with_line_items, line_items_count: 1, user: customer2,
-        distributor: distributor2, bill_address_id: nil, ship_address_id: nil)
+                                       distributor: distributor2, bill_address_id: nil, ship_address_id: nil)
       }
 
       before do

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -814,8 +814,9 @@ describe "Product Import" do
                               'price', 'on_hand', 'shipping_category', 'name']
 
           product_headings.each do |heading|
-            expect(page).to have_content 
-            I18n.t("admin.product_import.product_headings.#{heading}").upcase
+            expect(page).to have_content(
+              I18n.t("admin.product_import.product_headings.#{heading}").upcase
+            )
           end
         end
       end

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -815,7 +815,7 @@ describe "Product Import" do
 
           product_headings.each do |heading|
             expect(page).to have_content 
-              I18n.t("admin.product_import.product_headings.#{heading}").upcase
+            I18n.t("admin.product_import.product_headings.#{heading}").upcase
           end
         end
       end

--- a/spec/system/admin/tag_rules_spec.rb
+++ b/spec/system/admin/tag_rules_spec.rb
@@ -142,7 +142,7 @@ describe 'Tag Rules' do
     it "saves changes to rules of each type" do
       # Tag groups exist
       expect(page).to have_selector '.customer_tag .header', text: "For customers tagged:",
-                                    count: 4
+                                                             count: 4
       expect(page).to have_selector '.customer_tag .header tags-input .tag-list ti-tag-item',
                                     text: "member", count: 1
       expect(page).to have_selector '.customer_tag .header tags-input .tag-list ti-tag-item',


### PR DESCRIPTION
#### What? Why?

- Part of #6055 

This fixes 5 more rubocop rules that are violated in our codebase. It was generated automatically with the [rubocop-autocorrect.sh](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/script/rubocop-autocorrect.sh) script.

#### What should we test?

No testing required since these are safe corrections

#### Release notes

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
