### PR TITLE
🚧 Admin style v3: Add ability for non super-admin user to see products_v3 page

### DIFF
--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -191,6 +191,8 @@ module Spree
         OpenFoodNetwork::Permissions.new(user).managed_product_enterprises.include? product.supplier
       end
 
+      can [:admin, :index], :products_v3
+
       can [:create], Spree::Variant
       can [:admin, :index, :read, :edit,
            :update, :search, :delete, :destroy], Spree::Variant do |variant|


### PR DESCRIPTION
#### What? Why?

- Closes #11268 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

##### With feature `admin_style_v3` deactivated
No user should have acess

##### With feature `admin_style_v3` activated (global or per actor)
- As a non super-admin user, check that you've access to `/admin/products_v3` page if feature is activated for you (global or per actor and if you also have access to `/admin/products` page)
- As a super-admin user, check that you've access to `/admin/products_v3` page if feature is activated for you (global or per actor)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
