### PR TITLE
Fix removing customer tag when using search bar for said tag

### DIFF
--- a/app/assets/javascripts/admin/index_utils/directives/obj_for_update.js.coffee
+++ b/app/assets/javascripts/admin/index_utils/directives/obj_for_update.js.coffee
@@ -12,8 +12,7 @@ angular.module("admin.indexUtils").directive "objForUpdate", (switchClass, pendi
         scope.clear()
       else
         scope.pending()
-        value = if value? then value else ""
-        addPendingChange(scope.attr, value)
+        addPendingChange(scope.attr, value ? "")
 
     scope.reset = (value) ->
       scope.savedValue = value

--- a/app/assets/javascripts/admin/index_utils/directives/obj_for_update.js.coffee
+++ b/app/assets/javascripts/admin/index_utils/directives/obj_for_update.js.coffee
@@ -30,21 +30,24 @@ angular.module("admin.indexUtils").directive "objForUpdate", (switchClass, pendi
     scope.clear = ->
       switchClass( element, "", ["update-pending", "update-error", "update-success"], false )
 
-    # In the particular case of a list of customer filtered by a tag, we want to make sure the
-    # tag is removed when deleting the tag the list is filtered by.
-    # As the list is filter by tag, deleting the tag will remove the customer entry, thus
+    # When a list of customer is filtered and we removed the "filtered value" from a customer, we
+    # want to make sure the customer is updated. IE. filtering by tag, and removing said tag.
+    # Deleting the "filtered value" from a customer will remove the customer entry, thus
     # removing "objForUpdate" directive from the active scope. That means $watch won't pick up
-    # the tag_list changed.
-    # To ensure the tag is still deleted, we check on the $destroy event to see if the tag_list has
-    # changed, if so we queue up deleting the tag.
+    # the attribute changed.
+    # To ensure the customer is still updated, we check on the $destroy event to see if
+    # the attribute has changed, if so we queue up the change.
     scope.$on '$destroy', (value) ->
-      return if scope.attr != 'tag_list'
+      # No update
+      return if scope.object()[scope.attr] is scope.savedValue
 
-      # No tag has been deleted
-      return if scope.object()['tag_list'] == scope.savedValue
+      # For some reason the code attribute is removed from the object when cleared, so we add
+      # an emptyvalue so it gets updated properly
+      if scope.attr is "code" and scope.object()[scope.attr] is undefined
+        scope.object()["code"] = ""
 
-      # Queuing up change to delete tag
-      addPendingChange('tag_list', scope.object()['tag_list'])
+      # Queuing up change
+      addPendingChange(scope.attr, scope.object()[scope.attr])
 
     # private
 

--- a/app/views/admin/customers/index.html.haml
+++ b/app/views/admin/customers/index.html.haml
@@ -39,16 +39,15 @@
       %h1
         = t :loading_customers
 
-  .row{ :class => "sixteen columns alpha", 'ng-show' => '!RequestMonitor.loading && filteredCustomers.length == 0'}
-    %h1#no_results
-      =t :no_customers_found
-
-  .row.margin-bottom-50{ ng: { show: "!RequestMonitor.loading && filteredCustomers.length > 0" } }
+  .row.margin-bottom-50{ ng: { show: "!RequestMonitor.loading" } }
     %form{ name: "customers_form" }
+      %h1#no_results{ 'ng-show' => '!RequestMonitor.loading && filteredCustomers.length == 0' }
+        =t :no_customers_found
+
       %save-bar{ dirty: "customers_form.$dirty", persist: "false" }
         %input.red{ type: "button", value: t(:save_changes), ng: { click: "submitAll(customers_form)" } }
 
-      %table.index#customers
+      %table.index#customers{ 'ng-show' => '!RequestMonitor.loading && filteredCustomers.length > 0' }
         %col.email{ width: "20%", 'ng-show' => 'columns.email.visible' }
         %col.first_name{ width: "20%", 'ng-show' => 'columns.first_name.visible' }
         %col.last_name{ width: "20%", 'ng-show' => 'columns.last_name.visible' }

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -35,9 +35,11 @@ describe 'Customers' do
 
       it "passes the smoke test" do
         # Prompts for a hub for a list of my managed enterprises
-        expect(page)
-          .to have_select2 "shop_id", with_options: [managed_distributor1.name,
-                                                     managed_distributor2.name], without_options: [unmanaged_distributor.name]
+        expect(page).to have_select2(
+          "shop_id",
+          with_options: [managed_distributor1.name, managed_distributor2.name],
+          without_options: [unmanaged_distributor.name]
+        )
 
         select2_select managed_distributor2.name, from: "shop_id"
 
@@ -191,7 +193,7 @@ describe 'Customers' do
 
         context "when filtering by code" do
           before do
-            customer4.update code: 12345
+            customer4.update code: 12_345
 
             select2_select managed_distributor1.name, from: "shop_id"
 

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -37,8 +37,7 @@ describe 'Customers' do
         # Prompts for a hub for a list of my managed enterprises
         expect(page)
           .to have_select2 "shop_id", with_options: [managed_distributor1.name,
-                                                     managed_distributor2.name],
-                                      without_options: [unmanaged_distributor.name]
+                                                     managed_distributor2.name], without_options: [unmanaged_distributor.name]
 
         select2_select managed_distributor2.name, from: "shop_id"
 
@@ -180,6 +179,77 @@ describe 'Customers' do
             within "tr#c_#{customer1.id}" do
               expect(page).to have_content "CREDIT OWED"
               expect(page).to have_content "$63.00"
+            end
+          end
+        end
+      end
+
+      describe "filtering" do
+        before do
+          customer4.update enterprise: managed_distributor1
+        end
+
+        context "when filtering by code" do
+          before do
+            customer4.update code: 12345
+
+            select2_select managed_distributor1.name, from: "shop_id"
+
+            fill_in "quick_search", with: customer4.code
+          end
+
+          it "displays only customer matching the code" do
+            expect(page).to have_content(customer4.email)
+            expect(page).not_to have_content(customer1.email)
+            expect(page).not_to have_content(customer2.email)
+          end
+
+          context "when updating code" do
+            pending "allows user to save changes" do
+              fill_in "code", with: ""
+
+              expect(page).not_to have_content("12345")
+              expect(page).to have_content 'You have unsaved changes'
+
+              click_button "Save Changes"
+
+              # changes are saved in the database
+              expect(customer4.reload.code).to eq(nil)
+            end
+          end
+        end
+
+        context "when filtering by tag" do
+          before do
+            # Add test_tag to customer4
+            select2_select managed_distributor1.name, from: "shop_id"
+            within "tr#c_#{customer4.id}" do
+              find(:css, "tags-input .tags input").set "test_tag\n"
+            end
+            click_button "Save Changes"
+
+            # Reload the page
+            visit admin_customers_path
+            select2_select managed_distributor1.name, from: "shop_id"
+            fill_in "quick_search", with: "test_tag"
+          end
+
+          it "displays only customer matching the tag" do
+            expect(page).to have_content(customer4.email)
+            expect(page).not_to have_content(customer1.email)
+            expect(page).not_to have_content(customer2.email)
+          end
+
+          context "when removing tag" do
+            it "allows user to save changes" do
+              find("tags-input li.tag-item a.remove-button").click
+
+              expect(page).to have_content("No customers found")
+              expect(page).to have_content 'You have unsaved changes'
+
+              click_button "Save Changes"
+
+              expect(customer4.reload.tag_list).to be_empty
             end
           end
         end

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -205,7 +205,7 @@ describe 'Customers' do
           end
 
           context "when updating code" do
-            pending "allows user to save changes" do
+            it "allows user to save changes" do
               fill_in "code", with: ""
 
               expect(page).not_to have_content("12345")


### PR DESCRIPTION
#### What? Why?

- Closes #9553 

This fix makes sure removal of tags are added to pending changes, when the customer list is filtered by a specific tag and the use remove said tag from a customer. It results in the customer disappearing from the screen as it doesn't match the current filter any more.

This is where the magic happens on the template : 
https://github.com/openfoodfoundation/openfoodnetwork/blob/6f83d5b3163409fd7e59e9452f541c6655c39537/app/views/admin/customers/index.html.haml#L93-L94

The [objForUpdate](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/app/assets/javascripts/admin/index_utils/directives/obj_for_update.js.coffee) directive is in charge monitoring change, and queue any changes. The issue here is when you remove the filtered by tag from a customer, the customer is removed from the filtered list, thus removing the `objForUpdate` directive. It result on the changes not being queued. 
To fix this, we listen on the `$destroy` event and queue up change if a tag has been removed.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Make sure you have an enterprise with an existing tag, and a the tag to a few customers

- Go to customer list of an enterprise with tags
- Search for the tag 
- From filtered list of customers, remove the tag from a customer
  -> Customer disappear from the filtered list
  -> Save bar with "You have unsaved changes" is displayed
- Click on "Save changes"
   -> it should save changes successfully 
 - Change enterprise to a different one/leave page and return to force refresh of customer list
 - Search the tag again 
  -> the customer you removed the tag from is not in the filtered list

Check the above scenario with removing the tag from multiple customers.
When removing the last customer :
- "No customers found" will be displayed
- The save bar with "You have unsaved changes" is displayed
- Make sure to click on "Save changes" otherwise the customers won't be updated

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
