### PR TITLE
Fix swagger-api integration after last update

### DIFF
--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -5,7 +5,7 @@ Rswag::Api.configure do |config|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  config.swagger_root = Rails.root.join("swagger")
+  config.swagger_root = Rails.root.join("swagger").to_s
 
   # Inject a lamda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/spec/requests/api_docs_spec.rb
+++ b/spec/requests/api_docs_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "API documentation", type: :request do
+  it "shows the OFN API v1" do
+    get rswag_ui_path
+    expect(response).to redirect_to "/api-docs/index.html"
+
+    get "/api-docs/index.html"
+    expect(response).to have_http_status :success
+
+    expect(response.body).to match "API V1"
+  end
+
+  it "can load the Swagger config" do
+    get "/api-docs/v1/swagger.yaml"
+    expect(response).to have_http_status :success
+  end
+end


### PR DESCRIPTION

#### What? Why?

The API docs are broken since we updated the rswag-api gem.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

See also:

* https://github.com/rswag/rswag/pull/668


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit `/api-docs`
- The API documentation should display.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
