### PR TITLE
White label: Update mobile variant size for white label logo to fit the same ratio

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -91,7 +91,7 @@ class Enterprise < ApplicationRecord
   end
   has_one_attached :white_label_logo, service: image_service do |attachment|
     attachment.variant :default, resize_to_fill: [217, 44]
-    attachment.variant :mobile,  resize_to_fill: [75, 26]
+    attachment.variant :mobile,  resize_to_fill: [128, 26]
   end
 
   validates :logo,


### PR DESCRIPTION
#### What? Why?

- Closes #11205 


Default size is `217*44`. On mobile, we used to use `75*26`, but with a different image.

With the white label, using the same image, we should have the same ratio between default and mobile ; that's why I've updated the width of the variant to 128. Seems to fit!

##### Desktop view
<img width="860" alt="Capture d’écran 2023-07-26 à 14 44 01" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/bf39193b-b5b8-4bbf-92c4-a7439e4be851">

##### Mobile view
<img width="459" alt="Capture d’écran 2023-07-26 à 14 44 08" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/04d6aa9f-e614-4a89-8b30-b092fc985ed3">


#### What should we test?

- As a shop manager, update your white label logo to a 217*44 (or same ratio) image
- As a shop visitor, check for both mobile and desktop views, image is displayed entirely.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes