### PR TITLE
White label: Customize rendering inside the trix-editor, to match the shopfront rendering

### DIFF
--- a/app/views/shopping_shared/tabs/_custom.html.haml
+++ b/app/views/shopping_shared/tabs/_custom.html.haml
@@ -1,4 +1,4 @@
 .content
   .row
-    .columns
+    .columns.custom-tab
       = sanitize(@distributor.custom_tab&.content, scrubber: TrixScrubber.new)

--- a/app/webpacker/css/admin/trix.scss
+++ b/app/webpacker/css/admin/trix.scss
@@ -2,9 +2,25 @@ trix-toolbar [data-trix-button-group="file-tools"] {
   display: none;
 }
 
+// Match the rendering into the shopfront
 trix-editor {
+  color: $darker-grey;
+
   ol,
   ul {
     margin-left: 1.5em;
+  }
+
+  a {
+    color: $ofn-brand;
+  }
+
+  // Copy/pasted from _type.scss
+  blockquote {
+    line-height: 1.6;
+    color: #6f6f6f;
+    margin: 0 0 1.25rem;
+    padding: 0.5625rem 1.25rem 0 1.1875rem;
+    border-left: 1px solid #dddddd;
   }
 }

--- a/app/webpacker/css/darkswarm/shop_tabs.scss
+++ b/app/webpacker/css/darkswarm/shop_tabs.scss
@@ -119,6 +119,20 @@
         margin-top: 0.75rem;
         margin-bottom: 2px;
       }
+
+      .custom-tab {
+        ol, ul {
+          margin-left: 1.5em;
+        }
+
+        ol {
+          list-style-type: decimal;
+        }
+
+        ul {
+          list-style-type: disc;
+        }
+      }
     }
 
     &.with-darker-background {


### PR DESCRIPTION
#### What? Why?

- Closes #11025 
- Closes #11024 

##### In the editor
<img width="776" alt="Capture d’écran 2023-07-27 à 11 41 56" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/98ad7732-fa87-4a23-bbf7-37e066406752">


##### In the shopfront
<img width="826" alt="Capture d’écran 2023-07-27 à 11 42 01" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/b354dc30-35e9-4214-a019-372e062e6840">


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, create a custom tab with formatted content
- As a shop visitor, check that rendering in the shopfront is as close as possible than inside the editor

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 