### PR TITLE
Admin: improve platform version displaying on admin homepage

### DIFF
--- a/app/views/spree/admin/overview/_version.html.haml
+++ b/app/views/spree/admin/overview/_version.html.haml
@@ -1,3 +1,5 @@
-%a{href:"https://github.com/openfoodfoundation/openfoodnetwork/releases", target: "_blank", title: t('.view_all_releases')}
-  =# Show the latest tag. If there are commits since the tag, show number of commits and an identifier. If the working tree is dirty, show 'modified'.
-  = Rails.application.config.x.git_version
+.row
+  .sixteen.columns{ style: "text-align: center;" }
+    %a{href:"https://github.com/openfoodfoundation/openfoodnetwork/releases", target: "_blank", title: t('.view_all_releases')}
+      =# Show the latest tag. If there are commits since the tag, show number of commits and an identifier. If the working tree is dirty, show 'modified'.
+      = Rails.application.config.x.git_version


### PR DESCRIPTION
#### What? Why?

- Closes #11108 


##### with multi enterprises manager
<img width="1380" alt="Capture d’écran 2023-07-27 à 15 41 15" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/b86086a6-9a2b-4b38-abbd-e43654425b92">


##### with single enterprise manager
<img width="1391" alt="Capture d’écran 2023-07-27 à 15 41 24" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/6a6ac13f-2d87-40da-9b22-1d33807b1451">

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a multi enterprises manager, check that version is correctly displayed on the backoffice homepage
- As a single enterprise manager, check that version is correctly displayed on the backoffice homepage

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes