### PR TITLE
🚧 Products V3: Display "None" is a product is not assigned to a tax category

### DIFF
--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -41,7 +41,7 @@
         %td.align-left
           .line-clamp-1= product.taxons.map(&:name).join(', ')
         %td.align-left
-          .line-clamp-1= product.tax_category&.name || "None" # TODO: convert to dropdown, else translate hardcoded string.
+          .line-clamp-1= product.tax_category_id && product.tax_category&.name || "None"
         %td.align-left
           .line-clamp-1= product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values, else use I18n.t (also below)
       - product.variants.each do |variant|


### PR DESCRIPTION
#### What? Why?

The `tax_category` method on Product is defined like this:

https://github.com/openfoodfoundation/openfoodnetwork/blob/55fbab4c0d6e56d6dd707c893f58c52507e8cc53/app/models/spree/product.rb#L208-L214

Thats why we need to check if product has a tax category before displaying its name. Otherwise, returns 'None'

 - I could also have created a `tax_category_name` method on Product, but I found it confusing
 - I could also have changed the `tax_category` method on Product, but I was afraid about the needed refactoring after that



- Closes #11291 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- With feature activated, check that a product that is not assigned to a tax category displays "None" in the table
<img width="1047" alt="Capture d’écran 2023-07-27 à 15 58 49" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/fc98f72a-3dee-4ee6-b471-bbd09b66473d">
<img width="1359" alt="Capture d’écran 2023-07-27 à 15 58 24" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/685c42a2-5d34-4b9d-8744-d0a82ea07e45">


- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes