### PR TITLE
Update CSP configuration for Safari

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,7 +14,12 @@ Rails.application.config.content_security_policy do |policy|
   policy.script_src :self, :https, :unsafe_inline, :unsafe_eval, "*.stripe.com", "openfoodnetwork.innocraft.cloud",
                     "maps.googleapis.com", "maps.gstatic.com", "d2wy8f7a9ursnm.cloudfront.net"
   policy.style_src :self, :https, :unsafe_inline, "fonts.googleapis.com", "cdnjs.cloudflare.com"
-  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+
+  if Rails.env.development?
+    policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035", "ws://localhost:3000"
+  else
+    policy.connect_src :self, :https, "https://#{ENV["SITE_URL"]}", "wss://#{ENV["SITE_URL"]}"
+  end
 
   # Specify URI for violation reports
   # policy.report_uri "/csp-violation-report-endpoint"


### PR DESCRIPTION
#### What? Why?

Closes #11174

Apparently some versions of Safari have issues with Websockets if the CSP doesn't explicitly define the `connect_src` in a certain way (including specifying the host). This issue is fixed in later versions of Safari and doesn't affect other browsers, for which the `default_src` with `:self` is usually sufficient.


#### What should we test?

When using Safari 13-15, should resolve the console error:
```
SecurityError: The operation is insecure.
```
and I think it will fix some of the related Safari/OSX issues.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
