### PR TITLE
Remove product display_as cell

### DIFF
--- a/app/views/spree/admin/products/index/_products_product.html.haml
+++ b/app/views/spree/admin/products/index/_products_product.html.haml
@@ -16,7 +16,6 @@
     %input{ 'ng-model' => 'product.master.unit_value_with_description', :name => 'master_unit_value_with_description', 'ofn-track-master' => 'unit_value_with_description', :type => 'text', :placeholder => 'value', 'ng-show' => "!hasVariants(product) && hasUnit(product)", 'ofn-maintain-unit-scale' => true }
     %input{ 'ng-model' => 'product.variant_unit_name', :name => 'variant_unit_name', 'ofn-track-product' => 'variant_unit_name', :placeholder => 'unit', 'ng-show' => "product.variant_unit_with_scale == 'items'", :type => 'text' }
   %td.display_as{ 'ng-show' => 'columns.unit.visible' }
-    %input{ 'ofn-display-as' => 'product.master', name: 'display_as', 'ofn-track-master' => 'display_as', type: 'text', placeholder: '{{ placeholder_text }}', ng: { hide: 'hasVariants(product)', model: 'product.master.display_as' } }
   %td.price{ 'ng-show' => 'columns.price.visible' }
     %input{ 'ng-model' => 'product.price', 'ofn-decimal' => :true, :name => 'price', 'ofn-track-product' => 'price', :type => 'text', 'ng-hide' => 'hasVariants(product)' }
   %td.on_hand{ 'ng-show' => 'columns.on_hand.visible' }


### PR DESCRIPTION
#### What? Why?

- Closes #11195

This bit of code was attempting to reference the master variant, which is now gone. Fixes an Angular scope/$eval error that shows up in the console on the admin products index page (and in Bugsnag).

#### What should we test?

No console errors on the admin products index page.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Related
This is an alternative solution which
- closes https://github.com/openfoodfoundation/openfoodnetwork/pull/11196
