### PR TITLE
Prevent git errors from showing in command output

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ require_relative "../lib/open_food_network/i18n_config"
 require_relative '../lib/spree/core/environment'
 require_relative '../lib/spree/core/mail_interceptor'
 require_relative "../lib/i18n_digests"
+require_relative "../lib/git_utils"
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
@@ -34,8 +35,8 @@ end
 
 module Openfoodnetwork
   class Application < Rails::Application
-    # Store a description of the current version, with linebreak trimmed
-    config.x.git_version = `git describe --tags --dirty=-modified`.strip
+    # Store a description of the current version
+    config.x.git_version = GitUtils::git_version
 
     config.after_initialize do
       # We need this here because the test env file loads before the Spree engine is loaded

--- a/lib/git_utils.rb
+++ b/lib/git_utils.rb
@@ -1,0 +1,15 @@
+class GitUtils
+  # Generate a description of the git version based on latest tag.
+  # Eg: "v4.4.4-156-g8afcd82-modified"
+  #  - tag name
+  #  - number of commits since tag
+  #  - commit ID
+  #  - "modified" if uncommitted changes
+  #
+  def self.git_version
+    # Capture stderr so that confusing errors aren't shown in comand output
+    stdout, _stderr, _status = Open3.capture3("git describe --tags --dirty=-modified")
+    # Strip trailing linebreak
+    stdout.strip
+  end
+end

--- a/lib/git_utils.rb
+++ b/lib/git_utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GitUtils
   # Generate a description of the git version based on latest tag.
   # Eg: "v4.4.4-156-g8afcd82-modified"


### PR DESCRIPTION
#### What? Why?
This would be a very rare case, but one time the git command failed, printing out an obscure "fatal" message to stderr which caused confusion.

https://openfoodnetwork.slack.com/archives/C02G54U7H/p1690478240843989?thread_ts=1690416052.303299&cid=C02G54U7H

> ```
> DLE9R1G:~/openfoodnetwork$ bundle exec rake db:test:prepare
> fatal: No names found, cannot describe anything.
> ```

#### What should a dev test?
I'm not sure it's worth testing, but if you want to: 

1. Break git somehow, eg `mv .git .git.bak`
2. Run any rails process, eg `rails s` or `rake db:test:prepare`
3. No "fatal" errors should appear in the first line of output. The rest of the process should succeed as usual
4. Don't forget to fix your git repo again!

![Screen Shot 2023-07-28 at 12 14 41 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/1c9f0d93-56ce-4beb-bfce-df8d69032104)
The version number doesn't appear, but there are no errors.
![Screen Shot 2023-07-28 at 12 13 53 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/c066896d-2932-42f4-8077-688cc52bf670)


I tested this already.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
