### PR TITLE
Sort orders by last name, then first name i.e. the same way bulk order management works

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -16,7 +16,8 @@ module Spree
     searchable_attributes :number, :state, :shipment_state, :payment_state, :distributor_id,
                           :order_cycle_id, :email, :total, :customer_id
     searchable_associations :shipping_method, :bill_address, :distributor
-    searchable_scopes :complete, :incomplete
+    searchable_scopes :complete, :incomplete, :sort_by_billing_address_name_asc,
+                      :sort_by_billing_address_name_desc
 
     checkout_flow do
       go_to_state :address
@@ -143,6 +144,14 @@ module Spree
       else
         where('spree_orders.distributor_id IN (?)', user.enterprises.select(&:id))
       end
+    }
+
+    scope :sort_by_billing_address_name_asc, -> {
+      joins(:bill_address).order("spree_addresses.lastname ASC, spree_addresses.firstname ASC")
+    }
+
+    scope :sort_by_billing_address_name_desc, -> {
+      joins(:bill_address).order("spree_addresses.lastname DESC, spree_addresses.firstname DESC")
     }
 
     scope :with_line_items_variants_and_products_outer, lambda {

--- a/app/views/spree/admin/orders/_table.html.haml
+++ b/app/views/spree/admin/orders/_table.html.haml
@@ -14,7 +14,7 @@
       %th
         = t(:products_distributor)
 
-      - columns = ['completed_at', 'number', 'state', 'payment_state', 'shipment_state', 'email', 'bill_address_lastname', 'total']
+      - columns = ['completed_at', 'number', 'state', 'payment_state', 'shipment_state', 'email', 'billing_address_name', 'total']
 
       = render partial: "spree/admin/shared/stimulus_sortable_header", collection: columns, as: :column,
         locals: { sorted: params.dig(:q, :s), default: "completed_at desc" }

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -33,7 +33,7 @@
     %a{ href: "mailto:#{order.email}", target: "_blank" }
       = order.email
   %td
-    = order.bill_address.full_name
+    = order.bill_address.full_name_for_sorting
   %td.align-center
     %span
       = order.display_total

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4346,7 +4346,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           shipment_state: "Shipment State"
           email: "Email"
           total: "Total"
-          bill_address_lastname: "Name"
+          billing_address_name: "Name"
       general_settings:
         edit:
           legal_settings: "Legal Settings"

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -410,22 +410,22 @@ describe '
 
       context "orders with different billing addresses" do
         before do
-          billing_address2.update!(lastname: "Mad Hatter")
-          billing_address3.update!(lastname: "Duchess")
-          billing_address4.update!(lastname: "Cheshire Cat")
-          billing_address5.update!(lastname: "Alice")
+          billing_address2.update!(firstname: "Mad", lastname: "Hatter")
+          billing_address3.update!(firstname: "Alice", lastname: "Smith")
+          billing_address4.update!(firstname: "Cheshire", lastname: "Cat")
+          billing_address5.update!(lastname: "Bob", lastname: "Smith")
           login_as_admin
           visit spree.admin_orders_path
         end
 
-        it "orders by last name" do
+        it "orders by last name then first name" do
           find("a", text: 'NAME').click # sets ascending ordering
           expect(page).to have_content(
-            /#{order5.number}.*#{order4.number}.*#{order3.number}.*#{order2.number}/m
+            /#{order4.number}.*#{order2.number}.*#{order3.number}.*#{order5.number}/m
           )
           find("a", text: 'NAME').click # sets descending ordering
           expect(page).to have_content(
-            /#{order2.number}.*#{order3.number}.*#{order4.number}.*#{order5.number}/m
+            /#{order5.number}.*#{order3.number}.*#{order2.number}.*#{order4.number}/m
           )
         end
       end

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -413,7 +413,7 @@ describe '
           billing_address2.update!(firstname: "Mad", lastname: "Hatter")
           billing_address3.update!(firstname: "Alice", lastname: "Smith")
           billing_address4.update!(firstname: "Cheshire", lastname: "Cat")
-          billing_address5.update!(lastname: "Bob", lastname: "Smith")
+          billing_address5.update!(firstname: "Bob", lastname: "Smith")
           login_as_admin
           visit spree.admin_orders_path
         end


### PR DESCRIPTION
#### What? Why?

- Closes https://github.com/openfoodfoundation/wishlist/issues/437 (I'm just noticing now this issue is still on the wishlist, sorry if this PR is too early)

https://github.com/openfoodfoundation/openfoodnetwork/assets/101088/7e75bb2f-b68a-4066-9bc2-a0326fe05c74

#### What should we test?

- Go to the Orders section in the admin area
- Click the 'Name' column and make sure orders are sorted by last name, then first name.
- Check orders are displayed the same way as they are in bulk order management i.e. `lastname, firstname`

#### Release notes

Changelog Category: User facing changes