### PR TITLE
Skip empty commits in Rubocop Autocorrect Script

### DIFF
--- a/script/rubocop-autocorrect.sh
+++ b/script/rubocop-autocorrect.sh
@@ -34,6 +34,11 @@ grep "This cop supports safe autocorrection" -A 5 .rubocop_todo.yml\
       echo "Safely autocorrect $cop" > .git/COMMIT_EDITMSG
       echo "" >> .git/COMMIT_EDITMSG
       bundle exec rubocop --autocorrect >> .git/COMMIT_EDITMSG
-      git add --all
-      git commit --file .git/COMMIT_EDITMSG
+      if grep -q "offenses corrected" .git/COMMIT_EDITMSG; then
+        git add --all
+        git commit --file .git/COMMIT_EDITMSG
+      else
+        echo "No corrections made for $cop. Skipping."
+      fi
+
     done


### PR DESCRIPTION
#### What? Why?

- Helps #11253 

The original script would create blank commits when it encountered a cop where some of the errors are autocorrectable and some of the errors aren't. It would fix the autocorrect errors, but keep attempting to correct the non-autocorrectable errors. 

A file limit has been added as well. This is necessary for when we try to autocorrect the Style/HashSyntax cop which has 1781 errors. If the limit is hit in the middle of a commit/cop the user is asked if they wish to commit the remaining files or keep the hard limit. That way, if there are a few remaining files left we can add them instead of splitting small cops into two commits.

#### What should we test?

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
