### PR TITLE
[Invoices] Adds unit level test coverage order model attributes

### DIFF
--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -58,6 +58,11 @@ describe OrderInvoiceComparator do
       end
 
       it "returns false if a non-relevant attribute changes" do
+        order.update!(special_instructions: "A very special insctruction.")
+        expect(subject).to be false
+      end
+
+      it "returns false if a non-relevant attribute changes" do
         order.update!(note: "THIS IS A NEW NOTE")
         expect(subject).to be false
       end

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -46,6 +46,17 @@ describe OrderInvoiceComparator do
         expect(subject).to be false
       end
 
+      it "returns true if a relevant attribute changes - order state: cancelled" do
+        order.cancel!
+        expect(subject).to be true
+      end
+
+      it "returns true if a relevant attribute changes - order state: resumed" do
+        order.cancel!
+        order.resume!
+        expect(subject).to be true
+      end
+
       it "returns false if a non-relevant attribute changes" do
         order.update!(note: "THIS IS A NEW NOTE")
         expect(subject).to be false

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -28,6 +28,12 @@ describe OrderInvoiceComparator do
         expect(subject).to be true
       end
 
+      it "returns true if a relevant attribute changes" do
+        Spree::Order.where(id: order.id).update_all(total: order.total + 10)
+        order.reload
+        expect(subject).to be true
+      end
+
       it "returns false if a non-relevant attribute changes" do
         order.update!(note: "THIS IS A NEW NOTE")
         expect(subject).to be false

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -18,7 +18,7 @@ describe OrderInvoiceComparator do
     }
 
     context "changes on the order object" do
-      it "returns true if the order didn't change" do
+      it "returns false if the order didn't change" do
         expect(subject).to be false
       end
 

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -53,7 +53,8 @@ describe OrderInvoiceComparator do
 
           it "returns returns true" do
             Spree::TaxRate.first.update!(amount: 0.15)
-            order.create_tax_charge! && order.save
+            order.create_tax_charge!
+            order.reload
             expect(subject).to be true
           end
         end
@@ -70,7 +71,8 @@ describe OrderInvoiceComparator do
 
           it "returns returns true" do
             Spree::TaxRate.first.update!(amount: 0.15)
-            order.create_tax_charge! && order.save
+            order.create_tax_charge!
+            order.reload
             expect(subject).to be true
           end
         end

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -26,7 +26,7 @@ describe OrderInvoiceComparator do
         expect(subject).to be true
       end
 
-      it "returns true if a non-relevant attribute changes" do
+      it "returns false if a non-relevant attribute changes" do
         order.update!(note: "THIS IS A NEW NOTE")
         expect(subject).to be false
       end

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -4,9 +4,8 @@ require 'spec_helper'
 
 describe OrderInvoiceComparator do
   describe '#can_generate_new_invoice?' do
-    let!(:completed_order_with_fees) { create(:completed_order_with_fees) }
     # this passes 'order' as argument to the invoice comparator
-    let(:order) { completed_order_with_fees }
+    let(:order) { create(:completed_order_with_fees) }
     let!(:invoice_data_generator){ InvoiceDataGenerator.new(order) }
     let!(:invoice){
       create(:invoice,
@@ -69,7 +68,7 @@ describe OrderInvoiceComparator do
 
       context "additional tax total changes" do
         let(:distributor) { create(:distributor_enterprise) }
-        let!(:order_with_taxes) do
+        let(:order) do
           create(:order_with_taxes, distributor: distributor, ship_address: create(:address),
                                     product_price: 110, tax_rate_amount: 0.1,
                                     included_in_price: false,
@@ -78,18 +77,17 @@ describe OrderInvoiceComparator do
                                       order.update_shipping_fees!
                                     end
         end
-        let!(:order) { order_with_taxes }
 
         it "returns returns true" do
           Spree::TaxRate.first.update!(amount: 0.15)
-          order_with_taxes.create_tax_charge! && order_with_taxes.save
+          order.create_tax_charge! && order.save
           expect(subject).to be true
         end
       end
 
       context "included tax total changes" do
         let(:distributor) { create(:distributor_enterprise) }
-        let!(:order_with_taxes) do
+        let(:order) do
           create(:order_with_taxes, distributor: distributor, ship_address: create(:address),
                                     product_price: 110, tax_rate_amount: 0.1,
                                     included_in_price: true,
@@ -98,18 +96,16 @@ describe OrderInvoiceComparator do
                                       order.update_shipping_fees!
                                     end
         end
-        let!(:order) { order_with_taxes }
 
         it "returns returns true" do
           Spree::TaxRate.first.update!(amount: 0.15)
-          order_with_taxes.create_tax_charge! && order_with_taxes.save
+          order.create_tax_charge! && order.save
           expect(subject).to be true
         end
       end
 
       context "shipping method changes" do
         let(:shipping_method) { create(:shipping_method) }
-        let!(:order) { completed_order_with_fees }
         it "returns returns true" do
           Spree::ShippingRate.first.update(shipping_method_id: shipping_method.id)
           expect(subject).to be true

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -67,15 +67,13 @@ describe OrderInvoiceComparator do
       end
 
       context "additional tax total changes" do
-        let(:distributor) { create(:distributor_enterprise) }
         let(:order) do
-          create(:order_with_taxes, distributor: distributor, ship_address: create(:address),
-                                    product_price: 110, tax_rate_amount: 0.1,
-                                    included_in_price: false,
-                                    tax_rate_name: "Tax 1").tap do |order|
-                                      order.create_tax_charge!
-                                      order.update_shipping_fees!
-                                    end
+          create(:order_with_taxes, product_price: 110, tax_rate_amount: 0.1,
+                                    included_in_price: false)
+            .tap do |order|
+            order.create_tax_charge!
+            order.update_shipping_fees!
+          end
         end
 
         it "returns returns true" do
@@ -86,15 +84,13 @@ describe OrderInvoiceComparator do
       end
 
       context "included tax total changes" do
-        let(:distributor) { create(:distributor_enterprise) }
         let(:order) do
-          create(:order_with_taxes, distributor: distributor, ship_address: create(:address),
-                                    product_price: 110, tax_rate_amount: 0.1,
-                                    included_in_price: true,
-                                    tax_rate_name: "Tax 1").tap do |order|
-                                      order.create_tax_charge!
-                                      order.update_shipping_fees!
-                                    end
+          create(:order_with_taxes, product_price: 110, tax_rate_amount: 0.1,
+                                    included_in_price: true)
+            .tap do |order|
+            order.create_tax_charge!
+            order.update_shipping_fees!
+          end
         end
 
         it "returns returns true" do

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -40,6 +40,12 @@ describe OrderInvoiceComparator do
         expect(subject).to be false
       end
 
+      it "returns false if an attribute which should not change, changes" do
+        Spree::Order.where(id: order.id).update_all(currency: 'EUR')
+        order.reload
+        expect(subject).to be false
+      end
+
       it "returns false if a non-relevant attribute changes" do
         order.update!(note: "THIS IS A NEW NOTE")
         expect(subject).to be false

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -34,6 +34,12 @@ describe OrderInvoiceComparator do
         expect(subject).to be true
       end
 
+      it "returns false if an attribute which should not change, changes" do
+        Spree::Order.where(id: order.id).update_all(number: 'R631504404')
+        order.reload
+        expect(subject).to be false
+      end
+
       it "returns false if a non-relevant attribute changes" do
         order.update!(note: "THIS IS A NEW NOTE")
         expect(subject).to be false

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -17,94 +17,98 @@ describe OrderInvoiceComparator do
     }
 
     context "changes on the order object" do
-      it "returns false if the order didn't change" do
-        expect(subject).to be false
-      end
+      describe "detecting relevant attribute changes" do
+        it "returns true if a relevant attribute changes" do
+          Spree::Order.where(id: order.id).update_all(payment_total: order.payment_total + 10)
+          order.reload
+          expect(subject).to be true
+        end
 
-      it "returns true if a relevant attribute changes" do
-        Spree::Order.where(id: order.id).update_all(payment_total: order.payment_total + 10)
-        order.reload
-        expect(subject).to be true
-      end
+        it "returns true if a relevant attribute changes" do
+          Spree::Order.where(id: order.id).update_all(total: order.total + 10)
+          order.reload
+          expect(subject).to be true
+        end
 
-      it "returns true if a relevant attribute changes" do
-        Spree::Order.where(id: order.id).update_all(total: order.total + 10)
-        order.reload
-        expect(subject).to be true
-      end
+        it "returns true if a relevant attribute changes - order state: cancelled" do
+          order.cancel!
+          expect(subject).to be true
+        end
 
-      it "returns false if an attribute which should not change, changes" do
-        Spree::Order.where(id: order.id).update_all(number: 'R631504404')
-        order.reload
-        expect(subject).to be false
-      end
+        it "returns true if a relevant attribute changes - order state: resumed" do
+          order.cancel!
+          order.resume!
+          expect(subject).to be true
+        end
 
-      it "returns false if an attribute which should not change, changes" do
-        Spree::Order.where(id: order.id).update_all(currency: 'EUR')
-        order.reload
-        expect(subject).to be false
-      end
+        context "additional tax total changes" do
+          let(:order) do
+            create(:order_with_taxes, product_price: 110, tax_rate_amount: 0.1,
+                                      included_in_price: false)
+              .tap do |order|
+              order.create_tax_charge!
+              order.update_shipping_fees!
+            end
+          end
 
-      it "returns true if a relevant attribute changes - order state: cancelled" do
-        order.cancel!
-        expect(subject).to be true
-      end
-
-      it "returns true if a relevant attribute changes - order state: resumed" do
-        order.cancel!
-        order.resume!
-        expect(subject).to be true
-      end
-
-      it "returns false if a non-relevant attribute changes" do
-        order.update!(special_instructions: "A very special insctruction.")
-        expect(subject).to be false
-      end
-
-      it "returns false if a non-relevant attribute changes" do
-        order.update!(note: "THIS IS A NEW NOTE")
-        expect(subject).to be false
-      end
-
-      context "additional tax total changes" do
-        let(:order) do
-          create(:order_with_taxes, product_price: 110, tax_rate_amount: 0.1,
-                                    included_in_price: false)
-            .tap do |order|
-            order.create_tax_charge!
-            order.update_shipping_fees!
+          it "returns returns true" do
+            Spree::TaxRate.first.update!(amount: 0.15)
+            order.create_tax_charge! && order.save
+            expect(subject).to be true
           end
         end
 
-        it "returns returns true" do
-          Spree::TaxRate.first.update!(amount: 0.15)
-          order.create_tax_charge! && order.save
-          expect(subject).to be true
-        end
-      end
+        context "included tax total changes" do
+          let(:order) do
+            create(:order_with_taxes, product_price: 110, tax_rate_amount: 0.1,
+                                      included_in_price: true)
+              .tap do |order|
+              order.create_tax_charge!
+              order.update_shipping_fees!
+            end
+          end
 
-      context "included tax total changes" do
-        let(:order) do
-          create(:order_with_taxes, product_price: 110, tax_rate_amount: 0.1,
-                                    included_in_price: true)
-            .tap do |order|
-            order.create_tax_charge!
-            order.update_shipping_fees!
+          it "returns returns true" do
+            Spree::TaxRate.first.update!(amount: 0.15)
+            order.create_tax_charge! && order.save
+            expect(subject).to be true
           end
         end
 
-        it "returns returns true" do
-          Spree::TaxRate.first.update!(amount: 0.15)
-          order.create_tax_charge! && order.save
-          expect(subject).to be true
+        context "shipping method changes" do
+          let(:shipping_method) { create(:shipping_method) }
+          it "returns returns true" do
+            Spree::ShippingRate.first.update(shipping_method_id: shipping_method.id)
+            expect(subject).to be true
+          end
         end
       end
 
-      context "shipping method changes" do
-        let(:shipping_method) { create(:shipping_method) }
-        it "returns returns true" do
-          Spree::ShippingRate.first.update(shipping_method_id: shipping_method.id)
-          expect(subject).to be true
+      describe "ignoring non-relevant attribute changes" do
+        it "returns false if the order didn't change" do
+          expect(subject).to be false
+        end
+
+        it "returns false if an attribute which should not change, changes" do
+          Spree::Order.where(id: order.id).update_all(number: 'R631504404')
+          order.reload
+          expect(subject).to be false
+        end
+
+        it "returns false if an attribute which should not change, changes" do
+          Spree::Order.where(id: order.id).update_all(currency: 'EUR')
+          order.reload
+          expect(subject).to be false
+        end
+
+        it "returns false if a non-relevant attribute changes" do
+          order.update!(special_instructions: "A very special insctruction.")
+          expect(subject).to be false
+        end
+
+        it "returns false if a non-relevant attribute changes" do
+          order.update!(note: "THIS IS A NEW NOTE")
+          expect(subject).to be false
         end
       end
     end

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -42,9 +42,7 @@ describe OrderInvoiceComparator do
                                     end
         end
 
-
-        it "returns returns true if additional tax total changes" do
-
+        it "returns returns true" do
           expect(order_with_taxes.additional_tax_total).to eq 0.11e2
           Spree::TaxRate.first.update!(amount: 0.15)
           order_with_taxes.create_tax_charge! && order_with_taxes.save
@@ -59,20 +57,33 @@ describe OrderInvoiceComparator do
         let(:distributor) { create(:distributor_enterprise) }
         let!(:order_with_taxes) do
           create(:order_with_taxes, distributor: distributor, ship_address: create(:address),
-                                    product_price: 110, tax_rate_amount: 0.1, included_in_price: true,
+                                    product_price: 110, tax_rate_amount: 0.1,
+                                    included_in_price: true,
                                     tax_rate_name: "Tax 1").tap do |order|
                                       order.create_tax_charge!
                                       order.update_shipping_fees!
                                     end
         end
 
-        it "returns returns true if included_tax_total changes" do
+        it "returns returns true" do
           expect(order_with_taxes.included_tax_total).to eq 0.1e2
           Spree::TaxRate.first.update!(amount: 0.15)
           order_with_taxes.create_tax_charge! && order_with_taxes.save
-          
+
           expect(order_with_taxes.included_tax_total).to eq 0.1435e2
 
+          expect(subject).to be true
+        end
+      end
+
+      context "shipping method changes" do
+        let(:shipping_method) { create(:shipping_method) }
+        let!(:order_ready_to_ship) {
+          create(:order_ready_to_ship)
+        }
+        it "returns returns true" do
+          Spree::ShippingRate.first.update(shipping_method_id: shipping_method.id)
+          order_ready_to_ship.update_shipping_fees! && order_ready_to_ship.save
           expect(subject).to be true
         end
       end


### PR DESCRIPTION
#### What? Why?

Completes coverage for order model attributes:

```
- additional_tax_total
- included_tax_total
- shipping_method_id
- total
- number
- currency
- state
- special_instructions
```
`- payment total` (existing before this PR)
`- note` (existing before this PR)

Ran this spec locally: it passed 30/30 times.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
