### PR TITLE
Rescue ImageMagick errors

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -461,7 +461,7 @@ class Enterprise < ApplicationRecord
     return unless image.variable?
 
     image_variant_url_for(image.variant(name))
-  rescue ActiveStorage::Error => e
+  rescue ActiveStorage::Error, MiniMagick::Error, ActionView::Template::Error => e
     Bugsnag.notify "Enterprise ##{id} #{image.try(:name)} error: #{e.message}"
     Rails.logger.error(e.message)
 

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -33,7 +33,7 @@ module Spree
       return self.class.default_image_url(size) unless attachment.attached?
 
       image_variant_url_for(variant(size))
-    rescue ActiveStorage::Error => e
+    rescue ActiveStorage::Error, MiniMagick::Error, ActionView::Template::Error => e
       Bugsnag.notify "Product ##{viewable_id} Image ##{id} error: #{e.message}"
       Rails.logger.error(e.message)
 


### PR DESCRIPTION
#### What? Why?

- Closes #11298

It seems like there are some cases where an image file is corrupted or missing in some way that can occur during product loading, and the errors are not being rescued nicely. The two error classes are `MiniMagick::Error` and `ActionView::Template::Error` and the stack trace points to the same place.

![Screenshot from 2023-07-31 17-19-42](https://github.com/openfoodfoundation/openfoodnetwork/assets/9029026/147056e1-a677-438c-94ed-f92b9c18ac84)

![Screenshot from 2023-07-31 17-22-24](https://github.com/openfoodfoundation/openfoodnetwork/assets/9029026/ce006cc4-1d89-41f2-9b7a-b9f6c8e22292)

Simple fix.

#### What should we test?

Not sure how to replicate this one, it seems triggered by a broken image.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
