### PR TITLE
Fix autocorrect Rails Cops

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -478,21 +478,6 @@ Rails/CompactBlank:
     - 'lib/reporting/report_ruler.rb'
     - 'lib/reporting/reports/enterprise_fee_summary/parameters.rb'
 
-# Offense count: 27
-# This cop supports safe autocorrection (--autocorrect).
-Rails/DurationArithmetic:
-  Exclude:
-    - 'app/services/create_order_cycle.rb'
-    - 'spec/jobs/order_cycle_closing_job_spec.rb'
-    - 'spec/jobs/order_cycle_opened_job_spec.rb'
-    - 'spec/services/permissions/order_spec.rb'
-    - 'spec/services/terms_of_service_spec.rb'
-    - 'spec/system/admin/bulk_order_management_spec.rb'
-    - 'spec/system/admin/order_cycles/list_spec.rb'
-    - 'spec/system/admin/orders_spec.rb'
-    - 'spec/system/admin/reports/orders_and_fulfillment_spec.rb'
-    - 'spec/system/admin/reports/packing_report_spec.rb'
-
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Rails/ExpandedDateRange:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -478,12 +478,6 @@ Rails/CompactBlank:
     - 'lib/reporting/report_ruler.rb'
     - 'lib/reporting/reports/enterprise_fee_summary/parameters.rb'
 
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-Rails/DotSeparatedKeys:
-  Exclude:
-    - 'app/controllers/api/v1/base_controller.rb'
-
 # Offense count: 27
 # This cop supports safe autocorrection (--autocorrect).
 Rails/DurationArithmetic:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -443,22 +443,6 @@ Naming/VariableNumber:
     - 'spec/models/spree/tax_rate_spec.rb'
     - 'spec/requests/api/orders_spec.rb'
 
-# Offense count: 9
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: ExpectedOrder, Include.
-# ExpectedOrder: index, show, new, edit, create, update, destroy
-# Include: app/controllers/**/*.rb
-Rails/ActionOrder:
-  Exclude:
-    - 'app/controllers/admin/resource_controller.rb'
-    - 'app/controllers/api/v0/orders_controller.rb'
-    - 'app/controllers/spree/admin/images_controller.rb'
-    - 'app/controllers/spree/admin/invoices_controller.rb'
-    - 'app/controllers/spree/admin/products_controller.rb'
-    - 'app/controllers/spree/admin/taxons_controller.rb'
-    - 'app/controllers/spree/admin/variants_controller.rb'
-    - 'app/controllers/user_confirmations_controller.rb'
-
 # Offense count: 12
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Include.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1108,7 +1108,7 @@ Style/HashLikeCase:
   Exclude:
     - 'app/models/enterprise.rb'
 
-# Offense count: 1781
+# Offense count: 1792
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
 # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -443,23 +443,6 @@ Naming/VariableNumber:
     - 'spec/models/spree/tax_rate_spec.rb'
     - 'spec/requests/api/orders_spec.rb'
 
-# Offense count: 12
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/ActiveRecordCallbacksOrder:
-  Exclude:
-    - 'app/models/customer.rb'
-    - 'app/models/enterprise.rb'
-    - 'app/models/enterprise_group.rb'
-    - 'app/models/enterprise_relationship.rb'
-    - 'app/models/spree/order.rb'
-    - 'app/models/spree/payment.rb'
-    - 'app/models/spree/product.rb'
-    - 'app/models/spree/return_authorization.rb'
-    - 'app/models/spree/user.rb'
-    - 'app/models/spree/variant.rb'
-
 # Offense count: 1
 # Configuration parameters: Severity, Include.
 # Include: app/models/**/*.rb

--- a/app/controllers/admin/resource_controller.rb
+++ b/app/controllers/admin/resource_controller.rb
@@ -24,9 +24,10 @@ module Admin
       end
     end
 
-    def update
-      if @object.update(permitted_resource_params)
-        flash[:success] = flash_message_for(@object, :successfully_updated)
+    def create
+      @object.attributes = permitted_resource_params
+      if @object.save
+        flash[:success] = flash_message_for(@object, :successfully_created)
         respond_with(@object) do |format|
           format.html { redirect_to location_after_save }
           format.js   { render layout: false }
@@ -36,10 +37,9 @@ module Admin
       end
     end
 
-    def create
-      @object.attributes = permitted_resource_params
-      if @object.save
-        flash[:success] = flash_message_for(@object, :successfully_created)
+    def update
+      if @object.update(permitted_resource_params)
+        flash[:success] = flash_message_for(@object, :successfully_updated)
         respond_with(@object) do |format|
           format.html { redirect_to location_after_save }
           format.js   { render layout: false }

--- a/app/controllers/api/v0/orders_controller.rb
+++ b/app/controllers/api/v0/orders_controller.rb
@@ -5,11 +5,6 @@ module Api
     class OrdersController < Api::V0::BaseController
       include PaginationData
 
-      def show
-        authorize! :read, order
-        render json: order, serializer: Api::OrderDetailedSerializer, current_order: order
-      end
-
       def index
         authorize! :admin, Spree::Order
 
@@ -24,6 +19,11 @@ module Api
           orders: serialized_orders(orders),
           pagination: pagination_data
         }
+      end
+
+      def show
+        authorize! :read, order
+        render json: order, serializer: Api::OrderDetailedSerializer, current_order: order
       end
 
       def update

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -69,14 +69,14 @@ module Api
       end
 
       def missing_parameter(error)
-        message = I18n.t(:missing_parameter, param: error.param, scope: :api)
+        message = I18n.t('api.missing_parameter', param: error.param)
 
         render status: :unprocessable_entity,
                json: json_api_error(message)
       end
 
       def unpermitted_parameters(error)
-        message = I18n.t(:unpermitted_parameters, params: error.params.join(", "), scope: :api)
+        message = I18n.t('api.unpermitted_parameters', params: error.params.join(", "))
 
         render status: :unprocessable_entity,
                json: json_api_error(message)

--- a/app/controllers/spree/admin/images_controller.rb
+++ b/app/controllers/spree/admin/images_controller.rb
@@ -20,6 +20,10 @@ module Spree
         render layout: !request.xhr?
       end
 
+      def edit
+        @url_filters = ::ProductFilters.new.extract(request.query_parameters)
+      end
+
       def create
         @url_filters = ::ProductFilters.new.extract(request.query_parameters)
         set_viewable
@@ -32,10 +36,6 @@ module Spree
         else
           respond_with(@object)
         end
-      end
-
-      def edit
-        @url_filters = ::ProductFilters.new.extract(request.query_parameters)
       end
 
       def update

--- a/app/controllers/spree/admin/invoices_controller.rb
+++ b/app/controllers/spree/admin/invoices_controller.rb
@@ -10,6 +10,13 @@ module Spree
         authorize! :invoice, @order
       end
 
+      def show
+        invoice_id = params[:id]
+        invoice_pdf = BulkInvoiceService.new.filepath(invoice_id)
+
+        send_file(invoice_pdf, type: 'application/pdf', disposition: :inline)
+      end
+
       def create
         Spree::Order.where(id: params[:order_ids]).find_each do |order|
           authorize! :invoice, order
@@ -38,13 +45,6 @@ module Spree
           )
         end
         redirect_back(fallback_location: spree.admin_dashboard_path)
-      end
-
-      def show
-        invoice_id = params[:id]
-        invoice_pdf = BulkInvoiceService.new.filepath(invoice_id)
-
-        send_file(invoice_pdf, type: 'application/pdf', disposition: :inline)
       end
 
       def poll

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -16,8 +16,22 @@ module Spree
       before_action :load_spree_api_key, only: [:index, :variant_overrides]
       before_action :strip_new_properties, only: [:create, :update]
 
+      def index
+        @current_user = spree_current_user
+        @show_latest_import = params[:latest_import] || false
+      end
+
+      def show
+        session[:return_to] ||= request.referer
+        redirect_to( action: :edit )
+      end
+
       def new
         @object.shipping_category = DefaultShippingCategory.find_or_create
+      end
+
+      def edit
+        @url_filters = ::ProductFilters.new.extract(request.query_parameters)
       end
 
       def create
@@ -33,20 +47,6 @@ module Spree
             render :new
           end
         end
-      end
-
-      def show
-        session[:return_to] ||= request.referer
-        redirect_to( action: :edit )
-      end
-
-      def index
-        @current_user = spree_current_user
-        @show_latest_import = params[:latest_import] || false
-      end
-
-      def edit
-        @url_filters = ::ProductFilters.new.extract(request.query_parameters)
       end
 
       def update

--- a/app/controllers/spree/admin/taxons_controller.rb
+++ b/app/controllers/spree/admin/taxons_controller.rb
@@ -5,6 +5,12 @@ module Spree
     class TaxonsController < Spree::Admin::BaseController
       respond_to :html, :json, :js
 
+      def edit
+        @taxonomy = Taxonomy.find(params[:taxonomy_id])
+        @taxon = @taxonomy.taxons.find(params[:id])
+        @permalink_part = @taxon.permalink.split("/").last
+      end
+
       def create
         @taxonomy = Taxonomy.find(params[:taxonomy_id])
         @taxon = @taxonomy.taxons.build(params[:taxon])
@@ -24,12 +30,6 @@ module Spree
             end
           end
         end
-      end
-
-      def edit
-        @taxonomy = Taxonomy.find(params[:taxonomy_id])
-        @taxon = @taxonomy.taxons.find(params[:id])
-        @permalink_part = @taxon.permalink.split("/").last
       end
 
       def update

--- a/app/controllers/spree/admin/variants_controller.rb
+++ b/app/controllers/spree/admin/variants_controller.rb
@@ -11,24 +11,11 @@ module Spree
         @url_filters = ::ProductFilters.new.extract(request.query_parameters)
       end
 
-      def edit
-        @url_filters = ::ProductFilters.new.extract(request.query_parameters)
-      end
-
-      def update
-        @url_filters = ::ProductFilters.new.extract(request.query_parameters)
-
-        if @object.update(permitted_resource_params)
-          flash[:success] = flash_message_for(@object, :successfully_updated)
-          redirect_to spree.admin_product_variants_url(params[:product_id], @url_filters)
-        else
-          redirect_to spree.edit_admin_product_variant_url(params[:product_id],
-                                                           @object,
-                                                           @url_filters)
-        end
-      end
-
       def new
+        @url_filters = ::ProductFilters.new.extract(request.query_parameters)
+      end
+
+      def edit
         @url_filters = ::ProductFilters.new.extract(request.query_parameters)
       end
 
@@ -51,6 +38,19 @@ module Spree
 
         @object.on_demand = on_demand if on_demand.present?
         @object.on_hand = on_hand.to_i if on_hand.present?
+      end
+
+      def update
+        @url_filters = ::ProductFilters.new.extract(request.query_parameters)
+
+        if @object.update(permitted_resource_params)
+          flash[:success] = flash_message_for(@object, :successfully_updated)
+          redirect_to spree.admin_product_variants_url(params[:product_id], @url_filters)
+        else
+          redirect_to spree.edit_admin_product_variant_url(params[:product_id],
+                                                           @object,
+                                                           @url_filters)
+        end
       end
 
       def search

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -5,6 +5,13 @@ class UserConfirmationsController < DeviseController
   include Spree::Core::ControllerHelpers::Auth
   include CablecarResponses
 
+  # GET /resource/confirmation?confirmation_token=abcdef
+  def show
+    self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+
+    respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource) }
+  end
+
   # GET /resource/confirmation/new
   def new
     build_resource({})
@@ -31,13 +38,6 @@ class UserConfirmationsController < DeviseController
     end
 
     respond_with_navigational(resource){ redirect_to login_path }
-  end
-
-  # GET /resource/confirmation?confirmation_token=abcdef
-  def show
-    self.resource = resource_class.confirm_by_token(params[:confirmation_token])
-
-    respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource) }
   end
 
   protected

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -19,6 +19,9 @@ class Customer < ApplicationRecord
   belongs_to :enterprise
   belongs_to :user, class_name: "Spree::User", optional: true
   has_many :orders, class_name: "Spree::Order"
+  before_validation :downcase_email
+  before_validation :empty_code
+  before_create :associate_user
   before_destroy :update_orders_and_delete_canceled_subscriptions
 
   belongs_to :bill_address, class_name: "Spree::Address", optional: true
@@ -28,9 +31,6 @@ class Customer < ApplicationRecord
   belongs_to :ship_address, class_name: "Spree::Address", optional: true
   alias_attribute :shipping_address, :ship_address
   accepts_nested_attributes_for :ship_address
-
-  before_validation :downcase_email
-  before_validation :empty_code
 
   validates :code, uniqueness: { scope: :enterprise_id, allow_nil: true }
   validates :email, presence: true, 'valid_email_2/email': true,
@@ -45,8 +45,6 @@ class Customer < ApplicationRecord
                      }
   scope :created_manually, -> { where(created_manually: true) }
   scope :visible, -> { where(id: Spree::Order.complete.select(:customer_id)).or(created_manually) }
-
-  before_create :associate_user
 
   attr_accessor :gateway_recurring_payment_client_secret, :gateway_shop_id
 

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -125,12 +125,11 @@ class Enterprise < ApplicationRecord
   before_validation :set_unused_address_fields
   after_validation :ensure_owner_is_manager, if: lambda { owner_id_changed? && !owner_id.nil? }
 
-  after_touch :touch_distributors
   after_create :set_default_contact
   after_create :relate_to_owners_enterprises
-  after_create_commit :send_welcome_email
-
   after_rollback :restore_permalink
+  after_touch :touch_distributors
+  after_create_commit :send_welcome_email
 
   scope :by_name, -> { order('name') }
   scope :visible, -> { where(visible: "public") }

--- a/app/models/enterprise_group.rb
+++ b/app/models/enterprise_group.rb
@@ -14,13 +14,13 @@ class EnterpriseGroup < ApplicationRecord
   validates :address, presence: true, associated: true
   before_validation :set_undefined_address_fields
   before_validation :set_unused_address_fields
-  after_find :unset_undefined_address_fields
+  before_validation :sanitize_permalink
   after_save :unset_undefined_address_fields
+  after_find :unset_undefined_address_fields
 
   validates :name, presence: true
   validates :description, presence: true
 
-  before_validation :sanitize_permalink
   validates :permalink, uniqueness: true, presence: true
 
   delegate :phone, :address1, :address2, :city, :zipcode, :state, :country, to: :address

--- a/app/models/enterprise_relationship.rb
+++ b/app/models/enterprise_relationship.rb
@@ -11,9 +11,9 @@ class EnterpriseRelationship < ApplicationRecord
     message: I18n.t('validation_msg_relationship_already_established')
   }
 
-  after_save :update_permissions_of_child_variant_overrides
   before_destroy :revoke_all_child_variant_overrides
   before_destroy :destroy_related_exchanges
+  after_save :update_permissions_of_child_variant_overrides
 
   scope :with_enterprises, -> {
     joins("

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -104,9 +104,9 @@ module Spree
     before_validation :clone_billing_address, if: :use_billing?
     before_validation :ensure_customer
 
-    before_create :link_by_email
     before_save :update_shipping_fees!, if: :complete?
     before_save :update_payment_fees!, if: :complete?
+    before_create :link_by_email
 
     after_create :create_tax_charge!
     after_save :reapply_tax_on_changed_address

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -25,14 +25,15 @@ module Spree
     has_one :adjustment, as: :adjustable, dependent: :destroy
 
     validate :validate_source
+    after_initialize :build_source
     before_create :set_unique_identifier
 
+    # invalidate previously entered payments
+    after_create :invalidate_old_payments
     after_save :create_payment_profile, if: :profiles_supported?
 
     # update the order totals, etc.
     after_save :ensure_correct_adjustment, :update_order
-    # invalidate previously entered payments
-    after_create :invalidate_old_payments
 
     # Skips the validation of the source (for example, credit card) of the payment.
     #
@@ -42,8 +43,6 @@ module Spree
     #    consider them invalid.
     attr_accessor :skip_source_validation
     attr_accessor :source_attributes
-
-    after_initialize :build_source
 
     scope :from_credit_card, -> { where(source_type: 'Spree::CreditCard') }
     scope :with_state, ->(s) { where(state: s.to_s) }

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -83,8 +83,8 @@ module Spree
 
     before_save :add_primary_taxon_to_taxons
 
-    after_save :remove_previous_primary_taxon_from_taxons
     after_create :ensure_standard_variant
+    after_save :remove_previous_primary_taxon_from_taxons
     after_save :update_units
 
     scope :with_properties, ->(*property_ids) {

--- a/app/models/spree/return_authorization.rb
+++ b/app/models/spree/return_authorization.rb
@@ -8,8 +8,8 @@ module Spree
 
     has_many :inventory_units, inverse_of: :return_authorization
     has_one :stock_location
-    before_create :generate_number
     before_save :force_positive_amount
+    before_create :generate_number
 
     validates :order, presence: true
     validates :amount, numericality: true

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -23,6 +23,7 @@ module Spree
     has_many :spree_orders, class_name: "Spree::Order"
 
     before_validation :set_login
+    after_create :associate_customers, :associate_orders
     before_destroy :check_completed_orders
 
     roles_table_name = Role.table_name
@@ -45,8 +46,6 @@ module Spree
 
     accepts_nested_attributes_for :bill_address
     accepts_nested_attributes_for :ship_address
-
-    after_create :associate_customers, :associate_orders
 
     validates :email, 'valid_email_2/email': { mx: true }, if: :email_changed?
     validate :limit_owned_enterprises

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -83,12 +83,10 @@ module Spree
       variant.new_record? || variant.changed_attributes.keys.intersection(NAME_FIELDS).any?
     }
 
-    after_save :save_default_price
-
     after_create :create_stock_items
     after_create :set_position
-
     around_destroy :destruction
+    after_save :save_default_price
 
     # default variant scope only lists non-deleted variants
     scope :deleted, lambda { where('deleted_at IS NOT NULL') }

--- a/app/services/create_order_cycle.rb
+++ b/app/services/create_order_cycle.rb
@@ -38,7 +38,7 @@ class CreateOrderCycle
       coordinator_id: enterprise.id,
       name: 'Monthly order cycle',
       orders_open_at: Time.zone.now,
-      orders_close_at: Time.zone.now + 1.month
+      orders_close_at: 1.month.from_now
     )
   end
 

--- a/spec/jobs/order_cycle_closing_job_spec.rb
+++ b/spec/jobs/order_cycle_closing_job_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 
 describe OrderCycleClosingJob do
   let(:order_cycle1) {
-    create(:order_cycle, automatic_notifications: true, orders_close_at: Time.zone.now - 1.minute)
+    create(:order_cycle, automatic_notifications: true, orders_close_at: 1.minute.ago)
   }
   let(:order_cycle2) {
-    create(:order_cycle, automatic_notifications: true, orders_close_at: Time.zone.now + 1.minute)
+    create(:order_cycle, automatic_notifications: true, orders_close_at: 1.minute.from_now)
   }
   let(:order_cycle3) {
-    create(:order_cycle, automatic_notifications: false, orders_close_at: Time.zone.now - 1.minute)
+    create(:order_cycle, automatic_notifications: false, orders_close_at: 1.minute.ago)
   }
 
   it "sends notifications for recently closed order cycles with automatic notifications enabled" do

--- a/spec/jobs/order_cycle_opened_job_spec.rb
+++ b/spec/jobs/order_cycle_opened_job_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 
 describe OrderCycleOpenedJob do
   let(:oc_opened_before) {
-    create(:order_cycle, orders_open_at: Time.zone.now - 1.hour)
+    create(:order_cycle, orders_open_at: 1.hour.ago)
   }
   let(:oc_opened_now) {
     create(:order_cycle, orders_open_at: Time.zone.now)
   }
   let(:oc_opening_soon) {
-    create(:order_cycle, orders_open_at: Time.zone.now + 1.minute)
+    create(:order_cycle, orders_open_at: 1.minute.from_now)
   }
 
   it "enqueues jobs for recently opened order cycles only" do

--- a/spec/services/permissions/order_spec.rb
+++ b/spec/services/permissions/order_spec.rb
@@ -23,7 +23,7 @@ module Permissions
     }
     let(:order_from_last_year) {
       create(:completed_order_with_totals, order_cycle: order_cycle, distributor: distributor,
-                                           completed_at: Time.zone.now - 1.year)
+                                           completed_at: 1.year.ago)
     }
 
     before { allow(OpenFoodNetwork::Permissions).to receive(:new) { basic_permissions } }

--- a/spec/services/terms_of_service_spec.rb
+++ b/spec/services/terms_of_service_spec.rb
@@ -18,8 +18,8 @@ describe TermsOfService do
 
   context "a customer has accepted the platform terms of service" do
     before do
-      allow(customer).to receive(:terms_and_conditions_accepted_at) { Time.zone.now - 1.week }
-      allow(TermsOfServiceFile).to receive(:updated_at) { Time.zone.now - 2.weeks }
+      allow(customer).to receive(:terms_and_conditions_accepted_at) { 1.week.ago }
+      allow(TermsOfServiceFile).to receive(:updated_at) { 2.weeks.ago }
     end
 
     it "should reflect whether the platform TOS have been accepted since the last update" do
@@ -33,9 +33,9 @@ describe TermsOfService do
 
   context "a customer has accepted the distributor terms of service" do
     before do
-      allow(customer).to receive(:terms_and_conditions_accepted_at) { Time.zone.now - 1.week }
+      allow(customer).to receive(:terms_and_conditions_accepted_at) { 1.week.ago }
       allow(distributor).to receive(:terms_and_conditions_blob) {
-        ActiveStorage::Blob.new(created_at: Time.zone.now - 2.weeks)
+        ActiveStorage::Blob.new(created_at: 2.weeks.ago)
       }
     end
 

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -644,12 +644,12 @@ describe '
         }
         let!(:o3) {
           create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
-                                          completed_at: Time.zone.now + 1.week,
+                                          completed_at: 1.week.from_now,
                                           order_cycle: oc3 )
         }
         let!(:o4) {
           create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
-                                          completed_at: Time.zone.now + 2.weeks,
+                                          completed_at: 2.weeks.from_now,
                                           order_cycle: oc3 )
         }
         let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
@@ -658,8 +658,8 @@ describe '
         let!(:li4) { create(:line_item_with_shipment, order: o4 ) }
 
         before do
-          oc3.update!(orders_close_at: Time.zone.now + 2.weeks)
-          oc3.update!(orders_open_at: Time.zone.now + 1.week)
+          oc3.update!(orders_close_at: 2.weeks.from_now)
+          oc3.update!(orders_open_at: 1.week.from_now)
           visit_bulk_order_management
         end
 

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -125,8 +125,8 @@ describe '
   end
 
   describe 'listing order cycles with other locales' do
-    oc_open_at = Time.zone.now - 2.weeks
-    oc_close_at = Time.zone.now + 2.weeks
+    oc_open_at = 2.weeks.ago
+    oc_close_at = 2.weeks.from_now
     let!(:oc_pt) {
       create(:simple_order_cycle, name: 'oc', orders_open_at: oc_open_at,
                                   orders_close_at: oc_close_at)

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -286,10 +286,10 @@ describe '
     describe "ordering" do
       context "orders with different completion dates" do
         before do
-          order2.update!(completed_at: Time.zone.now - 2.weeks)
-          order3.update!(completed_at: Time.zone.now - 3.weeks)
-          order4.update!(completed_at: Time.zone.now - 4.weeks)
-          order5.update!(completed_at: Time.zone.now - 5.weeks)
+          order2.update!(completed_at: 2.weeks.ago)
+          order3.update!(completed_at: 3.weeks.ago)
+          order4.update!(completed_at: 4.weeks.ago)
+          order5.update!(completed_at: 5.weeks.ago)
           login_as_admin
           visit spree.admin_orders_path
         end

--- a/spec/system/admin/reports/orders_and_fulfillment_spec.rb
+++ b/spec/system/admin/reports/orders_and_fulfillment_spec.rb
@@ -110,11 +110,11 @@ describe "Orders And Fulfillment" do
       end
 
       context "with two orders on the same day at different times" do
-        let(:completed_at1) { Time.zone.now - 1500.hours } # 1500 hours in the past
-        let(:completed_at2) { Time.zone.now - 1700.hours } # 1700 hours in the past
-        let(:datetime_start1) { Time.zone.now - 1600.hours } # 1600 hours in the past
-        let(:datetime_start2) { Time.zone.now - 1800.hours } # 1600 hours in the past
-        let(:datetime_end) { Time.zone.now - 1400.hours } # 1400 hours in the past
+        let(:completed_at1) { 1500.hours.ago } # 1500 hours in the past
+        let(:completed_at2) { 1700.hours.ago } # 1700 hours in the past
+        let(:datetime_start1) { 1600.hours.ago } # 1600 hours in the past
+        let(:datetime_start2) { 1800.hours.ago } # 1600 hours in the past
+        let(:datetime_end) { 1400.hours.ago } # 1400 hours in the past
         before do
           Timecop.travel(completed_at1) { order1.finalize! }
           Timecop.travel(completed_at2) { order2.finalize! }

--- a/spec/system/admin/reports/packing_report_spec.rb
+++ b/spec/system/admin/reports/packing_report_spec.rb
@@ -10,7 +10,7 @@ describe "Packing Reports" do
     Timecop.freeze(Time.zone.now.strftime("%Y-%m-%d 00:00")) { example.run }
   end
 
-  let!(:open_datetime) { (Time.zone.now - 1.month).strftime("%Y-%m-%d 00:00") }
+  let!(:open_datetime) { 1.month.ago.strftime("%Y-%m-%d 00:00") }
   let!(:close_datetime) { Time.zone.now.strftime("%Y-%m-%d 00:00") }
 
   describe "Packing reports" do


### PR DESCRIPTION
#### What? Why?

- Part of #11253

This fixes 4 more rubocop rules that are violated in our codebase. It was generated automatically with the [rubocop-autocorrect.sh](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/script/rubocop-autocorrect.sh) script.

#### What should we test?

No testing is required since these are safe corrections

#### Release notes

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
