### PR TITLE
Skip online domain validation of dev user email

### DIFF
--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -58,6 +58,10 @@ def create_admin_user
     admin = Spree::User.new(attributes)
     admin.skip_confirmation!
     admin.skip_confirmation_notification!
+
+    # The default domain example.com is not resolved by all nameservers.
+    ValidEmail2::Address.define_method(:valid_mx?) { true }
+
     if admin.save
       role = Spree::Role.find_or_create_by(name: 'admin')
       admin.spree_roles << role

--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -65,7 +65,6 @@ def create_admin_user
     if admin.save
       role = Spree::Role.find_or_create_by(name: 'admin')
       admin.spree_roles << role
-      admin.save
       say "New admin user persisted!"
     else
       say "There was some problems with persisting new admin user:"


### PR DESCRIPTION
#### What? Why?

Whenever I ran `rails db:reset` the default test user couldn't be created because my internet service provider doesn't resolve the example.com domain. Skipping the validation solves this.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
