### PR TITLE
Fix display invoice tab for completed, resumed and canceled orders only

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -357,6 +357,10 @@ module Spree
       complete? || resumed? || awaiting_return? || returned?
     end
 
+    def can_show_invoice?
+      complete? || resumed? || canceled?
+    end
+
     # Finalizes an in progress order after checkout is complete.
     # Called after transition to complete state when payments will have been processed
     def finalize!

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -61,11 +61,10 @@
         %li{ class: adjustments_classes }
           = link_to_with_icon 'icon-cogs', t(:adjustments), spree.admin_order_adjustments_url(@order)
 
-        - if feature?(:invoices, spree_current_user)
-          - if @order.can_show_invoice?
-            - invoices_classes = "active" if current == 'Invoices'
-            %li{ class: invoices_classes }
-              = link_to_with_icon 'icon-cogs', t(:invoices), spree.admin_order_invoices_url(@order)
+        - if feature?(:invoices) && @order.can_show_invoice?
+          - invoices_classes = "active" if current == 'Invoices'
+          %li{ class: invoices_classes }
+            = link_to_with_icon 'icon-cogs', t(:invoices), spree.admin_order_invoices_url(@order)
 
         - if @order.completed?
           - authorizations_classes = "active" if current == "Return Authorizations"

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -61,10 +61,11 @@
         %li{ class: adjustments_classes }
           = link_to_with_icon 'icon-cogs', t(:adjustments), spree.admin_order_adjustments_url(@order)
 
-        - if feature?(:invoices)
-          - invoices_classes = "active" if current == 'Invoices'
-          %li{ class: invoices_classes }
-            = link_to_with_icon 'icon-cogs', t(:invoices), spree.admin_order_invoices_url(@order)
+        - if feature?(:invoices, spree_current_user)
+          - if @order.can_show_invoice?
+            - invoices_classes = "active" if current == 'Invoices'
+            %li{ class: invoices_classes }
+              = link_to_with_icon 'icon-cogs', t(:invoices), spree.admin_order_invoices_url(@order)
 
         - if @order.completed?
           - authorizations_classes = "active" if current == "Return Authorizations"

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -1005,9 +1005,9 @@ describe '
     end
   end
 
-  describe "Legal Invoices" do
+  describe "Legal Invoices - Invoices feature enabled" do
     before do
-      Flipper.enable(:invoices)
+      Flipper.enable(:invoices, user)
       login_as user
     end
 
@@ -1123,8 +1123,7 @@ describe '
           visit spree.edit_admin_order_path(order_empty)
         end
 
-        it "displays the invoice tab" do
-          pending "issue #11240"
+        it "not displays the invoice tab" do
           expect(page).to have_content "Cart".upcase
           expect(page).not_to have_content "Invoices".upcase
         end
@@ -1140,8 +1139,46 @@ describe '
           visit spree.edit_admin_order_path(order4)
         end
 
+        it "not displays the invoice tab" do
+          expect(page).to have_content "Payment".upcase
+          expect(page).not_to have_content "Invoices".upcase
+        end
+      end
+    end
+  end
+
+  describe "Legal Invoices - Invoices feature not enabled" do
+    before do
+      login_as user
+    end
+    describe "for order states" do
+      context "resumed" do
+        let!(:order2) {
+          create(:order_with_totals_and_distribution, user: user, distributor:,
+                                                      order_cycle: order_cycle, state: 'resumed',
+                                                      payment_state: 'balance_due')
+        }
+        before do
+          visit spree.edit_admin_order_path(order2)
+        end
+
         it "displays the invoice tab" do
-          pending "issue #11240"
+          expect(page).to have_content "Resumed".upcase
+          expect(page).not_to have_content "Invoices".upcase
+        end
+      end
+
+      context "payment" do
+        let!(:order4) do
+          create(:order_ready_for_payment, user: user, distributor: distributor,
+                                           order_cycle: order_cycle,
+                                           payment_state: 'balance_due')
+        end
+        before do
+          visit spree.edit_admin_order_path(order4)
+        end
+
+        it "not displays the invoice tab" do
           expect(page).to have_content "Payment".upcase
           expect(page).not_to have_content "Invoices".upcase
         end

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -1005,9 +1005,9 @@ describe '
     end
   end
 
-  describe "Legal Invoices - Invoices feature enabled" do
+  describe "Legal Invoices" do
     before do
-      Flipper.enable(:invoices, user)
+      Flipper.enable(:invoices)
       login_as user
     end
 
@@ -1123,7 +1123,7 @@ describe '
           visit spree.edit_admin_order_path(order_empty)
         end
 
-        it "not displays the invoice tab" do
+        it "should not display the invoice tab" do
           expect(page).to have_content "Cart".upcase
           expect(page).not_to have_content "Invoices".upcase
         end
@@ -1139,46 +1139,7 @@ describe '
           visit spree.edit_admin_order_path(order4)
         end
 
-        it "not displays the invoice tab" do
-          expect(page).to have_content "Payment".upcase
-          expect(page).not_to have_content "Invoices".upcase
-        end
-      end
-    end
-  end
-
-  describe "Legal Invoices - Invoices feature not enabled" do
-    before do
-      login_as user
-    end
-    describe "for order states" do
-      context "resumed" do
-        let!(:order2) {
-          create(:order_with_totals_and_distribution, user: user, distributor:,
-                                                      order_cycle: order_cycle, state: 'resumed',
-                                                      payment_state: 'balance_due')
-        }
-        before do
-          visit spree.edit_admin_order_path(order2)
-        end
-
-        it "displays the invoice tab" do
-          expect(page).to have_content "Resumed".upcase
-          expect(page).not_to have_content "Invoices".upcase
-        end
-      end
-
-      context "payment" do
-        let!(:order4) do
-          create(:order_ready_for_payment, user: user, distributor: distributor,
-                                           order_cycle: order_cycle,
-                                           payment_state: 'balance_due')
-        end
-        before do
-          visit spree.edit_admin_order_path(order4)
-        end
-
-        it "not displays the invoice tab" do
+        it "should not display the invoice tab" do
           expect(page).to have_content "Payment".upcase
           expect(page).not_to have_content "Invoices".upcase
         end


### PR DESCRIPTION
#### What? Why?
Closes #11240

<!-- Explain why this change is needed and the solution you propose. -->

Show invoice tab if the invoice feature is enabled for the current user

Also adding method in the Order model that checks the state of the order, and using it in the  edit page to fix the display of the invoice tab

 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Change the state of the orders and check if the invoice tab is displayed for `completed`, `resumed` and `canceled` only

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category:  Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

