### PR TITLE
fix Non-empty orders in the cart state do not appear in orders page 

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -149,11 +149,13 @@ module Spree
     }
 
     scope :sort_by_billing_address_name_asc, -> {
-      joins(:bill_address).order("spree_addresses.lastname ASC, spree_addresses.firstname ASC")
+      references(:bill_address)
+        .order("spree_addresses.lastname ASC, spree_addresses.firstname ASC")
     }
 
     scope :sort_by_billing_address_name_desc, -> {
-      joins(:bill_address).order("spree_addresses.lastname DESC, spree_addresses.firstname DESC")
+      references(:bill_address)
+        .order("spree_addresses.lastname DESC, spree_addresses.firstname DESC")
     }
 
     scope :with_line_items_variants_and_products_outer, lambda {

--- a/app/services/search_orders.rb
+++ b/app/services/search_orders.rb
@@ -15,21 +15,19 @@ class SearchOrders
   attr_reader :params, :current_user
 
   def fetch_orders
-    @search = search_query.
+    search = search_query.
       includes(:payments, :subscription, :shipments, :bill_address, :distributor, :order_cycle).
-      ransack(params[:q])
-
-    @search = @search.result(distinct: true)
+      ransack(params[:q]).
+      result(distinct: true)
 
     if ['bill_address',
         'billing_address'].any?{ |param|
          params.dig(:q, :s)&.starts_with?(param)
        }
-      @search = @search.left_joins(:bill_address).
-        select('spree_addresses.*, spree_orders.*')
+      search = search.select('spree_addresses.*, spree_orders.*')
     end
 
-    @search
+    search
   end
 
   def search_query

--- a/app/services/search_orders.rb
+++ b/app/services/search_orders.rb
@@ -19,7 +19,17 @@ class SearchOrders
       includes(:payments, :subscription, :shipments, :bill_address, :distributor, :order_cycle).
       ransack(params[:q])
 
-    @search.result(distinct: true).joins(:bill_address)
+    @search = @search.result(distinct: true)
+
+    if ['bill_address',
+        'billing_address'].any?{ |param|
+         params.dig(:q, :s)&.starts_with?(param)
+       }
+      @search = @search.left_joins(:bill_address).
+        select('spree_addresses.*, spree_orders.*')
+    end
+
+    @search
   end
 
   def search_query

--- a/app/services/search_orders.rb
+++ b/app/services/search_orders.rb
@@ -20,10 +20,7 @@ class SearchOrders
       ransack(params[:q]).
       result(distinct: true)
 
-    if ['bill_address',
-        'billing_address'].any?{ |param|
-         params.dig(:q, :s)&.starts_with?(param)
-       }
+    if params.dig(:q, :s)&.starts_with?("bill_address_")
       search = search.select('spree_addresses.*, spree_orders.*')
     end
 

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -33,7 +33,7 @@
     %a{ href: "mailto:#{order.email}", target: "_blank" }
       = order.email
   %td
-    = order.bill_address.full_name_for_sorting
+    = order&.bill_address.full_name_for_sorting
   %td.align-center
     %span
       = order.display_total

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -33,7 +33,7 @@
     %a{ href: "mailto:#{order.email}", target: "_blank" }
       = order.email
   %td
-    = order&.bill_address.full_name_for_sorting
+    = order&.bill_address&.full_name_for_sorting
   %td.align-center
     %span
       = order.display_total

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -149,6 +149,33 @@ module Api
             .map{ |o| o[:id] }).to eq serialized_orders([order2, order3, order1, order4])
               .map{ |o| o["id"] }
         end
+
+        context "with an order without billing address" do
+          let!(:order7) {
+            create(:order_with_line_items, billing_address: nil, order_cycle: order_cycle,
+                                           distributor: distributor)
+          }
+
+          it 'can show orders without bill address' do
+            get :index, params: { q: {} },
+                        as: :json
+
+            expect(json_response['orders']
+              .map{ |o| o[:id] }).to match_array serialized_orders([order2, order3, order1, order4,
+                                                                    order7])
+                .map{ |o|
+                                                   o["id"]
+                                                 }
+          end
+
+          it 'can sort orders by bill_address.lastname' do
+            get :index, params: { q: { s: 'bill_address_lastname ASC' } },
+                        as: :json
+            expect(json_response['orders']
+              .map{ |o| o[:id] }).to eq serialized_orders([order2, order3, order1, order4, order7])
+                .map{ |o| o["id"] }
+          end
+        end
       end
 
       context 'with pagination' do

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -269,8 +269,6 @@ describe '
       end
 
       it "displays non-empty cart orders" do
-        pending "issue #11120"
-
         # empty cart order does not appear in the results
         expect(page).not_to have_content order_empty.number
 
@@ -278,8 +276,6 @@ describe '
         expect(page).to have_content order_not_empty.number
 
         # non-empty cart order, with no with bill- and ship-address appear in the results
-
-        # pending issue #11120
         expect(page).to have_content order_not_empty_no_address.number
       end
     end

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -277,6 +277,13 @@ describe '
 
         # non-empty cart order, with no with bill- and ship-address appear in the results
         expect(page).to have_content order_not_empty_no_address.number
+
+        # And the same orders are displayed when sorting by name:
+        find("th a", text: "NAME").click
+
+        expect(page).to have_no_content order_empty.number
+        expect(page).to have_content order_not_empty.number
+        expect(page).to have_content order_not_empty_no_address.number
       end
     end
 


### PR DESCRIPTION
#### What? Why?

- Closes #11120

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
I edited the SearchOrders to include the orders that are without a billing address.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- described on: https://github.com/openfoodfoundation/openfoodnetwork/issues/11120#issue-1775250227
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
