### PR TITLE
Admin: in "Pack by Customer|Product|Supplier" report, use the final weight|volume value instead of original one

### DIFF
--- a/lib/reporting/reports/packing/base.rb
+++ b/lib/reporting/reports/packing/base.rb
@@ -48,7 +48,7 @@ module Reporting
               supplier: supplier_alias[:name],
               product: product_table[:name],
               variant: variant_full_name,
-              weight: line_item_table[:weight],
+              weight: line_item_table[:final_weight_volume],
               height: line_item_table[:height],
               width: line_item_table[:width],
               depth: line_item_table[:depth],


### PR DESCRIPTION
#### What? Why?

I'm a bit confused with this one, which is so simple, but as the linked issue mention:

> The user said that until recently, any weight adjustments in BOM were reflected in the Pack by Customer report.

And I can't see any related on that line after 1 year ago... 

I hope that the code review or test ready step will reveal any inconsistencies if this is the case.

The PR basically use `final_weight_volume` instead of `weight` in order to display adjusted with Bulk Order Management interface item value.

###### In BOM interface
<img width="503" alt="Capture d’écran 2023-08-09 à 15 40 03" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/4c009012-025e-415d-aadd-9ca522348e63">

###### Updated value in report for that line item
<img width="613" alt="Capture d’écran 2023-08-09 à 15 40 20" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/1d566f7b-e9e8-420d-9907-ddf6561a59ae">


- Closes #11356



#### What should we test?
Can't say more than the original one. I'd add test also others (ie. Product and Supplier) report as they've been also modified.
 
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes