### PR TITLE
Account creation: translate some messages around password creation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,6 +115,10 @@ en:
             using_producer_stock_settings_but_count_on_hand_set: "must be blank because using producer stock settings"
             on_demand_but_count_on_hand_set: "must be blank if on demand"
             limited_stock_but_no_count_on_hand: "must be specified because forcing limited stock"
+      messages:
+        confirmation: "doesn't match %{attribute}"
+        blank: "can't be blank"
+        too_short: "is too short (minimum is %{count} characters)"
   # Used by active_storage_validations
   errors:
     messages:


### PR DESCRIPTION
#### What? Why?
Add missing i18n keys: was already translated into some others languages (french?) by default. Add those keys to translate for all languages.

- Closes #8443





#### What should we test?
I don't exactly know how to test this one, but I'm sure @filipefurtad0 knows how to do this. This is basically about testing that for account creation, the following errors are well translated into the selected language:
 - password input is blank
 - password does not match
 - password is too short
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes