### PR TITLE
Drop :is_master column from variants table

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -13,8 +13,6 @@ module Spree
 
     acts_as_paranoid
 
-    self.ignored_columns = [:is_master]
-
     searchable_attributes :sku, :display_as, :display_name
     searchable_associations :product, :default_price
     searchable_scopes :active, :deleted

--- a/db/migrate/20230809195519_drop_variant_is_master.rb
+++ b/db/migrate/20230809195519_drop_variant_is_master.rb
@@ -1,0 +1,5 @@
+class DropVariantIsMaster < ActiveRecord::Migration[7.0]
+  def up
+    remove_column :spree_variants, :is_master
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_09_194304) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_09_195519) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -995,7 +995,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_194304) do
     t.decimal "width", precision: 8, scale: 2
     t.decimal "depth", precision: 8, scale: 2
     t.datetime "deleted_at", precision: nil
-    t.boolean "is_master", default: false
     t.integer "product_id"
     t.string "cost_currency", limit: 255
     t.float "unit_value"


### PR DESCRIPTION
#### What? Why?

A little bit of tidyup that was pending from the removal of master variants. We can drop this column now.

#### What should we test?

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

