### PR TITLE
Stabilise flaky checkout spec with voucher

### DIFF
--- a/spec/system/consumer/split_checkout_tax_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_incl_spec.rb
@@ -125,6 +125,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
           # add Voucher
           fill_in "Enter voucher code", with: "some_code"
           click_button("Apply")
+          expect(page).to have_link "Remove code"
 
           # Choose payment
           click_on "Next - Order summary"


### PR DESCRIPTION

#### What? Why?

While applying a voucher the spec tried to proceed the checkout before the voucher update completed rendering. It failed when the machine was slow.

With rspec-slow-repeat I got 100% fail rate before and 100% pass after this change.

* https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/5815143314/job/15766141975?pr=11354
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Spec only

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
