### PR TITLE
🚧 Products V3: Do not display "Producers" selector if only one is possible

### DIFF
--- a/app/views/admin/products_v3/_filters.html.haml
+++ b/app/views/admin/products_v3/_filters.html.haml
@@ -2,7 +2,7 @@
   .query
     .search-input
       = text_field_tag :search_term, search_term, placeholder: t('.search_products')
-  - if producer_options.any?
+  - if producer_options.many?
     .producers
       .label= t('.producers.label')
       = select_tag :producer_id, options_for_select(producer_options, producer_id), include_blank: t('.all_producers'), "data-controller": "tom-select", "data-tom-select-options-value": '{ "plugins": [] }', class: "fullwidth"

--- a/app/views/admin/products_v3/_filters.html.haml
+++ b/app/views/admin/products_v3/_filters.html.haml
@@ -2,9 +2,10 @@
   .query
     .search-input
       = text_field_tag :search_term, search_term, placeholder: t('.search_products')
-  .producers
-    .label= t('.producers.label')
-    = select_tag :producer_id, options_for_select(producer_options, producer_id), include_blank: t('.all_producers'), "data-controller": "tom-select", "data-tom-select-options-value": '{ "plugins": [] }', class: "fullwidth"
+  - if producer_options.any?
+    .producers
+      .label= t('.producers.label')
+      = select_tag :producer_id, options_for_select(producer_options, producer_id), include_blank: t('.all_producers'), "data-controller": "tom-select", "data-tom-select-options-value": '{ "plugins": [] }', class: "fullwidth"
   .categories
     .label= t('.categories.label')
     = select_tag :category_id, options_for_select(category_options, category_id), include_blank: t('.all_categories'),  "data-controller": "tom-select", "data-tom-select-options-value": '{ "plugins": [] }', class: "fullwidth"

--- a/spec/views/admin/products_v3/_filters.html.haml_spec.rb
+++ b/spec/views/admin/products_v3/_filters.html.haml_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "admin/products_v3/_filters.html.haml" do
+  subject { render }
+
+  let(:locals) do
+    {
+      search_term: "",
+      producer_options: [],
+      producer_id: nil,
+      category_options: [],
+      category_id: nil,
+    }
+  end
+
+  it "shows the producer filter when there are options" do
+    allow(view).to receive_messages locals.merge(
+      producer_options: [
+        ["Ada's Apples", 1],
+        ["Ben's Bananas", 2],
+      ],
+    )
+
+    is_expected.to have_content "Producers"
+    is_expected.to have_select "producer_id", options: [
+      "All producers",
+      "Ada's Apples",
+      "Ben's Bananas",
+    ], selected: nil
+  end
+
+  it "doesn't show the producer filter when there's only one option" do
+    allow(view).to receive_messages locals.merge(
+      producer_options: [
+        ["Ada's Apples", 1],
+      ],
+    )
+
+    is_expected.to have_no_content "Producers"
+    is_expected.to have_no_select "producer_id"
+  end
+end


### PR DESCRIPTION

#### What? Why?

- Closes #11274

<img width="1392" alt="Capture d’écran 2023-08-10 à 11 09 29" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/108f959b-a66b-456b-9709-c7d15fd14ffb">



#### What should we test?

- As a user with only one producer available, do not display producer selector

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes