### PR TITLE
Admin, White Label: add translation for invalid URL in white label context

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -453,7 +453,7 @@ class Enterprise < ApplicationRecord
     uri = URI(white_label_logo_link)
     self.white_label_logo_link = "http://#{white_label_logo_link}" if uri.scheme.nil?
   rescue URI::InvalidURIError
-    errors.add(:white_label_logo_link, I18n.t(:invalid_url))
+    errors.add(:white_label_logo_link, I18n.t(:invalid_url, url: white_label_logo_link))
   end
 
   def image_url_for(image, name)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,8 @@ en:
         preferred_discount_amount: "Calculator Discount Amount:"
         preferred_unit_from_list: "Calculator Unit From List:"
         preferred_per_unit: "Calculator Per Unit:"
+      enterprise:
+        white_label_logo_link: "Link for the logo used in shopfront"
     errors:
       models:
         enterprise_fee:
@@ -3174,6 +3176,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   amount: "Amount"
   invoice_number: "Invoice Number"
   invoice_file: "File"
+  invalid_url: "'%{url}' is an invalid URL"
   state_names:
     ready: Ready
     pending: Pending

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -716,6 +716,20 @@ describe '
             it_behaves_like "edit link with", "www.openfoodnetwork.org", "http://www.openfoodnetwork.org"
             it_behaves_like "edit link with", "openfoodnetwork.org", "http://openfoodnetwork.org"
           end
+
+          shared_examples "edit link with invalid" do |url|
+            it "url: #{url}" do
+              fill_in "enterprise_white_label_logo_link", with: url
+              click_button 'Update'
+              expect(page)
+                .to have_content "Link for the logo used in shopfront '#{url}' is an invalid URL"
+              expect(distributor1.reload.white_label_logo_link).to be_nil
+            end
+          end
+
+          context "can not edit white label logo link" do
+            it_behaves_like "edit link with invalid", "invalid url"
+          end
         end
 
         it "can check/uncheck the hide_groups_tab attribute" do


### PR DESCRIPTION
#### What? Why?

- Closes #10957 

<img width="636" alt="Capture d’écran 2023-08-10 à 15 20 10" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/baac90f2-a718-4e76-95c3-bf5e326604ee">



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, try to edit URL input in white label section with an invalid one
- You should see a _translated_ message 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes