### PR TITLE
Release template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -19,12 +19,7 @@ assignees: ''
     git commit -a -m "Update all locales with the latest Transifex translations"
     git push upstream master</pre>
   </details>
-- [ ] Create a tag:
-  <details><summary>Command line instructions:</summary>
-    <pre>
-    git tag vX.X.X
-    git push upstream vX.X.X</pre>
-  </details>  
+- [ ] Create a tag: `git push upstream HEAD:refs/tags/vX.Y.Z`
 - [ ] [Draft new release]. Look at previous [releases] for inspiration.
     - Select new release tag
     - _Generate release notes_ and arrange into categories as required.
@@ -44,7 +39,7 @@ assignees: ''
   <pre>
   cd ofn-install
   git pull
-  ansible-playbook --limit all-prod --extra-vars "git_version=vx.y.z" playbooks/deploy.yml
+  ansible-playbook --limit all-prod --extra-vars "git_version=vX.Y.Z" playbooks/deploy.yml
   </pre>
   </details>
 - [ ] Notify [#instance-managers]:

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -10,8 +10,18 @@ assignees: ''
 ## 1. Preparation on Thursday
 
 - [ ] Merge pull requests in the [Ready To Go] column
-- [ ] Include translations: `tx pull --force`
+- [ ] Include translations 
+  <details><summary>Command line instructions:</summary>
+    <pre>
+    git checkout master
+    git pull upstream master
+    tx pull --force
+    git commit -a -m "Update all locales with the latest Transifex translations"
+    git push upstream master</pre>
+  </details>
 - [ ] [Draft new release]. Look at previous [releases] for inspiration.
+    - Select latest master commit
+    - _Generate release notes_ and arrange into categories as required.
 - [ ] Notify [#instance-managers] of user-facing changes.
 
 ## 2. Testing

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -19,17 +19,22 @@ assignees: ''
     git commit -a -m "Update all locales with the latest Transifex translations"
     git push upstream master</pre>
   </details>
+- [ ] Create a tag:
+  <details><summary>Command line instructions:</summary>
+    <pre>
+    git tag vX.X.X
+    git push upstream vX.X.X</pre>
+  </details>  
 - [ ] [Draft new release]. Look at previous [releases] for inspiration.
-    - Select latest master commit
+    - Select new release tag
     - _Generate release notes_ and arrange into categories as required.
 - [ ] Notify [#instance-managers] of user-facing changes.
 
 ## 2. Testing
 
-- [ ] Copy the release commit below
 - [ ] Move this issue to Test Ready.
 - [ ] Notify `@testers` in [#testing].
-- [ ] Test build: [Deploy to Staging] with commit <!-- paste commit ID here, eg bb8bcecc9... -->
+- [ ] Test build: [Deploy to Staging] with release tag.
 
 ## 3. Finish on Tuesday
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -26,10 +26,10 @@ assignees: ''
 
 ## 2. Testing
 
-- [ ] [Find build] of the release commit and copy it below.
+- [ ] Copy the release commit below
 - [ ] Move this issue to Test Ready.
 - [ ] Notify `@testers` in [#testing].
-- [ ] Test build: <!-- paste build link here, e.g. https://semaphore...builds/1234 -->
+- [ ] Test build: [Deploy to Staging] with commit <!-- paste commit ID here, eg bb8bcecc9... -->
 
 ## 3. Finish on Tuesday
 
@@ -54,5 +54,5 @@ The full process is described at https://github.com/openfoodfoundation/openfoodn
 [releases]: https://github.com/openfoodfoundation/openfoodnetwork/releases
 [#instance-managers]: https://app.slack.com/client/T02G54U79/CG7NJ966B
 [#testing]: https://openfoodnetwork.slack.com/app_redirect?channel=C02TZ6X00
-[Find build]: https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2/branches/master
+[Deploy to Staging]: https://github.com/openfoodfoundation/openfoodnetwork/actions/workflows/stage.yml
 [#global-community]: https://app.slack.com/client/T02G54U79/C59ADD8F2


### PR DESCRIPTION
#### What? Why?

Now that we’re not using Semaphore, we need a different way to trigger a deploy of the release. (GitHub Actions won’t let you choose a specific commit). I think we have two options:

1. Create a PR for the release. A PR has to have at least one change, so we can include the Transifex update on it. Then it’s a simple matter of applying the label in order to deploy, just like any other PR.
2. Create the tag for the release first. Then you can manually deploy to staging using the new tag. 


Thanks to Filipe and Maikel for working on the PR process.

_Edit:_ A new option is to continue with a process similar to the old way:

3.  We paste the commit id in the issue and you need to copy&paste it when deploying that commit.