### PR TITLE
Invoice data generator, fix flaky test

### DIFF
--- a/spec/services/invoice_data_generator_spec.rb
+++ b/spec/services/invoice_data_generator_spec.rb
@@ -54,7 +54,7 @@ describe InvoiceDataGenerator do
 
     context "line items" do
       it "should reflect the changes" do
-        line_item = order.line_items.first
+        line_item = order.sorted_line_items.first
         new_quantity = line_item.quantity + 1
         line_item.update!(quantity: new_quantity)
 
@@ -62,7 +62,7 @@ describe InvoiceDataGenerator do
       end
 
       it "should not reflect variant changes" do
-        line_item = order.line_items.first
+        line_item = order.sorted_line_items.first
         old_variant_name = line_item.variant.display_name
         line_item.variant.update!(display_name: "NEW NAME")
 


### PR DESCRIPTION
#### What? Why?

- Closes #11402

The test was using order.line_items.first to pick an line item to update, the expectation was using order.sorted_line_items. Sometimes those two returns line_items in different order, thus the flakyness 


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green test suite

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
