### PR TITLE
Don't show extra red messages when gems missing

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,8 @@ FileUtils.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system! "script/install-bundler"
-  system("bundle check") || system!(BUNDLE_ENV, "bundle install")
+  # Check first (it's quicker), then install new gems if necessary
+  system("bundle check 2> /dev/null") || system!(BUNDLE_ENV, "bundle install")
 
   # Install JavaScript dependencies
   system("bin/yarn")


### PR DESCRIPTION
#### What? Why?
When a gem is missing, it looks like a big ugly error. But we don't need to see this, because `bundle install` will run next and tell us which gems it is installing.

![Screen Shot 2023-08-16 at 10 25 01 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/f6697ae3-f7e7-49fe-9016-3345c896a96a)

Note that `bundle check` isn't actually necessary because bundle install will handle this, but for some reason it's 300ms slower. So I chose to keep 'check' to help keep this script nice and quick.

This is such a tiny change I think one review will be more than enough.

#### What should a dev test?
Try running the script with a gem missing. I've already done this, so I don't think worth further testing:

![Screen Shot 2023-08-16 at 10 26 29 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/df9e7209-8131-4f4a-acb7-8d04e75a5727)


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category:  Technical changes
