### PR TITLE
🚧 BUU: Once products are loaded, scroll higher, ie. just above filters

### DIFF
--- a/app/webpacker/controllers/products_controller.js
+++ b/app/webpacker/controllers/products_controller.js
@@ -11,6 +11,7 @@ export default class extends ApplicationController {
 
   beforeReflex() {
     this.showLoading();
+    this.scrollToElement();
   }
 
   afterReflex() {
@@ -27,6 +28,10 @@ export default class extends ApplicationController {
     if (this.getLoadingController()) {
       this.getLoadingController().hideLoading();
     }
+  };
+
+  scrollToElement = () => {
+    this.element.scrollIntoView();
   };
 
   getLoadingController = () => {


### PR DESCRIPTION
#### What? Why?

- Closes #11410 
![2023-08-18 10 19 11](https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/cf0336d0-0731-4fff-bc25-4517380d7a02)




#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Nothing?

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes under feature toggle