### PR TITLE
Fix Rails and Style Autocorrect Rubocop Errors

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1096,7 +1096,6 @@ Style/HashSyntax:
     - 'spec/helpers/spree/base_helper_spec.rb'
     - 'spec/jobs/report_job_spec.rb'
     - 'spec/jobs/subscription_confirm_job_spec.rb'
-    - 'spec/jobs/subscription_placement_job_spec.rb'
     - 'spec/jobs/webhook_delivery_job_spec.rb'
     - 'spec/lib/open_food_network/address_finder_spec.rb'
     - 'spec/lib/open_food_network/enterprise_fee_applicator_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,6 +6,14 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+# Offense count: 1
+# This cop supports safe autocorrection (--autocorrect).
+# Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
+# URISchemes: http, https
+Layout/LineLength:
+  Exclude:
+    - 'spec/system/admin/tag_rules_spec.rb'
+
 # Offense count: 17
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: enums
@@ -800,20 +808,6 @@ Style/ClassAndModuleChildren:
 Style/ClassVars:
   Exclude:
     - 'lib/spree/core/delegate_belongs_to.rb'
-
-# Offense count: 9
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowedVars.
-Style/FetchEnvVar:
-  Exclude:
-    - 'app/helpers/discourse_helper.rb'
-    - 'app/models/spree/preferences/configuration.rb'
-    - 'app/models/spree/preferences/preferable.rb'
-    - 'app/services/default_country.rb'
-    - 'spec/base_spec_helper.rb'
-    - 'spec/controllers/spree/credit_cards_controller_spec.rb'
-    - 'spec/models/order_balance_spec.rb'
-    - 'spec/support/vcr_setup.rb'
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -761,12 +761,6 @@ Style/ArrayIntersect:
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
-Style/BlockComments:
-  Exclude:
-    - 'spec/system/admin/tag_rules_spec.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowOnConstant, AllowOnSelfClass.
 Style/CaseEquality:
   Exclude:
@@ -903,7 +897,7 @@ Style/HashLikeCase:
   Exclude:
     - 'app/models/enterprise.rb'
 
-# Offense count: 1782
+# Offense count: 1784
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
 # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -741,28 +741,6 @@ Rails/WhereExists:
     - 'lib/tasks/sample_data/order_cycle_factory.rb'
     - 'lib/tasks/sample_data/taxon_factory.rb'
 
-# Offense count: 24
-# This cop supports safe autocorrection (--autocorrect).
-Rails/WhereNot:
-  Exclude:
-    - 'app/controllers/spree/admin/products_controller.rb'
-    - 'app/models/concerns/permalink_generator.rb'
-    - 'app/models/enterprise.rb'
-    - 'app/models/enterprise_fee.rb'
-    - 'app/models/enterprise_relationship.rb'
-    - 'app/models/product_import/inventory_reset_strategy.rb'
-    - 'app/models/proxy_order.rb'
-    - 'app/models/spree/credit_card.rb'
-    - 'app/models/spree/product.rb'
-    - 'app/models/spree/variant.rb'
-    - 'app/models/spree/zone.rb'
-    - 'app/models/variant_override.rb'
-    - 'app/services/cap_quantity.rb'
-    - 'engines/catalog/app/services/catalog/product_import/products_reset_strategy.rb'
-    - 'engines/order_management/app/services/order_management/subscriptions/proxy_order_syncer.rb'
-    - 'lib/reporting/reports/users_and_enterprises/base.rb'
-    - 'lib/tasks/data/anonymize_data.rake'
-
 # Offense count: 1
 Security/Open:
   Exclude:

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -180,7 +180,7 @@ module Spree
           select('DISTINCT spree_variants.import_date').
           joins(:product).
           where('spree_products.supplier_id IN (?)', editable_enterprises.collect(&:id)).
-          where('spree_variants.import_date IS NOT NULL').
+          where.not(spree_variants: { import_date: nil }).
           where(spree_variants: { deleted_at: nil }).
           order('spree_variants.import_date DESC')
       end

--- a/app/helpers/discourse_helper.rb
+++ b/app/helpers/discourse_helper.rb
@@ -6,7 +6,7 @@ module DiscourseHelper
   end
 
   def discourse_url
-    ENV['DISCOURSE_URL']
+    ENV.fetch('DISCOURSE_URL', nil)
   end
 
   def discourse_login_url

--- a/app/models/concerns/permalink_generator.rb
+++ b/app/models/concerns/permalink_generator.rb
@@ -34,7 +34,7 @@ module PermalinkGenerator
     if id.nil?
       scope_with_deleted
     else
-      scope_with_deleted.where('id != ?', id)
+      scope_with_deleted.where.not(id:)
     end
   end
 

--- a/app/models/enterprise_fee.rb
+++ b/app/models/enterprise_fee.rb
@@ -37,7 +37,7 @@ class EnterpriseFee < ApplicationRecord
   }
 
   scope :per_item, lambda {
-    joins(:calculator).where('spree_calculators.type NOT IN (?)', PER_ORDER_CALCULATORS)
+    joins(:calculator).where.not(spree_calculators: { type: PER_ORDER_CALCULATORS })
   }
   scope :per_order, lambda {
     joins(:calculator).where('spree_calculators.type IN (?)', PER_ORDER_CALCULATORS)

--- a/app/models/enterprise_relationship.rb
+++ b/app/models/enterprise_relationship.rb
@@ -75,7 +75,7 @@ class EnterpriseRelationship < ApplicationRecord
     if perms.nil?
       permissions.destroy_all
     else
-      permissions.where('name NOT IN (?)', perms).destroy_all
+      permissions.where.not(name: perms).destroy_all
       perms.map { |name| permissions.find_or_initialize_by name: name }
     end
   end

--- a/app/models/product_import/inventory_reset_strategy.rb
+++ b/app/models/product_import/inventory_reset_strategy.rb
@@ -24,7 +24,7 @@ module ProductImport
       relation = VariantOverride.where(hub_id: enterprise_ids)
       return relation if excluded_items_ids.blank?
 
-      relation.where('id NOT IN (?)', excluded_items_ids)
+      relation.where.not(id: excluded_items_ids)
     end
   end
 end

--- a/app/models/proxy_order.rb
+++ b/app/models/proxy_order.rb
@@ -16,7 +16,7 @@ class ProxyOrder < ApplicationRecord
   scope :active, -> { joins(:order_cycle).merge(OrderCycle.active) }
   scope :closed, -> { joins(:order_cycle).merge(OrderCycle.closed) }
   scope :not_closed, -> { joins(:order_cycle).merge(OrderCycle.not_closed) }
-  scope :canceled, -> { where('proxy_orders.canceled_at IS NOT NULL') }
+  scope :canceled, -> { where.not(proxy_orders: { canceled_at: nil }) }
   scope :not_canceled, -> { where('proxy_orders.canceled_at IS NULL') }
   scope :placed_and_open, -> {
                             joins(:order).not_closed

--- a/app/models/spree/credit_card.rb
+++ b/app/models/spree/credit_card.rb
@@ -23,7 +23,7 @@ module Spree
     after_create :ensure_single_default_card
     after_save :ensure_single_default_card, if: :default_card_needs_updating?
 
-    scope :with_payment_profile, -> { where('gateway_customer_profile_id IS NOT NULL') }
+    scope :with_payment_profile, -> { where.not(gateway_customer_profile_id: nil) }
 
     # needed for some of the ActiveMerchant gateways (eg. SagePay)
     alias_attribute :brand, :cc_type

--- a/app/models/spree/preferences/configuration.rb
+++ b/app/models/spree/preferences/configuration.rb
@@ -32,7 +32,7 @@ module Spree
       end
 
       def preference_cache_key(name)
-        [ENV['RAILS_CACHE_ID'], self.class.name, name].flatten.join('::').underscore
+        [ENV.fetch('RAILS_CACHE_ID', nil), self.class.name, name].flatten.join('::').underscore
       end
 
       def reset

--- a/app/models/spree/preferences/preferable.rb
+++ b/app/models/spree/preferences/preferable.rb
@@ -81,7 +81,7 @@ module Spree
       def preference_cache_key(name)
         return unless id
 
-        [ENV["RAILS_CACHE_ID"], self.class.name, name, id].join('::').underscore
+        [ENV.fetch("RAILS_CACHE_ID", nil), self.class.name, name, id].join('::').underscore
       end
 
       def save_pending_preferences

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -163,7 +163,7 @@ module Spree
       with_order_cycles_inner.
         merge(OrderCycle.active).
         merge(Exchange.outgoing).
-        where('order_cycles.id IS NOT NULL')
+        where.not(order_cycles: { id: nil })
     }
 
     scope :by_producer, -> { joins(:supplier).order('enterprises.name') }

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -91,7 +91,7 @@ module Spree
     after_save :save_default_price
 
     # default variant scope only lists non-deleted variants
-    scope :deleted, lambda { where('deleted_at IS NOT NULL') }
+    scope :deleted, lambda { where.not(deleted_at: nil) }
 
     scope :with_order_cycles_inner, -> { joins(exchanges: :order_cycle) }
 
@@ -162,7 +162,7 @@ module Spree
                                           where(deleted_at: nil).
                                           where('spree_prices.currency' =>
                                             currency || Spree::Config[:currency]).
-                                          where('spree_prices.amount IS NOT NULL').
+                                          where.not(spree_prices: { amount: nil }).
                                           select("spree_variants.id"))
     end
 

--- a/app/models/spree/zone.rb
+++ b/app/models/spree/zone.rb
@@ -138,7 +138,7 @@ module Spree
     end
 
     def remove_previous_default
-      Spree::Zone.where('id != ?', id).update_all(default_tax: false) if default_tax
+      Spree::Zone.where.not(id:).update_all(default_tax: false) if default_tax
     end
   end
 end

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -29,7 +29,7 @@ class VariantOverride < ApplicationRecord
 
   scope :distinct_import_dates, lambda {
     select('DISTINCT variant_overrides.import_date').
-      where('variant_overrides.import_date IS NOT NULL').
+      where.not(variant_overrides: { import_date: nil }).
       order('import_date DESC')
   }
 

--- a/app/services/cap_quantity.rb
+++ b/app/services/cap_quantity.rb
@@ -42,7 +42,7 @@ class CapQuantity
   end
 
   def unavailable_stock_lines_for
-    order.line_items.where('variant_id NOT IN (?)', available_variants_for.select(&:id))
+    order.line_items.where.not(variant_id: available_variants_for.select(&:id))
   end
 
   def available_variants_for

--- a/app/services/default_country.rb
+++ b/app/services/default_country.rb
@@ -10,6 +10,7 @@ class DefaultCountry
   end
 
   def self.country
-    Spree::Country.cached_find_by(iso: ENV["DEFAULT_COUNTRY_CODE"]) || Spree::Country.first
+    Spree::Country.cached_find_by(iso: ENV.fetch("DEFAULT_COUNTRY_CODE",
+                                                 nil)) || Spree::Country.first
   end
 end

--- a/engines/catalog/app/services/catalog/product_import/products_reset_strategy.rb
+++ b/engines/catalog/app/services/catalog/product_import/products_reset_strategy.rb
@@ -29,7 +29,7 @@ module Catalog
 
         return relation if excluded_items_ids.blank?
 
-        relation.where('spree_variants.id NOT IN (?)', excluded_items_ids)
+        relation.where.not(spree_variants: { id: excluded_items_ids })
       end
 
       def reset_variants_on_hand_and_on_demand(variants)

--- a/engines/order_management/app/services/order_management/subscriptions/proxy_order_syncer.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/proxy_order_syncer.rb
@@ -75,7 +75,7 @@ module OrderManagement
         order_cycle_ids = in_range_order_cycles.pluck(:id)
         return orphaned unless order_cycle_ids.any?
 
-        orphaned.where('order_cycle_id NOT IN (?)', order_cycle_ids)
+        orphaned.where.not(order_cycle_id: order_cycle_ids)
       end
 
       def insert_values

--- a/lib/tasks/data/anonymize_data.rake
+++ b/lib/tasks/data/anonymize_data.rake
@@ -47,7 +47,7 @@ namespace :ofn do
       Customer.where("user_id IS NULL")
         .update_all("email = concat(id, '_ofn_customer@example.com'),
                      name = concat('Customer Number ', id, ' (without connected User)')")
-      Customer.where("user_id IS NOT NULL")
+      Customer.where.not(user_id: nil)
         .update_all("email = concat(user_id, '_ofn_user@example.com'),
                      name = concat('Customer Number ', id, ' - User ', user_id)")
 

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -48,7 +48,7 @@ Capybara.configure do |config|
 end
 
 # Override setting in Spree engine: Spree::Core::MailSettings
-ActionMailer::Base.default_url_options[:host] = ENV["SITE_URL"]
+ActionMailer::Base.default_url_options[:host] = ENV.fetch("SITE_URL", nil)
 
 FactoryBot.use_parent_strategy = false
 FactoryBot::SyntaxRunner.include FileHelper

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Spree::CreditCardsController, type: :controller do
   describe "using VCR", :vcr do
     let(:user) { create(:user) }
-    let(:secret) { ENV['STRIPE_SECRET_TEST_API_KEY'] }
+    let(:secret) { ENV.fetch('STRIPE_SECRET_TEST_API_KEY', nil) }
 
     before do
       Stripe.api_key = secret

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -19,9 +19,9 @@ describe SubscriptionPlacementJob do
                                   orders_close_at: 1.minute.ago)
     }
     let(:schedule) { create(:schedule, order_cycles: [order_cycle1, order_cycle2]) }
-    let(:subscription) { create(:subscription, shop: shop, schedule: schedule) }
+    let(:subscription) { create(:subscription, shop:, schedule:) }
     let!(:proxy_order) {
-      create(:proxy_order, subscription: subscription, order_cycle: order_cycle1)
+      create(:proxy_order, subscription:, order_cycle: order_cycle1)
     } # OK
 
     it "ignores proxy orders where the OC has closed" do
@@ -58,12 +58,11 @@ describe SubscriptionPlacementJob do
       let(:shop) { order_cycle.coordinator }
       let(:order_cycle) { create(:simple_order_cycle) }
       let(:exchange) {
-        create(
-          :exchange, order_cycle: order_cycle,
-          sender: shop, receiver: shop, incoming: false
-        )
+        create(:exchange, order_cycle:, sender: shop, receiver: shop, incoming: false)
       }
-      let!(:proxy_order) { create(:proxy_order, subscription: subscription, order_cycle: order_cycle, order: order) }
+      let!(:proxy_order) {
+        create(:proxy_order, subscription:, order_cycle:, order:)
+      }
 
       before do
         allow(job).to receive(:proxy_orders) { ProxyOrder.where(id: proxy_order.id) }
@@ -101,8 +100,8 @@ describe SubscriptionPlacementJob do
     let!(:shipping_method_created_later) { create(:shipping_method, distributors: [shop]) }
 
     let(:shop) { create(:enterprise) }
-    let(:subscription) { create(:subscription, shop: shop, with_items: true) }
-    let(:proxy_order) { create(:proxy_order, subscription: subscription) }
+    let(:subscription) { create(:subscription, shop:, with_items: true) }
+    let(:proxy_order) { create(:proxy_order, subscription:) }
     let(:oc) { proxy_order.order_cycle }
     let(:ex) { oc.exchanges.outgoing.find_by(sender_id: shop.id, receiver_id: shop.id) }
     let(:fee) { create(:enterprise_fee, enterprise: shop, fee_type: 'sales', amount: 10) }
@@ -192,9 +191,9 @@ describe SubscriptionPlacementJob do
       )
     }
     let(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
-    let(:subscription) { create(:subscription, shop: shop, schedule: schedule) }
+    let(:subscription) { create(:subscription, shop:, schedule:) }
     let!(:proxy_order) {
-      create(:proxy_order, subscription: subscription, order_cycle: order_cycle)
+      create(:proxy_order, subscription:, order_cycle:)
     }
     let(:breakpoint) { Mutex.new }
 

--- a/spec/models/order_balance_spec.rb
+++ b/spec/models/order_balance_spec.rb
@@ -45,7 +45,9 @@ describe OrderBalance do
     end
 
     it 'returns the balance wraped in a Money object' do
-      expect(order_balance.display_amount).to eq(Spree::Money.new(20, currency: ENV['currency']))
+      expect(order_balance.display_amount).to eq(Spree::Money.new(20,
+                                                                  currency: ENV.fetch('currency',
+                                                                                      nil)))
     end
   end
 

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -7,7 +7,7 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.ignore_localhost = true
   config.configure_rspec_metadata!
-  config.filter_sensitive_data('<HIDDEN_KEY>') { ENV['STRIPE_SECRET_TEST_API_KEY'] }
-  config.filter_sensitive_data('<HIDDEN_CUSTOMER>') { ENV['STRIPE_CUSTOMER'] }
+  config.filter_sensitive_data('<HIDDEN_KEY>') { ENV.fetch('STRIPE_SECRET_TEST_API_KEY', nil) }
+  config.filter_sensitive_data('<HIDDEN_CUSTOMER>') { ENV.fetch('STRIPE_CUSTOMER', nil) }
   config.ignore_hosts('localhost', '127.0.0.1', '0.0.0.0', 'api.knapsackpro.com')
 end

--- a/spec/system/admin/tag_rules_spec.rb
+++ b/spec/system/admin/tag_rules_spec.rb
@@ -206,41 +206,39 @@ describe 'Tag Rules' do
                        from: "enterprise_tag_rules_attributes_4_preferred_matched_" \
                              "shipping_methods_visibility"
       end
-=begin
-      # Moving the Shipping Methods to top priority
-      find(".customer_tag#tg_4 .header", ).drag_to find(".customer_tag#tg_1 .header")
-
-      click_button 'Update'
-
-      # DEFAULT FilterShippingMethods rule
-      expect(default_fsm_tag_rule.reload.preferred_customer_tags).to eq ""
-      expect(default_fsm_tag_rule.preferred_shipping_method_tags).to eq "volunteers-only"
-      expect(default_fsm_tag_rule.preferred_matched_shipping_methods_visibility).to eq "hidden"
-
-      # FilterShippingMethods rule
-      expect(fsm_tag_rule.reload.priority).to eq 1
-      expect(fsm_tag_rule.preferred_customer_tags).to eq "volunteer"
-      expect(fsm_tag_rule.preferred_shipping_method_tags).to eq "volunteers-only4"
-      expect(fsm_tag_rule.preferred_matched_shipping_methods_visibility).to eq "visible"
-
-      # FilterProducts rule
-      expect(fp_tag_rule.reload.priority).to eq 2
-      expect(fp_tag_rule.preferred_customer_tags).to eq "volunteer"
-      expect(fp_tag_rule.preferred_variant_tags).to eq "volunteers-only1"
-      expect(fp_tag_rule.preferred_matched_variants_visibility).to eq "hidden"
-
-      # FilterPaymentMethods rule
-      expect(fpm_tag_rule.reload.priority).to eq 3
-      expect(fpm_tag_rule.preferred_customer_tags).to eq "volunteer"
-      expect(fpm_tag_rule.preferred_payment_method_tags).to eq "volunteers-only2"
-      expect(fpm_tag_rule.preferred_matched_payment_methods_visibility).to eq "visible"
-
-      # FilterOrderCycles rule
-      expect(foc_tag_rule.reload.priority).to eq 4
-      expect(foc_tag_rule.preferred_customer_tags).to eq "volunteer"
-      expect(foc_tag_rule.preferred_exchange_tags).to eq "volunteers-only3"
-      expect(foc_tag_rule.preferred_matched_order_cycles_visibility).to eq "hidden"
-=end
+      #       # Moving the Shipping Methods to top priority
+      #       find(".customer_tag#tg_4 .header", ).drag_to find(".customer_tag#tg_1 .header")
+      #
+      #       click_button 'Update'
+      #
+      #       # DEFAULT FilterShippingMethods rule
+      #       expect(default_fsm_tag_rule.reload.preferred_customer_tags).to eq ""
+      #       expect(default_fsm_tag_rule.preferred_shipping_method_tags).to eq "volunteers-only"
+      #       expect(default_fsm_tag_rule.preferred_matched_shipping_methods_visibility).to eq "hidden"
+      #
+      #       # FilterShippingMethods rule
+      #       expect(fsm_tag_rule.reload.priority).to eq 1
+      #       expect(fsm_tag_rule.preferred_customer_tags).to eq "volunteer"
+      #       expect(fsm_tag_rule.preferred_shipping_method_tags).to eq "volunteers-only4"
+      #       expect(fsm_tag_rule.preferred_matched_shipping_methods_visibility).to eq "visible"
+      #
+      #       # FilterProducts rule
+      #       expect(fp_tag_rule.reload.priority).to eq 2
+      #       expect(fp_tag_rule.preferred_customer_tags).to eq "volunteer"
+      #       expect(fp_tag_rule.preferred_variant_tags).to eq "volunteers-only1"
+      #       expect(fp_tag_rule.preferred_matched_variants_visibility).to eq "hidden"
+      #
+      #       # FilterPaymentMethods rule
+      #       expect(fpm_tag_rule.reload.priority).to eq 3
+      #       expect(fpm_tag_rule.preferred_customer_tags).to eq "volunteer"
+      #       expect(fpm_tag_rule.preferred_payment_method_tags).to eq "volunteers-only2"
+      #       expect(fpm_tag_rule.preferred_matched_payment_methods_visibility).to eq "visible"
+      #
+      #       # FilterOrderCycles rule
+      #       expect(foc_tag_rule.reload.priority).to eq 4
+      #       expect(foc_tag_rule.preferred_customer_tags).to eq "volunteer"
+      #       expect(foc_tag_rule.preferred_exchange_tags).to eq "volunteers-only3"
+      #       expect(foc_tag_rule.preferred_matched_order_cycles_visibility).to eq "hidden"
     end
   end
 


### PR DESCRIPTION
#### What? Why?

- Part of #11253

This fixes 3 more rubocop rules that are violated in our codebase. It was generated automatically with the [rubocop-autocorrect.sh](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/script/rubocop-autocorrect.sh) script.

The correction also seems to fix a subscription bug. When no items where available then it looked like all items were available. This is just true for a part of the subscription code though and there may be other parts covering this. The bug may not have been visible at all.

#### What should we test?

* Test placing a subscription.
* Test the edge case of all subscription items becoming unavailable (no stock or removed from the order cycle).
* Don't worry about reproducing the bug, it may have been hidden, but test that it now works as expected: you should receive an email that the order is empty: "Unfortunately, none of products that you ordered were available, so no order has been placed. The original quantities that you requested appear crossed-out below."

#### Release notes

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
