### PR TITLE
Fix Rails/ActiveRecordOverride

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -420,13 +420,6 @@ Naming/VariableNumber:
     - 'spec/models/spree/tax_rate_spec.rb'
     - 'spec/requests/api/orders_spec.rb'
 
-# Offense count: 1
-# Configuration parameters: Severity, Include.
-# Include: app/models/**/*.rb
-Rails/ActiveRecordOverride:
-  Exclude:
-    - 'app/models/spree/product.rb'
-
 # Offense count: 47
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb


### PR DESCRIPTION
#### What? Why?

- Helps #6055 

This resolves a cop error that came up in #11405 . Instead of overriding ActiveRecord method, which is considered a bad practice, a callback is used with `around_destroy` which accomplishes the same result.


#### What should we test?
The current specs should cover this case.

#### Release notes

Changelog Category: Technical changes

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
