### PR TITLE
Generate all release note categories with labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,11 @@
 
 <!-- Please select one for your PR and delete the other. -->
 
-Changelog Category: User facing changes | Technical changes
+Changelog Category (reviewers may add a label for the release notes):
+
+- [x] User facing changes
+- [ ] Technical changes only
+- [ ] Feature toggled
 
 <!-- Choose a pull request title above which explains your change to a
      a user of the Open Food Network app. -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,13 @@ changelog:
       exclude:
         labels:
           - dependencies
-    - title: Dependencies 📦
+          - feature toggled
+          - technical changes only
+    - title: "Experimental features for testing 😎"
+        - feature toggled
+    - title: "Technical changes 🔧"
+      labels:
+        - technical changes only
+    - title: "Dependencies 📦"
       labels:
         - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,6 @@
 changelog:
   categories:
-    - title: "User-facing changes 👀" # Other categories will need to be manually arrange for now.
+    - title: "User-facing changes 👀"
       labels:
         - '*'
       exclude:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,7 +8,7 @@ changelog:
           - dependencies
           - feature toggled
           - technical changes only
-    - title: "Experimental features for testing 😎"
+    - title: "Features under construction 🚧"
         - feature toggled
     - title: "Technical changes 🔧"
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -10,7 +10,7 @@ changelog:
           - technical changes only
     - title: "Features under construction 🚧"
         - feature toggled
-    - title: "Technical changes 🔧"
+    - title: "Technical changes 🛠️"
       labels:
         - technical changes only
     - title: "Dependencies 📦"


### PR DESCRIPTION
#### What? Why?

- Learnings from #11422

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

If reviewers add the right labels to pull requests then the release note categories can be generated automatically.

There are two new labels:
![Screen Shot 2023-08-23 at 11 09 51 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/9e416003-aa02-47bd-b841-8aae7f8de079)



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
