### PR TITLE
fix order invoice generator must update the latest invoice

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -9,6 +9,10 @@ class Invoice < ApplicationRecord
   after_create :cancel_previous_invoices
   default_scope { order(created_at: :desc) }
 
+  def self.latest
+    reorder(created_at: :desc).first
+  end
+
   def presenter
     @presenter ||= Invoice::DataPresenter.new(self)
   end

--- a/app/services/order_invoice_generator.rb
+++ b/app/services/order_invoice_generator.rb
@@ -13,7 +13,7 @@ class OrderInvoiceGenerator
         data: invoice_data
       )
     elsif comparator.can_update_latest_invoice?
-      order.invoices.last.update!(
+      order.invoices.first.update!(
         date: Time.zone.today,
         data: invoice_data
       )

--- a/app/services/order_invoice_generator.rb
+++ b/app/services/order_invoice_generator.rb
@@ -13,7 +13,7 @@ class OrderInvoiceGenerator
         data: invoice_data
       )
     elsif comparator.can_update_latest_invoice?
-      order.invoices.first.update!(
+      order.invoices.latest.update!(
         date: Time.zone.today,
         data: invoice_data
       )

--- a/spec/services/order_invoice_generator_spec.rb
+++ b/spec/services/order_invoice_generator_spec.rb
@@ -43,6 +43,19 @@ describe OrderInvoiceGenerator do
         expect{ subject }.to change{ latest_invoice.reload.data }
           .and change{ order.invoices.count }.by(0)
       end
+
+      context "when there are more than one invoice" do
+        before do
+          latest_invoice.update!(number: 2, created_at: 1.day.ago)
+          create(:invoice, order:, number: 1, created_at: 2.days.ago)
+        end
+        it "should update the most recent invoice" do
+          expect{ subject }.to change{ latest_invoice.reload.data }
+            .and change{ latest_invoice.date }.to(Time.zone.today)
+            .and change{ latest_invoice.number }.by(0)
+            .and change{ order.invoices.count }.by(0)
+        end
+      end
     end
 
     context "when can't generate new invoice or update latest invoice" do


### PR DESCRIPTION
#### What? Why?

When we generate an invoice, we use OrderInvoiceGenerator to decide if
* we can update the latest invoice with fresher data from the order
* or in case the last invoice is invalid, we need to generate a new invoice (with a new number)

When I wrote the first tests, I considered the case where we need to update the invoice of an order with one existing invoice.
Now, I noticed that if the order has two invoices, the earliest invoice will always be updated (instead of the latest). 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Use [this document](https://docs.google.com/spreadsheets/d/1hOM6UL4mWeRCFLcDQ3fTkbhbUQ2WvIUCCA1IerDBtUA/edit#gid=0) for reference
- Create one order
- generate an invoice
- update the order (the changes must require a new invoice) (edit line item quantity for example)
- click generate/update invoice
- update the order (the changes must require updating the latest invoice) (note for example)
- click generate/update invoice
- Only the latest invoice must be updated 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
