### PR TITLE
Activate vouchers feature per user or enterprise

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,8 +23,9 @@ module ApplicationHelper
     end
   end
 
-  def feature?(feature, user = nil)
-    OpenFoodNetwork::FeatureToggle.enabled?(feature, user)
+  # Checks weather a feature is enabled for any of the given actors.
+  def feature?(feature, *actors)
+    OpenFoodNetwork::FeatureToggle.enabled?(feature, *actors)
   end
 
   def language_meta_tags

--- a/app/views/admin/enterprises/_form.html.haml
+++ b/app/views/admin/enterprises/_form.html.haml
@@ -10,7 +10,7 @@
       %legend= t(".#{ item[:name] }.legend")
 
   - when 'vouchers'
-    - if feature?(:vouchers, spree_current_user) || feature?(:vouchers, @enterprise)
+    - if feature?(:vouchers, spree_current_user, @enterprise)
       %fieldset.alpha.no-border-bottom{ id: "#{item[:name]}_panel", data: { "tabs-and-panels-target": "panel"  }}
         %legend= t(".#{ item[:form_name] || item[:name] }.legend")
         = render "admin/enterprises/form/#{ item[:form_name] || item[:name] }", f: f

--- a/app/views/admin/enterprises/_form.html.haml
+++ b/app/views/admin/enterprises/_form.html.haml
@@ -10,7 +10,7 @@
       %legend= t(".#{ item[:name] }.legend")
 
   - when 'vouchers'
-    - if feature?(:vouchers, spree_current_user)
+    - if feature?(:vouchers, spree_current_user) || feature?(:vouchers, @enterprise)
       %fieldset.alpha.no-border-bottom{ id: "#{item[:name]}_panel", data: { "tabs-and-panels-target": "panel"  }}
         %legend= t(".#{ item[:form_name] || item[:name] }.legend")
         = render "admin/enterprises/form/#{ item[:form_name] || item[:name] }", f: f

--- a/app/views/admin/shared/_side_menu.html.haml
+++ b/app/views/admin/shared/_side_menu.html.haml
@@ -1,7 +1,7 @@
 .side_menu#side_menu
   - if @enterprise
     - enterprise_side_menu_items(@enterprise).each do |item|
-    - next if !item[:show] || (item[:name] == 'vouchers' && !feature?(:vouchers, spree_current_user))
+    - next if !item[:show] || (item[:name] == 'vouchers' && !(feature?(:vouchers, spree_current_user) || feature?(:vouchers, @enterprise)))
       %a.menu_item{ href: item[:href] || "##{item[:name]}_panel", id: item[:name], data: { action: "tabs-and-panels#changeActivePanel tabs-and-panels#changeActiveTab", "tabs-and-panels-target": "tab" }, class: item[:selected] }
         %i{ class: item[:icon_class] }
         %span= t(".enterprise.#{item[:name] }")

--- a/app/views/admin/shared/_side_menu.html.haml
+++ b/app/views/admin/shared/_side_menu.html.haml
@@ -1,7 +1,7 @@
 .side_menu#side_menu
   - if @enterprise
     - enterprise_side_menu_items(@enterprise).each do |item|
-    - next if !item[:show] || (item[:name] == 'vouchers' && !(feature?(:vouchers, spree_current_user) || feature?(:vouchers, @enterprise)))
+    - next if !item[:show] || (item[:name] == 'vouchers' && !feature?(:vouchers, spree_current_user, @enterprise))
       %a.menu_item{ href: item[:href] || "##{item[:name]}_panel", id: item[:name], data: { action: "tabs-and-panels#changeActivePanel tabs-and-panels#changeActiveTab", "tabs-and-panels-target": "tab" }, class: item[:selected] }
         %i{ class: item[:icon_class] }
         %span= t(".enterprise.#{item[:name] }")

--- a/app/views/split_checkout/_payment.html.haml
+++ b/app/views/split_checkout/_payment.html.haml
@@ -1,5 +1,5 @@
 .medium-6#checkout-payment-methods
-  - if feature?(:vouchers, spree_current_user) && @order.distributor.vouchers.present?
+  - if (feature?(:vouchers, spree_current_user) || feature?(:vouchers, @order.distributor)) && @order.distributor.vouchers.present?
     %div.checkout-substep
       = render partial: "split_checkout/voucher_section", locals: { order: @order, voucher_adjustment: @order.voucher_adjustments.first }
 

--- a/app/views/split_checkout/_payment.html.haml
+++ b/app/views/split_checkout/_payment.html.haml
@@ -1,5 +1,5 @@
 .medium-6#checkout-payment-methods
-  - if (feature?(:vouchers, spree_current_user) || feature?(:vouchers, @order.distributor)) && @order.distributor.vouchers.present?
+  - if feature?(:vouchers, spree_current_user, @order.distributor) && @order.distributor.vouchers.present?
     %div.checkout-substep
       = render partial: "split_checkout/voucher_section", locals: { order: @order, voucher_adjustment: @order.voucher_adjustments.first }
 

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -41,9 +41,7 @@ Openfoodnetwork::Application.routes.draw do
 
       resources :tag_rules, only: [:destroy]
 
-      constraints FeatureToggleConstraint.new(:vouchers) do
-        resources :vouchers, only: [:new, :create]
-      end
+      resources :vouchers, only: [:new, :create]
     end
 
     resources :enterprise_relationships

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -49,12 +49,18 @@ module OpenFoodNetwork
       end
     end
 
-    def self.enabled?(feature_name, user = nil)
-      Flipper.enabled?(feature_name, user)
+    # Checks weather a feature is enabled for any of the given actors.
+    def self.enabled?(feature_name, *actors)
+      return Flipper.enabled?(feature_name) if actors.empty?
+
+      actors.any? do |actor|
+        Flipper.enabled?(feature_name, actor)
+      end
     end
 
-    def self.disabled?(feature_name, user = nil)
-      !enabled?(feature_name, user)
+    # Checks weather a feature is disabled for all given actors.
+    def self.disabled?(feature_name, *actors)
+      !enabled?(feature_name, *actors)
     end
   end
 end

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -31,6 +31,7 @@ module OpenFoodNetwork
       DESC
       "vouchers" => <<~DESC,
         Add voucher functionality. Voucher can be managed via Enterprise settings.
+        This is activated per enterprise. Enter actors as <code>Enterprise;1234</code>.
       DESC
       "invoices" => <<~DESC,
         Preserve the state of generated invoices and enable multiple invoice numbers instead of only one live-updating invoice.

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,6 +3,15 @@
 require 'spec_helper'
 
 describe ApplicationHelper, type: :helper do
+  describe "#feature?" do
+    it "takes several actors" do
+      user = Spree::User.new(id: 4)
+      enterprise = Enterprise.new(id: 5)
+
+      expect(helper.feature?(:foo, user, enterprise)).to eq false
+    end
+  end
+
   describe "#language_meta_tags" do
     let(:request) { double("request", host_with_port: "test.host", protocol: "http://") }
     before do

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -14,6 +14,15 @@ describe OpenFoodNetwork::FeatureToggle do
       Flipper.enable(:foo)
       expect(feature_toggle.enabled?(:foo)).to be true
     end
+
+    it "can be activated per enterprise" do
+      enterprise = Enterprise.new(id: 5)
+
+      Flipper.enable(:foo, enterprise)
+
+      expect(feature_toggle.enabled?(:foo)).to eq false
+      expect(feature_toggle.enabled?(:foo, enterprise)).to eq true
+    end
   end
 
   describe ".setup!" do

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe OpenFoodNetwork::FeatureToggle do
   subject(:feature_toggle) { OpenFoodNetwork::FeatureToggle }
 
-  context 'when users are not specified' do
+  describe ".enabled?" do
     it "returns false when feature is undefined" do
       expect(feature_toggle.enabled?(:foo)).to be false
     end
@@ -22,6 +22,25 @@ describe OpenFoodNetwork::FeatureToggle do
 
       expect(feature_toggle.enabled?(:foo)).to eq false
       expect(feature_toggle.enabled?(:foo, enterprise)).to eq true
+    end
+
+    it "returns true for an enabled user amongst other actors" do
+      user = Spree::User.new(id: 4)
+      enterprise = Enterprise.new(id: 5)
+
+      Flipper.enable(:foo, user)
+
+      expect(feature_toggle.enabled?(:foo, user, enterprise)).to eq true
+      expect(feature_toggle.enabled?(:foo, enterprise, user)).to eq true
+    end
+  end
+
+  describe ".disabled?" do
+    it "returns true if the feature is disabled for all actors" do
+      user = Spree::User.new(id: 4)
+      enterprise = Enterprise.new(id: 5)
+
+      expect(feature_toggle.disabled?(:foo, user, enterprise)).to eq true
     end
   end
 

--- a/spec/system/admin/vouchers_spec.rb
+++ b/spec/system/admin/vouchers_spec.rb
@@ -15,7 +15,7 @@ describe '
   let(:enterprise_user) { create(:user, enterprise_limit: 1) }
 
   before do
-    Flipper.enable(:vouchers)
+    Flipper.enable(:vouchers, enterprise)
 
     enterprise_user.enterprise_roles.build(enterprise: enterprise).save
     login_as enterprise_user


### PR DESCRIPTION
#### What? Why?

- Closes #11445 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Some features like vouchers are too limited when activated by user. We can't possibly know all potential customers of an enterprise with vouchers. So we are adding a per-enterprise toggle as well.

The issue above was for per-enterprise features in general but I changed the feature toggle for vouchers in the PR at the same time because I needed a good example, something to test and we want to do it anyway.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit `/admin`
- Go to an enterprise and check the voucher interface.
- Once vouchers are set up, check the shopfront for the voucher input.
- Go through the above with different feature toggle combinations:
- Vouchers disabled globally.
- Vouchers enabled globally.
- Vouchers activated for one user.
- Vouchers activated for one enterprise.
- Vouchers activated for the user and the enterprise.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

I updated the wiki page:

* https://github.com/openfoodfoundation/openfoodnetwork/wiki/Feature-toggles