### PR TITLE
De-flake voucher specs by checking success

### DIFF
--- a/spec/support/split_checkout_helper.rb
+++ b/spec/support/split_checkout_helper.rb
@@ -43,6 +43,13 @@ module SplitCheckoutHelper
     expect(page).to have_button("Next - Order summary")
   end
 
+  def apply_voucher(code)
+    expect(page).to have_content "Apply voucher"
+    fill_in "Enter voucher code", with: code
+    click_button "Apply"
+    expect(page).to have_link "Remove code"
+  end
+
   def expect_to_be_on_first_step
     expect(page).to have_content("1 - Your details")
     expect(page).to have_selector("div.checkout-tab.selected", text: "1 - Your details")

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -706,8 +706,7 @@ describe "As a consumer, I want to checkout my order" do
 
             shared_examples "adding voucher to the order" do
               before do
-                fill_in "Enter voucher code", with: "some_code"
-                click_button("Apply")
+                apply_voucher "some_code"
               end
 
               it "adds a voucher to the order" do
@@ -727,8 +726,7 @@ describe "As a consumer, I want to checkout my order" do
               it_behaves_like "adding voucher to the order"
 
               it "shows a warning message" do
-                fill_in "Enter voucher code", with: "some_code"
-                click_button("Apply")
+                apply_voucher "some_code"
 
                 expect(page).to have_content(
                   "Note: if your order total is less than your voucher " \
@@ -737,8 +735,7 @@ describe "As a consumer, I want to checkout my order" do
               end
 
               it "proceeds without requiring payment" do
-                fill_in "Enter voucher code", with: "some_code"
-                click_button("Apply")
+                apply_voucher "some_code"
 
                 expect(page).to have_content "No payment required"
                 click_button "Next - Order summary"
@@ -779,9 +776,7 @@ describe "As a consumer, I want to checkout my order" do
             end
 
             it "can re-enter a voucher" do
-              # Re-enter a voucher code
-              fill_in "Enter voucher code", with: "some_code"
-              click_button("Apply")
+              apply_voucher "some_code"
 
               expect(page).to have_content("$15.00 Voucher")
               expect(order.reload.voucher_adjustments.length).to eq(1)

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -704,18 +704,12 @@ describe "As a consumer, I want to checkout my order" do
               visit checkout_step_path(:payment)
             end
 
-            shared_examples "adding voucher to the order" do
-              before do
-                apply_voucher "some_code"
-              end
+            it "adds a voucher to the order" do
+              apply_voucher "some_code"
 
-              it "adds a voucher to the order" do
-                expect(page).to have_content("$15.00 Voucher")
-                expect(order.reload.voucher_adjustments.length).to eq(1)
-              end
+              expect(page).to have_content "$15.00 Voucher"
+              expect(order.reload.voucher_adjustments.length).to eq(1)
             end
-
-            it_behaves_like "adding voucher to the order"
 
             context "when voucher covers more then the order total" do
               before do
@@ -723,19 +717,14 @@ describe "As a consumer, I want to checkout my order" do
                 order.save!
               end
 
-              it_behaves_like "adding voucher to the order"
-
-              it "shows a warning message" do
+              it "shows a warning message and doesn't require payment" do
                 apply_voucher "some_code"
 
+                expect(page).to have_content "$15.00 Voucher"
                 expect(page).to have_content(
                   "Note: if your order total is less than your voucher " \
                   "you may not be able to spend the remaining value."
                 )
-              end
-
-              it "proceeds without requiring payment" do
-                apply_voucher "some_code"
 
                 expect(page).to have_content "No payment required"
                 click_button "Next - Order summary"

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -699,12 +699,6 @@ describe "As a consumer, I want to checkout my order" do
             create(:voucher_flat_rate, code: 'some_code', enterprise: distributor, amount: 15)
           end
 
-          it "shows voucher input" do
-            visit checkout_step_path(:payment)
-            expect(page).to have_field "Enter voucher code"
-            expect(page).to have_content "Apply voucher"
-          end
-
           describe "adding voucher to the order" do
             before do
               visit checkout_step_path(:payment)

--- a/spec/system/consumer/split_checkout_tax_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_incl_spec.rb
@@ -122,10 +122,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
           click_button "Next - Payment method"
 
-          # add Voucher
-          fill_in "Enter voucher code", with: "some_code"
-          click_button("Apply")
-          expect(page).to have_link "Remove code"
+          apply_voucher "some_code"
 
           # Choose payment
           click_on "Next - Order summary"
@@ -155,9 +152,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
             visit checkout_step_path(:details)
             proceed_to_payment
 
-            # add Voucher
-            fill_in "Enter voucher code", with: "good_code"
-            click_button("Apply")
+            apply_voucher "good_code"
 
             proceed_to_summary
 

--- a/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
+++ b/spec/system/consumer/split_checkout_tax_not_incl_spec.rb
@@ -128,10 +128,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
 
           click_button "Next - Payment method"
 
-          # add Voucher
-          fill_in "Enter voucher code", with: "some_code"
-          click_button("Apply")
-          expect(page).to have_selector ".voucher-added"
+          apply_voucher "some_code"
 
           click_on "Next - Order summary"
           click_on "Complete order"
@@ -163,9 +160,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
             visit checkout_step_path(:details)
             proceed_to_payment
 
-            # add Voucher
-            fill_in "Enter voucher code", with: voucher.code
-            click_button("Apply")
+            apply_voucher voucher.code
 
             proceed_to_summary
             assert_db_voucher_adjustment(-2.00, -0.26)


### PR DESCRIPTION
#### What? Why?

- Closes #10989 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Most system specs testing vouchers didn't wait for a voucher being applied and spec code right after was flaky.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
