### PR TITLE
Renames Knapsack nodes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,10 +106,10 @@ jobs:
         # [n] - where the n is a number of parallel jobs you want to run your tests on.
         # Use a higher number if you have slow tests to split them between more parallel jobs.
         # Remember to update the value of the `ci_node_index` below to (0..n-1).
-        ci_node_total: [7]
+        ci_node_total: [5]
         # Indexes for parallel jobs (starting from zero).
         # E.g. use [0, 1] for 2 parallel jobs, [0, 1, 2] for 3 parallel jobs, etc.
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6]
+        ci_node_index: [0, 1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v3
 
@@ -175,10 +175,10 @@ jobs:
         # [n] - where the n is a number of parallel jobs you want to run your tests on.
         # Use a higher number if you have slow tests to split them between more parallel jobs.
         # Remember to update the value of the `ci_node_index` below to (0..n-1).
-        ci_node_total: [10]
+        ci_node_total: [13]
         # Indexes for parallel jobs (starting from zero).
         # E.g. use [0, 1] for 2 parallel jobs, [0, 1, 2] for 3 parallel jobs, etc.
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] 
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] 
     steps:
       - uses: actions/checkout@v3
 
@@ -253,10 +253,10 @@ jobs:
         # [n] - where the n is a number of parallel jobs you want to run your tests on.
         # Use a higher number if you have slow tests to split them between more parallel jobs.
         # Remember to update the value of the `ci_node_index` below to (0..n-1).
-        ci_node_total: [10]
+        ci_node_total: [12]
         # Indexes for parallel jobs (starting from zero).
         # E.g. use [0, 1] for 2 parallel jobs, [0, 1, 2] for 3 parallel jobs, etc.
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] 
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] 
     steps:
       - uses: actions/checkout@v3
 
@@ -331,10 +331,10 @@ jobs:
         # [n] - where the n is a number of parallel jobs you want to run your tests on.
         # Use a higher number if you have slow tests to split them between more parallel jobs.
         # Remember to update the value of the `ci_node_index` below to (0..n-1).
-        ci_node_total: [5]
+        ci_node_total: [2]
         # Indexes for parallel jobs (starting from zero).
         # E.g. use [0, 1] for 2 parallel jobs, [0, 1, 2] for 3 parallel jobs, etc.
-        ci_node_index: [0, 1, 2, 3, 4]
+        ci_node_index: [0, 1]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  knapsack_rspec_controllers:
+  controllers:
     runs-on: ubuntu-22.04
     services:
       postgres:
@@ -85,7 +85,7 @@ jobs:
           git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
           bundle exec rake knapsack_pro:rspec
 
-  knapsack_rspec_models:
+  models:
     runs-on: ubuntu-22.04
     services:
       postgres:
@@ -154,7 +154,7 @@ jobs:
         run: |
           bundle exec rake knapsack_pro:rspec
 
-  knapsack_rspec_system_admin:
+  system_admin:
     runs-on: ubuntu-22.04
     services:
       postgres:
@@ -232,7 +232,7 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  knapsack_rspec_system_consumer:
+  system_consumer:
     runs-on: ubuntu-22.04
     services:
       postgres:
@@ -310,7 +310,7 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  knapsack_rspec_engines:
+  engines:
     runs-on: ubuntu-22.04
     services:
       postgres:
@@ -388,7 +388,7 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  knapsack_rspec_test_the_rest:
+  test_the_rest:
     runs-on: ubuntu-22.04
     services:
       postgres:


### PR DESCRIPTION
#### What? Why?

Thank you @dacook for noticing and suggesting this improvement!

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The prefix `knapsack_rspec_` on each build nodes was added to help introduce Knapsack on our build, and help to spot which nodes were being split by Knapsack and which weren't. This naming is no longer necessary, this PR removes it, since all test are now split using Knapsack (exception are the Jest tests).

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build

We should see the following change on the naming of each node, on all build runs:

  - before this PR

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/49817236/9f624bee-ba73-4ec8-9b74-59f5b6b00e0e)

  - after this PR

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/49817236/9d17cda2-4ec8-4d71-bc54-bdc01c99ad16)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
