### PR TITLE
[tech debt] Fix require order on dfc_provider engine

### DIFF
--- a/engines/dfc_provider/spec/requests/addresses_spec.rb
+++ b/engines/dfc_provider/spec/requests/addresses_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/swagger_helper")
+require_relative "../swagger_helper"
 
 describe "Addresses", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rswag_autodoc: true do
   let(:user) { create(:oidc_user) }

--- a/engines/dfc_provider/spec/requests/catalog_items_spec.rb
+++ b/engines/dfc_provider/spec/requests/catalog_items_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/swagger_helper")
+require_relative "../swagger_helper"
 
 describe "CatalogItems", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml",
                          rswag_autodoc: true do

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/swagger_helper")
+require_relative "../swagger_helper"
 
 describe "Enterprises", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rswag_autodoc: true do
   let!(:user) { create(:oidc_user) }

--- a/engines/dfc_provider/spec/requests/persons_spec.rb
+++ b/engines/dfc_provider/spec/requests/persons_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/swagger_helper")
+require_relative "../swagger_helper"
 
 describe "Persons", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml", rswag_autodoc: true do
   let(:user) { create(:oidc_user, id: 10_000) }

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/swagger_helper")
+require_relative "../swagger_helper"
 
 describe "SuppliedProducts", type: :request, swagger_doc: "dfc-v1.7/swagger.yaml",
                              rswag_autodoc: true do

--- a/engines/dfc_provider/spec/services/address_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/address_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/spec_helper")
+require_relative "../spec_helper"
 
 describe AddressBuilder do
   subject(:result) { described_class.address(address) }

--- a/engines/dfc_provider/spec/services/authorization_control_spec.rb
+++ b/engines/dfc_provider/spec/services/authorization_control_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/spec_helper")
+require_relative "../spec_helper"
 
 describe AuthorizationControl do
   include AuthorizationHelper

--- a/engines/dfc_provider/spec/services/catalog_item_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/catalog_item_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/spec_helper")
+require_relative "../spec_helper"
 
 describe DfcBuilder do
   let(:variant) { build(:variant) }

--- a/engines/dfc_provider/spec/services/dfc_io_spec.rb
+++ b/engines/dfc_provider/spec/services/dfc_io_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/spec_helper")
+require_relative "../spec_helper"
 
 describe DfcIo do
   let(:person) do

--- a/engines/dfc_provider/spec/services/dfc_loader_spec.rb
+++ b/engines/dfc_provider/spec/services/dfc_loader_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/spec_helper")
+require_relative "../spec_helper"
 
 describe DfcLoader do
   it "prepares the DFC Connector to provide DFC object classes for export" do

--- a/engines/dfc_provider/spec/services/enterprise_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/enterprise_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/spec_helper")
+require_relative "../spec_helper"
 
 describe EnterpriseBuilder do
   subject(:builder) { described_class }

--- a/engines/dfc_provider/spec/services/offer_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/offer_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/spec_helper")
+require_relative "../spec_helper"
 
 describe DfcBuilder do
   let(:variant) { build(:variant) }

--- a/engines/dfc_provider/spec/services/quantitative_value_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/quantitative_value_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/spec_helper")
+require_relative "../spec_helper"
 
 describe QuantitativeValueBuilder do
   subject(:builder) { described_class }

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/spec_helper")
+require_relative "../spec_helper"
 
 describe SuppliedProductBuilder do
   subject(:builder) { described_class }

--- a/engines/dfc_provider/spec/services/variant_fetcher_spec.rb
+++ b/engines/dfc_provider/spec/services/variant_fetcher_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require DfcProvider::Engine.root.join("spec/spec_helper")
+require_relative "../spec_helper"
 
 describe VariantFetcher do
   subject { VariantFetcher.new(enterprise) }

--- a/engines/dfc_provider/spec/swagger_helper.rb
+++ b/engines/dfc_provider/spec/swagger_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require Rails.root.join("spec/swagger_helper")
 require_relative "spec_helper"
+require Rails.root.join("spec/swagger_helper")
 
 RSpec.configure do |config|
   # Override swagger docs to generate only this file:


### PR DESCRIPTION
#### What? Why?

- Closes #11464 

Previously the test expected a class to already be defined in order to load swagger test config, without explicitly loading the base_spec_helper (that loads the app, and the classes).

Occasionally, depending on the order of execution, the app could be loaded if another test required the spec_helper / base_spec_helper.

#### What should we test?

Individual testing allows to expose the problem in master:

```
find  engines/dfc_provider/spec | grep _spec.rb | xargs -L1 bundle exec rspec
```

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

The title of the pull request will be included in the release notes.
