### PR TITLE
[BUU] Editing - part 2 (product and variant text fields) 🚧 

### DIFF
--- a/app/models/spree/price.rb
+++ b/app/models/spree/price.rb
@@ -44,7 +44,7 @@ module Spree
                                       :'number.currency.format.delimiter'])
       non_price_characters = /[^0-9\-#{separator}]/
       # Strip everything else first
-      price.gsub!(non_price_characters, '')
+      price = price.gsub(non_price_characters, '')
       # Then replace the locale-specific decimal separator with the standard separator if necessary
       price.gsub!(separator, '.') unless separator == '.'
 

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -70,7 +70,7 @@
                 %td.align-right
                   .line-clamp-1= variant.unit_to_display
                 %td.align-right
-                  .line-clamp-1= number_to_currency(variant.price)
+                  = variant_form.text_field :price, name: "#{prefix}[price]", 'aria-label': t('admin.products_page.columns.price'), value: number_to_currency(variant.price, unit: '')&.strip # TODO: add a spec to prove that this formatting is necessary. If so, it should be in a shared form helper for currency inputs
                 %td.align-right
                   .line-clamp-1= variant.on_hand || 0 #TODO: spec for this according to requirements.
                 %td.align-left

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -59,22 +59,24 @@
             %td.align-left
               .line-clamp-1= product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values, else use I18n.t (also below)
           - product.variants.each do |variant|
-            %tr.condensed
-              %td.align-left
-                .line-clamp-1= variant.display_name
-              %td.align-right
-                .line-clamp-1= variant.sku
-              %td.align-right
-                .line-clamp-1= variant.unit_to_display
-              %td.align-right
-                .line-clamp-1= number_to_currency(variant.price)
-              %td.align-right
-                .line-clamp-1= variant.on_hand || 0 #TODO: spec for this according to requirements.
-              %td.align-left
-                .line-clamp-1= variant.product.supplier.name # same as product
-              %td.align-left
-                -# empty
-              %td.align-left
-                .line-clamp-1= variant.tax_category&.name || "None" # TODO: convert to dropdown, else translate hardcoded string.
-              %td.align-left
-                -# empty
+            = form.fields_for(variant) do |variant_form|
+              %tr.condensed
+                %td.align-left
+                  = variant_form.hidden_field :id, name: "[products][#{i}][variants_attributes][][id]"
+                  = variant_form.text_field :display_name, name: "[products][#{i}][variants_attributes][][display_name]", 'aria-label': t('admin.products_page.columns.name'), placeholder: product.name
+                %td.align-right
+                  .line-clamp-1= variant.sku
+                %td.align-right
+                  .line-clamp-1= variant.unit_to_display
+                %td.align-right
+                  .line-clamp-1= number_to_currency(variant.price)
+                %td.align-right
+                  .line-clamp-1= variant.on_hand || 0 #TODO: spec for this according to requirements.
+                %td.align-left
+                  .line-clamp-1= variant.product.supplier.name # same as product
+                %td.align-left
+                  -# empty
+                %td.align-left
+                  .line-clamp-1= variant.tax_category&.name || "None" # TODO: convert to dropdown, else translate hardcoded string.
+                %td.align-left
+                  -# empty

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -33,14 +33,14 @@
         %th.align-left= t('admin.products_page.columns.tax_category')
         %th.align-left= t('admin.products_page.columns.inherits_properties')
     - products.each do |product|
-      = form.fields_for(product) do |product_form|
+      = form.fields_for("products", product, index: nil) do |product_form|
         %tbody.relaxed
           %tr
             %td.align-left.header
-              = product_form.hidden_field :id, name: "[products][][id]"
-              = product_form.text_field :name, name: "[products][][name]", 'aria-label': t('admin.products_page.columns.name')
+              = product_form.hidden_field :id
+              = product_form.text_field :name, 'aria-label': t('admin.products_page.columns.name')
             %td.align-right
-              = product_form.text_field :sku, name: "[products][][sku]", 'aria-label': t('admin.products_page.columns.sku')
+              = product_form.text_field :sku, 'aria-label': t('admin.products_page.columns.sku')
             %td.align-right
               .line-clamp-1
                 = product.variant_unit.upcase_first
@@ -59,11 +59,12 @@
             %td.align-left
               .line-clamp-1= product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values, else use I18n.t (also below)
           - product.variants.each do |variant|
+            - prefix = "[products][][variants_attributes][]" # Couldn't convince the formbuilder to generate this for me, so for now we manually add the prefix
             = form.fields_for(variant) do |variant_form|
               %tr.condensed
                 %td.align-left
-                  = variant_form.hidden_field :id, name: "[products][][variants_attributes][][id]"
-                  = variant_form.text_field :display_name, name: "[products][][variants_attributes][][display_name]", 'aria-label': t('admin.products_page.columns.name'), placeholder: product.name
+                  = variant_form.hidden_field :id, name: "#{prefix}[id]"
+                  = variant_form.text_field :display_name, name: "#{prefix}[display_name]", 'aria-label': t('admin.products_page.columns.name'), placeholder: product.name
                 %td.align-right
                   .line-clamp-1= variant.sku
                 %td.align-right

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -32,15 +32,15 @@
         %th.align-left= t('admin.products_page.columns.category')
         %th.align-left= t('admin.products_page.columns.tax_category')
         %th.align-left= t('admin.products_page.columns.inherits_properties')
-    - products.each do |product, i|
+    - products.each do |product|
       = form.fields_for(product) do |product_form|
         %tbody.relaxed
           %tr
             %td.align-left.header
-              = product_form.hidden_field :id, name: "[products][#{i}][id]" #todo: can we remove #{i} and implicitly pop?
-              = product_form.text_field :name, name: "[products][#{i}][name]", 'aria-label': t('admin.products_page.columns.name')
+              = product_form.hidden_field :id, name: "[products][][id]"
+              = product_form.text_field :name, name: "[products][][name]", 'aria-label': t('admin.products_page.columns.name')
             %td.align-right
-              = product_form.text_field :sku, name: "[products][#{i}][sku]", 'aria-label': t('admin.products_page.columns.sku')
+              = product_form.text_field :sku, name: "[products][][sku]", 'aria-label': t('admin.products_page.columns.sku')
             %td.align-right
               .line-clamp-1
                 = product.variant_unit.upcase_first
@@ -62,8 +62,8 @@
             = form.fields_for(variant) do |variant_form|
               %tr.condensed
                 %td.align-left
-                  = variant_form.hidden_field :id, name: "[products][#{i}][variants_attributes][][id]"
-                  = variant_form.text_field :display_name, name: "[products][#{i}][variants_attributes][][display_name]", 'aria-label': t('admin.products_page.columns.name'), placeholder: product.name
+                  = variant_form.hidden_field :id, name: "[products][][variants_attributes][][id]"
+                  = variant_form.text_field :display_name, name: "[products][][variants_attributes][][display_name]", 'aria-label': t('admin.products_page.columns.name'), placeholder: product.name
                 %td.align-right
                   .line-clamp-1= variant.sku
                 %td.align-right

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -38,7 +38,7 @@
           %tr
             %td.align-left.header
               = product_form.hidden_field :id, name: "[products][#{i}][id]" #todo: can we remove #{i} and implicitly pop?
-              .line-clamp-1= product_form.text_field :name, name: "[products][#{i}][name]", id: "_product_name_#{product.id}", 'aria-label': t('admin.products_page.columns.name')
+              .line-clamp-1= product_form.text_field :name, name: "[products][#{i}][name]", 'aria-label': t('admin.products_page.columns.name')
             %td.align-right
               .line-clamp-1= product.sku
             %td.align-right

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -66,7 +66,7 @@
                   = variant_form.hidden_field :id, name: "#{prefix}[id]"
                   = variant_form.text_field :display_name, name: "#{prefix}[display_name]", 'aria-label': t('admin.products_page.columns.name'), placeholder: product.name
                 %td.align-right
-                  .line-clamp-1= variant.sku
+                  = variant_form.text_field :sku, name: "#{prefix}[sku]", 'aria-label': t('admin.products_page.columns.sku')
                 %td.align-right
                   .line-clamp-1= variant.unit_to_display
                 %td.align-right

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -40,7 +40,7 @@
               = product_form.hidden_field :id, name: "[products][#{i}][id]" #todo: can we remove #{i} and implicitly pop?
               = product_form.text_field :name, name: "[products][#{i}][name]", 'aria-label': t('admin.products_page.columns.name')
             %td.align-right
-              .line-clamp-1= product.sku
+              = product_form.text_field :sku, name: "[products][#{i}][sku]", 'aria-label': t('admin.products_page.columns.sku')
             %td.align-right
               .line-clamp-1
                 = product.variant_unit.upcase_first

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -38,7 +38,7 @@
           %tr
             %td.align-left.header
               = product_form.hidden_field :id, name: "[products][#{i}][id]" #todo: can we remove #{i} and implicitly pop?
-              .line-clamp-1= product_form.text_field :name, name: "[products][#{i}][name]", 'aria-label': t('admin.products_page.columns.name')
+              = product_form.text_field :name, name: "[products][#{i}][name]", 'aria-label': t('admin.products_page.columns.name')
             %td.align-right
               .line-clamp-1= product.sku
             %td.align-right

--- a/spec/models/spree/price_spec.rb
+++ b/spec/models/spree/price_spec.rb
@@ -25,5 +25,14 @@ module Spree
         expect(expensive_variant.persisted?).to be true
       end
     end
+
+    context "with string" do
+      it "parses the price" do
+        variant.price = " 10.25 eur"
+        variant.save
+
+        expect(variant.reload.price).to eq 10.25
+      end
+    end
   end
 end

--- a/spec/reflexes/products_reflex_spec.rb
+++ b/spec/reflexes/products_reflex_spec.rb
@@ -38,7 +38,8 @@ describe ProductsReflex, type: :reflex do
       create(:variant,
              product: product_a,
              display_name: "Medium box",
-             sku: "APL-01")
+             sku: "APL-01",
+             price: 5.25)
     }
     let!(:product_b) { create(:simple_product, name: "Bananas", sku: "BAN-00") }
     let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
@@ -75,6 +76,7 @@ describe ProductsReflex, type: :reflex do
                 "id" => variant_a1.id.to_s,
                 "display_name" => "Large box",
                 "sku" => "POM-01",
+                "price" => "10.25",
               }
             ],
           }
@@ -88,6 +90,7 @@ describe ProductsReflex, type: :reflex do
       }.to change{ product_a.name }.to("Pommes")
         .and change{ variant_a1.display_name }.to("Large box")
         .and change{ variant_a1.sku }.to("POM-01")
+        .and change{ variant_a1.price }.to(10.25)
     end
 
     describe "sorting" do

--- a/spec/reflexes/products_reflex_spec.rb
+++ b/spec/reflexes/products_reflex_spec.rb
@@ -34,8 +34,8 @@ describe ProductsReflex, type: :reflex do
   end
 
   describe '#bulk_update' do
-    let!(:product_b) { create(:simple_product, name: "Bananas") }
-    let!(:product_a) { create(:simple_product, name: "Apples") }
+    let!(:product_b) { create(:simple_product, name: "Bananas", sku: "BAN-01") }
+    let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-01") }
 
     it "saves valid changes" do
       params = {
@@ -44,6 +44,7 @@ describe ProductsReflex, type: :reflex do
           {
             "id" => product_a.id.to_s,
             "name" => "Pommes",
+            "sku" => "POM-01",
           }
         ]
       }
@@ -51,7 +52,8 @@ describe ProductsReflex, type: :reflex do
       expect{
         run_reflex(:bulk_update, params:)
         product_a.reload
-      }.to change(product_a, :name).to("Pommes")
+      }.to change{ product_a.name }.to("Pommes")
+       .and change{ product_a.sku }.to("POM-01")
     end
 
     describe "sorting" do

--- a/spec/reflexes/products_reflex_spec.rb
+++ b/spec/reflexes/products_reflex_spec.rb
@@ -34,9 +34,14 @@ describe ProductsReflex, type: :reflex do
   end
 
   describe '#bulk_update' do
-    let!(:product_b) { create(:simple_product, name: "Bananas", sku: "BAN-01") }
-    let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-01") }
-    let(:variant_a1) { create(:variant, product: product_a, display_name: "Medium box") }
+    let!(:variant_a1) {
+      create(:variant,
+             product: product_a,
+             display_name: "Medium box",
+             sku: "APL-01")
+    }
+    let!(:product_b) { create(:simple_product, name: "Bananas", sku: "BAN-00") }
+    let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
 
     it "saves valid changes" do
       params = {
@@ -45,7 +50,7 @@ describe ProductsReflex, type: :reflex do
           {
             "id" => product_a.id.to_s,
             "name" => "Pommes",
-            "sku" => "POM-01",
+            "sku" => "POM-00",
           }
         ]
       }
@@ -54,10 +59,10 @@ describe ProductsReflex, type: :reflex do
         run_reflex(:bulk_update, params:)
         product_a.reload
       }.to change{ product_a.name }.to("Pommes")
-        .and change{ product_a.sku }.to("POM-01")
+        .and change{ product_a.sku }.to("POM-00")
     end
 
-    it "saves valid changes to nested variants" do
+    it "saves valid changes to products and nested variants" do
       params = {
         # '[products][][name]'
         # '[products][][variants_attributes][][display_name]'
@@ -69,6 +74,7 @@ describe ProductsReflex, type: :reflex do
               {
                 "id" => variant_a1.id.to_s,
                 "display_name" => "Large box",
+                "sku" => "POM-01",
               }
             ],
           }
@@ -81,6 +87,7 @@ describe ProductsReflex, type: :reflex do
         variant_a1.reload
       }.to change{ product_a.name }.to("Pommes")
         .and change{ variant_a1.display_name }.to("Large box")
+        .and change{ variant_a1.sku }.to("POM-01")
     end
 
     describe "sorting" do

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -158,24 +158,29 @@ describe 'As an admin, I can see the new product page' do
   end
 
   describe "updating" do
+    let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-01") }
+
     before do
       visit admin_products_v3_index_url
     end
 
     it "can update product fields" do
-      within row_containing_name("product 1") do
-        fill_in "Name", with: "An updated name"
+      within row_containing_name("Apples") do
+        fill_in "Name", with: "Pommes"
+        fill_in "SKU", with: "POM-01"
       end
 
       expect {
         click_button "Save changes"
-        product_1.reload
+        product_a.reload
       }.to(
-        change { product_1.name }.to("An updated name")
+        change { product_a.name }.to("Pommes")
+        .and change{ product_a.sku }.to("POM-01")
       )
 
-      within row_containing_name("An updated name") do
-        expect(page).to have_field "Name", with: "An updated name"
+      within row_containing_name("Pommes") do
+        expect(page).to have_field "Name", with: "Pommes"
+        expect(page).to have_field "SKU", with: "POM-01"
       end
       pending
       expect(page).to have_content "Changes saved"

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -162,7 +162,8 @@ describe 'As an admin, I can see the new product page' do
       create(:variant,
              product: product_a,
              display_name: "Medium box",
-             sku: "APL-01")
+             sku: "APL-01",
+             price: 5.25)
     }
     let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
 
@@ -178,6 +179,7 @@ describe 'As an admin, I can see the new product page' do
       within row_containing_name("Medium box") do
         fill_in "Name", with: "Large box"
         fill_in "SKU", with: "POM-01"
+        fill_in "Price", with: "10.25"
       end
 
       expect {
@@ -188,6 +190,7 @@ describe 'As an admin, I can see the new product page' do
         .and change{ product_a.sku }.to("POM-00")
         .and change{ variant_a1.display_name }.to("Large box")
         .and change{ variant_a1.sku }.to("POM-01")
+        .and change{ variant_a1.price }.to(10.25)
 
       within row_containing_name("Pommes") do
         expect(page).to have_field "Name", with: "Pommes"
@@ -196,6 +199,7 @@ describe 'As an admin, I can see the new product page' do
       within row_containing_name("Large box") do
         expect(page).to have_field "Name", with: "Large box"
         expect(page).to have_field "SKU", with: "POM-01"
+        expect(page).to have_field "Price", with: "10.25"
       end
 
       pending

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -163,7 +163,9 @@ describe 'As an admin, I can see the new product page' do
     end
 
     it "can update product fields" do
-      fill_in id: "_product_name_#{product_1.id}", with: "An updated name"
+      within row_containing_name("product 1") do
+        fill_in "Name", with: "An updated name"
+      end
 
       expect {
         click_button "Save changes"
@@ -172,7 +174,9 @@ describe 'As an admin, I can see the new product page' do
         change { product_1.name }.to("An updated name")
       )
 
-      expect(page).to have_field id: "_product_name_#{product_1.id}", with: "An updated name"
+      within row_containing_name("An updated name") do
+        expect(page).to have_field "Name", with: "An updated name"
+      end
       pending
       expect(page).to have_content "Changes saved"
     end
@@ -204,5 +208,12 @@ describe 'As an admin, I can see the new product page' do
   def search_by_category(category)
     select category, from: "category_id"
     click_button "Search"
+  end
+
+  # Selector for table row that has an input with this value.
+  # Because there are no visible labels, the user has to assume which product it is, based on the
+  # visible name.
+  def row_containing_name(value)
+    "tr:has(input[aria-label=Name][value='#{value}'])"
   end
 end

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -158,30 +158,40 @@ describe 'As an admin, I can see the new product page' do
   end
 
   describe "updating" do
+    let!(:variant_a1) { create(:variant, product: product_a, display_name: "Medium box") }
     let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-01") }
 
     before do
       visit admin_products_v3_index_url
     end
 
-    it "can update product fields" do
+    it "can update product and variant fields" do
       within row_containing_name("Apples") do
         fill_in "Name", with: "Pommes"
         fill_in "SKU", with: "POM-01"
+      end
+      within row_containing_name("Medium box") do
+        fill_in "Name", with: "Large box"
       end
 
       expect {
         click_button "Save changes"
         product_a.reload
+        variant_a1.reload
       }.to(
         change { product_a.name }.to("Pommes")
         .and change{ product_a.sku }.to("POM-01")
+        .and change{ variant_a1.display_name }.to("Large box")
       )
 
       within row_containing_name("Pommes") do
         expect(page).to have_field "Name", with: "Pommes"
         expect(page).to have_field "SKU", with: "POM-01"
       end
+      within row_containing_name("Large box") do
+        expect(page).to have_field "Name", with: "Large box"
+      end
+
       pending
       expect(page).to have_content "Changes saved"
     end

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -158,8 +158,13 @@ describe 'As an admin, I can see the new product page' do
   end
 
   describe "updating" do
-    let!(:variant_a1) { create(:variant, product: product_a, display_name: "Medium box") }
-    let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-01") }
+    let!(:variant_a1) {
+      create(:variant,
+             product: product_a,
+             display_name: "Medium box",
+             sku: "APL-01")
+    }
+    let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
 
     before do
       visit admin_products_v3_index_url
@@ -168,28 +173,29 @@ describe 'As an admin, I can see the new product page' do
     it "can update product and variant fields" do
       within row_containing_name("Apples") do
         fill_in "Name", with: "Pommes"
-        fill_in "SKU", with: "POM-01"
+        fill_in "SKU", with: "POM-00"
       end
       within row_containing_name("Medium box") do
         fill_in "Name", with: "Large box"
+        fill_in "SKU", with: "POM-01"
       end
 
       expect {
         click_button "Save changes"
         product_a.reload
         variant_a1.reload
-      }.to(
-        change { product_a.name }.to("Pommes")
-        .and change{ product_a.sku }.to("POM-01")
+      }.to change { product_a.name }.to("Pommes")
+        .and change{ product_a.sku }.to("POM-00")
         .and change{ variant_a1.display_name }.to("Large box")
-      )
+        .and change{ variant_a1.sku }.to("POM-01")
 
       within row_containing_name("Pommes") do
         expect(page).to have_field "Name", with: "Pommes"
-        expect(page).to have_field "SKU", with: "POM-01"
+        expect(page).to have_field "SKU", with: "POM-00"
       end
       within row_containing_name("Large box") do
         expect(page).to have_field "Name", with: "Large box"
+        expect(page).to have_field "SKU", with: "POM-01"
       end
 
       pending


### PR DESCRIPTION
#### What? Why?

- Part of #11059
- Continues from part one: https://github.com/openfoodfoundation/openfoodnetwork/pull/11208

Enabling editing for the remainder of product and variant text fields, with some caveats:

* we don't yet highlight modified/unsaved fields
* On saving, any modified products will attempt to update
* Any product errors are captured and some information is displayed to the user
    * Variants seem to need some extra work when handling errors too.
* On successful save, the table reloads to show saved fields 
    * (but there's no success message yet).



#### What should we test?
No manual testing required at this stage

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] Technical changes only
- [x] Feature toggled
