### PR TITLE
Stabilise flaky enterprise fee spec

### DIFF
--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -161,6 +161,7 @@ describe '
       let!(:fee1) { create(:enterprise_fee, fee_type: "sales", enterprise_id: enterprise.id) }
 
       before do
+        visit admin_enterprise_fees_path
         # edits the existing fee
         select 'Fundraising', from: "#{prefix}_fee_type"
         fill_in "#{prefix}_name", with: 'Hello!'


### PR DESCRIPTION
#### What? Why?

- Closes #11461<!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The spec was creating a second fee while the page was loading data via Javascript. This created a race condition and sometimes the second fee was missing from the page and the editing failed.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
