### PR TITLE
Fix error when importing entries with a tax category

### DIFF
--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -28,7 +28,6 @@ module ProductImport
         description: :description,
         unit_type: :variant_unit_scale,
         variant_unit_name: :variant_unit_name,
-        tax_category: :tax_category_id,
       }
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #11492 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Fixes a recent regression in product import, where products could not be updated due to a validation error being shown.

#### What should we test?

Updating products via product import should work without error if tax category is set.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

Tax Category can now be updated via Product Import. Previously this was disabled / not possible.

