### PR TITLE
[Admin] Highlight 'Configuration' tab on 'Terms of Service' page

### DIFF
--- a/app/helpers/spree/admin/navigation_helper.rb
+++ b/app/helpers/spree/admin/navigation_helper.rb
@@ -3,7 +3,7 @@
 module Spree
   module Admin
     module NavigationHelper
-      # Make an admin tab that coveres one or more resources supplied by symbols
+      # Make an admin tab that covers one or more resources supplied by symbols
       # Option hash may follow. Valid options are
       #   * :label to override link text, otherwise based on the first resource name (translated)
       #   * :route to override automatically determining the default route

--- a/app/views/spree/admin/shared/_tabs.html.haml
+++ b/app/views/spree/admin/shared/_tabs.html.haml
@@ -3,7 +3,7 @@
 = tab :order_cycles, url: main_app.admin_order_cycles_path, icon: 'icon-refresh'
 = tab :orders, :subscriptions, :customer_details, :adjustments, :payments, :return_authorizations, url: admin_orders_path, icon: 'icon-shopping-cart'
 = tab :reports, url: main_app.admin_reports_path, icon: 'icon-file'
-= tab :general_settings, :mail_methods, :tax_categories, :tax_rates, :tax_settings, :zones, :countries, :states, :payment_methods, :taxonomies, :shipping_methods, :shipping_categories, :enterprise_fees, :contents, :invoice_settings, :matomo_settings, :stripe_connect_settings, label: 'configuration', icon: 'icon-wrench', url: edit_admin_general_settings_path
+= tab :general_settings, :terms_of_service_files, :mail_methods, :tax_categories, :tax_rates, :tax_settings, :zones, :countries, :states, :payment_methods, :taxonomies, :shipping_methods, :shipping_categories, :enterprise_fees, :contents, :invoice_settings, :matomo_settings, :stripe_connect_settings, label: 'configuration', icon: 'icon-wrench', url: edit_admin_general_settings_path
 = tab :enterprises, :enterprise_relationships, :vouchers, :oidc_settings, url: main_app.admin_enterprises_path
 = tab :customers, url: main_app.admin_customers_path
 = tab :enterprise_groups, url: main_app.admin_enterprise_groups_path, label: 'groups'


### PR DESCRIPTION
#### What? Why?

- Closes #11503 

Fixes the missing highlight of the configuration tab on the 'Terms of Service' page in the super admin area.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Log in as super admin.
- Visit the configuration tab.
- Check that it is highlighted in green when visiting the Terms of Service sub page.
- Make sure I didn't break anything else. :-)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1 or DFC)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
