### PR TITLE
[BUU] Bulk form editing features

### DIFF
--- a/app/views/admin/products_v3/_content.html.haml
+++ b/app/views/admin/products_v3/_content.html.haml
@@ -7,10 +7,10 @@
                                               category_options: category_options,
                                               category_id: category_id }
   - if products.any?
-    .container
+    .container.results
       .sixteen.columns
         = render partial: 'sort', locals: { pagy: pagy, search_term: search_term, producer_id: producer_id, category_id: category_id }
-    = render partial: 'table', locals: { products: products }
+        = render partial: 'table', locals: { products: products }
     - if pagy.pages > 1
       = render partial: 'admin/shared/v3/pagy', locals: { pagy: pagy, reflex: "click->Products#fetch" }
   - else

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,6 +1,6 @@
 = form_with url: bulk_update_admin_products_v3_index_path, method: :patch, id: "products-form",
             html: {'data-reflex-serialize-form': true, 'data-reflex': 'submit->products#bulk_update',
-                   'data-controller': "bulk-form"} do |form|
+                   'data-controller': "bulk-form", 'data-bulk-form-disable-selector-value': "#sort,#filters"} do |form|
   %fieldset.form-actions.hidden{ 'data-bulk-form-target': "actions" }
     .container
       .status.ten.columns

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,10 +1,10 @@
 = form_with url: bulk_update_admin_products_v3_index_path, method: :patch, id: "products-form",
             html: {'data-reflex-serialize-form': true, 'data-reflex': 'submit->products#bulk_update',
                    'data-controller': "bulk-form"} do |form|
-  %fieldset.form-actions
+  %fieldset.form-actions{ 'data-bulk-form-target': "actions" }
     .container
       .status.ten.columns
-        / = t('.products_modified', count: 'X')
+        .modified_summary{ 'data-bulk-form-target': "modifiedSummary", 'data-translation-key': 'admin.products_v3.table.modified_summary'}
         - if defined?(error_msg) && error_msg.present?
           .error
             = error_msg
@@ -34,7 +34,7 @@
         %th.align-left= t('admin.products_page.columns.inherits_properties')
     - products.each do |product|
       = form.fields_for("products", product, index: nil) do |product_form|
-        %tbody.relaxed
+        %tbody.relaxed{ 'data-record-id': product_form.object.id }
           %tr
             %td.align-left.header
               = product_form.hidden_field :id

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,7 +1,7 @@
 = form_with url: bulk_update_admin_products_v3_index_path, method: :patch, id: "products-form",
             html: {'data-reflex-serialize-form': true, 'data-reflex': 'submit->products#bulk_update',
                    'data-controller': "bulk-form"} do |form|
-  %fieldset.form-actions{ 'data-bulk-form-target': "actions" }
+  %fieldset.form-actions.hidden{ 'data-bulk-form-target': "actions" }
     .container
       .status.ten.columns
         .modified_summary{ 'data-bulk-form-target': "modifiedSummary", 'data-translation-key': 'admin.products_v3.table.modified_summary'}

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -9,7 +9,7 @@
           .error
             = error_msg
       .form-buttons.six.columns
-        = form.submit t('.reset'), type: :reset, class: "medium"
+        = form.submit t('.reset'), type: :reset, class: "medium", 'data-reflex': 'click->products#fetch'
         = form.submit t('.save'), class: "medium"
   %table.products
     %col{ width:"15%" }

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,6 +1,6 @@
 = form_with url: bulk_update_admin_products_v3_index_path, method: :patch, id: "products-form",
-
-            html: {'data-reflex-serialize-form': true, 'data-reflex': 'submit->products#bulk_update'} do |form|
+            html: {'data-reflex-serialize-form': true, 'data-reflex': 'submit->products#bulk_update',
+                   'data-controller': "bulk-form"} do |form|
   %fieldset.form-actions
     .container
       .status.ten.columns

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -2,6 +2,9 @@ import { Controller } from "stimulus";
 
 // Manages "modified" state for a form with multiple records
 export default class BulkFormController extends Controller {
+  static targets = ["actions", "modifiedSummary"];
+  recordElements = {};
+
   connect() {
     this.form = this.element;
 
@@ -10,12 +13,37 @@ export default class BulkFormController extends Controller {
     for (const element of this.form.elements) {
       element.addEventListener("keyup", this.toggleModified.bind(this)); // instant response
       element.addEventListener("change", this.toggleModified.bind(this)); // just in case (eg right-click paste)
+
+      // Set up a tree of fields according to their associated record
+      const recordContainer = element.closest("[data-record-id]"); // The JS could be more efficient if this data was added to each element. But I didn't want to pollute the HTML too much.
+      const recordId = recordContainer && recordContainer.dataset.recordId;
+      if (recordId) {
+        this.recordElements[recordId] ||= [];
+        this.recordElements[recordId].push(element);
+      }
     }
   }
 
   toggleModified(e) {
     const element = e.target;
-    const changed = element.value != element.defaultValue;
-    element.classList.toggle("modified", changed);
+    const modified = element.value != element.defaultValue;
+    element.classList.toggle("modified", modified);
+
+    this.toggleFormModified();
+  }
+
+  toggleFormModified() {
+    // For each record, check if any fields are modified
+    const modifiedRecordCount = Object.keys(this.recordElements).filter((recordId) => {
+      return this.recordElements[recordId].some((element) => {
+        return element.value != element.defaultValue;
+      });
+    }).length;
+
+    // Display number of records modified
+    const key = this.modifiedSummaryTarget && this.modifiedSummaryTarget.dataset.translationKey;
+    if (key) {
+      this.modifiedSummaryTarget.textContent = I18n.t(key, { count: modifiedRecordCount });
+    }
   }
 }

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -40,6 +40,8 @@ export default class BulkFormController extends Controller {
       });
     }).length;
 
+    this.actionsTarget.classList.toggle("hidden", modifiedRecordCount == 0);
+
     // Display number of records modified
     const key = this.modifiedSummaryTarget && this.modifiedSummaryTarget.dataset.translationKey;
     if (key) {

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -30,6 +30,7 @@ export default class BulkFormController extends Controller {
   disconnect() {
     // Make sure to clean up anything that happened outside
     this.#disableOtherElements(false);
+    window.removeEventListener("beforeunload", this.preventLeavingBulkForm);
   }
 
   toggleModified(e) {
@@ -58,6 +59,21 @@ export default class BulkFormController extends Controller {
     if (key) {
       this.modifiedSummaryTarget.textContent = I18n.t(key, { count: modifiedRecordCount });
     }
+
+    // Prevent accidental data loss
+    if (formModified) {
+      window.addEventListener("beforeunload", this.preventLeavingBulkForm);
+    } else {
+      window.removeEventListener("beforeunload", this.preventLeavingBulkForm);
+    }
+  }
+
+  preventLeavingBulkForm(e) {
+    // Cancel the event
+    e.preventDefault();
+    // Chrome requires returnValue to be set. Other browsers may display this if provided, but let's
+    // not create a new translation key, and keep the behaviour consistent.
+    e.returnValue = "";
   }
 
   // private

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "stimulus";
+
+// Manages "modified" state for a form with multiple records
+export default class BulkFormController extends Controller {
+  connect() {
+    this.form = this.element;
+
+    // Start listening for any changes within the form
+    // this.element.addEventListener('change', this.toggleModified.bind(this)); // dunno why this doesn't work
+    for (const element of this.form.elements) {
+      element.addEventListener("keyup", this.toggleModified.bind(this)); // instant response
+      element.addEventListener("change", this.toggleModified.bind(this)); // just in case (eg right-click paste)
+    }
+  }
+
+  toggleModified(e) {
+    const element = e.target;
+    const changed = element.value != element.defaultValue;
+    element.classList.toggle("modified", changed);
+  }
+}

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -15,6 +15,18 @@
     padding: 0;
   }
 
+  .results {
+    position: relative;
+  }
+
+  // Form actions floats over other controls when active
+  .form-actions {
+    position: absolute;
+    top: 1em;
+    left: 0;
+    right: 0;
+  }
+
   // Hopefully these rules will be moved to component(s).
   table.products {
     table-layout: fixed; // Column widths are based solely on col definitions (not content). This allows more efficient rendering.

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -100,6 +100,10 @@
       &:focus {
         border-color: $color-txt-hover-brd;
       }
+
+      &.modified {
+        border-color: $color-txt-modified-brd;
+      }
     }
 
     .field_with_errors {

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -22,9 +22,10 @@
   // Form actions floats over other controls when active
   .form-actions {
     position: absolute;
-    top: 1em;
+    top: -1em;
     left: 0;
     right: 0;
+    z-index: 1; // Ensure tom-select and .disabled-section are covered
   }
 
   // Hopefully these rules will be moved to component(s).
@@ -232,6 +233,24 @@
           padding-left: 30px;
         }
       }
+    }
+  }
+
+  // Blurred and non-clickable
+  $disabled-blur: 1.5px;
+  .disabled-section {
+    position: relative;
+
+    &::after {
+      content: "";
+      position: absolute;
+      backdrop-filter: blur($disabled-blur);
+      // Stretch outside for a soft blur edge:
+      left: -$disabled-blur;
+      top: -$disabled-blur;
+      bottom: -$disabled-blur;
+      right: -$disabled-blur;
+      z-index: 1; // Ensure tom-select is covered
     }
   }
 }

--- a/app/webpacker/css/admin_v3/globals/variables.scss
+++ b/app/webpacker/css/admin_v3/globals/variables.scss
@@ -74,6 +74,7 @@ $color-sel-hover-text:           $white !default;
 $color-txt-brd:                  $color-border !default;
 $color-txt-text:                 $near-black !default;
 $color-txt-hover-brd:            $teal !default;
+$color-txt-modified-brd:         $bright-orange !default;
 $vpadding-txt:                   5px;
 $hpadding-txt:                   8px;
 

--- a/app/webpacker/css/admin_v3/shared/forms.scss
+++ b/app/webpacker/css/admin_v3/shared/forms.scss
@@ -21,6 +21,10 @@ fieldset {
   &[disabled] {
     opacity: 0.7;
   }
+
+  &.modified {
+    border-color: $color-txt-modified-brd;
+  }
 }
 
 textarea {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -818,6 +818,10 @@ en:
         import_products: Import multiple products
         no_products_found_for_search: No products found for your search criteria
       table:
+        modified_summary:
+          zero: ""
+          one: "%{count} product modified."
+          other: "%{count} products modified."
         save: Save changes
         reset: Discard changes
       bulk_update: # TODO: fix these

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -46,10 +46,7 @@ describe("BulkFormController", () => {
   });
 
   describe("Modifying input values", () => {
-    // This is more of a behaviour spec. Jest doesn't have all the niceties of RSpec so lots of code
-    // would be repeated if these were broken into multiple examples. So it seems impractical to
-    // write individual unit tests.
-    it("counts modified fields and records", () => {
+    beforeEach(() => {
       const disable1 = document.getElementById("disable1");
       const disable2 = document.getElementById("disable2");
       const actions = document.getElementById("actions");
@@ -57,74 +54,97 @@ describe("BulkFormController", () => {
       const input1a = document.getElementById("input1a");
       const input1b = document.getElementById("input1b");
       const input2 = document.getElementById("input2");
+    });
 
-      // Record 1: First field changed (we're not simulating a user in a browser here; we're testing DOM events directly)
-      input1a.value = 'updated1a';
-      input1a.dispatchEvent(new Event("change"));
-      // Expect only first field to show modified
-      expect(input1a.classList).toContain('modified');
-      expect(input1b.classList).not.toContain('modified');
-      expect(input2.classList).not.toContain('modified');
-      // Actions and modified summary are shown, with other sections disabled
-      expect(actions.classList).not.toContain('hidden');
-      expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
-      expect(disable1.classList).toContain('disabled-section');
-      expect(disable2.classList).toContain('disabled-section');
+    describe("marking changed fields", () => {
+      it("onChange", () => {
+        input1a.value = 'updated1a';
+        input1a.dispatchEvent(new Event("change"));
+        // Expect only first field to show modified
+        expect(input1a.classList).toContain('modified');
+        expect(input1b.classList).not.toContain('modified');
+        expect(input2.classList).not.toContain('modified');
 
-      // Record 1: Second field changed
-      input1b.value = 'updated1b';
-      input1b.dispatchEvent(new Event("change"));
-      // Expect to show modified, and same summary translation
-      expect(input1a.classList).toContain('modified');
-      expect(input1b.classList).toContain('modified');
-      expect(input2.classList).not.toContain('modified');
-      expect(actions.classList).not.toContain('hidden');
-      expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
+        // Change back to original value
+        input1a.value = 'initial1a';
+        input1a.dispatchEvent(new Event("change"));
+        expect(input1a.classList).not.toContain('modified');
 
-      // Record 2: has been changed
-      input2.value = 'updated2';
-      input2.dispatchEvent(new Event("change"));
-      // Expect all fields to show modified, summary counts both records
-      expect(input1a.classList).toContain('modified');
-      expect(input1b.classList).toContain('modified');
-      expect(input2.classList).toContain('modified');
-      expect(actions.classList).not.toContain('hidden');
-      expect(modified_summary.textContent).toBe('modified_summary, {"count":2}');
+      });
 
-      // Record 1: Change first field back to original value
-      input1a.value = 'initial1a';
-      input1a.dispatchEvent(new Event("change"));
-      // Expect first field to not show modified. But both records are still modified.
-      expect(input1a.classList).not.toContain('modified');
-      expect(input1b.classList).toContain('modified');
-      expect(input2.classList).toContain('modified');
-      expect(actions.classList).not.toContain('hidden');
-      expect(modified_summary.textContent).toBe('modified_summary, {"count":2}');
+      it("multiple fields", () => {
+        input1a.value = 'updated1a';
+        input1a.dispatchEvent(new Event("change"));
+        input2.value = 'updated2';
+        input2.dispatchEvent(new Event("change"));
+        // Expect only first field to show modified
+        expect(input1a.classList).toContain('modified');
+        expect(input1b.classList).not.toContain('modified');
+        expect(input2.classList).toContain('modified');
 
-      // Record 1: Change second field back to original value
-      input1b.value = 'initial1b';
-      input1b.dispatchEvent(new Event("change"));
-      // Both fields for record 1 show unmodified, but second record is still modified
-      expect(input1a.classList).not.toContain('modified');
-      expect(input1b.classList).not.toContain('modified');
-      expect(input2.classList).toContain('modified');
-      expect(actions.classList).not.toContain('hidden');
-      expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
-      expect(disable1.classList).toContain('disabled-section');
-      expect(disable2.classList).toContain('disabled-section');
+        // Change only one back to original value
+        input1a.value = 'initial1a';
+        input1a.dispatchEvent(new Event("change"));
+        expect(input1a.classList).not.toContain('modified');
+        expect(input1b.classList).not.toContain('modified');
+        expect(input2.classList).toContain('modified');
+      });
+    })
 
-      // Record 2: Change back to original value
-      input2.value = 'initial2';
-      input2.dispatchEvent(new Event("change"));
-      // No fields or records are modified
-      expect(input1a.classList).not.toContain('modified');
-      expect(input1b.classList).not.toContain('modified');
-      expect(input2.classList).not.toContain('modified');
-      // Actions are hidden and other sections are now re-enabled
-      expect(actions.classList).toContain('hidden');
-      expect(modified_summary.textContent).toBe('modified_summary, {"count":0}');
-      expect(disable1.classList).not.toContain('disabled-section');
-      expect(disable2.classList).not.toContain('disabled-section');
+    describe("activating sections, and showing a summary", () => {
+      // This scenario should probably be broken up into smaller units.
+      it("counts modified records ", () => {
+        // Record 1: First field changed
+        input1a.value = 'updated1a';
+        input1a.dispatchEvent(new Event("change"));
+        // Actions and modified summary are shown, with other sections disabled
+        expect(actions.classList).not.toContain('hidden');
+        expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
+        expect(disable1.classList).toContain('disabled-section');
+        expect(disable2.classList).toContain('disabled-section');
+
+        // Record 1: Second field changed
+        input1b.value = 'updated1b';
+        input1b.dispatchEvent(new Event("change"));
+        // Expect to show same summary translation
+        expect(actions.classList).not.toContain('hidden');
+        expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
+
+        // Record 2: has been changed
+        input2.value = 'updated2';
+        input2.dispatchEvent(new Event("change"));
+        // Expect summary to count both records
+        expect(actions.classList).not.toContain('hidden');
+        expect(modified_summary.textContent).toBe('modified_summary, {"count":2}');
+
+        // Record 1: Change first field back to original value
+        input1a.value = 'initial1a';
+        input1a.dispatchEvent(new Event("change"));
+        // Both records are still modified.
+        expect(input1a.classList).not.toContain('modified');
+        expect(input1b.classList).toContain('modified');
+        expect(input2.classList).toContain('modified');
+        expect(actions.classList).not.toContain('hidden');
+        expect(modified_summary.textContent).toBe('modified_summary, {"count":2}');
+
+        // Record 1: Change second field back to original value
+        input1b.value = 'initial1b';
+        input1b.dispatchEvent(new Event("change"));
+        // Both fields for record 1 show unmodified, but second record is still modified
+        expect(actions.classList).not.toContain('hidden');
+        expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
+        expect(disable1.classList).toContain('disabled-section');
+        expect(disable2.classList).toContain('disabled-section');
+
+        // Record 2: Change back to original value
+        input2.value = 'initial2';
+        input2.dispatchEvent(new Event("change"));
+        // Actions are hidden and other sections are now re-enabled
+        expect(actions.classList).toContain('hidden');
+        expect(modified_summary.textContent).toBe('modified_summary, {"count":0}');
+        expect(disable1.classList).not.toContain('disabled-section');
+        expect(disable2.classList).not.toContain('disabled-section');
+      });
     });
   });
 

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -29,6 +29,7 @@ describe("BulkFormController", () => {
   beforeEach(() => {
     document.body.innerHTML = `
       <form data-controller="bulk-form">
+        <div id="actions" data-bulk-form-target="actions" class="hidden"></div>
         <div id="modified_summary" data-bulk-form-target="modifiedSummary" data-translation-key="modified_summary"></div>
         <div data-record-id="1">
           <input id="input1a" type="text" value="initial1a">
@@ -46,6 +47,7 @@ describe("BulkFormController", () => {
     // would be repeated if these were broken into multiple examples. So it seems impractical to
     // write individual unit tests.
     it("counts modified fields and records", () => {
+      const actions = document.getElementById("actions");
       const modified_summary = document.getElementById("modified_summary");
       const input1a = document.getElementById("input1a");
       const input1b = document.getElementById("input1b");
@@ -58,6 +60,7 @@ describe("BulkFormController", () => {
       expect(input1a.classList).toContain('modified');
       expect(input1b.classList).not.toContain('modified');
       expect(input2.classList).not.toContain('modified');
+      expect(actions.classList).not.toContain('hidden');
       expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
 
       // Record 1: Second field changed
@@ -67,6 +70,7 @@ describe("BulkFormController", () => {
       expect(input1a.classList).toContain('modified');
       expect(input1b.classList).toContain('modified');
       expect(input2.classList).not.toContain('modified');
+      expect(actions.classList).not.toContain('hidden');
       expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
 
       // Record 2: has been changed
@@ -76,6 +80,7 @@ describe("BulkFormController", () => {
       expect(input1a.classList).toContain('modified');
       expect(input1b.classList).toContain('modified');
       expect(input2.classList).toContain('modified');
+      expect(actions.classList).not.toContain('hidden');
       expect(modified_summary.textContent).toBe('modified_summary, {"count":2}');
 
       // Record 1: Change first field back to original value
@@ -85,6 +90,7 @@ describe("BulkFormController", () => {
       expect(input1a.classList).not.toContain('modified');
       expect(input1b.classList).toContain('modified');
       expect(input2.classList).toContain('modified');
+      expect(actions.classList).not.toContain('hidden');
       expect(modified_summary.textContent).toBe('modified_summary, {"count":2}');
 
       // Record 1: Change second field back to original value
@@ -94,6 +100,7 @@ describe("BulkFormController", () => {
       expect(input1a.classList).not.toContain('modified');
       expect(input1b.classList).not.toContain('modified');
       expect(input2.classList).toContain('modified');
+      expect(actions.classList).not.toContain('hidden');
       expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
 
       // Record 2: Change back to original value
@@ -103,6 +110,7 @@ describe("BulkFormController", () => {
       expect(input1a.classList).not.toContain('modified');
       expect(input1b.classList).not.toContain('modified');
       expect(input2.classList).not.toContain('modified');
+      expect(actions.classList).toContain('hidden');
       expect(modified_summary.textContent).toBe('modified_summary, {"count":0}');
     });
   });

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -28,7 +28,9 @@ describe("BulkFormController", () => {
 
   beforeEach(() => {
     document.body.innerHTML = `
-      <form data-controller="bulk-form">
+      <div id="disable1"></div>
+      <div id="disable2"></div>
+      <form data-controller="bulk-form" data-bulk-form-disable-selector-value="#disable1,#disable2">
         <div id="actions" data-bulk-form-target="actions" class="hidden"></div>
         <div id="modified_summary" data-bulk-form-target="modifiedSummary" data-translation-key="modified_summary"></div>
         <div data-record-id="1">
@@ -38,6 +40,7 @@ describe("BulkFormController", () => {
         <div data-record-id="2">
           <input id="input2" type="text" value="initial2">
         </div>
+        <input type="submit">
       </form>
     `;
   });
@@ -47,6 +50,8 @@ describe("BulkFormController", () => {
     // would be repeated if these were broken into multiple examples. So it seems impractical to
     // write individual unit tests.
     it("counts modified fields and records", () => {
+      const disable1 = document.getElementById("disable1");
+      const disable2 = document.getElementById("disable2");
       const actions = document.getElementById("actions");
       const modified_summary = document.getElementById("modified_summary");
       const input1a = document.getElementById("input1a");
@@ -56,12 +61,15 @@ describe("BulkFormController", () => {
       // Record 1: First field changed (we're not simulating a user in a browser here; we're testing DOM events directly)
       input1a.value = 'updated1a';
       input1a.dispatchEvent(new Event("change"));
-      // Expect only first field to show modified, and show modified summary translation
+      // Expect only first field to show modified
       expect(input1a.classList).toContain('modified');
       expect(input1b.classList).not.toContain('modified');
       expect(input2.classList).not.toContain('modified');
+      // Actions and modified summary are shown, with other sections disabled
       expect(actions.classList).not.toContain('hidden');
       expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
+      expect(disable1.classList).toContain('disabled-section');
+      expect(disable2.classList).toContain('disabled-section');
 
       // Record 1: Second field changed
       input1b.value = 'updated1b';
@@ -102,6 +110,8 @@ describe("BulkFormController", () => {
       expect(input2.classList).toContain('modified');
       expect(actions.classList).not.toContain('hidden');
       expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
+      expect(disable1.classList).toContain('disabled-section');
+      expect(disable2.classList).toContain('disabled-section');
 
       // Record 2: Change back to original value
       input2.value = 'initial2';
@@ -110,8 +120,34 @@ describe("BulkFormController", () => {
       expect(input1a.classList).not.toContain('modified');
       expect(input1b.classList).not.toContain('modified');
       expect(input2.classList).not.toContain('modified');
+      // Actions are hidden and other sections are now re-enabled
       expect(actions.classList).toContain('hidden');
       expect(modified_summary.textContent).toBe('modified_summary, {"count":0}');
+      expect(disable1.classList).not.toContain('disabled-section');
+      expect(disable2.classList).not.toContain('disabled-section');
     });
   });
+
+  // unable to test disconnect at this stage
+  // describe("disconnect()", () => {
+  //   it("resets other elements", () => {
+  //     const disable1 = document.getElementById("disable1");
+  //     const disable2 = document.getElementById("disable2");
+  //     const controller = document.querySelector('[data-controller="bulk-form"]');
+  //     const form = document.querySelector('[data-controller="bulk-form"]');
+
+  //     // Form is modified and other sections are disabled
+  //     input1a.value = 'updated1a';
+  //     input1a.dispatchEvent(new Event("change"));
+  //     expect(disable1.classList).toContain('disabled-section');
+  //     expect(disable2.classList).toContain('disabled-section');
+
+  //     // form.submit(); //not implemented
+  //     document.body.removeChild(controller); //doesn't trigger disconnect
+  //     controller.innerHTML = ''; //doesn't trigger disconnect
+
+  //     expect(disable1.classList).not.toContain('disabled-section');
+  //     expect(disable2.classList).not.toContain('disabled-section');
+  //   });
+  // });
 });

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -72,6 +72,20 @@ describe("BulkFormController", () => {
 
       });
 
+      it("onKeyup", () => {
+        input1a.value = 'u1a';
+        input1a.dispatchEvent(new Event("keyup"));
+        // Expect only first field to show modified
+        expect(input1a.classList).toContain('modified');
+        expect(input1b.classList).not.toContain('modified');
+        expect(input2.classList).not.toContain('modified');
+
+        // Change back to original value
+        input1a.value = 'initial1a';
+        input1a.dispatchEvent(new Event("keyup"));
+        expect(input1a.classList).not.toContain('modified');
+      });
+
       it("multiple fields", () => {
         input1a.value = 'updated1a';
         input1a.dispatchEvent(new Event("change"));

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -148,6 +148,7 @@ describe("BulkFormController", () => {
 
   //     expect(disable1.classList).not.toContain('disabled-section');
   //     expect(disable2.classList).not.toContain('disabled-section');
+  //     //TODO: expect window to have no beforeunload event listener
   //   });
   // });
 });

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -11,39 +11,99 @@ describe("BulkFormController", () => {
     application.register("bulk-form", bulk_form_controller);
   });
 
+  // Mock I18n. TODO: moved to a shared helper
+  beforeAll(() => {
+    const mockedT = jest.fn();
+    mockedT.mockImplementation((string, opts) => (string + ', ' + JSON.stringify(opts)));
+
+    global.I18n =  {
+      t: mockedT
+    };
+  })
+
+  // (jest still doesn't have aroundEach https://github.com/jestjs/jest/issues/4543 )
+  afterAll(() => {
+    delete global.I18n;
+  })
+
   beforeEach(() => {
     document.body.innerHTML = `
       <form data-controller="bulk-form">
-        <input id="input1" type="text" value="initial1">
-        <input id="input2" type="text" value="initial2">
+        <div id="modified_summary" data-bulk-form-target="modifiedSummary" data-translation-key="modified_summary"></div>
+        <div data-record-id="1">
+          <input id="input1a" type="text" value="initial1a">
+          <input id="input1b" type="text" value="initial1b">
+        </div>
+        <div data-record-id="2">
+          <input id="input2" type="text" value="initial2">
+        </div>
       </form>
     `;
   });
 
-  describe("#toggleModified", () => {
-    it("marks a changed element as modified", () => {
-      // const form = document.getElementsByTagName("form")[0];
-      const input1 = document.getElementById("input1");
+  describe("Modifying input values", () => {
+    // This is more of a behaviour spec. Jest doesn't have all the niceties of RSpec so lots of code
+    // would be repeated if these were broken into multiple examples. So it seems impractical to
+    // write individual unit tests.
+    it("counts modified fields and records", () => {
+      const modified_summary = document.getElementById("modified_summary");
+      const input1a = document.getElementById("input1a");
+      const input1b = document.getElementById("input1b");
       const input2 = document.getElementById("input2");
 
-      expect(input1.classList).not.toContain('modified');
+      // Record 1: First field changed (we're not simulating a user in a browser here; we're testing DOM events directly)
+      input1a.value = 'updated1a';
+      input1a.dispatchEvent(new Event("change"));
+      // Expect only first field to show modified, and show modified summary translation
+      expect(input1a.classList).toContain('modified');
+      expect(input1b.classList).not.toContain('modified');
       expect(input2.classList).not.toContain('modified');
+      expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
 
-      // Value has been changed (we're not simulating a user in a browser here; we're testing DOM events directly)
-      input1.value = 'updated1';
-      input1.dispatchEvent(new Event("change"));
-      // form.dispatchEvent(new Event("change"));
-
-      expect(input1.classList).toContain('modified');
+      // Record 1: Second field changed
+      input1b.value = 'updated1b';
+      input1b.dispatchEvent(new Event("change"));
+      // Expect to show modified, and same summary translation
+      expect(input1a.classList).toContain('modified');
+      expect(input1b.classList).toContain('modified');
       expect(input2.classList).not.toContain('modified');
+      expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
 
-      // Change back to original value
-      input1.value = 'initial1';
-      input1.dispatchEvent(new Event("change"));
-      // form.dispatchEvent(new Event("change"));
+      // Record 2: has been changed
+      input2.value = 'updated2';
+      input2.dispatchEvent(new Event("change"));
+      // Expect all fields to show modified, summary counts both records
+      expect(input1a.classList).toContain('modified');
+      expect(input1b.classList).toContain('modified');
+      expect(input2.classList).toContain('modified');
+      expect(modified_summary.textContent).toBe('modified_summary, {"count":2}');
 
-      expect(input1.classList).not.toContain('modified');
+      // Record 1: Change first field back to original value
+      input1a.value = 'initial1a';
+      input1a.dispatchEvent(new Event("change"));
+      // Expect first field to not show modified. But both records are still modified.
+      expect(input1a.classList).not.toContain('modified');
+      expect(input1b.classList).toContain('modified');
+      expect(input2.classList).toContain('modified');
+      expect(modified_summary.textContent).toBe('modified_summary, {"count":2}');
+
+      // Record 1: Change second field back to original value
+      input1b.value = 'initial1b';
+      input1b.dispatchEvent(new Event("change"));
+      // Both fields for record 1 show unmodified, but second record is still modified
+      expect(input1a.classList).not.toContain('modified');
+      expect(input1b.classList).not.toContain('modified');
+      expect(input2.classList).toContain('modified');
+      expect(modified_summary.textContent).toBe('modified_summary, {"count":1}');
+
+      // Record 2: Change back to original value
+      input2.value = 'initial2';
+      input2.dispatchEvent(new Event("change"));
+      // No fields or records are modified
+      expect(input1a.classList).not.toContain('modified');
+      expect(input1b.classList).not.toContain('modified');
       expect(input2.classList).not.toContain('modified');
+      expect(modified_summary.textContent).toBe('modified_summary, {"count":0}');
     });
   });
 });

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { Application } from "stimulus";
+import bulk_form_controller from "../../../app/webpacker/controllers/bulk_form_controller";
+
+describe("BulkFormController", () => {
+  beforeAll(() => {
+    const application = Application.start();
+    application.register("bulk-form", bulk_form_controller);
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <form data-controller="bulk-form">
+        <input id="input1" type="text" value="initial1">
+        <input id="input2" type="text" value="initial2">
+      </form>
+    `;
+  });
+
+  describe("#toggleModified", () => {
+    it("marks a changed element as modified", () => {
+      // const form = document.getElementsByTagName("form")[0];
+      const input1 = document.getElementById("input1");
+      const input2 = document.getElementById("input2");
+
+      expect(input1.classList).not.toContain('modified');
+      expect(input2.classList).not.toContain('modified');
+
+      // Value has been changed (we're not simulating a user in a browser here; we're testing DOM events directly)
+      input1.value = 'updated1';
+      input1.dispatchEvent(new Event("change"));
+      // form.dispatchEvent(new Event("change"));
+
+      expect(input1.classList).toContain('modified');
+      expect(input2.classList).not.toContain('modified');
+
+      // Change back to original value
+      input1.value = 'initial1';
+      input1.dispatchEvent(new Event("change"));
+      // form.dispatchEvent(new Event("change"));
+
+      expect(input1.classList).not.toContain('modified');
+      expect(input2.classList).not.toContain('modified');
+    });
+  });
+});

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -205,6 +205,25 @@ describe 'As an admin, I can see the new product page' do
       pending
       expect(page).to have_content "Changes saved"
     end
+
+    it "can discard changes and reload latest data" do
+      within row_containing_name("Apples") do
+        fill_in "Name", with: "Pommes"
+      end
+
+      # Meanwhile, the SKU was updated
+      product_a.update! sku: "APL-10"
+
+      expect {
+        click_button "Discard changes"
+        product_a.reload
+      }.to_not change { product_a.name }
+
+      within row_containing_name("Apples") do
+        expect(page).to have_field "Name", with: "Apples" # Changed value wasn't saved
+        expect(page).to have_field "SKU", with: "APL-10" # Updated value shown
+      end
+    end
   end
 
   def expect_page_to_be(page_number)

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -211,6 +211,14 @@ describe 'As an admin, I can see the new product page' do
         fill_in "Name", with: "Pommes"
       end
 
+      # Expect to be alerted when attempting to navigate away. Cancel.
+      dismiss_confirm do
+        click_link "Dashboard"
+      end
+      within row_containing_name("Apples") do
+        expect(page).to have_field "Name", with: "Pommes" # Changed value wasn't lost
+      end
+
       # Meanwhile, the SKU was updated
       product_a.update! sku: "APL-10"
 


### PR DESCRIPTION
#### What? Why?

- Part of #11059

Adding in dynamic behaviours with a Stimulus controller on the `form`. I've been able to keep it generic with no references to products or variants!

Changes:
- [x] Mark unsaved fields with an orange border. (Hmm, now I can't find this requirement in the issue.. did I dream it?)
- [x] Only show form actions bar if products are modified
- [x] Show count of modified products in actions bar
- [x] prevent accidentally leaving the form
- [x] Change "discard changes" button to reload all products from the DB. Although a simple form reset could be enough, it might be more useful for the user if it loads the latest values in case they've changed.
- [ ] ~~Optmisation: submit only modified fields.~~ I decided not to, because this depends on the submission method, which may change (currently stimulus-reflex, but I would consider switching to [use mrujs](https://docs.stimulusreflex.com/guide/working-with-forms.html#stimulusreflex-mrujs-%F0%9F%A5%B0) if possible)


https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/26920994-2d0e-4072-bfd5-7cdfd66ba9d9


It's been a bit of a learning curve with Stimulus and JS in general, but am enjoying it now. I left notes in comments and commit messages to share my learnings. (BTW I certainly didn't do this all in a few clear steps like the commits might suggest. It took a bit of back and forth but I kept work on each step separate so i could rebase it all).

#### What should we test?
This would be a good one to test out and give feedback on usability. 
Scenarios 1-7 described on the issue (#11059) are now fully implemented. Error messages haven't been implemented yet.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1 or DFC)
- [x] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
This is still under a feature toggle.
