### PR TITLE
Fix Update button sizing

### DIFF
--- a/app/views/spree/orders/form/_cart_actions_row.html.haml
+++ b/app/views/spree/orders/form/_cart_actions_row.html.haml
@@ -1,10 +1,8 @@
 %tr
   %td{colspan:"2"}
   %td
-    %button#update-button.secondary.radius.small{"ng-class" => "{ alert: form.$dirty && form.$valid }"}<
-      =# Trimmed whitespace (angle brackets) to ensure first word doesn't wrap after icon
-      %i.ofn-i_023-refresh>
-      &nbsp;
+    %button#update-button.secondary.radius.small{"ng-class" => "{ alert: form.$dirty && form.$valid }"}
+      %i.ofn-i_023-refresh
       = t(:orders_form_update_cart)
   %td
   %td#empty-cart.text-center

--- a/app/views/spree/orders/form/_cart_actions_row.html.haml
+++ b/app/views/spree/orders/form/_cart_actions_row.html.haml
@@ -1,8 +1,10 @@
 %tr
   %td{colspan:"2"}
   %td
-    %button#update-button.secondary.radius.expand.small{"ng-class" => "{ alert: form.$dirty && form.$valid }"}
-      %i.ofn-i_023-refresh
+    %button#update-button.secondary.radius.small{"ng-class" => "{ alert: form.$dirty && form.$valid }"}<
+      =# Trimmed whitespace (angle brackets) to ensure first word doesn't wrap after icon
+      %i.ofn-i_023-refresh>
+      &nbsp;
       = t(:orders_form_update_cart)
   %td
   %td#empty-cart.text-center

--- a/app/webpacker/css/darkswarm/cart-page.scss
+++ b/app/webpacker/css/darkswarm/cart-page.scss
@@ -28,6 +28,7 @@
   button,
   .button {
     margin: 0;
+    padding: 0.875rem; // Compact buttons inside table
   }
 
   .toggle-bought {

--- a/app/webpacker/css/darkswarm/cart-page.scss
+++ b/app/webpacker/css/darkswarm/cart-page.scss
@@ -29,6 +29,7 @@
   .button {
     margin: 0;
     padding: 0.875rem; // Compact buttons inside table
+    white-space: nowrap;
   }
 
   .toggle-bought {


### PR DESCRIPTION
#### What? Why?

This was broken when [upgrading Foundation](https://github.com/openfoodfoundation/openfoodnetwork/pull/11349). 

I think a single review is fine, then it can be tested and merged sooner.

#### What should we test?
As pictured on above PR^

1. Visit cart edit page
2. Observe the "Update" button appears as expected

- It would be good to check how this appears in another language, if the word is longer.

#### Release notes

It's not worth noting this to instance managers, especially if the fix can be merged before the above PR is released.

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1 or DFC)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
