### PR TITLE
BUU: Fix question mark icon for tooltip

### DIFF
--- a/app/assets/javascripts/templates/shared/question_mark_with_tooltip_icon.html.haml
+++ b/app/assets/javascripts/templates/shared/question_mark_with_tooltip_icon.html.haml
@@ -1,1 +1,1 @@
-%button.question-mark-icon{"ng-class" => "{open: tt_isOpen}", type: 'button'}
+.question-mark-icon{"ng-class" => "{open: tt_isOpen}", type: 'button'}

--- a/app/webpacker/css/admin_v3/all.scss
+++ b/app/webpacker/css/admin_v3/all.scss
@@ -121,7 +121,7 @@
 @import "../admin/variant_overrides";
 @import "../admin/welcome";
 
-@import "../shared/question-mark-icon";
+@import "shared/question-mark-icon";
 @import "../admin/question-mark-tooltip";
 
 @import "~tom-select/src/scss/tom-select.default";

--- a/app/webpacker/css/admin_v3/shared/question-mark-icon.scss
+++ b/app/webpacker/css/admin_v3/shared/question-mark-icon.scss
@@ -1,0 +1,98 @@
+.unit-price {
+  display: flex;
+  align-items: center;
+}
+
+.question-mark-icon {
+  background-image: url("../images/question-mark-icon.svg");
+  background-size: cover;
+  background-repeat: no-repeat;
+  border-radius: 50%;
+  cursor: pointer;
+
+  // Reset button element css attributes
+  padding: 0;
+  margin: 0;
+  width: 20px;
+  min-width: 20px;
+  height: 20px;
+  background-color: transparent;
+
+  &:hover,
+  &:focus {
+    background-color: transparent;
+  }
+
+  &.open {
+    background-image: none;
+    background-color: $teal-500;
+
+    &:focus {
+      outline: 0;
+    }
+
+    &::before {
+      @include icon-font;
+      content: "";
+      color: $white;
+      vertical-align: super;
+    }
+  }
+}
+
+// Question mark icon into a field
+.field .question-mark-icon {
+  width: 15px;
+  min-width: 15px;
+  height: 15px;
+  margin-left: 2px;
+}
+
+.joyride-tip-guide.question-mark-tooltip {
+  width: 16rem;
+  max-width: 65%;
+  // JS needs to be tweaked to adjust for left alignment - this is dynamic can't rewrite in CSS
+  margin-left: -7.4rem;
+  margin-top: -0.1rem;
+  background-color: transparent;
+  z-index: $modal-zIndex + 1;
+
+  .background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    cursor: pointer;
+  }
+
+  .joyride-content-wrapper {
+    background-color: $dynamic-blue;
+    padding: $padding-small;
+    border-radius: $radius-small;
+    color: $white;
+    width: 100%;
+    font-size: 0.8rem;
+  }
+
+  .joyride-nub.bottom {
+    // Need to rewrite all with !important as it's marked as !important in the original file
+    border-color: $dynamic-blue !important;
+    border-bottom-color: transparent !important;
+    border-left-color: transparent !important;
+    border-right-color: transparent !important;
+    left: 7.4rem;
+    z-index: -1;
+  }
+
+  &.cart-sidebar {
+    // Small size (used in the cart sidebar)
+    width: 13rem;
+    margin-left: -10.4rem;
+
+    .joyride-nub.bottom {
+      left: 10.4rem;
+    }
+  }
+}

--- a/app/webpacker/css/admin_v3/shared/question-mark-icon.scss
+++ b/app/webpacker/css/admin_v3/shared/question-mark-icon.scss
@@ -25,7 +25,7 @@
 
   &.open {
     background-image: none;
-    background-color: $teal-500;
+    background-color: $orient;
 
     &:focus {
       outline: 0;
@@ -68,7 +68,7 @@
   }
 
   .joyride-content-wrapper {
-    background-color: $dynamic-blue;
+    background-color: $orient;
     padding: $padding-small;
     border-radius: $radius-small;
     color: $white;
@@ -78,7 +78,7 @@
 
   .joyride-nub.bottom {
     // Need to rewrite all with !important as it's marked as !important in the original file
-    border-color: $dynamic-blue !important;
+    border-color: $orient !important;
     border-bottom-color: transparent !important;
     border-left-color: transparent !important;
     border-right-color: transparent !important;

--- a/app/webpacker/css/shared/question-mark-icon.scss
+++ b/app/webpacker/css/shared/question-mark-icon.scss
@@ -10,6 +10,7 @@
   background-size: cover;
   background-repeat: no-repeat;
   border-radius: 50%;
+  cursor: pointer;
 
   // Reset button element css attributes
   padding: 0;


### PR DESCRIPTION
#### What? Why?

Fixed in legacy backoffice, so this one closes #11524 as well.
<img width="404" alt="Capture d’écran 2023-09-11 à 15 35 20" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/b1e6f446-9bab-420b-8350-f1424c9147f3">

<img width="489" alt="Capture d’écran 2023-09-11 à 15 35 15" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/ba17d7de-53ba-4f1e-9178-f6458e397333">

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, visit product creation/edition page, and check that question mark for tooltip renders well.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1 or DFC)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
