### PR TITLE
Renames product so it always appears first on the report results

### DIFF
--- a/spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb
@@ -67,7 +67,8 @@ describe Reporting::Reports::OrdersAndFulfillment::OrderCycleSupplierTotals do
 
     it "is summarised" do
       expect(report).to receive(:display_summary_row?).and_return(true)
-
+      # assures product appears first on report table
+      variant.product.update!(name: "Alpha-Product #000")
       variant.product.update!(variant_unit: "weight")
       variant.update!(unit_value: 200) # grams
       item.update!(final_weight_volume: nil) # reset unit information


### PR DESCRIPTION
#### What? Why?

- Closes #11473

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

In some cases (I could not nail exactly which ones), the reports results order were inverted, which made the test fail.

Since all factory generated products are named `Product (...)`, renaming one of them to `Alpha-Product (...)` should do the trick to make it always appear first (ordering is alphabetical, by product name):
```

[["Enterprise 2",
  "Alpha-Product #000",
  "200g",
  3,
  0.6e0,
  0.1e2,
  0.3e2,
  "2cce0732b332bb87c0e87a6d880872e3",
  "No",
  "none"],
 ["Enterprise 2",
  "Product #2 - 1944",
  "1g",
  1,
  0.1e-2,
  0.1e2,
  0.1e2,
  "c1ed3afd42800b1c71d1f49509439441",
  "No",
  "none"],
 ["", "", "TOTAL", 4, 0.601e0, "", 0.4e2, "", "", ""]]
```

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1 or DFC)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
