### PR TITLE
[Release test automation] Adds assertions on bulk invoice creation

### DIFF
--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -577,13 +577,21 @@ describe '
 
           page.find("span.icon-reorder", text: "ACTIONS").click
           within ".ofn-drop-down .menu" do
-            page.find("span", text: "Print Invoices").click
+            expect {
+              page.find("span", text: "Print Invoices").click # Prints invoices in bulk
+            }.to enqueue_job(BulkInvoiceJob).exactly(:once)
           end
 
           expect(page).to have_content "Compiling Invoices"
           expect(page).to have_content "Please wait until the PDF is ready " \
                                        "before closing this modal."
-          # an error 422 is generated in the console
+
+          # we don't run Sidekiq in test environment, so we need to manually run enqueued jobs
+          # to generate PDF files, and change the modal accordingly
+          perform_enqueued_jobs(only: BulkInvoiceJob)
+
+          expect(page).to have_content "Bulk Invoice created"
+          expect(page).to have_content "VIEW FILE"
         end
 
         it "can bulk cancel 2 orders" do

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -591,7 +591,7 @@ describe '
           perform_enqueued_jobs(only: BulkInvoiceJob)
 
           expect(page).to have_content "Bulk Invoice created"
-          expect(page).to have_content "VIEW FILE"
+          expect(page).to have_link(class: "button", text: "VIEW FILE", href: /invoices/)
         end
 
         it "can bulk cancel 2 orders" do


### PR DESCRIPTION
#### What? Why?

- Closes #10967 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The system spec only went as far as clicking on the menu. Because we don't have Sidekiq running in the test environment, we can explicitly trigger the BulkPrint job, and assert that the new modal appears, with the correct link to the pdf file.

We were checking this manually, during release testing.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1 or DFC)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
