### PR TITLE
Removes signup from fix_require_login_link_html key in fr_BE locale

### DIFF
--- a/config/locales/fr_BE.yml
+++ b/config/locales/fr_BE.yml
@@ -1579,7 +1579,7 @@ fr_BE:
         login: "Se connecter"
         contact: "contacter"
         require_customer_login: "Seuls les clients approuvés peuvent accéder à ce comptoir."
-        require_login_link_html: "Si vous êtes déjà un client approuvé, %{login} ou %{signup} pour continuer."
+        require_login_link_html: "Si vous êtes déjà un client approuvé, %{login} pour continuer."
         require_login_2_html: "Vous voulez commencer à faire vos achats ici? Veuillez %{contact} %{enterprise} et demandez à vous inscrire."
         require_customer_html: "Si vous souhaitez commencer à faire vos achats ici, veuillez %{contact}%{enterprise} et demandez pour vous inscrire."
       select_oc:


### PR DESCRIPTION
#### What? Why?

- Closes #11560 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The `fr_BE.yml` was pointing to both `login` and `signup`, but the page view was only calling `login`. This seems to have affected only OFN BE.

The PR changes the fr_BE.yml locale 
#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As admin:
  - visit the Dashboard and, under Shop preferences: enable the `Visible to registered customers only` option

- As the customer, on a guest session:
  - select the fr_BE locale
  - visit the shopfront from that shop
  - the user should see the translated message, and no error 500


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
