### PR TITLE
🚧 [BUU] Add `Edit` link into a small menu on the last Actions column to the right of the table

### DIFF
--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -61,6 +61,7 @@
             %td.align-left
               .line-clamp-1= product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values, else use I18n.t (also below)
             %td.align-right
+              = link_to t('admin.products_page.actions.edit'), edit_admin_product_path(product)
           - product.variants.each do |variant|
             - prefix = "[products][][variants_attributes][]" # Couldn't convince the formbuilder to generate this for me, so for now we manually add the prefix
             = form.fields_for(variant) do |variant_form|
@@ -85,3 +86,4 @@
                 %td.align-left
                   -# empty
                 %td.align-right
+                  = link_to t('admin.products_page.actions.edit'), edit_admin_product_variant_path(product, variant)

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -61,7 +61,7 @@
             %td.align-left
               .line-clamp-1= product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values, else use I18n.t (also below)
             %td.align-right
-              = link_to t('admin.products_page.actions.edit'), edit_admin_product_path(product)
+              = render partial: 'admin/products_v3/components/product_actions', locals: { product: product }
           - product.variants.each do |variant|
             - prefix = "[products][][variants_attributes][]" # Couldn't convince the formbuilder to generate this for me, so for now we manually add the prefix
             = form.fields_for(variant) do |variant_form|
@@ -86,4 +86,4 @@
                 %td.align-left
                   -# empty
                 %td.align-right
-                  = link_to t('admin.products_page.actions.edit'), edit_admin_product_variant_path(product, variant)
+                  = render partial: 'admin/products_v3/components/product_actions', locals: { product: product, variant: variant }

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -21,6 +21,7 @@
     %col{ width:"10%" }
     %col{ width:"5%" }
     %col{ width:"5%", style: "max-width:5em" }
+    %col{ width:"5%", style: "max-width:5em" }
     %thead
       %tr
         %th.align-left.with-input= t('admin.products_page.columns.name')
@@ -32,6 +33,7 @@
         %th.align-left= t('admin.products_page.columns.category')
         %th.align-left= t('admin.products_page.columns.tax_category')
         %th.align-left= t('admin.products_page.columns.inherits_properties')
+        %th.align-right= t('admin.products_page.columns.actions')
     - products.each do |product|
       = form.fields_for("products", product, index: nil) do |product_form|
         %tbody.relaxed
@@ -58,6 +60,7 @@
             %td.align-left
             %td.align-left
               .line-clamp-1= product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values, else use I18n.t (also below)
+            %td.align-right
           - product.variants.each do |variant|
             - prefix = "[products][][variants_attributes][]" # Couldn't convince the formbuilder to generate this for me, so for now we manually add the prefix
             = form.fields_for(variant) do |variant_form|
@@ -81,3 +84,4 @@
                   .line-clamp-1= variant.tax_category&.name || "None" # TODO: convert to dropdown, else translate hardcoded string.
                 %td.align-left
                   -# empty
+                %td.align-right

--- a/app/views/admin/products_v3/components/_product_actions.html.haml
+++ b/app/views/admin/products_v3/components/_product_actions.html.haml
@@ -1,0 +1,7 @@
+.vertical-ellipsis-menu{ "data-controller": "vertical-ellipsis-menu" }
+  %i.fa.fa-ellipsis-v{ "data-action": "click->vertical-ellipsis-menu#toggle" }
+  .vertical-ellipsis-menu-content{ "data-vertical-ellipsis-menu-target": "content" }
+    - if defined?(variant)
+      = link_to t('admin.products_page.actions.edit'), edit_admin_product_variant_path(product, variant), class: "vertical-ellipsis-menu-content-item"
+    - else
+      = link_to t('admin.products_page.actions.edit'), edit_admin_product_path(product), class: "vertical-ellipsis-menu-content-item"

--- a/app/webpacker/controllers/vertical_ellipsis_menu_controller.js
+++ b/app/webpacker/controllers/vertical_ellipsis_menu_controller.js
@@ -5,15 +5,19 @@ export default class extends Controller {
 
   connect() {
     super.connect();
-    window.addEventListener("click", (e) => {
-      if (this.element.contains(e.target)) return;
-      this.#hide();
-    });
+    window.addEventListener("click", this.#hideIfClickedOutside);
   }
 
   toggle() {
     this.contentTarget.classList.toggle("show");
   }
+
+  #hideIfClickedOutside = (event) => {
+    if (this.element.contains(event.target)) {
+      return;
+    }
+    this.#hide();
+  };
 
   #hide() {
     this.contentTarget.classList.remove("show");

--- a/app/webpacker/controllers/vertical_ellipsis_menu_controller.js
+++ b/app/webpacker/controllers/vertical_ellipsis_menu_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static targets = ["content"];
+
+  connect() {
+    super.connect();
+    window.addEventListener("click", (e) => {
+      if (this.element.contains(e.target)) return;
+      this.#hide();
+    });
+  }
+
+  toggle() {
+    this.contentTarget.classList.toggle("show");
+  }
+
+  #hide() {
+    this.contentTarget.classList.remove("show");
+  }
+}

--- a/app/webpacker/css/admin_v3/all.scss
+++ b/app/webpacker/css/admin_v3/all.scss
@@ -113,6 +113,7 @@
 @import "../admin/reports";
 @import "components/select2"; // admin_v3
 @import "components/sidebar-item"; // admin_v3
+@import "components/vertical_ellipsis_menu"; // admin_v3 and only V3
 @import "../admin/side_menu";
 @import "../admin/tables";
 @import "../admin/tag_rules";

--- a/app/webpacker/css/admin_v3/components/vertical_ellipsis_menu.scss
+++ b/app/webpacker/css/admin_v3/components/vertical_ellipsis_menu.scss
@@ -1,0 +1,62 @@
+.vertical-ellipsis-menu {
+  position: relative;
+  width: $btn-relaxed-height;
+
+  i.fa-ellipsis-v {
+    cursor: pointer;
+    display: block;
+    height: $btn-relaxed-height;
+    width: $btn-relaxed-height;
+    line-height: $btn-relaxed-height;
+    text-align: center;
+    border-radius: 3px;
+    background-color: white;
+  }
+
+  .vertical-ellipsis-menu-content {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    background-color: white;
+    @include defaultBoxShadow;
+    border-radius: 3px;
+    min-width: 80px;
+    display: none;
+    z-index: 100;
+
+    &.show {
+      display: block;
+    }
+
+    .vertical-ellipsis-menu-content-item {
+      display: block;
+      padding: 5px 10px;
+      cursor: pointer;
+      text-align: left;
+      border-left: 3px solid white;
+      color: $near-black;
+      text-decoration: none;
+      border-bottom: none;
+
+      &:hover {
+        background-color: $light-grey;
+        border-left: 3px solid $spree-blue;
+      }
+
+      &.delete {
+        color: $red;
+
+        &:hover {
+          border-left: 3px solid $red;
+          background-color: $fair-pink;
+        }
+      }
+    }
+  }
+}
+
+table.products td .vertical-ellipsis-menu {
+  float: right;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -550,6 +550,7 @@ en:
         tax_category: "Tax Category"
         inherits_properties: "Inherits Properties?"
         import_date: "Import Date"
+        actions: Actions
       columns_selector:
         unit: Unit
         price: Price

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -562,6 +562,8 @@ en:
         tax_category: "Tax Category"
         inherits_properties: "Inherits Properties?"
         import_date: "Import Date"
+      actions:
+        edit: Edit
     adjustments:
       skipped_changing_canceled_order: "You can't change a cancelled order."
     # Common properties / models

--- a/spec/javascripts/stimulus/vertical_ellipsis_menu_controller_test.js
+++ b/spec/javascripts/stimulus/vertical_ellipsis_menu_controller_test.js
@@ -20,12 +20,11 @@ describe("VerticalEllipsisMenuController test", () => {
         </div>
       </div>
     `;
+    const button = document.getElementById("button");
+    const content = document.getElementById("content");
   });
 
   it("add show class to content when toggle is called", () => {
-    const button = document.getElementById("button");
-    const content = document.getElementById("content");
-
     expect(content.classList.contains("show")).toBe(false);
     button.click();
     expect(content.classList.contains("show")).toBe(true);
@@ -33,9 +32,6 @@ describe("VerticalEllipsisMenuController test", () => {
 
 
   it("remove show class from content when clicking button", () => {
-    const button = document.getElementById("button");
-    const content = document.getElementById("content");
-
     button.click();
     expect(content.classList.contains("show")).toBe(true);
     button.click();
@@ -44,9 +40,6 @@ describe("VerticalEllipsisMenuController test", () => {
 
   
   it("remove show class from content when clicking outside", () => {
-    const button = document.getElementById("button");
-    const content = document.getElementById("content");
-
     button.click();
     expect(content.classList.contains("show")).toBe(true);
     document.body.click();

--- a/spec/javascripts/stimulus/vertical_ellipsis_menu_controller_test.js
+++ b/spec/javascripts/stimulus/vertical_ellipsis_menu_controller_test.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { Application } from "stimulus";
+import vertical_ellipsis_menu_controller from "../../../app/webpacker/controllers/vertical_ellipsis_menu_controller";
+
+describe("VerticalEllipsisMenuController test", () => {
+  beforeAll(() => {
+    const application = Application.start();
+    application.register("vertical-ellipsis-menu", vertical_ellipsis_menu_controller);
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-controller="vertical-ellipsis-menu" id="root">
+        <div data-action="click->vertical-ellipsis-menu#toggle" id="button">...</div>
+        <div data-vertical-ellipsis-menu-target="content" id="content">
+          
+        </div>
+      </div>
+    `;
+  });
+
+  it("add show class to content when toggle is called", () => {
+    const button = document.getElementById("button");
+    const content = document.getElementById("content");
+
+    expect(content.classList.contains("show")).toBe(false);
+    button.click();
+    expect(content.classList.contains("show")).toBe(true);
+  });
+
+
+  it("remove show class from content when clicking button", () => {
+    const button = document.getElementById("button");
+    const content = document.getElementById("content");
+
+    button.click();
+    expect(content.classList.contains("show")).toBe(true);
+    button.click();
+    expect(content.classList.contains("show")).toBe(false);
+  });
+
+  
+  it("remove show class from content when clicking outside", () => {
+    const button = document.getElementById("button");
+    const content = document.getElementById("content");
+
+    button.click();
+    expect(content.classList.contains("show")).toBe(true);
+    document.body.click();
+    expect(content.classList.contains("show")).toBe(false);
+  });
+});

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -157,6 +157,36 @@ describe 'As an admin, I can see the new product page' do
     end
   end
 
+  describe "Actions columns (edit)" do
+    let!(:variant_a1) {
+      create(:variant,
+             product: product_a,
+             display_name: "Medium box",
+             sku: "APL-01",
+             price: 5.25)
+    }
+    let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
+
+    before do
+      visit admin_products_v3_index_url
+    end
+
+    it "shows an actions memu with an edit link when clicking on icon for product" do
+      within row_containing_name("Apples") do
+        page.find(".vertical-ellipsis-menu").click
+        expect(page).to have_link "Edit", href: spree.edit_admin_product_path(product_a)
+      end
+    end
+
+    it "shows an actions memu with an edit link when clicking on icon for variant" do
+      within row_containing_name("Medium box") do
+        page.find(".vertical-ellipsis-menu").click
+        expect(page).to have_link "Edit",
+                                  href: spree.edit_admin_product_variant_path(product_a, variant_a1)
+      end
+    end
+  end
+
   describe "updating" do
     let!(:variant_a1) {
       create(:variant,


### PR DESCRIPTION
#### What? Why?

- Closes #11069

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

![2023-09-19 15 31 35](https://github.com/openfoodfoundation/openfoodnetwork/assets/296452/dc3d848e-3745-4e13-ba6d-09e8a396e101)

(there is no delete action in this PR, but I wanted to show here that I've prepared the CSS for a `.delete` item)


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a hub manager, with feature toggle activated, check the new product page, and see that you can use that small component to fully edit product/variant (by going into its edition page)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
