### PR TITLE
[BUU] editing fixups

### DIFF
--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -63,18 +63,17 @@
             %td.align-right
               = render partial: 'admin/products_v3/components/product_actions', locals: { product: product }
           - product.variants.each do |variant|
-            - prefix = "[products][][variants_attributes][]" # Couldn't convince the formbuilder to generate this for me, so for now we manually add the prefix
-            = form.fields_for(variant) do |variant_form|
+            = form.fields_for("products][][variants_attributes][", variant, index: nil) do |variant_form|
               %tr.condensed
                 %td.align-left
-                  = variant_form.hidden_field :id, name: "#{prefix}[id]"
-                  = variant_form.text_field :display_name, name: "#{prefix}[display_name]", 'aria-label': t('admin.products_page.columns.name'), placeholder: product.name
+                  = variant_form.hidden_field :id
+                  = variant_form.text_field :display_name, 'aria-label': t('admin.products_page.columns.name'), placeholder: product.name
                 %td.align-right
-                  = variant_form.text_field :sku, name: "#{prefix}[sku]", 'aria-label': t('admin.products_page.columns.sku')
+                  = variant_form.text_field :sku, 'aria-label': t('admin.products_page.columns.sku')
                 %td.align-right
                   .line-clamp-1= variant.unit_to_display
                 %td.align-right
-                  = variant_form.text_field :price, name: "#{prefix}[price]", 'aria-label': t('admin.products_page.columns.price'), value: number_to_currency(variant.price, unit: '')&.strip # TODO: add a spec to prove that this formatting is necessary. If so, it should be in a shared form helper for currency inputs
+                  = variant_form.text_field :price, 'aria-label': t('admin.products_page.columns.price'), value: number_to_currency(variant.price, unit: '')&.strip # TODO: add a spec to prove that this formatting is necessary. If so, it should be in a shared form helper for currency inputs
                 %td.align-right
                   .line-clamp-1= variant.on_hand || 0 #TODO: spec for this according to requirements.
                 %td.align-left

--- a/app/webpacker/controllers/application_controller.js
+++ b/app/webpacker/controllers/application_controller.js
@@ -43,7 +43,11 @@ export default class extends Controller {
   }
 
   reflexError(element, reflex, error, reflexId) {
+    // Log to console (it normally only gets logged in dev mode)
+    console.error(reflex + ":\n " + error);
+
     // show error message
+    alert(I18n.t("errors.stimulus_reflex_error"));
   }
 
   reflexForbidden(element, reflex, noop, reflexId) {

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -43,11 +43,9 @@ export default class BulkFormController extends Controller {
 
   toggleFormModified() {
     // For each record, check if any fields are modified
-    const modifiedRecordCount = Object.keys(this.recordElements).filter((recordId) => {
-      return this.recordElements[recordId].some((element) => {
-        return element.value != element.defaultValue;
-      });
-    }).length;
+    const modifiedRecordCount = Object.values(this.recordElements).filter((elements) =>
+      elements.some((element) => element.value != element.defaultValue)
+    ).length;
     const formModified = modifiedRecordCount > 0;
 
     // Show actions

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -35,8 +35,7 @@ export default class BulkFormController extends Controller {
 
   toggleModified(e) {
     const element = e.target;
-    const modified = element.value != element.defaultValue;
-    element.classList.toggle("modified", modified);
+    element.classList.toggle("modified", this.#isModified(element));
 
     this.toggleFormModified();
   }
@@ -44,7 +43,7 @@ export default class BulkFormController extends Controller {
   toggleFormModified() {
     // For each record, check if any fields are modified
     const modifiedRecordCount = Object.values(this.recordElements).filter((elements) =>
-      elements.some((element) => element.value != element.defaultValue)
+      elements.some(this.#isModified)
     ).length;
     const formModified = modifiedRecordCount > 0;
 
@@ -84,5 +83,9 @@ export default class BulkFormController extends Controller {
         element.classList.toggle("disabled-section", disable);
       });
     }
+  }
+
+  #isModified(element) {
+    return element.value != element.defaultValue;
   }
 }

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -109,6 +109,10 @@
     // "Naked" inputs. Row hover helps reveal them.
     input {
       border-color: transparent;
+      background-color: $color-tbl-cell-bg;
+      height: auto;
+      font-size: inherit;
+      font-weight: inherit;
 
       &:focus {
         border-color: $color-txt-hover-brd;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,14 @@ en:
       message_html: "<p>The change you wanted was rejected. Maybe you tried to change something you don't have access to.
       <br><h3><a href='/' >Return home</a></h3>
       </p>"
+    stimulus_reflex_error: "We're sorry, but something went wrong.
+
+
+      This might be a temporary problem, so please try again or reload the page.
+
+      We record all errors and may be working on a fix.
+
+      If the problem persists or is urgent, please contact us."
   stripe:
     error_code:
       incorrect_number: "The card number is incorrect."


### PR DESCRIPTION
#### What? Why?

The next PR was getting too big, so I  moved these general fixes out to apply separately.


#### What should we test?
The only user-facing change is a change to the StimulusReflex config, which now lets the user know if an unknown error had occurred (previously it did nothing, and may leave the page in an incomplete/unexplained state). StimulusReflex is currently used for some actions in the admin interface (eg bulk order actions).

However the only way that I can currently find to trigger such an error is in the new `products_v3` screen. Go there and try to update a field with more than 255 characters. You should get an error as pictured below (this error will be fixed in a future PR).

![Screen Shot 2023-09-20 at 2 05 10 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/ddd7a085-d193-42f9-b2ef-ca7a99c7cc6e)

I added a cut-down version of the 500 error message (translatable). I fought the temptation to include a 🐌 icon..

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
