### PR TITLE
Redirect to admin users edit path on success

### DIFF
--- a/app/controllers/spree/admin/users_controller.rb
+++ b/app/controllers/spree/admin/users_controller.rb
@@ -33,8 +33,8 @@ module Spree
             @user.spree_roles = roles.compact_blank.collect{ |r| Spree::Role.find(r) }
           end
 
-          flash.now[:success] = Spree.t(:created_successfully)
-          render :edit
+          flash[:success] = Spree.t(:created_successfully)
+          redirect_to edit_admin_user_path(@user)
         else
           render :new
         end
@@ -50,9 +50,11 @@ module Spree
             @user.spree_roles = roles.compact_blank.collect{ |r| Spree::Role.find(r) }
           end
 
-          flash.now[:success] = update_message
+          flash[:success] = update_message
+          redirect_to edit_admin_user_path(@user)
+        else
+          render :edit
         end
-        render :edit
       end
 
       protected

--- a/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/spec/controllers/spree/admin/users_controller_spec.rb
@@ -22,6 +22,13 @@ describe Spree::Admin::UsersController do
     it "allows admins to update a user's show api key view" do
       user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
       spree_put :update, id: test_user.id, user: { show_api_key_view: true }
+      expect(response).to redirect_to spree.edit_admin_user_path(test_user)
+    end
+
+    it "re-renders the edit form if error" do
+      user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
+      spree_put :update, id: test_user.id, user: { password: "blah", password_confirmation: "" }
+
       expect(response).to render_template :edit
     end
 


### PR DESCRIPTION
#### What? Why?

- Closes #9833

As on the above issue, if you followed a certain path, it would lead you to a 404. 


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As super admin go to /admin/users/USER_ID/edit (for any user)
- Toggle the 'Show API key view for user' checkbox or click the 'update' button
- Observe that the URL now doesn't have the /edit anymore
- Klick one of the API key buttons 'generate key', 'clear key' or 'regenerate key'
- [ ] 🎉  It works?!

Additionally, confirm that the rest of the form still works as expected. Eg:
- Type in an invalid email
- Click submit
- An error message appears, and the invalid email is still present allowing you to correct it
- Enter a correct address and save.
- [ ] 🎉  It works?!

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
