### PR TITLE
[BUU] Bulk product saving, with summary error message

### DIFF
--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -71,7 +71,7 @@ module Spree
 
         product_set.collection.each { |p| authorize! :update, p }
 
-        if product_set.save
+        if product_set.save.positive?
           redirect_to main_app.bulk_products_api_v0_products_path(bulk_index_query)
         elsif product_set.errors.present?
           render json: { errors: product_set.errors }, status: :bad_request

--- a/app/reflexes/products_reflex.rb
+++ b/app/reflexes/products_reflex.rb
@@ -37,7 +37,7 @@ class ProductsReflex < ApplicationReflex
     product_set.collection.each { |p| authorize! :update, p }
     @products = product_set.collection # use instance variable mainly for testing
 
-    if product_set.save
+    if product_set.save.positive?
       # flash[:success] = with_locale { I18n.t('.success') }
       # morph_admin_flashes  # ERROR: selector morph type has already been set
     elsif product_set.errors.present?

--- a/app/services/sets/model_set.rb
+++ b/app/services/sets/model_set.rb
@@ -79,5 +79,11 @@ module Sets
     def persisted?
       false
     end
+
+    def find_model(collection, model_id)
+      collection.find do |model|
+        model.id.to_s == model_id.to_s && model.persisted?
+      end
+    end
   end
 end

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -16,7 +16,7 @@ module Sets
       # Attempt to save all records, collecting model errors.
       @collection_hash.each_value.map do |product_attributes|
         update_product_attributes(product_attributes)
-      end.all?
+      end.count(true)
     end
 
     def collection_attributes=(attributes)
@@ -75,7 +75,7 @@ module Sets
 
       validate_presence_of_unit_value_in_product(product)
 
-      product.errors.empty? && product.save
+      product.errors.empty? && product.changed? && product.save
     end
 
     def validate_presence_of_unit_value_in_product(product)

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -150,11 +150,5 @@ module Sets
         report.add_metadata(:variant_error, variant.errors.first) unless variant.valid?
       end
     end
-
-    def find_model(collection, model_id)
-      collection.find do |model|
-        model.id.to_s == model_id.to_s && model.persisted?
-      end
-    end
   end
 end

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -55,12 +55,15 @@ module Sets
     end
 
     def update_product(product, attributes)
-      return false unless update_product_only_attributes(product, attributes)
+      # Attempt all updates, but return false if any failed.
+      success = [
+        update_product_only_attributes(product, attributes),
+        update_product_variants(product, attributes),
+        update_product_master(product, attributes),
+      ].all?
 
       ExchangeVariantDeleter.new.delete(product) if product.saved_change_to_supplier_id?
-
-      update_product_variants(product, attributes) &&
-        update_product_master(product, attributes)
+      success
     end
 
     def update_product_only_attributes(product, attributes)

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,6 +1,8 @@
 = form_with url: bulk_update_admin_products_v3_index_path, method: :patch, id: "products-form",
             html: {'data-reflex-serialize-form': true, 'data-reflex': 'submit->products#bulk_update',
-                   'data-controller': "bulk-form", 'data-bulk-form-disable-selector-value': "#sort,#filters" } do |form|
+                   'data-controller': "bulk-form", 'data-bulk-form-disable-selector-value': "#sort,#filters",
+                   'data-bulk-form-error-value': defined?(error_counts),
+                  } do |form|
   %fieldset.form-actions{ class: ("hidden" unless defined?(error_counts)), 'data-bulk-form-target': "actions" }
     .container
       .status.eleven.columns

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,14 +1,15 @@
 = form_with url: bulk_update_admin_products_v3_index_path, method: :patch, id: "products-form",
             html: {'data-reflex-serialize-form': true, 'data-reflex': 'submit->products#bulk_update',
-                   'data-controller': "bulk-form", 'data-bulk-form-disable-selector-value': "#sort,#filters"} do |form|
-  %fieldset.form-actions.hidden{ 'data-bulk-form-target': "actions" }
+                   'data-controller': "bulk-form", 'data-bulk-form-disable-selector-value': "#sort,#filters" } do |form|
+  %fieldset.form-actions{ class: ("hidden" unless defined?(error_counts)), 'data-bulk-form-target': "actions" }
     .container
-      .status.ten.columns
+      .status.eleven.columns
         .modified_summary{ 'data-bulk-form-target': "modifiedSummary", 'data-translation-key': 'admin.products_v3.table.modified_summary'}
-        - if defined?(error_msg) && error_msg.present?
-          .error
-            = error_msg
-      .form-buttons.six.columns
+        - if defined?(error_counts)
+          .error_summary
+            -# X products were saved correctly, but Y products could not be saved correctly. Please review errors and try again
+            = t('.error_summary.saved', count: error_counts[:saved]) + t('.error_summary.unsaved', count: error_counts[:unsaved])
+      .form-buttons.five.columns
         = form.submit t('.reset'), type: :reset, class: "medium", 'data-reflex': 'click->products#fetch'
         = form.submit t('.save'), class: "medium"
   %table.products

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -52,7 +52,7 @@ export default class BulkFormController extends Controller {
     this.#disableOtherElements(formModified); // like filters and sorting
 
     // Display number of records modified
-    const key = this.modifiedSummaryTarget && this.modifiedSummaryTarget.dataset.translationKey;
+    const key = this.hasModifiedSummaryTarget && this.modifiedSummaryTarget.dataset.translationKey;
     if (key) {
       this.modifiedSummaryTarget.textContent = I18n.t(key, { count: modifiedRecordCount });
     }
@@ -76,13 +76,15 @@ export default class BulkFormController extends Controller {
   // private
 
   #disableOtherElements(disable) {
+    if (!this.hasDisableSelectorValue) return;
+
     this.disableElements ||= document.querySelectorAll(this.disableSelectorValue);
 
-    if (this.disableElements) {
-      this.disableElements.forEach((element) => {
-        element.classList.toggle("disabled-section", disable);
-      });
-    }
+    if (!this.disableElements) return;
+
+    this.disableElements.forEach((element) => {
+      element.classList.toggle("disabled-section", disable);
+    });
   }
 
   #isModified(element) {

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -5,6 +5,7 @@ export default class BulkFormController extends Controller {
   static targets = ["actions", "modifiedSummary"];
   static values = {
     disableSelector: String,
+    error: Boolean,
   };
   recordElements = {};
 
@@ -25,6 +26,8 @@ export default class BulkFormController extends Controller {
         this.recordElements[recordId].push(element);
       }
     }
+
+    this.toggleFormModified();
   }
 
   disconnect() {
@@ -45,7 +48,7 @@ export default class BulkFormController extends Controller {
     const modifiedRecordCount = Object.values(this.recordElements).filter((elements) =>
       elements.some(this.#isModified)
     ).length;
-    const formModified = modifiedRecordCount > 0;
+    const formModified = modifiedRecordCount > 0 || this.errorValue;
 
     // Show actions
     this.actionsTarget.classList.toggle("hidden", !formModified);
@@ -54,6 +57,7 @@ export default class BulkFormController extends Controller {
     // Display number of records modified
     const key = this.hasModifiedSummaryTarget && this.modifiedSummaryTarget.dataset.translationKey;
     if (key) {
+      // TODO: save processing and only run if modifiedRecordCount has changed.
       this.modifiedSummaryTarget.textContent = I18n.t(key, { count: modifiedRecordCount });
     }
 

--- a/app/webpacker/css/admin_v3/shared/forms.scss
+++ b/app/webpacker/css/admin_v3/shared/forms.scss
@@ -282,6 +282,20 @@ fieldset {
   text-align: center;
 }
 
+.modified_summary {
+  font-size: inherit;
+}
+
+.error_summary {
+  font-size: inherit;
+
+  @extend .icon-remove-sign;
+  &:before {
+    font-family: FontAwesome;
+    color: $color-error;
+  }
+}
+
 select {
   @extend input, [type="text"];
   background-color: white;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -833,13 +833,18 @@ en:
           zero: ""
           one: "%{count} product modified."
           other: "%{count} products modified."
+        error_summary:
+          saved:
+            zero: ""
+            one: "%{count} product was saved correctly, but "
+            other: "%{count} products were saved correctly, but "
+          unsaved:
+            one: "%{count} product could not be saved. Please review the errors and try again."
+            other: "%{count} products could not be saved. Please review the errors and try again."
         save: Save changes
         reset: Discard changes
       bulk_update: # TODO: fix these
         success: "Products successfully updated" #TODO: add count
-        products_have_error:
-          one: "%{count} product has an error."
-          other: "%{count} products have an error."
     product_import:
       title: Product Import
       file_not_found: File not found or could not be opened

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -11,42 +11,39 @@ describe("BulkFormController", () => {
     application.register("bulk-form", bulk_form_controller);
   });
 
-  // Mock I18n. TODO: moved to a shared helper
-  beforeAll(() => {
-    const mockedT = jest.fn();
-    mockedT.mockImplementation((string, opts) => (string + ', ' + JSON.stringify(opts)));
-
-    global.I18n =  {
-      t: mockedT
-    };
-  })
-
-  // (jest still doesn't have aroundEach https://github.com/jestjs/jest/issues/4543 )
-  afterAll(() => {
-    delete global.I18n;
-  })
-
-  beforeEach(() => {
-    document.body.innerHTML = `
-      <div id="disable1"></div>
-      <div id="disable2"></div>
-      <form data-controller="bulk-form" data-bulk-form-disable-selector-value="#disable1,#disable2">
-        <div id="actions" data-bulk-form-target="actions" class="hidden"></div>
-        <div id="modified_summary" data-bulk-form-target="modifiedSummary" data-translation-key="modified_summary"></div>
-        <div data-record-id="1">
-          <input id="input1a" type="text" value="initial1a">
-          <input id="input1b" type="text" value="initial1b">
-        </div>
-        <div data-record-id="2">
-          <input id="input2" type="text" value="initial2">
-        </div>
-        <input type="submit">
-      </form>
-    `;
-  });
-
   describe("Modifying input values", () => {
+    // Mock I18n. TODO: moved to a shared helper
+    beforeAll(() => {
+      const mockedT = jest.fn();
+      mockedT.mockImplementation((string, opts) => (string + ', ' + JSON.stringify(opts)));
+
+      global.I18n =  {
+        t: mockedT
+      };
+    })
+    // (jest still doesn't have aroundEach https://github.com/jestjs/jest/issues/4543 )
+    afterAll(() => {
+      delete global.I18n;
+    })
+
     beforeEach(() => {
+      document.body.innerHTML = `
+        <div id="disable1"></div>
+        <div id="disable2"></div>
+        <form data-controller="bulk-form" data-bulk-form-disable-selector-value="#disable1,#disable2">
+          <div id="actions" data-bulk-form-target="actions" class="hidden"></div>
+          <div id="modified_summary" data-bulk-form-target="modifiedSummary" data-translation-key="modified_summary"></div>
+          <div data-record-id="1">
+            <input id="input1a" type="text" value="initial1a">
+            <input id="input1b" type="text" value="initial1b">
+          </div>
+          <div data-record-id="2">
+            <input id="input2" type="text" value="initial2">
+          </div>
+          <input type="submit">
+        </form>
+      `;
+
       const disable1 = document.getElementById("disable1");
       const disable2 = document.getElementById("disable2");
       const actions = document.getElementById("actions");
@@ -159,6 +156,43 @@ describe("BulkFormController", () => {
         expect(disable1.classList).not.toContain('disabled-section');
         expect(disable2.classList).not.toContain('disabled-section');
       });
+    });
+  });
+
+  describe("When there are errors", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <form data-controller="bulk-form" data-bulk-form-error-value="true">
+          <div id="actions" data-bulk-form-target="actions">
+            An error occurred.
+            <input type="submit">
+          </div>
+          <div data-record-id="1">
+            <input id="input1a" type="text" value="initial1a">
+          </div>
+        </form>
+      `;
+
+      const actions = document.getElementById("actions");
+      const modified_summary = document.getElementById("modified_summary");
+      const input1a = document.getElementById("input1a");
+    });
+
+    it("form actions section remains visible", () => {
+      // Expect actions to remain visible
+      expect(actions.classList).not.toContain('hidden');
+
+      // Record 1: First field changed
+      input1a.value = 'updated1a';
+      input1a.dispatchEvent(new Event("change"));
+      // Expect actions to remain visible
+      expect(actions.classList).not.toContain('hidden');
+
+      // Change back to original value
+      input1a.value = 'initial1a';
+      input1a.dispatchEvent(new Event("change"));
+      // Expect actions to remain visible
+      expect(actions.classList).not.toContain('hidden');
     });
   });
 

--- a/spec/reflexes/products_reflex_spec.rb
+++ b/spec/reflexes/products_reflex_spec.rb
@@ -13,7 +13,7 @@ describe ProductsReflex, type: :reflex do
     Flipper.enable(:admin_style_v3)
   end
 
-  describe 'fetch' do
+  describe '#fetch' do
     subject{ build_reflex(method_name: :fetch, **context) }
 
     describe "sorting" do
@@ -41,6 +41,7 @@ describe ProductsReflex, type: :reflex do
              sku: "APL-01",
              price: 5.25)
     }
+    let!(:product_c) { create(:simple_product, name: "Carrots", sku: "CAR-00") }
     let!(:product_b) { create(:simple_product, name: "Bananas", sku: "BAN-00") }
     let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
 
@@ -123,17 +124,21 @@ describe ProductsReflex, type: :reflex do
           "products" => [
             {
               "id" => product_a.id.to_s,
-              "name" => "",
+              "name" => "Pommes",
             },
             {
               "id" => product_b.id.to_s,
-              "name" => "",
+              "name" => "", # Name can't be blank
+            },
+            {
+              "id" => product_c.id.to_s,
+              "name" => "", # Name can't be blank
             },
           ]
         }
 
         reflex = run_reflex(:bulk_update, params:)
-        expect(reflex.get(:error_msg)).to include "2 products have errors"
+        expect(reflex.get(:error_counts)).to eq({ saved: 1, unsaved: 2 })
 
         # # WTF
         # expect{ reflex(:bulk_update, params:) }.to broadcast(

--- a/spec/services/sets/product_set_spec.rb
+++ b/spec/services/sets/product_set_spec.rb
@@ -138,12 +138,11 @@ describe Sets::ProductSet do
               it 'updates product and variant attributes' do
                 collection_hash[0][:sku] = "test_sku"
 
-                product_set.save
-
-                expect(product.reload.variants.first[:sku]).to eq variants_attributes.first[:sku]
-                expect(product.reload.attributes).to include(
-                  'sku' => "test_sku"
-                )
+                expect {
+                  product_set.save
+                  product.reload
+                }.to change { product.sku }.to("test_sku")
+                  .and change { product.variants.first.sku }.to("123")
               end
             end
           end

--- a/spec/services/sets/product_set_spec.rb
+++ b/spec/services/sets/product_set_spec.rb
@@ -137,6 +137,19 @@ describe Sets::ProductSet do
                   .and change { product.variants.first.sku }.to("123")
               end
             end
+
+            context 'and when product attributes have an error' do
+              it 'updates variant attributes' do
+                collection_hash[0][:name] = "" # product.name can't be blank
+
+                expect {
+                  product_set.save
+                  product.reload
+                }.to change { product.variants.first.sku }.to("123")
+
+                expect(product.name).to_not eq ""
+              end
+            end
           end
 
           context 'when :master_attributes is passed' do

--- a/spec/services/sets/product_set_spec.rb
+++ b/spec/services/sets/product_set_spec.rb
@@ -56,22 +56,14 @@ describe Sets::ProductSet do
             }
           end
 
-          it 'updates the product' do
-            product_set.save
+          it 'updates the product without error' do
+            expect(product_set.save).to eq true
 
             expect(product.reload.attributes).to include(
               'variant_unit' => 'weight'
             )
-          end
 
-          it 'does not add an error' do
-            product_set.save
-            expect(product_set.errors)
-              .to be_empty
-          end
-
-          it 'returns true' do
-            expect(product_set.save).to eq(true)
+            expect(product_set.errors).to be_empty
           end
         end
 

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -196,7 +196,6 @@ describe 'As an admin, I can see the new product page' do
              price: 5.25)
     }
     let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
-
     before do
       visit admin_products_v3_index_url
     end
@@ -263,37 +262,64 @@ describe 'As an admin, I can see the new product page' do
       end
     end
 
-    it "shows errors for both product and variant fields" do
-      within row_containing_name("Apples") do
-        fill_in "Name", with: ""
-        fill_in "SKU", with: "A" * 256
-      end
-      within row_containing_name("Medium box") do
-        fill_in "Name", with: "L" * 256
-        fill_in "SKU", with: "1" * 256
+    context "with invalid data" do
+      let!(:product_b) { create(:simple_product, name: "Bananas") }
+
+      before do
+        within row_containing_name("Apples") do
+          fill_in "Name", with: ""
+          fill_in "SKU", with: "A" * 256
+        end
+        within row_containing_name("Medium box") do
+          fill_in "Name", with: "L" * 256
+          fill_in "SKU", with: "1" * 256
+        end
       end
 
-      expect {
-        click_button "Save changes"
-        product_a.reload
-      }.to_not change { product_a.name }
+      it "shows errors for both product and variant fields" do
+        # Also update a product with valid data
+        within row_containing_name("Bananas") do
+          fill_in "Name", with: "Bananes"
+        end
 
-      # (there's no identifier displayed, so the user must remember which product it is..)
-      within row_containing_name("") do
-        expect(page).to have_field "Name", with: ""
-        expect(page).to have_content "can't be blank"
-        expect(page).to have_field "SKU", with: "A" * 256
-        expect(page).to have_content "is too long"
-      end
-      pending
-      within row_containing_name("L" * 256) do
-        expect(page).to have_field "Name", with: "L" * 256
-        expect(page).to have_field "SKU", with: "1" * 256
-        expect(page).to have_content "is too long"
-        expect(page).to have_field "Price", with: "10.25"
+        expect {
+          click_button "Save changes"
+          product_a.reload
+        }.to_not change { product_a.name }
+
+        expect(page).to have_content(
+          "1 product was saved correctly, but 1 product could not be saved."
+        )
+
+        # (there's no identifier displayed, so the user must remember which product it is..)
+        within row_containing_name("") do
+          expect(page).to have_field "Name", with: ""
+          expect(page).to have_content "can't be blank"
+          expect(page).to have_field "SKU", with: "A" * 256
+          expect(page).to have_content "is too long"
+        end
+        pending
+        within row_containing_name("L" * 256) do
+          expect(page).to have_field "Name", with: "L" * 256
+          expect(page).to have_field "SKU", with: "1" * 256
+          expect(page).to have_content "is too long"
+          expect(page).to have_field "Price", with: "10.25"
+        end
       end
 
-      expect(page).to have_content "Please review the errors and try again"
+      it "saves changes after fixing errors" do
+        within row_containing_name("Apples") do
+          fill_in "Name", with: "Pommes"
+          fill_in "SKU", with: "POM-00"
+        end
+
+        expect {
+          click_button "Save changes"
+          product_a.reload
+          variant_a1.reload
+        }.to change { product_a.name }.to("Pommes")
+          .and change{ product_a.sku }.to("POM-00")
+      end
     end
   end
 


### PR DESCRIPTION
#### What? Why?

- One of the final parts of #11059 (but there's currently still a bit more to fix)
- This affects the existing bulk edit products screen.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

**Presenting an error summary** at the top of the form when performing a bulk update. And lots of necessary refactors.

This also includes a minor **change to the way products are saved in bulk**, which also affects the _existing_ bulk edit products screen. 
1. Before, if you edited a product and it's associated variant, but the product has an error, the unsaved variant values would be discarded. Now the variant values are kept and saved if valid.
2. Before, if you edited two products, and the first one has an error, the second product is ignored until you fix the first error. Now, all products are processed the first time, so the valid second product is saved.

In summary: any valid records will get saved. Records with errors will be unsaved until corrected.

### What should we test?
~~All scenarios on https://github.com/openfoodfoundation/openfoodnetwork/issues/11059 can now be tested, noting that `#7` and `#8` are incomplete and branched out into a new issue.~~

We'll skip testing BUU, as there's still a bit more to do. But we can test the existing screen with feature toggle turned OFF.
It's hard to observe any difference, but you can see what has/hasn't saved by reloading the page.

* When product has two fields updated:   
  - [ ] one has error and other is valid. Neither are saved until error is corrected. (empty name, and changed unit)

* When product and associated variant are updated:
  - [ ] product has error, variant has error. Neither are saved, but the unsaved values should be retained to try again (before, the unsaved variant values were discarded)
  - [ ] product has error, variant is valid. Variant has been saved, and unsaved product values retained.
  - [ ] product is valid, variant has error. Product has been saved.

* When multiple products are updated
  - [ ] product 1 has error, product 2 has error
  - [ ] product 1 has error, product 2 is valid
  - [ ] product 1 is valid, product 2 has error


### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


### Dependencies
1. [ ] https://github.com/openfoodfoundation/openfoodnetwork/pull/11509
3. [ ] https://github.com/openfoodfoundation/openfoodnetwork/pull/11571
4. [ ] #11565 




### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
