### PR TITLE
[Vouchers] Fix tax included in price amount

### DIFF
--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -2,6 +2,8 @@
 
 module Admin
   module OrdersHelper
+    AdjustmentData = Struct.new(:label, :amount)
+
     # Adjustments to display under "Order adjustments".
     #
     # We exclude shipping method adjustments because they are displayed in a
@@ -18,10 +20,10 @@ module Admin
       adjustment = order.voucher_adjustments.first
 
       [
-        Spree::Adjustment.new(
-          label: I18n.t("admin.orders.edit.voucher_tax_included_in_price",
-                        label: adjustment.label),
-          amount: adjustment.included_tax
+        AdjustmentData.new(
+          I18n.t("admin.orders.edit.voucher_tax_included_in_price",
+                 label: adjustment.label),
+          adjustment.included_tax
         )
       ]
     end

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -7,7 +7,17 @@ module Admin
     # We exclude shipping method adjustments because they are displayed in a
     # separate table together with the order line items.
     def order_adjustments_for_display(order)
-      order.adjustments + order.all_adjustments.payment_fee.eligible
+      adjustments_for_display = order.adjustments + order.all_adjustments.payment_fee.eligible
+
+      if VoucherAdjustmentsService.new(order).voucher_included_tax.negative?
+        adjustment = order.voucher_adjustments.first
+        adjustments_for_display << Spree::Adjustment.new(
+          label: I18n.t("admin.orders.edit.voucher_tax_included_in_price", label: adjustment.label),
+          amount: adjustment.included_tax
+        )
+      end
+
+      adjustments_for_display
     end
   end
 end

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -7,17 +7,23 @@ module Admin
     # We exclude shipping method adjustments because they are displayed in a
     # separate table together with the order line items.
     def order_adjustments_for_display(order)
-      adjustments_for_display = order.adjustments + order.all_adjustments.payment_fee.eligible
+      order.adjustments +
+        voucher_included_tax_representations(order) +
+        order.all_adjustments.payment_fee.eligible
+    end
 
-      if VoucherAdjustmentsService.new(order).voucher_included_tax.negative?
-        adjustment = order.voucher_adjustments.first
-        adjustments_for_display << Spree::Adjustment.new(
-          label: I18n.t("admin.orders.edit.voucher_tax_included_in_price", label: adjustment.label),
+    def voucher_included_tax_representations(order)
+      return [] unless VoucherAdjustmentsService.new(order).voucher_included_tax.negative?
+
+      adjustment = order.voucher_adjustments.first
+
+      [
+        Spree::Adjustment.new(
+          label: I18n.t("admin.orders.edit.voucher_tax_included_in_price",
+                        label: adjustment.label),
           amount: adjustment.included_tax
         )
-      end
-
-      adjustments_for_display
+      ]
     end
   end
 end

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -53,7 +53,9 @@ module CheckoutHelper
   end
 
   def display_checkout_tax_total(order)
-    Spree::Money.new order.total_tax, currency: order.currency
+    total_tax = order.total_tax + VoucherAdjustmentsService.new(order).voucher_included_tax
+
+    Spree::Money.new(total_tax, currency: order.currency)
   end
 
   def display_checkout_taxes_hash(order)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -974,7 +974,7 @@ en:
     orders:
       edit:
         order_sure_want_to: Are you sure you want to %{event} this order?
-        voucher_tax_included_in_price: "%{label} (tax included in price)"
+        voucher_tax_included_in_price: "%{label} (tax included in voucher)"
       invoice_email_sent: 'Invoice email has been sent'
       order_email_resent: 'Order email has been resent'
       bulk_management:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -974,6 +974,7 @@ en:
     orders:
       edit:
         order_sure_want_to: Are you sure you want to %{event} this order?
+        voucher_tax_included_in_price: "%{label} (tax included in price)"
       invoice_email_sent: 'Invoice email has been sent'
       order_email_resent: 'Order email has been resent'
       bulk_management:

--- a/spec/helpers/admin/orders_helper_spec.rb
+++ b/spec/helpers/admin/orders_helper_spec.rb
@@ -51,7 +51,7 @@ describe Admin::OrdersHelper, type: :helper do
         voucher_adjustment.update(included_tax: voucher_included_tax)
 
         fake_adjustment = helper.order_adjustments_for_display(order).last
-        expect(fake_adjustment.label).to eq("new_code (tax included in price)")
+        expect(fake_adjustment.label).to eq("new_code (tax included in voucher)")
         expect(fake_adjustment.amount).to eq(-0.5)
       end
     end

--- a/spec/helpers/admin/orders_helper_spec.rb
+++ b/spec/helpers/admin/orders_helper_spec.rb
@@ -5,9 +5,7 @@ require "spec_helper"
 describe Admin::OrdersHelper, type: :helper do
   describe "#order_adjustments_for_display" do
     let(:order) { create(:order) }
-    let(:service) do
-      instance_double(VoucherAdjustmentsService, voucher_included_tax: voucher_included_tax)
-    end
+    let(:service) { instance_double(VoucherAdjustmentsService, voucher_included_tax:) }
     let(:voucher_included_tax) { 0.0 }
 
     before do
@@ -44,7 +42,7 @@ describe Admin::OrdersHelper, type: :helper do
     context "with a voucher with tax included in price" do
       let(:enterprise) { build(:enterprise) }
       let(:voucher) do
-        create(:voucher_flat_rate, code: 'new_code', enterprise: enterprise, amount: 10)
+        create(:voucher_flat_rate, code: 'new_code', enterprise:, amount: 10)
       end
       let(:voucher_included_tax) { -0.5 }
 

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -19,9 +19,7 @@ describe CheckoutHelper, type: :helper do
     subject(:display_checkout_tax_total) { helper.display_checkout_tax_total(order) }
 
     let(:order) { instance_double(Spree::Order, total_tax: 123.45, currency: 'AUD') }
-    let(:service) do
-      instance_double(VoucherAdjustmentsService, voucher_included_tax: voucher_included_tax)
-    end
+    let(:service) { instance_double(VoucherAdjustmentsService, voucher_included_tax: ) }
     let(:voucher_included_tax) { 0.0 }
 
     before do

--- a/spec/system/consumer/checkout/tax_incl_spec.rb
+++ b/spec/system/consumer/checkout/tax_incl_spec.rb
@@ -131,7 +131,7 @@ describe "As a consumer, I want to see adjustment breakdown" do
           # UI checks
           expect(page).to have_content("Confirmed")
           expect(page).to have_selector('#order_total', text: with_currency(0.00))
-          expect(page).to have_selector('#tax-row', text: with_currency(1.15))
+          expect(page).to have_selector('#tax-row', text: with_currency(0.00))
 
           # Voucher
           within "#line-items" do


### PR DESCRIPTION
#### What? Why?

- Closes #11363 

When tax are included in price, we store the tax part of the voucher in the voucher adjustment itself. The issue is, this value isn't displayed anywhere nor is it used to display the discount tax to the customer. This PR fix this.
In the case of tax excluded from price, we store the tax part of the voucher as its own adjustment, which are both displayed to the customer and in the backoffice, so we no fix is needed there.

#### What should we test?

1. As enterprise user set up a shop with a percentage voucher and a product with included tax.
2. As customer put that product in your cart.
3. Proceed to checkout step 2.
4. Select the percentage voucher and a payment method.
5. Proceed to step 3.
6. Calculate the numbers.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
Based on #11543, it will need to be merged first
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->
