### PR TITLE
Prevent customers from editing shipped orders

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -225,7 +225,10 @@ module Spree
     end
 
     def changes_allowed?
-      complete? && distributor&.allow_order_changes? && order_cycle&.open?
+      !!(complete? &&
+         !shipped? &&
+         distributor&.allow_order_changes? &&
+         order_cycle&.open?)
     end
 
     # Is this a free order in which case the payment step should be skipped


### PR DESCRIPTION
#### What? Why?

- Closes #9235 

Shipped orders are editable by customers in conditions where an enterprise allows order changes. More specifically, the quantity is editable. If a customer makes changes to an order and submits, the application throws an error and the customer sees an error page. Customers shouldn't be allowed to make changes to shipped orders.

This change prevents customers from editing shipped orders in two ways:
1. On the order confirmation page, the quantity is read only.
2. On the order history page (account -> orders tab), the order shows as past instead of open. Past orders don't have an edit link.

### Before
**Order History**
![Screenshot from 2023-09-30 13-11-19](https://github.com/openfoodfoundation/openfoodnetwork/assets/14116496/1b439ce3-772b-470d-9d12-a3e202dae374)

**Order Confirmation**
![Screenshot from 2023-09-30 13-11-39](https://github.com/openfoodfoundation/openfoodnetwork/assets/14116496/258222ed-ad80-4adf-b883-c2263851bcee)

### After
**Order History**
![Screenshot from 2023-09-30 13-12-42](https://github.com/openfoodfoundation/openfoodnetwork/assets/14116496/b02ff38d-4c90-4bd5-a553-658e14e16053)

**Order Confirmation**
![Screenshot from 2023-09-30 13-12-03](https://github.com/openfoodfoundation/openfoodnetwork/assets/14116496/f7924ff6-4292-4794-bca3-6f6eeadfd767)


#### What should we test?

1. Sign in as an enterprise owner.
2. Visit your enterprise's shop preferences (Enterprise -> Settings -> Shop Preferences).
3. Set "Change Orders" to "Customers Can Change" and save.
    - ![Screenshot from 2023-09-30 13-24-30](https://github.com/openfoodfoundation/openfoodnetwork/assets/14116496/df7e984d-943b-4c3a-985c-4616a7a24207)
4. Sign in as a customer.
5. Find the shop you just updated as an owner.
6. Start a new order and complete it.
7. Visit your account page and click the orders tab.
8. Ensure the order shows under past orders.
9. Click on the order (Completed link).
10. Ensure the quantity cannot be edited.

More technically speaking, this is solved by changing adding a not yet shipped condition to `Order#changes_allowed?`. Any known pages that are impacted by this should be tested. As far as I can tell, this method is mostly used around these account pages.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

The title of the pull request will be included in the release notes.

#### Dependencies

#### Documentation updates
