### PR TITLE
Add ability to customers report to filter with open ended boundaries

### DIFF
--- a/lib/reporting/reports/customers/base.rb
+++ b/lib/reporting/reports/customers/base.rb
@@ -50,10 +50,10 @@ module Reporting
         private
 
         def filter_to_completed_at(orders)
-          min = params.dig(:q, :completed_at_gt)
-          max = params.dig(:q, :completed_at_lt)
+          min = params.dig(:q, :completed_at_gt).presence
+          max = params.dig(:q, :completed_at_lt).presence
 
-          return orders if min.blank? || max.blank?
+          return orders if min.nil? && max.nil?
 
           orders.where(completed_at: [min..max])
         end

--- a/spec/lib/reports/customers_report_spec.rb
+++ b/spec/lib/reports/customers_report_spec.rb
@@ -244,18 +244,40 @@ module Reporting
               expect(subject.filter(orders)).to eq(orders)
             end
 
-            it "filters to a specific completed_at date" do
-              o1 = create(:order, completed_at: 1.day.ago)
-              o2 = create(:order, completed_at: 3.days.ago)
-              o3 = create(:order, completed_at: 5.days.ago)
+            describe "filters to a specific completed_at date range" do
+              let!(:o1) { create(:order, completed_at: 1.day.ago) }
+              let!(:o2) { create(:order, completed_at: 3.days.ago) }
+              let!(:o3) { create(:order, completed_at: 5.days.ago) }
 
-              allow(subject).to receive(:params).and_return(
-                q: {
-                  completed_at_gt: 1.day.before(o2.completed_at),
-                  completed_at_lt: 1.day.after(o2.completed_at)
-                }
-              )
-              expect(subject.filter(orders)).to eq([o2])
+              it do
+                allow(subject).to receive(:params).and_return(
+                  q: {
+                    completed_at_gt: 1.day.before(o2.completed_at),
+                    completed_at_lt: 1.day.after(o2.completed_at)
+                 }
+                )
+                expect(subject.filter(orders)).to eq([o2])
+              end
+
+              it "when completed_at_gt param is missing" do
+                allow(subject).to receive(:params).and_return(
+                  q: {
+                    completed_at_gt: "",
+                    completed_at_lt: 1.day.after(o2.completed_at)
+                  }
+                )
+                expect(subject.filter(orders)).to eq([o2, o3])
+              end
+
+              it "when completed_at_lt param is missing" do
+                allow(subject).to receive(:params).and_return(
+                  q: {
+                    completed_at_gt: 1.day.before(o2.completed_at),
+                    completed_at_lt: ""
+                  }
+                )
+                expect(subject.filter(orders)).to eq([o1, o2])
+              end
             end
 
             it "filters to a specific distributor" do

--- a/spec/lib/reports/customers_report_spec.rb
+++ b/spec/lib/reports/customers_report_spec.rb
@@ -254,7 +254,7 @@ module Reporting
                   q: {
                     completed_at_gt: 1.day.before(o2.completed_at),
                     completed_at_lt: 1.day.after(o2.completed_at)
-                 }
+                  }
                 )
                 expect(subject.filter(orders)).to eq([o2])
               end


### PR DESCRIPTION
#### What? Why?

- Closes #11611 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This PR,  modifies `#filter_to_completed_at` method. With the change, it can handle blank boundary parameters.

`presence` method is used to convert blank parameters to `nil`, so that it can be accepted by in `.where(completed_at: [min..max])` method.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit `/admin/reports/customers` page.
1. Do not enter start or end date
2. Click Go button
3. You should see all completed orders

- Visit `/admin/reports/customers` page.
1. Enter start date only
2. Click Go button
3. You should see all completed orders completed after the start date

- Visit `/admin/reports/customers` page.
1. Enter end date only
2. Click Go button
3. You should see all completed orders completed before the end date

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Add ability to customers report to filter with open ended boundaries upon missing start date or end date
