### PR TITLE
Fix occurring time shift in customers report results

### DIFF
--- a/lib/reporting/reports/customers/base.rb
+++ b/lib/reporting/reports/customers/base.rb
@@ -50,8 +50,8 @@ module Reporting
         private
 
         def filter_to_completed_at(orders)
-          min = params.dig(:q, :completed_at_gt).presence
-          max = params.dig(:q, :completed_at_lt).presence
+          min = params.dig(:q, :completed_at_gt).presence&.in_time_zone
+          max = params.dig(:q, :completed_at_lt).presence&.in_time_zone
 
           return orders if min.nil? && max.nil?
 


### PR DESCRIPTION
#### What? Why?

- Closes #11607 

This PR, 
* calls `in_time_zone` in order to be aware of time zone when determining boundary parameters on customers report
https://apidock.com/rails/String/in_time_zone

Based on proposed solution on comment https://github.com/openfoodfoundation/openfoodnetwork/issues/11607#issuecomment-1745885727

#### What should we test?

- described on https://github.com/openfoodfoundation/openfoodnetwork/issues/11607

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Fix occurring time shift in customers report results

#### Dependencies

Kind of depends on https://github.com/openfoodfoundation/openfoodnetwork/pull/11619 , since it has commits from that PR(in order to prevent possible code conflicts). 
Rebasing after that PR's merge would be ideal imo. 


