### PR TITLE
[dev ENV only] Adds attribute to enterprise factory

### DIFF
--- a/lib/tasks/sample_data/enterprise_factory.rb
+++ b/lib/tasks/sample_data/enterprise_factory.rb
@@ -50,6 +50,7 @@ DESC
           owner: users["Freddy Shop Farmer"],
           is_primary_producer: true,
           sells: "own",
+          visible: "public",
           address: address("72 Lake Road, Blackburn, 3130"),
           long_description: <<DESC
           This enterprise is a producer which also sells directly to consumers.
@@ -61,6 +62,7 @@ DESC
           owner: users["Fredo Hub Farmer"],
           is_primary_producer: true,
           sells: "any",
+          visible: "public",
           address: address("7 Verbena Street, Mordialloc, 3195"),
           long_description: <<DESC
           This enterprise is a producer selling its own and other produce to
@@ -72,6 +74,7 @@ DESC
           owner: users["Mary Retailer"],
           is_primary_producer: false,
           sells: "any",
+          visible: "public",
           address: address("20 Galvin Street, Altona, 3018"),
           long_description: <<DESC
           This enterprise sells the products of producers, but doesn't have any
@@ -83,6 +86,7 @@ DESC
           owner: users["Maryse Private"],
           is_primary_producer: false,
           sells: "any",
+          visible: "public",
           address: address("6 Martin Street, Belgrave, 3160"),
           require_login: true,
           long_description: <<DESC


### PR DESCRIPTION
...so that sample data rake task creates visible enterprises by default

#### What? Why?

We've had reports of new contributors struggling to have an open shop after running docker seed data; enterprises seem to be created as not visible by default, which is confusing to newcomers. This might be a side effect from [this PR](https://github.com/openfoodfoundation/openfoodnetwork/pull/11247). 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This PR changes this default behavior, so that seed data creates visible enterprises.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build.
- running the [docker scripts](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/docker/README.md#docker-scripts) should create a visible, open shop.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
