### PR TITLE
Ensure dynamic modals always use selected locale

### DIFF
--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -11,9 +11,7 @@ module Admin
         morph dom_id(@order), render(partial: "spree/admin/orders/table_row",
                                      locals: { order: @order.reload, success: true })
       else
-        flash[:error] = with_locale{
-          payment_capture.gateway_error || I18n.t(:payment_processing_failed)
-        }
+        flash[:error] = payment_capture.gateway_error || I18n.t(:payment_processing_failed)
         morph_admin_flashes
       end
     end
@@ -23,7 +21,7 @@ module Admin
         morph dom_id(@order), render(partial: "spree/admin/orders/table_row",
                                      locals: { order: @order.reload, success: true })
       else
-        flash[:error] = with_locale{ I18n.t("api.orders.failed_to_update") }
+        flash[:error] = I18n.t("api.orders.failed_to_update")
         morph_admin_flashes
       end
     end
@@ -90,7 +88,7 @@ module Admin
     end
 
     def success(i18n_key, count)
-      flash[:success] = with_locale { I18n.t(i18n_key, count:) }
+      flash[:success] = I18n.t(i18n_key, count:)
       cable_ready.dispatch_event(name: "modal:close")
       morph_admin_flashes
     end

--- a/app/reflexes/application_reflex.rb
+++ b/app/reflexes/application_reflex.rb
@@ -5,20 +5,15 @@ class ApplicationReflex < StimulusReflex::Reflex
   #
   # Learn more at: https://docs.stimulusreflex.com/rtfm/reflex-classes
   #
-  # If your ActionCable connection is: `identified_by :current_user`
-  #   delegate :current_user, to: :connection
-  #
-  # If you need to localize your Reflexes, you can set the I18n locale here:
-  #
-  #   before_reflex do
-  #     I18n.locale = :fr
-  #   end
-  #
   # For code examples, considerations and caveats, see:
   # https://docs.stimulusreflex.com/rtfm/patterns#internationalization
   include CanCan::ControllerAdditions
 
   delegate :current_user, to: :connection
+
+  before_reflex do
+    I18n.locale = current_user.locale
+  end
 
   private
 

--- a/app/reflexes/application_reflex.rb
+++ b/app/reflexes/application_reflex.rb
@@ -21,10 +21,6 @@ class ApplicationReflex < StimulusReflex::Reflex
     Spree::Ability.new(current_user)
   end
 
-  def with_locale(&)
-    I18n.with_locale(current_user.locale, &)
-  end
-
   def morph_admin_flashes
     morph "#flashes", render(partial: "admin/shared/flashes", locals: { flashes: flash })
   end

--- a/app/reflexes/invite_manager_reflex.rb
+++ b/app/reflexes/invite_manager_reflex.rb
@@ -35,8 +35,6 @@ class InviteManagerReflex < ApplicationReflex
 
   def return_morph(locals)
     morph "#add_manager_modal",
-          with_locale {
-            render(partial: "admin/enterprises/form/add_new_unregistered_manager", locals:)
-          }
+          render(partial: "admin/enterprises/form/add_new_unregistered_manager", locals:)
   end
 end

--- a/app/reflexes/white_label_reflex.rb
+++ b/app/reflexes/white_label_reflex.rb
@@ -11,15 +11,11 @@ class WhiteLabelReflex < ApplicationReflex
 
     f = ActionView::Helpers::FormBuilder.new(:enterprise, @enterprise, view_context, {})
 
-    html = with_locale {
-      render(partial: "admin/enterprises/form/white_label",
+    html = render(partial: "admin/enterprises/form/white_label",
              locals: { f:, enterprise: @enterprise })
-    }
     morph "#white_label_panel", html
 
-    flash[:success] = with_locale {
-      I18n.t("admin.enterprises.form.white_label.remove_logo_success")
-    }
+    flash[:success] = I18n.t("admin.enterprises.form.white_label.remove_logo_success")
     cable_ready.dispatch_event(name: "modal:close")
     morph_admin_flashes
   end

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -56,9 +56,9 @@
               -# TODO: new requirement "DISPLAY ON DEMAND IF ALL VARIANTS ARE ON DEMAND". And translate value
               .content= if product.variants.all?(&:on_demand) then "On demand" else product.on_hand || 0 end
             %td.align-left
-              .content= product.supplier.name
+              .content= product.supplier&.name
             %td.align-left
-              .content= product.primary_taxon.name
+              .content= product.primary_taxon&.name
             %td.align-left
             %td.align-left
               .content= product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values, else use I18n.t (also below)
@@ -82,7 +82,7 @@
                 %td.align-right
                   .content= variant.on_hand || 0 #TODO: spec for this according to requirements.
                 %td.align-left
-                  .content= variant.product.supplier.name # same as product
+                  .content= variant.product.supplier&.name # same as product
                 %td.align-left
                   -# empty
                 %td.align-left


### PR DESCRIPTION
### What? Why?

- Raised in https://github.com/openfoodfoundation/openfoodnetwork/pull/11565#issuecomment-1746814011

Some reflexes were displaying content in the _**instance default**_ language, rather than the _**user-selected**_ language. I've added a general solution for this (similar to what we do for normal web requests), which now ensures _all_ reflexes are in the selected language.

### What should we test?
* Log in to an instance with multiple languages.
* Select a non-default language
* It doesn't matter if `admin_style_v3` enabled or not.

Note: I found that `es` didn't have translations for some parts, which caused some text to show in English. So it might be helpful to test in another language that has better translations. If at least part of the updated area is in the right language, then it should be ok.

- [x] products_v3: load products and inspect column headers
- [x] admin/enterprise: add unregistered enterprise manager
- [ ] admin/enterprise: delete whitelabel logo. There was an unrelated error on dev (`WhiteLabel#remove_logo: undefined method 'capture_haml'`), but it seems to be fine in staging. 🤷 let's see how it goes in staging.
- [ ] admin/orders: these were correct before, but have been updated with general solution so it's worth checking)
    - capture
    - ship
    - resend_confirmation_emails 
    - send_invoices
 - admin/orders: these didn't have correct language before
    - [x] bulk_invoice
    - [ ] cancel_orders

#### Screenshots example
With system default of `en`, and user-selected `es`.
Before, the dynamic modals were in English:
![Screen Shot 2023-10-11 at 10 54 57 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/0491849e-7d72-4688-8a36-293be7d26c3a)
![Screen Shot 2023-10-11 at 10 53 08 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/fa53f04d-a0b2-4c08-9be6-b47e9e7a1fa4)
![Screen Shot 2023-10-11 at 10 54 00 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/747e36cf-3485-4833-9fe1-901b1a911dee)

Now they are in Spanish as expected:
![Screen Shot 2023-10-11 at 10 55 04 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/75598ed7-bb41-4cb1-9822-af9a03916dc8)
![Screen Shot 2023-10-11 at 10 55 22 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/3164f4f6-6dff-431a-a531-f92684a98640)


### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

