### PR TITLE
[BUU] Left-align headers of new orders table

### DIFF
--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -19,7 +19,7 @@
       = t('js.admin.orders.order_state.' + order.state.to_s)
   %td.align-left
     - if order.payment_state
-      %span.state{class: 'order.payment_state'}
+      %span.state{ class: order.payment_state.to_s }
         %a{href: spree.admin_order_payments_path(order) }
           = t('js.admin.orders.payment_states.' + order.payment_state.to_s)
           - if order.display_outstanding_balance
@@ -27,7 +27,7 @@
               = "(#{order.display_outstanding_balance})"
   %td.align-left
     - if order.shipment_state
-      %span.state{class: order.shipment_state.to_s}
+      %span.state{ class: order.shipment_state.to_s}
         = t('js.admin.orders.shipment_states.' + order.shipment_state.to_s)
   %td
     %a{ href: "mailto:#{order.email}", target: "_blank" }

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -1,9 +1,9 @@
 %tr{ id: dom_id(order), class: "state-#{order.state}" }
-  %td.align-center
+  %td.align-left
     %input{type: 'checkbox', value: order.id, name: 'bulk_ids[]', "data-checked-target": "checkbox", "data-action": "change->checked#toggleCheckbox" }
-  %td.align-center
+  %td.align-left
     = order.distributor.name
-  %td.align-center
+  %td.align-left
     = I18n.l(order.completed_at, format: '%B %d, %Y') if order.completed_at
   %td
     %a{ href: edit_admin_order_path(order) }
@@ -14,10 +14,10 @@
         %div{ "data-controller": "tooltip", "data-tooltip-tip-value": order.special_instructions.to_s }
           %span.icon-warning-sign{ "data-tooltip-target": "element" }
             = t('spree.admin.orders.index.note')
-  %td.align-center
+  %td.align-left
     %span.state{ class: order.state.to_s }
       = t('js.admin.orders.order_state.' + order.state.to_s)
-  %td.align-center
+  %td.align-left
     - if order.payment_state
       %span.state{class: 'order.payment_state'}
         %a{href: spree.admin_order_payments_path(order) }
@@ -25,7 +25,7 @@
           - if order.display_outstanding_balance
             %span
               = "(#{order.display_outstanding_balance})"
-  %td.align-center
+  %td.align-left
     - if order.shipment_state
       %span.state{class: order.shipment_state.to_s}
         = t('js.admin.orders.shipment_states.' + order.shipment_state.to_s)
@@ -34,7 +34,7 @@
       = order.email
   %td
     = order&.bill_address&.full_name_for_sorting
-  %td.align-center
+  %td.align-left
     %span
       = order.display_total
   %td.actions

--- a/app/webpacker/css/admin_v3/shared/tables.scss
+++ b/app/webpacker/css/admin_v3/shared/tables.scss
@@ -2,7 +2,6 @@ table {
   width: 100%;
   margin-bottom: 15px;
   border-collapse: separate;
-
   th,
   td {
     padding: 7px 5px;

--- a/app/webpacker/css/admin_v3/shared/tables.scss
+++ b/app/webpacker/css/admin_v3/shared/tables.scss
@@ -136,7 +136,7 @@ table {
 
   thead {
     th {
-      padding: 10px;
+      padding: 5px;
       border-bottom: none;
       background-color: $color-tbl-thead-bg;
       color: $color-tbl-thead-txt;


### PR DESCRIPTION

#### What? Why?

- Closes #11610 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
To correct the alignment of the table header and table rows on the /admin/orders screen in feature-preview mode.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

1. Visit admin/feature-toggle/features/admin_style_v3
2. Select Fully Enable

As a Hub admin or Superadmin:
3. Visit the orders page - admin/orders
4. Notice the mismatch on the table header vs table contents orientation


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
