### PR TITLE
Show only the new products page in the menu

### DIFF
--- a/app/views/spree/admin/shared/_product_sub_menu.html.haml
+++ b/app/views/spree/admin/shared/_product_sub_menu.html.haml
@@ -1,8 +1,9 @@
 - content_for :sub_menu do
   %ul#sub_nav.inline-menu
-    = tab :products
+    - if feature?(:admin_style_v3, spree_current_user)
+      = tab :products_v3, url: main_app.admin_products_v3_index_path
+    - else
+      = tab :products
     = tab :properties
     = tab :variant_overrides, url: main_app.admin_inventory_path, match_path: '/inventory'
     = tab :import, url: main_app.admin_product_import_path, match_path: '/product_import'
-    - if feature?(:admin_style_v3, spree_current_user)
-      = tab :products_v3, url: main_app.admin_products_v3_index_path


### PR DESCRIPTION
When the feature toggle is enabled, we don't want to see the old products page. It's a bit broken and causes confusion. But we still want to be able to access it by the URL for now.


#### What should we test?
There should be only one "products" page in the menu when feature toggle admin_style_v3:
- disabled
- enabled



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
