### PR TITLE
Only validate image when changed

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -300,7 +300,7 @@ module Spree
     end
 
     def validate_image
-      return if image.blank? || image.valid?
+      return if image.blank? || !image.changed? || image.valid?
 
       errors.add(:base, I18n.t('spree.admin.products.image_not_processable'))
     end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -292,11 +292,19 @@ module Spree
         subject(:product) { create(:product_with_image) }
 
         context "when the image is invalid" do
-          before { expect(product.image).to receive(:valid?).and_return(false) }
+          before { allow(product.image).to receive(:valid?).and_return(false) }
 
-          it "adds an error message to the base object" do
-            expect(product).not_to be_valid
-            expect(product.errors[:base]).to include('Image attachment is not a valid image.')
+          context "and has been changed" do
+            before { expect(product.image).to receive(:changed?).and_return(true) }
+
+            it "adds an error message to the base object" do
+              expect(product).not_to be_valid
+              expect(product.errors[:base]).to include('Image attachment is not a valid image.')
+            end
+          end
+
+          it "ignores if unchanged" do
+            expect(product).to be_valid
           end
         end
 

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -289,7 +289,7 @@ module Spree
       end
 
       describe "#validate_image" do
-        let(:product) { create(:product_with_image) }
+        subject(:product) { create(:product_with_image) }
 
         context "when the image is invalid" do
           before { expect(product.image).to receive(:valid?).and_return(false) }
@@ -300,10 +300,14 @@ module Spree
           end
         end
 
-        context "when master variant is valid" do
-          it "returns true" do
-            expect(product).to be_valid
-          end
+        context "when image is valid" do
+          it { is_expected.to be_valid }
+        end
+
+        context "when image is blank" do
+          subject { create(:product) }
+
+          it { is_expected.to be_valid }
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Many product images in the au-staging environment are broken, probably due to an activestorage migration going wrong. They fail validation, and result in being unable to save any other part of the product until the image is fixed. This was especially a problem when trying to bulk update products.
I thought it should only validate the image when it's being updated.

Of course, you would want to fix the image, and arguably the product _is_ invalid and it's a helpful prompt to fix the problem.. 🤔  hmm but I still think this way is better and probably more efficient.


#### What should we test?
This problem can currently be replicated on au-staging.

In new products bulk edit screen: https://staging.openfoodnetwork.org.au/admin/products_v3
- Update one of the products
- Click save
- Before: No inline error message shows (because there's no image field on this screen), but if you refresh the page you'll see that your change didn't save
- After: record saves successfully (refresh the page to confirm)

In product edit screen, we don't currently handle the error:
- Update the product
- Click save
- Before: No error message shows, but if you refresh the page you'll see that your change didn't save
- After: record saves successfully ("Product x has been successfully updated!")

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):
It doesnt' seem worth announcing because it only affects the rare case when data is corrupted.

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
