### PR TITLE
Display ordered lists uniform with unordered lists in Trix editor

### DIFF
--- a/app/webpacker/css/darkswarm/lists.scss
+++ b/app/webpacker/css/darkswarm/lists.scss
@@ -1,7 +1,6 @@
 body ol {
   list-style-type: none;
   margin-left: 0em;
-  padding-top: 1em;
 
   li {
     margin-left: 0;


### PR DESCRIPTION
#### What? Why?
> The padding-top style made the ordered lists in the Trix editor look ununiform compared to the unordered list. I checked and removing the padding-top doesn't affect any other part of the project so I removed it to fix the issue.

- Closes #11491

#### What should we test?

- Edit a product description on page /admin/products/ID/edit.
- Use ordered and unordered lists and shift some to higher levels (using the editor buttons).
- Click update.
- Look at the product description in the shop front.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
