### PR TITLE
Fixes un-localized Order date and time format on edit order page

### DIFF
--- a/app/helpers/spree/base_helper.rb
+++ b/app/helpers/spree/base_helper.rb
@@ -36,8 +36,7 @@ module Spree
     end
 
     def pretty_time(time)
-      [I18n.l(time.to_date, format: :long),
-       time.strftime("%l:%M %p")].join(" ")
+      I18n.l(time, format: :long)
     end
   end
 end

--- a/config/locales/de_CH.yml
+++ b/config/locales/de_CH.yml
@@ -1,5 +1,10 @@
 de_CH:
   language_name: "Deutsch"
+  date:
+    day_names: [Sonntag, Montag, Dienstag, Mittwoch, Donnerstag, Freitag, Samstag]
+    abbr_day_names: [So, Mo, Di, Mi, Do, Fr, Sa]
+    month_names: [~, Januar, Februar, März, April, Mai, Juni, Juli, August, September, Oktober, November, Dezember]
+    abbr_month_names: [~, Jan, Feb, Mär, Apr, Mai, Jun, Jul, Aug, Sep, Okt, Nov, Dez]
   activerecord:
     models:
       spree/product: Produkt

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -1,5 +1,10 @@
 de_DE:
   language_name: "Deutsch"
+  date:
+    day_names: [Sonntag, Montag, Dienstag, Mittwoch, Donnerstag, Freitag, Samstag]
+    abbr_day_names: [So, Mo, Di, Mi, Do, Fr, Sa]
+    month_names: [~, Januar, Februar, März, April, Mai, Juni, Juli, August, September, Oktober, November, Dezember]
+    abbr_month_names: [~, Jan, Feb, Mär, Apr, Mai, Jun, Jul, Aug, Sep, Okt, Nov, Dez]
   activerecord:
     models:
       spree/product: Produkt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
   language_name: "English" # Localised name of this language
   time:
     formats:
-      long: "%B %d, %Y%l:%M %p" # %l adds a single space to the left
+      long: "%B %d, %Y %-l:%M %p"
   activerecord:
     models:
       spree/product: Product

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,9 @@
 en:
   # Overridden here due to a bug in spree i18n (Issue #870, and issue #1800)
   language_name: "English" # Localised name of this language
+  time:
+    formats:
+      long: "%B %d, %Y%l:%M %p" # %l adds a single space to the left
   activerecord:
     models:
       spree/product: Product

--- a/config/locales/es_CO.yml
+++ b/config/locales/es_CO.yml
@@ -1,5 +1,10 @@
 es_CO:
   language_name: "Español"
+  date:
+    day_names: [domingo, lunes, martes, miércoles, jueves, viernes, sábado]
+    abbr_day_names: [dom, lun, mar, mié, jue, vie, sáb]
+    month_names: [~, enero, febrero, marzo, abril, mayo, junio, julio, agosto, septiembre, octubre, noviembre, diciembre]
+    abbr_month_names: [ ~, ene, feb, mar, abr, may, jun, jul, ago, sep, oct, nov, dic]
   activerecord:
     models:
       spree/product: Producto

--- a/config/locales/es_CR.yml
+++ b/config/locales/es_CR.yml
@@ -1,5 +1,10 @@
 es_CR:
   language_name: "Español"
+  date:
+    day_names: [domingo, lunes, martes, miércoles, jueves, viernes, sábado]
+    abbr_day_names: [dom, lun, mar, mié, jue, vie, sáb]
+    month_names: [~, enero, febrero, marzo, abril, mayo, junio, julio, agosto, septiembre, octubre, noviembre, diciembre]
+    abbr_month_names: [~, ene, feb, mar, abr, may, jun, jul, ago, sep, oct, nov, dic]
   activerecord:
     models:
       spree/product: Producto

--- a/config/locales/es_US.yml
+++ b/config/locales/es_US.yml
@@ -1,5 +1,10 @@
 es_US:
   language_name: "Español"
+  date:
+    day_names: [domingo, lunes, martes, miércoles, jueves, viernes, sábado]
+    abbr_day_names: [dom, lun, mar, mié, jue, vie, sáb]
+    month_names: [~, enero, febrero, marzo, abril, mayo, junio, julio, agosto, septiembre, octubre, noviembre, diciembre]
+    abbr_month_names: [~, ene, feb, mar, abr, may, jun, jul, ago, sep, oct, nov, dic]
   activerecord:
     models:
       spree/product: Producto

--- a/config/locales/fil_PH.yml
+++ b/config/locales/fil_PH.yml
@@ -1,5 +1,10 @@
 fil_PH:
   language_name: "Filipino"
+  date:
+    day_names: [Linggo, Lunes, Martes, Miyerkoles, Huwebes, Biyernes, Sabado]
+    abbr_day_names: [Lin, Lun, Mar, Miy, Huw, Biy, Sab]
+    month_names: [~, Enero, Pebrero, Marso, Abril, Mayo, Hunyo, Hulyo, Agosto, Setyembre, Oktubre, Nobyembre, Disyembre]
+    abbr_month_names: [~, Ene, Peb, Mar, Abr, May, Hun, Hul, Ago, Set, Okt, Nob, Dis]
   activerecord:
     models:
       spree/product: Produkto

--- a/config/locales/fr_BE.yml
+++ b/config/locales/fr_BE.yml
@@ -1,5 +1,10 @@
 fr_BE:
   language_name: "Français"
+  date:
+    day_names: [dimanche, lundi, mardi, mercredi, jeudi, vendredi, samedi]
+    abbr_day_names: [dim, lun, mar, mer, jeu, ven, sam]
+    month_names: [~, janvier, février, mars, avril, mai, juin, juillet, août, septembre, octobre, novembre, décembre]
+    abbr_month_names: [~, jan, fév, mar, avr, mai, jun, jui, aoû, sep, oct, nov, déc]
   activerecord:
     models:
       spree/product: Produit

--- a/config/locales/fr_CA.yml
+++ b/config/locales/fr_CA.yml
@@ -1,5 +1,10 @@
 fr_CA:
   language_name: "Français"
+  date:
+    day_names: [dimanche, lundi, mardi, mercredi, jeudi, vendredi, samedi]
+    abbr_day_names: [dim, lun, mar, mer, jeu, ven, sam]
+    month_names: [~, janvier, février, mars, avril, mai, juin, juillet, août, septembre, octobre, novembre, décembre]
+    abbr_month_names: [~, jan, fév, mar, avr, mai, jun, jui, aoû, sep, oct, nov, déc]
   activerecord:
     models:
       spree/product: Produit

--- a/config/locales/fr_CH.yml
+++ b/config/locales/fr_CH.yml
@@ -1,5 +1,10 @@
 fr_CH:
   language_name: "Français"
+  date:
+    day_names: [dimanche, lundi, mardi, mercredi, jeudi, vendredi, samedi]
+    abbr_day_names: [dim, lun, mar, mer, jeu, ven, sam]
+    month_names: [~, janvier, février, mars, avril, mai, juin, juillet, août, septembre, octobre, novembre, décembre]
+    abbr_month_names: [~, jan, fév, mar, avr, mai, jun, jui, aoû, sep, oct, nov, déc]
   activerecord:
     models:
       spree/product: Produit

--- a/config/locales/fr_CM.yml
+++ b/config/locales/fr_CM.yml
@@ -1,5 +1,10 @@
 fr_CM:
   language_name: "Français"
+  date:
+    day_names: [dimanche, lundi, mardi, mercredi, jeudi, vendredi, samedi]
+    abbr_day_names: [dim, lun, mar, mer, jeu, ven, sam]
+    month_names: [~, janvier, février, mars, avril, mai, juin, juillet, août, septembre, octobre, novembre, décembre]
+    abbr_month_names: [~, jan, fév, mar, avr, mai, jun, jui, aoû, sep, oct, nov, déc]
   activerecord:
     models:
       spree/product: Produit

--- a/config/locales/it_CH.yml
+++ b/config/locales/it_CH.yml
@@ -1,5 +1,10 @@
 it_CH:
   language_name: "Italiano"
+  date:
+    day_names: [domenica, lunedì, martedì, mercoledì, giovedì, venerdì, sabato]
+    abbr_day_names: [dom, lun, mar, mer, gio, ven, sab]
+    month_names: [~, gennaio, febbraio, marzo, aprile, maggio, giugno, luglio, agosto, settembre, ottobre, novembre, dicembre]
+    abbr_month_names: [~, gen, feb, mar, apr, mag, giu, lug, ago, set, ott, nov, dic]
   activerecord:
     models:
       spree/product: Prodotto

--- a/config/locales/nl_BE.yml
+++ b/config/locales/nl_BE.yml
@@ -1,5 +1,10 @@
 nl_BE:
   language_name: "Nederlands"
+  date:
+    day_names: [zondag, maandag, dinsdag, woensdag, donderdag, vrijdag, zaterdag]
+    abbr_day_names: [zo, ma, di, wo, do, vr, za]
+    month_names: [~, januari, februari, maart, april, mei, juni, juli, augustus, september, oktober, november, december]
+    abbr_month_names: [~, jan, feb, mrt, apr, mei, jun, jul, aug, sep, okt, nov, dec]
   activerecord:
     models:
       spree/product: Product

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -1,5 +1,10 @@
 pt_BR:
   language_name: "Português do Brasil"
+  date:
+    day_names: [domingo, segunda, terça, quarta, quinta, sexta, sábado]
+    abbr_day_names: [dom, seg, ter, qua, qui, sex, sáb]
+    month_names: [~, janeiro, fevereiro, março, abril, maio, junho, julho, agosto, setembro, outubro, novembro, dezembro]
+    abbr_month_names: [~, jan, fev, mar, abr, mai, jun, jul, ago, set, out, nov, dez]
   activerecord:
     models:
       spree/product: Produto

--- a/spec/helpers/spree/base_helper_spec.rb
+++ b/spec/helpers/spree/base_helper_spec.rb
@@ -56,7 +56,7 @@ describe Spree::BaseHelper do
     end
 
     it "prints in a format with double digit time" do
-      expect(pretty_time(DateTime.new(2012, 5, 6, 12, 00))).to eq "May 06, 2012 12:00 PM"
+      expect(pretty_time(DateTime.new(2012, 5, 6, 12, 33))).to eq "May 06, 2012 12:33 PM"
     end
   end
 end

--- a/spec/helpers/spree/base_helper_spec.rb
+++ b/spec/helpers/spree/base_helper_spec.rb
@@ -51,8 +51,12 @@ describe Spree::BaseHelper do
   end
 
   context "pretty_time" do
-    it "prints in a format" do
-      expect(pretty_time(DateTime.new(2012, 5, 6, 13, 33))).to eq "May 06, 2012  1:33 PM"
+    it "prints in a format with single digit time" do
+      expect(pretty_time(DateTime.new(2012, 5, 6, 13, 33))).to eq "May 06, 2012 1:33 PM"
+    end
+
+    it "prints in a format with double digit time" do
+      expect(pretty_time(DateTime.new(2012, 5, 6, 12, 00))).to eq "May 06, 2012 12:00 PM"
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #11606 
- Rails `I18n.l` is unable to translate the date/time to the languages which have country-specific locales e.g. German for Germany (_de_DE.yml_), German for Switzerland (_de_CH.yml_), etc. It means languages like `Arabic (_ar.yml_), Català (_ca.yml_),  Cymraeg (_cy.yml_) are being translated fine
- I've added their translations manually to the locales affected by the above issue by using this [locale reference](https://lh.2xlibre.net/locales/).
- As days and months translations are generally the same in any language, that's why I hardcoded their values in the affected locales
- For the date/time formatting, I've added the English formatting string in `en.yml`
- This format needs to be customized as per other locale's date/time formatting via Transifex by the natives so that the `I18n.l`  has the ability to translate the date/time `format` as per respective countries requirements.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Choose the German as the language
- Visit Order's edit page
- Please validate that you should be able to see the `order completed` in German
- The above scenario needs to be tested for every language supported by the system just  to make sure we don't miss anything

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
