### PR TITLE
Hide old products screen when admin_style_v3 enabled

### DIFF
--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,4 +1,4 @@
-= form_with url: bulk_update_admin_products_v3_index_path, method: :patch, id: "products-form",
+= form_with url: bulk_update_admin_products_path, method: :patch, id: "products-form",
             html: {'data-reflex-serialize-form': true, 'data-reflex': 'submit->products#bulk_update',
                    'data-controller': "bulk-form", 'data-bulk-form-disable-selector-value': "#sort,#filters"} do |form|
   %fieldset.form-actions.hidden{ 'data-bulk-form-target': "actions" }

--- a/app/views/spree/admin/shared/_product_sub_menu.html.haml
+++ b/app/views/spree/admin/shared/_product_sub_menu.html.haml
@@ -1,9 +1,6 @@
 - content_for :sub_menu do
   %ul#sub_nav.inline-menu
-    - if feature?(:admin_style_v3, spree_current_user)
-      = tab :products_v3, url: main_app.admin_products_v3_index_path
-    - else
-      = tab :products
+    = tab :products
     = tab :properties
     = tab :variant_overrides, url: main_app.admin_inventory_path, match_path: '/inventory'
     = tab :import, url: main_app.admin_product_import_path, match_path: '/product_import'

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -68,7 +68,7 @@ Openfoodnetwork::Application.routes.draw do
     post '/product_import/reset_absent', to: 'product_import#reset_absent_products', as: 'product_import_reset_async'
 
     constraints FeatureToggleConstraint.new(:admin_style_v3) do
-      resources :products_v3, as: :products_v3, only: :index do
+      resources :products, to: 'products_v3#index', only: :index do
         patch :bulk_update, on: :collection
       end
     end

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -50,9 +50,15 @@ Spree::Core::Engine.routes.draw do
 
     resources :users
 
-    resources :products do
-      post :bulk_update, :on => :collection, :as => :bulk_update
 
+    constraints FeatureToggleConstraint.new(:admin_style_v3, negate: true) do
+      # Show old bulk products screen
+      resources :products, :index do
+        post :bulk_update, :on => :collection, :as => :bulk_update
+      end
+    end
+
+    resources :products, except: :index do
       member do
         get :clone
         get :group_buy_options
@@ -77,6 +83,9 @@ Spree::Core::Engine.routes.draw do
         end
       end
     end
+
+    # duplicate old path for reference when admin_style_v3 enabled
+    resources :products_old, to: 'products#index', only: :index
 
     get '/variants/search', :to => "variants#search", :as => :search_variants
 

--- a/spec/reflexes/products_reflex_spec.rb
+++ b/spec/reflexes/products_reflex_spec.rb
@@ -5,7 +5,7 @@ require "reflex_helper"
 describe ProductsReflex, type: :reflex do
   let(:current_user) { create(:admin_user) } # todo: set up an enterprise user to test permissions
   let(:context) {
-    { url: admin_products_v3_index_url, connection: { current_user: } }
+    { url: admin_products_url, connection: { current_user: } }
   }
 
   before do

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -19,7 +19,7 @@ describe 'As an admin, I can see the new product page' do
   end
 
   it "can see the new product page" do
-    visit admin_products_v3_index_url
+    visit admin_products_url
     expect(page).to have_content "Bulk Edit Products"
   end
 
@@ -28,7 +28,7 @@ describe 'As an admin, I can see the new product page' do
     let!(:product_a) { create(:simple_product, name: "Apples") }
 
     before do
-      visit admin_products_v3_index_url
+      visit admin_products_url
     end
 
     it "Should sort products alphabetically by default" do
@@ -44,7 +44,7 @@ describe 'As an admin, I can see the new product page' do
 
   describe "pagination" do
     before do
-      visit admin_products_v3_index_url
+      visit admin_products_url
     end
 
     it "has a pagination, has 15 products per page by default and can change the page" do
@@ -76,7 +76,7 @@ describe 'As an admin, I can see the new product page' do
       let!(:product_by_name) { create(:simple_product, name: "searchable product") }
 
       before do
-        visit admin_products_v3_index_url
+        visit admin_products_url
       end
 
       it "can search for a product" do
@@ -128,7 +128,7 @@ describe 'As an admin, I can see the new product page' do
       let!(:product_by_supplier) { create(:simple_product, supplier: producer) }
 
       it "can search for a product" do
-        visit admin_products_v3_index_url
+        visit admin_products_url
 
         search_by_producer "Producer 1"
 
@@ -145,7 +145,7 @@ describe 'As an admin, I can see the new product page' do
       }
 
       it "can search for a product" do
-        visit admin_products_v3_index_url
+        visit admin_products_url
 
         search_by_category "Category 1"
 
@@ -168,7 +168,7 @@ describe 'As an admin, I can see the new product page' do
     let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
 
     before do
-      visit admin_products_v3_index_url
+      visit admin_products_url
     end
 
     it "shows an actions memu with an edit link when clicking on icon for product" do
@@ -198,7 +198,7 @@ describe 'As an admin, I can see the new product page' do
     let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
 
     before do
-      visit admin_products_v3_index_url
+      visit admin_products_url
     end
 
     it "updates product and variant fields" do


### PR DESCRIPTION
The feature toggle will determine which bulk products screen shows. 
An additional `/admin/products_old` path is also temporarily added for easy reference.


#### What? Why?

- https://github.com/openfoodfoundation/openfoodnetwork/pull/11646#issuecomment-1759142306

#### What should we test?

**Disable** `admin_style_v3` feature toggle

- Visit `/admin/products`. Observe **old** screen.
- Click ⋯ > Edit, then "Back to products list"
- Observe old screen.

**Enable** `admin_style_v3` feature toggle
- Visit `/admin/products`. Observe **new** screen.
- Click ⋯ > Edit, then "Back to products list"
- Observe new screen.
- Visit `/admin/products_old`. Observe old screen.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
