### PR TITLE
Update tag_release script

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -22,11 +22,13 @@ assignees: ''
     </code>
     </pre>
   </details>
-- [ ] Create a tag: `git push upstream HEAD:refs/tags/vX.Y.Z`
+- [ ] Create a tag:
+    - `script/tag_release` will auto increment patch version, otherwise
+    - `git push upstream HEAD:refs/tags/vX.Y.Z`
 - [ ] [Draft new release]. Look at previous [releases] for inspiration.
     - Select new release tag
     - _Generate release notes_ and check to ensure all items are arranged in the right category.
-- [ ] Notify [#instance-managers] of both user-facing :eyes: and :warning: API changes.
+- [ ] Notify [#instance-managers] of user-facing :eyes:, API :warning: and experimental :construction: changes.
 
 ## 2. Testing
 

--- a/script/tag_release
+++ b/script/tag_release
@@ -19,3 +19,6 @@ major, minor, patch = latest_version.segments
 next_tag = "v#{major}.#{minor}.#{patch.succ}"
 
 puts `git push upstream 'HEAD:refs/tags/#{next_tag}'`
+
+puts "Draft a new release with this tag:
+    https://github.com/openfoodfoundation/openfoodnetwork/releases/new?tag=#{next_tag}&title=#{next_tag}+Code+Name"


### PR DESCRIPTION
#### What? Why?
Adds a shortcut URL to draft a new release, with the version number pre-filled.

Also updating the release process checklist a bit.




#### What should we test?
Just try it for the next release.
