### PR TITLE
Format money amounts according to locale, not currency

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,4 +1,5 @@
 Rails.application.reloader.to_prepare do
+  Money.locale_backend = :i18n
   Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
   Money.default_currency = Money::Currency.new(ENV.fetch('CURRENCY'))
 end


### PR DESCRIPTION
#### What? Why?

- Closes #10045 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

It used to be formatted according to the currency. So even if the default currency is USD but your locale is French then you should see it formatted as $10.000,00 instead of the US formatting of $10,000.00.

This behaviour was already the case in the shopfront and other places where we use Rails or AngularJS to format the currency. Just the old Spree::Money formatting was outdated.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Choose a locale with different currency formatting to the instance default. For example, choose Spanish on an English server.
- Observe the correct currency formatting in the shop front (unchanged).
- Observe the now also correct currency formatting in the order summary during checkout (fixed).

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
