### PR TITLE
[vouchers] fix tax calculation when moving back in the checkout process

### DIFF
--- a/app/controllers/concerns/checkout_steps.rb
+++ b/app/controllers/concerns/checkout_steps.rb
@@ -13,6 +13,10 @@ module CheckoutSteps
     params[:step] == "payment"
   end
 
+  def details_step?
+    params[:step] == "details"
+  end
+
   def redirect_to_step_based_on_order
     case @order.state
     when "cart", "address", "delivery"
@@ -39,9 +43,19 @@ module CheckoutSteps
   def check_step
     case @order.state
     when "cart", "address", "delivery"
-      redirect_to checkout_step_path(:details) unless params[:step] == "details"
+      redirect_to checkout_step_path(:details) unless details_step?
     when "payment"
-      redirect_to checkout_step_path(:payment) if params[:step] == "summary"
+      redirect_to checkout_step_path(:payment) if summary_step?
     end
+  end
+
+  def update_order_state
+    if @order.state == "confirmation" && payment_step?
+      @order.back_to_payment
+    end
+
+    return unless @order.state.in?(["payment", "confirmation"]) && details_step?
+
+    @order.back_to_address
   end
 end

--- a/app/controllers/concerns/checkout_steps.rb
+++ b/app/controllers/concerns/checkout_steps.rb
@@ -40,6 +40,10 @@ module CheckoutSteps
     redirect_to_step_based_on_order
   end
 
+  # Checkout step and allowed order state
+  # * step details : order state in cart, address or delivery
+  # * step payment : order state is payment
+  # * step summary : order state is confirmation
   def check_step
     case @order.state
     when "cart", "address", "delivery"
@@ -47,15 +51,5 @@ module CheckoutSteps
     when "payment"
       redirect_to checkout_step_path(:payment) if summary_step?
     end
-  end
-
-  def update_order_state
-    if @order.state == "confirmation" && payment_step?
-      @order.back_to_payment
-    end
-
-    return unless @order.state.in?(["payment", "confirmation"]) && details_step?
-
-    @order.back_to_address
   end
 end

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -24,6 +24,8 @@ class SplitCheckoutController < ::BaseController
 
   def edit
     redirect_to_step_based_on_order unless params[:step]
+
+    update_order_state if params[:step]
     check_step if params[:step]
 
     return if available_shipping_methods.any?

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -112,7 +112,7 @@ class SplitCheckoutController < ::BaseController
   def recalculate_voucher
     return if @order.voucher_adjustments.empty?
 
-    return if @order.shipment.shipping_method.id == params[:shipping_method_id].to_i
+    return if @order.shipping_method&.id == params[:shipping_method_id].to_i
 
     VoucherAdjustmentsService.new(@order).update
   end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -616,6 +616,10 @@ module Spree
       state.in?(["cart", "address", "delivery"])
     end
 
+    def after_delivery_state?
+      state.in?(["payment", "confirmation"])
+    end
+
     private
 
     def reapply_tax_on_changed_address

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -71,6 +71,14 @@ module Spree
                 transition to: :complete, from: :confirmation
               end
 
+              event :back_to_payment do
+                transition to: :payment, from: :confirmation
+              end
+
+              event :back_to_address do
+                transition to: :address, from: [:payment, :confirmation]
+              end
+
               before_transition from: :cart, do: :ensure_line_items_present
 
               before_transition to: :delivery, do: :create_proposed_shipments

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -90,11 +90,6 @@ module Spree
                 order.update_totals_and_states
               end
 
-              after_transition to: :confirmation do |order|
-                VoucherAdjustmentsService.new(order).update
-                order.update_totals_and_states
-              end
-
               after_transition to: :complete, do: :finalize!
               after_transition to: :resumed,  do: :after_resume
               after_transition to: :canceled, do: :after_cancel

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -8,10 +8,7 @@ describe SplitCheckoutController, type: :controller do
   let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
   let(:order_cycle) { create(:order_cycle, distributors: [distributor]) }
   let(:exchange) { order_cycle.exchanges.outgoing.first }
-  let(:order) {
-    create(:order_with_line_items, line_items_count: 1, distributor:,
-                                   order_cycle:)
-  }
+  let(:order) { create(:order_with_line_items, line_items_count: 1, distributor:, order_cycle:) }
   let(:payment_method) { distributor.payment_methods.first }
   let(:shipping_method) { distributor.shipping_methods.first }
 
@@ -211,7 +208,7 @@ describe SplitCheckoutController, type: :controller do
           }
         end
 
-        it "updates and redirects to payment step" do
+        it "updates and redirects to summary step" do
           put(:update, params:)
 
           expect(response).to redirect_to checkout_step_path(:summary)

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -216,6 +216,13 @@ describe SplitCheckoutController, type: :controller do
             end
             let(:new_shipping_method) { create(:shipping_method, distributors: [distributor]) }
 
+            before do
+              # Add a shipping rates for the new shipping method to prevent
+              # order.select_shipping_method from failing
+              order.shipment.shipping_rates <<
+                Spree::ShippingRate.create(shipping_method: new_shipping_method, selected: true)
+            end
+
             it "recalculates the voucher adjustment" do
               expect(service).to receive(:update)
 

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -74,6 +74,7 @@ describe SplitCheckoutController, type: :controller do
           it "updates the order state to payment" do
             get :edit, params: { step: "payment" }
 
+            expect(response.status).to eq 200
             expect(order.reload.state).to eq("payment")
           end
         end
@@ -82,6 +83,7 @@ describe SplitCheckoutController, type: :controller do
           it "updates the order state to address" do
             get :edit, params: { step: "details" }
 
+            expect(response.status).to eq 200
             expect(order.reload.state).to eq("address")
           end
         end
@@ -96,6 +98,7 @@ describe SplitCheckoutController, type: :controller do
           it "updates the order state to address" do
             get :edit, params: { step: "details" }
 
+            expect(response.status).to eq 200
             expect(order.reload.state).to eq("address")
           end
         end

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -67,6 +67,42 @@ describe SplitCheckoutController, type: :controller do
           expect(response).to redirect_to checkout_step_path(:payment)
         end
       end
+
+      context "when order state is 'confirmation'" do
+        before do
+          order.update!(state: "confirmation")
+        end
+
+        context "when loading payment step" do
+          it "updates the order state to payment" do
+            get :edit, params: { step: "payment" }
+
+            expect(order.reload.state).to eq("payment")
+          end
+        end
+
+        context "when loading address step" do
+          it "updates the order state to address" do
+            get :edit, params: { step: "details" }
+
+            expect(order.reload.state).to eq("address")
+          end
+        end
+      end
+
+      context "when order state is 'payment'" do
+        context "when loading address step" do
+          before do
+            order.update!(state: "payment")
+          end
+
+          it "updates the order state to address" do
+            get :edit, params: { step: "details" }
+
+            expect(order.reload.state).to eq("address")
+          end
+        end
+      end
     end
   end
 

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -223,6 +223,20 @@ describe SplitCheckoutController, type: :controller do
 
               expect(response).to redirect_to checkout_step_path(:payment)
             end
+
+            context "when no shipments available" do
+              before do
+                order.shipments.destroy_all
+              end
+
+              it "recalculates the voucher adjustment" do
+                expect(service).to receive(:update)
+
+                put(:update, params:)
+
+                expect(response).to redirect_to checkout_step_path(:payment)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
#### What? Why?

- Closes #11359 
- Closes #11361

In certain scenario when a voucher is applied to an order, moving back to a previous checkout step from the confirmation one, the voucher tax calculation can be wrong. ~~This is due to the order state not being updated when moving back to a previous step. It's particularly important for the payment step, as vouchers are recalculated after the order transition from the payment step. This is to take into account any payment fees applied to the order.~~ 

This is due to the voucher adjustment not being recalculated when it needs to. This fix the issue as well as negative order total one by recalculating the voucher adjustment when : 
* moving away from the details step, to account for any potential change in shipping fees
* moving away from the payment step, to take into account payment fees

Additionally, the solution also updates the order state if needed, based on the step we are loading. This is not necessary to fix the issue, as now voucher recalculation isn't dependent on order state transition, but I think it makes sense to keep the order state in sync with the checkout step.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

##### tax calculation 
* As enterprise user set up a shop with a voucher, a product with tax excluded from price and a payment method with transaction fee.

Correct calculation :
1. As customer put that product in your cart (make sure your order total is higher than the voucher amount) and proceed to checkout.
2. Finish step 1 of the checkout.
3. In step 2 add the voucher code and select the payment method with transaction fees.
4. Proceed to step 3 and check the order summary. 

Go through checkout an move back during the checkout process :
1. As customer put that product in your cart (make sure your order total is higher than the voucher amount) and proceed to checkout.
2. Finish step 1 of the checkout.
3. In step 2 DO NOT add the voucher code but select the payment method with transaction fees.
4. Proceed to step 3.
5. Go back to step 2.
6. Add the voucher code and select the payment method with transaction fees.
7. Proceed to step 3 and check the order summary.
=> this should be the same as the "correct calculation" scenario above

8. Repeat this scenario but go back to step 1 this time 
=> the order summary should be the same as the "correct calculation" scenario above

##### Negative order total 

1. As enterprise user set up a shop with a voucher and two shipping methods (one with a shipping fee and one without).
2. As customer put items in your cart with an order total less than the voucher amount.
3. Proceed to checkout and select the shipping method with shipping fee in step 1.
4. Continue to step 2 and finish it.
5. In step 3 select 'Edit' next to Delivery details.
6. Select the shipping method without shipping fee.
7. Continue to step 2 and select a payment method (if required).
8. Continue to step 3.
9. Look at the order summary with the negative order total.
10. Complete the order.
11. As enterprise user look at the order in the back office and see that there is a 'credit owed'.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.