### PR TITLE
Moves assertions within before do block

### DIFF
--- a/spec/system/consumer/checkout/payment_spec.rb
+++ b/spec/system/consumer/checkout/payment_spec.rb
@@ -187,14 +187,14 @@ describe "As a consumer, I want to checkout my order" do
               accept_confirm "Are you sure you want to remove the voucher?" do
                 click_on "Remove code"
               end
-            end
 
-            it "removes voucher" do
               within '#voucher-section' do
                 expect(page).to have_button("Apply", disabled: true)
                 expect(page).to have_field "Enter voucher code" # Currently no confirmation msg
               end
+            end
 
+            it "removes voucher" do
               expect(page).not_to have_content "No payment required"
               expect(order.voucher_adjustments.length).to eq(0)
             end


### PR DESCRIPTION
The `before` block right above the failing example is removing the voucher, but it looks like this page section was not completely finished when `click_button "Next - Order summary"` was triggered.

So, clicking indeed took place, but without proceeding to the next section, which caused the assertion to fail.

#### What? Why?

- Closes #11686 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This PR moves assertions on the removal of the voucher within the before block; this assures the removal is complete before running the subsequent test cases.

Before this PR, running the failed example spec 10 times -> failed 10 times :red_circle: 
After this PR, running the failed example spec 10 times -> passed 10 times :green_circle: 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
