### PR TITLE
Avoid error when generating Enterprise fees w/ Tax Report by Producer

### DIFF
--- a/lib/reporting/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_producer.rb
+++ b/lib/reporting/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_producer.rb
@@ -138,7 +138,7 @@ module Reporting
             filtered_line_items(order)
               .filter do |line_item|
                 item[:enterprise_fee_id].in?(
-                  enterprise_fees_per_variant[line_item.variant]
+                  enterprise_fees_per_variant.fetch(line_item.variant, [])
                 )
               end
               .map do |line_item|

--- a/spec/lib/reports/enterprise_fee_summary/enterprise_fee_summary_report_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/enterprise_fee_summary_report_spec.rb
@@ -100,12 +100,6 @@ describe Reporting::Reports::EnterpriseFeeSummary::FeeSummary do
     let!(:second_customer_order) { prepare_order(customer:) }
     let!(:other_customer_order) { prepare_order(customer: another_customer) }
 
-    it "doesn't delete params" do
-      params = ActionController::Parameters.new("completed_at_gt" => "2023-02-08+00:00")
-      described_class.new(current_user, params)
-      expect(params["completed_at_gt"]).to eq "2023-02-08+00:00"
-    end
-
     it "groups and sorts entries correctly" do
       totals = subject.query_result
 

--- a/spec/lib/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_producer_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_producer_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Reporting::Reports::EnterpriseFeeSummary::EnterpriseFeesWithTaxReportByProducer do
+  let(:current_user) { create(:admin_user) }
+
+  let(:enterprise) {
+    create(:distributor_enterprise_with_tax, is_primary_producer: true,
+                                             shipping_methods: [shipping_method])
+  }
+  let(:shipping_method) { create(:shipping_method) }
+  let(:order_cycle) {
+    create(:simple_order_cycle, coordinator: enterprise).tap do |order_cycle|
+      incoming = order_cycle.exchanges.create!(incoming: true, sender: enterprise,
+                                               receiver: enterprise)
+      outgoing = order_cycle.exchanges.create!(incoming: false, sender: enterprise,
+                                               receiver: enterprise)
+
+      supplier_fee = create(:enterprise_fee, :per_item, enterprise:, amount: 15,
+                                                        name: 'Transport',
+                                                        fee_type: 'transport',)
+      incoming.exchange_fees.create!(enterprise_fee: supplier_fee)
+
+      incoming.exchange_variants.create(variant:)
+      outgoing.exchange_variants.create(variant:)
+    end
+  }
+  let(:variant) { create(:product, supplier: enterprise).variants.first }
+  let(:order) {
+    create(
+      :order, :with_line_item,
+      variant:, distributor: enterprise, order_cycle:,
+      shipping_method:, ship_address: create(:address)
+    ).tap do |order|
+      order.recreate_all_fees!
+      OrderWorkflow.new(order).complete!
+    end
+  }
+
+  it "renders an empty report" do
+    report = described_class.new(current_user)
+    expect(report.query_result).to eq({})
+  end
+
+  it "lists orders" do
+    order
+    report = described_class.new(current_user)
+    expect(report.query_result.values).to eq [[order]]
+  end
+
+  it "handles products removed from the order cycle" do
+    pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/11530"
+
+    order
+    order_cycle.exchanges.incoming.first.exchange_variants.first.destroy!
+
+    report = described_class.new(current_user)
+
+    expect(report.query_result.values).to eq [[order]]
+  end
+end

--- a/spec/lib/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_producer_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_producer_spec.rb
@@ -50,13 +50,12 @@ describe Reporting::Reports::EnterpriseFeeSummary::EnterpriseFeesWithTaxReportBy
   end
 
   it "handles products removed from the order cycle" do
-    pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/11530"
-
     order
     order_cycle.exchanges.incoming.first.exchange_variants.first.destroy!
 
     report = described_class.new(current_user)
 
+    pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/11529"
     expect(report.query_result.values).to eq [[order]]
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #11530 <!-- Insert issue number here. -->
- Specs #11529

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

In some ways I would prefer an error over missing data. So I'm open to remove the fix again and only include the spec. But while the report is still not officially released, this will help with the development and testing.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


- Create an order from an order cycle with supplier level enterprise fees
- Edit the order cycle and remove the variant, from that order cycle.
- Run the Enterprise fees w/ Tax Report by Producer report
- No error is reported.
- Sadly the fee related to the removed variant is missing. :cry: 


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
