### PR TITLE
add condition on warning_forfeit_remaining_amount note

### DIFF
--- a/app/views/split_checkout/_voucher_section.html.haml
+++ b/app/views/split_checkout/_voucher_section.html.haml
@@ -11,7 +11,7 @@
           = link_to t("split_checkout.step2.voucher.remove_code"), voucher_adjustment_path(id: voucher_adjustment.id), method: "delete", data: { confirm: t("split_checkout.step2.voucher.confirm_delete") }
 
           - # This might not be true, ie payment method including a fee which wouldn't be covered by voucher or tax implication raising total to be bigger than the voucher amount ?
-          - if voucher_adjustment.originator.amount > order.pre_discount_total
+          - if voucher_adjustment.originator.amount > order.pre_discount_total && voucher_adjustment.originator.is_a?(Vouchers::FlatRate)
             .checkout-input
               %span.formError.standalone
                 = t("split_checkout.step2.voucher.warning_forfeit_remaining_amount")

--- a/spec/views/split_checkout/_voucher_section.html.haml_spec.rb
+++ b/spec/views/split_checkout/_voucher_section.html.haml_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "split_checkout/_voucher_section.html.haml" do
+  let(:order) { create(:order_with_distributor, total: 10) }
+  let(:flat_voucher) {
+    create(:voucher_flat_rate, code: "flat_code",
+                               enterprise: order.distributor, amount: 20)
+  }
+  let(:percent_voucher) {
+    create(:voucher_percentage_rate, code: 'percent_code',
+                                     enterprise: order.distributor, amount: 20)
+  }
+  let(:note) {
+    ["Note: if your order total is less than your voucher",
+     "you may not be able to spend the remaining value."].join(" ")
+  }
+
+  it "should display warning_forfeit_remaining_amount note" do
+    add_voucher(flat_voucher, order)
+
+    allow(view).to receive_messages(
+      order:,
+      voucher_adjustment: order.voucher_adjustments.first
+    )
+    assign(:order, order)
+
+    render
+    expect(rendered).to have_content(note)
+  end
+
+  it "should not display warning_forfeit_remaining_amount note" do
+    add_voucher(percent_voucher, order)
+
+    allow(view).to receive_messages(
+      order:,
+      voucher_adjustment: order.voucher_adjustments.first
+    )
+    assign(:order, order)
+
+    render
+    expect(rendered).to_not have_content(note)
+  end
+
+  def add_voucher(voucher, order)
+    voucher.create_adjustment(voucher.code, order)
+    order.update_order!
+
+    VoucherAdjustmentsService.new(order).update
+  end
+end


### PR DESCRIPTION
#### What? Why?

Resolves the issue where the **warning_forfeit_remaining_amount note ** ->(Note: if your order total is less than your voucher you may not be able to spend the remaining value.') was still visible even when the percentage voucher was applied. 

- Closes #11666 

What should we test?

1. As an enterprise manager, Set up a percentage voucher on a shop (make sure the feature toggle "vouchers" is activated"
2. As a shopper, apply that voucher to step 2 of the checkout process - the message should not be displayed
3. Again check with a (non percentage/flat) voucher and check the message is showing up.

Changelog Category:

- [x]  User facing changes
- [ ]  API changes (V0, V1, DFC or Webhook)
- [ ]  Technical changes only
- [x]  Feature toggled

<img width="1183" alt="Screenshot 2023-10-20 at 1 31 17 PM" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/40080039/130fdc0e-7050-4c66-ba0a-d089951a8d57">

<img width="1221" alt="Screenshot 2023-10-20 at 1 30 50 PM" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/40080039/be352041-dae2-4f19-829e-252899960044">
