### PR TITLE
Make update button on enterprises primary details form clickable upon input to name field

### DIFF
--- a/app/views/admin/enterprises/_ng_form.html.haml
+++ b/app/views/admin/enterprises/_ng_form.html.haml
@@ -2,7 +2,7 @@
 -# ng-change is only valid for inputs, not for a form.
 -# So we use onchange and have to get the scope to access the ng controller
 = form_for [main_app, :admin, @enterprise], html: { name: "enterprise_form",
-  onchange: "angular.element(enterprise_form).scope().setFormDirty()",
+  oninput: "angular.element(enterprise_form).scope().setFormDirty()",
   "ng-controller" => 'enterpriseCtrl',
   "ng-cloak" => true } do |f|
 

--- a/app/views/admin/enterprises/_ng_form.html.haml
+++ b/app/views/admin/enterprises/_ng_form.html.haml
@@ -2,6 +2,7 @@
 -# ng-change is only valid for inputs, not for a form.
 -# So we use onchange and have to get the scope to access the ng controller
 = form_for [main_app, :admin, @enterprise], html: { name: "enterprise_form",
+  onchange: "angular.element(enterprise_form).scope().setFormDirty()",
   oninput: "angular.element(enterprise_form).scope().setFormDirty()",
   "ng-controller" => 'enterpriseCtrl',
   "ng-cloak" => true } do |f|

--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -3,7 +3,7 @@
     = f.label :name, t('.name')
     %span.required *
   .eight.columns.omega
-    = f.text_field :name, { placeholder: t('.name_placeholder') }
+    = f.text_field :name, { oninput: "angular.element(enterprise_form).scope().setFormDirty()", placeholder: t('.name_placeholder') }
 - if @groups.present?
   .row
     .three.columns.alpha

--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -3,7 +3,7 @@
     = f.label :name, t('.name')
     %span.required *
   .eight.columns.omega
-    = f.text_field :name, { oninput: "angular.element(enterprise_form).scope().setFormDirty()", placeholder: t('.name_placeholder') }
+    = f.text_field :name, { placeholder: t('.name_placeholder') }
 - if @groups.present?
   .row
     .three.columns.alpha


### PR DESCRIPTION
#### What? Why?

- Closes #8943 

This PR, adds `oninput` to name text field on enterprise form in order to declare that the form has changed and can be saved upon input.
Before, it was using default `onchange` - which is set on `enterprises/_ng_form.html.haml`.

#### What should we test?

As described on #8943.

This behaviour affects any other text inputs under Enterprise Settings/edit (eg address).

Look at the bottom of the screen for "You have unsaved changes".
* Note existing style issue in `admin_style_v3` means the update button appears clickable, [this will be handled separately](https://openfoodnetwork.slack.com/archives/C01CXQNJ1J6/p1698189065550479))

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Make update button on enterprises primary details form clickable upon input to name field
