### PR TITLE
Sequential invoice numbers per distributor

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -26,4 +26,8 @@ class Invoice < ApplicationRecord
   def cancel_previous_invoices
     order.invoices.where.not(id:).update_all(cancelled: true)
   end
+
+  def display_number
+    "#{order.distributor.id}-#{number}"
+  end
 end

--- a/app/models/invoice/data_presenter.rb
+++ b/app/models/invoice/data_presenter.rb
@@ -5,8 +5,8 @@ class Invoice
     include ::ActionView::Helpers::NumberHelper
     attr_reader :invoice
 
-    delegate :data, to: :invoice
-    delegate :number, :date, to: :invoice, prefix: true
+    delegate :display_number, :data, to: :invoice
+    delegate :date, to: :invoice, prefix: true
 
     FINALIZED_NON_SUCCESSFUL_STATES = %w(canceled returned).freeze
 

--- a/app/services/order_invoice_generator.rb
+++ b/app/services/order_invoice_generator.rb
@@ -9,7 +9,7 @@ class OrderInvoiceGenerator
     if comparator.can_generate_new_invoice?
       order.invoices.create!(
         date: Time.zone.today,
-        number: order.invoices.count + 1,
+        number: total_invoices_created_by_distributor + 1,
         data: invoice_data
       )
     elsif comparator.can_update_latest_invoice?
@@ -30,5 +30,9 @@ class OrderInvoiceGenerator
 
   def invoice_data
     @invoice_data ||= InvoiceDataGenerator.new(order).generate
+  end
+
+  def total_invoices_created_by_distributor
+    Invoice.joins(:order).where(order: { distributor: order.distributor }).count
   end
 end

--- a/app/views/spree/admin/invoices/_invoices_table.html.haml
+++ b/app/views/spree/admin/invoices/_invoices_table.html.haml
@@ -14,7 +14,7 @@
         %td.align-center.created_at
           = invoice.presenter.display_date
         %td.align-center.label
-          = invoice.number
+          = invoice.display_number
         %td.align-center.label
           = invoice.presenter.total
         %td.align-center.label

--- a/app/views/spree/admin/orders/invoice4.html.haml
+++ b/app/views/spree/admin/orders/invoice4.html.haml
@@ -45,7 +45,7 @@
       %td{ :align => "left" }
         %br
         = "#{t :invoice_number}:"
-        = @order.invoice_number
+        = @order.display_number
         %br
         = t :invoice_issued_on
         = l @order.invoice_date

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -1078,10 +1078,11 @@ describe '
             ].join(" ").upcase
           }
 
+          let(:invoice_number){ "#{order.distributor_id}-1" }
           let(:table_contents) {
             [
               Invoice.first.created_at.strftime('%B %d, %Y').to_s,
-              "1",
+              invoice_number,
               "0.0",
               "Active",
               "Download"

--- a/spec/system/admin/orders/invoices_spec.rb
+++ b/spec/system/admin/orders/invoices_spec.rb
@@ -170,10 +170,13 @@ describe '
   describe 'listing invoices' do
     let(:date){ Time.current.to_date }
 
+    let(:first_invoice){ "#{distributor.id}-1" }
+    let(:second_invoice){ "#{distributor.id}-2" }
+
     let(:row1){
       [
         I18n.l(date, format: :long),
-        "2",
+        second_invoice,
         order.total,
         "Active",
         "Download"
@@ -183,7 +186,7 @@ describe '
     let(:row2){
       [
         I18n.l(date, format: :long),
-        "1",
+        first_invoice,
         order.total,
         "Cancelled",
         "Download"


### PR DESCRIPTION
#### What? Why?

- Closes #11458

Depends on another PR, this one starts at: https://github.com/openfoodfoundation/openfoodnetwork/pull/11696/commits/bd8460d664c29dbe04c167405a3d44f88391e231

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Some possible scenarios
Scenario 1:
1. Create an order for Distributor 1 (suppose id is 123)
2. Generate an invoice,  the invoice number should be: 123-1
3. Update the order (quantity for example)
4. Generate another invoice, the invoice number should be: 123-2

Scenario 2:
1. Create an order O1 for Distributor 1 (suppose id is 123)
2. Generate an invoice for O1,  the invoice number should be: 123-1
3. Generate another order O2
4. Generate an invoice for O2, the invoice number should be: 123-2
5. Edit O1 (update quantity for example) and generate another invoice for O1. The invoice number should be 123-3
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->
- #11679


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
