### PR TITLE
Fix invoice printing tests

### DIFF
--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -462,7 +462,7 @@ describe '
   end
   context "when invoice feature is enabled" do
     before do
-      Flipper.enable(:invoice)
+      Flipper.enable(:invoices)
     end
     it_behaves_like "contains right Payment Description at Checkout information"
     it_behaves_like "Check display on each invoice: legacy and alternative", false

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -120,16 +120,9 @@ describe '
                                          user: create(:user, email: "xxxxxx@example.com"),
                                          bill_address: create(:address, phone: '1234567890'))
     end
-    let(:url_params) {
-      if OpenFoodNetwork::FeatureToggle.enabled?(:invoices)
-        { invoice_id: completed_order.invoices.first.id }
-      else
-        {}
-      end
-    }
+    let(:url_params) {{}}
 
     before do
-      completed_order.invoices.create!
       allow(Spree::Config).to receive(:invoice_style2?).and_return(alternative_invoice)
       login_as_admin
       visit spree.print_admin_order_path(completed_order, params: url_params)

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -469,7 +469,8 @@ describe '
         }
         let!(:shipping_method_name) { "SM1" }
         let!(:shipping_method) {
-          create(:shipping_method_with, :expensive_name, name: shipping_method_name, distributors: [distributor],
+          create(:shipping_method_with, :expensive_name, name: shipping_method_name,
+                                                         distributors: [distributor],
                                                          tax_category: shipping_tax_category)
         }
         let!(:enterprise_fee) {
@@ -556,6 +557,7 @@ describe '
           # Tax totals
           expect(page).to have_content "Total tax (10.0%): $9.14 " \
                                        "Total tax (15.0%): $15.65 Total tax (20.0%): $250.08"
+          expect(page).to have_content "Total tax: $274.87"
           # Order Totals
           expect(page).to have_content "Total (Incl. tax): $1,733.54"
           expect(page).to have_content "Total (Excl. tax): $1,458.67"
@@ -575,7 +577,8 @@ describe '
         let(:fee_tax_category) { create(:tax_category, tax_rates: [enterprise_fee_rate_added]) }
         let!(:shipping_method_name) { "SM2" }
         let!(:shipping_method) {
-          create(:shipping_method_with, :expensive_name, name: shipping_method_name, distributors: [distributor],
+          create(:shipping_method_with, :expensive_name, name: shipping_method_name,
+                                                         distributors: [distributor],
                                                          tax_category: shipping_tax_category)
         }
         let(:enterprise_fee) {
@@ -658,6 +661,7 @@ describe '
           # Tax totals
           expect(page).to have_content "Total tax (10.0%): $10.06 " \
                                        "Total tax (15.0%): $18.00 Total tax (20.0%): $300.09"
+          expect(page).to have_content "Total tax: $328.15"
           # Order Totals
           expect(page).to have_content "Total (Incl. tax): $2,061.69"
           expect(page).to have_content "Total (Excl. tax): $1,733.54"

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -37,13 +37,7 @@ describe '
   end
 
   shared_examples "contains right Payment Description at Checkout information" do
-    let(:url_params) {
-      if OpenFoodNetwork::FeatureToggle.enabled?(:invoices)
-        { invoice_id: order.invoices.first.id }
-      else
-        {}
-      end
-    }
+    let(:url_params) {{}}
 
     let!(:payment_method1) do
       create(:stripe_sca_payment_method, distributors: [distributor], description: "description1")
@@ -54,7 +48,6 @@ describe '
 
     context "with no payment" do
       it "do not display the payment description information" do
-        order.invoices.create!
         login_as_admin
         visit spree.print_admin_order_path(order, params: url_params)
         convert_pdf_to_page
@@ -68,7 +61,6 @@ describe '
       end
       before do
         order.save!
-        order.invoices.create!
       end
 
       it "display the payment description section" do
@@ -90,7 +82,6 @@ describe '
                                            payment_method: payment_method2,
                                            created_at: 2.days.ago)
         order.save!
-        order.invoices.create!
       end
 
       it "display the payment description section and use the one from the completed payment" do
@@ -112,7 +103,6 @@ describe '
                                                        payment_method: payment_method2,
                                                        created_at: 1.day.ago)
         order.save!
-        order.invoices.create!
       end
 
       it "display the payment description section and use the one from the last payment" do

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -22,6 +22,7 @@ describe '
 
   let(:order) do
     create(:order_with_totals_and_distribution, user:, distributor:,
+                                                completed_at: 1.day.ago,
                                                 order_cycle:, state: 'complete',
                                                 payment_state: 'balance_due')
   end


### PR DESCRIPTION
#### What? Why?

On `spec/system/admin/invoice_print_spec.rb`, we test printing invoices when the invoices feature is enabled and when it's disabled.
I noticed later that the invoices feature is not enabled properly during the test (we enable the feature flag `invoice` instead of `invoices`).
As a result, when I created this [PR](https://github.com/openfoodfoundation/openfoodnetwork/pull/11679), the tests on that file didn't fail.
This objective of this PR is to fix the existing tests. 

This PR is based on [PR](https://github.com/openfoodfoundation/openfoodnetwork/pull/11679)
#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

The automated tests must pass.  

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
