### PR TITLE
11318 - Fix flaky packing_report_spec.rb

### DIFF
--- a/spec/controllers/api/v0/reports/packing_report_spec.rb
+++ b/spec/controllers/api/v0/reports/packing_report_spec.rb
@@ -9,7 +9,7 @@ describe Api::V0::ReportsController, type: :controller do
       # rspec seems to remove empty values to setting something dummy so the
       # default_params will not overwritting this params
       fields_to_hide: [:none],
-      q: { order_created_at_lt: Time.zone.now }
+      q: { order_created_at_lt: 2.seconds.from_now }
     }
   }
 


### PR DESCRIPTION
#### What? Why?

- Closes # [11318](https://github.com/openfoodfoundation/openfoodnetwork/issues/11318)

This is minor time difference between the `order_created_at_lt` and actual order created_at time.
I was able to reproduce this flakey test locally
```
Api::V0::ReportsController
  packing report
    as an enterprise user with full order permissions (distributor)
params <---- Debug
{"fields_to_hide"=>["none"], "q"=>{"order_created_at_lt"=>"2023-10-25 00:11:21 +1100"}, "use_route"=>"main_app", "format"=>"json", "report_type"=>"packing", "controller"=>"api/v0/reports", "action"=>"show", "report_format"=>"json"}
order.created_at <---- Debug
2023-10-25 00:11:21 +1100
      renders results (FAILED - 1)


Failures:

  1) Api::V0::ReportsController packing report as an enterprise user with full order permissions (distributor) renders results
     Failure/Error: expect(json_response[:data]).to match_array report_output(order, "distributor")

       expected collection contained:  [{"customer_code"=>nil, "depth"=>"160.1", "first_name"=>"John", "height"=>"150.51", "hub"=>"Enterpris...er"=>"Enterprise 2", "temp_controlled"=>false, "variant"=>"1g", "weight"=>"1.0", "width"=>"154.53"}]
       actual collection contained:    []
       the missing elements were:      [{"customer_code"=>nil, "depth"=>"160.1", "first_name"=>"John", "height"=>"150.51", "hub"=>"Enterpris...er"=>"Enterprise 2", "temp_controlled"=>false, "variant"=>"1g", "weight"=>"1.0", "width"=>"154.53"}]
     # ./spec/controllers/api/v0/reports/packing_report_spec.rb:33:in `block (4 levels) in <top (required)>'      
```


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


- Just a test fix so no testing is needed.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
