### PR TITLE
replace hiredis gem with hiredis-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,9 +98,9 @@ gem 'rack-rewrite'
 gem 'rack-timeout'
 gem 'roadie-rails'
 
-gem 'hiredis'
+gem 'hiredis-client'
 gem 'puma'
-gem 'redis', '>= 4.0', require: ['redis', 'redis/connection/hiredis']
+gem 'redis', '>= 5.0', require: 'hiredis-client'
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
 

--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ gem 'roadie-rails'
 
 gem 'hiredis-client'
 gem 'puma'
-gem 'redis', '>= 5.0', require: 'hiredis-client'
+gem 'redis'
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -885,7 +885,7 @@ DEPENDENCIES
   rails_safe_tasks (~> 1.0)
   ransack (~> 2.6.0)
   redcarpet
-  redis (>= 5.0)
+  redis
   responders
   rexml
   roadie-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,8 @@ GEM
     hashery (2.1.2)
     hashie (5.0.0)
     highline (2.0.3)
-    hiredis (0.6.3)
+    hiredis-client (0.17.0)
+      redis-client (= 0.17.0)
     htmlentities (4.3.4)
     httpclient (2.8.3)
     i18n (1.14.1)
@@ -564,7 +565,8 @@ GEM
     rdf (3.2.11)
       link_header (~> 0.0, >= 0.0.8)
     redcarpet (3.6.0)
-    redis (4.8.1)
+    redis (5.0.8)
+      redis-client (>= 0.17.0)
     redis-client (0.17.0)
       connection_pool
     regexp_parser (2.8.2)
@@ -839,7 +841,7 @@ DEPENDENCIES
   good_migrations
   haml
   highline (= 2.0.3)
-  hiredis
+  hiredis-client
   i18n
   i18n-js (~> 3.9.0)
   image_processing
@@ -883,7 +885,7 @@ DEPENDENCIES
   rails_safe_tasks (~> 1.0)
   ransack (~> 2.6.0)
   redcarpet
-  redis (>= 4.0)
+  redis (>= 5.0)
   responders
   rexml
   roadie-rails

--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -197,8 +197,14 @@ module Spree
 
       def clear_preference_cache
         @payment_method.calculator.preferences.each_key do |key|
-          Rails.cache.delete(@payment_method.calculator.preference_cache_key(key))
+          delete_from_cache @payment_method.calculator.preference_cache_key(key)
         end
+      end
+
+      def delete_from_cache(cache_key)
+        return unless cache_key.class.in? [String, Integer, Float, Symbol]
+
+        Rails.cache.delete(cache_key)
       end
 
       def add_type_to_calculator_attributes(hash)


### PR DESCRIPTION
#### What? Why?

In this [PR](https://github.com/openfoodfoundation/openfoodnetwork/pull/11698), the [dependabot](https://github.com/openfoodfoundation/openfoodnetwork/tree/dependabot/bundler/redis-5.0.8) is trying to upgrade the redis library to 5.0.8. The tests are failing due to what looks like a compatibility issue between `redis` and `hiredis`  ([the latest release was in 2018](https://github.com/redis/hiredis-rb/tags)).

I found that  `hiredis-client` is used in the example given on [redis gem documentation](https://github.com/redis/redis-rb#hiredis-binding).
In this PR, I want to check if replace `hiredis` with `hiredis-client` will solve the issue.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- run some operations that require using Redis, for example, bulk printing of orders.
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
