### PR TITLE
Fix Stripe payment flash rendering issue

### DIFF
--- a/app/assets/javascripts/admin/payments/services/payment.js.coffee
+++ b/app/assets/javascripts/admin/payments/services/payment.js.coffee
@@ -42,8 +42,9 @@ angular.module('admin.payments').factory 'Payment', (AdminStripeElements, curren
 
     submit: =>
       munged = @preprocess()
-      PaymentResource.create({order_id: munged.order_id}, munged, (response, headers, status)=>
-        $window.location.pathname = "/admin/orders/" + munged.order_id + "/payments"
+      PaymentResource.create({order_id: munged.order_id}, munged, (response, headers, status) ->
+        document.body.innerHTML = Object.values(response).join('')
+        $window.history.pushState({}, '', "/admin/orders/" + munged.order_id + "/payments")
       , (response) ->
         StatusMessage.display 'error', t("spree.admin.payments.source_forms.stripe.error_saving_payment")
       )

--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -33,23 +33,15 @@ module Spree
             return
           end
 
-          if @order.completed?
-            authorize_stripe_sca_payment
-            @payment.process_offline!
-            flash[:success] = flash_message_for(@payment, :successfully_created)
+          OrderWorkflow.new(@order).complete! unless @order.completed?
 
-            redirect_to spree.admin_order_payments_path(@order)
-          else
-            OrderWorkflow.new(@order).complete!
-            authorize_stripe_sca_payment
-            @payment.process_offline!
-
-            flash[:success] = Spree.t(:new_order_completed)
-            redirect_to spree.edit_admin_order_url(@order)
-          end
+          authorize_stripe_sca_payment
+          @payment.process_offline!
+          flash[:success] = flash_message_for(@payment, :successfully_created)
+          redirect_to spree.admin_order_payments_path(@order)
         rescue Spree::Core::GatewayError => e
           flash[:error] = e.message.to_s
-          redirect_to spree.new_admin_order_payment_path(@order)
+          redirect_to spree.admin_order_payments_path(@order)
         end
       end
 

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -3590,7 +3590,6 @@ ar:
     gateway_error: "عملية الدفع فشلت"
     more: "أكثر"
     new_adjustment: "تعديل جديد"
-    new_order_completed: "طلب جديد مكتمل"
     new_tax_category: "فئة ضريبية جديدة"
     new_taxon: "اصنوفة جديدة"
     new_user: "مستخدم جديد"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3398,7 +3398,6 @@ ca:
     gateway_error: "El pagament ha fallat"
     more: "Més"
     new_adjustment: "Nou ajustament"
-    new_order_completed: "S'ha completat la nova comanda"
     new_tax_category: "Nova categoria fiscal"
     new_taxon: "Nou tàxon"
     new_user: "Nou usuari"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -3658,7 +3658,6 @@ cy:
     gateway_error: "Taliad wedi methu"
     more: "Mwy"
     new_adjustment: "Addasiad newydd"
-    new_order_completed: "Cwblhawyd archeb newydd"
     new_tax_category: "Categori treth newydd"
     new_taxon: "Tacson newydd"
     new_user: "Defnyddiwr newydd"

--- a/config/locales/de_CH.yml
+++ b/config/locales/de_CH.yml
@@ -3392,7 +3392,6 @@ de_CH:
     gateway_error: "Zahlung fehlgeschlagen"
     more: "Mehr"
     new_adjustment: "Neue Anpassung"
-    new_order_completed: "Neue Bestellung abgeschlossen"
     new_tax_category: "Neue Steuerkategorie"
     new_taxon: "Neue Kategorie"
     new_user: "Neuer Benutzer"

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -3635,7 +3635,6 @@ de_DE:
     gateway_error: "Zahlung fehlgeschlagen"
     more: "Mehr"
     new_adjustment: "Neue Anpassung"
-    new_order_completed: "Neue Bestellung abgeschlossen"
     new_tax_category: "Neue Steuerkategorie"
     new_taxon: "Neue Kategorie"
     new_user: "Neuer Benutzer"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -3055,7 +3055,6 @@ el:
     gateway_error: "Η πληρωμή απέτυχε"
     more: "Περισσότερα"
     new_adjustment: "Νέα προσαρμογή"
-    new_order_completed: "Η νέα παραγγελία ολοκληρώθηκε"
     new_tax_category: "Νέα Φορολογική Κατηγορία"
     new_taxon: "Νέο ταξί"
     new_user: "Νέος χρήστης"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3781,7 +3781,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     gateway_error: "Payment failed"
     more: "More"
     new_adjustment: "New adjustment"
-    new_order_completed: "New order completed"
     new_tax_category: "New Tax Category"
     new_taxon: "New taxon"
     new_user: "New user"

--- a/config/locales/en_CA.yml
+++ b/config/locales/en_CA.yml
@@ -3617,7 +3617,6 @@ en_CA:
     gateway_error: "Payment failed"
     more: "More"
     new_adjustment: "New adjustment"
-    new_order_completed: "New order completed"
     new_tax_category: "New Tax Category"
     new_taxon: "New taxon"
     new_user: "New user"

--- a/config/locales/en_FR.yml
+++ b/config/locales/en_FR.yml
@@ -3620,7 +3620,6 @@ en_FR:
     gateway_error: "Payment failed"
     more: "More"
     new_adjustment: "New adjustment"
-    new_order_completed: "New order completed"
     new_tax_category: "New Tax Category"
     new_taxon: "New taxon"
     new_user: "New user"

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -3622,7 +3622,6 @@ en_GB:
     gateway_error: "Payment failed"
     more: "More"
     new_adjustment: "New adjustment"
-    new_order_completed: "New order completed"
     new_tax_category: "New Tax Category"
     new_taxon: "New taxon"
     new_user: "New user"

--- a/config/locales/en_IE.yml
+++ b/config/locales/en_IE.yml
@@ -3484,7 +3484,6 @@ en_IE:
     gateway_error: "Payment failed"
     more: "More"
     new_adjustment: "New adjustment"
-    new_order_completed: "New order completed"
     new_tax_category: "New Tax Category"
     new_taxon: "New taxon"
     new_user: "New user"

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -3330,7 +3330,6 @@ en_US:
     gateway_error: "Payment failed"
     more: "More"
     new_adjustment: "New adjustment"
-    new_order_completed: "New order completed"
     new_tax_category: "New Tax Category"
     new_taxon: "New taxon"
     new_user: "New user"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3464,7 +3464,6 @@ es:
     gateway_error: "Pago fallido"
     more: "Más"
     new_adjustment: "Nuevo ajuste"
-    new_order_completed: "Nuevo pedido completado"
     new_tax_category: "Nueva categoría de impuestos"
     new_taxon: "Nuevo taxón"
     new_user: "Nuevo usuario"

--- a/config/locales/es_CR.yml
+++ b/config/locales/es_CR.yml
@@ -3429,7 +3429,6 @@ es_CR:
     gateway_error: "Pago fallido"
     more: "Más"
     new_adjustment: "Nuevo ajuste"
-    new_order_completed: "Nuevo pedido completado"
     new_tax_category: "Nueva categoría de impuestos"
     new_taxon: "Nuevo taxon"
     new_user: "Nuevo usuari"

--- a/config/locales/es_US.yml
+++ b/config/locales/es_US.yml
@@ -3285,7 +3285,6 @@ es_US:
     gateway_error: "Pago fallido"
     more: "Más"
     new_adjustment: "Nuevo ajuste"
-    new_order_completed: "Nuevo pedido completado"
     new_tax_category: "Nueva categoría de impuestos"
     new_user: "Nuevo usuario"
     no_pending_payments: "No tiene pagos pendientes"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3678,7 +3678,6 @@ fr:
     gateway_error: "Le paiement a échoué"
     more: "Plus"
     new_adjustment: "Nouvel ajustement"
-    new_order_completed: "Nouvelle commande finalisée"
     new_tax_category: "Nouvelle catégorie de taxe"
     new_taxon: "Nouvelle taxonomie"
     new_user: "Nouvel utilisateur"

--- a/config/locales/fr_BE.yml
+++ b/config/locales/fr_BE.yml
@@ -3291,7 +3291,6 @@ fr_BE:
     gateway_error: "Paiement échoué"
     more: "Plus"
     new_adjustment: "Nouvel ajustement"
-    new_order_completed: "Nouvelle commande terminée"
     new_tax_category: "Nouvelle catégorie de taxe"
     no_pending_payments: "Aucun paiement en attente"
     none: "Aucun"

--- a/config/locales/fr_CA.yml
+++ b/config/locales/fr_CA.yml
@@ -3661,7 +3661,6 @@ fr_CA:
     gateway_error: "Le paiement a échoué"
     more: "Plus"
     new_adjustment: "Nouvel ajustement"
-    new_order_completed: "Nouvelle commande finalisée"
     new_tax_category: "Nouvelle catégorie de taxe"
     new_taxon: "Nouvelle taxonomie"
     new_user: "Nouvel utilisateur"

--- a/config/locales/fr_CH.yml
+++ b/config/locales/fr_CH.yml
@@ -3436,7 +3436,6 @@ fr_CH:
     gateway_error: "Le paiement a échoué"
     more: "Plus"
     new_adjustment: "Nouvel ajustement"
-    new_order_completed: "Nouvelle commande finalisée"
     new_tax_category: "Nouvelle catégorie de taxe"
     new_taxon: "Nouvelle taxonomie"
     new_user: "Nouvel utilisateur"

--- a/config/locales/fr_CM.yml
+++ b/config/locales/fr_CM.yml
@@ -3330,7 +3330,6 @@ fr_CM:
     gateway_error: "Le paiement a échoué"
     more: "Plus"
     new_adjustment: "Nouvel ajustement"
-    new_order_completed: "Nouvelle commande finalisée"
     new_tax_category: "Nouvelle catégorie de taxe"
     new_taxon: "Nouvelle taxonomie"
     new_user: "Nouvel utilisateur"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -3424,7 +3424,6 @@ hu:
     gateway_error: "Fizetés meghiúsult"
     more: "Több"
     new_adjustment: "Új beállítás"
-    new_order_completed: "Új megrendelés elkészült"
     new_tax_category: "Új adókategória"
     new_taxon: "Új taxon"
     new_user: "Új felhasználó"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -3503,7 +3503,6 @@ it:
     gateway_error: "Pagamento fallito"
     more: "Di più"
     new_adjustment: "Nuovo aggiustamento"
-    new_order_completed: "Nuova richiesta completata"
     new_tax_category: "Nuova Categoria imposta"
     new_taxon: "Nuova tassonomia"
     new_user: "Nuovo utente"

--- a/config/locales/it_CH.yml
+++ b/config/locales/it_CH.yml
@@ -3365,7 +3365,6 @@ it_CH:
     gateway_error: "Pagamento fallito"
     more: "Di più"
     new_adjustment: "Nuovo aggiustamento"
-    new_order_completed: "Nuova richiesta completata"
     new_tax_category: "Nuova Categoria imposta"
     new_taxon: "Nuova tassonomia"
     new_user: "Nuovo utente"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -3331,7 +3331,6 @@ ko:
     gateway_error: "결제 실패"
     more: "추가 정보"
     new_adjustment: "새 조정"
-    new_order_completed: "신규 주문 완료"
     new_tax_category: "신규 세금 카테고리"
     new_taxon: "새 분류군"
     new_user: "신규 사용자"

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -3591,7 +3591,6 @@ nb:
     gateway_error: "Betalingen feilet"
     more: "Mer"
     new_adjustment: "Ny justering"
-    new_order_completed: "Ny bestilling fullført"
     new_tax_category: "Ny avgiftskategori"
     new_taxon: "Ny kategori"
     new_user: "Ny bruker"

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -3227,7 +3227,6 @@ pt_BR:
     gateway_error: "Falha no pagamento"
     more: "Mais"
     new_adjustment: "Novo ajuste"
-    new_order_completed: "Novo pedido realizado"
     new_tax_category: "Nova Categoria de Taxa"
     new_taxon: "Nova taxonomia"
     new_user: "Novo usuário"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -3647,7 +3647,6 @@ ru:
     gateway_error: "Платеж не прошел"
     more: "Ещё"
     new_adjustment: "Новая корректировка"
-    new_order_completed: "Новый заказ выполнен"
     new_tax_category: "Новая Налоговая Категория"
     new_taxon: "Новая таксономия"
     new_user: "Новый пользователь"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -3222,7 +3222,6 @@ tr:
     gateway_error: "Ödeme başarısız"
     more: "Daha Fazla"
     new_adjustment: "Yeni düzenleme"
-    new_order_completed: "Yeni sipariş tamamlandı"
     new_tax_category: "Yeni Vergi Kategorisi"
     new_taxon: "Yeni kategori"
     new_user: "Yeni kullanıcı"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -3446,7 +3446,6 @@ uk:
     gateway_error: "Платіж не вдався"
     more: "Більше"
     new_adjustment: "Нове коригування"
-    new_order_completed: "Нове замовлення виконано"
     new_tax_category: "Нова податкова категорія"
     new_taxon: "Новий таксон"
     new_user: "Новий користувач"

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -57,7 +57,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
           it "redirects to new payment page with flash error" do
             spree_post :create, payment: params, order_id: order.number
 
-            redirects_to_new_payment_page_with_flash_error("Stripe Authorization Failure")
+            redirects_to_payments_list_page_with_flash_error("Stripe Authorization Failure")
             expect(order.reload.payments.last.state).to eq "checkout"
           end
         end
@@ -70,7 +70,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
           it "redirects to new payment page with flash error" do
             spree_post :create, payment: params, order_id: order.number
 
-            redirects_to_new_payment_page_with_flash_error("Authorization Failure")
+            redirects_to_payments_list_page_with_flash_error("Authorization Failure")
             expect(order.reload.payments.last.state).to eq "checkout"
           end
         end
@@ -85,7 +85,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
           it "redirects to new payment page with flash error" do
             spree_post :create, payment: params, order_id: order.number
 
-            redirects_to_new_payment_page_with_flash_error('Action required')
+            redirects_to_payments_list_page_with_flash_error('Action required')
           end
         end
 
@@ -127,8 +127,8 @@ describe Spree::Admin::PaymentsController, type: :controller do
         expect(flash[:success]).to eq "Payment has been successfully created!"
       end
 
-      def redirects_to_new_payment_page_with_flash_error(flash_error)
-        expect_redirect_to spree.new_admin_order_payment_url(order)
+      def redirects_to_payments_list_page_with_flash_error(flash_error)
+        expect_redirect_to spree.admin_order_payments_url(order)
         expect(flash[:error]).to eq flash_error
       end
 

--- a/spec/system/admin/payments_spec.rb
+++ b/spec/system/admin/payments_spec.rb
@@ -60,6 +60,7 @@ describe '
 
       click_button "Update"
       expect(page).to have_content "Payments"
+      expect(page).to have_content "Payment has been successfully created!"
 
       order.reload
       expect(order.state).to eq "complete"


### PR DESCRIPTION
#### What? Why?
- Closes #9048 

When creating a Stripe payment from the backoffice, the user should receive feedback in the form of a flash message whether or not the payment was successful. Currently, this does not occur because the frontend forces a redirect to the payments list, completely ignoring the result of the saved payment.

This is what the flash looks like after saving a payment from the backoffice:
![Screenshot from 2023-10-27 09-26-04](https://github.com/openfoodfoundation/openfoodnetwork/assets/14116496/d286e0dc-9deb-49c8-b089-1538323b388b)



#### What should we test?
1. Sign in as a customer.
2. Find a shop with Stripe configured to accept payments.
3. Start a new order and complete it.
4. Sign in as an enterprise owner.
5. Visit your enterprise's orders.
6. Click edit on the recent order.
7. This order will probably be marked paid. To add a balance, add another product.
8. Click the payments tab.
9. Click New Payment.
10. Select Stripe for the payment method.
11. Fill in the payment details and click Update.
12. Ensure the payments list/index is rendered with the new payment.
13. Ensure the flash message "Payment has been successfully created!" is rendered.
14. Ensure the current path is `admin/orders/:order_id/payments`.

Other payment methods should also be checked, along with any known payment failure conditions.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies

#### Documentation updates

