### PR TITLE
Print robots tag for registration layout

### DIFF
--- a/app/views/layouts/registration.html.haml
+++ b/app/views/layouts/registration.html.haml
@@ -2,6 +2,8 @@
   %head
     %meta{charset: 'utf-8'}/
     %meta{name: 'viewport', content: "width=device-width,initial-scale=1.0"}/
+    - if !Rails.env.production? || @noindex_meta_tag
+      %meta{name: "robots", content: "noindex"}
 
     %title= content_for?(:title) ? "#{yield(:title)} - #{Spree::Config[:site_name]}".html_safe : "#{t(:welcome_to)} #{Spree::Config[:site_name]}"
     - if Rails.env.production?


### PR DESCRIPTION
I  noticed a couple of pages on a staging server were being indexed: https://www.google.com/search?q=site%3Astaging.openfoodnetwork.org.au

This addresses the Registration page. 

To address PDFs, I think the only way is to set a robots HTTP header. That's probably easy, we should do that too... (but I won't right now).

(There is PDF html layout, but this is used for rendering the PDF file, so adding a robots meta tag to that won't have an effect.)

This is different to setting Disallow in robots.txt (which is also generally a good idea for staging environments). That would disallow crawling of the page or file, but not remove it from the index. 

#### What should we test?
Tested on dev env (below). I don't think there's any point testing further.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
