### PR TITLE
Revert "replace hiredis gem with hiredis-client"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,9 +98,9 @@ gem 'rack-rewrite'
 gem 'rack-timeout'
 gem 'roadie-rails'
 
-gem 'hiredis-client'
+gem 'hiredis'
 gem 'puma'
-gem 'redis'
+gem 'redis', '>= 4.0', require: ['redis', 'redis/connection/hiredis']
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,8 +332,7 @@ GEM
     hashery (2.1.2)
     hashie (5.0.0)
     highline (2.0.3)
-    hiredis-client (0.17.0)
-      redis-client (= 0.17.0)
+    hiredis (0.6.3)
     htmlentities (4.3.4)
     httpclient (2.8.3)
     i18n (1.14.1)
@@ -566,8 +565,7 @@ GEM
     rdf (3.2.11)
       link_header (~> 0.0, >= 0.0.8)
     redcarpet (3.6.0)
-    redis (5.0.8)
-      redis-client (>= 0.17.0)
+    redis (4.8.1)
     redis-client (0.17.0)
       connection_pool
     regexp_parser (2.8.2)
@@ -841,7 +839,7 @@ DEPENDENCIES
   good_migrations
   haml
   highline (= 2.0.3)
-  hiredis-client
+  hiredis
   i18n
   i18n-js (~> 3.9.0)
   image_processing
@@ -885,7 +883,7 @@ DEPENDENCIES
   rails_safe_tasks (~> 1.0)
   ransack (~> 2.6.0)
   redcarpet
-  redis
+  redis (>= 4.0)
   responders
   rexml
   roadie-rails

--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -197,14 +197,8 @@ module Spree
 
       def clear_preference_cache
         @payment_method.calculator.preferences.each_key do |key|
-          delete_from_cache @payment_method.calculator.preference_cache_key(key)
+          Rails.cache.delete(@payment_method.calculator.preference_cache_key(key))
         end
-      end
-
-      def delete_from_cache(cache_key)
-        return unless cache_key.class.in? [String, Integer, Float, Symbol]
-
-        Rails.cache.delete(cache_key)
       end
 
       def add_type_to_calculator_attributes(hash)


### PR DESCRIPTION
Reverts openfoodfoundation/openfoodnetwork#11708

Our specs started failing:

* https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/6714637038/job/18248168144
* https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/6714719538/job/18248363684
* https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/6715013068/job/18249086162
* ... and at least three more

```
Failures:

  1) Multilingual fallbacks to default_locale
     Got 0 failures and 2 other errors:

     1.1) Failure/Error: raise Client::ERROR_MAPPING.fetch(event.class), event.message
          
          Redis::CommandError:
            ERR Protocol error: too big inline request
          # /home/runner/work/openfoodnetwork/openfoodnetwork/vendor/bundle/ruby/3.1.0/gems/redis-5.0.8/lib/redis/subscribe.rb:68:in `subscription'
          # /home/runner/work/openfoodnetwork/openfoodnetwork/vendor/bundle/ruby/3.1.0/gems/redis-5.0.8/lib/redis/subscribe.rb:17:in `subscribe'
          # /home/runner/work/openfoodnetwork/openfoodnetwork/vendor/bundle/ruby/3.1.0/gems/redis-5.0.8/lib/redis.rb:175:in `_subscription'
          # /home/runner/work/openfoodnetwork/openfoodnetwork/vendor/bundle/ruby/3.1.0/gems/redis-5.0.8/lib/redis/commands/pubsub.rb:17:in `subscribe'
          # /home/runner/work/openfoodnetwork/openfoodnetwork/vendor/bundle/ruby/3.1.0/gems/actioncable-7.0.8/lib/action_cable/subscription_adapter/redis.rb:92:in `block in listen'
          # /home/runner/work/openfoodnetwork/openfoodnetwork/vendor/bundle/ruby/3.1.0/gems/redis-client-0.17.0/lib/redis_client.rb:662:in `ensure_connected'
          # /home/runner/work/openfoodnetwork/openfoodnetwork/vendor/bundle/ruby/3.1.0/gems/redis-client-0.17.0/lib/redis_client.rb:366:in `disable_reconnection'
          # /home/runner/work/openfoodnetwork/openfoodnetwork/vendor/bundle/ruby/3.1.0/gems/redis-5.0.8/lib/redis.rb:79:in `without_reconnect'
          # /home/runner/work/openfoodnetwork/openfoodnetwork/vendor/bundle/ruby/3.1.0/gems/actioncable-7.0.8/lib/action_cable/subscription_adapter/redis.rb:89:in `listen'
          # /home/runner/work/openfoodnetwork/openfoodnetwork/vendor/bundle/ruby/3.1.0/gems/actioncable-7.0.8/lib/action_cable/subscription_adapter/redis.rb:165:in `block in ensure_listener_running'
          # 
          #   Showing full backtrace because every line was filtered out.
          #   See docs for RSpec::Configuration#backtrace_exclusion_patterns and
          #   RSpec::Configuration#backtrace_inclusion_patterns for more information.

     1.2) Failure/Error: example.run
          
          Ferrum::DeadBrowserError:
            Browser is dead or given window is closed
          # ./spec/system/support/cuprite_setup.rb:41:in `block (2 levels) in <top (required)>'


Finished in 4 minutes 43.3 seconds
67 examples, 1 failure

Failed examples:

rspec ./spec/system/admin/multilingual_spec.rb:38 # Multilingual fallbacks to default_locale
```

Also failing:

```
Failures:

  1) 
  As an Administrator
  I want to be able to delete orders in bulk
 deleting orders deletes orders
     Failure/Error:
       expect {
         find_button("Confirm").click
       }.to change { o1.reload.state }.from('complete').to('canceled')
         .and change { o2.reload.state }.from('complete').to('canceled')
     
          expected `o1.reload.state` to have changed from "complete" to "canceled", but did not change
     
       ...and:
     
          expected `o2.reload.state` to have changed from "complete" to "canceled", but did not change
     
     [Screenshot Image]: /home/runner/work/openfoodnetwork/openfoodnetwork/tmp/capybara/screenshots/failures_r_spec_example_groups_as_an_administrator_i_want_to_be_able_to_delete_orders_in_bulk_deleting_orders_deletes_orders_908.png

     
     # ./spec/system/admin/bulk_order_cancellation_spec.rb:40:in `block (4 levels) in <top (required)>'
     # ./spec/system/admin/bulk_order_cancellation_spec.rb:39:in `block (3 levels) in <top (required)>'
     # ./spec/system/support/cuprite_setup.rb:41:in `block (2 levels) in <top (required)>'


Finished in 3 minutes 51 seconds
54 examples, 1 failure

Failed examples:

rspec ./spec/system/admin/bulk_order_cancellation_spec.rb:28 # 
```