### PR TITLE
Clarify cuprite driver configuration

### DIFF
--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -7,7 +7,7 @@ headless = ActiveModel::Type::Boolean.new.cast(ENV.fetch("HEADLESS", true))
 browser_options = {}
 browser_options["no-sandbox"] = nil if ENV['CI']
 
-Capybara.register_driver(:cuprite) do |app|
+Capybara.register_driver(:cuprite_ofn) do |app|
   Capybara::Cuprite::Driver.new(
     app,
     **{
@@ -24,14 +24,14 @@ Capybara.register_driver(:cuprite) do |app|
   )
 end
 
-# Configure Capybara to use :cuprite driver by default
-Capybara.default_driver = Capybara.javascript_driver = :cuprite
+# Configure Capybara to use :cuprite_ofn driver by default
+Capybara.default_driver = Capybara.javascript_driver = :cuprite_ofn
 
 RSpec.configure do |config|
   config.include CupriteHelpers, type: :system
   config.include Devise::Test::IntegrationHelpers, type: :system
 
-  config.prepend_before(:each, type: :system) { driven_by :cuprite }
+  config.prepend_before(:each, type: :system) { driven_by :cuprite_ofn }
 
   # Make sure url helpers in mailers use the Capybara server host.
   config.around(:each, type: :system) do |example|


### PR DESCRIPTION

#### What? Why?

Rails is registering a driver called `cuprite`. And when we did that as well the driver got registered three times somehow. It looked like our driver options were used in the end but just to clarify I gave it a unique name.

This was inspired by:

* https://github.com/ViewComponent/view_component/pull/1877

It suggests that it may avoid dead browser errors on CI. We'll see. It could close:

- #11669
- #11027
- #10220

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only. Maybe run them a few times?

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
