### PR TITLE
[BUU] Showing error summary at top of form

### DIFF
--- a/app/reflexes/products_reflex.rb
+++ b/app/reflexes/products_reflex.rb
@@ -41,8 +41,7 @@ class ProductsReflex < ApplicationReflex
       # flash[:success] = with_locale { I18n.t('.success') }
       # morph_admin_flashes  # ERROR: selector morph type has already been set
     elsif product_set.errors.present?
-      # @error_msg = with_locale{ I18n.t('.products_have_error', count: product_set.invalid.count) }
-      @error_msg = "#{product_set.invalid.count} products have errors."
+      @error_counts = { saved: product_set.saved_count, invalid: product_set.invalid.count }
     end
 
     render_products_form
@@ -87,10 +86,12 @@ class ProductsReflex < ApplicationReflex
   end
 
   def render_products_form
+    locals = { products: @products }
+    locals[:error_counts] = @error_counts if @error_counts.present?
+
     cable_ready.replace(
       selector: "#products-form",
-      html: render(partial: "admin/products_v3/table",
-                   locals: { products: @products, error_msg: @error_msg })
+      html: render(partial: "admin/products_v3/table", locals:)
     ).broadcast
     morph :nothing
 

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -8,11 +8,15 @@ module Sets
   # }
   #
   class ProductSet < ModelSet
+    attr_reader :saved_count
+
     def initialize(attributes = {})
       super(Spree::Product, [], attributes)
     end
 
     def save
+      @saved_count = 0
+
       # Attempt to save all records, collecting model errors.
       @collection_hash.each_value.map do |product_attributes|
         update_product_attributes(product_attributes)
@@ -71,7 +75,10 @@ module Sets
 
       validate_presence_of_unit_value_in_product(product)
 
-      product.errors.empty? && product.save
+      changed = product.changed?
+      success = product.errors.empty? && product.save
+      count_result(success && changed)
+      success
     end
 
     def validate_presence_of_unit_value_in_product(product)
@@ -135,6 +142,10 @@ module Sets
       end
 
       variant
+    end
+
+    def count_result(saved)
+      @saved_count += 1 if saved
     end
 
     def notify_bugsnag(error, product, variant, variant_attributes)

--- a/app/views/admin/products_v3/_sort.html.haml
+++ b/app/views/admin/products_v3/_sort.html.haml
@@ -4,6 +4,6 @@
     - if search_term.present? || producer_id.present? || category_id.present?
       %a{ href: "#", class: "button disruptive", data: { reflex: "click->products#clear_search" } }
         = t(".pagination.clear_search")  
-  %div.with-dropdown
+  %form.with-dropdown
     = t(".pagination.per_page.show")
     = select_tag :per_page, options_for_select([15, 25, 50, 100].collect{|i| [t('.pagination.per_page.per_page', num: i), i]}, pagy.items), data: { reflex: "change->products#change_per_page" }

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,15 +1,16 @@
 = form_with url: bulk_update_admin_products_path, method: :patch, id: "products-form",
             builder: BulkFormBuilder,
             html: {'data-reflex-serialize-form': true, 'data-reflex': 'submit->products#bulk_update',
-                   'data-controller': "bulk-form", 'data-bulk-form-disable-selector-value': "#sort,#filters"} do |form|
-  %fieldset.form-actions.hidden{ 'data-bulk-form-target': "actions" }
+                   'data-controller': "bulk-form", 'data-bulk-form-disable-selector-value': "#sort,#filters" } do |form|
+  %fieldset.form-actions{ class: ("hidden" unless defined?(error_counts)), 'data-bulk-form-target': "actions" }
     .container
-      .status.ten.columns
-        .changed_summary{ 'data-bulk-form-target': "changedSummary", 'data-translation-key': 'admin.products_v3.table.changed_summary'}
-        - if defined?(error_msg) && error_msg.present?
-          .error
-            = error_msg
-      .form-buttons.six.columns
+      .status.eleven.columns
+        .modified_summary{ 'data-bulk-form-target': "changedSummary", 'data-translation-key': 'admin.products_v3.table.changed_summary'}
+        - if defined?(error_counts)
+          .error_summary
+            -# X products were saved correctly, but Y products could not be saved correctly. Please review errors and try again
+            = t('.error_summary.saved', count: error_counts[:saved]) + t('.error_summary.invalid', count: error_counts[:invalid])
+      .form-buttons.five.columns
         = form.submit t('.reset'), type: :reset, class: "medium", 'data-reflex': 'click->products#fetch'
         = form.submit t('.save'), class: "medium"
   %table.products

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,7 +1,9 @@
 = form_with url: bulk_update_admin_products_path, method: :patch, id: "products-form",
             builder: BulkFormBuilder,
             html: {'data-reflex-serialize-form': true, 'data-reflex': 'submit->products#bulk_update',
-                   'data-controller': "bulk-form", 'data-bulk-form-disable-selector-value': "#sort,#filters" } do |form|
+                   'data-controller': "bulk-form", 'data-bulk-form-disable-selector-value': "#sort,#filters",
+                   'data-bulk-form-error-value': defined?(error_counts),
+                  } do |form|
   %fieldset.form-actions{ class: ("hidden" unless defined?(error_counts)), 'data-bulk-form-target': "actions" }
     .container
       .status.eleven.columns

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -52,7 +52,7 @@ export default class BulkFormController extends Controller {
     this.#disableOtherElements(formChanged); // like filters and sorting
 
     // Display number of records changed
-    const key = this.changedSummaryTarget && this.changedSummaryTarget.dataset.translationKey;
+    const key = this.hasChangedSummaryTarget && this.changedSummaryTarget.dataset.translationKey;
     if (key) {
       this.changedSummaryTarget.textContent = I18n.t(key, { count: changedRecordCount });
     }
@@ -76,13 +76,15 @@ export default class BulkFormController extends Controller {
   // private
 
   #disableOtherElements(disable) {
+    if (!this.hasDisableSelectorValue) return;
+
     this.disableElements ||= document.querySelectorAll(this.disableSelectorValue);
 
-    if (this.disableElements) {
-      this.disableElements.forEach((element) => {
-        element.classList.toggle("disabled-section", disable);
-      });
-    }
+    if (!this.disableElements) return;
+
+    this.disableElements.forEach((element) => {
+      element.classList.toggle("disabled-section", disable);
+    });
   }
 
   #isChanged(element) {

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -5,6 +5,7 @@ export default class BulkFormController extends Controller {
   static targets = ["actions", "changedSummary"];
   static values = {
     disableSelector: String,
+    error: Boolean,
   };
   recordElements = {};
 
@@ -25,6 +26,8 @@ export default class BulkFormController extends Controller {
         this.recordElements[recordId].push(element);
       }
     }
+
+    this.toggleFormChanged();
   }
 
   disconnect() {
@@ -45,7 +48,7 @@ export default class BulkFormController extends Controller {
     const changedRecordCount = Object.values(this.recordElements).filter((elements) =>
       elements.some(this.#isChanged)
     ).length;
-    const formChanged = changedRecordCount > 0;
+    const formChanged = changedRecordCount > 0 || this.errorValue;
 
     // Show actions
     this.actionsTarget.classList.toggle("hidden", !formChanged);
@@ -54,6 +57,7 @@ export default class BulkFormController extends Controller {
     // Display number of records changed
     const key = this.hasChangedSummaryTarget && this.changedSummaryTarget.dataset.translationKey;
     if (key) {
+      // TODO: save processing and only run if changedRecordCount has changed.
       this.changedSummaryTarget.textContent = I18n.t(key, { count: changedRecordCount });
     }
 

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -88,6 +88,14 @@ export default class BulkFormController extends Controller {
 
     this.disableElements.forEach((element) => {
       element.classList.toggle("disabled-section", disable);
+
+      // Also disable any form elements
+      let forms = element.tagName == "FORM" ? [element] : element.querySelectorAll("form");
+
+      forms &&
+        forms.forEach((form) =>
+          Array.from(form.elements).forEach((formElement) => (formElement.disabled = disable))
+        );
     });
   }
 

--- a/app/webpacker/css/admin_v3/shared/forms.scss
+++ b/app/webpacker/css/admin_v3/shared/forms.scss
@@ -282,6 +282,20 @@ fieldset {
   text-align: center;
 }
 
+.modified_summary {
+  font-size: inherit;
+}
+
+.error_summary {
+  font-size: inherit;
+
+  @extend .icon-remove-sign;
+  &:before {
+    font-family: FontAwesome;
+    color: $color-error;
+  }
+}
+
 select {
   @extend input, [type="text"];
   background-color: white;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -837,13 +837,18 @@ en:
           zero: ""
           one: "%{count} product modified."
           other: "%{count} products modified."
+        error_summary:
+          saved:
+            zero: ""
+            one: "%{count} product was saved correctly, but "
+            other: "%{count} products were saved correctly, but "
+          invalid:
+            one: "%{count} product could not be saved. Please review the errors and try again."
+            other: "%{count} products could not be saved. Please review the errors and try again."
         save: Save changes
         reset: Discard changes
       bulk_update: # TODO: fix these
         success: "Products successfully updated" #TODO: add count
-        products_have_error:
-          one: "%{count} product has an error."
-          other: "%{count} products have an error."
     product_import:
       title: Product Import
       file_not_found: File not found or could not be opened

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -28,8 +28,8 @@ describe("BulkFormController", () => {
 
     beforeEach(() => {
       document.body.innerHTML = `
-        <div id="disable1"></div>
-        <div id="disable2"></div>
+        <form id="disable1"><input id="disable1_element"></form>
+        <div id="disable2"><form><input id="disable2_element"></form></div>
         <form data-controller="bulk-form" data-bulk-form-disable-selector-value="#disable1,#disable2">
           <div id="actions" data-bulk-form-target="actions" class="hidden"></div>
           <div id="changed_summary" data-bulk-form-target="changedSummary" data-translation-key="changed_summary"></div>
@@ -45,7 +45,9 @@ describe("BulkFormController", () => {
       `;
 
       const disable1 = document.getElementById("disable1");
+      const disable1_element = document.getElementById("disable1_element");
       const disable2 = document.getElementById("disable2");
+      const disable2_element = document.getElementById("disable2_element");
       const actions = document.getElementById("actions");
       const changed_summary = document.getElementById("changed_summary");
       const input1a = document.getElementById("input1a");
@@ -112,7 +114,9 @@ describe("BulkFormController", () => {
         expect(actions.classList).not.toContain('hidden');
         expect(changed_summary.textContent).toBe('changed_summary, {"count":1}');
         expect(disable1.classList).toContain('disabled-section');
+        expect(disable1_element.disabled).toBe(true);
         expect(disable2.classList).toContain('disabled-section');
+        expect(disable2_element.disabled).toBe(true);
 
         // Record 1: Second field changed
         input1b.value = 'updated1b';
@@ -145,7 +149,9 @@ describe("BulkFormController", () => {
         expect(actions.classList).not.toContain('hidden');
         expect(changed_summary.textContent).toBe('changed_summary, {"count":1}');
         expect(disable1.classList).toContain('disabled-section');
+        expect(disable1_element.disabled).toBe(true);
         expect(disable2.classList).toContain('disabled-section');
+        expect(disable2_element.disabled).toBe(true);
 
         // Record 2: Change back to original value
         input2.value = 'initial2';
@@ -154,7 +160,9 @@ describe("BulkFormController", () => {
         expect(actions.classList).toContain('hidden');
         expect(changed_summary.textContent).toBe('changed_summary, {"count":0}');
         expect(disable1.classList).not.toContain('disabled-section');
+        expect(disable1_element.disabled).toBe(false);
         expect(disable2.classList).not.toContain('disabled-section');
+        expect(disable2_element.disabled).toBe(false);
       });
     });
   });

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -11,42 +11,39 @@ describe("BulkFormController", () => {
     application.register("bulk-form", bulk_form_controller);
   });
 
-  // Mock I18n. TODO: moved to a shared helper
-  beforeAll(() => {
-    const mockedT = jest.fn();
-    mockedT.mockImplementation((string, opts) => (string + ', ' + JSON.stringify(opts)));
-
-    global.I18n =  {
-      t: mockedT
-    };
-  })
-
-  // (jest still doesn't have aroundEach https://github.com/jestjs/jest/issues/4543 )
-  afterAll(() => {
-    delete global.I18n;
-  })
-
-  beforeEach(() => {
-    document.body.innerHTML = `
-      <div id="disable1"></div>
-      <div id="disable2"></div>
-      <form data-controller="bulk-form" data-bulk-form-disable-selector-value="#disable1,#disable2">
-        <div id="actions" data-bulk-form-target="actions" class="hidden"></div>
-        <div id="changed_summary" data-bulk-form-target="changedSummary" data-translation-key="changed_summary"></div>
-        <div data-record-id="1">
-          <input id="input1a" type="text" value="initial1a">
-          <input id="input1b" type="text" value="initial1b">
-        </div>
-        <div data-record-id="2">
-          <input id="input2" type="text" value="initial2">
-        </div>
-        <input type="submit">
-      </form>
-    `;
-  });
-
   describe("Modifying input values", () => {
+    // Mock I18n. TODO: moved to a shared helper
+    beforeAll(() => {
+      const mockedT = jest.fn();
+      mockedT.mockImplementation((string, opts) => (string + ', ' + JSON.stringify(opts)));
+
+      global.I18n =  {
+        t: mockedT
+      };
+    })
+    // (jest still doesn't have aroundEach https://github.com/jestjs/jest/issues/4543 )
+    afterAll(() => {
+      delete global.I18n;
+    })
+
     beforeEach(() => {
+      document.body.innerHTML = `
+        <div id="disable1"></div>
+        <div id="disable2"></div>
+        <form data-controller="bulk-form" data-bulk-form-disable-selector-value="#disable1,#disable2">
+          <div id="actions" data-bulk-form-target="actions" class="hidden"></div>
+          <div id="changed_summary" data-bulk-form-target="changedSummary" data-translation-key="changed_summary"></div>
+          <div data-record-id="1">
+            <input id="input1a" type="text" value="initial1a">
+            <input id="input1b" type="text" value="initial1b">
+          </div>
+          <div data-record-id="2">
+            <input id="input2" type="text" value="initial2">
+          </div>
+          <input type="submit">
+        </form>
+      `;
+
       const disable1 = document.getElementById("disable1");
       const disable2 = document.getElementById("disable2");
       const actions = document.getElementById("actions");
@@ -159,6 +156,43 @@ describe("BulkFormController", () => {
         expect(disable1.classList).not.toContain('disabled-section');
         expect(disable2.classList).not.toContain('disabled-section');
       });
+    });
+  });
+
+  describe("When there are errors", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <form data-controller="bulk-form" data-bulk-form-error-value="true">
+          <div id="actions" data-bulk-form-target="actions">
+            An error occurred.
+            <input type="submit">
+          </div>
+          <div data-record-id="1">
+            <input id="input1a" type="text" value="initial1a">
+          </div>
+        </form>
+      `;
+
+      const actions = document.getElementById("actions");
+      const changed_summary = document.getElementById("changed_summary");
+      const input1a = document.getElementById("input1a");
+    });
+
+    it("form actions section remains visible", () => {
+      // Expect actions to remain visible
+      expect(actions.classList).not.toContain('hidden');
+
+      // Record 1: First field changed
+      input1a.value = 'updated1a';
+      input1a.dispatchEvent(new Event("change"));
+      // Expect actions to remain visible
+      expect(actions.classList).not.toContain('hidden');
+
+      // Change back to original value
+      input1a.value = 'initial1a';
+      input1a.dispatchEvent(new Event("change"));
+      // Expect actions to remain visible
+      expect(actions.classList).not.toContain('hidden');
     });
   });
 

--- a/spec/reflexes/products_reflex_spec.rb
+++ b/spec/reflexes/products_reflex_spec.rb
@@ -13,7 +13,7 @@ describe ProductsReflex, type: :reflex do
     Flipper.enable(:admin_style_v3)
   end
 
-  describe 'fetch' do
+  describe '#fetch' do
     subject{ build_reflex(method_name: :fetch, **context) }
 
     describe "sorting" do
@@ -41,6 +41,7 @@ describe ProductsReflex, type: :reflex do
              sku: "APL-01",
              price: 5.25)
     }
+    let!(:product_c) { create(:simple_product, name: "Carrots", sku: "CAR-00") }
     let!(:product_b) { create(:simple_product, name: "Bananas", sku: "BAN-00") }
     let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
 
@@ -123,17 +124,21 @@ describe ProductsReflex, type: :reflex do
           "products" => [
             {
               "id" => product_a.id.to_s,
-              "name" => "",
+              "name" => "Pommes",
             },
             {
               "id" => product_b.id.to_s,
-              "name" => "",
+              "name" => "", # Name can't be blank
+            },
+            {
+              "id" => product_c.id.to_s,
+              "name" => "", # Name can't be blank
             },
           ]
         }
 
         reflex = run_reflex(:bulk_update, params:)
-        expect(reflex.get(:error_msg)).to include "2 products have errors"
+        expect(reflex.get(:error_counts)).to eq({ saved: 1, invalid: 2 })
 
         # # WTF
         # expect{ reflex(:bulk_update, params:) }.to broadcast(

--- a/spec/services/sets/product_set_spec.rb
+++ b/spec/services/sets/product_set_spec.rb
@@ -154,6 +154,8 @@ describe Sets::ProductSet do
             product_set.save
             product.reload
           }.to_not change { product.sku }
+
+          expect(product_set.invalid.count).to be_positive
         end
 
         it "doesn't update variant" do
@@ -171,7 +173,7 @@ describe Sets::ProductSet do
         end
       end
 
-      xcontext "variant has error" do
+      context "variant has error" do
         let(:variant_attributes) { { sku: "var_sku", display_name: "A" * 256 } } # maximum length
 
         include_examples "nothing saved"

--- a/spec/services/sets/product_set_spec.rb
+++ b/spec/services/sets/product_set_spec.rb
@@ -139,9 +139,11 @@ describe Sets::ProductSet do
         before { collection_hash[0][:variants_attributes] = variants_attributes }
 
         it 'updates the attributes of the variant' do
-          product_set.save
+          expect {
+            expect(product_set.save).to eq true
+          }.to change { product.variants.first.sku }.to("123")
 
-          expect(product.reload.variants.first[:sku]).to eq variants_attributes.first[:sku]
+          expect(product_set.invalid.count).to eq 0
         end
 
         context 'and when product attributes are also passed' do

--- a/spec/services/sets/product_set_spec.rb
+++ b/spec/services/sets/product_set_spec.rb
@@ -7,6 +7,7 @@ describe Sets::ProductSet do
     let(:product_set) do
       described_class.new(collection_attributes: collection_hash)
     end
+    subject{ product_set.save }
 
     context 'when the product does not exist yet' do
       let!(:stock_location) { create(:stock_location, backorderable_default: false) }
@@ -33,6 +34,24 @@ describe Sets::ProductSet do
     end
 
     context 'when the product does exist' do
+      let(:product) { create(:simple_product, name: "product name") }
+
+      context "with valid name" do
+        let(:collection_hash) {
+          { 0 => { id: product.id, name: "New season product" } }
+        }
+
+        it { is_expected.to eq true }
+      end
+
+      context "with invalid name" do
+        let(:collection_hash) {
+          { 0 => { id: product.id, name: "" } } # Product Name can't be blank
+        }
+
+        it { is_expected.to eq false }
+      end
+
       context 'when a different variant_unit is passed' do
         let!(:product) do
           create(
@@ -68,7 +87,6 @@ describe Sets::ProductSet do
 
       context "when the product is in an order cycle" do
         let(:producer) { create(:enterprise) }
-        let(:product) { create(:simple_product) }
 
         let(:distributor) { create(:distributor_enterprise) }
         let!(:order_cycle) {

--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -307,7 +307,7 @@ describe '
 
         click_button 'Save Changes', match: :first
         expect(page.find("#status-message"))
-          .to have_content "Unit value can't be blank Unit value is not a number"
+          .to have_content "Variant unit value can't be blank Variant unit value is not a number"
       end
 
       it "creating a variant with unit value is: '120g' and 'on_demand' checked" do
@@ -323,7 +323,7 @@ describe '
 
         click_button 'Save Changes', match: :first
         expect(page.find("#status-message"))
-          .to have_content "Unit value can't be blank Unit value is not a number"
+          .to have_content "Variant unit value can't be blank Variant unit value is not a number"
       end
     end
   end

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -270,37 +270,54 @@ describe 'As an admin, I can see the new product page' do
       end
     end
 
-    it "shows errors for both product and variant fields" do
-      within row_containing_name("Apples") do
-        fill_in "Name", with: ""
-        fill_in "SKU", with: "A" * 256
-      end
-      within row_containing_name("Medium box") do
-        fill_in "Name", with: "L" * 256
-        fill_in "SKU", with: "1" * 256
+    context "with invalid data" do
+      let!(:product_b) { create(:simple_product, name: "Bananas") }
+
+      before do
+        within row_containing_name("Apples") do
+          fill_in "Name", with: ""
+          fill_in "SKU", with: "A" * 256
+        end
+        within row_containing_name("Medium box") do
+          fill_in "Name", with: "L" * 256
+          fill_in "SKU", with: "1" * 256
+          fill_in "Price", with: "10.25"
+        end
       end
 
-      expect {
-        click_button "Save changes"
-        product_a.reload
-      }.to_not change { product_a.name }
+      it "shows errors for both product and variant fields" do
+        # Also update another product with valid data
+        within row_containing_name("Bananas") do
+          fill_in "Name", with: "Bananes"
+        end
 
-      # (there's no identifier displayed, so the user must remember which product it is..)
-      within row_containing_name("") do
-        expect(page).to have_field "Name", with: ""
-        expect(page).to have_content "can't be blank"
-        expect(page).to have_field "SKU", with: "A" * 256
-        expect(page).to have_content "is too long"
-      end
-      pending
-      within row_containing_name("L" * 256) do
-        expect(page).to have_field "Name", with: "L" * 256
-        expect(page).to have_field "SKU", with: "1" * 256
-        expect(page).to have_content "is too long"
-        expect(page).to have_field "Price", with: "10.25"
-      end
+        expect {
+          click_button "Save changes"
+          product_a.reload
+        }.to_not change { product_a.name }
 
-      expect(page).to have_content "Please review the errors and try again"
+        # pending("unchanged rows are being saved") # TODO: don't report unchanged rows
+        # expect(page).to_not have_content("rows were saved correctly")
+        # Both the product and variant couldn't be saved.
+        expect(page).to have_content("1 product could not be saved")
+        expect(page).to have_content "Please review the errors and try again"
+
+        # (there's no identifier displayed, so the user must remember which product it is..)
+        within row_containing_name("") do
+          expect(page).to have_field "Name", with: ""
+          expect(page).to have_content "can't be blank"
+          expect(page).to have_field "SKU", with: "A" * 256
+          expect(page).to have_content "is too long"
+        end
+
+        pending "bug #11748"
+        within row_containing_name("L" * 256) do
+          expect(page).to have_field "Name", with: "L" * 256
+          expect(page).to have_field "SKU", with: "1" * 256
+          expect(page).to have_content "is too long"
+          expect(page).to have_field "Price", with: "10.25" # other updated value is retained
+        end
+      end
     end
   end
 

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -203,7 +203,6 @@ describe 'As an admin, I can see the new product page' do
              price: 5.25)
     }
     let!(:product_a) { create(:simple_product, name: "Apples", sku: "APL-00") }
-
     before do
       visit admin_products_url
     end
@@ -317,6 +316,23 @@ describe 'As an admin, I can see the new product page' do
           expect(page).to have_content "is too long"
           expect(page).to have_field "Price", with: "10.25" # other updated value is retained
         end
+      end
+
+      it "saves changes after fixing errors" do
+        within row_containing_name("Apples") do
+          fill_in "Name", with: "Pommes"
+          fill_in "SKU", with: "POM-00"
+        end
+
+        expect {
+          click_button "Save changes"
+          product_a.reload
+          variant_a1.reload
+        }.to change { product_a.name }.to("Pommes")
+          .and change{ product_a.sku }.to("POM-00")
+
+        pending
+        expect(page).to have_content "Changes saved"
       end
     end
   end


### PR DESCRIPTION
### What? Why?

- I think this finally closes #11059 ??! (noting that some parts are moved to other issues)

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

**Presenting an error summary** at the top of the form when performing a bulk update. And lots of necessary refactors.

This makes a small change to the backend of the _current_ bulk edit products screen, but doesn't change any behaviour, so I think doesn't need manual testing.

### What should we test? [admin_style_v3]
Changes listed below (Unchecked parts are not fully implemented).

**1. When product has two fields updated:**   
  - [x] one has error and other is valid. Neither are saved until error is corrected. (empty name, and changed unit)
    ![Screen Shot 2023-11-02 at 4 31 16 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/62038a52-8766-4325-9b4c-fa6df1172ed5)

**2. When product and associated variant are updated, but there are errors:**  
    Neither should be saved, summary should show, and unsaved values retained with red/orange border.
    But these fail due to [#11748](https://github.com/openfoodfoundation/openfoodnetwork/issues/11748)
  - [ ] product has error, variant has error. 🆇 Variant values are lost
  - [ ] product has error, variant is valid. 🆇 Variant values are lost
  - [ ] product is valid, variant has error. 🆇 Product got saved
    ![Screen Shot 2023-11-02 at 4 30 21 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/1efd6568-620b-4a1c-920d-e843b4d9cd80)


**3. When multiple products are updated**
  - [x] product 1 has error, product 2 has error
    ![Screen Shot 2023-11-02 at 4 26 00 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/3185164c-ebff-4c16-8d9f-22d332577362)
  - [x] product 1 has error, product 2 is valid
    ![Screen Shot 2023-11-02 at 4 26 27 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/a3b4fbfe-561b-4f94-a2e0-b82498ae234e)
  - [x] product 1 is valid, product 2 has error
    ![Screen Shot 2023-11-02 at 4 27 04 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/f2fa33cb-19c6-4a1f-a732-f50331e5d9e2)



### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

