### PR TITLE
Don't update order when not enough stock when editing as admin

### DIFF
--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -51,10 +51,10 @@ $(document).ready(function() {
         quantity = maxQuantity;
         save.parents('tr').find('input.line_item_quantity').val(maxQuantity);
         ofnAlert(t("js.admin.orders.quantity_adjusted"));
+      } else {
+        adjustItems(shipment_number, variant_id, quantity, true);
       }
-      toggleItemEdit();
 
-      adjustItems(shipment_number, variant_id, quantity, true);
       return false;
     }
     $('a.save-item').click(handle_save_click);

--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -50,7 +50,7 @@ $(document).ready(function() {
       if (quantity > maxQuantity) {
         quantity = maxQuantity;
         save.parents('tr').find('input.line_item_quantity').val(maxQuantity);
-        ofnAlert(t("js.admin.orders.quantity_adjusted"));
+        ofnAlert(t("js.admin.orders.quantity_unavailable"));
       } else {
         adjustItems(shipment_number, variant_id, quantity, true);
       }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3440,7 +3440,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           processing: "processing"
           void: "void"
           invalid: "invalid"
-        quantity_adjusted: "Insufficient stock available. Line item updated to maximum available quantity."
+        quantity_unavailable: "Insufficient stock available. Line item unsaved!"
         quantity_unchanged: "Quantity unchanged from previous amount."
         cancel_the_order_html: "This will cancel the current order.<br />Are you sure you want to proceed?"
         cancel_the_order_send_cancelation_email: "Send a cancellation email to the customer"

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -350,7 +350,17 @@ describe '
       fill_in(:quantity, with: max_quantity + 1)
       find("a.save-item").click
     end
-    click_button("OK")
+
+    pending "Reload bug"
+    # The following modal is displayed but disappears straight away because the
+    # page is reloaded after the click on the save button. Somehow this happens
+    # only the first time the page is loaded and after that this logic seems to
+    # work fine.
+    sleep 1
+    within(".modal") do
+      expect(page).to have_content "Quantity unchanged from previous amount"
+      click_on "OK"
+    end
 
     expect(page).to_not have_content "Loading..."
     within("tr.stock-item", text: order.products.first.name) do

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -339,34 +339,27 @@ describe '
     login_as_admin
     visit spree.edit_admin_order_path(order)
 
-    quantity = order.line_items.first.quantity
-    max_quantity = 0
+    item = order.line_items.first
+    quantity = item.quantity
+    max_quantity = quantity + item.variant.on_hand
     total = order.display_total
 
     within("tr.stock-item", text: order.products.first.name) do
       find("a.edit-item").click
       expect(page).to have_input(:quantity)
-      max_quantity = find("input[name='quantity']")["max"].to_i
       fill_in(:quantity, with: max_quantity + 1)
       find("a.save-item").click
     end
 
-    pending "Reload bug"
-    # The following modal is displayed but disappears straight away because the
-    # page is reloaded after the click on the save button. Somehow this happens
-    # only the first time the page is loaded and after that this logic seems to
-    # work fine.
-    sleep 1
     within(".modal") do
-      expect(page).to have_content "Quantity unchanged from previous amount"
+      expect(page).to have_content "Insufficient stock available"
       click_on "OK"
     end
 
-    expect(page).to_not have_content "Loading..."
     within("tr.stock-item", text: order.products.first.name) do
-      expect(page).to have_text(max_quantity.to_s)
+      expect(page).to have_field :quantity, with: max_quantity.to_s
     end
-    expect(order.reload.line_items.first.quantity).to eq(max_quantity)
+    expect { item.reload }.to_not change { item.quantity }
   end
 
   it "there are infinite items available (variant is on demand)" do


### PR DESCRIPTION
#### What? Why?

- Closes #9971 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit /admin/orders.
- Select a complete order with items.
- Make sure that some items have limited stock.
- Edit such an item on the order.
- The browser buttons (increase number) shouldn't allow you to exceed the stock level. (previous behaviour)
- You can type a higher quantity with your keyboard.
- Try to save the item.
- You should see a warning message. Click OK.
- You can edit further, save or cancel.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
