### PR TITLE
[DFC API] add image to product

### DIFF
--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -14,6 +14,7 @@ class SuppliedProductBuilder < DfcBuilder
       productType: product_type,
       quantity: QuantitativeValueBuilder.quantity(variant),
       spree_product_id: variant.product.id,
+      image_url: variant.product&.image&.url(:product)
     )
   end
 

--- a/engines/dfc_provider/lib/dfc_provider/supplied_product.rb
+++ b/engines/dfc_provider/lib/dfc_provider/supplied_product.rb
@@ -3,14 +3,20 @@
 module DfcProvider
   class SuppliedProduct < DataFoodConsortium::Connector::SuppliedProduct
     attr_accessor :spree_product_id
+    attr_accessor :image
 
-    def initialize(semantic_id, spree_product_id: nil, **properties)
+    def initialize(semantic_id, spree_product_id: nil, image_url: nil, **properties)
       super(semantic_id, **properties)
 
       self.spree_product_id = spree_product_id
+      self.image = image_url
 
       registerSemanticProperty("ofn:spree_product_id") do
         self.spree_product_id
+      end
+      # Temporary solution, will be replaced by "dfc_b:image" in future version of the DFC connector
+      registerSemanticProperty("ofn:image") do
+        self.image
       end
     end
   end

--- a/engines/dfc_provider/lib/dfc_provider/supplied_product.rb
+++ b/engines/dfc_provider/lib/dfc_provider/supplied_product.rb
@@ -2,8 +2,7 @@
 
 module DfcProvider
   class SuppliedProduct < DataFoodConsortium::Connector::SuppliedProduct
-    attr_accessor :spree_product_id
-    attr_accessor :image
+    attr_accessor :spree_product_id, :image
 
     def initialize(semantic_id, spree_product_id: nil, image_url: nil, **properties)
       super(semantic_id, **properties)
@@ -16,7 +15,7 @@ module DfcProvider
       end
       # Temporary solution, will be replaced by "dfc_b:image" in future version of the DFC connector
       registerSemanticProperty("ofn:image") do
-        self.image
+        image
       end
     end
   end

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -21,7 +21,7 @@ describe "Enterprises", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: 
   end
   let!(:product) {
     create(
-      :base_product,
+      :product_with_image,
       id: 90_000, supplier: enterprise, name: "Apple", description: "Round",
       variants: [variant],
     )

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -59,6 +59,12 @@ describe "Enterprises", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: 
             expect(json_response["@graph"][0]).to include(
               "dfc-b:affiliates" => "http://test.host/api/dfc/enterprise_groups/60000",
             )
+
+            # Insert static value to keep documentation deterministic:
+            response.body.gsub!(
+              %r{active_storage/[0-9A-Za-z/=-]*/logo-white.png},
+              "active_storage/url/logo-white.png",
+            )
           end
         end
       end

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -2,13 +2,12 @@
 
 require_relative "../swagger_helper"
 
-describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml",
-                             rswag_autodoc: true do
+describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: true do
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) { create(:distributor_enterprise, id: 10_000, owner: user) }
   let!(:product) {
     create(
-      :base_product,
+      :product_with_image,
       id: 90_000,
       supplier: enterprise, name: "Pesto", description: "Basil Pesto",
       variants: [variant],
@@ -146,6 +145,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml",
         run_test! do
           expect(response.body).to include variant.name
           expect(json_response["ofn:spree_product_id"]).to eq 90_000
+          expect(json_response["ofn:image"]).to include("logo-white.png")
         end
       end
 

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -117,6 +117,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
           expect(second_variant.unit_value).to eq 6
 
           # Insert static value to keep documentation deterministic:
+          supplied_product[:'ofn:spree_product_id'] = 90_000
           response.body.gsub!(
             "supplied_products/#{variant_id}",
             "supplied_products/10001"
@@ -146,6 +147,12 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
           expect(response.body).to include variant.name
           expect(json_response["ofn:spree_product_id"]).to eq 90_000
           expect(json_response["ofn:image"]).to include("logo-white.png")
+
+          # Insert static value to keep documentation deterministic:
+          response.body.gsub!(
+            %r{active_storage/[0-9A-Za-z/=-]*/logo-white.png},
+            "active_storage/url/logo-white.png",
+          )
         end
       end
 

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -49,7 +49,7 @@ describe SuppliedProductBuilder do
     end
 
     it "assigns an image_url type" do
-      image = Spree::Image.create!(
+      Spree::Image.create!(
         attachment: white_logo_file,
         viewable_id: variant.product.id,
         viewable_type: 'Spree::Product'

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -3,6 +3,8 @@
 require_relative "../spec_helper"
 
 describe SuppliedProductBuilder do
+  include FileHelper
+
   subject(:builder) { described_class }
   let(:variant) {
     build(:variant, id: 5).tap { |v| v.product.supplier_id = 7 }
@@ -44,6 +46,17 @@ describe SuppliedProductBuilder do
       vegetable = DfcLoader.connector.PRODUCT_TYPES.VEGETABLE.NON_LOCAL_VEGETABLE
 
       expect(product.productType).to eq vegetable
+    end
+
+    it "assigns an image_url type" do
+      image = Spree::Image.create!(
+        attachment: white_logo_file,
+        viewable_id: variant.product.id,
+        viewable_type: 'Spree::Product'
+      )
+      product = builder.supplied_product(variant)
+
+      expect(product.image).to eq variant.product.image.url(:product)
     end
   end
 end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -343,7 +343,7 @@ paths:
                       dfc-b:usageOrStorageCondition: ''
                       dfc-b:totalTheoreticalStock: 0.0
                       ofn:spree_product_id: 90000
-                      ofn:image: http://test.host/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZzBCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--cec5b9e04720cada9134f6757e3dd8156aeccbf0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2RkhKbGMybDZaVjkwYjE5c2FXMXBkRnNIYVFId2FRSHciLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--a8632e6a563a139dfae774530b275266f6aef5f5/logo-white.png
+                      ofn:image: http://test.host/rails/active_storage/url/logo-white.png
                     - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       "@type": dfc-b:CatalogItem
                       dfc-b:references: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
@@ -437,7 +437,7 @@ paths:
                 dfc-b:lifetime: ''
                 dfc-b:usageOrStorageCondition: ''
                 dfc-b:totalTheoreticalStock: 0.0
-                ofn:spree_product_id: 33774
+                ofn:spree_product_id: 90000
   "/api/dfc/enterprises/{enterprise_id}/supplied_products/{id}":
     parameters:
     - name: enterprise_id
@@ -477,7 +477,7 @@ paths:
                     dfc-b:usageOrStorageCondition: ''
                     dfc-b:totalTheoreticalStock: 0.0
                     ofn:spree_product_id: 90000
-                    ofn:image: http://test.host/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBaElCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f578e58da95a3e1f6a4774dfeef31ac7cb039f0f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2RkhKbGMybDZaVjkwYjE5c2FXMXBkRnNIYVFId2FRSHciLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--a8632e6a563a139dfae774530b275266f6aef5f5/logo-white.png
+                    ofn:image: http://test.host/rails/active_storage/url/logo-white.png
         '404':
           description: not found
     put:

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -343,11 +343,12 @@ paths:
                       dfc-b:usageOrStorageCondition: ''
                       dfc-b:totalTheoreticalStock: 0.0
                       ofn:spree_product_id: 90000
+                      ofn:image: http://test.host/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZzBCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--cec5b9e04720cada9134f6757e3dd8156aeccbf0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2RkhKbGMybDZaVjkwYjE5c2FXMXBkRnNIYVFId2FRSHciLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--a8632e6a563a139dfae774530b275266f6aef5f5/logo-white.png
                     - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       "@type": dfc-b:CatalogItem
                       dfc-b:references: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
                       dfc-b:sku: APP
-                      dfc-b:stockLimitation: 0
+                      dfc-b:stockLimitation: 5
                       dfc-b:offeredThrough: http://test.host/api/dfc/enterprises/10000/offers/10001
         '404':
           description: not found
@@ -406,7 +407,7 @@ paths:
                     dfc-b:hasQuantity:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
-                      dfc-b:value: 3.0
+                      dfc-b:value: 6.0
                     dfc-b:alcoholPercentage: 0.0
                     dfc-b:lifetime: ''
                     dfc-b:usageOrStorageCondition: ''
@@ -431,11 +432,12 @@ paths:
                 dfc-b:hasQuantity:
                   "@type": dfc-b:QuantitativeValue
                   dfc-b:hasUnit: dfc-m:Gram
-                  dfc-b:value: 3.0
+                  dfc-b:value: 6
                 dfc-b:alcoholPercentage: 0.0
                 dfc-b:lifetime: ''
                 dfc-b:usageOrStorageCondition: ''
                 dfc-b:totalTheoreticalStock: 0.0
+                ofn:spree_product_id: 33774
   "/api/dfc/enterprises/{enterprise_id}/supplied_products/{id}":
     parameters:
     - name: enterprise_id
@@ -475,6 +477,7 @@ paths:
                     dfc-b:usageOrStorageCondition: ''
                     dfc-b:totalTheoreticalStock: 0.0
                     ofn:spree_product_id: 90000
+                    ofn:image: http://test.host/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBaElCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f578e58da95a3e1f6a4774dfeef31ac7cb039f0f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2RkhKbGMybDZaVjkwYjE5c2FXMXBkRnNIYVFId2FRSHciLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--a8632e6a563a139dfae774530b275266f6aef5f5/logo-white.png
         '404':
           description: not found
     put:


### PR DESCRIPTION
ℹ️ This is a funded feature :
* **All Global work to be tracked in Clockify `11242 Discovery Endpoints` - including testing, code review etc**
* **Aus devs to track in `11242 Task within Macdoch Regen Discovery`**

#### What? Why?

- Closes #11712  <!-- Insert issue number here. -->

As explained on the issue, we don't think DFC can make image available on supplied product in a timely manner. So we work around that by adding a ofn specific identifier "ofn:image". It will eventually be replace by "dfc_b:image" in the DFC connector.
This is read only, we don't support adding a product with an image


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- specs only
 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
