### PR TITLE
[BUU] Grey out disabled button

### DIFF
--- a/app/webpacker/css/admin_v3/components/buttons.scss
+++ b/app/webpacker/css/admin_v3/components/buttons.scss
@@ -1,3 +1,13 @@
+@mixin disabled-button() {
+  &:disabled,
+  &:disabled:hover {
+    cursor: initial;
+    color: $color-btn-disabled-text;
+    background-color: $color-btn-disabled-bg;
+    border-color: transparent;
+  }
+}
+
 input[type="submit"],
 input[type="reset"],
 input[type="button"]:not(.trix-button),
@@ -15,6 +25,7 @@ button:not(.plain):not(.trix-button),
   line-height: $btn-regular-height - 2px; // remove 2px to compensate for border
   height: $btn-regular-height;
   font-weight: bold;
+  @include disabled-button();
 
   &:before {
     font-weight: normal !important;
@@ -100,6 +111,7 @@ button:not(.plain):not(.trix-button),
   &.red {
     background-color: $color-btn-red-bg;
     border-color: $color-btn-red-bg;
+    @include disabled-button(); // required for specifity
 
     &:hover {
       background-color: $color-btn-red-hover-bg;

--- a/app/webpacker/css/admin_v3/globals/variables.scss
+++ b/app/webpacker/css/admin_v3/globals/variables.scss
@@ -44,7 +44,8 @@ $color-btn-shadow:               0px 1px 0px rgba(0, 0, 0, 0.05), 0px 2px 2px rg
 $color-btn-hover-bg:             $orient !default;
 $color-btn-hover-text:           $white !default;
 $color-btn-hover-border:         $dark-blue !default;
-$color-btn-disabled-bg:          $light-grey !default;
+$color-btn-disabled-bg:          $medium-grey !default;
+$color-btn-disabled-text:        $lighter-grey !default;
 $color-btn-red-bg:               $red !default;
 $color-btn-red-hover-bg:         $roof-terracotta !default;
 


### PR DESCRIPTION
#### What? Why?

- https://openfoodnetwork.slack.com/archives/C01CXQNJ1J6/p1698189065550479

Under the `admin_style_v3` feature toggle, the disabled button didn't look disabled. Now it does.

![Screen Shot 2023-11-03 at 5 30 00 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/39483a0b-edc0-43ed-9307-1b21f6239ef4)
![Screen Shot 2023-11-03 at 5 30 19 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/805a4f2e-5d1d-408b-812d-773e1d5f35dc)

#### What should we test?
I don't think it's necessary to test for BUU. For reference:

- Visit /admin/enterprises and choose an enterprise to edit
- Observe disabled button

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
