### PR TITLE
Fix hidden input showing on Producer registration

### DIFF
--- a/app/views/registration/steps/_type.html.haml
+++ b/app/views/registration/steps/_type.html.haml
@@ -26,7 +26,7 @@
 
           .row
             .small-12.columns
-              %input.chunky{ id: 'enterprise_is_primary_producer', name: 'is_primary_producer', hidden: true, required: true, ng: { model: 'enterprise.is_primary_producer' } }
+              %input.chunky{ id: 'enterprise_is_primary_producer', name: 'is_primary_producer', type: "hidden", required: true, ng: { model: 'enterprise.is_primary_producer' } }
               %span.error{ ng: { show: "type.is_primary_producer.$error.required && submitted" } }
                 = t(".producer_field_error")
           .row


### PR DESCRIPTION
CSS defined in `node_modules/foundation-sites/scss/foundation/components/_forms.scss` breaks the use of `hidden` on a `<input>` tag with no specified `type`


#### What? Why?

- Closes #11775 

Set the input type to hidden so it's actually hidden


#### What should we test?
See step to reproduce in #11775

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
