### PR TITLE
Fixes pending tests cases on invoices spec

### DIFF
--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -111,17 +111,10 @@ shared_examples "associated attribute changes - adjustments (create/delete)" do 
   end
 end
 
-shared_examples "associated attribute changes - adjustments (edit)" do |boolean, type|
+shared_examples "associated attribute changes - adjustments (edit amount)" do |boolean, type|
   context "with an existing adjustments" do
     context "editing the amount" do
-      before { Spree::Adjustment.first.update!(amount: 123) }
-      it "returns #{boolean} if a #{type} attribute changes" do
-        expect(subject).to be boolean
-      end
-    end
-
-    context "changing the adjustment type" do
-      before { Spree::Adjustment.first.update!(adjustable_type: "Spree::Shipment") }
+      before { order.all_adjustments.first.update!(amount: 123) }
       it "returns #{boolean} if a #{type} attribute changes" do
         expect(subject).to be boolean
       end
@@ -129,12 +122,11 @@ shared_examples "associated attribute changes - adjustments (edit)" do |boolean,
   end
 end
 
-shared_examples "associated attribute changes - adjustments (update)" do |boolean, type|
+shared_examples "associated attribute changes - adjustments (edit label)" do |boolean, type|
   context "adjustment changes" do
-    context "with an existing adjustment" do
-      before { Spree::Adjustment.first.update!(label: "It's a new label") }
+    context "editing the label" do
+      before { order.all_adjustments.first.update!(label: "It's a new label") }
       it "returns #{boolean} if a #{type} attribute changes" do
-        order.reload
         expect(subject).to be boolean
       end
     end
@@ -331,6 +323,8 @@ describe OrderInvoiceComparator do
         # creating and deleting adjustments is relevant both for generate and update comparator
         it_behaves_like "associated attribute changes - adjustments (create/delete)",
                         true, "relevant"
+        it_behaves_like "associated attribute changes - adjustments (edit amount)", true,
+                        "relevant"
         it_behaves_like "associated attribute changes - bill address", true, "relevant"
         it_behaves_like "associated attribute changes - ship address", true, "relevant"
         it_behaves_like "associated attribute changes - line items", true, "relevant"
@@ -346,7 +340,7 @@ describe OrderInvoiceComparator do
         it_behaves_like "no attribute changes"
         it_behaves_like "attribute changes - special insctructions", false, "non-relevant"
         it_behaves_like "attribute changes - note", false, "non-relevant"
-        it_behaves_like "associated attribute changes - adjustments (update)", false,
+        it_behaves_like "associated attribute changes - adjustments (edit label)", false,
                         "non-relevant"
         it_behaves_like "attribute changes - payment state", false, "non-relevant"
       end
@@ -369,7 +363,8 @@ describe OrderInvoiceComparator do
         it_behaves_like "attribute changes - order state: cancelled", true, "relevant"
         it_behaves_like "attribute changes - special insctructions", true, "relevant"
         it_behaves_like "attribute changes - note", true, "relevant"
-        it_behaves_like "associated attribute changes - adjustments (update)", true, "relevant"
+        it_behaves_like "associated attribute changes - adjustments (edit label)", true, "relevant"
+
         it_behaves_like "attribute changes - payment state", true, "relevant"
         # creating and deleting adjustments is relevant both for generate and update comparator
         it_behaves_like "associated attribute changes - adjustments (create/delete)", true,
@@ -387,8 +382,10 @@ describe OrderInvoiceComparator do
         it_behaves_like "associated attribute changes - ship address", false, "non-relevant"
         it_behaves_like "associated attribute changes - payments", false,
                         "non-relevant" do
-          before { pending }
+          before { pending("also related to issue #11350") }
         end
+        it_behaves_like "associated attribute changes - adjustments (edit amount)", false,
+                        "non-relevant"
       end
     end
   end

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -96,25 +96,23 @@ shared_examples "attribute changes - note" do |boolean, type|
 end
 
 shared_examples "associated attribute changes - adjustments (create)" do |boolean, type|
-  before { order.adjustments << create(:adjustment, order:) }
   context "creating an adjustment" do
+    before { order.adjustments << create(:adjustment, order:) }
     it "returns #{boolean} if a #{type} attribute changes" do
       expect(subject).to be boolean
     end
   end
 
-  context "with an existing adjustment" do
-    before { order.adjustments << create(:adjustment, order:) }
-
+  context "with an existing adjustments" do
     context "editing the amount" do
-      before { order.adjustments.first.update!(amount: 123) }
+      before { Spree::Adjustment.first.update!(amount: 123) }
       it "returns #{boolean} if a #{type} attribute changes" do
         expect(subject).to be boolean
       end
     end
 
     context "changing the adjustment type" do
-      before { order.adjustments.first.update!(adjustable_type: "Spree::Payment") }
+      before { Spree::Adjustment.first.update!(adjustable_type: "Spree::Shipment") }
       it "returns #{boolean} if a #{type} attribute changes" do
         expect(subject).to be boolean
       end
@@ -123,7 +121,6 @@ shared_examples "associated attribute changes - adjustments (create)" do |boolea
     context "deleting an adjustment" do
       before { order.all_adjustments.destroy_all }
       it "returns #{boolean} if a #{type} attribute changes" do
-        order.reload
         expect(subject).to be boolean
       end
     end
@@ -379,14 +376,12 @@ describe OrderInvoiceComparator do
         it_behaves_like "attribute changes - shipping method", false, "non-relevant"
         it_behaves_like "no attribute changes"
         it_behaves_like "associated attribute changes - adjustments (create)", false,
-                        "non-relevant" do
-          before { pending }
-        end
+                        "non-relevant"
         it_behaves_like "associated attribute changes - line items", false, "non-relevant"
         it_behaves_like "associated attribute changes - bill address", false, "non-relevant"
         it_behaves_like "associated attribute changes - ship address", false, "non-relevant"
         it_behaves_like "associated attribute changes - payments", false,
-                        "non-relevant" do |_variable|
+                        "non-relevant" do
           before { pending }
         end
       end

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -337,9 +337,8 @@ describe OrderInvoiceComparator do
         it_behaves_like "attribute changes - payment total", false, "relevant" do
           before { pending("a payment capture shouldn't trigger a new invoice - issue #11350") }
         end
-        it_behaves_like "attribute changes - order state: cancelled", false, "non-relevant" do
-          before { pending }
-        end
+        # order-state change is relevant both for generate and update comparator
+        it_behaves_like "attribute changes - order state: cancelled", true, "relevant"
         it_behaves_like "no attribute changes"
         it_behaves_like "attribute changes - special insctructions", false, "non-relevant"
         it_behaves_like "attribute changes - note", false, "non-relevant"
@@ -362,6 +361,7 @@ describe OrderInvoiceComparator do
         it_behaves_like "attribute changes - payment total", true, "relevant" do
           before { pending("a payment capture shouldn't trigger a new invoice - issue #11350") }
         end
+        # order-state change is relevant both for generate and update comparator
         it_behaves_like "attribute changes - order state: cancelled", true, "relevant"
         it_behaves_like "attribute changes - special insctructions", true, "relevant"
         it_behaves_like "attribute changes - note", true, "relevant"

--- a/spec/services/order_invoice_comparator_spec.rb
+++ b/spec/services/order_invoice_comparator_spec.rb
@@ -132,10 +132,8 @@ end
 
 shared_examples "associated attribute changes - adjustments (update)" do |boolean, type|
   context "adjustment changes" do
-    let!(:adjustment) { create(:adjustment, order_id: order.id) }
-
     context "with an existing adjustment" do
-      before { adjustment.update!(label: "It's a new label") }
+      before { Spree::Adjustment.first.update!(label: "It's a new label") }
       it "returns #{boolean} if a #{type} attribute changes" do
         order.reload
         expect(subject).to be boolean
@@ -349,9 +347,7 @@ describe OrderInvoiceComparator do
         it_behaves_like "attribute changes - special insctructions", false, "non-relevant"
         it_behaves_like "attribute changes - note", false, "non-relevant"
         it_behaves_like "associated attribute changes - adjustments (update)", false,
-                        "non-relevant" do
-          before { pending }
-        end
+                        "non-relevant"
         it_behaves_like "attribute changes - payment state", false, "non-relevant"
       end
     end


### PR DESCRIPTION
#### What? Why?

Improves existing spec by solving some pending test cases

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

When an attribute is changed, both "comparators" should work in a complementary way, i.e. if:
`can_generate_latest_invoice?` is `true` then `can_update_latest_invoice?` should be `false`.

This was sometimes not observed and the PR tries to fix this.

Pinging @abdellani here for help: I'm stuck on the create and destroy adjustment tests: as these return true, for both `create` and `update` comparators.

EDIT: as discussed earlier today: creating/deleting adjustments and order state changes (cancelling) should trigger both an `update` and create new `invoice` response. This happens due to associations in these attributes; it's not possible to test these in isolation.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
