### PR TITLE
Don't load Bugsnag in dev env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,6 @@ gem 'omniauth-rails_csrf_protection'
 gem 'openid_connect', '~> 1.3'
 
 gem 'angularjs-rails', '1.8.0'
-gem 'bugsnag'
 gem 'haml'
 gem 'redcarpet'
 
@@ -142,6 +141,8 @@ gem "faraday"
 gem "private_address_check"
 
 gem 'newrelic_rpm'
+
+gem 'bugsnag', group: [:test, :staging, :production]
 
 group :production, :staging do
   gem 'sd_notify' # For better Systemd process management. Used by Puma.

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,4 +1,6 @@
-Bugsnag.configure do |config|
-  config.api_key = ENV['BUGSNAG_API_KEY']
-  config.notify_release_stages = %w(production staging)
+# Bugsnag will notify for any environment that the gem is installed (see Gemfile)
+if defined? Bugsnag
+  Bugsnag.configure do |config|
+    config.api_key = ENV['BUGSNAG_API_KEY']
+  end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #11714
  - Closes #11733 as alternative solution

There were unnecessary Bugsnag messages in Dev mode, causing confusion. I realised that if we don't use it in `dev`, we don't need to install it! 

Yay for efficiency!

#### What should we test?
Just that specs pass and staging deployment success. 
We can also easily verify Bugsnag still works by triggering a 404 in staging, for example:
* https://staging.openfoodnetwork.org.au/not-found

#### Documentation
If this works, we should add a comment about this alternative fix on https://github.com/bugsnag/bugsnag-ruby/issues/552
