### PR TITLE
Only display Supplier column in Order Cycle Report email if there is more than one supplier

### DIFF
--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -20,8 +20,9 @@
       %tr
         %th
           = t :sku
-        %th
-          = t :supplier
+        - if @distributors_pickup_times.many?
+          %th
+            = t :supplier
         %th
           = t :product
         %th.text-right
@@ -37,8 +38,9 @@
         %tr
           %td
             #{line_items.first.variant.sku}
-          %td
-            #{raw(line_items.first.product.supplier.name)}
+          - if @distributors_pickup_times.many?
+            %td
+              #{raw(line_items.first.product.supplier.name)}
           %td
             #{raw(product_and_full_name)}
           %td.text-right

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -53,7 +53,8 @@
             #{Spree::Money.new(line_items.sum(&:included_tax), currency: line_items.first.currency) }
       %tr.total-row
         %td
-        %td
+        - if @distributors_pickup_times.many?
+          %td
         %td
         %td
         %td

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -70,8 +70,9 @@
       %tr
         %th
           = t :sku
-        %th
-          = t :supplier
+        - if @distributors_pickup_times.many?
+          %th
+            = t :supplier
         %th
           = t :product
         %th.text-right
@@ -85,8 +86,9 @@
         %tr
           %td
             #{line_item[:sku]}
-          %td
-            #{raw(line_item[:supplier_name])}
+          - if @distributors_pickup_times.many?
+            %td
+              #{raw(line_item[:supplier_name])}
           %td
             #{raw(line_item[:product_and_full_name])}
           %td.text-right

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -201,12 +201,30 @@ describe ProducerMailer, type: :mailer do
       expect(body_as_html(mail).find(".order-summary"))
         .to have_selector("th", text: "Supplier")
     end
+
+    context "when the show customer names to suppliers setting is enabled" do
+      before { order_cycle.coordinator.update!(show_customer_names_to_suppliers: true) }
+
+      it "displays a supplier column in the summary of orders grouped by customer" do
+        expect(body_as_html(mail).find(".customer-order"))
+          .to have_selector("th", text: "Supplier")
+      end
+    end
   end
 
   context "products from only one supplier" do
     it "doesn't display a supplier column" do
       expect(body_as_html(mail).find(".order-summary"))
         .to have_no_selector("th", text: "Supplier")
+    end
+
+    context "when the show customer names to suppliers setting is enabled" do
+      before { order_cycle.coordinator.update!(show_customer_names_to_suppliers: true) }
+
+      it "doesn't display a supplier column in the summary of orders grouped by customer" do
+        expect(body_as_html(mail).find(".customer-order"))
+          .to have_no_selector("th", text: "Supplier")
+      end
     end
   end
 


### PR DESCRIPTION
#### What? Why?

- Closes #11601

Note, the failing test on this branch is one that is failing on the `master` branch.

#### What should we test?

1. Create an order cycle with orders containing products from _more than one supplier_. Click the `Notify producers` button and check that the Order Cycle Report email contains a 'Supplier' column.
2. Create an order cycle with orders containing products from _only one supplier_. Click the `Notify producers` button and check that the Order Cycle Report email does not contain a 'Supplier' column.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled