### PR TITLE
Fix navigation behavior on enterprise settings panel tabs

### DIFF
--- a/app/webpacker/controllers/tabs_and_panels_controller.js
+++ b/app/webpacker/controllers/tabs_and_panels_controller.js
@@ -37,6 +37,16 @@ export default class extends Controller {
     window.addEventListener("tabs-and-panels:click", (event) => {
       this.simulateClick(event.detail.tab, event.detail.panel);
     });
+
+    window.addEventListener("popstate", (event) => {
+      const newPanelId = event.target.location.hash.replace("#/", "");
+      const currentPanelId = this.currentActivePanel.id;
+
+      if (newPanelId !== currentPanelId) {
+        const newTabId = newPanelId.split("_panel").shift();
+        this.simulateClick(newTabId, newPanelId);
+      }
+    });
   }
 
   simulateClick(tab, panel) {

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -119,6 +119,15 @@ describe '
     accept_alert do
       click_link "Primary Details"
     end
+
+    # Back navigation loads the tab content
+    page.execute_script('window.history.back()')
+    expect(page).to have_selector '#enterprise_description'
+
+    accept_alert do
+      click_link "Primary Details"
+    end
+
     # Unchecking hides the Properties tab
     uncheck 'enterprise_is_primary_producer'
     choose 'None'


### PR DESCRIPTION
#### What? Why?

- Closes #6754 

Panel navigation through back and forward buttons isn't working on enterprise settings page. The tab selection changes, but the content does not change.


#### What should we test?
1.  As an admin, go to an enterprise edit settings page (`admin/enterprises/[ENTERPRISE-SLUG]/edit#/primary_details`).
2.  Navigate with the left panel, and see content on the right is changing
3.  Using the browser's back and forward buttons observe the url path and the content both change appropriately.

[Screencast from 11-10-2023 01:13:42 PM.webm](https://github.com/openfoodfoundation/openfoodnetwork/assets/14116496/5acf8533-970c-443e-a35b-16270ab65feb)

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

The title of the pull request will be included in the release notes.


#### Dependencies

#### Documentation updates
