### PR TITLE
[Invoices] fix bulk invoice printing

### DIFF
--- a/app/helpers/terms_and_conditions_helper.rb
+++ b/app/helpers/terms_and_conditions_helper.rb
@@ -2,8 +2,8 @@
 
 module TermsAndConditionsHelper
   def link_to_platform_terms
-    link_to(t("terms_of_service"), TermsOfServiceFile.current_url, target: "_blank",
-                                                                   rel: "noopener")
+    content_tag(:a, t("terms_of_service"), href: TermsOfServiceFile.current_url, target: "_blank",
+                                           rel: "noopener")
   end
 
   def any_terms_required?(distributor)


### PR DESCRIPTION
#### What? Why?

- Closes #11791
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

`InvoiceRenderer#render_to_string` uses an instant of `ApplicationController`.
In the invoice V3, we're using `TermsAndConditionsHelper#link_to_platform_terms` to render the link to the terms of service pdf. This method used `link_to` which seems trying to access `request.host`.
Since the code is executed under SideKiq, This object is not accessible, and that causes the bulk invoice printing/sending to crash.
In this PR, I suggest replacing `link_to` with `content_tag`


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Since I updated the Term of Service helper, I suggest checking all the places where that link is rendered.
* bulk invoices pdf/email
* single invoice pdf/email
* footer of the shopfront
* and any other place that I didn't mention.
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
