### PR TITLE
[VCR, automation] Adds payment intent tests with invalid cards

### DIFF
--- a/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Exceeding_velocity_limit_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Exceeding_velocity_limit_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: type=card&card[number]=4000000000009995&card[exp_month]=12&card[exp_year]=2034&card[cvc]=314
+      string: type=card&card[number]=4000000000006975&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -14,14 +14,14 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_lDPJ62zgG8A9FL","request_duration_ms":372}}'
+      - '{"last_request_metrics":{"request_id":"req_ni5sEg4CW8KyB5","request_duration_ms":421}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.1.0-12-amd64 (debian-kernel@lists.debian.org) (gcc-12 (Debian 12.2.0-14)
-        12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT_DYNAMIC Debian
-        6.1.52-1 (2023-09-07)","hostname":"blackbox"}'
+        version 6.2.0-36-generic (buildd@lcy02-amd64-050) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #37~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct  9 15:34:04 UTC 2","hostname":"ff-LAT"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -34,7 +34,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 08 Nov 2023 21:53:53 GMT
+      - Wed, 15 Nov 2023 12:12:43 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -59,11 +59,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 75a4ebeb-6038-4dad-b537-211f6f71b7f1
+      - 6ddea5c1-08dc-4fc1-b0a9-2a2bd776e4ba
       Original-Request:
-      - req_CXWU1cVDbwleGf
+      - req_mNUdfzCcBijtrH
       Request-Id:
-      - req_CXWU1cVDbwleGf
+      - req_mNUdfzCcBijtrH
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -78,7 +78,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OAJh7KuuB1fWySnzX7O7p6v",
+          "id": "pm_1OChxXKuuB1fWySn8MhrnITD",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -102,11 +102,11 @@ http_interactions:
             },
             "country": "US",
             "exp_month": 12,
-            "exp_year": 2034,
-            "fingerprint": "O0I0muUGQBJy3p73",
+            "exp_year": 2024,
+            "fingerprint": "WoxwxVPUPcg0EjXW",
             "funding": "credit",
             "generated_from": null,
-            "last4": "9995",
+            "last4": "6975",
             "networks": {
               "available": [
                 "visa"
@@ -118,19 +118,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1699480433,
+          "created": 1700050363,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Wed, 08 Nov 2023 21:53:53 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:43 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=100&currency=eur&payment_method=pm_1OAJh7KuuB1fWySnzX7O7p6v&payment_method_types[0]=card&capture_method=manual
+      string: amount=100&currency=eur&payment_method=pm_1OChxXKuuB1fWySn8MhrnITD&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -139,14 +139,14 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_CXWU1cVDbwleGf","request_duration_ms":504}}'
+      - '{"last_request_metrics":{"request_id":"req_mNUdfzCcBijtrH","request_duration_ms":419}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.1.0-12-amd64 (debian-kernel@lists.debian.org) (gcc-12 (Debian 12.2.0-14)
-        12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT_DYNAMIC Debian
-        6.1.52-1 (2023-09-07)","hostname":"blackbox"}'
+        version 6.2.0-36-generic (buildd@lcy02-amd64-050) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #37~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct  9 15:34:04 UTC 2","hostname":"ff-LAT"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -159,7 +159,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 08 Nov 2023 21:53:54 GMT
+      - Wed, 15 Nov 2023 12:12:44 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -184,11 +184,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 7ce09a3a-1ae3-44bf-a4a1-b4892300bee8
+      - 51dc1e6b-8cda-4be9-b382-55e24cc1977d
       Original-Request:
-      - req_7vL6AMoApGaPOn
+      - req_k97HGWX1oX9S8p
       Request-Id:
-      - req_7vL6AMoApGaPOn
+      - req_k97HGWX1oX9S8p
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -203,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OAJh8KuuB1fWySn0KV6OR9K",
+          "id": "pi_3OChxYKuuB1fWySn2jBvkkhl",
           "object": "payment_intent",
           "amount": 100,
           "amount_capturable": 0,
@@ -217,9 +217,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OAJh8KuuB1fWySn0KV6OR9K_secret_GwjdRrh93OZLch9K7bSGXthZQ",
+          "client_secret": "pi_3OChxYKuuB1fWySn2jBvkkhl_secret_cmyhGSAsXwWzWH6s6oFEsvBkW",
           "confirmation_method": "automatic",
-          "created": 1699480434,
+          "created": 1700050364,
           "currency": "eur",
           "customer": null,
           "description": null,
@@ -230,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OAJh7KuuB1fWySnzX7O7p6v",
+          "payment_method": "pm_1OChxXKuuB1fWySn8MhrnITD",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -255,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Wed, 08 Nov 2023 21:53:54 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:44 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OAJh8KuuB1fWySn0KV6OR9K/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OChxYKuuB1fWySn2jBvkkhl/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -270,14 +270,14 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_7vL6AMoApGaPOn","request_duration_ms":481}}'
+      - '{"last_request_metrics":{"request_id":"req_k97HGWX1oX9S8p","request_duration_ms":376}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.1.0-12-amd64 (debian-kernel@lists.debian.org) (gcc-12 (Debian 12.2.0-14)
-        12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT_DYNAMIC Debian
-        6.1.52-1 (2023-09-07)","hostname":"blackbox"}'
+        version 6.2.0-36-generic (buildd@lcy02-amd64-050) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #37~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct  9 15:34:04 UTC 2","hostname":"ff-LAT"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -290,11 +290,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 08 Nov 2023 21:53:55 GMT
+      - Wed, 15 Nov 2023 12:12:45 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '4736'
+      - '4872'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -316,11 +316,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - f1ac8418-72c6-40a2-83a3-2e43b42f9338
+      - e5cea37b-d38b-4208-af42-7f93089d503d
       Original-Request:
-      - req_T5Mfbcixmq8B95
+      - req_F6I0q8qE35Eriq
       Request-Id:
-      - req_T5Mfbcixmq8B95
+      - req_F6I0q8qE35Eriq
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -336,13 +336,13 @@ http_interactions:
       string: |
         {
           "error": {
-            "charge": "ch_3OAJh8KuuB1fWySn0ZBV99yj",
+            "charge": "ch_3OChxYKuuB1fWySn2hVnmVei",
             "code": "card_declined",
-            "decline_code": "insufficient_funds",
+            "decline_code": "card_velocity_exceeded",
             "doc_url": "https://stripe.com/docs/error-codes/card-declined",
-            "message": "Your card has insufficient funds.",
+            "message": "Your card was declined for making repeated attempts too frequently or exceeding its amount limit.",
             "payment_intent": {
-              "id": "pi_3OAJh8KuuB1fWySn0KV6OR9K",
+              "id": "pi_3OChxYKuuB1fWySn2jBvkkhl",
               "object": "payment_intent",
               "amount": 100,
               "amount_capturable": 0,
@@ -357,21 +357,21 @@ http_interactions:
               "canceled_at": null,
               "cancellation_reason": null,
               "capture_method": "manual",
-              "client_secret": "pi_3OAJh8KuuB1fWySn0KV6OR9K_secret_GwjdRrh93OZLch9K7bSGXthZQ",
+              "client_secret": "pi_3OChxYKuuB1fWySn2jBvkkhl_secret_cmyhGSAsXwWzWH6s6oFEsvBkW",
               "confirmation_method": "automatic",
-              "created": 1699480434,
+              "created": 1700050364,
               "currency": "eur",
               "customer": null,
               "description": null,
               "invoice": null,
               "last_payment_error": {
-                "charge": "ch_3OAJh8KuuB1fWySn0ZBV99yj",
+                "charge": "ch_3OChxYKuuB1fWySn2hVnmVei",
                 "code": "card_declined",
-                "decline_code": "insufficient_funds",
+                "decline_code": "card_velocity_exceeded",
                 "doc_url": "https://stripe.com/docs/error-codes/card-declined",
-                "message": "Your card has insufficient funds.",
+                "message": "Your card was declined for making repeated attempts too frequently or exceeding its amount limit.",
                 "payment_method": {
-                  "id": "pm_1OAJh7KuuB1fWySnzX7O7p6v",
+                  "id": "pm_1OChxXKuuB1fWySn8MhrnITD",
                   "object": "payment_method",
                   "billing_details": {
                     "address": {
@@ -395,11 +395,11 @@ http_interactions:
                     },
                     "country": "US",
                     "exp_month": 12,
-                    "exp_year": 2034,
-                    "fingerprint": "O0I0muUGQBJy3p73",
+                    "exp_year": 2024,
+                    "fingerprint": "WoxwxVPUPcg0EjXW",
                     "funding": "credit",
                     "generated_from": null,
-                    "last4": "9995",
+                    "last4": "6975",
                     "networks": {
                       "available": [
                         "visa"
@@ -411,7 +411,7 @@ http_interactions:
                     },
                     "wallet": null
                   },
-                  "created": 1699480433,
+                  "created": 1700050363,
                   "customer": null,
                   "livemode": false,
                   "metadata": {
@@ -420,7 +420,7 @@ http_interactions:
                 },
                 "type": "card_error"
               },
-              "latest_charge": "ch_3OAJh8KuuB1fWySn0ZBV99yj",
+              "latest_charge": "ch_3OChxYKuuB1fWySn2hVnmVei",
               "livemode": false,
               "metadata": {
               },
@@ -452,7 +452,7 @@ http_interactions:
               "transfer_group": null
             },
             "payment_method": {
-              "id": "pm_1OAJh7KuuB1fWySnzX7O7p6v",
+              "id": "pm_1OChxXKuuB1fWySn8MhrnITD",
               "object": "payment_method",
               "billing_details": {
                 "address": {
@@ -476,11 +476,11 @@ http_interactions:
                 },
                 "country": "US",
                 "exp_month": 12,
-                "exp_year": 2034,
-                "fingerprint": "O0I0muUGQBJy3p73",
+                "exp_year": 2024,
+                "fingerprint": "WoxwxVPUPcg0EjXW",
                 "funding": "credit",
                 "generated_from": null,
-                "last4": "9995",
+                "last4": "6975",
                 "networks": {
                   "available": [
                     "visa"
@@ -492,196 +492,16 @@ http_interactions:
                 },
                 "wallet": null
               },
-              "created": 1699480433,
+              "created": 1700050363,
               "customer": null,
               "livemode": false,
               "metadata": {
               },
               "type": "card"
             },
-            "request_log_url": "https://dashboard.stripe.com/test/logs/req_T5Mfbcixmq8B95?t=1699480434",
+            "request_log_url": "https://dashboard.stripe.com/test/logs/req_F6I0q8qE35Eriq?t=1700050364",
             "type": "card_error"
           }
         }
-  recorded_at: Wed, 08 Nov 2023 21:53:55 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OAJh8KuuB1fWySn0KV6OR9K
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/10.1.0
-      Authorization:
-      - Bearer <HIDDEN_KEY>
-      Content-Type:
-      - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_7vL6AMoApGaPOn","request_duration_ms":481}}'
-      Stripe-Version:
-      - '2023-10-16'
-      X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.1.0-12-amd64 (debian-kernel@lists.debian.org) (gcc-12 (Debian 12.2.0-14)
-        12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT_DYNAMIC Debian
-        6.1.52-1 (2023-09-07)","hostname":"blackbox"}'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Wed, 08 Nov 2023 21:53:55 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '2741'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
-      Request-Id:
-      - req_oFg3Mxdsl0kbmA
-      Stripe-Version:
-      - '2023-10-16'
-      Vary:
-      - Origin
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pi_3OAJh8KuuB1fWySn0KV6OR9K",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 0,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OAJh8KuuB1fWySn0KV6OR9K_secret_GwjdRrh93OZLch9K7bSGXthZQ",
-          "confirmation_method": "automatic",
-          "created": 1699480434,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": {
-            "charge": "ch_3OAJh8KuuB1fWySn0ZBV99yj",
-            "code": "card_declined",
-            "decline_code": "insufficient_funds",
-            "doc_url": "https://stripe.com/docs/error-codes/card-declined",
-            "message": "Your card has insufficient funds.",
-            "payment_method": {
-              "id": "pm_1OAJh7KuuB1fWySnzX7O7p6v",
-              "object": "payment_method",
-              "billing_details": {
-                "address": {
-                  "city": null,
-                  "country": null,
-                  "line1": null,
-                  "line2": null,
-                  "postal_code": null,
-                  "state": null
-                },
-                "email": null,
-                "name": null,
-                "phone": null
-              },
-              "card": {
-                "brand": "visa",
-                "checks": {
-                  "address_line1_check": null,
-                  "address_postal_code_check": null,
-                  "cvc_check": "pass"
-                },
-                "country": "US",
-                "exp_month": 12,
-                "exp_year": 2034,
-                "fingerprint": "O0I0muUGQBJy3p73",
-                "funding": "credit",
-                "generated_from": null,
-                "last4": "9995",
-                "networks": {
-                  "available": [
-                    "visa"
-                  ],
-                  "preferred": null
-                },
-                "three_d_secure_usage": {
-                  "supported": true
-                },
-                "wallet": null
-              },
-              "created": 1699480433,
-              "customer": null,
-              "livemode": false,
-              "metadata": {},
-              "type": "card"
-            },
-            "type": "card_error"
-          },
-          "latest_charge": "ch_3OAJh8KuuB1fWySn0ZBV99yj",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": null,
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_payment_method",
-          "transfer_data": null,
-          "transfer_group": null
-        }
-  recorded_at: Wed, 08 Nov 2023 21:53:56 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:45 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Expired_card_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Expired_card_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: type=card&card[number]=4242424242424242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
+      string: type=card&card[number]=4000000000000069&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -13,6 +13,8 @@ http_interactions:
       - Bearer <HIDDEN_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_wz9ngtsjxiowwD","request_duration_ms":414}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -32,7 +34,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:05 GMT
+      - Wed, 15 Nov 2023 12:12:37 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -57,11 +59,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 17bbe933-7643-4ec9-bd1b-69681c72adf2
+      - ec4f03a3-88d0-4f4f-ba87-c1df34896cd9
       Original-Request:
-      - req_XmkH194g2YhHQE
+      - req_DvYWcYZSE8ppIG
       Request-Id:
-      - req_XmkH194g2YhHQE
+      - req_DvYWcYZSE8ppIG
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -76,7 +78,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "id": "pm_1OChxRKuuB1fWySneXOy7EmK",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -101,10 +103,10 @@ http_interactions:
             "country": "US",
             "exp_month": 12,
             "exp_year": 2024,
-            "fingerprint": "6E6tgVjx6U65iHFV",
+            "fingerprint": "qpQikrTL7IyNA2rE",
             "funding": "credit",
             "generated_from": null,
-            "last4": "4242",
+            "last4": "0069",
             "networks": {
               "available": [
                 "visa"
@@ -116,19 +118,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1700050565,
+          "created": 1700050357,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:05 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:38 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=100&currency=eur&payment_method=pm_1OCi0nKuuB1fWySnIYqzx8kS&payment_method_types[0]=card&capture_method=manual
+      string: amount=100&currency=eur&payment_method=pm_1OChxRKuuB1fWySneXOy7EmK&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -137,7 +139,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_XmkH194g2YhHQE","request_duration_ms":712}}'
+      - '{"last_request_metrics":{"request_id":"req_DvYWcYZSE8ppIG","request_duration_ms":484}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -157,7 +159,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:06 GMT
+      - Wed, 15 Nov 2023 12:12:38 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,11 +184,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - d8823767-1297-46e7-b0b8-4232c6d8f8d2
+      - a50f284c-b460-4e73-8f61-42f87b7785d6
       Original-Request:
-      - req_jj5gDAn7KGM55p
+      - req_9I8tZ97u4CIxxy
       Request-Id:
-      - req_jj5gDAn7KGM55p
+      - req_9I8tZ97u4CIxxy
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -201,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
+          "id": "pi_3OChxSKuuB1fWySn04kAIot4",
           "object": "payment_intent",
           "amount": 100,
           "amount_capturable": 0,
@@ -215,9 +217,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
+          "client_secret": "pi_3OChxSKuuB1fWySn04kAIot4_secret_y6sM69iV7bprOSZSKIzVkcra0",
           "confirmation_method": "automatic",
-          "created": 1700050565,
+          "created": 1700050358,
           "currency": "eur",
           "customer": null,
           "description": null,
@@ -228,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "payment_method": "pm_1OChxRKuuB1fWySneXOy7EmK",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -253,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:06 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:38 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OChxSKuuB1fWySn04kAIot4/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -268,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jj5gDAn7KGM55p","request_duration_ms":544}}'
+      - '{"last_request_metrics":{"request_id":"req_9I8tZ97u4CIxxy","request_duration_ms":412}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -282,17 +284,17 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 200
-      message: OK
+      code: 402
+      message: Payment Required
     headers:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:07 GMT
+      - Wed, 15 Nov 2023 12:12:39 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1365'
+      - '4678'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -314,11 +316,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - ac3db256-8b8e-47e7-874d-2a84454ae5ea
+      - 605b8f34-bbfe-41e0-8728-a67dcf5ac1cd
       Original-Request:
-      - req_xFWSrTTsvhUfXf
+      - req_MUoHbIvw8cGTeE
       Request-Id:
-      - req_xFWSrTTsvhUfXf
+      - req_MUoHbIvw8cGTeE
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -331,185 +333,175 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: |-
+      string: |
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
+          "error": {
+            "charge": "ch_3OChxSKuuB1fWySn0ecBJhAc",
+            "code": "expired_card",
+            "doc_url": "https://stripe.com/docs/error-codes/expired-card",
+            "message": "Your card has expired.",
+            "param": "exp_month",
+            "payment_intent": {
+              "id": "pi_3OChxSKuuB1fWySn04kAIot4",
+              "object": "payment_intent",
+              "amount": 100,
+              "amount_capturable": 0,
+              "amount_details": {
+                "tip": {
+                }
+              },
+              "amount_received": 0,
+              "application": null,
+              "application_fee_amount": null,
+              "automatic_payment_methods": null,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "manual",
+              "client_secret": "pi_3OChxSKuuB1fWySn04kAIot4_secret_y6sM69iV7bprOSZSKIzVkcra0",
+              "confirmation_method": "automatic",
+              "created": 1700050358,
+              "currency": "eur",
+              "customer": null,
+              "description": null,
+              "invoice": null,
+              "last_payment_error": {
+                "charge": "ch_3OChxSKuuB1fWySn0ecBJhAc",
+                "code": "expired_card",
+                "doc_url": "https://stripe.com/docs/error-codes/expired-card",
+                "message": "Your card has expired.",
+                "param": "exp_month",
+                "payment_method": {
+                  "id": "pm_1OChxRKuuB1fWySneXOy7EmK",
+                  "object": "payment_method",
+                  "billing_details": {
+                    "address": {
+                      "city": null,
+                      "country": null,
+                      "line1": null,
+                      "line2": null,
+                      "postal_code": null,
+                      "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null
+                  },
+                  "card": {
+                    "brand": "visa",
+                    "checks": {
+                      "address_line1_check": null,
+                      "address_postal_code_check": null,
+                      "cvc_check": "pass"
+                    },
+                    "country": "US",
+                    "exp_month": 12,
+                    "exp_year": 2024,
+                    "fingerprint": "qpQikrTL7IyNA2rE",
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "0069",
+                    "networks": {
+                      "available": [
+                        "visa"
+                      ],
+                      "preferred": null
+                    },
+                    "three_d_secure_usage": {
+                      "supported": true
+                    },
+                    "wallet": null
+                  },
+                  "created": 1700050357,
+                  "customer": null,
+                  "livemode": false,
+                  "metadata": {
+                  },
+                  "type": "card"
+                },
+                "type": "card_error"
+              },
+              "latest_charge": "ch_3OChxSKuuB1fWySn0ecBJhAc",
+              "livemode": false,
+              "metadata": {
+              },
+              "next_action": null,
+              "on_behalf_of": null,
+              "payment_method": null,
+              "payment_method_configuration_details": null,
+              "payment_method_options": {
+                "card": {
+                  "installments": null,
+                  "mandate_options": null,
+                  "network": null,
+                  "request_three_d_secure": "automatic"
+                }
+              },
+              "payment_method_types": [
+                "card"
+              ],
+              "processing": null,
+              "receipt_email": null,
+              "review": null,
+              "setup_future_usage": null,
+              "shipping": null,
+              "source": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": null,
+              "status": "requires_payment_method",
+              "transfer_data": null,
+              "transfer_group": null
+            },
+            "payment_method": {
+              "id": "pm_1OChxRKuuB1fWySneXOy7EmK",
+              "object": "payment_method",
+              "billing_details": {
+                "address": {
+                  "city": null,
+                  "country": null,
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": null,
+                  "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null
+              },
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2024,
+                "fingerprint": "qpQikrTL7IyNA2rE",
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "0069",
+                "networks": {
+                  "available": [
+                    "visa"
+                  ],
+                  "preferred": null
+                },
+                "three_d_secure_usage": {
+                  "supported": true
+                },
+                "wallet": null
+              },
+              "created": 1700050357,
+              "customer": null,
+              "livemode": false,
+              "metadata": {
+              },
+              "type": "card"
+            },
+            "request_log_url": "https://dashboard.stripe.com/test/logs/req_MUoHbIvw8cGTeE?t=1700050358",
+            "type": "card_error"
+          }
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:07 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/10.1.0
-      Authorization:
-      - Bearer <HIDDEN_KEY>
-      Content-Type:
-      - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_xFWSrTTsvhUfXf","request_duration_ms":1003}}'
-      Stripe-Version:
-      - '2023-10-16'
-      X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.2.0-36-generic (buildd@lcy02-amd64-050) (x86_64-linux-gnu-gcc-11
-        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
-        #37~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct  9 15:34:04 UTC 2","hostname":"ff-LAT"}'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Wed, 15 Nov 2023 12:16:08 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1365'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
-      Request-Id:
-      - req_rdUoEaNBJ1QdYa
-      Stripe-Version:
-      - '2023-10-16'
-      Vary:
-      - Origin
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
-        }
-  recorded_at: Wed, 15 Nov 2023 12:16:08 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:39 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Generic_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Generic_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: type=card&card[number]=4242424242424242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
+      string: type=card&card[number]=4000000000000002&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -13,6 +13,8 @@ http_interactions:
       - Bearer <HIDDEN_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_nL0VGP6BJtWnUy","request_duration_ms":319}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -32,7 +34,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:05 GMT
+      - Wed, 15 Nov 2023 12:12:29 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -57,11 +59,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 17bbe933-7643-4ec9-bd1b-69681c72adf2
+      - 2f0617f5-fb98-4b33-8c65-d4e03e180e4c
       Original-Request:
-      - req_XmkH194g2YhHQE
+      - req_M7hxrFGbWieOvj
       Request-Id:
-      - req_XmkH194g2YhHQE
+      - req_M7hxrFGbWieOvj
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -76,7 +78,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "id": "pm_1OChxJKuuB1fWySnzaAMnGfJ",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -101,10 +103,10 @@ http_interactions:
             "country": "US",
             "exp_month": 12,
             "exp_year": 2024,
-            "fingerprint": "6E6tgVjx6U65iHFV",
+            "fingerprint": "IKC2ubfpSLuZKsVs",
             "funding": "credit",
             "generated_from": null,
-            "last4": "4242",
+            "last4": "0002",
             "networks": {
               "available": [
                 "visa"
@@ -116,19 +118,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1700050565,
+          "created": 1700050349,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:05 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:30 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=100&currency=eur&payment_method=pm_1OCi0nKuuB1fWySnIYqzx8kS&payment_method_types[0]=card&capture_method=manual
+      string: amount=100&currency=eur&payment_method=pm_1OChxJKuuB1fWySnzaAMnGfJ&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -137,7 +139,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_XmkH194g2YhHQE","request_duration_ms":712}}'
+      - '{"last_request_metrics":{"request_id":"req_M7hxrFGbWieOvj","request_duration_ms":512}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -157,7 +159,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:06 GMT
+      - Wed, 15 Nov 2023 12:12:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,11 +184,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - d8823767-1297-46e7-b0b8-4232c6d8f8d2
+      - 47a9d43e-2cde-477e-a59d-1733587ed0f4
       Original-Request:
-      - req_jj5gDAn7KGM55p
+      - req_KdvLGoQMfCL2nw
       Request-Id:
-      - req_jj5gDAn7KGM55p
+      - req_KdvLGoQMfCL2nw
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -201,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
+          "id": "pi_3OChxKKuuB1fWySn2DH3GyDt",
           "object": "payment_intent",
           "amount": 100,
           "amount_capturable": 0,
@@ -215,9 +217,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
+          "client_secret": "pi_3OChxKKuuB1fWySn2DH3GyDt_secret_jO0ZfpOQP9xi9w4QvnOglcUYI",
           "confirmation_method": "automatic",
-          "created": 1700050565,
+          "created": 1700050350,
           "currency": "eur",
           "customer": null,
           "description": null,
@@ -228,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "payment_method": "pm_1OChxJKuuB1fWySnzaAMnGfJ",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -253,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:06 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:30 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OChxKKuuB1fWySn2DH3GyDt/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -268,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jj5gDAn7KGM55p","request_duration_ms":544}}'
+      - '{"last_request_metrics":{"request_id":"req_KdvLGoQMfCL2nw","request_duration_ms":414}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -282,17 +284,17 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 200
-      message: OK
+      code: 402
+      message: Payment Required
     headers:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:07 GMT
+      - Wed, 15 Nov 2023 12:12:31 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1365'
+      - '4710'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -314,11 +316,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - ac3db256-8b8e-47e7-874d-2a84454ae5ea
+      - '095cb360-0fb6-4a1d-9fb8-d89c8acdfd16'
       Original-Request:
-      - req_xFWSrTTsvhUfXf
+      - req_cOd2gQ9X5pxlLi
       Request-Id:
-      - req_xFWSrTTsvhUfXf
+      - req_cOd2gQ9X5pxlLi
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -331,185 +333,175 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: |-
+      string: |
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
+          "error": {
+            "charge": "ch_3OChxKKuuB1fWySn2SkQxjyF",
+            "code": "card_declined",
+            "decline_code": "generic_decline",
+            "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+            "message": "Your card was declined.",
+            "payment_intent": {
+              "id": "pi_3OChxKKuuB1fWySn2DH3GyDt",
+              "object": "payment_intent",
+              "amount": 100,
+              "amount_capturable": 0,
+              "amount_details": {
+                "tip": {
+                }
+              },
+              "amount_received": 0,
+              "application": null,
+              "application_fee_amount": null,
+              "automatic_payment_methods": null,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "manual",
+              "client_secret": "pi_3OChxKKuuB1fWySn2DH3GyDt_secret_jO0ZfpOQP9xi9w4QvnOglcUYI",
+              "confirmation_method": "automatic",
+              "created": 1700050350,
+              "currency": "eur",
+              "customer": null,
+              "description": null,
+              "invoice": null,
+              "last_payment_error": {
+                "charge": "ch_3OChxKKuuB1fWySn2SkQxjyF",
+                "code": "card_declined",
+                "decline_code": "generic_decline",
+                "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+                "message": "Your card was declined.",
+                "payment_method": {
+                  "id": "pm_1OChxJKuuB1fWySnzaAMnGfJ",
+                  "object": "payment_method",
+                  "billing_details": {
+                    "address": {
+                      "city": null,
+                      "country": null,
+                      "line1": null,
+                      "line2": null,
+                      "postal_code": null,
+                      "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null
+                  },
+                  "card": {
+                    "brand": "visa",
+                    "checks": {
+                      "address_line1_check": null,
+                      "address_postal_code_check": null,
+                      "cvc_check": "pass"
+                    },
+                    "country": "US",
+                    "exp_month": 12,
+                    "exp_year": 2024,
+                    "fingerprint": "IKC2ubfpSLuZKsVs",
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "0002",
+                    "networks": {
+                      "available": [
+                        "visa"
+                      ],
+                      "preferred": null
+                    },
+                    "three_d_secure_usage": {
+                      "supported": true
+                    },
+                    "wallet": null
+                  },
+                  "created": 1700050349,
+                  "customer": null,
+                  "livemode": false,
+                  "metadata": {
+                  },
+                  "type": "card"
+                },
+                "type": "card_error"
+              },
+              "latest_charge": "ch_3OChxKKuuB1fWySn2SkQxjyF",
+              "livemode": false,
+              "metadata": {
+              },
+              "next_action": null,
+              "on_behalf_of": null,
+              "payment_method": null,
+              "payment_method_configuration_details": null,
+              "payment_method_options": {
+                "card": {
+                  "installments": null,
+                  "mandate_options": null,
+                  "network": null,
+                  "request_three_d_secure": "automatic"
+                }
+              },
+              "payment_method_types": [
+                "card"
+              ],
+              "processing": null,
+              "receipt_email": null,
+              "review": null,
+              "setup_future_usage": null,
+              "shipping": null,
+              "source": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": null,
+              "status": "requires_payment_method",
+              "transfer_data": null,
+              "transfer_group": null
+            },
+            "payment_method": {
+              "id": "pm_1OChxJKuuB1fWySnzaAMnGfJ",
+              "object": "payment_method",
+              "billing_details": {
+                "address": {
+                  "city": null,
+                  "country": null,
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": null,
+                  "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null
+              },
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2024,
+                "fingerprint": "IKC2ubfpSLuZKsVs",
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "0002",
+                "networks": {
+                  "available": [
+                    "visa"
+                  ],
+                  "preferred": null
+                },
+                "three_d_secure_usage": {
+                  "supported": true
+                },
+                "wallet": null
+              },
+              "created": 1700050349,
+              "customer": null,
+              "livemode": false,
+              "metadata": {
+              },
+              "type": "card"
+            },
+            "request_log_url": "https://dashboard.stripe.com/test/logs/req_cOd2gQ9X5pxlLi?t=1700050350",
+            "type": "card_error"
+          }
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:07 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/10.1.0
-      Authorization:
-      - Bearer <HIDDEN_KEY>
-      Content-Type:
-      - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_xFWSrTTsvhUfXf","request_duration_ms":1003}}'
-      Stripe-Version:
-      - '2023-10-16'
-      X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.2.0-36-generic (buildd@lcy02-amd64-050) (x86_64-linux-gnu-gcc-11
-        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
-        #37~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct  9 15:34:04 UTC 2","hostname":"ff-LAT"}'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Wed, 15 Nov 2023 12:16:08 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1365'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
-      Request-Id:
-      - req_rdUoEaNBJ1QdYa
-      Stripe-Version:
-      - '2023-10-16'
-      Vary:
-      - Origin
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
-        }
-  recorded_at: Wed, 15 Nov 2023 12:16:08 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:31 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Incorrect_CVC_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Incorrect_CVC_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: type=card&card[number]=4242424242424242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
+      string: type=card&card[number]=4000000000000127&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -13,6 +13,8 @@ http_interactions:
       - Bearer <HIDDEN_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_9I8tZ97u4CIxxy","request_duration_ms":412}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -32,7 +34,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:05 GMT
+      - Wed, 15 Nov 2023 12:12:39 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -57,11 +59,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 17bbe933-7643-4ec9-bd1b-69681c72adf2
+      - b6b3d298-cf9e-4ded-b1fc-4ee9d053df01
       Original-Request:
-      - req_XmkH194g2YhHQE
+      - req_gVKgu0rhCR01Cb
       Request-Id:
-      - req_XmkH194g2YhHQE
+      - req_gVKgu0rhCR01Cb
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -76,7 +78,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "id": "pm_1OChxTKuuB1fWySncxVWyTGO",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -101,10 +103,10 @@ http_interactions:
             "country": "US",
             "exp_month": 12,
             "exp_year": 2024,
-            "fingerprint": "6E6tgVjx6U65iHFV",
+            "fingerprint": "eWmxEL5j3bNdPnK5",
             "funding": "credit",
             "generated_from": null,
-            "last4": "4242",
+            "last4": "0127",
             "networks": {
               "available": [
                 "visa"
@@ -116,19 +118,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1700050565,
+          "created": 1700050359,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:05 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:39 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=100&currency=eur&payment_method=pm_1OCi0nKuuB1fWySnIYqzx8kS&payment_method_types[0]=card&capture_method=manual
+      string: amount=100&currency=eur&payment_method=pm_1OChxTKuuB1fWySncxVWyTGO&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -137,7 +139,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_XmkH194g2YhHQE","request_duration_ms":712}}'
+      - '{"last_request_metrics":{"request_id":"req_gVKgu0rhCR01Cb","request_duration_ms":473}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -157,7 +159,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:06 GMT
+      - Wed, 15 Nov 2023 12:12:40 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,11 +184,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - d8823767-1297-46e7-b0b8-4232c6d8f8d2
+      - 7219e66a-4f82-4fad-8f2a-82bb4a675dfd
       Original-Request:
-      - req_jj5gDAn7KGM55p
+      - req_CgYr5edkZxNSG7
       Request-Id:
-      - req_jj5gDAn7KGM55p
+      - req_CgYr5edkZxNSG7
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -201,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
+          "id": "pi_3OChxUKuuB1fWySn0BE2hR0a",
           "object": "payment_intent",
           "amount": 100,
           "amount_capturable": 0,
@@ -215,9 +217,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
+          "client_secret": "pi_3OChxUKuuB1fWySn0BE2hR0a_secret_2iVjUwUVeb8TwV5wTwWHz8QmR",
           "confirmation_method": "automatic",
-          "created": 1700050565,
+          "created": 1700050360,
           "currency": "eur",
           "customer": null,
           "description": null,
@@ -228,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "payment_method": "pm_1OChxTKuuB1fWySncxVWyTGO",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -253,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:06 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:40 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OChxUKuuB1fWySn0BE2hR0a/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -268,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jj5gDAn7KGM55p","request_duration_ms":544}}'
+      - '{"last_request_metrics":{"request_id":"req_CgYr5edkZxNSG7","request_duration_ms":414}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -282,17 +284,17 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 200
-      message: OK
+      code: 402
+      message: Payment Required
     headers:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:07 GMT
+      - Wed, 15 Nov 2023 12:12:41 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1365'
+      - '4704'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -314,11 +316,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - ac3db256-8b8e-47e7-874d-2a84454ae5ea
+      - 4bd41431-2995-487e-876b-9bdfc627d828
       Original-Request:
-      - req_xFWSrTTsvhUfXf
+      - req_NidZyJouDIa9zm
       Request-Id:
-      - req_xFWSrTTsvhUfXf
+      - req_NidZyJouDIa9zm
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -331,185 +333,175 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: |-
+      string: |
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
+          "error": {
+            "charge": "ch_3OChxUKuuB1fWySn0xTRQSy2",
+            "code": "incorrect_cvc",
+            "doc_url": "https://stripe.com/docs/error-codes/incorrect-cvc",
+            "message": "Your card's security code is incorrect.",
+            "param": "cvc",
+            "payment_intent": {
+              "id": "pi_3OChxUKuuB1fWySn0BE2hR0a",
+              "object": "payment_intent",
+              "amount": 100,
+              "amount_capturable": 0,
+              "amount_details": {
+                "tip": {
+                }
+              },
+              "amount_received": 0,
+              "application": null,
+              "application_fee_amount": null,
+              "automatic_payment_methods": null,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "manual",
+              "client_secret": "pi_3OChxUKuuB1fWySn0BE2hR0a_secret_2iVjUwUVeb8TwV5wTwWHz8QmR",
+              "confirmation_method": "automatic",
+              "created": 1700050360,
+              "currency": "eur",
+              "customer": null,
+              "description": null,
+              "invoice": null,
+              "last_payment_error": {
+                "charge": "ch_3OChxUKuuB1fWySn0xTRQSy2",
+                "code": "incorrect_cvc",
+                "doc_url": "https://stripe.com/docs/error-codes/incorrect-cvc",
+                "message": "Your card's security code is incorrect.",
+                "param": "cvc",
+                "payment_method": {
+                  "id": "pm_1OChxTKuuB1fWySncxVWyTGO",
+                  "object": "payment_method",
+                  "billing_details": {
+                    "address": {
+                      "city": null,
+                      "country": null,
+                      "line1": null,
+                      "line2": null,
+                      "postal_code": null,
+                      "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null
+                  },
+                  "card": {
+                    "brand": "visa",
+                    "checks": {
+                      "address_line1_check": null,
+                      "address_postal_code_check": null,
+                      "cvc_check": "fail"
+                    },
+                    "country": "US",
+                    "exp_month": 12,
+                    "exp_year": 2024,
+                    "fingerprint": "eWmxEL5j3bNdPnK5",
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "0127",
+                    "networks": {
+                      "available": [
+                        "visa"
+                      ],
+                      "preferred": null
+                    },
+                    "three_d_secure_usage": {
+                      "supported": true
+                    },
+                    "wallet": null
+                  },
+                  "created": 1700050359,
+                  "customer": null,
+                  "livemode": false,
+                  "metadata": {
+                  },
+                  "type": "card"
+                },
+                "type": "card_error"
+              },
+              "latest_charge": "ch_3OChxUKuuB1fWySn0xTRQSy2",
+              "livemode": false,
+              "metadata": {
+              },
+              "next_action": null,
+              "on_behalf_of": null,
+              "payment_method": null,
+              "payment_method_configuration_details": null,
+              "payment_method_options": {
+                "card": {
+                  "installments": null,
+                  "mandate_options": null,
+                  "network": null,
+                  "request_three_d_secure": "automatic"
+                }
+              },
+              "payment_method_types": [
+                "card"
+              ],
+              "processing": null,
+              "receipt_email": null,
+              "review": null,
+              "setup_future_usage": null,
+              "shipping": null,
+              "source": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": null,
+              "status": "requires_payment_method",
+              "transfer_data": null,
+              "transfer_group": null
+            },
+            "payment_method": {
+              "id": "pm_1OChxTKuuB1fWySncxVWyTGO",
+              "object": "payment_method",
+              "billing_details": {
+                "address": {
+                  "city": null,
+                  "country": null,
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": null,
+                  "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null
+              },
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "fail"
+                },
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2024,
+                "fingerprint": "eWmxEL5j3bNdPnK5",
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "0127",
+                "networks": {
+                  "available": [
+                    "visa"
+                  ],
+                  "preferred": null
+                },
+                "three_d_secure_usage": {
+                  "supported": true
+                },
+                "wallet": null
+              },
+              "created": 1700050359,
+              "customer": null,
+              "livemode": false,
+              "metadata": {
+              },
+              "type": "card"
+            },
+            "request_log_url": "https://dashboard.stripe.com/test/logs/req_NidZyJouDIa9zm?t=1700050360",
+            "type": "card_error"
+          }
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:07 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/10.1.0
-      Authorization:
-      - Bearer <HIDDEN_KEY>
-      Content-Type:
-      - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_xFWSrTTsvhUfXf","request_duration_ms":1003}}'
-      Stripe-Version:
-      - '2023-10-16'
-      X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.2.0-36-generic (buildd@lcy02-amd64-050) (x86_64-linux-gnu-gcc-11
-        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
-        #37~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct  9 15:34:04 UTC 2","hostname":"ff-LAT"}'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Wed, 15 Nov 2023 12:16:08 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1365'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
-      Request-Id:
-      - req_rdUoEaNBJ1QdYa
-      Stripe-Version:
-      - '2023-10-16'
-      Vary:
-      - Origin
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
-        }
-  recorded_at: Wed, 15 Nov 2023 12:16:08 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:41 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Insufficient_funds_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Insufficient_funds_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: type=card&card[number]=4242424242424242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
+      string: type=card&card[number]=4000000000009995&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -13,6 +13,8 @@ http_interactions:
       - Bearer <HIDDEN_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_KdvLGoQMfCL2nw","request_duration_ms":414}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -32,7 +34,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:05 GMT
+      - Wed, 15 Nov 2023 12:12:32 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -57,11 +59,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 17bbe933-7643-4ec9-bd1b-69681c72adf2
+      - 1f31327d-24b5-4635-9d3d-6ef9a28b6eab
       Original-Request:
-      - req_XmkH194g2YhHQE
+      - req_9HHPnkYxYtqNLl
       Request-Id:
-      - req_XmkH194g2YhHQE
+      - req_9HHPnkYxYtqNLl
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -76,7 +78,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "id": "pm_1OChxLKuuB1fWySnR2TcwSUA",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -101,10 +103,10 @@ http_interactions:
             "country": "US",
             "exp_month": 12,
             "exp_year": 2024,
-            "fingerprint": "6E6tgVjx6U65iHFV",
+            "fingerprint": "O0I0muUGQBJy3p73",
             "funding": "credit",
             "generated_from": null,
-            "last4": "4242",
+            "last4": "9995",
             "networks": {
               "available": [
                 "visa"
@@ -116,19 +118,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1700050565,
+          "created": 1700050351,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:05 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:32 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=100&currency=eur&payment_method=pm_1OCi0nKuuB1fWySnIYqzx8kS&payment_method_types[0]=card&capture_method=manual
+      string: amount=100&currency=eur&payment_method=pm_1OChxLKuuB1fWySnR2TcwSUA&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -137,7 +139,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_XmkH194g2YhHQE","request_duration_ms":712}}'
+      - '{"last_request_metrics":{"request_id":"req_9HHPnkYxYtqNLl","request_duration_ms":483}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -157,7 +159,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:06 GMT
+      - Wed, 15 Nov 2023 12:12:32 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,11 +184,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - d8823767-1297-46e7-b0b8-4232c6d8f8d2
+      - acccacfe-b2c2-4b36-b83b-1fd3bb860af4
       Original-Request:
-      - req_jj5gDAn7KGM55p
+      - req_MhpndywbNGjZMK
       Request-Id:
-      - req_jj5gDAn7KGM55p
+      - req_MhpndywbNGjZMK
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -201,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
+          "id": "pi_3OChxMKuuB1fWySn1rcTfG3I",
           "object": "payment_intent",
           "amount": 100,
           "amount_capturable": 0,
@@ -215,9 +217,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
+          "client_secret": "pi_3OChxMKuuB1fWySn1rcTfG3I_secret_8u7eMhSwjkHRQwtDtQxowkWXE",
           "confirmation_method": "automatic",
-          "created": 1700050565,
+          "created": 1700050352,
           "currency": "eur",
           "customer": null,
           "description": null,
@@ -228,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "payment_method": "pm_1OChxLKuuB1fWySnR2TcwSUA",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -253,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:06 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:32 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OChxMKuuB1fWySn1rcTfG3I/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -268,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jj5gDAn7KGM55p","request_duration_ms":544}}'
+      - '{"last_request_metrics":{"request_id":"req_MhpndywbNGjZMK","request_duration_ms":415}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -282,17 +284,17 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 200
-      message: OK
+      code: 402
+      message: Payment Required
     headers:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:07 GMT
+      - Wed, 15 Nov 2023 12:12:33 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1365'
+      - '4736'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -314,11 +316,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - ac3db256-8b8e-47e7-874d-2a84454ae5ea
+      - 3517f029-b052-4f08-9f9c-cfb5b0fa8555
       Original-Request:
-      - req_xFWSrTTsvhUfXf
+      - req_kdMi9XpMqE5Qbl
       Request-Id:
-      - req_xFWSrTTsvhUfXf
+      - req_kdMi9XpMqE5Qbl
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -331,185 +333,175 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: |-
+      string: |
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
+          "error": {
+            "charge": "ch_3OChxMKuuB1fWySn1Dvim04f",
+            "code": "card_declined",
+            "decline_code": "insufficient_funds",
+            "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+            "message": "Your card has insufficient funds.",
+            "payment_intent": {
+              "id": "pi_3OChxMKuuB1fWySn1rcTfG3I",
+              "object": "payment_intent",
+              "amount": 100,
+              "amount_capturable": 0,
+              "amount_details": {
+                "tip": {
+                }
+              },
+              "amount_received": 0,
+              "application": null,
+              "application_fee_amount": null,
+              "automatic_payment_methods": null,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "manual",
+              "client_secret": "pi_3OChxMKuuB1fWySn1rcTfG3I_secret_8u7eMhSwjkHRQwtDtQxowkWXE",
+              "confirmation_method": "automatic",
+              "created": 1700050352,
+              "currency": "eur",
+              "customer": null,
+              "description": null,
+              "invoice": null,
+              "last_payment_error": {
+                "charge": "ch_3OChxMKuuB1fWySn1Dvim04f",
+                "code": "card_declined",
+                "decline_code": "insufficient_funds",
+                "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+                "message": "Your card has insufficient funds.",
+                "payment_method": {
+                  "id": "pm_1OChxLKuuB1fWySnR2TcwSUA",
+                  "object": "payment_method",
+                  "billing_details": {
+                    "address": {
+                      "city": null,
+                      "country": null,
+                      "line1": null,
+                      "line2": null,
+                      "postal_code": null,
+                      "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null
+                  },
+                  "card": {
+                    "brand": "visa",
+                    "checks": {
+                      "address_line1_check": null,
+                      "address_postal_code_check": null,
+                      "cvc_check": "pass"
+                    },
+                    "country": "US",
+                    "exp_month": 12,
+                    "exp_year": 2024,
+                    "fingerprint": "O0I0muUGQBJy3p73",
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "9995",
+                    "networks": {
+                      "available": [
+                        "visa"
+                      ],
+                      "preferred": null
+                    },
+                    "three_d_secure_usage": {
+                      "supported": true
+                    },
+                    "wallet": null
+                  },
+                  "created": 1700050351,
+                  "customer": null,
+                  "livemode": false,
+                  "metadata": {
+                  },
+                  "type": "card"
+                },
+                "type": "card_error"
+              },
+              "latest_charge": "ch_3OChxMKuuB1fWySn1Dvim04f",
+              "livemode": false,
+              "metadata": {
+              },
+              "next_action": null,
+              "on_behalf_of": null,
+              "payment_method": null,
+              "payment_method_configuration_details": null,
+              "payment_method_options": {
+                "card": {
+                  "installments": null,
+                  "mandate_options": null,
+                  "network": null,
+                  "request_three_d_secure": "automatic"
+                }
+              },
+              "payment_method_types": [
+                "card"
+              ],
+              "processing": null,
+              "receipt_email": null,
+              "review": null,
+              "setup_future_usage": null,
+              "shipping": null,
+              "source": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": null,
+              "status": "requires_payment_method",
+              "transfer_data": null,
+              "transfer_group": null
+            },
+            "payment_method": {
+              "id": "pm_1OChxLKuuB1fWySnR2TcwSUA",
+              "object": "payment_method",
+              "billing_details": {
+                "address": {
+                  "city": null,
+                  "country": null,
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": null,
+                  "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null
+              },
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2024,
+                "fingerprint": "O0I0muUGQBJy3p73",
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "9995",
+                "networks": {
+                  "available": [
+                    "visa"
+                  ],
+                  "preferred": null
+                },
+                "three_d_secure_usage": {
+                  "supported": true
+                },
+                "wallet": null
+              },
+              "created": 1700050351,
+              "customer": null,
+              "livemode": false,
+              "metadata": {
+              },
+              "type": "card"
+            },
+            "request_log_url": "https://dashboard.stripe.com/test/logs/req_kdMi9XpMqE5Qbl?t=1700050352",
+            "type": "card_error"
+          }
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:07 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/10.1.0
-      Authorization:
-      - Bearer <HIDDEN_KEY>
-      Content-Type:
-      - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_xFWSrTTsvhUfXf","request_duration_ms":1003}}'
-      Stripe-Version:
-      - '2023-10-16'
-      X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.2.0-36-generic (buildd@lcy02-amd64-050) (x86_64-linux-gnu-gcc-11
-        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
-        #37~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct  9 15:34:04 UTC 2","hostname":"ff-LAT"}'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Wed, 15 Nov 2023 12:16:08 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1365'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
-      Request-Id:
-      - req_rdUoEaNBJ1QdYa
-      Stripe-Version:
-      - '2023-10-16'
-      Vary:
-      - Origin
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
-        }
-  recorded_at: Wed, 15 Nov 2023 12:16:08 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:33 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Lost_card_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Lost_card_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: type=card&card[number]=4242424242424242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
+      string: type=card&card[number]=4000000000009987&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -13,6 +13,8 @@ http_interactions:
       - Bearer <HIDDEN_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_MhpndywbNGjZMK","request_duration_ms":415}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -32,7 +34,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:05 GMT
+      - Wed, 15 Nov 2023 12:12:34 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -57,11 +59,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 17bbe933-7643-4ec9-bd1b-69681c72adf2
+      - 12ea57ae-c49d-4fd3-bb64-45f9da8d9211
       Original-Request:
-      - req_XmkH194g2YhHQE
+      - req_pAwnGMzGTJ2DxB
       Request-Id:
-      - req_XmkH194g2YhHQE
+      - req_pAwnGMzGTJ2DxB
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -76,7 +78,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "id": "pm_1OChxNKuuB1fWySnUdnDAd2K",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -101,10 +103,10 @@ http_interactions:
             "country": "US",
             "exp_month": 12,
             "exp_year": 2024,
-            "fingerprint": "6E6tgVjx6U65iHFV",
+            "fingerprint": "hMDekBwrnWL1oLxe",
             "funding": "credit",
             "generated_from": null,
-            "last4": "4242",
+            "last4": "9987",
             "networks": {
               "available": [
                 "visa"
@@ -116,19 +118,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1700050565,
+          "created": 1700050353,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:05 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:34 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=100&currency=eur&payment_method=pm_1OCi0nKuuB1fWySnIYqzx8kS&payment_method_types[0]=card&capture_method=manual
+      string: amount=100&currency=eur&payment_method=pm_1OChxNKuuB1fWySnUdnDAd2K&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -137,7 +139,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_XmkH194g2YhHQE","request_duration_ms":712}}'
+      - '{"last_request_metrics":{"request_id":"req_pAwnGMzGTJ2DxB","request_duration_ms":456}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -157,7 +159,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:06 GMT
+      - Wed, 15 Nov 2023 12:12:34 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,11 +184,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - d8823767-1297-46e7-b0b8-4232c6d8f8d2
+      - 6645c22f-c593-4834-a0ee-e8478efdff04
       Original-Request:
-      - req_jj5gDAn7KGM55p
+      - req_iylTlHMVdXBgXo
       Request-Id:
-      - req_jj5gDAn7KGM55p
+      - req_iylTlHMVdXBgXo
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -201,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
+          "id": "pi_3OChxOKuuB1fWySn2NxC80za",
           "object": "payment_intent",
           "amount": 100,
           "amount_capturable": 0,
@@ -215,9 +217,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
+          "client_secret": "pi_3OChxOKuuB1fWySn2NxC80za_secret_IxfxcX0AoNOPnUqIL3qIf1M9Z",
           "confirmation_method": "automatic",
-          "created": 1700050565,
+          "created": 1700050354,
           "currency": "eur",
           "customer": null,
           "description": null,
@@ -228,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "payment_method": "pm_1OChxNKuuB1fWySnUdnDAd2K",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -253,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:06 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:34 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OChxOKuuB1fWySn2NxC80za/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -268,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jj5gDAn7KGM55p","request_duration_ms":544}}'
+      - '{"last_request_metrics":{"request_id":"req_iylTlHMVdXBgXo","request_duration_ms":411}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -282,17 +284,17 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 200
-      message: OK
+      code: 402
+      message: Payment Required
     headers:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:07 GMT
+      - Wed, 15 Nov 2023 12:12:35 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1365'
+      - '4698'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -314,11 +316,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - ac3db256-8b8e-47e7-874d-2a84454ae5ea
+      - 62039d13-ad58-44b5-a8c8-ba873745b3ac
       Original-Request:
-      - req_xFWSrTTsvhUfXf
+      - req_ulpnPgDeUS1LkU
       Request-Id:
-      - req_xFWSrTTsvhUfXf
+      - req_ulpnPgDeUS1LkU
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -331,185 +333,175 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: |-
+      string: |
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
+          "error": {
+            "charge": "ch_3OChxOKuuB1fWySn2NSqw6ES",
+            "code": "card_declined",
+            "decline_code": "lost_card",
+            "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+            "message": "Your card was declined.",
+            "payment_intent": {
+              "id": "pi_3OChxOKuuB1fWySn2NxC80za",
+              "object": "payment_intent",
+              "amount": 100,
+              "amount_capturable": 0,
+              "amount_details": {
+                "tip": {
+                }
+              },
+              "amount_received": 0,
+              "application": null,
+              "application_fee_amount": null,
+              "automatic_payment_methods": null,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "manual",
+              "client_secret": "pi_3OChxOKuuB1fWySn2NxC80za_secret_IxfxcX0AoNOPnUqIL3qIf1M9Z",
+              "confirmation_method": "automatic",
+              "created": 1700050354,
+              "currency": "eur",
+              "customer": null,
+              "description": null,
+              "invoice": null,
+              "last_payment_error": {
+                "charge": "ch_3OChxOKuuB1fWySn2NSqw6ES",
+                "code": "card_declined",
+                "decline_code": "lost_card",
+                "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+                "message": "Your card was declined.",
+                "payment_method": {
+                  "id": "pm_1OChxNKuuB1fWySnUdnDAd2K",
+                  "object": "payment_method",
+                  "billing_details": {
+                    "address": {
+                      "city": null,
+                      "country": null,
+                      "line1": null,
+                      "line2": null,
+                      "postal_code": null,
+                      "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null
+                  },
+                  "card": {
+                    "brand": "visa",
+                    "checks": {
+                      "address_line1_check": null,
+                      "address_postal_code_check": null,
+                      "cvc_check": "pass"
+                    },
+                    "country": "US",
+                    "exp_month": 12,
+                    "exp_year": 2024,
+                    "fingerprint": "hMDekBwrnWL1oLxe",
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "9987",
+                    "networks": {
+                      "available": [
+                        "visa"
+                      ],
+                      "preferred": null
+                    },
+                    "three_d_secure_usage": {
+                      "supported": true
+                    },
+                    "wallet": null
+                  },
+                  "created": 1700050353,
+                  "customer": null,
+                  "livemode": false,
+                  "metadata": {
+                  },
+                  "type": "card"
+                },
+                "type": "card_error"
+              },
+              "latest_charge": "ch_3OChxOKuuB1fWySn2NSqw6ES",
+              "livemode": false,
+              "metadata": {
+              },
+              "next_action": null,
+              "on_behalf_of": null,
+              "payment_method": null,
+              "payment_method_configuration_details": null,
+              "payment_method_options": {
+                "card": {
+                  "installments": null,
+                  "mandate_options": null,
+                  "network": null,
+                  "request_three_d_secure": "automatic"
+                }
+              },
+              "payment_method_types": [
+                "card"
+              ],
+              "processing": null,
+              "receipt_email": null,
+              "review": null,
+              "setup_future_usage": null,
+              "shipping": null,
+              "source": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": null,
+              "status": "requires_payment_method",
+              "transfer_data": null,
+              "transfer_group": null
+            },
+            "payment_method": {
+              "id": "pm_1OChxNKuuB1fWySnUdnDAd2K",
+              "object": "payment_method",
+              "billing_details": {
+                "address": {
+                  "city": null,
+                  "country": null,
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": null,
+                  "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null
+              },
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2024,
+                "fingerprint": "hMDekBwrnWL1oLxe",
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "9987",
+                "networks": {
+                  "available": [
+                    "visa"
+                  ],
+                  "preferred": null
+                },
+                "three_d_secure_usage": {
+                  "supported": true
+                },
+                "wallet": null
+              },
+              "created": 1700050353,
+              "customer": null,
+              "livemode": false,
+              "metadata": {
+              },
+              "type": "card"
+            },
+            "request_log_url": "https://dashboard.stripe.com/test/logs/req_ulpnPgDeUS1LkU?t=1700050354",
+            "type": "card_error"
+          }
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:07 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/10.1.0
-      Authorization:
-      - Bearer <HIDDEN_KEY>
-      Content-Type:
-      - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_xFWSrTTsvhUfXf","request_duration_ms":1003}}'
-      Stripe-Version:
-      - '2023-10-16'
-      X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.2.0-36-generic (buildd@lcy02-amd64-050) (x86_64-linux-gnu-gcc-11
-        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
-        #37~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct  9 15:34:04 UTC 2","hostname":"ff-LAT"}'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Wed, 15 Nov 2023 12:16:08 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1365'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
-      Request-Id:
-      - req_rdUoEaNBJ1QdYa
-      Stripe-Version:
-      - '2023-10-16'
-      Vary:
-      - Origin
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
-        }
-  recorded_at: Wed, 15 Nov 2023 12:16:08 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:35 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Processing_error_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Processing_error_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: type=card&card[number]=4242424242424242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
+      string: type=card&card[number]=4000000000000119&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -13,6 +13,8 @@ http_interactions:
       - Bearer <HIDDEN_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_CgYr5edkZxNSG7","request_duration_ms":414}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -32,7 +34,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:05 GMT
+      - Wed, 15 Nov 2023 12:12:41 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -57,11 +59,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 17bbe933-7643-4ec9-bd1b-69681c72adf2
+      - 8575b755-00be-48b3-a7c9-06b9e746e6d2
       Original-Request:
-      - req_XmkH194g2YhHQE
+      - req_zCdYh2l6XYOnd4
       Request-Id:
-      - req_XmkH194g2YhHQE
+      - req_zCdYh2l6XYOnd4
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -76,7 +78,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "id": "pm_1OChxVKuuB1fWySnjRUecECL",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -101,10 +103,10 @@ http_interactions:
             "country": "US",
             "exp_month": 12,
             "exp_year": 2024,
-            "fingerprint": "6E6tgVjx6U65iHFV",
+            "fingerprint": "9HWWxe4EyniQy61z",
             "funding": "credit",
             "generated_from": null,
-            "last4": "4242",
+            "last4": "0119",
             "networks": {
               "available": [
                 "visa"
@@ -116,19 +118,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1700050565,
+          "created": 1700050361,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:05 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:41 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=100&currency=eur&payment_method=pm_1OCi0nKuuB1fWySnIYqzx8kS&payment_method_types[0]=card&capture_method=manual
+      string: amount=100&currency=eur&payment_method=pm_1OChxVKuuB1fWySnjRUecECL&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -137,7 +139,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_XmkH194g2YhHQE","request_duration_ms":712}}'
+      - '{"last_request_metrics":{"request_id":"req_zCdYh2l6XYOnd4","request_duration_ms":481}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -157,7 +159,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:06 GMT
+      - Wed, 15 Nov 2023 12:12:42 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,11 +184,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - d8823767-1297-46e7-b0b8-4232c6d8f8d2
+      - 5f837170-dc04-4954-91f6-2e773c0e2fa3
       Original-Request:
-      - req_jj5gDAn7KGM55p
+      - req_ni5sEg4CW8KyB5
       Request-Id:
-      - req_jj5gDAn7KGM55p
+      - req_ni5sEg4CW8KyB5
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -201,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
+          "id": "pi_3OChxWKuuB1fWySn0XVHPPq0",
           "object": "payment_intent",
           "amount": 100,
           "amount_capturable": 0,
@@ -215,9 +217,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
+          "client_secret": "pi_3OChxWKuuB1fWySn0XVHPPq0_secret_ZG2ki9dNIIOFsS6yZVS0Cvcmt",
           "confirmation_method": "automatic",
-          "created": 1700050565,
+          "created": 1700050362,
           "currency": "eur",
           "customer": null,
           "description": null,
@@ -228,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "payment_method": "pm_1OChxVKuuB1fWySnjRUecECL",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -253,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:06 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:42 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OChxWKuuB1fWySn0XVHPPq0/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -268,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jj5gDAn7KGM55p","request_duration_ms":544}}'
+      - '{"last_request_metrics":{"request_id":"req_ni5sEg4CW8KyB5","request_duration_ms":421}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -282,17 +284,17 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 200
-      message: OK
+      code: 402
+      message: Payment Required
     headers:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:07 GMT
+      - Wed, 15 Nov 2023 12:12:43 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1365'
+      - '4738'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -314,11 +316,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - ac3db256-8b8e-47e7-874d-2a84454ae5ea
+      - 0aecb857-f0e6-4d92-a497-d8e5ab4dc8f7
       Original-Request:
-      - req_xFWSrTTsvhUfXf
+      - req_k76DAtaPz87zEV
       Request-Id:
-      - req_xFWSrTTsvhUfXf
+      - req_k76DAtaPz87zEV
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -331,185 +333,173 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: |-
+      string: |
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
+          "error": {
+            "charge": "ch_3OChxWKuuB1fWySn0kineRTW",
+            "code": "processing_error",
+            "doc_url": "https://stripe.com/docs/error-codes/processing-error",
+            "message": "An error occurred while processing your card. Try again in a little bit.",
+            "payment_intent": {
+              "id": "pi_3OChxWKuuB1fWySn0XVHPPq0",
+              "object": "payment_intent",
+              "amount": 100,
+              "amount_capturable": 0,
+              "amount_details": {
+                "tip": {
+                }
+              },
+              "amount_received": 0,
+              "application": null,
+              "application_fee_amount": null,
+              "automatic_payment_methods": null,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "manual",
+              "client_secret": "pi_3OChxWKuuB1fWySn0XVHPPq0_secret_ZG2ki9dNIIOFsS6yZVS0Cvcmt",
+              "confirmation_method": "automatic",
+              "created": 1700050362,
+              "currency": "eur",
+              "customer": null,
+              "description": null,
+              "invoice": null,
+              "last_payment_error": {
+                "charge": "ch_3OChxWKuuB1fWySn0kineRTW",
+                "code": "processing_error",
+                "doc_url": "https://stripe.com/docs/error-codes/processing-error",
+                "message": "An error occurred while processing your card. Try again in a little bit.",
+                "payment_method": {
+                  "id": "pm_1OChxVKuuB1fWySnjRUecECL",
+                  "object": "payment_method",
+                  "billing_details": {
+                    "address": {
+                      "city": null,
+                      "country": null,
+                      "line1": null,
+                      "line2": null,
+                      "postal_code": null,
+                      "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null
+                  },
+                  "card": {
+                    "brand": "visa",
+                    "checks": {
+                      "address_line1_check": null,
+                      "address_postal_code_check": null,
+                      "cvc_check": "pass"
+                    },
+                    "country": "US",
+                    "exp_month": 12,
+                    "exp_year": 2024,
+                    "fingerprint": "9HWWxe4EyniQy61z",
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "0119",
+                    "networks": {
+                      "available": [
+                        "visa"
+                      ],
+                      "preferred": null
+                    },
+                    "three_d_secure_usage": {
+                      "supported": true
+                    },
+                    "wallet": null
+                  },
+                  "created": 1700050361,
+                  "customer": null,
+                  "livemode": false,
+                  "metadata": {
+                  },
+                  "type": "card"
+                },
+                "type": "card_error"
+              },
+              "latest_charge": "ch_3OChxWKuuB1fWySn0kineRTW",
+              "livemode": false,
+              "metadata": {
+              },
+              "next_action": null,
+              "on_behalf_of": null,
+              "payment_method": null,
+              "payment_method_configuration_details": null,
+              "payment_method_options": {
+                "card": {
+                  "installments": null,
+                  "mandate_options": null,
+                  "network": null,
+                  "request_three_d_secure": "automatic"
+                }
+              },
+              "payment_method_types": [
+                "card"
+              ],
+              "processing": null,
+              "receipt_email": null,
+              "review": null,
+              "setup_future_usage": null,
+              "shipping": null,
+              "source": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": null,
+              "status": "requires_payment_method",
+              "transfer_data": null,
+              "transfer_group": null
+            },
+            "payment_method": {
+              "id": "pm_1OChxVKuuB1fWySnjRUecECL",
+              "object": "payment_method",
+              "billing_details": {
+                "address": {
+                  "city": null,
+                  "country": null,
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": null,
+                  "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null
+              },
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2024,
+                "fingerprint": "9HWWxe4EyniQy61z",
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "0119",
+                "networks": {
+                  "available": [
+                    "visa"
+                  ],
+                  "preferred": null
+                },
+                "three_d_secure_usage": {
+                  "supported": true
+                },
+                "wallet": null
+              },
+              "created": 1700050361,
+              "customer": null,
+              "livemode": false,
+              "metadata": {
+              },
+              "type": "card"
+            },
+            "request_log_url": "https://dashboard.stripe.com/test/logs/req_k76DAtaPz87zEV?t=1700050362",
+            "type": "card_error"
+          }
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:07 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/10.1.0
-      Authorization:
-      - Bearer <HIDDEN_KEY>
-      Content-Type:
-      - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_xFWSrTTsvhUfXf","request_duration_ms":1003}}'
-      Stripe-Version:
-      - '2023-10-16'
-      X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.2.0-36-generic (buildd@lcy02-amd64-050) (x86_64-linux-gnu-gcc-11
-        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
-        #37~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct  9 15:34:04 UTC 2","hostname":"ff-LAT"}'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Wed, 15 Nov 2023 12:16:08 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1365'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
-      Request-Id:
-      - req_rdUoEaNBJ1QdYa
-      Stripe-Version:
-      - '2023-10-16'
-      Vary:
-      - Origin
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
-        }
-  recorded_at: Wed, 15 Nov 2023 12:16:08 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:43 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Stolen_card_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.1.0/Stripe_PaymentIntentValidator/_call/when_payment_intent_is_invalid/invalid_credit_cards_are_correctly_handled/behaves_like_payments_intents/from_Stolen_card_decline/raises_Stripe_error_with_payment_intent_last_payment_error_as_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: type=card&card[number]=4242424242424242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
+      string: type=card&card[number]=4000000000009979&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -13,6 +13,8 @@ http_interactions:
       - Bearer <HIDDEN_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_iylTlHMVdXBgXo","request_duration_ms":411}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -32,7 +34,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:05 GMT
+      - Wed, 15 Nov 2023 12:12:35 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -57,11 +59,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 17bbe933-7643-4ec9-bd1b-69681c72adf2
+      - f310cb72-95f4-429e-8743-ea05ccbd6e0b
       Original-Request:
-      - req_XmkH194g2YhHQE
+      - req_ojZDNu2s0z2Ynl
       Request-Id:
-      - req_XmkH194g2YhHQE
+      - req_ojZDNu2s0z2Ynl
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -76,7 +78,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "id": "pm_1OChxPKuuB1fWySnyX5Vskoi",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -101,10 +103,10 @@ http_interactions:
             "country": "US",
             "exp_month": 12,
             "exp_year": 2024,
-            "fingerprint": "6E6tgVjx6U65iHFV",
+            "fingerprint": "1pjhEFFOW1eCi1AB",
             "funding": "credit",
             "generated_from": null,
-            "last4": "4242",
+            "last4": "9979",
             "networks": {
               "available": [
                 "visa"
@@ -116,19 +118,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1700050565,
+          "created": 1700050355,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:05 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:36 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=100&currency=eur&payment_method=pm_1OCi0nKuuB1fWySnIYqzx8kS&payment_method_types[0]=card&capture_method=manual
+      string: amount=100&currency=eur&payment_method=pm_1OChxPKuuB1fWySnyX5Vskoi&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.1.0
@@ -137,7 +139,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_XmkH194g2YhHQE","request_duration_ms":712}}'
+      - '{"last_request_metrics":{"request_id":"req_ojZDNu2s0z2Ynl","request_duration_ms":473}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -157,7 +159,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:06 GMT
+      - Wed, 15 Nov 2023 12:12:36 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,11 +184,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - d8823767-1297-46e7-b0b8-4232c6d8f8d2
+      - 81399087-6fda-44c4-8f1b-9e6599aa97c7
       Original-Request:
-      - req_jj5gDAn7KGM55p
+      - req_wz9ngtsjxiowwD
       Request-Id:
-      - req_jj5gDAn7KGM55p
+      - req_wz9ngtsjxiowwD
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -201,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
+          "id": "pi_3OChxQKuuB1fWySn07fl8qbw",
           "object": "payment_intent",
           "amount": 100,
           "amount_capturable": 0,
@@ -215,9 +217,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
+          "client_secret": "pi_3OChxQKuuB1fWySn07fl8qbw_secret_Hoy9sV6OdwlpCSX0i3qx4yJsg",
           "confirmation_method": "automatic",
-          "created": 1700050565,
+          "created": 1700050356,
           "currency": "eur",
           "customer": null,
           "description": null,
@@ -228,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
+          "payment_method": "pm_1OChxPKuuB1fWySnyX5Vskoi",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -253,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:06 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:36 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OChxQKuuB1fWySn07fl8qbw/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -268,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jj5gDAn7KGM55p","request_duration_ms":544}}'
+      - '{"last_request_metrics":{"request_id":"req_wz9ngtsjxiowwD","request_duration_ms":414}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -282,17 +284,17 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 200
-      message: OK
+      code: 402
+      message: Payment Required
     headers:
       Server:
       - nginx
       Date:
-      - Wed, 15 Nov 2023 12:16:07 GMT
+      - Wed, 15 Nov 2023 12:12:37 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1365'
+      - '4702'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -314,11 +316,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - ac3db256-8b8e-47e7-874d-2a84454ae5ea
+      - e7f4760b-bd06-4010-9da0-fc55c87b726c
       Original-Request:
-      - req_xFWSrTTsvhUfXf
+      - req_GzdO4ZhbmhszW9
       Request-Id:
-      - req_xFWSrTTsvhUfXf
+      - req_GzdO4ZhbmhszW9
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -331,185 +333,175 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: |-
+      string: |
         {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
+          "error": {
+            "charge": "ch_3OChxQKuuB1fWySn0HdCe6Ib",
+            "code": "card_declined",
+            "decline_code": "stolen_card",
+            "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+            "message": "Your card was declined.",
+            "payment_intent": {
+              "id": "pi_3OChxQKuuB1fWySn07fl8qbw",
+              "object": "payment_intent",
+              "amount": 100,
+              "amount_capturable": 0,
+              "amount_details": {
+                "tip": {
+                }
+              },
+              "amount_received": 0,
+              "application": null,
+              "application_fee_amount": null,
+              "automatic_payment_methods": null,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "manual",
+              "client_secret": "pi_3OChxQKuuB1fWySn07fl8qbw_secret_Hoy9sV6OdwlpCSX0i3qx4yJsg",
+              "confirmation_method": "automatic",
+              "created": 1700050356,
+              "currency": "eur",
+              "customer": null,
+              "description": null,
+              "invoice": null,
+              "last_payment_error": {
+                "charge": "ch_3OChxQKuuB1fWySn0HdCe6Ib",
+                "code": "card_declined",
+                "decline_code": "stolen_card",
+                "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+                "message": "Your card was declined.",
+                "payment_method": {
+                  "id": "pm_1OChxPKuuB1fWySnyX5Vskoi",
+                  "object": "payment_method",
+                  "billing_details": {
+                    "address": {
+                      "city": null,
+                      "country": null,
+                      "line1": null,
+                      "line2": null,
+                      "postal_code": null,
+                      "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null
+                  },
+                  "card": {
+                    "brand": "visa",
+                    "checks": {
+                      "address_line1_check": null,
+                      "address_postal_code_check": null,
+                      "cvc_check": "pass"
+                    },
+                    "country": "US",
+                    "exp_month": 12,
+                    "exp_year": 2024,
+                    "fingerprint": "1pjhEFFOW1eCi1AB",
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "9979",
+                    "networks": {
+                      "available": [
+                        "visa"
+                      ],
+                      "preferred": null
+                    },
+                    "three_d_secure_usage": {
+                      "supported": true
+                    },
+                    "wallet": null
+                  },
+                  "created": 1700050355,
+                  "customer": null,
+                  "livemode": false,
+                  "metadata": {
+                  },
+                  "type": "card"
+                },
+                "type": "card_error"
+              },
+              "latest_charge": "ch_3OChxQKuuB1fWySn0HdCe6Ib",
+              "livemode": false,
+              "metadata": {
+              },
+              "next_action": null,
+              "on_behalf_of": null,
+              "payment_method": null,
+              "payment_method_configuration_details": null,
+              "payment_method_options": {
+                "card": {
+                  "installments": null,
+                  "mandate_options": null,
+                  "network": null,
+                  "request_three_d_secure": "automatic"
+                }
+              },
+              "payment_method_types": [
+                "card"
+              ],
+              "processing": null,
+              "receipt_email": null,
+              "review": null,
+              "setup_future_usage": null,
+              "shipping": null,
+              "source": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": null,
+              "status": "requires_payment_method",
+              "transfer_data": null,
+              "transfer_group": null
+            },
+            "payment_method": {
+              "id": "pm_1OChxPKuuB1fWySnyX5Vskoi",
+              "object": "payment_method",
+              "billing_details": {
+                "address": {
+                  "city": null,
+                  "country": null,
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": null,
+                  "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null
+              },
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2024,
+                "fingerprint": "1pjhEFFOW1eCi1AB",
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "9979",
+                "networks": {
+                  "available": [
+                    "visa"
+                  ],
+                  "preferred": null
+                },
+                "three_d_secure_usage": {
+                  "supported": true
+                },
+                "wallet": null
+              },
+              "created": 1700050355,
+              "customer": null,
+              "livemode": false,
+              "metadata": {
+              },
+              "type": "card"
+            },
+            "request_log_url": "https://dashboard.stripe.com/test/logs/req_GzdO4ZhbmhszW9?t=1700050356",
+            "type": "card_error"
+          }
         }
-  recorded_at: Wed, 15 Nov 2023 12:16:07 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OCi0nKuuB1fWySn2TWSR23z
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/10.1.0
-      Authorization:
-      - Bearer <HIDDEN_KEY>
-      Content-Type:
-      - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_xFWSrTTsvhUfXf","request_duration_ms":1003}}'
-      Stripe-Version:
-      - '2023-10-16'
-      X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.1.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.2.0-36-generic (buildd@lcy02-amd64-050) (x86_64-linux-gnu-gcc-11
-        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
-        #37~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct  9 15:34:04 UTC 2","hostname":"ff-LAT"}'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Wed, 15 Nov 2023 12:16:08 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1365'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
-      Request-Id:
-      - req_rdUoEaNBJ1QdYa
-      Stripe-Version:
-      - '2023-10-16'
-      Vary:
-      - Origin
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pi_3OCi0nKuuB1fWySn2TWSR23z",
-          "object": "payment_intent",
-          "amount": 100,
-          "amount_capturable": 100,
-          "amount_details": {
-            "tip": {}
-          },
-          "amount_received": 0,
-          "application": null,
-          "application_fee_amount": null,
-          "automatic_payment_methods": null,
-          "canceled_at": null,
-          "cancellation_reason": null,
-          "capture_method": "manual",
-          "client_secret": "pi_3OCi0nKuuB1fWySn2TWSR23z_secret_EbRoOHNbUyOIYKuMgSYjgFnMs",
-          "confirmation_method": "automatic",
-          "created": 1700050565,
-          "currency": "eur",
-          "customer": null,
-          "description": null,
-          "invoice": null,
-          "last_payment_error": null,
-          "latest_charge": "ch_3OCi0nKuuB1fWySn2kYbfP21",
-          "livemode": false,
-          "metadata": {},
-          "next_action": null,
-          "on_behalf_of": null,
-          "payment_method": "pm_1OCi0nKuuB1fWySnIYqzx8kS",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "installments": null,
-              "mandate_options": null,
-              "network": null,
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "processing": null,
-          "receipt_email": null,
-          "review": null,
-          "setup_future_usage": null,
-          "shipping": null,
-          "source": null,
-          "statement_descriptor": null,
-          "statement_descriptor_suffix": null,
-          "status": "requires_capture",
-          "transfer_data": null,
-          "transfer_group": null
-        }
-  recorded_at: Wed, 15 Nov 2023 12:16:08 GMT
+  recorded_at: Wed, 15 Nov 2023 12:12:37 GMT
 recorded_with: VCR 6.2.0

--- a/spec/lib/stripe/payment_intent_validator_spec.rb
+++ b/spec/lib/stripe/payment_intent_validator_spec.rb
@@ -60,7 +60,7 @@ module Stripe
           }.to_not raise_error Stripe::StripeError
         end
       end
-      context "when payment intent is invalid" do 
+      context "when payment intent is invalid" do
         shared_examples "payments intents" do |card_type, card_number, error_message|
           context "from #{card_type}" do
             let!(:pm_card) do
@@ -107,7 +107,7 @@ module Stripe
                           "An error occurred while processing your card. Try again in a little bit."
           it_behaves_like "payments intents", "Exceeding velocity limit decline",
                           4_000_000_000_006_975,
-            %(Your card was declined for making repeated attempts too frequently 
+                          %(Your card was declined for making repeated attempts too frequently
             or exceeding its amount limit.).squish
         end
       end

--- a/spec/lib/stripe/payment_intent_validator_spec.rb
+++ b/spec/lib/stripe/payment_intent_validator_spec.rb
@@ -11,13 +11,12 @@ module Stripe
       create(:stripe_sca_payment_method, distributor_ids: [create(:distributor_enterprise).id],
                                          preferred_enterprise_id: create(:enterprise).id)
     }
-    let(:source) {
-      create(:credit_card)
-    }
+    let(:source) { create(:credit_card) }
+    let(:year_valid) { Time.zone.now.year.next }
 
-    before do
+    before {
       Stripe.api_key = secret
-    end
+    }
 
     describe "#call", :vcr, :stripe_version do
       let(:payment) {
@@ -33,12 +32,11 @@ module Stripe
                                          card: {
                                            number: '4242424242424242',
                                            exp_month: 12,
-                                           exp_year: 2034,
+                                           exp_year: year_valid,
                                            cvc: '314',
                                          },
                                        })
         end
-
         let!(:payment_intent) do
           Stripe::PaymentIntent.create({
                                          amount: 100,
@@ -48,7 +46,6 @@ module Stripe
                                          capture_method: 'manual',
                                        })
         end
-
         let(:payment_intent_response_body) {
           [id: payment_intent.id, status: payment_intent.status]
         }
@@ -56,7 +53,6 @@ module Stripe
         before do
           Stripe::PaymentIntent.confirm(payment_intent.id)
         end
-
         it "returns payment intent id and does not raise" do
           expect {
             result = validator.call
@@ -64,43 +60,55 @@ module Stripe
           }.to_not raise_error Stripe::StripeError
         end
       end
-
-      context "when payment intent contains an error" do
-        let!(:pm_card) do
-          Stripe::PaymentMethod.create({
-                                         type: 'card',
-                                         card: {
-                                           # decline code: insufficient_funds
-                                           number: '4000000000009995',
-                                           exp_month: 12,
-                                           exp_year: 2034,
-                                           cvc: '314',
-                                         },
-                                       })
+      context "when payment intent is invalid" do 
+        shared_examples "payments intents" do |card_type, card_number, error_message|
+          context "from #{card_type}" do
+            let!(:pm_card) do
+              Stripe::PaymentMethod.create({
+                                             type: 'card',
+                                             card: {
+                                               number: card_number,
+                                               exp_month: 12,
+                                               exp_year: year_valid,
+                                               cvc: '314',
+                                             },
+                                           })
+            end
+            let(:payment_intent) do
+              Stripe::PaymentIntent.create({
+                                             amount: 100,
+                                             currency: 'eur',
+                                             payment_method: pm_card,
+                                             payment_method_types: ['card'],
+                                             capture_method: 'manual',
+                                           })
+            end
+            it "raises Stripe error with payment intent last_payment_error as message" do
+              expect {
+                Stripe::PaymentIntent.confirm(payment_intent.id)
+              }.to raise_error Stripe::StripeError, error_message
+            end
+          end
         end
-
-        let!(:payment_intent) do
-          Stripe::PaymentIntent.create({
-                                         amount: 100,
-                                         currency: 'eur',
-                                         payment_method: pm_card,
-                                         payment_method_types: ['card'],
-                                         capture_method: 'manual',
-                                       })
-        end
-
-        let(:payment_intent_response_body) {
-          JSON.generate(id: payment_intent_id, last_payment_error: { message: "No money" })
-        }
-
-        it "raises Stripe error with payment intent last_payment_error as message" do
-          expect {
-            Stripe::PaymentIntent.confirm(payment_intent.id)
-          }.to raise_error Stripe::StripeError, "Your card has insufficient funds."
-
-          expect {
-            validator.call
-          }.to raise_error Stripe::StripeError, "Your card has insufficient funds."
+        context "invalid credit cards are correctly handled" do
+          it_behaves_like "payments intents", "Generic decline", 4_000_000_000_000_002,
+                          "Your card was declined."
+          it_behaves_like "payments intents", "Insufficient funds decline", 4_000_000_000_009_995,
+                          "Your card has insufficient funds."
+          it_behaves_like "payments intents", "Lost card decline", 4_000_000_000_009_987,
+                          "Your card was declined."
+          it_behaves_like "payments intents", "Stolen card decline", 4_000_000_000_009_979,
+                          "Your card was declined."
+          it_behaves_like "payments intents", "Expired card decline", 4_000_000_000_000_069,
+                          "Your card has expired."
+          it_behaves_like "payments intents", "Incorrect CVC decline", 4_000_000_000_000_127,
+                          "Your card's security code is incorrect."
+          it_behaves_like "payments intents", "Processing error decline", 4_000_000_000_000_119,
+                          "An error occurred while processing your card. Try again in a little bit."
+          it_behaves_like "payments intents", "Exceeding velocity limit decline",
+                          4_000_000_000_006_975,
+            %(Your card was declined for making repeated attempts too frequently 
+            or exceeding its amount limit.).squish
         end
       end
     end

--- a/spec/lib/stripe/payment_intent_validator_spec.rb
+++ b/spec/lib/stripe/payment_intent_validator_spec.rb
@@ -3,113 +3,111 @@
 require 'spec_helper'
 require 'stripe/payment_intent_validator'
 
-module Stripe
-  describe PaymentIntentValidator do
-    let(:secret) { ENV.fetch('STRIPE_SECRET_TEST_API_KEY', nil) }
+describe Stripe::PaymentIntentValidator do
+  let(:secret) { ENV.fetch('STRIPE_SECRET_TEST_API_KEY', nil) }
 
-    let(:payment_method) {
-      create(:stripe_sca_payment_method, distributor_ids: [create(:distributor_enterprise).id],
-                                         preferred_enterprise_id: create(:enterprise).id)
+  let(:payment_method) {
+    create(:stripe_sca_payment_method, distributor_ids: [create(:distributor_enterprise).id],
+                                       preferred_enterprise_id: create(:enterprise).id)
+  }
+  let(:source) { create(:credit_card) }
+  let(:year_valid) { Time.zone.now.year.next }
+
+  before {
+    Stripe.api_key = secret
+  }
+
+  describe "#call", :vcr, :stripe_version do
+    let(:payment) {
+      create(:payment, amount: payment_intent.amount, payment_method:,
+                       response_code: payment_intent.id, source:)
     }
-    let(:source) { create(:credit_card) }
-    let(:year_valid) { Time.zone.now.year.next }
+    let(:validator) { Stripe::PaymentIntentValidator.new(payment) }
 
-    before {
-      Stripe.api_key = secret
-    }
-
-    describe "#call", :vcr, :stripe_version do
-      let(:payment) {
-        create(:payment, amount: payment_intent.amount, payment_method:,
-                         response_code: payment_intent.id, source:)
-      }
-      let(:validator) { Stripe::PaymentIntentValidator.new(payment) }
-
-      context "when payment intent is valid" do
-        let!(:pm_card) do
-          Stripe::PaymentMethod.create({
-                                         type: 'card',
-                                         card: {
-                                           number: '4242424242424242',
-                                           exp_month: 12,
-                                           exp_year: year_valid,
-                                           cvc: '314',
-                                         },
-                                       })
-        end
-        let!(:payment_intent) do
-          Stripe::PaymentIntent.create({
-                                         amount: 100,
-                                         currency: 'eur',
-                                         payment_method: pm_card,
-                                         payment_method_types: ['card'],
-                                         capture_method: 'manual',
-                                       })
-        end
-        let(:payment_intent_response_body) {
-          [id: payment_intent.id, status: payment_intent.status]
-        }
-
-        before do
-          Stripe::PaymentIntent.confirm(payment_intent.id)
-        end
-        it "returns payment intent id and does not raise" do
-          expect {
-            result = validator.call
-            expect(result).to eq payment_intent_response_body
-          }.to_not raise_error Stripe::StripeError
-        end
+    context "when payment intent is valid" do
+      let!(:pm_card) do
+        Stripe::PaymentMethod.create({
+                                       type: 'card',
+                                       card: {
+                                         number: '4242424242424242',
+                                         exp_month: 12,
+                                         exp_year: year_valid,
+                                         cvc: '314',
+                                       },
+                                     })
       end
-      context "when payment intent is invalid" do
-        shared_examples "payments intents" do |card_type, card_number, error_message|
-          context "from #{card_type}" do
-            let!(:pm_card) do
-              Stripe::PaymentMethod.create({
-                                             type: 'card',
-                                             card: {
-                                               number: card_number,
-                                               exp_month: 12,
-                                               exp_year: year_valid,
-                                               cvc: '314',
-                                             },
-                                           })
-            end
-            let(:payment_intent) do
-              Stripe::PaymentIntent.create({
-                                             amount: 100,
-                                             currency: 'eur',
-                                             payment_method: pm_card,
-                                             payment_method_types: ['card'],
-                                             capture_method: 'manual',
-                                           })
-            end
-            it "raises Stripe error with payment intent last_payment_error as message" do
-              expect {
-                Stripe::PaymentIntent.confirm(payment_intent.id)
-              }.to raise_error Stripe::StripeError, error_message
-            end
+      let!(:payment_intent) do
+        Stripe::PaymentIntent.create({
+                                       amount: 100,
+                                       currency: 'eur',
+                                       payment_method: pm_card,
+                                       payment_method_types: ['card'],
+                                       capture_method: 'manual',
+                                     })
+      end
+      let(:payment_intent_response_body) {
+        [id: payment_intent.id, status: payment_intent.status]
+      }
+
+      before do
+        Stripe::PaymentIntent.confirm(payment_intent.id)
+      end
+      it "returns payment intent id and does not raise" do
+        expect {
+          result = validator.call
+          expect(result).to eq payment_intent_response_body
+        }.to_not raise_error Stripe::StripeError
+      end
+    end
+    context "when payment intent is invalid" do
+      shared_examples "payments intents" do |card_type, card_number, error_message|
+        context "from #{card_type}" do
+          let!(:pm_card) do
+            Stripe::PaymentMethod.create({
+                                           type: 'card',
+                                           card: {
+                                             number: card_number,
+                                             exp_month: 12,
+                                             exp_year: year_valid,
+                                             cvc: '314',
+                                           },
+                                         })
+          end
+          let(:payment_intent) do
+            Stripe::PaymentIntent.create({
+                                           amount: 100,
+                                           currency: 'eur',
+                                           payment_method: pm_card,
+                                           payment_method_types: ['card'],
+                                           capture_method: 'manual',
+                                         })
+          end
+          it "raises Stripe error with payment intent last_payment_error as message" do
+            expect {
+              Stripe::PaymentIntent.confirm(payment_intent.id)
+            }.to raise_error Stripe::StripeError, error_message
           end
         end
-        context "invalid credit cards are correctly handled" do
-          it_behaves_like "payments intents", "Generic decline", 4_000_000_000_000_002,
-                          "Your card was declined."
-          it_behaves_like "payments intents", "Insufficient funds decline", 4_000_000_000_009_995,
-                          "Your card has insufficient funds."
-          it_behaves_like "payments intents", "Lost card decline", 4_000_000_000_009_987,
-                          "Your card was declined."
-          it_behaves_like "payments intents", "Stolen card decline", 4_000_000_000_009_979,
-                          "Your card was declined."
-          it_behaves_like "payments intents", "Expired card decline", 4_000_000_000_000_069,
-                          "Your card has expired."
-          it_behaves_like "payments intents", "Incorrect CVC decline", 4_000_000_000_000_127,
-                          "Your card's security code is incorrect."
-          it_behaves_like "payments intents", "Processing error decline", 4_000_000_000_000_119,
-                          "An error occurred while processing your card. Try again in a little bit."
-          it_behaves_like "payments intents", "Exceeding velocity limit decline",
-                          4_000_000_000_006_975,
-                          %(Your card was declined for making repeated attempts too frequently
-            or exceeding its amount limit.).squish
-        end
+      end
+      context "invalid credit cards are correctly handled" do
+        it_behaves_like "payments intents", "Generic decline", 4_000_000_000_000_002,
+                        "Your card was declined."
+        it_behaves_like "payments intents", "Insufficient funds decline", 4_000_000_000_009_995,
+                        "Your card has insufficient funds."
+        it_behaves_like "payments intents", "Lost card decline", 4_000_000_000_009_987,
+                        "Your card was declined."
+        it_behaves_like "payments intents", "Stolen card decline", 4_000_000_000_009_979,
+                        "Your card was declined."
+        it_behaves_like "payments intents", "Expired card decline", 4_000_000_000_000_069,
+                        "Your card has expired."
+        it_behaves_like "payments intents", "Incorrect CVC decline", 4_000_000_000_000_127,
+                        "Your card's security code is incorrect."
+        it_behaves_like "payments intents", "Processing error decline", 4_000_000_000_000_119,
+                        "An error occurred while processing your card. Try again in a little bit."
+        it_behaves_like "payments intents", "Exceeding velocity limit decline",
+                        4_000_000_000_006_975,
+                        %(Your card was declined for making repeated attempts too frequently
+          or exceeding its amount limit.).squish
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Tests payment intent confirmation errors, when the associated cards are invalid.
 
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Since we're now able to record Stripe API calls when creating payment intents, we can create a list of credit cards (each of them with the respective error, as indicated in [Stripe's documentation](https://stripe.com/docs/testing?testing-method=card-numbers#declined-payments)), to request/record/assert payment intent refusals. 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
