### PR TITLE
[DFC] match taxons to dfc product types

### DIFF
--- a/app/controllers/spree/admin/taxons_controller.rb
+++ b/app/controllers/spree/admin/taxons_controller.rb
@@ -117,8 +117,8 @@ module Spree
 
       def taxon_params
         params.require(:taxon).permit(
-          :name, :parent_id, :position, :icon, :description, :permalink,
-          :taxonomy_id, :meta_description, :meta_keywords, :meta_title
+          :name, :parent_id, :position, :icon, :description, :permalink, :taxonomy_id,
+          :meta_description, :meta_keywords, :meta_title, :dfc_name
         )
       end
     end

--- a/app/controllers/spree/admin/taxons_controller.rb
+++ b/app/controllers/spree/admin/taxons_controller.rb
@@ -118,7 +118,7 @@ module Spree
       def taxon_params
         params.require(:taxon).permit(
           :name, :parent_id, :position, :icon, :description, :permalink, :taxonomy_id,
-          :meta_description, :meta_keywords, :meta_title, :dfc_name
+          :meta_description, :meta_keywords, :meta_title, :dfc_id
         )
       end
     end

--- a/app/views/spree/admin/taxons/_form.html.haml
+++ b/app/views/spree/admin/taxons/_form.html.haml
@@ -1,31 +1,31 @@
 .row
   .alpha.five.columns
     = f.field_container :name do
-      = f.label :name, t(:name)
+      = f.label :name, t(".name")
       %span.required *
       %br/
       = error_message_on :taxon, :name, class: 'fullwidth title'
       = text_field :taxon, :name, class: 'fullwidth'
     = f.field_container :permalink_part do
-      = f.label :permalink_part, t(:permalink)
+      = f.label :permalink_part, t(".permalink")
       %span.required *
       %br/
       = @taxon.permalink.split("/")[0...-1].join("/") + "/"
       = text_field_tag :permalink_part, @permalink_part
     = f.field_container :meta_title do
-      = f.label :meta_title, t(:meta_title)
+      = f.label :meta_title, t(".meta_title")
       %br/
       = f.text_field :meta_title, class: 'fullwidth', rows: 6
     = f.field_container :meta_description do
-      = f.label :meta_description, t(:meta_description)
+      = f.label :meta_description, t(".meta_description")
       %br/
       = f.text_field :meta_description, class: 'fullwidth', rows: 6
     = f.field_container :meta_description do
-      = f.label :meta_keywords, t(:meta_keywords)
+      = f.label :meta_keywords, t(".meta_keywords")
       %br/
       = f.text_field :meta_keywords, class: 'fullwidth', rows: 6
   .omega.seven.columns
     = f.field_container :description do
-      = f.label :description, t(:description)
+      = f.label :description, t(".description")
       %br/
       = f.text_area :description, class: 'fullwidth', rows: 6

--- a/app/views/spree/admin/taxons/_form.html.haml
+++ b/app/views/spree/admin/taxons/_form.html.haml
@@ -24,6 +24,10 @@
       = f.label :meta_keywords, t(".meta_keywords")
       %br/
       = f.text_field :meta_keywords, class: 'fullwidth', rows: 6
+    = f.field_container :dfc_name do
+      = f.label :dfc_name, t(".dfc_name")
+      %br/
+      = f.text_field :dfc_name, class: 'fullwidth', rows: 6
   .omega.seven.columns
     = f.field_container :description do
       = f.label :description, t(".description")

--- a/app/views/spree/admin/taxons/_form.html.haml
+++ b/app/views/spree/admin/taxons/_form.html.haml
@@ -24,10 +24,10 @@
       = f.label :meta_keywords, t(".meta_keywords")
       %br/
       = f.text_field :meta_keywords, class: 'fullwidth', rows: 6
-    = f.field_container :dfc_name do
-      = f.label :dfc_name, t(".dfc_name")
+    = f.field_container :dfc_id do
+      = f.label :dfc_id, t(".dfc_id")
       %br/
-      = f.text_field :dfc_name, class: 'fullwidth', rows: 6
+      = f.text_field :dfc_id, class: 'fullwidth', rows: 6
   .omega.seven.columns
     = f.field_container :description do
       = f.label :description, t(".description")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4487,7 +4487,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           meta_description: Meta Description
           meta_keywords: Meta Keywords
           description: Description
-          dfc_name: DFC name 
+          dfc_id: DFC URI 
       general_settings:
         edit:
           legal_settings: "Legal Settings"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4479,6 +4479,14 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           email: "Email"
           total: "Total"
           billing_address_name: "Name"
+      taxons:
+        form:
+          name: Name
+          permalink: Permalink
+          meta_title: Meta Title
+          meta_description: Meta Description
+          meta_keywords: Meta Keywords
+          description: Description
       general_settings:
         edit:
           legal_settings: "Legal Settings"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4487,6 +4487,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           meta_description: Meta Description
           meta_keywords: Meta Keywords
           description: Description
+          dfc_name: DFC name 
       general_settings:
         edit:
           legal_settings: "Legal Settings"

--- a/db/migrate/20231027041224_add_dfc_name_to_spree_taxons.rb
+++ b/db/migrate/20231027041224_add_dfc_name_to_spree_taxons.rb
@@ -1,5 +1,5 @@
 class AddDfcNameToSpreeTaxons < ActiveRecord::Migration[7.0]
   def change
-    add_column :spree_taxons, :dfc_name, :string
+    add_column :spree_taxons, :dfc_id, :string
   end
 end

--- a/db/migrate/20231027041224_add_dfc_name_to_spree_taxons.rb
+++ b/db/migrate/20231027041224_add_dfc_name_to_spree_taxons.rb
@@ -1,0 +1,5 @@
+class AddDfcNameToSpreeTaxons < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_taxons, :dfc_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -881,7 +881,7 @@ ActiveRecord::Schema[7.0].define(version: 20231003000823494) do
     t.string "meta_title", limit: 255
     t.string "meta_description", limit: 255
     t.string "meta_keywords", limit: 255
-    t.string "dfc_name"
+    t.string "dfc_id"
     t.index ["parent_id"], name: "index_taxons_on_parent_id"
     t.index ["permalink"], name: "index_taxons_on_permalink"
     t.index ["taxonomy_id"], name: "index_taxons_on_taxonomy_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -881,6 +881,7 @@ ActiveRecord::Schema[7.0].define(version: 20231003000823494) do
     t.string "meta_title", limit: 255
     t.string "meta_description", limit: 255
     t.string "meta_keywords", limit: 255
+    t.string "dfc_name"
     t.index ["parent_id"], name: "index_taxons_on_parent_id"
     t.index ["permalink"], name: "index_taxons_on_permalink"
     t.index ["taxonomy_id"], name: "index_taxons_on_taxonomy_id"

--- a/engines/dfc_provider/app/services/dfc_product_type_factory.rb
+++ b/engines/dfc_provider/app/services/dfc_product_type_factory.rb
@@ -23,39 +23,25 @@ class DfcProductTypeFactory
 
   def populate_product_types
     DfcLoader.connector.PRODUCT_TYPES.topConcepts.each do |product_type|
-      stack = []
-      record_type(stack, product_type.to_s)
+      record_type(DfcLoader.connector.PRODUCT_TYPES, product_type.to_s)
     end
   end
 
-  def record_type(stack, product_type)
-    name = product_type.to_s
-    current_stack = stack.dup.push(name)
+  def record_type(product_type_object, product_type)
+    current_product_type = product_type_object.public_send(product_type.to_s)
 
-    type = call_dfc_product_type(current_stack)
-
-    id = type.semanticId
-    @product_types[id] = type
+    id = current_product_type.semanticId
+    @product_types[id] = current_product_type
 
     # Narrower product types are defined as class method on the current product type object
-    narrowers = type.methods(false).sort
+    narrowers = current_product_type.methods(false).sort
 
     # Leaf node
     return if narrowers.empty?
 
     narrowers.each do |narrower|
       # recursive call
-      record_type(current_stack, narrower)
+      record_type(current_product_type, narrower)
     end
-  end
-
-  # Callproduct type method ie: DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
-  def call_dfc_product_type(product_type_path)
-    type = DfcLoader.connector.PRODUCT_TYPES
-    product_type_path.each do |pt|
-      type = type.public_send(pt)
-    end
-
-    type
   end
 end

--- a/engines/dfc_provider/app/services/dfc_product_type_factory.rb
+++ b/engines/dfc_provider/app/services/dfc_product_type_factory.rb
@@ -16,9 +16,7 @@ class DfcProductTypeFactory
   end
 
   def for(dfc_id)
-    return nil if @product_types[dfc_id].nil?
-
-    call_dfc_product_type(@product_types[dfc_id])
+    @product_types[dfc_id]
   end
 
   private
@@ -37,7 +35,7 @@ class DfcProductTypeFactory
     type = call_dfc_product_type(current_stack)
 
     id = type.semanticId
-    @product_types[id] = current_stack
+    @product_types[id] = type
 
     # Narrower product types are defined as class method on the current product type object
     narrowers = type.methods(false).sort

--- a/engines/dfc_provider/app/services/dfc_product_type_factory.rb
+++ b/engines/dfc_provider/app/services/dfc_product_type_factory.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'singleton'
+
+class DfcProductTypeFactory
+  include Singleton
+
+  def self.for(dfc_id)
+    instance.for(dfc_id)
+  end
+
+  def initialize
+    @product_types = {}
+
+    populate_product_types
+  end
+
+  def for(dfc_id)
+    return nil if @product_types[dfc_id].nil?
+
+    call_dfc_product_type(@product_types[dfc_id])
+  end
+
+  private
+
+  def populate_product_types
+    DfcLoader.connector.PRODUCT_TYPES.topConcepts.each do |product_type|
+      stack = []
+      record_type(stack, product_type.to_s)
+    end
+  end
+
+  def record_type(stack, product_type)
+    name = product_type.to_s
+    current_stack = stack.dup.push(name)
+
+    type = call_dfc_product_type(current_stack)
+
+    id = type.semanticId
+    @product_types[id] = current_stack
+
+    # Narrower product types are defined as class method on the current product type object
+    narrowers = type.methods(false).sort
+
+    # Leaf node
+    return if narrowers.empty?
+
+    narrowers.each do |narrower|
+      # recursive call
+      record_type(current_stack, narrower)
+    end
+  end
+
+  # Callproduct type method ie: DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
+  def call_dfc_product_type(product_type_path)
+    type = DfcLoader.connector.PRODUCT_TYPES
+    product_type_path.each do |pt|
+      type = type.public_send(pt)
+    end
+
+    type
+  end
+end

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -52,6 +52,7 @@ class SuppliedProductBuilder < DfcBuilder
   def self.apply(supplied_product, variant)
     variant.product.assign_attributes(
       description: supplied_product.description,
+      primary_taxon: taxon(supplied_product)
     )
 
     variant.display_name = supplied_product.name

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -67,9 +67,10 @@ class SuppliedProductBuilder < DfcBuilder
 
     populate_product_types if PRODUCT_TYPES.empty?
 
-    return nil if PRODUCT_TYPES[taxon_name.to_sym].nil?
+    name = taxon_name.downcase.gsub(" ", "_").to_sym
+    return nil if PRODUCT_TYPES[name].nil?
 
-    call_dfc_product_type(PRODUCT_TYPES[taxon_name.to_sym])
+    call_dfc_product_type(PRODUCT_TYPES[name])
   end
 
   def self.populate_product_types

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -111,13 +111,8 @@ class SuppliedProductBuilder < DfcBuilder
   end
 
   def self.taxon(supplied_product)
-    # We use english locale, might need to make this configurable
-    dfc_id = supplied_product.productType.prefLabels[:en].downcase
-    taxon = Spree::Taxon.find_by(dfc_id: )
-
-    return taxon if taxon.present?
-
-    nil
+    dfc_id = supplied_product.productType.semanticId
+    Spree::Taxon.find_by(dfc_id: )
   end
 
   private_class_method :product_type, :populate_product_types, :record_type, :call_dfc_product_type,

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -38,13 +38,12 @@ class SuppliedProductBuilder < DfcBuilder
     end
   end
 
-  # TODO fix the taxon here
   def self.import_product(supplied_product)
     Spree::Product.new(
       name: supplied_product.name,
       description: supplied_product.description,
       price: 0, # will be in DFC Offer
-      primary_taxon: Spree::Taxon.first, # dummy value until we have a mapping
+      primary_taxon: taxon(supplied_product)
     ).tap do |product|
       QuantitativeValueBuilder.apply(supplied_product.quantity, product)
     end
@@ -109,5 +108,16 @@ class SuppliedProductBuilder < DfcBuilder
     type
   end
 
-  private_class_method :product_type, :populate_product_types, :record_type
+  def self.taxon(supplied_product)
+    # We use english locale, might need to make this configurable
+    dfc_name = supplied_product.productType.prefLabels[:en].downcase
+    taxon = Spree::Taxon.find_by(dfc_name: )
+
+    return taxon if taxon.present?
+
+    nil
+  end
+
+  private_class_method :product_type, :populate_product_types, :record_type, :call_dfc_product_type,
+                       :taxon
 end

--- a/engines/dfc_provider/lib/data_food_consortium/connector/importer.rb
+++ b/engines/dfc_provider/lib/data_food_consortium/connector/importer.rb
@@ -120,18 +120,13 @@ module DataFoodConsortium
       end
 
       def skos_concept(object)
-        # Sometimes we get given a literal object with a value referring to skos concept
-        # ie "dfc-pt:drink"
-        return unless object.value.match(":") || object.uri?
+        return unless object.uri?
 
         id = object.value.sub(
           "http://static.datafoodconsortium.org/data/measures.rdf#", "dfc-m:"
         ).sub(
           "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/measures.rdf#",
           "dfc-m:"
-        ).sub(
-          "dfc-pt:",
-          "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#"
         )
 
         SKOSParser.concepts[id]

--- a/engines/dfc_provider/lib/data_food_consortium/connector/importer.rb
+++ b/engines/dfc_provider/lib/data_food_consortium/connector/importer.rb
@@ -130,8 +130,8 @@ module DataFoodConsortium
           "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/measures.rdf#",
           "dfc-m:"
         ).sub(
-          "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#",
-          "dfc-pt:"
+          "dfc-pt:",
+          "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#"
         )
 
         SKOSParser.concepts[id]

--- a/engines/dfc_provider/lib/data_food_consortium/connector/importer.rb
+++ b/engines/dfc_provider/lib/data_food_consortium/connector/importer.rb
@@ -120,6 +120,10 @@ module DataFoodConsortium
       end
 
       def skos_concept(object)
+        # Sometimes we get given a literal object with a value referring to skos concept
+        # ie "dfc-pt:drink"
+        return unless object.value.match(":") || object.uri?
+
         id = object.value.sub(
           "http://static.datafoodconsortium.org/data/measures.rdf#", "dfc-m:"
         ).sub(

--- a/engines/dfc_provider/lib/data_food_consortium/connector/importer.rb
+++ b/engines/dfc_provider/lib/data_food_consortium/connector/importer.rb
@@ -4,7 +4,7 @@ require_relative "skos_parser"
 
 module DataFoodConsortium
   module Connector
-    class Importer
+    class Importer # rubocop:disable Metrics/ClassLength
       TYPES = [
         DataFoodConsortium::Connector::CatalogItem,
         DataFoodConsortium::Connector::Enterprise,
@@ -106,7 +106,7 @@ module DataFoodConsortium
         if property.value.is_a?(Enumerable)
           property.value << value
         else
-          setter = guess_setter_name(statement.predicate)
+          setter = guess_setter_name(statement)
           subject.try(setter, value) if setter
         end
       end
@@ -120,18 +120,26 @@ module DataFoodConsortium
       end
 
       def skos_concept(object)
-        return unless object.uri?
-
         id = object.value.sub(
           "http://static.datafoodconsortium.org/data/measures.rdf#", "dfc-m:"
         ).sub(
           "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/measures.rdf#",
           "dfc-m:"
+        ).sub(
+          "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#",
+          "dfc-pt:"
         )
+
         SKOSParser.concepts[id]
       end
 
-      def guess_setter_name(predicate)
+      def guess_setter_name(statement)
+        predicate = statement.predicate
+
+        # Ideally the product models would be consitent with the rule below and use "type"
+        # instead of "productType" but alast they are not so we need this exception
+        return "productType=" if predicate.fragment == "hasType" && product_type?(statement)
+
         name =
           # Some predicates are named like `hasQuantity`
           # but the attribute name would be `quantity`.
@@ -140,6 +148,14 @@ module DataFoodConsortium
           predicate.to_s.split(":").last
 
         "#{name}="
+      end
+
+      def product_type?(statement)
+        return true if statement.object.literal? && statement.object.value.match("dfc-pt")
+
+        return true if statement.object.path.match("productTypes")
+
+        false
       end
     end
   end

--- a/engines/dfc_provider/lib/data_food_consortium/connector/skos_parser.rb
+++ b/engines/dfc_provider/lib/data_food_consortium/connector/skos_parser.rb
@@ -90,13 +90,8 @@ module DataFoodConsortium
           prefLabels: element.label
         )
         skosConcept.semanticType = element.type
-        # Gaetan's fix for productTypes
-        id = element.id.sub(
-          "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#",
-          "dfc-pt:"
-        )
         # Maikel's patch
-        self.class.concepts[id] = skosConcept
+        self.class.concepts[element.id] = skosConcept
         skosConcept
       end
 

--- a/engines/dfc_provider/lib/data_food_consortium/connector/skos_parser.rb
+++ b/engines/dfc_provider/lib/data_food_consortium/connector/skos_parser.rb
@@ -90,8 +90,13 @@ module DataFoodConsortium
           prefLabels: element.label
         )
         skosConcept.semanticType = element.type
+        # Gaetan's fix for productTypes
+        id = element.id.sub(
+          "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#",
+          "dfc-pt:"
+        )
         # Maikel's patch
-        self.class.concepts[element.id] = skosConcept
+        self.class.concepts[id] = skosConcept
         skosConcept
       end
 

--- a/engines/dfc_provider/spec/fixtures/files/put_supplied_product.json
+++ b/engines/dfc_provider/spec/fixtures/files/put_supplied_product.json
@@ -93,7 +93,7 @@
     "dfc-b:hasUnit": "dfc-m:Piece",
     "dfc-b:value": 17
   },
-  "dfc-b:hasType": "dfc-pt:non-local-vegetable",
+  "dfc-b:hasType": "dfc-pt:drink",
   "dfc-b:lifetime": "",
   "dfc-b:name": "Pesto novo",
   "dfc-b:totalTheoreticalStock": 0,

--- a/engines/dfc_provider/spec/lib/data_food_consortium/connector/importer_spec.rb
+++ b/engines/dfc_provider/spec/lib/data_food_consortium/connector/importer_spec.rb
@@ -23,6 +23,7 @@ describe DataFoodConsortium::Connector::Importer do
       name: "Tomato",
       description: "Awesome tomato",
       totalTheoreticalStock: 3,
+      productType: non_local_vegetable,
     )
   end
   let(:product_data) do
@@ -36,7 +37,8 @@ describe DataFoodConsortium::Connector::Importer do
         "dfc-b:alcoholPercentage":0.0,
         "dfc-b:lifetime":"",
         "dfc-b:usageOrStorageCondition":"",
-        "dfc-b:totalTheoreticalStock":3
+        "dfc-b:totalTheoreticalStock":3,
+        "dfc-b:hasType": "dfc-pt:non-local-vegetable"
       }
     JSON
   end
@@ -55,7 +57,8 @@ describe DataFoodConsortium::Connector::Importer do
         "dfc-b:alcoholPercentage":0.0,
         "dfc-b:lifetime":"",
         "dfc-b:usageOrStorageCondition":"",
-        "dfc-b:totalTheoreticalStock":3
+        "dfc-b:totalTheoreticalStock":3,
+        "dfc-b:hasType": "dfc-pt:non-local-vegetable"
       }
     JSON
   end
@@ -74,7 +77,8 @@ describe DataFoodConsortium::Connector::Importer do
         "dfc-b:alcoholPercentage":0.0,
         "dfc-b:lifetime":"",
         "dfc-b:usageOrStorageCondition":"",
-        "dfc-b:totalTheoreticalStock":3
+        "dfc-b:totalTheoreticalStock":3,
+        "dfc-b:hasType": "dfc-pt:non-local-vegetable"
       }
     JSON
   end
@@ -96,6 +100,11 @@ describe DataFoodConsortium::Connector::Importer do
     end
     connector.MEASURES.PIECE
   end
+  let(:non_local_vegetable) do
+    connector.PRODUCT_TYPES.VEGETABLE.NON_LOCAL_VEGETABLE
+  end
+
+  before { connector.loadProductTypes(read_file("productTypes")) }
 
   it "imports a single object with simple properties" do
     result = import(product)
@@ -105,6 +114,7 @@ describe DataFoodConsortium::Connector::Importer do
     expect(result.semanticId).to eq "https://example.net/tomato"
     expect(result.name).to eq "Tomato"
     expect(result.description).to eq "Awesome tomato"
+    expect(result.productType).to eq non_local_vegetable
     expect(result.totalTheoreticalStock).to eq 3
   end
 
@@ -116,6 +126,7 @@ describe DataFoodConsortium::Connector::Importer do
     expect(result.semanticId).to eq "https://example.net/tomato"
     expect(result.name).to eq "Tomato"
     expect(result.description).to eq "Awesome tomato"
+    expect(result.productType).to eq non_local_vegetable
     expect(result.totalTheoreticalStock).to eq 3
   end
 
@@ -127,6 +138,7 @@ describe DataFoodConsortium::Connector::Importer do
     expect(result.semanticId).to eq "https://example.net/tomato"
     expect(result.name).to eq "Tomato"
     expect(result.description).to eq "Awesome tomato"
+    expect(result.productType).to eq non_local_vegetable
     expect(result.totalTheoreticalStock).to eq 3
   end
 
@@ -138,6 +150,7 @@ describe DataFoodConsortium::Connector::Importer do
     expect(result.semanticId).to eq "https://example.net/tomato"
     expect(result.name).to eq "Tomato"
     expect(result.description).to eq "Awesome tomato"
+    expect(result.productType).to eq non_local_vegetable
     expect(result.totalTheoreticalStock).to eq 3
   end
 
@@ -154,6 +167,7 @@ describe DataFoodConsortium::Connector::Importer do
     expect(item.semanticId).to eq "https://example.net/tomatoItem"
     expect(tomato.name).to eq "Tomato"
     expect(tomato.description).to eq "Awesome tomato"
+    expect(tomato.productType).to eq non_local_vegetable
     expect(tomato.totalTheoreticalStock).to eq 3
   end
 
@@ -164,6 +178,7 @@ describe DataFoodConsortium::Connector::Importer do
 
     expect(tomato.name).to eq "Tomato"
     expect(tomato.quantity).to eq items
+    expect(tomato.productType).to eq non_local_vegetable
     expect(items.value).to eq 5
     expect(items.unit).to eq piece
   end

--- a/engines/dfc_provider/spec/lib/data_food_consortium/connector/importer_spec.rb
+++ b/engines/dfc_provider/spec/lib/data_food_consortium/connector/importer_spec.rb
@@ -42,33 +42,14 @@ describe DataFoodConsortium::Connector::Importer do
       }
     JSON
   end
-  let(:product_data_with_context) do
-    <<~JSON
-      {
-        "@context": {
-          "dfc-b": "http://static.datafoodconsortium.org/ontologies/DFC_BusinessOntology.owl#",
-          "dfc-m": "http://static.datafoodconsortium.org/data/measures.rdf#",
-          "dfc-pt": "http://static.datafoodconsortium.org/data/productTypes.rdf#"
-        },
-        "@id":"https://example.net/tomato",
-        "@type":"dfc-b:SuppliedProduct",
-        "dfc-b:name":"Tomato",
-        "dfc-b:description":"Awesome tomato",
-        "dfc-b:alcoholPercentage":0.0,
-        "dfc-b:lifetime":"",
-        "dfc-b:usageOrStorageCondition":"",
-        "dfc-b:totalTheoreticalStock":3,
-        "dfc-b:hasType": "dfc-pt:non-local-vegetable"
-      }
-    JSON
-  end
   let(:product_data_with_context_v1_8) do
     <<~JSON
       {
         "@context": {
           "dfc-b": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_BusinessOntology.owl#",
           "dfc-m": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/measures.rdf#",
-          "dfc-pt": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#"
+          "dfc-pt": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#",
+          "dfc-b:hasType":{"@type":"@id"}
         },
         "@id":"https://example.net/tomato",
         "@type":"dfc-b:SuppliedProduct",
@@ -120,18 +101,6 @@ describe DataFoodConsortium::Connector::Importer do
 
   it "imports an object with referenced context" do
     result = connector.import(product_data)
-
-    expect(result).to be_a DataFoodConsortium::Connector::SuppliedProduct
-    expect(result.semanticType).to eq "dfc-b:SuppliedProduct"
-    expect(result.semanticId).to eq "https://example.net/tomato"
-    expect(result.name).to eq "Tomato"
-    expect(result.description).to eq "Awesome tomato"
-    expect(result.productType).to eq non_local_vegetable
-    expect(result.totalTheoreticalStock).to eq 3
-  end
-
-  it "imports an object with included context" do
-    result = connector.import(product_data_with_context)
 
     expect(result).to be_a DataFoodConsortium::Connector::SuppliedProduct
     expect(result.semanticType).to eq "dfc-b:SuppliedProduct"

--- a/engines/dfc_provider/spec/requests/catalog_items_spec.rb
+++ b/engines/dfc_provider/spec/requests/catalog_items_spec.rb
@@ -17,7 +17,14 @@ describe "CatalogItems", type: :request, swagger_doc: "dfc.yaml",
       :base_product,
       id: 90_000, supplier: enterprise, name: "Apple", description: "Red",
       variants: [variant],
-      primary_taxon: build(:taxon, name: "Non local vegetable", dfc_name: "non local vegetable"),
+      primary_taxon: non_local_vegetable
+    )
+  }
+  let(:non_local_vegetable) {
+    build(
+      :taxon,
+      name: "Non Local Vegetable",
+      dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#non-local-vegetable"
     )
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "AR") }

--- a/engines/dfc_provider/spec/requests/catalog_items_spec.rb
+++ b/engines/dfc_provider/spec/requests/catalog_items_spec.rb
@@ -17,7 +17,7 @@ describe "CatalogItems", type: :request, swagger_doc: "dfc.yaml",
       :base_product,
       id: 90_000, supplier: enterprise, name: "Apple", description: "Red",
       variants: [variant],
-      primary_taxon: build(:taxon, name: "Non local vegetable", dfc_name: "non_local_vegetable"),
+      primary_taxon: build(:taxon, name: "Non local vegetable", dfc_name: "non local vegetable"),
     )
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "AR") }

--- a/engines/dfc_provider/spec/requests/catalog_items_spec.rb
+++ b/engines/dfc_provider/spec/requests/catalog_items_spec.rb
@@ -17,6 +17,7 @@ describe "CatalogItems", type: :request, swagger_doc: "dfc.yaml",
       :base_product,
       id: 90_000, supplier: enterprise, name: "Apple", description: "Red",
       variants: [variant],
+      primary_taxon: build(:taxon, name: "Non local vegetable", dfc_name: "non_local_vegetable"),
     )
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "AR") }

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -29,7 +29,14 @@ describe "Enterprises", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: 
       :product_with_image,
       id: 90_000, supplier: enterprise, name: "Apple", description: "Round",
       variants: [variant],
-      primary_taxon: build(:taxon, name: "Non local vegetable", dfc_name: "non local vegetable"),
+      primary_taxon: non_local_vegetable
+    )
+  }
+  let(:non_local_vegetable) {
+    build(
+      :taxon,
+      name: "Non Local Vegetable",
+      dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#non-local-vegetable"
     )
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "APP") }

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -29,6 +29,7 @@ describe "Enterprises", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: 
       :product_with_image,
       id: 90_000, supplier: enterprise, name: "Apple", description: "Round",
       variants: [variant],
+      primary_taxon: build(:taxon, name: "Non local vegetable", dfc_name: "non_local_vegetable"),
     )
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "APP") }

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -29,7 +29,7 @@ describe "Enterprises", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: 
       :product_with_image,
       id: 90_000, supplier: enterprise, name: "Apple", description: "Round",
       variants: [variant],
-      primary_taxon: build(:taxon, name: "Non local vegetable", dfc_name: "non_local_vegetable"),
+      primary_taxon: build(:taxon, name: "Non local vegetable", dfc_name: "non local vegetable"),
     )
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "APP") }

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -184,7 +184,11 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
 
     put "Update SuppliedProduct" do
       let!(:drink_taxon) {
-        create(:taxon, name: "Drink", dfc_id: "drink")
+        create(
+          :taxon,
+          name: "Drink",
+          dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#drink"
+        )
       }
 
       consumes "application/json"

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -15,9 +15,20 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
     )
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1) }
-  let(:taxon) { build(:taxon, name: "Processed Vegetable", dfc_name: "processed vegetable") }
+  let(:taxon) {
+    build(
+      :taxon,
+      name: "Processed Vegetable",
+      dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#processed-vegetable"
+    )
+  }
+
   let!(:non_local_vegetable) {
-    create(:taxon, name: "Non Local Vegetable", dfc_name: "non local vegetable")
+    create(
+      :taxon,
+      name: "Non Local Vegetable",
+      dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#non-local-vegetable"
+    )
   }
 
   before { login_as user }
@@ -173,7 +184,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
 
     put "Update SuppliedProduct" do
       let!(:drink_taxon) {
-        create(:taxon, name: "Drink", dfc_name: "drink")
+        create(:taxon, name: "Drink", dfc_id: "drink")
       }
 
       consumes "application/json"

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -11,9 +11,11 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
       id: 90_000,
       supplier: enterprise, name: "Pesto", description: "Basil Pesto",
       variants: [variant],
+      primary_taxon: taxon
     )
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1) }
+  let(:taxon) { build(:taxon, name: "Local grocery store", dfc_name: "local_grocery_store") }
 
   before { login_as user }
 
@@ -146,6 +148,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
         run_test! do
           expect(response.body).to include variant.name
           expect(json_response["ofn:spree_product_id"]).to eq 90_000
+          expect(json_response["dfc-b:hasType"]).to include("Local grocery store")
           expect(json_response["ofn:image"]).to include("logo-white.png")
 
           # Insert static value to keep documentation deterministic:

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -15,7 +15,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
     )
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1) }
-  let(:taxon) { build(:taxon, name: "Processed Vegetable", dfc_name: "processed_vegetable") }
+  let(:taxon) { build(:taxon, name: "Processed Vegetable", dfc_name: "processed vegetable") }
 
   before { login_as user }
 

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -15,7 +15,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
     )
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1) }
-  let(:taxon) { build(:taxon, name: "Local grocery store", dfc_name: "local_grocery_store") }
+  let(:taxon) { build(:taxon, name: "Processed Vegetable", dfc_name: "processed_vegetable") }
 
   before { login_as user }
 
@@ -148,7 +148,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
         run_test! do
           expect(response.body).to include variant.name
           expect(json_response["ofn:spree_product_id"]).to eq 90_000
-          expect(json_response["dfc-b:hasType"]).to include("Local grocery store")
+          expect(json_response["dfc-b:hasType"]).to eq("dfc-pt:processed-vegetable")
           expect(json_response["ofn:image"]).to include("logo-white.png")
 
           # Insert static value to keep documentation deterministic:

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -172,6 +172,10 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
     end
 
     put "Update SuppliedProduct" do
+      let!(:drink_taxon) {
+        create(:taxon, name: "Drink", dfc_name: "drink")
+      }
+
       consumes "application/json"
 
       parameter name: :supplied_product, in: :body, schema: {
@@ -197,6 +201,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
           }.to change { variant.description }.to("DFC-Pesto updated")
             .and change { variant.display_name }.to("Pesto novo")
             .and change { variant.unit_value }.to(17)
+            .and change { variant.product.primary_taxon }.to(drink_taxon)
         end
       end
     end

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -44,14 +44,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
 
       parameter name: :supplied_product, in: :body, schema: {
         example: {
-          '@context': {
-            'dfc-b': "http://static.datafoodconsortium.org/ontologies/DFC_BusinessOntology.owl#",
-            'dfc-m': "http://static.datafoodconsortium.org/data/measures.rdf#",
-            'dfc-pt': "http://static.datafoodconsortium.org/data/productTypes.rdf#",
-            'dfc-b:hasUnit': {
-              '@type': "@id"
-            },
-          },
+          '@context': "https://www.datafoodconsortium.org",
           '@id': "http://test.host/api/dfc/enterprises/6201/supplied_products/0",
           '@type': "dfc-b:SuppliedProduct",
           'dfc-b:name': "Apple",

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -16,6 +16,9 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
   }
   let(:variant) { build(:base_variant, id: 10_001, unit_value: 1) }
   let(:taxon) { build(:taxon, name: "Processed Vegetable", dfc_name: "processed vegetable") }
+  let!(:non_local_vegetable) {
+    create(:taxon, name: "Non Local Vegetable", dfc_name: "non local vegetable")
+  }
 
   before { login_as user }
 
@@ -102,6 +105,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
           product = Spree::Product.find(product_id)
           expect(product.name).to eq "Apple"
           expect(product.variants).to eq [variant]
+          expect(product.primary_taxon).to eq(non_local_vegetable)
 
           # Creates a variant for existing product
           supplied_product[:'ofn:spree_product_id'] = product_id

--- a/engines/dfc_provider/spec/services/dfc_product_type_factory_spec.rb
+++ b/engines/dfc_provider/spec/services/dfc_product_type_factory_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+describe DfcProductTypeFactory do
+  describe ".for" do
+    let(:dfc_id) {
+      "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#drink"
+    }
+
+    it "assigns a top level product type" do
+      drink = DfcLoader.connector.PRODUCT_TYPES.DRINK
+
+      expect(described_class.for(dfc_id)).to eq drink
+    end
+
+    context "with second level product type" do
+      let(:dfc_id) {
+        "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#soft-drink"
+      }
+
+      it "assigns a second level product type" do
+        soft_drink = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
+
+        expect(described_class.for(dfc_id)).to eq soft_drink
+      end
+    end
+
+    context "with leaf level product type" do
+      let(:dfc_id) {
+        "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#lemonade"
+      }
+
+      it "assigns a leaf level product type" do
+        lemonade = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.LEMONADE
+
+        expect(described_class.for(dfc_id)).to eq lemonade
+      end
+    end
+
+    context "with non existing product type" do
+      let(:dfc_id) { "other" }
+
+      it "returns nil" do
+        expect(described_class.for(dfc_id)).to be_nil
+      end
+    end
+  end
+end

--- a/engines/dfc_provider/spec/services/dfc_product_type_factory_spec.rb
+++ b/engines/dfc_provider/spec/services/dfc_product_type_factory_spec.rb
@@ -11,7 +11,7 @@ describe DfcProductTypeFactory do
     it "assigns a top level product type" do
       drink = DfcLoader.connector.PRODUCT_TYPES.DRINK
 
-      expect(described_class.for(dfc_id)).to eq drink
+      expect(described_class.for(dfc_id).semanticId).to eq drink.semanticId
     end
 
     context "with second level product type" do
@@ -22,7 +22,7 @@ describe DfcProductTypeFactory do
       it "assigns a second level product type" do
         soft_drink = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
 
-        expect(described_class.for(dfc_id)).to eq soft_drink
+        expect(described_class.for(dfc_id).semanticId).to eq soft_drink.semanticId
       end
     end
 
@@ -34,7 +34,7 @@ describe DfcProductTypeFactory do
       it "assigns a leaf level product type" do
         lemonade = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.LEMONADE
 
-        expect(described_class.for(dfc_id)).to eq lemonade
+        expect(described_class.for(dfc_id).semanticId).to eq lemonade.semanticId
       end
     end
 

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -55,7 +55,7 @@ describe SuppliedProductBuilder do
       end
 
       context "with second level product type" do
-        let(:taxon) { build(:taxon, name: "Soft Drink", dfc_name: "soft_drink") }
+        let(:taxon) { build(:taxon, name: "Soft Drink", dfc_name: "Soft drink") }
 
         it "assigns a second level product type" do
           soft_drink = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -46,19 +46,38 @@ describe SuppliedProductBuilder do
     end
 
     context "product_type mapping" do
-      it "assigns a product type" do
-        product = builder.supplied_product(variant)
+      subject(:product) { builder.supplied_product(variant) }
+
+      it "assigns a top level product type" do
         drink = DfcLoader.connector.PRODUCT_TYPES.DRINK
 
         expect(product.productType).to eq drink
+      end
+
+      context "with second level product type" do
+        let(:taxon) { build(:taxon, name: "Soft Drink", dfc_name: "soft_drink") }
+
+        it "assigns a second level product type" do
+          soft_drink = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
+
+          expect(product.productType).to eq soft_drink
+        end
+      end
+
+      context "with leaf level product type" do
+        let(:taxon) { build(:taxon, name: "Lemonade", dfc_name: "lemonade") }
+
+        it "assigns a leaf level product type" do
+          lemonade = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.LEMONADE
+
+          expect(product.productType).to eq lemonade
+        end
       end
 
       context "with non existing product type" do
         let(:taxon) { build(:taxon, name: "other", dfc_name: "other") }
 
         it "returns nil" do
-          product = builder.supplied_product(variant)
-
           expect(product.productType).to be_nil
         end
       end
@@ -67,8 +86,6 @@ describe SuppliedProductBuilder do
         let(:taxon) { nil }
 
         it "returns nil" do
-          product = builder.supplied_product(variant)
-
           expect(product.productType).to be_nil
         end
       end

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -135,7 +135,13 @@ describe SuppliedProductBuilder do
       )
     end
     let(:product_type) { DfcLoader.connector.PRODUCT_TYPES.VEGETABLE.NON_LOCAL_VEGETABLE }
-    let!(:taxon) { create(:taxon, name: "Non local vegetable", dfc_id: "non local vegetable") }
+    let!(:taxon) {
+      create(
+        :taxon,
+        name: "Non local vegetable",
+        dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#non-local-vegetable"
+      )
+    }
 
     it "creates a new Spree::Product" do
       product = builder.import_product(supplied_product)

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -12,7 +12,13 @@ describe SuppliedProductBuilder do
       v.product.primary_taxon = taxon
     end
   }
-  let(:taxon) { build(:taxon, name: "Drink", dfc_name: "drink") }
+  let(:taxon) {
+    build(
+      :taxon,
+      name: "Drink",
+      dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#drink"
+    )
+  }
 
   describe ".supplied_product" do
     it "assigns a semantic id" do
@@ -55,7 +61,13 @@ describe SuppliedProductBuilder do
       end
 
       context "with second level product type" do
-        let(:taxon) { build(:taxon, name: "Soft Drink", dfc_name: "Soft drink") }
+        let(:taxon) {
+          build(
+            :taxon,
+            name: "Soft Drink",
+            dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#soft-drink"
+          )
+        }
 
         it "assigns a second level product type" do
           soft_drink = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
@@ -65,7 +77,13 @@ describe SuppliedProductBuilder do
       end
 
       context "with leaf level product type" do
-        let(:taxon) { build(:taxon, name: "Lemonade", dfc_name: "lemonade") }
+        let(:taxon) {
+          build(
+            :taxon,
+            name: "Lemonade",
+            dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#lemonade"
+          )
+        }
 
         it "assigns a leaf level product type" do
           lemonade = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.LEMONADE
@@ -75,7 +93,7 @@ describe SuppliedProductBuilder do
       end
 
       context "with non existing product type" do
-        let(:taxon) { build(:taxon, name: "other", dfc_name: "other") }
+        let(:taxon) { build(:taxon, name: "other", dfc_id: "other") }
 
         it "returns nil" do
           expect(product.productType).to be_nil
@@ -117,7 +135,7 @@ describe SuppliedProductBuilder do
       )
     end
     let(:product_type) { DfcLoader.connector.PRODUCT_TYPES.VEGETABLE.NON_LOCAL_VEGETABLE }
-    let!(:taxon) { create(:taxon, name: "Non local vegetable", dfc_name: "non local vegetable") }
+    let!(:taxon) { create(:taxon, name: "Non local vegetable", dfc_id: "non local vegetable") }
 
     it "creates a new Spree::Product" do
       product = builder.import_product(supplied_product)

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -15,8 +15,8 @@ describe SuppliedProductBuilder do
   let(:taxon) {
     build(
       :taxon,
-      name: "Drink",
-      dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#drink"
+      name: "Soft Drink",
+      dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#soft-drink"
     )
   }
 
@@ -54,50 +54,10 @@ describe SuppliedProductBuilder do
     context "product_type mapping" do
       subject(:product) { builder.supplied_product(variant) }
 
-      it "assigns a top level product type" do
-        drink = DfcLoader.connector.PRODUCT_TYPES.DRINK
+      it "assigns a product type" do
+        soft_drink = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
 
-        expect(product.productType).to eq drink
-      end
-
-      context "with second level product type" do
-        let(:taxon) {
-          build(
-            :taxon,
-            name: "Soft Drink",
-            dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#soft-drink"
-          )
-        }
-
-        it "assigns a second level product type" do
-          soft_drink = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
-
-          expect(product.productType).to eq soft_drink
-        end
-      end
-
-      context "with leaf level product type" do
-        let(:taxon) {
-          build(
-            :taxon,
-            name: "Lemonade",
-            dfc_id: "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#lemonade"
-          )
-        }
-
-        it "assigns a leaf level product type" do
-          lemonade = DfcLoader.connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.LEMONADE
-
-          expect(product.productType).to eq lemonade
-        end
-      end
-
-      context "with non existing product type" do
-        let(:taxon) { build(:taxon, name: "other", dfc_id: "other") }
-
-        it "returns nil" do
-          expect(product.productType).to be_nil
-        end
+        expect(product.productType).to eq soft_drink
       end
 
       context "when no taxon set" do

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -553,12 +553,7 @@ paths:
           application/json:
             schema:
               example:
-                "@context":
-                  dfc-b: http://static.datafoodconsortium.org/ontologies/DFC_BusinessOntology.owl#
-                  dfc-m: http://static.datafoodconsortium.org/data/measures.rdf#
-                  dfc-pt: http://static.datafoodconsortium.org/data/productTypes.rdf#
-                  dfc-b:hasUnit:
-                    "@type": "@id"
+                "@context": https://www.datafoodconsortium.org
                 "@id": http://test.host/api/dfc/enterprises/6201/supplied_products/0
                 "@type": dfc-b:SuppliedProduct
                 dfc-b:name: Apple

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -698,7 +698,7 @@ paths:
                   "@type": dfc-b:QuantitativeValue
                   dfc-b:hasUnit: dfc-m:Piece
                   dfc-b:value: 17
-                dfc-b:hasType: dfc-pt:non-local-vegetable
+                dfc-b:hasType: dfc-pt:drink
                 dfc-b:lifetime: ''
                 dfc-b:name: Pesto novo
                 dfc-b:totalTheoreticalStock: 0

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -602,7 +602,7 @@ paths:
                     "@type": dfc-b:SuppliedProduct
                     dfc-b:name: Pesto - 1g
                     dfc-b:description: Basil Pesto
-                    dfc-b:hasType: dfc-pt:non-local-vegetable
+                    dfc-b:hasType: dfc-pt:processed-vegetable
                     dfc-b:hasQuantity:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram


### PR DESCRIPTION
ℹ️ **This is a funded feature.** Please use the Clockify project with the following name when working on this, including review and test: #9170 OFN DFC Products
#### What? Why?

- Closes [#10809](https://github.com/openfoodfoundation/openfoodnetwork/issues/10809)

Upstream patch has been merged https://github.com/datafoodconsortium/connector-codegen/pull/10, which fix previously blocking issue: https://github.com/datafoodconsortium/connector-ruby/issues/13. We'll have to remove the parser monkey patching once the changes are releases.

To make matching taxon to DFC product type, we added a "dfc id" field so the user can specify which DFC product type a given taxon refers to. "dfc id" are meant to refers to a DFC product type URI defined in https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf, you can browse the file [here](https://showvoc.datafoodconsortium.org/showvoc/#/datasets/ProductTypes/data) . For instance, if you wanted to link the "Bread" category to the "DFC Bread", you would use the following URI : https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#bread
The "dfc id" is then used to pick the correct DFC product type when the API returns a product.
Similarly, when creating/updating a product, the DFC api will try to find the appropriate taxon using the taxon's dfc id.

##### Technical note:
Product types (and other SKOSConcepts) are modelled as Class method on the connector, which return a `SKOSConcept` object. IE: to access the "soft drink" product type you call `connector.PRODUCT_TYPES.DRINK.SOFT_DRINK`. For ease of retrieving the SKOSConcept we want, we first parse the Product type tree and store it in  `SuppliedProductBuilder::PRODUCT_TYPES` hash, ~~with the path to access it, for instance :
 `PRODUCT_TYPES.DRINK.SOFT_DRINK.LEMONADE` is stored as : 
  `SuppliedProductBuilder::PRODUCT_TYPES = { lemonade: [:DRINK, :SOFT_DRINK] }`~~


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

As a super admin 
- visit Configuration -> Taxonomies
- Edit the product Taxon
- Right click on your chosen taxon -> Edit

NOTE "dfc name" has been renamed "dfc id"

![taxon_dfc_name](https://github.com/openfoodfoundation/openfoodnetwork/assets/40413322/a46c4a98-cdb3-424b-9d35-50c4e658c95c)

- Add a dfc id click update
  -> dfc id is saved
- Right click on the same taxon -> Edit
- Update the dfc id 
  -> dfc id is saved
 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

