### PR TITLE
Revert prettier to v 2.8.8 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "karma-chrome-launcher": "~3.2.0",
     "karma-coffee-preprocessor": "~1.0.1",
     "karma-jasmine": "~0.3.8",
-    "prettier": "3.1.0",
+    "prettier": "2.8.8",
     "pretty-quick": "^3.1.3",
     "webpack-dev-server": "~3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7454,10 +7454,10 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.0.tgz#c6d16474a5f764ea1a4a373c593b779697744d5e"
-  integrity sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==
+prettier@2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^27.5.1:
   version "27.5.1"


### PR DESCRIPTION


#### What? Why?
Change introduced here : https://github.com/openfoodfoundation/openfoodnetwork/pull/11806

As explained here : https://github.com/azz/pretty-quick/issues/164 `pretty-quick` will break with `prettier` version 3 and above 

This was first noted here : https://github.com/openfoodfoundation/openfoodnetwork/pull/11165#issuecomment-1627870317, I think we should move to a different tool. 


#### What should we test?
- check that `yarn pretty-quick` runs without error

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


