### PR TITLE
Extends bulk print invoice spec to assert on file contents

### DIFF
--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -510,7 +510,7 @@ describe '
           visit spree.admin_orders_path
         end
 
-        context "bulk print invoices" do
+        context "can bulk send invoices per email" do
           before do
             Spree::Config[:enable_invoices?] = true
             Spree::Config[:enterprise_number_required_on_invoices?] = false
@@ -524,7 +524,7 @@ describe '
               order5.update(state: "payment")
             end
 
-            it "can bulk print invoices but only for the 'complete' or 'resumed' ones" do
+            it "can bulk send invoices per email, but only for the 'complete' or 'resumed' ones" do
               within "#listing_orders" do
                 page.find("input[name='bulk_ids[]'][value='#{order2.id}']").click
                 page.find("input[name='bulk_ids[]'][value='#{order3.id}']").click
@@ -572,37 +572,48 @@ describe '
           expect(page).to have_content "Confirmation emails sent for 2 orders."
         end
 
-        it "can bulk print invoices from 2 orders" do
-          page.find("#listing_orders tbody tr:nth-child(1) input[name='bulk_ids[]']").click
-          page.find("#listing_orders tbody tr:nth-child(2) input[name='bulk_ids[]']").click
-
-          page.find("span.icon-reorder", text: "ACTIONS").click
-          within ".ofn-drop-down .menu" do
-            expect {
-              page.find("span", text: "Print Invoices").click # Prints invoices in bulk
-            }.to enqueue_job(BulkInvoiceJob).exactly(:once)
+        context "can bulk print invoices" do
+          def extract_pdf_content
+            pdf_href = page.all('a').pluck('href')
+            page.find(class: "button", text: "VIEW FILE").click
+            invoice_file_number = pdf_href[0][45..59]
+            invoice_path = "tmp/invoices/#{invoice_file_number}.pdf"
+            reader = PDF::Reader.new(invoice_path)
+            invoice_content = reader.pages.map(&:text)
           end
 
-          expect(page).to have_content "Compiling Invoices"
-          expect(page).to have_content "Please wait until the PDF is ready " \
-                                       "before closing this modal."
+          it "bulk prints invoices in pdf format" do
+            page.find("#listing_orders tbody tr:nth-child(1) input[name='bulk_ids[]']").click
+            page.find("#listing_orders tbody tr:nth-child(2) input[name='bulk_ids[]']").click
 
-          # we don't run Sidekiq in test environment, so we need to manually run enqueued jobs
-          # to generate PDF files, and change the modal accordingly
-          perform_enqueued_jobs(only: BulkInvoiceJob)
+            page.find("span.icon-reorder", text: "ACTIONS").click
+            within ".ofn-drop-down .menu" do
+              expect {
+                page.find("span", text: "Print Invoices").click # Prints invoices in bulk
+              }.to enqueue_job(BulkInvoiceJob).exactly(:once)
+            end
 
-          expect(page).to have_content "Bulk Invoice created"
+            expect(page).to have_content "Compiling Invoices"
+            expect(page).to have_content "Please wait until the PDF is ready " \
+                                         "before closing this modal."
 
-          within ".modal-content" do
-            expect(page).to have_link(class: "button", text: "VIEW FILE", href: /invoices/)
+            # we don't run Sidekiq in test environment, so we need to manually run enqueued jobs
+            # to generate PDF files, and change the modal accordingly
+            perform_enqueued_jobs(only: BulkInvoiceJob)
 
-            extract_pdf_content # extracts content do variable invoice_content
+            expect(page).to have_content "Bulk Invoice created"
 
-            expect(@invoice_content).to have_content("TAX INVOICE", count: 2)
-            expect(@invoice_content).to have_content("TAX INVOICE: #{order4.number}")
-            expect(@invoice_content).to have_content("TAX INVOICE: #{order5.number}")
-            expect(@invoice_content).to have_content("From: #{distributor4.name}")
-            expect(@invoice_content).to have_content("From: #{distributor5.name}")
+            within ".modal-content" do
+              expect(page).to have_link(class: "button", text: "VIEW FILE", href: /invoices/)
+
+              invoice_content = extract_pdf_content # extracts content do variable invoice_content
+
+              expect(invoice_content).to have_content("TAX INVOICE", count: 2)
+              expect(invoice_content).to have_content("TAX INVOICE: #{order4.number}")
+              expect(invoice_content).to have_content("TAX INVOICE: #{order5.number}")
+              expect(invoice_content).to have_content("From: #{distributor4.name}")
+              expect(invoice_content).to have_content("From: #{distributor5.name}")
+            end
           end
         end
 
@@ -932,13 +943,4 @@ describe '
       expect(find("input.datepicker").value).to be_empty
     end
   end
-end
-
-def extract_pdf_content
-  pdf_href = page.all('a').pluck('href')
-  page.find(class: "button", text: "VIEW FILE").click
-  invoice_file_number = pdf_href[0][45..59]
-  invoice_path = "tmp/invoices/#{invoice_file_number}.pdf"
-  reader = PDF::Reader.new(invoice_path)
-  @invoice_content = reader.pages.map(&:text)
 end

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -579,7 +579,8 @@ describe '
             invoice_file_number = pdf_href[0][45..59]
             invoice_path = "tmp/invoices/#{invoice_file_number}.pdf"
             reader = PDF::Reader.new(invoice_path)
-            invoice_content = reader.pages.map(&:text)
+
+            reader.pages.map(&:text)
           end
 
           it "bulk prints invoices in pdf format" do
@@ -606,7 +607,7 @@ describe '
             within ".modal-content" do
               expect(page).to have_link(class: "button", text: "VIEW FILE", href: /invoices/)
 
-              invoice_content = extract_pdf_content # extracts content do variable invoice_content
+              invoice_content = extract_pdf_content
 
               expect(invoice_content).to have_content("TAX INVOICE", count: 2)
               expect(invoice_content).to have_content("TAX INVOICE: #{order4.number}")


### PR DESCRIPTION
#### What? Why?

Checks for the contents of bulk generated pdf files. This came up [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/11792#discussion_r1390343532). Thank you for bringing this up @abdellani :pray: 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Rather than converting the what the browser displays to text (as invoice_print_spec.rb does) it:
- extracts the invoice pdf file name from the URL
- uses the name to open and convert the *.pdf file
- asserts on its contents

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
