### PR TITLE
[System specs, CI] Fixes blacklist/whitelist deprecation warning

### DIFF
--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -15,7 +15,7 @@ Capybara.register_driver(:cuprite_ofn) do |app|
     process_timeout: 60,
     timeout: 60,
     # Don't load scripts from external sources, like google maps or stripe
-    url_whitelist: ["http://localhost", "http://0.0.0.0", "http://127.0.0.1"],
+    url_whitelist: [%r{http://localhost}i, %r{http://0.0.0.0}i, %r{http://127.0.0.1}],
     inspector: true,
     headless:,
     js_errors: true


### PR DESCRIPTION
#### What? Why?

- Closes #11793.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Converts whitelist URLs to regular expressions, on the cuprite setup.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build
- the message `Passing strings to blacklist/whitelist is deprecated, pass regexp at ./.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/capybara-3.39.2/lib/capybara.rb:327:in `block in reset_sessions!` should not appear anymore, when running system specs

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
