### PR TITLE
Fix display inventory warning spec

### DIFF
--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -395,7 +395,7 @@ describe '
           ex_out.save!
 
           # hide via inventory settings variant v1
-          supplier_managed.update preferred_product_selection_from_inventory_only: true
+          distributor_managed.update preferred_product_selection_from_inventory_only: true
           oc.update prefers_product_selection_from_coordinator_inventory_only: false
         end
 


### PR DESCRIPTION
#### What? Why?

- corrects test introduced in #11501 
- adds spec to reproduce issue #11851 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The message about hidden variants through inventory should not be displayed, if the hub has the setting `New products can be put into my shopfront (recommended)` enabled.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
