### PR TITLE
Help Dependabot to update rswag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -160,7 +160,7 @@ group :test, :development do
   gem 'letter_opener', '>= 1.4.1'
   gem 'rspec-rails', ">= 3.5.2"
   gem 'rspec-retry', require: false
-  gem 'rswag-specs'
+  gem 'rswag'
   gem 'shoulda-matchers'
   gem 'stimulus_reflex_testing'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -614,6 +614,10 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.12.1)
+    rswag (2.13.0)
+      rswag-api (= 2.13.0)
+      rswag-specs (= 2.13.0)
+      rswag-ui (= 2.13.0)
     rswag-api (2.13.0)
       activesupport (>= 3.1, < 7.2)
       railties (>= 3.1, < 7.2)
@@ -894,8 +898,8 @@ DEPENDENCIES
   roo
   rspec-rails (>= 3.5.2)
   rspec-retry
+  rswag
   rswag-api
-  rswag-specs
   rswag-ui
   rubocop
   rubocop-rails


### PR DESCRIPTION

#### What? Why?

The rswag gem consists of three gem which are all maintained in the same repository. So when one of the three gems is updated, the version of all three gems is bumped. Dependabot was opening 3 independent pull requests with the same release notes and linking to the same repository.

* #11875
* #11876
* #11878

I hope that making the rswag gem a dependency will make Dependabot try to update all gems together in one pull request.

We are still listing two gems separately to be loaded in production. They enable us to view the API documentation. But we don't need the third gem rswag-specs in production. That one is only useful in tests.



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
