### PR TITLE
Fix mapping of flash messages on order cycle pages

### DIFF
--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -48,7 +48,7 @@ module Admin
       @order_cycle_form = OrderCycleForm.new(@order_cycle, order_cycle_params, spree_current_user)
 
       if @order_cycle_form.save
-        flash[:notice] = t('.success')
+        flash[:success] = t('.success')
         render json: { success: true,
                        edit_path: main_app.admin_order_cycle_incoming_path(@order_cycle) }
       else
@@ -66,7 +66,7 @@ module Admin
       if @order_cycle_form.save
         update_nil_subscription_line_items_price_estimate(@order_cycle)
         respond_to do |format|
-          flash[:notice] = t('.success') if params[:reloading] == '1'
+          flash[:success] = t('.success') if params[:reloading] == '1'
           format.html { redirect_to_after_update_path }
           format.json { render json: { success: true } }
         end
@@ -118,7 +118,7 @@ module Admin
       @order_cycle = OrderCycle.find params[:id]
       @order_cycle.clone!
       redirect_to main_app.admin_order_cycles_path,
-                  notice: t('.success', name: @order_cycle.name)
+                  flash: { success: t('.success', name: @order_cycle.name) }
     end
 
     # Send notifications to all producers who are part of the order cycle
@@ -126,7 +126,7 @@ module Admin
       OrderCycleNotificationJob.perform_later params[:id].to_i
 
       redirect_to main_app.admin_order_cycles_path,
-                  notice: t('.success')
+                  flash: { success: t('.success') }
     end
 
     protected

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -48,7 +48,7 @@ module Admin
       @order_cycle_form = OrderCycleForm.new(@order_cycle, order_cycle_params, spree_current_user)
 
       if @order_cycle_form.save
-        flash[:notice] = I18n.t(:order_cycles_create_notice)
+        flash[:notice] = t('.success')
         render json: { success: true,
                        edit_path: main_app.admin_order_cycle_incoming_path(@order_cycle) }
       else
@@ -66,7 +66,7 @@ module Admin
       if @order_cycle_form.save
         update_nil_subscription_line_items_price_estimate(@order_cycle)
         respond_to do |format|
-          flash[:notice] = I18n.t(:order_cycles_update_notice) if params[:reloading] == '1'
+          flash[:notice] = t('.success') if params[:reloading] == '1'
           format.html { redirect_to_after_update_path }
           format.json { render json: { success: true } }
         end
@@ -118,7 +118,7 @@ module Admin
       @order_cycle = OrderCycle.find params[:id]
       @order_cycle.clone!
       redirect_to main_app.admin_order_cycles_path,
-                  notice: I18n.t(:order_cycles_clone_notice, name: @order_cycle.name)
+                  notice: t('.success', name: @order_cycle.name)
     end
 
     # Send notifications to all producers who are part of the order cycle
@@ -126,7 +126,7 @@ module Admin
       OrderCycleNotificationJob.perform_later params[:id].to_i
 
       redirect_to main_app.admin_order_cycles_path,
-                  notice: I18n.t(:order_cycles_email_to_producers_notice)
+                  notice: t('.success')
     end
 
     protected

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1353,6 +1353,14 @@ en:
         create: "Create"
         cancel: "Cancel"
         back_to_list: "Back To List"
+      create:
+        success: 'Your order cycle has been created.'
+      update:
+        success: 'Your order cycle has been updated.'
+      clone:
+        success: "Your order cycle %{name} has been cloned."
+      notify_producers:
+        success: 'Emails to be sent to producers have been queued for sending.'
       edit:
         save: "Save"
         save_and_next: "Save and Next"
@@ -1750,9 +1758,9 @@ en:
         save: Save
         voucher_code: Voucher Code
         voucher_amount: Amount
-        voucher_type: Voucher Type 
-        flat_rate: Flat 
-        percentage_rate: Percentage (%) 
+        voucher_type: Voucher Type
+        flat_rate: Flat
+        percentage_rate: Percentage (%)
 
     # Admin controllers
     controllers:
@@ -3208,11 +3216,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   enterprise_bulk_update_success_notice: "Enterprises updated successfully"
   enterprise_bulk_update_error: 'Update failed'
   enterprise_shop_show_error: "The shop you are looking for doesn't exist or is inactive on OFN. Please check other shops."
-  order_cycles_create_notice: 'Your order cycle has been created.'
-  order_cycles_update_notice: 'Your order cycle has been updated.'
   order_cycles_bulk_update_notice: 'Order cycles have been updated.'
-  order_cycles_clone_notice: "Your order cycle %{name} has been cloned."
-  order_cycles_email_to_producers_notice: 'Emails to be sent to producers have been queued for sending.'
   order_cycles_no_permission_to_coordinate_error: "None of your enterprises have permission to coordinate an order cycle"
   order_cycles_no_permission_to_create_error: "You don't have permission to create an order cycle coordinated by that enterprise"
   order_cycle_closed: "The order cycle you've selected has just closed. Please try again!"

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -252,14 +252,14 @@ module Admin
 
             it "sets flash message" do
               spree_put :update, params
-              expect(flash[:notice]).to eq('Your order cycle has been updated.')
+              expect(flash[:success]).to eq('Your order cycle has been updated.')
             end
           end
 
           context "when the page is not reloading" do
             it "does not set flash message" do
               spree_put :update, params
-              expect(flash[:notice]).to be nil
+              expect(flash[:success]).to be nil
             end
           end
         end
@@ -445,7 +445,7 @@ module Admin
       it "redirects back to the order cycles path with a success message" do
         spree_post :notify_producers, id: order_cycle.id
         expect(response).to redirect_to admin_order_cycles_path
-        expect(flash[:notice]).to eq('Emails to be sent to producers have been queued for sending.')
+        expect(flash[:success]).to eq('Emails to be sent to producers have been queued for sending.')
       end
     end
 

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -445,7 +445,9 @@ module Admin
       it "redirects back to the order cycles path with a success message" do
         spree_post :notify_producers, id: order_cycle.id
         expect(response).to redirect_to admin_order_cycles_path
-        expect(flash[:success]).to eq('Emails to be sent to producers have been queued for sending.')
+        expect(flash[:success]).to eq(
+          'Emails to be sent to producers have been queued for sending.'
+        )
       end
     end
 


### PR DESCRIPTION
#### What? Why?
While working on flash messages I noticed these could be tidied up.

I think lazy-lookup is the way to go for helping organise the locale file. However it does  mean these strings might need re-translating. Does Transifex automatically copy duplicates for you? We shall see..


- part of https://github.com/openfoodfoundation/openfoodnetwork/issues/11884



#### What should we test?
Test on the old design, or if https://github.com/openfoodfoundation/openfoodnetwork/pull/11874 has been merged, you can check the new `admin_style_v3` design.
The success messages now appear as a success, not a 'notice'. (Green in the old design, black in the new)

* Order cycle create
* Order cycle update
* Order cycle clone
* Order cycle notify producers


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
