### PR TITLE
add condition on invoices tab

### DIFF
--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -61,7 +61,7 @@
         %li{ class: adjustments_classes }
           = link_to_with_icon 'icon-cogs', t(:adjustments), spree.admin_order_adjustments_url(@order)
 
-        - if feature?(:invoices, spree_current_user) && @order.can_show_invoice?
+        - if feature?(:invoices, spree_current_user) && @order.can_show_invoice? && Spree::Config[:enable_invoices?]
           - invoices_classes = "active" if current == 'Invoices'
           %li{ class: invoices_classes }
             = link_to_with_icon 'icon-cogs', t(:invoices), spree.admin_order_invoices_url(@order)


### PR DESCRIPTION
#### What? Why?
Resolves the issue when feature toggle "invoices" is fully enabled, the invoices tab under edit order was still visible even if the  admin has unchecked enable invoices option from the invoices settings.

- Closes #11828 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
The change is necessary as that invoices tab comes under a feature toggle "invoices" and If the feature "invoices" is enabled then  it should be visible/hidden based on enable invoices checkbox under Configuration/invoice_settings which  only super admins has the option to change. Right now Even if the enable invoices checkbox is unchecked still we can see the invoices option in Orders edit page i.e. invoices tab is only dependent on feature toggle "invoices" state, this change will resolve the same.

#### What should we test?

1. Log in as super admin
2. Fully enable feature toggle "invoices" from (/admin/feature-toggle/features/invoices)
3. Uncheck the enable invoices option under invoice settings (admin/invoice_settings/edit)
4. Check you CAN'T see invoice tab on orders edit page as well send, print invoice options under Actions
5. Tick/Check the enable invoices option under invoice settings,  Invoices tab as well as send,print invoices options should be back & working


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled


<img width="1433" alt="Screenshot 2023-12-04 at 8 31 58 PM" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/40080039/3e6572ea-6b80-474e-93be-552bf927fb32">


