### PR TITLE
Ensure pagination appears at bottom of table

### DIFF
--- a/app/views/admin/shared/_angular_pagination.html.haml
+++ b/app/views/admin/shared/_angular_pagination.html.haml
@@ -1,4 +1,4 @@
-.pagination
+.pagination{style: "clear: both;"}
   %button{'ng-click' => 'changePage(1)', 'ng-class' => "{'disabled': pagination.page == 1}", 'ng-disabled' => "pagination.page == 1"}
     = "&laquo;".html_safe
     = t(:first)


### PR DESCRIPTION
#### What? Why?

- Closes #11608

Simply fixes the position. I considered updating the design to match the new pagination components, but it doesn't match 100%. The new design doesn't have first/last page buttons.

![Screen Shot 2023-12-05 at 2 52 05 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/88eece7e-0b54-4453-bcaf-dfe45b0c4671)




#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit `/admin/orders/bulk_management`
- Test that pagination appears as expected

Note that `/admin/products_old` is also fixed by this, but we're not supporting it so it doesn't need testing.

