### PR TITLE
Adds build node to check for i18n exceptions

### DIFF
--- a/app/models/content_configuration.rb
+++ b/app/models/content_configuration.rb
@@ -23,25 +23,29 @@ class ContentConfiguration < Spree::Preferences::Configuration
   # Producer sign-up page
   # All the following defaults using I18n don't work.
   # https://github.com/openfoodfoundation/openfoodnetwork/issues/3816
-  preference :producer_signup_pricing_table_html, :text,
-             default: I18n.t(:content_configuration_pricing_table)
-  preference :producer_signup_case_studies_html, :text,
-             default: I18n.t(:content_configuration_case_studies)
-  preference :producer_signup_detail_html, :text, default: I18n.t(:content_configuration_detail)
+  # default values for these fields are commented out below
+  preference :producer_signup_pricing_table_html, :text
+  # default: I18n.t(:content_configuration_pricing_table)
+  preference :producer_signup_case_studies_html, :text
+  # default: I18n.t(:content_configuration_case_studies)
+  preference :producer_signup_detail_html, :text
+  # default: I18n.t(:content_configuration_detail)
 
   # Hubs sign-up page
-  preference :hub_signup_pricing_table_html, :text,
-             default: I18n.t(:content_configuration_pricing_table)
-  preference :hub_signup_case_studies_html, :text,
-             default: I18n.t(:content_configuration_case_studies)
-  preference :hub_signup_detail_html, :text, default: I18n.t(:content_configuration_detail)
+  preference :hub_signup_pricing_table_html, :text
+  # default: I18n.t(:content_configuration_pricing_table)
+  preference :hub_signup_case_studies_html, :text
+  # default: I18n.t(:content_configuration_case_studies)
+  preference :hub_signup_detail_html, :text
+  # default: I18n.t(:content_configuration_detail)
 
   # Groups sign-up page
-  preference :group_signup_pricing_table_html, :text,
-             default: I18n.t(:content_configuration_pricing_table)
-  preference :group_signup_case_studies_html, :text,
-             default: I18n.t(:content_configuration_case_studies)
-  preference :group_signup_detail_html, :text, default: I18n.t(:content_configuration_detail)
+  preference :group_signup_pricing_table_html, :text
+  # default: I18n.t(:content_configuration_pricing_table)
+  preference :group_signup_case_studies_html, :text
+  # default: I18n.t(:content_configuration_case_studies)
+  preference :group_signup_detail_html, :text
+  # default: I18n.t(:content_configuration_detail)
 
   # Main URLs
   preference :menu_1, :boolean, default: true

--- a/app/models/content_configuration.rb
+++ b/app/models/content_configuration.rb
@@ -24,28 +24,28 @@ class ContentConfiguration < Spree::Preferences::Configuration
   # All the following defaults using I18n don't work.
   # https://github.com/openfoodfoundation/openfoodnetwork/issues/3816
   # default values for these fields are commented out below
-  preference :producer_signup_pricing_table_html, :text
-  # default: I18n.t(:content_configuration_pricing_table)
-  preference :producer_signup_case_studies_html, :text
-  # default: I18n.t(:content_configuration_case_studies)
-  preference :producer_signup_detail_html, :text
-  # default: I18n.t(:content_configuration_detail)
+  preference :producer_signup_pricing_table_html, :text,
+             default: I18n.t(:content_configuration_pricing_table)
+  preference :producer_signup_case_studies_html, :text,
+             default: I18n.t(:content_configuration_case_studies)
+  preference :producer_signup_detail_html, :text,
+             default: I18n.t(:content_configuration_detail)
 
   # Hubs sign-up page
-  preference :hub_signup_pricing_table_html, :text
-  # default: I18n.t(:content_configuration_pricing_table)
-  preference :hub_signup_case_studies_html, :text
-  # default: I18n.t(:content_configuration_case_studies)
-  preference :hub_signup_detail_html, :text
-  # default: I18n.t(:content_configuration_detail)
+  preference :hub_signup_pricing_table_html, :text,
+             default: I18n.t(:content_configuration_pricing_table)
+  preference :hub_signup_case_studies_html, :text,
+             default: I18n.t(:content_configuration_case_studies)
+  preference :hub_signup_detail_html, :text,
+             default: I18n.t(:content_configuration_detail)
 
   # Groups sign-up page
-  preference :group_signup_pricing_table_html, :text
-  # default: I18n.t(:content_configuration_pricing_table)
-  preference :group_signup_case_studies_html, :text
-  # default: I18n.t(:content_configuration_case_studies)
-  preference :group_signup_detail_html, :text
-  # default: I18n.t(:content_configuration_detail)
+  preference :group_signup_pricing_table_html, :text,
+             default: I18n.t(:content_configuration_pricing_table)
+  preference :group_signup_case_studies_html, :text,
+             default: I18n.t(:content_configuration_case_studies)
+  preference :group_signup_detail_html, :text,
+             default: I18n.t(:content_configuration_detail)
 
   # Main URLs
   preference :menu_1, :boolean, default: true

--- a/config/initializers/test.rb
+++ b/config/initializers/test.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-I18n.exception_handler = Proc.new do |exception, *_|
-  raise exception.to_exception
-end

--- a/config/initializers/test.rb
+++ b/config/initializers/test.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+I18n.exception_handler = Proc.new do |exception, *_|
+  raise exception.to_exception
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -951,6 +951,7 @@ en:
         view_products: Go To Products Page
         view_inventory: Go To Inventory Page
       product_headings:
+        distributor: Distributor
         producer: Producer
         sku: SKU
         name: Name

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -50,6 +50,11 @@ end
 FactoryBot.use_parent_strategy = false
 FactoryBot::SyntaxRunner.include FileHelper
 
+# raise I18n exception handler
+I18n.exception_handler = proc do |exception, *_|
+  raise exception.to_exception
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{Rails.root.join('spec/fixtures')}"
@@ -204,11 +209,6 @@ RSpec.configure do |config|
 
   # You can use `rspec -n` to run only failed specs.
   config.example_status_persistence_file_path = "tmp/rspec-status.txt"
-
-  # raise I18n exception handler
-  I18n.exception_handler = proc do |exception, *_|
-    raise exception.to_exception
-  end
 
   # Helpers
   config.include FactoryBot::Syntax::Methods

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -205,6 +205,11 @@ RSpec.configure do |config|
   # You can use `rspec -n` to run only failed specs.
   config.example_status_persistence_file_path = "tmp/rspec-status.txt"
 
+  # raise I18n exception handler
+  I18n.exception_handler = proc do |exception, *_|
+    raise exception.to_exception
+  end
+
   # Helpers
   config.include FactoryBot::Syntax::Methods
   config.include JsonSpec::Helpers


### PR DESCRIPTION
Contributes to #2626.

This follows this approach https://guides.rubyonrails.org/i18n.html#customizing-how-i18n-missingtranslationdata-is-handled

#### What? Why?

Adds an additional knapsack node to check for I18n exceptions.
It's enough to run it as a `dry run`, so it does not compromise the build run time.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This node breaks the build and points out the respective key.
After commenting out the culprits, the build is green again - so, it works.

Do you think this additional check brings value @openfoodfoundation/developers ?

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build, if there are no inconsistent (JS?) translations on the build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
