### PR TITLE
11599-Change page title on checkout pages

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -149,7 +149,7 @@ module CheckoutHelper
     end
   end
 
-  # Set the Page title of checkout process as step based like 
+  # Set the Page title of checkout process as step based like
   # Checkout Details, Checkout Payment and Checkout Summary
   def checkout_page_title
     t("checkout_#{checkout_step}_title")

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -148,4 +148,10 @@ module CheckoutHelper
       ]
     end
   end
+
+  # Set the Page title of checkout process as step based like 
+  # Checkout Details, Checkout Payment and Checkout Summary
+  def checkout_page_title
+    t("checkout_#{checkout_step}_title")
+  end
 end

--- a/app/views/checkout/edit.html.haml
+++ b/app/views/checkout/edit.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title) do
-  = t :checkout_title
+  = checkout_page_title
 
 .darkswarm.footer-pad{"data-turbo": "true"}
   - content_for :order_cycle_form do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2227,6 +2227,9 @@ en:
   order_back_to_store: Back To Store
   order_back_to_cart: Back To Cart
   order_back_to_website: Back To Website
+  checkout_details_title: Checkout Details
+  checkout_payment_title: Checkout Payment
+  checkout_summary_title: Checkout Summary
 
   bom_tip: "Use this page to alter product quantities across multiple orders. Products may also be removed from orders entirely, if required."
 

--- a/spec/system/consumer/checkout/details_spec.rb
+++ b/spec/system/consumer/checkout/details_spec.rb
@@ -396,6 +396,12 @@ describe "As a consumer, I want to checkout my order" do
           expect(page).to have_field "order_bill_address_attributes_zipcode", with: "TST01"
         end
       end
+
+      describe "show page title as Checkout Details - Open Food Network" do
+        it "should display title as Checkout Details - Open Food Network" do
+          page.has_title? "Checkout Details - Open Food Network"
+        end
+      end
     end
   end
 end

--- a/spec/system/consumer/checkout/details_spec.rb
+++ b/spec/system/consumer/checkout/details_spec.rb
@@ -389,17 +389,15 @@ describe "As a consumer, I want to checkout my order" do
         end
 
         it "pre-fills address details" do
+          # Check for the right title first. This is a random place here but
+          # we don't have a standard success checkout flow case to add this to.
+          expect(page).to have_title "Checkout Details - Open Food Network"
+
           visit checkout_path
           expect(page).to have_select(
             "order_bill_address_attributes_state_id", selected: "Testville"
           )
           expect(page).to have_field "order_bill_address_attributes_zipcode", with: "TST01"
-        end
-      end
-
-      describe "show page title as Checkout Details - Open Food Network" do
-        it "should display title as Checkout Details - Open Food Network" do
-          expect(page).to have_title "Checkout Details - Open Food Network"
         end
       end
     end

--- a/spec/system/consumer/checkout/details_spec.rb
+++ b/spec/system/consumer/checkout/details_spec.rb
@@ -399,7 +399,7 @@ describe "As a consumer, I want to checkout my order" do
 
       describe "show page title as Checkout Details - Open Food Network" do
         it "should display title as Checkout Details - Open Food Network" do
-          page.has_title? "Checkout Details - Open Food Network"
+          expect(page).to have_title "Checkout Details - Open Food Network"
         end
       end
     end

--- a/spec/system/consumer/checkout/payment_spec.rb
+++ b/spec/system/consumer/checkout/payment_spec.rb
@@ -334,7 +334,7 @@ describe "As a consumer, I want to checkout my order" do
 
       describe "show page title as Checkout Payment - Open Food Network" do
         it "should display title as Checkout Payment - Open Food Network" do
-          page.has_title? "Checkout Payment - Open Food Network"
+          expect(page).to have_title "Checkout Payment - Open Food Network"
         end
       end
     end

--- a/spec/system/consumer/checkout/payment_spec.rb
+++ b/spec/system/consumer/checkout/payment_spec.rb
@@ -331,6 +331,12 @@ describe "As a consumer, I want to checkout my order" do
           end
         end
       end
+
+      describe "show page title as Checkout Payment - Open Food Network" do
+        it "should display title as Checkout Payment - Open Food Network" do
+          page.has_title? "Checkout Payment - Open Food Network"
+        end
+      end
     end
   end
 

--- a/spec/system/consumer/checkout/payment_spec.rb
+++ b/spec/system/consumer/checkout/payment_spec.rb
@@ -62,14 +62,12 @@ describe "As a consumer, I want to checkout my order" do
       let(:order) { create(:order_ready_for_payment, distributor:) }
 
       context "with one payment method, with a fee" do
-        before do
-          visit checkout_step_path(:payment)
-        end
         it "preselect the payment method if only one is available" do
-          expect(page).to have_checked_field "payment_method_#{payment_with_fee.id}"
-        end
-        it "displays the transaction fee" do
-          expect(page).to have_content("#{payment_with_fee.name} " + with_currency(1.23).to_s)
+          visit checkout_step_path(:payment)
+
+          expect(page).to have_title "Checkout Payment - Open Food Network"
+          expect(page).to have_checked_field "Payment with Fee"
+          expect(page).to have_content "Payment with Fee $1.23"
         end
       end
 
@@ -329,12 +327,6 @@ describe "As a consumer, I want to checkout my order" do
           it "displays the payment method" do
             expect(page).to have_content hidden_method.name
           end
-        end
-      end
-
-      describe "show page title as Checkout Payment - Open Food Network" do
-        it "should display title as Checkout Payment - Open Food Network" do
-          expect(page).to have_title "Checkout Payment - Open Food Network"
         end
       end
     end

--- a/spec/system/consumer/checkout/summary_spec.rb
+++ b/spec/system/consumer/checkout/summary_spec.rb
@@ -407,7 +407,7 @@ describe "As a consumer, I want to checkout my order" do
 
     describe "show page title as Checkout Summary - Open Food Network" do
       it "should display title as Checkout Summary - Open Food Network" do
-        page.has_title? "Checkout Summary - Open Food Network"
+        expect(page).to have_title "Checkout Summary - Open Food Network"
       end
     end
   end

--- a/spec/system/consumer/checkout/summary_spec.rb
+++ b/spec/system/consumer/checkout/summary_spec.rb
@@ -404,6 +404,12 @@ describe "As a consumer, I want to checkout my order" do
         end
       end
     end
+
+    describe "show page title as Checkout Summary - Open Food Network" do
+      it "should display title as Checkout Summary - Open Food Network" do
+        page.has_title? "Checkout Summary - Open Food Network"
+      end
+    end
   end
 
   def add_voucher_to_order(voucher, order)

--- a/spec/system/consumer/checkout/summary_spec.rb
+++ b/spec/system/consumer/checkout/summary_spec.rb
@@ -66,15 +66,16 @@ describe "As a consumer, I want to checkout my order" do
           visit checkout_step_path(:summary)
         end
 
-        it "displays the ship address" do
+        it "displays title and ship address" do
+          expect(page).to have_title "Checkout Summary - Open Food Network"
+
           expect(page).to have_content "Delivery address"
           expect(page).to have_content order.ship_address.address1
           expect(page).to have_content order.ship_address.city
           expect(page).to have_content order.ship_address.zipcode
           expect(page).to have_content order.ship_address.phone
-        end
 
-        it "and not the billing address" do
+          # but not the billing address
           expect(page).not_to have_content order.bill_address.address1
           expect(page).not_to have_content order.bill_address.city
           expect(page).not_to have_content order.bill_address.zipcode
@@ -402,12 +403,6 @@ describe "As a consumer, I want to checkout my order" do
             expect(page).to_not have_selector('h5', text: "Balance Due")
           end
         end
-      end
-    end
-
-    describe "show page title as Checkout Summary - Open Food Network" do
-      it "should display title as Checkout Summary - Open Food Network" do
-        expect(page).to have_title "Checkout Summary - Open Food Network"
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

- Closes #11599  

#### What should we test?
- As a: guest shopper or loggedin shopper
- On page: checkout process
- Previously Checkout pages have the same title for all steps(details, payment and summary ): Checkout - Open Food Network
- Now Page title has changed for every step 
- URL ending with /checkout/details -> have page title Checkout Details - Open Food Network
- URL ending with /checkout/payment -> have page title Checkout Payment - Open Food Network
- URL ending with /checkout/summary -> have page title Checkout Summary - Open Food Network
- 

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

The title of the pull request will be included in the release notes.

