### PR TITLE
Cleanse JS errors from DOM on Stripe failure

### DIFF
--- a/app/assets/javascripts/admin/payments/services/payment.js.coffee
+++ b/app/assets/javascripts/admin/payments/services/payment.js.coffee
@@ -43,7 +43,8 @@ angular.module('admin.payments').factory 'Payment', (AdminStripeElements, curren
     submit: =>
       munged = @preprocess()
       PaymentResource.create({order_id: munged.order_id}, munged, (response, headers, status) ->
-        document.body.innerHTML = Object.values(response).join('')
+        rawHtml = Object.values(response).join('').replace('[object Object]true', '')
+        document.body.innerHTML = rawHtml
         $window.history.pushState({}, '', "/admin/orders/" + munged.order_id + "/payments")
       , (response) ->
         StatusMessage.display 'error', t("spree.admin.payments.source_forms.stripe.error_saving_payment")

--- a/spec/system/admin/payments_spec.rb
+++ b/spec/system/admin/payments_spec.rb
@@ -62,6 +62,7 @@ describe '
       click_button "Update"
       expect(page).to have_content "Payments"
       expect(page).to have_content "Payment has been successfully created!"
+      expect(page).not_to have_content "[object Object]true"
 
       order.reload
       expect(order.state).to eq "complete"


### PR DESCRIPTION
#### What? Why?

- Closes #11886 

This change removes the `[object Object]true` output from the bottom of the page that appears when Stripe payments fail. 

This output appears to be generated when the Angular resource code parses the response. Upon inspecting the backend response, it does not contain this output. Angular is likely expecting a JSON response but the endpoint returns an HTML response. As such, the response object is an object mapping each character to its own key like this:
```
{ 0: "<", 1: "!", 2: "D", 3: "O", 4: "C", 5: "T", 6: "Y", 7: "P", 8: "E", 9: " ", … }
```
The  `[object Object]true` output is observed upon parsing this response object. This change simply removes this substring from the final HTML.

#### What should we test?
1. Sign in as a hub
2. Add a Stripe payment to an order: use the card 4100000000000019.
3. You should see the flash message introduced in #11730.
4. The output `[object Object]true` does not show on the bottom left corner of the screen.

#### Release notes
Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
