### PR TITLE
Bump json-canonicalization from 0.3.2 to 0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ GEM
     jquery-ui-rails (4.2.1)
       railties (>= 3.2.16)
     json (2.7.1)
-    json-canonicalization (0.3.2)
+    json-canonicalization (0.4.0)
     json-jwt (1.16.3)
       activesupport (>= 4.2)
       aes_key_wrap


### PR DESCRIPTION


#### What? Why?

The build is currently broken because a gem version was removed from Rubygems.

This update is actually not changing anything. The author didn't realise the bad implications of yanking 0.3.2 and restored it as 0.4.0.

* https://github.com/dryruby/json-canonicalization/issues/2

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
