### PR TITLE
Bulk printing/sending should show warning if ABN is required but not set.

### DIFF
--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -32,13 +32,16 @@ module Admin
     end
 
     def bulk_invoice(params)
+      visible_orders = editable_orders.where(id: params[:bulk_ids]).filter(&:invoiceable?)
+      return unless all_distributors_can_invoice?(visible_orders)
+
       cable_ready.append(
         selector: "#orders-index",
         html: render(partial: "spree/admin/orders/bulk/invoice_modal")
       ).broadcast
 
       BulkInvoiceJob.perform_later(
-        params[:bulk_ids],
+        visible_orders.pluck(:id),
         "tmp/invoices/#{Time.zone.now.to_i}-#{SecureRandom.hex(2)}.pdf",
         channel: SessionChannel.for_request(request),
         current_user_id: current_user.id
@@ -105,6 +108,17 @@ module Admin
 
     def set_param_for_controller
       params[:id] = @order.number
+    end
+
+    def all_distributors_can_invoice?(orders)
+      distributors = orders.map(&:distributor).uniq.reject(&:can_invoice?)
+
+      return true if distributors.empty?
+
+      flash[:error] = I18n.t(:must_have_valid_business_number,
+                             enterprise_name: distributors.map(&:name).join(", "))
+      morph_admin_flashes
+      false
     end
   end
 end

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -736,7 +736,7 @@ describe '
 
                   expect(page).to have_content "#{
                     order5.distributor.name
-                  } must have a valid ABN before invoices can be sent."
+                  } must have a valid ABN before invoices can be used."
                 end
               end
               it_behaves_like "should not print the invoice"

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -675,8 +675,6 @@ describe '
             context "one of the two orders is not invoiceable" do
               before do
                 order4.cancel!
-                assert(!order4.invoiceable?)
-                assert(order5.invoiceable?)
               end
 
               it_behaves_like "should ignore the non invoiceable order"
@@ -697,10 +695,6 @@ describe '
                 order5.distributor.update(abn: "987654321")
               end
               context "all the orders are invoiceable (completed/resumed)" do
-                before do
-                  assert(order4.invoiceable?)
-                  assert(order5.invoiceable?)
-                end
                 it_behaves_like "can bulk print invoices from 2 orders"
                 context "with legal invoices feature", feature: :invoices do
                   it_behaves_like "can bulk print invoices from 2 orders"
@@ -710,8 +704,6 @@ describe '
               context "one of the two orders is not invoiceable" do
                 before do
                   order4.cancel!
-                  assert(!order4.invoiceable?)
-                  assert(order5.invoiceable?)
                 end
 
                 it_behaves_like "should ignore the non invoiceable order"


### PR DESCRIPTION
#### What? Why?

- Closes #11896

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- bulk printing/sending when ABN is required/not required.
try to bulk-print a set of orders where
- some orders come from enterprises that have an ABN.
- some orders come from enterprises that doesn't have an ABN? 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
