### PR TITLE
Replaces Stripe Stubs with VCR calls

### DIFF
--- a/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_error_message/when_payment_intent_state_is_not_in_requires_capture_state/does_not_succeed_if_payment_intent_state_is_not_requires_capture.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_error_message/when_payment_intent_state_is_not_in_requires_capture_state/does_not_succeed_if_payment_intent_state_is_not_requires_capture.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_yPW1h61ihGksLY","request_duration_ms":1020}}'
+      - '{"last_request_metrics":{"request_id":"req_kEuP9BShlEJBEh","request_duration_ms":1066}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -34,7 +34,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:55 GMT
+      - Tue, 12 Dec 2023 13:16:41 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -59,11 +59,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - db697186-403f-48de-9453-7dcbe705363e
+      - 31802e28-8d9a-4a22-a684-db641e5edb91
       Original-Request:
-      - req_LqTDQPa09gORLx
+      - req_ycRJsY0xEobgbQ
       Request-Id:
-      - req_LqTDQPa09gORLx
+      - req_ycRJsY0xEobgbQ
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -78,7 +78,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OMHNKKuuB1fWySnXahBsdmJ",
+          "id": "pm_1OMVpFKuuB1fWySnMHJj4rV0",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -118,19 +118,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1702331455,
+          "created": 1702387001,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:55 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:42 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=1000&currency=aud&payment_method=pm_1OMHNKKuuB1fWySnXahBsdmJ&payment_method_types[0]=card&capture_method=manual
+      string: amount=1000&currency=aud&payment_method=pm_1OMVpFKuuB1fWySnMHJj4rV0&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.2.0
@@ -139,7 +139,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_LqTDQPa09gORLx","request_duration_ms":473}}'
+      - '{"last_request_metrics":{"request_id":"req_ycRJsY0xEobgbQ","request_duration_ms":651}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -159,7 +159,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:55 GMT
+      - Tue, 12 Dec 2023 13:16:42 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -184,11 +184,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 45d1ef7b-9056-4248-ade7-518867d7b378
+      - 4c2ec975-dcac-4183-94be-5cc42388abaa
       Original-Request:
-      - req_tneQMoYlODp4Ut
+      - req_7jzbnRugdmJUxG
       Request-Id:
-      - req_tneQMoYlODp4Ut
+      - req_7jzbnRugdmJUxG
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -203,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OMHNLKuuB1fWySn2AwSg35E",
+          "id": "pi_3OMVpGKuuB1fWySn1V3lr4qv",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -217,9 +217,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OMHNLKuuB1fWySn2AwSg35E_secret_Rc0C8yuSK7ZSxhhway0UwKhhm",
+          "client_secret": "pi_3OMVpGKuuB1fWySn1V3lr4qv_secret_mv7HDgsiBtwrCKWIgPM81tNmQ",
           "confirmation_method": "automatic",
-          "created": 1702331455,
+          "created": 1702387002,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -230,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OMHNKKuuB1fWySnXahBsdmJ",
+          "payment_method": "pm_1OMVpFKuuB1fWySnMHJj4rV0",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -255,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:55 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:42 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OMHNLKuuB1fWySn2AwSg35E
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OMVpGKuuB1fWySn1V3lr4qv
     body:
       encoding: US-ASCII
       string: ''
@@ -270,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_tneQMoYlODp4Ut","request_duration_ms":407}}'
+      - '{"last_request_metrics":{"request_id":"req_7jzbnRugdmJUxG","request_duration_ms":423}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -290,7 +290,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:57 GMT
+      - Tue, 12 Dec 2023 13:16:42 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -316,7 +316,7 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Request-Id:
-      - req_XG2JlCPei8f4NV
+      - req_5eOQLL9A6WDALS
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -329,7 +329,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OMHNLKuuB1fWySn2AwSg35E",
+          "id": "pi_3OMVpGKuuB1fWySn1V3lr4qv",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -343,9 +343,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OMHNLKuuB1fWySn2AwSg35E_secret_Rc0C8yuSK7ZSxhhway0UwKhhm",
+          "client_secret": "pi_3OMVpGKuuB1fWySn1V3lr4qv_secret_mv7HDgsiBtwrCKWIgPM81tNmQ",
           "confirmation_method": "automatic",
-          "created": 1702331455,
+          "created": 1702387002,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -356,7 +356,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OMHNKKuuB1fWySnXahBsdmJ",
+          "payment_method": "pm_1OMVpFKuuB1fWySnMHJj4rV0",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -381,5 +381,5 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:58 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:42 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_error_message/when_payment_intent_state_is_not_in_requires_capture_state/does_not_succeed_if_payment_intent_state_is_not_requires_capture.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_error_message/when_payment_intent_state_is_not_in_requires_capture_state/does_not_succeed_if_payment_intent_state_is_not_requires_capture.yml
@@ -1,0 +1,385 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[number]=4242424242424242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.2.0
+      Authorization:
+      - Bearer <HIDDEN_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yPW1h61ihGksLY","request_duration_ms":1020}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.2.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2","hostname":"ff-LAT"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '931'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Idempotency-Key:
+      - db697186-403f-48de-9453-7dcbe705363e
+      Original-Request:
+      - req_LqTDQPa09gORLx
+      Request-Id:
+      - req_LqTDQPa09gORLx
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1OMHNKKuuB1fWySnXahBsdmJ",
+          "object": "payment_method",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "exp_month": 12,
+            "exp_year": 2024,
+            "fingerprint": "6E6tgVjx6U65iHFV",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1702331455,
+          "customer": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:55 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=1000&currency=aud&payment_method=pm_1OMHNKKuuB1fWySnXahBsdmJ&payment_method_types[0]=card&capture_method=manual
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.2.0
+      Authorization:
+      - Bearer <HIDDEN_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_LqTDQPa09gORLx","request_duration_ms":473}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.2.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2","hostname":"ff-LAT"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1344'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Idempotency-Key:
+      - 45d1ef7b-9056-4248-ade7-518867d7b378
+      Original-Request:
+      - req_tneQMoYlODp4Ut
+      Request-Id:
+      - req_tneQMoYlODp4Ut
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3OMHNLKuuB1fWySn2AwSg35E",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "manual",
+          "client_secret": "pi_3OMHNLKuuB1fWySn2AwSg35E_secret_Rc0C8yuSK7ZSxhhway0UwKhhm",
+          "confirmation_method": "automatic",
+          "created": 1702331455,
+          "currency": "aud",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "metadata": {},
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1OMHNKKuuB1fWySnXahBsdmJ",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_confirmation",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:55 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OMHNLKuuB1fWySn2AwSg35E
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.2.0
+      Authorization:
+      - Bearer <HIDDEN_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_tneQMoYlODp4Ut","request_duration_ms":407}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.2.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2","hostname":"ff-LAT"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1344'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent;
+        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
+        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
+        style-src 'self'
+      Request-Id:
+      - req_XG2JlCPei8f4NV
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3OMHNLKuuB1fWySn2AwSg35E",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "manual",
+          "client_secret": "pi_3OMHNLKuuB1fWySn2AwSg35E_secret_Rc0C8yuSK7ZSxhhway0UwKhhm",
+          "confirmation_method": "automatic",
+          "created": 1702331455,
+          "currency": "aud",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "metadata": {},
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1OMHNKKuuB1fWySnXahBsdmJ",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_confirmation",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:58 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_purchase/completes_the_purchase.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_purchase/completes_the_purchase.yml
@@ -1,0 +1,790 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[number]=4242424242424242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.2.0
+      Authorization:
+      - Bearer <HIDDEN_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.2.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2","hostname":"ff-LAT"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '931'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Idempotency-Key:
+      - fab25397-66dc-4f60-8d61-3cb6f971cbd4
+      Original-Request:
+      - req_FLU1yYk8sZamRa
+      Request-Id:
+      - req_FLU1yYk8sZamRa
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+          "object": "payment_method",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "exp_month": 12,
+            "exp_year": 2024,
+            "fingerprint": "6E6tgVjx6U65iHFV",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1702331445,
+          "customer": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:45 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=1000&currency=aud&payment_method=pm_1OMHNAKuuB1fWySn3cnBHQQP&payment_method_types[0]=card&capture_method=manual
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.2.0
+      Authorization:
+      - Bearer <HIDDEN_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_FLU1yYk8sZamRa","request_duration_ms":780}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.2.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2","hostname":"ff-LAT"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1344'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Idempotency-Key:
+      - bf584387-be9e-41e4-b68e-6a67bf247609
+      Original-Request:
+      - req_yZ6n7FCPagLueX
+      Request-Id:
+      - req_yZ6n7FCPagLueX
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "manual",
+          "client_secret": "pi_3OMHNBKuuB1fWySn0FeJ0eva_secret_GiprxonohIUvx3wCtswBzMwZN",
+          "confirmation_method": "automatic",
+          "created": 1702331445,
+          "currency": "aud",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "metadata": {},
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_confirmation",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:45 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OMHNBKuuB1fWySn0FeJ0eva/confirm
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.2.0
+      Authorization:
+      - Bearer <HIDDEN_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yZ6n7FCPagLueX","request_duration_ms":610}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.2.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2","hostname":"ff-LAT"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1367'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent%2Fconfirm;
+        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
+        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
+        style-src 'self'
+      Idempotency-Key:
+      - 384e14c9-8af4-4834-b89b-65e61985ba47
+      Original-Request:
+      - req_9ThsIdXtzA4sZE
+      Request-Id:
+      - req_9ThsIdXtzA4sZE
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 1000,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "manual",
+          "client_secret": "pi_3OMHNBKuuB1fWySn0FeJ0eva_secret_GiprxonohIUvx3wCtswBzMwZN",
+          "confirmation_method": "automatic",
+          "created": 1702331445,
+          "currency": "aud",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3OMHNBKuuB1fWySn0xy3HD2l",
+          "livemode": false,
+          "metadata": {},
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_capture",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:47 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OMHNBKuuB1fWySn0FeJ0eva
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.2.0
+      Authorization:
+      - Bearer <HIDDEN_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_9ThsIdXtzA4sZE","request_duration_ms":1021}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.2.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2","hostname":"ff-LAT"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1367'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent;
+        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
+        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
+        style-src 'self'
+      Request-Id:
+      - req_AY1AvcFROeAfTp
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 1000,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "manual",
+          "client_secret": "pi_3OMHNBKuuB1fWySn0FeJ0eva_secret_GiprxonohIUvx3wCtswBzMwZN",
+          "confirmation_method": "automatic",
+          "created": 1702331445,
+          "currency": "aud",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3OMHNBKuuB1fWySn0xy3HD2l",
+          "livemode": false,
+          "metadata": {},
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_capture",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:49 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OMHNBKuuB1fWySn0FeJ0eva/capture
+    body:
+      encoding: UTF-8
+      string: amount_to_capture=100
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic c2tfdGVzdF94RmdKUU9sWHBNQUZzb3p0endGQlRGaFAwMEhHN0J1Q0ptOg==
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.123.0
+      Stripe-Version:
+      - '2019-05-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.123.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5895'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent%2Fcapture;
+        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
+        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
+        style-src 'self'
+      Idempotency-Key:
+      - efea335a-33bf-447d-b78f-230e525e4949
+      Original-Request:
+      - req_R14YpeW4IlTstq
+      Request-Id:
+      - req_R14YpeW4IlTstq
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2019-05-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "manual",
+          "charges": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ch_3OMHNBKuuB1fWySn0xy3HD2l",
+                "object": "charge",
+                "amount": 1000,
+                "amount_captured": 100,
+                "amount_refunded": 900,
+                "application": null,
+                "application_fee": null,
+                "application_fee_amount": null,
+                "balance_transaction": "txn_3OMHNBKuuB1fWySn0pt5PJmY",
+                "billing_details": {
+                  "address": {
+                    "city": null,
+                    "country": null,
+                    "line1": null,
+                    "line2": null,
+                    "postal_code": null,
+                    "state": null
+                  },
+                  "email": null,
+                  "name": null,
+                  "phone": null
+                },
+                "calculated_statement_descriptor": "OFNOFNOFN",
+                "captured": true,
+                "created": 1702331446,
+                "currency": "aud",
+                "customer": null,
+                "description": null,
+                "destination": null,
+                "dispute": null,
+                "disputed": false,
+                "failure_balance_transaction": null,
+                "failure_code": null,
+                "failure_message": null,
+                "fraud_details": {},
+                "invoice": null,
+                "livemode": false,
+                "metadata": {},
+                "on_behalf_of": null,
+                "order": null,
+                "outcome": {
+                  "network_status": "approved_by_network",
+                  "reason": null,
+                  "risk_level": "normal",
+                  "risk_score": 27,
+                  "seller_message": "Payment complete.",
+                  "type": "authorized"
+                },
+                "paid": true,
+                "payment_intent": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
+                "payment_method": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+                "payment_method_details": {
+                  "card": {
+                    "amount_authorized": 1000,
+                    "brand": "visa",
+                    "capture_before": 1702936246,
+                    "checks": {
+                      "address_line1_check": null,
+                      "address_postal_code_check": null,
+                      "cvc_check": "pass"
+                    },
+                    "country": "US",
+                    "exp_month": 12,
+                    "exp_year": 2024,
+                    "extended_authorization": {
+                      "status": "disabled"
+                    },
+                    "fingerprint": "6E6tgVjx6U65iHFV",
+                    "funding": "credit",
+                    "incremental_authorization": {
+                      "status": "unavailable"
+                    },
+                    "installments": null,
+                    "last4": "4242",
+                    "mandate": null,
+                    "multicapture": {
+                      "status": "unavailable"
+                    },
+                    "network": "visa",
+                    "network_token": {
+                      "used": false
+                    },
+                    "overcapture": {
+                      "maximum_amount_capturable": 1000,
+                      "status": "unavailable"
+                    },
+                    "three_d_secure": null,
+                    "wallet": null
+                  },
+                  "type": "card"
+                },
+                "receipt_email": null,
+                "receipt_number": null,
+                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xRmlxRXNLdXVCMWZXeVNuKLqI3qsGMgaLkjk5OjA6LBZEnFvUuRGg_EGGN1wJqtHkfq2TM1hFAIlkmFy2OJggp9G4-FS_qNSKwCRi",
+                "refunded": false,
+                "refunds": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "re_3OMHNBKuuB1fWySn0hwLz9zP",
+                      "object": "refund",
+                      "amount": 900,
+                      "balance_transaction": "txn_3OMHNBKuuB1fWySn0iYQuOne",
+                      "charge": "ch_3OMHNBKuuB1fWySn0xy3HD2l",
+                      "created": 1702331450,
+                      "currency": "aud",
+                      "destination_details": {
+                        "card": {
+                          "type": "reversal"
+                        },
+                        "type": "card"
+                      },
+                      "metadata": {},
+                      "payment_intent": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
+                      "reason": null,
+                      "receipt_number": null,
+                      "source_transfer_reversal": null,
+                      "status": "succeeded",
+                      "transfer_reversal": null
+                    }
+                  ],
+                  "has_more": false,
+                  "total_count": 1,
+                  "url": "/v1/charges/ch_3OMHNBKuuB1fWySn0xy3HD2l/refunds"
+                },
+                "review": null,
+                "shipping": null,
+                "source": null,
+                "source_transfer": null,
+                "statement_descriptor": null,
+                "statement_descriptor_suffix": null,
+                "status": "succeeded",
+                "transfer_data": null,
+                "transfer_group": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/charges?payment_intent=pi_3OMHNBKuuB1fWySn0FeJ0eva"
+          },
+          "client_secret": "pi_3OMHNBKuuB1fWySn0FeJ0eva_secret_GiprxonohIUvx3wCtswBzMwZN",
+          "confirmation_method": "automatic",
+          "created": 1702331445,
+          "currency": "aud",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3OMHNBKuuB1fWySn0xy3HD2l",
+          "livemode": false,
+          "metadata": {},
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:51 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_purchase/completes_the_purchase.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_purchase/completes_the_purchase.yml
@@ -32,7 +32,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:45 GMT
+      - Tue, 12 Dec 2023 13:16:29 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -57,11 +57,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - fab25397-66dc-4f60-8d61-3cb6f971cbd4
+      - 0e3af981-5d45-47a8-8df4-f5a4cf65e6a2
       Original-Request:
-      - req_FLU1yYk8sZamRa
+      - req_a3ZY1GPrHId050
       Request-Id:
-      - req_FLU1yYk8sZamRa
+      - req_a3ZY1GPrHId050
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -76,7 +76,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+          "id": "pm_1OMVp3KuuB1fWySnSK98tJrM",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -116,19 +116,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1702331445,
+          "created": 1702386989,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:45 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:29 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=1000&currency=aud&payment_method=pm_1OMHNAKuuB1fWySn3cnBHQQP&payment_method_types[0]=card&capture_method=manual
+      string: amount=1000&currency=aud&payment_method=pm_1OMVp3KuuB1fWySnSK98tJrM&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.2.0
@@ -137,7 +137,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_FLU1yYk8sZamRa","request_duration_ms":780}}'
+      - '{"last_request_metrics":{"request_id":"req_a3ZY1GPrHId050","request_duration_ms":728}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -157,7 +157,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:45 GMT
+      - Tue, 12 Dec 2023 13:16:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,11 +182,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - bf584387-be9e-41e4-b68e-6a67bf247609
+      - ab30b417-ce24-41d8-bbd1-2353ea63aaa4
       Original-Request:
-      - req_yZ6n7FCPagLueX
+      - req_p7U3IYlR3bX9WW
       Request-Id:
-      - req_yZ6n7FCPagLueX
+      - req_p7U3IYlR3bX9WW
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -201,7 +201,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
+          "id": "pi_3OMVp4KuuB1fWySn01foecB2",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -215,9 +215,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OMHNBKuuB1fWySn0FeJ0eva_secret_GiprxonohIUvx3wCtswBzMwZN",
+          "client_secret": "pi_3OMVp4KuuB1fWySn01foecB2_secret_bJt23IgqwzKzKbjrEVe5bbDw6",
           "confirmation_method": "automatic",
-          "created": 1702331445,
+          "created": 1702386990,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -228,7 +228,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+          "payment_method": "pm_1OMVp3KuuB1fWySnSK98tJrM",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -253,10 +253,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:45 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:30 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OMHNBKuuB1fWySn0FeJ0eva/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OMVp4KuuB1fWySn01foecB2/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -268,7 +268,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_yZ6n7FCPagLueX","request_duration_ms":610}}'
+      - '{"last_request_metrics":{"request_id":"req_p7U3IYlR3bX9WW","request_duration_ms":713}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -288,7 +288,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:46 GMT
+      - Tue, 12 Dec 2023 13:16:31 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -314,11 +314,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - 384e14c9-8af4-4834-b89b-65e61985ba47
+      - 06b4730a-4174-430c-89fd-acafe2a33b23
       Original-Request:
-      - req_9ThsIdXtzA4sZE
+      - req_U3DvUitYuieWsD
       Request-Id:
-      - req_9ThsIdXtzA4sZE
+      - req_U3DvUitYuieWsD
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -333,7 +333,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
+          "id": "pi_3OMVp4KuuB1fWySn01foecB2",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 1000,
@@ -347,20 +347,20 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OMHNBKuuB1fWySn0FeJ0eva_secret_GiprxonohIUvx3wCtswBzMwZN",
+          "client_secret": "pi_3OMVp4KuuB1fWySn01foecB2_secret_bJt23IgqwzKzKbjrEVe5bbDw6",
           "confirmation_method": "automatic",
-          "created": 1702331445,
+          "created": 1702386990,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3OMHNBKuuB1fWySn0xy3HD2l",
+          "latest_charge": "ch_3OMVp4KuuB1fWySn0YT4k7zE",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+          "payment_method": "pm_1OMVp3KuuB1fWySnSK98tJrM",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -385,10 +385,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:47 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:31 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OMHNBKuuB1fWySn0FeJ0eva
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OMVp4KuuB1fWySn01foecB2
     body:
       encoding: US-ASCII
       string: ''
@@ -400,7 +400,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_9ThsIdXtzA4sZE","request_duration_ms":1021}}'
+      - '{"last_request_metrics":{"request_id":"req_U3DvUitYuieWsD","request_duration_ms":1066}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -420,7 +420,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:49 GMT
+      - Tue, 12 Dec 2023 13:16:34 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -446,7 +446,7 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Request-Id:
-      - req_AY1AvcFROeAfTp
+      - req_2hI8JKOwY7kSNH
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -459,7 +459,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
+          "id": "pi_3OMVp4KuuB1fWySn01foecB2",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 1000,
@@ -473,20 +473,20 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OMHNBKuuB1fWySn0FeJ0eva_secret_GiprxonohIUvx3wCtswBzMwZN",
+          "client_secret": "pi_3OMVp4KuuB1fWySn01foecB2_secret_bJt23IgqwzKzKbjrEVe5bbDw6",
           "confirmation_method": "automatic",
-          "created": 1702331445,
+          "created": 1702386990,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3OMHNBKuuB1fWySn0xy3HD2l",
+          "latest_charge": "ch_3OMVp4KuuB1fWySn0YT4k7zE",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+          "payment_method": "pm_1OMVp3KuuB1fWySnSK98tJrM",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -511,13 +511,13 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:49 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:34 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OMHNBKuuB1fWySn0FeJ0eva/capture
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OMVp4KuuB1fWySn01foecB2/capture
     body:
       encoding: UTF-8
-      string: amount_to_capture=100
+      string: amount_to_capture=1000
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -545,11 +545,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:51 GMT
+      - Tue, 12 Dec 2023 13:16:36 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '5895'
+      - '5092'
       Connection:
       - close
       Access-Control-Allow-Credentials:
@@ -571,11 +571,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - efea335a-33bf-447d-b78f-230e525e4949
+      - b362b837-8ebb-4369-beb4-e8a02d02c590
       Original-Request:
-      - req_R14YpeW4IlTstq
+      - req_ZRw3vk5NZdPl51
       Request-Id:
-      - req_R14YpeW4IlTstq
+      - req_ZRw3vk5NZdPl51
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -590,14 +590,14 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
+          "id": "pi_3OMVp4KuuB1fWySn01foecB2",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
           "amount_details": {
             "tip": {}
           },
-          "amount_received": 100,
+          "amount_received": 1000,
           "application": null,
           "application_fee_amount": null,
           "automatic_payment_methods": null,
@@ -608,15 +608,15 @@ http_interactions:
             "object": "list",
             "data": [
               {
-                "id": "ch_3OMHNBKuuB1fWySn0xy3HD2l",
+                "id": "ch_3OMVp4KuuB1fWySn0YT4k7zE",
                 "object": "charge",
                 "amount": 1000,
-                "amount_captured": 100,
-                "amount_refunded": 900,
+                "amount_captured": 1000,
+                "amount_refunded": 0,
                 "application": null,
                 "application_fee": null,
                 "application_fee_amount": null,
-                "balance_transaction": "txn_3OMHNBKuuB1fWySn0pt5PJmY",
+                "balance_transaction": "txn_3OMVp4KuuB1fWySn0E6LUvdB",
                 "billing_details": {
                   "address": {
                     "city": null,
@@ -632,7 +632,7 @@ http_interactions:
                 },
                 "calculated_statement_descriptor": "OFNOFNOFN",
                 "captured": true,
-                "created": 1702331446,
+                "created": 1702386991,
                 "currency": "aud",
                 "customer": null,
                 "description": null,
@@ -652,18 +652,18 @@ http_interactions:
                   "network_status": "approved_by_network",
                   "reason": null,
                   "risk_level": "normal",
-                  "risk_score": 27,
+                  "risk_score": 3,
                   "seller_message": "Payment complete.",
                   "type": "authorized"
                 },
                 "paid": true,
-                "payment_intent": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
-                "payment_method": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+                "payment_intent": "pi_3OMVp4KuuB1fWySn01foecB2",
+                "payment_method": "pm_1OMVp3KuuB1fWySnSK98tJrM",
                 "payment_method_details": {
                   "card": {
                     "amount_authorized": 1000,
                     "brand": "visa",
-                    "capture_before": 1702936246,
+                    "capture_before": 1702991791,
                     "checks": {
                       "address_line1_check": null,
                       "address_postal_code_check": null,
@@ -701,37 +701,14 @@ http_interactions:
                 },
                 "receipt_email": null,
                 "receipt_number": null,
-                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xRmlxRXNLdXVCMWZXeVNuKLqI3qsGMgaLkjk5OjA6LBZEnFvUuRGg_EGGN1wJqtHkfq2TM1hFAIlkmFy2OJggp9G4-FS_qNSKwCRi",
+                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xRmlxRXNLdXVCMWZXeVNuKLS64asGMgbwhD1CoTg6LBanMnQfUGRA4FPL3EBN7ZpQEoO0qNMiyQNtQRvkNHn-zA3EVQ2sn8sHhztn",
                 "refunded": false,
                 "refunds": {
                   "object": "list",
-                  "data": [
-                    {
-                      "id": "re_3OMHNBKuuB1fWySn0hwLz9zP",
-                      "object": "refund",
-                      "amount": 900,
-                      "balance_transaction": "txn_3OMHNBKuuB1fWySn0iYQuOne",
-                      "charge": "ch_3OMHNBKuuB1fWySn0xy3HD2l",
-                      "created": 1702331450,
-                      "currency": "aud",
-                      "destination_details": {
-                        "card": {
-                          "type": "reversal"
-                        },
-                        "type": "card"
-                      },
-                      "metadata": {},
-                      "payment_intent": "pi_3OMHNBKuuB1fWySn0FeJ0eva",
-                      "reason": null,
-                      "receipt_number": null,
-                      "source_transfer_reversal": null,
-                      "status": "succeeded",
-                      "transfer_reversal": null
-                    }
-                  ],
+                  "data": [],
                   "has_more": false,
-                  "total_count": 1,
-                  "url": "/v1/charges/ch_3OMHNBKuuB1fWySn0xy3HD2l/refunds"
+                  "total_count": 0,
+                  "url": "/v1/charges/ch_3OMVp4KuuB1fWySn0YT4k7zE/refunds"
                 },
                 "review": null,
                 "shipping": null,
@@ -746,22 +723,22 @@ http_interactions:
             ],
             "has_more": false,
             "total_count": 1,
-            "url": "/v1/charges?payment_intent=pi_3OMHNBKuuB1fWySn0FeJ0eva"
+            "url": "/v1/charges?payment_intent=pi_3OMVp4KuuB1fWySn01foecB2"
           },
-          "client_secret": "pi_3OMHNBKuuB1fWySn0FeJ0eva_secret_GiprxonohIUvx3wCtswBzMwZN",
+          "client_secret": "pi_3OMVp4KuuB1fWySn01foecB2_secret_bJt23IgqwzKzKbjrEVe5bbDw6",
           "confirmation_method": "automatic",
-          "created": 1702331445,
+          "created": 1702386990,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3OMHNBKuuB1fWySn0xy3HD2l",
+          "latest_charge": "ch_3OMVp4KuuB1fWySn0YT4k7zE",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OMHNAKuuB1fWySn3cnBHQQP",
+          "payment_method": "pm_1OMVp3KuuB1fWySnSK98tJrM",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -786,5 +763,5 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:51 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:36 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_purchase/provides_an_error_message_to_help_developer_debug.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_purchase/provides_an_error_message_to_help_developer_debug.yml
@@ -1,0 +1,391 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[number]=4242424242424242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=314
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.2.0
+      Authorization:
+      - Bearer <HIDDEN_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_AY1AvcFROeAfTp","request_duration_ms":347}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.2.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2","hostname":"ff-LAT"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '931'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Idempotency-Key:
+      - 47e4c0fb-44e8-4db6-97b0-d64112d4046d
+      Original-Request:
+      - req_RbBkJRyrViOJXY
+      Request-Id:
+      - req_RbBkJRyrViOJXY
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1OMHNHKuuB1fWySn3IPVEgHw",
+          "object": "payment_method",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "exp_month": 12,
+            "exp_year": 2024,
+            "fingerprint": "6E6tgVjx6U65iHFV",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1702331451,
+          "customer": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:51 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=1000&currency=aud&payment_method=pm_1OMHNHKuuB1fWySn3IPVEgHw&payment_method_types[0]=card&capture_method=manual
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.2.0
+      Authorization:
+      - Bearer <HIDDEN_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_RbBkJRyrViOJXY","request_duration_ms":478}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.2.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2","hostname":"ff-LAT"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1344'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Idempotency-Key:
+      - 50fc3198-f2d6-4727-b516-731726442667
+      Original-Request:
+      - req_HjHfVysPjs01jM
+      Request-Id:
+      - req_HjHfVysPjs01jM
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3OMHNHKuuB1fWySn1oPNtGzx",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "manual",
+          "client_secret": "pi_3OMHNHKuuB1fWySn1oPNtGzx_secret_i1rN6p1XtyEpiGRt24Jwpkzkp",
+          "confirmation_method": "automatic",
+          "created": 1702331451,
+          "currency": "aud",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "metadata": {},
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1OMHNHKuuB1fWySn3IPVEgHw",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_confirmation",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:52 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OMHNHKuuB1fWySn1oPNtGzx/confirm
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.2.0
+      Authorization:
+      - Bearer <HIDDEN_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_HjHfVysPjs01jM","request_duration_ms":406}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.2.0","lang":"ruby","lang_version":"3.1.4 p223 (2023-03-30)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11
+        (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38)
+        #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2","hostname":"ff-LAT"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 11 Dec 2023 21:50:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1367'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent%2Fconfirm;
+        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
+        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
+        style-src 'self'
+      Idempotency-Key:
+      - 37c3e7b7-e6e5-40c7-912d-c377bf35f461
+      Original-Request:
+      - req_yPW1h61ihGksLY
+      Request-Id:
+      - req_yPW1h61ihGksLY
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3OMHNHKuuB1fWySn1oPNtGzx",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 1000,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "manual",
+          "client_secret": "pi_3OMHNHKuuB1fWySn1oPNtGzx_secret_i1rN6p1XtyEpiGRt24Jwpkzkp",
+          "confirmation_method": "automatic",
+          "created": 1702331451,
+          "currency": "aud",
+          "customer": null,
+          "description": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3OMHNHKuuB1fWySn1fcp4UKj",
+          "livemode": false,
+          "metadata": {},
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1OMHNHKuuB1fWySn3IPVEgHw",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_capture",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Mon, 11 Dec 2023 21:50:53 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_purchase/provides_an_error_message_to_help_developer_debug.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.2.0/Spree_Gateway_StripeSCA/_purchase/provides_an_error_message_to_help_developer_debug.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_AY1AvcFROeAfTp","request_duration_ms":347}}'
+      - '{"last_request_metrics":{"request_id":"req_2hI8JKOwY7kSNH","request_duration_ms":434}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -34,7 +34,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:51 GMT
+      - Tue, 12 Dec 2023 13:16:36 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -59,11 +59,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 47e4c0fb-44e8-4db6-97b0-d64112d4046d
+      - 4a150ad2-88fe-4533-a7bc-1fa073f32a9b
       Original-Request:
-      - req_RbBkJRyrViOJXY
+      - req_162AvbiORsNRF5
       Request-Id:
-      - req_RbBkJRyrViOJXY
+      - req_162AvbiORsNRF5
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -78,7 +78,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1OMHNHKuuB1fWySn3IPVEgHw",
+          "id": "pm_1OMVpAKuuB1fWySnqhQjziYH",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -118,19 +118,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1702331451,
+          "created": 1702386996,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:51 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:37 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=1000&currency=aud&payment_method=pm_1OMHNHKuuB1fWySn3IPVEgHw&payment_method_types[0]=card&capture_method=manual
+      string: amount=1000&currency=aud&payment_method=pm_1OMVpAKuuB1fWySnqhQjziYH&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.2.0
@@ -139,7 +139,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_RbBkJRyrViOJXY","request_duration_ms":478}}'
+      - '{"last_request_metrics":{"request_id":"req_162AvbiORsNRF5","request_duration_ms":639}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -159,7 +159,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:52 GMT
+      - Tue, 12 Dec 2023 13:16:37 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -184,11 +184,11 @@ http_interactions:
         default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
       Idempotency-Key:
-      - 50fc3198-f2d6-4727-b516-731726442667
+      - 491db942-7198-4ee3-8423-a903b73b87ac
       Original-Request:
-      - req_HjHfVysPjs01jM
+      - req_f9tvJ0rgpXxio1
       Request-Id:
-      - req_HjHfVysPjs01jM
+      - req_f9tvJ0rgpXxio1
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -203,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OMHNHKuuB1fWySn1oPNtGzx",
+          "id": "pi_3OMVpBKuuB1fWySn0QfFlIV8",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -217,9 +217,9 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OMHNHKuuB1fWySn1oPNtGzx_secret_i1rN6p1XtyEpiGRt24Jwpkzkp",
+          "client_secret": "pi_3OMVpBKuuB1fWySn0QfFlIV8_secret_bUDMPJVVChVdfO3y49EbdwwxL",
           "confirmation_method": "automatic",
-          "created": 1702331451,
+          "created": 1702386997,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -230,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OMHNHKuuB1fWySn3IPVEgHw",
+          "payment_method": "pm_1OMVpAKuuB1fWySnqhQjziYH",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -255,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:52 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:37 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3OMHNHKuuB1fWySn1oPNtGzx/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3OMVpBKuuB1fWySn0QfFlIV8/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -270,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_HjHfVysPjs01jM","request_duration_ms":406}}'
+      - '{"last_request_metrics":{"request_id":"req_f9tvJ0rgpXxio1","request_duration_ms":406}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -290,7 +290,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 11 Dec 2023 21:50:53 GMT
+      - Tue, 12 Dec 2023 13:16:38 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -316,11 +316,11 @@ http_interactions:
         'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
         style-src 'self'
       Idempotency-Key:
-      - 37c3e7b7-e6e5-40c7-912d-c377bf35f461
+      - f34fdfb3-c2c1-423f-b39f-3e4692e0ec24
       Original-Request:
-      - req_yPW1h61ihGksLY
+      - req_kEuP9BShlEJBEh
       Request-Id:
-      - req_yPW1h61ihGksLY
+      - req_kEuP9BShlEJBEh
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -335,7 +335,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3OMHNHKuuB1fWySn1oPNtGzx",
+          "id": "pi_3OMVpBKuuB1fWySn0QfFlIV8",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 1000,
@@ -349,20 +349,20 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "manual",
-          "client_secret": "pi_3OMHNHKuuB1fWySn1oPNtGzx_secret_i1rN6p1XtyEpiGRt24Jwpkzkp",
+          "client_secret": "pi_3OMVpBKuuB1fWySn0QfFlIV8_secret_bUDMPJVVChVdfO3y49EbdwwxL",
           "confirmation_method": "automatic",
-          "created": 1702331451,
+          "created": 1702386997,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3OMHNHKuuB1fWySn1fcp4UKj",
+          "latest_charge": "ch_3OMVpBKuuB1fWySn01HyMd2n",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1OMHNHKuuB1fWySn3IPVEgHw",
+          "payment_method": "pm_1OMVpAKuuB1fWySnqhQjziYH",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -387,5 +387,5 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 11 Dec 2023 21:50:53 GMT
+  recorded_at: Tue, 12 Dec 2023 13:16:38 GMT
 recorded_with: VCR 6.2.0

--- a/spec/models/spree/gateway/stripe_sca_spec.rb
+++ b/spec/models/spree/gateway/stripe_sca_spec.rb
@@ -3,52 +3,106 @@
 require 'spec_helper'
 
 describe Spree::Gateway::StripeSCA, type: :model do
-  before { Stripe.api_key = "sk_test_12345" }
+  let(:secret) { ENV.fetch('STRIPE_SECRET_TEST_API_KEY', nil) }
 
-  let(:order) { create(:order_with_totals_and_distribution) }
-  let(:credit_card) { create(:credit_card) }
+  let(:order) { create(:order_ready_for_payment) }
+
+  let(:year_valid) { Time.zone.now.year.next }
+
+  let(:credit_card) { create(:credit_card, gateway_payment_profile_id: pm_card.id) }
+
   let(:payment) {
     create(
       :payment,
-      state: "checkout",
       order:,
       amount: order.total,
       payment_method: subject,
       source: credit_card,
-      response_code: "12345"
+      response_code: payment_intent.id
     )
   }
+
   let(:gateway_options) {
     { order_id: order.number }
   }
-  let(:payment_authorised) {
-    payment_intent(payment.amount, "requires_capture")
-  }
-  let(:capture_successful) {
-    payment_intent(payment.amount, "succeeded")
-  }
 
-  describe "#purchase" do
-    it "captures the payment" do
-      stub_request(:get, "https://api.stripe.com/v1/payment_intents/12345").
-        to_return(status: 200, body: payment_authorised)
-      stub_request(:post, "https://api.stripe.com/v1/payment_intents/12345/capture").
-        with(body: { "amount_to_capture" => order.total }).
-        to_return(status: 200, body: capture_successful)
+  describe "#purchase", :vcr, :stripe_version do
+    before { Stripe.api_key = secret }
 
-      response = subject.purchase(order.total, credit_card, gateway_options)
+    let!(:pm_card) do
+      Stripe::PaymentMethod.create({
+                                     type: 'card',
+                                     card: {
+                                       number: '4242424242424242',
+                                       exp_month: 12,
+                                       exp_year: year_valid,
+                                       cvc: '314',
+                                     },
+                                   })
+    end
+    let!(:payment_intent) do
+      Stripe::PaymentIntent.create({
+                                     amount: 1000, # given in AUD cents
+                                     currency: 'aud', # AUD to match order currency
+                                     payment_method: pm_card,
+                                     payment_method_types: ['card'],
+                                     capture_method: 'manual',
+                                   })
+    end
+
+    # Stripe acepts amounts as positive integers representing how much to charge
+    # in the smallest currency unit
+    let(:capture_amount) { order.total.to_i * 10 }
+    let(:response) { subject.purchase(capture_amount, credit_card, gateway_options) }
+
+    before do
+      # confirms the payment
+      Stripe::PaymentIntent.confirm(payment_intent.id)
+    end
+
+    it "completes the purchase" do
+      payment
+
+      expect {
+        response.to
+        change(
+          Stripe::PaymentIntent.retrieve(payment_intent.id).status
+        ).from("requires_capture").to("suceeded")
+      }
 
       expect(response.success?).to eq true
     end
 
     it "provides an error message to help developer debug" do
-      stub_request(:get, "https://api.stripe.com/v1/payment_intents/12345").
-        to_return(status: 200, body: capture_successful)
+      response_error = subject.purchase(capture_amount, credit_card, gateway_options)
 
-      response = subject.purchase(order.total, credit_card, gateway_options)
+      expect(response_error.success?).to eq false
+      expect(response_error.message).to eq "No pending payments"
+    end
+  end
 
-      expect(response.success?).to eq false
-      expect(response.message).to eq "Invalid payment state: succeeded"
+  context "#error message", :vcr, :stripe_version do
+    before { Stripe.api_key = secret }
+
+    let!(:pm_card) do
+      Stripe::PaymentMethod.create({
+                                     type: 'card',
+                                     card: {
+                                       number: '4242424242424242',
+                                       exp_month: 12,
+                                       exp_year: year_valid,
+                                       cvc: '314',
+                                     },
+                                   })
+    end
+    let!(:payment_intent) do
+      Stripe::PaymentIntent.create({
+                                     amount: 1000, # given in AUD cents
+                                     currency: 'aud', # AUD to match order currency
+                                     payment_method: pm_card,
+                                     payment_method_types: ['card'],
+                                     capture_method: 'manual',
+                                   })
     end
 
     context "when payment intent state is not in 'requires_capture' state" do
@@ -56,27 +110,10 @@ describe Spree::Gateway::StripeSCA, type: :model do
         payment
       end
 
-      it "succeeds if payment intent state is requires_capture" do
-        stub_request(:post, "https://api.stripe.com/v1/payment_intents/12345/capture").
-          with(body: { "amount_to_capture" => order.total }).
-          to_return(status: 200, body: capture_successful)
-
-        allow(Stripe::PaymentIntentValidator).to receive_message_chain(:new, :call).
-          and_return(double(status: "requires_capture"))
-
-        response = subject.purchase(order.total, credit_card, gateway_options)
-
-        expect(response.success?).to eq true
-      end
-
       it "does not succeed if payment intent state is not requires_capture" do
-        allow(Stripe::PaymentIntentValidator).to receive_message_chain(:new, :call).
-          and_return(double(status: "not_ready_yet"))
-
         response = subject.purchase(order.total, credit_card, gateway_options)
-
         expect(response.success?).to eq false
-        expect(response.message).to eq "Invalid payment state: not_ready_yet"
+        expect(response.message).to eq "Invalid payment state: requires_confirmation"
       end
     end
   end


### PR DESCRIPTION
Replaces stubs on VCR cassettes. We do this here for the file `./spec/models/spree/gateway/stripe_sca_spec.rb`.

#### What? Why?

- Closes #11925

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

~~Instead of asserting on our DB we can call `Stripe::PaymentIntent.retrieve` to actually be sure that the Stripe payment~~ ~~changes status, by running our code :tada:~~ -> rookie optimism :-) 

Edit: ~~we can~~ we'll _just_ do the above _and_ assert on the ActiveMerchant response...

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
