### PR TITLE
Show Dashboard header in the header area for multi-enterprise users

### DIFF
--- a/app/views/spree/admin/overview/multi_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/multi_enterprise_dashboard.html.haml
@@ -1,11 +1,10 @@
+- content_for :page_title do
+  = t('dashboard')
+
 - content_for :page_actions do
   = render 'admin/shared/user_guide_link'
 
-
 %div{ 'ng-app' => 'ofn.admin' }
-  %h1{ :style => 'margin-bottom: 30px' }
-    = t 'dashboard'
-
   - if @enterprises.empty?
 
     = render partial: "enterprises"


### PR DESCRIPTION
#### What? Why?

- Closes a minor issue from this testing document:
https://docs.google.com/document/d/1YoAoAbdXx2z3q2FfNlWD_aRvNa5C9SKX_NSfABoM42g/edit

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
For multi-enterprise users the header 'Dashboard' on the dashboard page was shown below the header area and not inside of it. This should be fixed now.

**Before:**
![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/1790176/b20d6313-e519-48b7-af23-38641f615359)

**After:**
![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/1790176/c725b661-268d-464c-b460-29d60d77dabd)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Make sure have multiple (at least two) enterprises.
- Visit the overview page /admin.
- Check the position of the header 'Dashboard'.
- It should be inside the light blue header area (same vertical position as the link to the user guide).

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
