### PR TITLE
Fix missing translation of tooltip in dashboard

### DIFF
--- a/app/views/spree/admin/overview/_products.html.haml
+++ b/app/views/spree/admin/overview/_products.html.haml
@@ -6,7 +6,7 @@
       %a.six.columns.omega.icon-plus.button.blue{ href: "#{new_admin_product_path}" }
         = t "spree_admin_enterprises_create_new"
     - else
-      %a{ "ofn-with-tip" => "The products that you sell through the Open Food Network." }
+      %a{ "ofn-with-tip" => t(".products_tip") }
         = t "admin.whats_this"
   %div.sixteen.columns.alpha.list
     - if @product_count > 0

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4188,6 +4188,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           has_no_payment_methods: "has no payment methods"
           has_no_shipping_methods: "has no shipping methods"
         products:
+          products_tip: "The products that you sell through the Open Food Network."
           active_products:
             zero: "You don't have any active products."
             one: "You have one active product"


### PR DESCRIPTION
#### What? Why?

- Fixes a missing translation I found in the dashboard.

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/1790176/32d0c80c-1726-4524-9760-08b32b8e20bd)

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Make sure you have NO products.
- Visit the overview page /admin.
- Make sure the tooltip can be translated.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
