### PR TITLE
make table head and message for edited products sticky

### DIFF
--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -32,7 +32,7 @@
     thead {
       top: 54px;
 
-      ::before {
+      &:before {
         content: '';
         position: absolute;
         top: 0;
@@ -42,6 +42,12 @@
         height: 0.5rem;
         background-color: white;
         transform: translate(-50%, -100%);
+      }
+    }
+
+    @media screen and (max-width: 984px) {
+      thead {
+        top: 86px;
       }
     }
   }

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -22,18 +22,19 @@
   // Form actions floats over other controls when active
   .form-actions {
     position: sticky;
-    top: 0;
+    top: 0.25rem;
     left: 0;
     right: 0;
     z-index: 1; // Ensure tom-select and .disabled-section are covered
   }
+  
 
   .form-actions:not(.hidden) + table.products {
     thead {
       top: 54px;
 
       &:before {
-        content: '';
+        content: "";
         position: absolute;
         top: 0;
         left: 50%;
@@ -51,6 +52,13 @@
       }
     }
   }
+
+  .form-actions:not(.hidden) > .error_summary + .table.products {
+    thead {
+      top: 88px;
+    }
+  }
+
 
   // Hopefully these rules will be moved to component(s).
   table.products {

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -20,13 +20,29 @@
   }
 
   // Form actions floats over other controls when active
-  #products-form {
-    .form-actions {
-      position: absolute;
-      top: -1em;
-      left: 0;
-      right: 0;
-      z-index: 1; // Ensure tom-select and .disabled-section are covered
+  .form-actions {
+    position: sticky;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1; // Ensure tom-select and .disabled-section are covered
+  }
+
+  .form-actions:not(.hidden) + table.products {
+    thead {
+      top: 54px;
+
+      ::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 50%;
+        right: 50%;
+        width: 102%;
+        height: 0.5rem;
+        background-color: white;
+        transform: translate(-50%, -100%);
+      }
     }
   }
 
@@ -37,6 +53,12 @@
     background-color: $color-tbl-bg;
     padding: 4px;
     border-collapse: separate; // This is needed for the outer padding. Also should be helpful to give more flexibility of borders between rows.
+
+    thead {
+      position: sticky;
+      top: 0;
+      z-index: 999;
+    }
 
     // Additional horizontal padding to align with input contents
     thead th.with-input {


### PR DESCRIPTION
#### What? Why?
Making  table header and saving banner sticky
- Closes #11902 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- With admin_style_v3 feature enabled, visit `/admin/products` page
- zoom in the page to enable scrolling 
- check the table head (as well as the banner when a product was edited) to see the new styles applied

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

 Table header and the banner for edited products sticky while scrolling


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
