### PR TITLE
Add new enterprise settings tab Connected Apps

### DIFF
--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -21,15 +21,28 @@ module Admin
       show_payment_methods = can?(:manage_payment_methods, enterprise) && is_shop
       show_enterprise_fees = can?(:manage_enterprise_fees,
                                   enterprise) && (is_shop || enterprise.is_primary_producer)
+      show_connected_apps = feature?(:connected_apps, spree_current_user, enterprise)
 
-      build_enterprise_side_menu_items(is_shop, show_properties, show_shipping_methods,
-                                       show_payment_methods, show_enterprise_fees)
+      build_enterprise_side_menu_items(
+        is_shop:,
+        show_properties:,
+        show_shipping_methods:,
+        show_payment_methods:,
+        show_enterprise_fees:,
+        show_connected_apps:,
+      )
     end
 
     private
 
-    def build_enterprise_side_menu_items(is_shop, show_properties, show_shipping_methods,
-                                         show_payment_methods, show_enterprise_fees)
+    def build_enterprise_side_menu_items(
+      is_shop:,
+      show_properties:,
+      show_shipping_methods:,
+      show_payment_methods:,
+      show_enterprise_fees:,
+      show_connected_apps:
+    )
       [
         { name: 'primary_details', icon_class: "icon-home", show: true, selected: 'selected' },
         { name: 'address', icon_class: "icon-map-marker", show: true },
@@ -50,7 +63,7 @@ module Admin
         { name: 'shop_preferences', icon_class: "icon-shopping-cart", show: is_shop },
         { name: 'users', icon_class: "icon-user", show: true },
         { name: 'white_label', icon_class: "icon-leaf", show: true },
-        { name: 'connected_apps', icon_class: "icon-puzzle-piece", show: feature?(:connected_apps) },
+        { name: 'connected_apps', icon_class: "icon-puzzle-piece", show: show_connected_apps },
       ]
     end
   end

--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -50,6 +50,7 @@ module Admin
         { name: 'shop_preferences', icon_class: "icon-shopping-cart", show: is_shop },
         { name: 'users', icon_class: "icon-user", show: true },
         { name: 'white_label', icon_class: "icon-leaf", show: true },
+        { name: 'connected_apps', icon_class: "icon-puzzle-piece", show: feature?(:connected_apps) },
       ]
     end
   end

--- a/app/jobs/connect_app_job.rb
+++ b/app/jobs/connect_app_job.rb
@@ -17,7 +17,7 @@ class ConnectAppJob < ApplicationJob
 
     return unless channel
 
-    selector = "#edit_enterprise_#{enterprise.id} #connected_apps_panel div"
+    selector = "#edit_enterprise_#{enterprise.id} #connected-app-discover-regen"
     html = ApplicationController.render(
       partial: "admin/enterprises/form/connected_apps",
       locals: { enterprise: },

--- a/app/jobs/connect_app_job.rb
+++ b/app/jobs/connect_app_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ConnectAppJob < ApplicationJob
+  def perform(app, token)
+    url = "https://n8n.openfoodnetwork.org.uk/webhook/regen/connect-enterprise"
+    event = "connect-app"
+    payload = {
+      enterprise_id: app.enterprise_id,
+      access_token: token,
+    }
+
+    response = WebhookDeliveryJob.perform_now(url, event, payload)
+    app.update!(data: JSON.parse(response))
+  end
+end

--- a/app/jobs/webhook_delivery_job.rb
+++ b/app/jobs/webhook_delivery_job.rb
@@ -46,5 +46,7 @@ class WebhookDeliveryJob < ApplicationJob
     # Raise a failed request error and let job runner handle retrying.
     # In theory, only 5xx errors should be retried, but who knows.
     raise FailedWebhookRequestError, response.status.to_s unless response.success?
+
+    response.body
   end
 end

--- a/app/models/connected_app.rb
+++ b/app/models/connected_app.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# An enterprise can be connected to other apps.
+#
+# Here we store keys and links to access the app.
+class ConnectedApp < ApplicationRecord
+  belongs_to :enterprise
+end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -62,6 +62,7 @@ class Enterprise < ApplicationRecord
   has_many :tag_rules, dependent: :destroy
   has_one :stripe_account, dependent: :destroy
   has_many :vouchers
+  has_many :connected_apps, dependent: :destroy
   has_one :custom_tab, dependent: :destroy
 
   delegate :latitude, :longitude, :city, :state_name, to: :address

--- a/app/reflexes/admin/connected_app_reflex.rb
+++ b/app/reflexes/admin/connected_app_reflex.rb
@@ -7,10 +7,20 @@ module Admin
       authorize! :admin, enterprise
       app = ConnectedApp.create!(enterprise_id: enterprise.id)
 
+      selector = "#edit_enterprise_#{enterprise.id} #connected-app-discover-regen"
+      html = ApplicationController.render(
+        partial: "admin/enterprises/form/connected_apps",
+        locals: { enterprise: },
+      )
+
+      # Avoid race condition by sending before enqueuing job:
+      cable_ready.morph(selector:, html:).broadcast
+
       ConnectAppJob.perform_later(
         app, current_user.spree_api_key,
         channel: SessionChannel.for_request(request),
       )
+      morph :nothing
     end
   end
 end

--- a/app/reflexes/admin/connected_app_reflex.rb
+++ b/app/reflexes/admin/connected_app_reflex.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Admin
+  class ConnectedAppReflex < ApplicationReflex
+    def create
+      enterprise = Enterprise.find(element.dataset.enterprise_id)
+      authorize! :admin, enterprise
+      ConnectedApp.create!(enterprise_id: enterprise.id)
+    end
+  end
+end

--- a/app/reflexes/admin/connected_app_reflex.rb
+++ b/app/reflexes/admin/connected_app_reflex.rb
@@ -6,7 +6,11 @@ module Admin
       enterprise = Enterprise.find(element.dataset.enterprise_id)
       authorize! :admin, enterprise
       app = ConnectedApp.create!(enterprise_id: enterprise.id)
-      ConnectAppJob.perform_later(app, current_user.spree_api_key)
+
+      ConnectAppJob.perform_later(
+        app, current_user.spree_api_key,
+        channel: SessionChannel.for_request(request),
+      )
     end
   end
 end

--- a/app/reflexes/admin/connected_app_reflex.rb
+++ b/app/reflexes/admin/connected_app_reflex.rb
@@ -5,7 +5,8 @@ module Admin
     def create
       enterprise = Enterprise.find(element.dataset.enterprise_id)
       authorize! :admin, enterprise
-      ConnectedApp.create!(enterprise_id: enterprise.id)
+      app = ConnectedApp.create!(enterprise_id: enterprise.id)
+      ConnectAppJob.perform_later(app, current_user.spree_api_key)
     end
   end
 end

--- a/app/views/admin/enterprises/form/_connected_apps.html.haml
+++ b/app/views/admin/enterprises/form/_connected_apps.html.haml
@@ -1,0 +1,1 @@
+in progress

--- a/app/views/admin/enterprises/form/_connected_apps.html.haml
+++ b/app/views/admin/enterprises/form/_connected_apps.html.haml
@@ -1,16 +1,17 @@
+- enterprise ||= f.object
 %div{ data: {reflex: {root: ".connected-app__head, .connected-app__connection"}} }
   .connected-app__head
     %div
       %h3= t ".title"
       %p= t ".tagline"
     %div
-      - if @enterprise.connected_apps.empty?
-        %button{ data: {reflex: "click->Admin::ConnectedApp#create", enterprise_id: @enterprise.id} }
+      - if enterprise.connected_apps.empty?
+        %button{ data: {reflex: "click->Admin::ConnectedApp#create", enterprise_id: enterprise.id} }
           = t ".action"
   .connected-app__connection
-    - if @enterprise.connected_apps.present?
+    - if enterprise.connected_apps.present?
       .connected-app__note
-        - link = @enterprise.connected_apps[0].data&.fetch("link", false)
+        - link = enterprise.connected_apps[0].data&.fetch("link", false)
         - if link
           %p= t ".note"
           %div

--- a/app/views/admin/enterprises/form/_connected_apps.html.haml
+++ b/app/views/admin/enterprises/form/_connected_apps.html.haml
@@ -10,7 +10,17 @@
   .connected-app__connection
     - if @enterprise.connected_apps.present?
       .connected-app__note
-        = t ".note"
+        - link = @enterprise.connected_apps[0].data&.fetch("link", false)
+        - if link
+          %p= t ".note"
+          %div
+            %a{ href: link, target: "_blank", class: "button" }
+              = t ".link_label"
+        - else
+          %p
+            %i.spinner.fa.fa-spin.fa-circle-o-notch
+            &nbsp;
+            = t ".saving_changes"
 
   %hr
   .connected-app__description

--- a/app/views/admin/enterprises/form/_connected_apps.html.haml
+++ b/app/views/admin/enterprises/form/_connected_apps.html.haml
@@ -1,11 +1,17 @@
-%div
+%div{ data: {reflex: {root: ".connected-app__head, .connected-app__connection"}} }
   .connected-app__head
     %div
       %h3= t ".title"
       %p= t ".tagline"
     %div
-      %button
-        = t ".action"
+      - if @enterprise.connected_apps.empty?
+        %button{ data: {reflex: "click->Admin::ConnectedApp#create", enterprise_id: @enterprise.id} }
+          = t ".action"
+  .connected-app__connection
+    - if @enterprise.connected_apps.present?
+      .connected-app__note
+        = t ".note"
+
   %hr
   .connected-app__description
     = t ".description_html"

--- a/app/views/admin/enterprises/form/_connected_apps.html.haml
+++ b/app/views/admin/enterprises/form/_connected_apps.html.haml
@@ -1,5 +1,5 @@
 - enterprise ||= f.object
-%div{ data: {reflex: {root: ".connected-app__head, .connected-app__connection"}} }
+#connected-app-discover-regen
   .connected-app__head
     %div
       %h3= t ".title"

--- a/app/views/admin/enterprises/form/_connected_apps.html.haml
+++ b/app/views/admin/enterprises/form/_connected_apps.html.haml
@@ -1,1 +1,11 @@
-in progress
+%div
+  .connected-app__head
+    %div
+      %h3= t ".title"
+      %p= t ".tagline"
+    %div
+      %button
+        = t ".action"
+  %hr
+  .connected-app__description
+    = t ".description_html"

--- a/app/webpacker/css/admin/all.scss
+++ b/app/webpacker/css/admin/all.scss
@@ -83,6 +83,7 @@
 @import "alert";
 @import "animations";
 @import "change_type_form";
+@import "connected_apps";
 @import "customers";
 @import "dashboard_item";
 @import "dashboard-single-ent";

--- a/app/webpacker/css/admin/connected_apps.scss
+++ b/app/webpacker/css/admin/connected_apps.scss
@@ -1,0 +1,15 @@
+.connected-app__head {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1em;
+
+  h3 {
+    margin-bottom: 1em;
+  }
+}
+
+.connected-app__description {
+  p {
+    margin-bottom: 1em;
+  }
+}

--- a/app/webpacker/css/admin/connected_apps.scss
+++ b/app/webpacker/css/admin/connected_apps.scss
@@ -18,10 +18,10 @@
   display: flex;
   justify-content: space-between;
 
-  background-color: #f8f9fa;
+  background-color: $color-14;
   border: none;
-  border-left: 4px solid #008397;
-  border-radius: 4px;
+  border-left: $border-radius solid $color-3;
+  border-radius: $border-radius;
   box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.05), 0px 2px 2px rgba(0, 0, 0, 0.07);
   margin: 2em 0;
   padding: 0.5em 1em;

--- a/app/webpacker/css/admin/connected_apps.scss
+++ b/app/webpacker/css/admin/connected_apps.scss
@@ -13,3 +13,13 @@
     margin-bottom: 1em;
   }
 }
+
+.connected-app__note {
+  background-color: #f8f9fa;
+  border: none;
+  border-left: 4px solid #008397;
+  border-radius: 4px;
+  box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.05), 0px 2px 2px rgba(0, 0, 0, 0.07);
+  margin: 2em 0;
+  padding: 0.5em 1em;
+}

--- a/app/webpacker/css/admin/connected_apps.scss
+++ b/app/webpacker/css/admin/connected_apps.scss
@@ -15,6 +15,9 @@
 }
 
 .connected-app__note {
+  display: flex;
+  justify-content: space-between;
+
   background-color: #f8f9fa;
   border: none;
   border-left: 4px solid #008397;
@@ -22,4 +25,13 @@
   box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.05), 0px 2px 2px rgba(0, 0, 0, 0.07);
   margin: 2em 0;
   padding: 0.5em 1em;
+
+  align-items: center;
+  gap: 1em;
+  * {
+    flex-shrink: 0;
+  }
+  p {
+    flex-shrink: 1;
+  }
 }

--- a/app/webpacker/css/admin/globals/palette.scss
+++ b/app/webpacker/css/admin/globals/palette.scss
@@ -13,6 +13,7 @@ $color-3: $spree-blue !default; // Light Blue
 $color-4: #6788a2 !default; // Dark Blue
 $color-5: #c60f13 !default; // Red
 $color-6: #ff9300 !default; // Yellow
+$color-14: #f8f9fa !default; // Lighter grey
 
 $dark-grey: #333;
 $light-grey: #ddd;

--- a/app/webpacker/css/admin_v3/all.scss
+++ b/app/webpacker/css/admin_v3/all.scss
@@ -87,6 +87,7 @@
 @import "../admin/alert";
 @import "../admin/animations";
 @import "pages/change_type_form"; // admin_v3
+@import "../admin/connected_apps";
 @import "../admin/customers";
 @import "dashboard/dashboard_item"; // admin_v3
 @import "pages/dashboard-single-ent"; // admin_v3

--- a/app/webpacker/css/admin_v3/globals/palette.scss
+++ b/app/webpacker/css/admin_v3/globals/palette.scss
@@ -34,3 +34,4 @@ $color-10: $orient;
 $color-11: $mystic;
 $color-12: $fair-pink;
 $color-13: $roof-terracotta;
+$color-14: $lighter-grey;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1279,6 +1279,8 @@ en:
           create_custom_tab: "Create custom tab in shopfront"
           custom_tab_title: "Title for custom tab"
           custom_tab_content: "Content for custom tab"
+        connected_apps:
+          legend: "Connected apps"
       actions:
         edit_profile: Settings
         properties: Properties
@@ -1532,6 +1534,7 @@ en:
           users: "Users"
           vouchers: Vouchers
           white_label: "White Label"
+          connected_apps: "Connected apps"
         enterprise_group:
           primary_details: "Primary Details"
           users: "Users"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1284,6 +1284,9 @@ en:
           title: "Discover Regenerative"
           tagline: "Allow website to publish your enterprise information."
           action: "Share data"
+          note: |
+            In order for this enterprise to be published, you need to include
+            regenerative details and accept the Terms and Conditions.
           description_html: |
             <p>
             Discover Regenerative makes it easier for buyers to discover

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1284,9 +1284,11 @@ en:
           title: "Discover Regenerative"
           tagline: "Allow website to publish your enterprise information."
           action: "Share data"
+          saving_changes: "Saving changes"
           note: |
             In order for this enterprise to be published, you need to include
             regenerative details and accept the Terms and Conditions.
+          link_label: "Update details"
           description_html: |
             <p>
             Discover Regenerative makes it easier for buyers to discover

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1281,6 +1281,17 @@ en:
           custom_tab_content: "Content for custom tab"
         connected_apps:
           legend: "Connected apps"
+          title: "Discover Regenerative"
+          tagline: "Allow website to publish your enterprise information."
+          action: "Share data"
+          description_html: |
+            <p>
+            Discover Regenerative makes it easier for buyers to discover
+            regenerative produce for their procurement, showcase producers that
+            are using regenerative farming practices, support connection
+            between buyers and producers within a trusted network.
+            </p>
+            <p><a href="" target="_blank"><b>Visit website</b> <i class="icon-external-link"></i></a></p>
       actions:
         edit_profile: Settings
         properties: Properties

--- a/db/migrate/20231213054115_create_connected_apps.rb
+++ b/db/migrate/20231213054115_create_connected_apps.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateConnectedApps < ActiveRecord::Migration[7.0]
+  def change
+    create_table :connected_apps do |t|
+      t.belongs_to :enterprise, foreign_key: true
+      t.json :data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,6 +63,14 @@ ActiveRecord::Schema[7.0].define(version: 20231003000823494) do
     t.index ["user_id", "action_name", "column_name"], name: "index_column_prefs_on_user_id_and_action_name_and_column_name", unique: true
   end
 
+  create_table "connected_apps", force: :cascade do |t|
+    t.bigint "enterprise_id"
+    t.json "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["enterprise_id"], name: "index_connected_apps_on_enterprise_id"
+  end
+
   create_table "coordinator_fees", id: :serial, force: :cascade do |t|
     t.integer "order_cycle_id", null: false
     t.integer "enterprise_fee_id", null: false
@@ -1101,6 +1109,7 @@ ActiveRecord::Schema[7.0].define(version: 20231003000823494) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "adjustment_metadata", "enterprises", name: "adjustment_metadata_enterprise_id_fk"
   add_foreign_key "adjustment_metadata", "spree_adjustments", column: "adjustment_id", name: "adjustment_metadata_adjustment_id_fk", on_delete: :cascade
+  add_foreign_key "connected_apps", "enterprises"
   add_foreign_key "coordinator_fees", "enterprise_fees", name: "coordinator_fees_enterprise_fee_id_fk"
   add_foreign_key "coordinator_fees", "order_cycles", name: "coordinator_fees_order_cycle_id_fk"
   add_foreign_key "custom_tabs", "enterprises", on_delete: :cascade

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -47,6 +47,10 @@ module OpenFoodNetwork
       "invoices" => <<~DESC,
         Preserve the state of generated invoices and enable multiple invoice numbers instead of only one live-updating invoice.
       DESC
+      "connected_apps" => <<~DESC,
+        Enterprise data can be shared with another app.
+        The first example is the Australian Discover Regenerative Portal.
+      DESC
     }.freeze
 
     # Features you would like to be enabled to start with.

--- a/spec/fixtures/vcr_cassettes/ConnectAppJob/stores_connection_data_on_the_app.yml
+++ b/spec/fixtures/vcr_cassettes/ConnectAppJob/stores_connection_data_on_the_app.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://n8n.openfoodnetwork.org.uk/webhook/regen/connect-enterprise
+    body:
+      encoding: UTF-8
+      string: '{"id":"6efbbeea-4078-4bb5-88b1-c8dbf599c520","at":"2023-12-14 12:13:39
+        +1100","event":"connect-app","data":{"enterprise_id":23,"access_token":"b5fa8c7fa1dd5331a2111fcc907040d842c5eb928c512e43"}}'
+    headers:
+      User-Agent:
+      - openfoodnetwork_webhook/1.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 14 Dec 2023 01:13:41 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '35'
+      Connection:
+      - keep-alive
+      Etag:
+      - W/"23-GW39X6dSljjgz4GPY7ICa+eNupE"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"link":"https://example.net/edit"}'
+  recorded_at: Thu, 14 Dec 2023 01:13:40 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Connected_Apps/can_be_enabled.yml
+++ b/spec/fixtures/vcr_cassettes/Connected_Apps/can_be_enabled.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://n8n.openfoodnetwork.org.uk/webhook/regen/connect-enterprise
+    body:
+      encoding: UTF-8
+      string: '{"id":"4da377c8-0c8f-4aaa-8f85-f2a218a13d6e","at":"2023-12-14 12:52:53
+        +1100","event":"connect-app","data":{"enterprise_id":45,"access_token":"2c5f828a1da2f5a87798e6d3ee44daee6729b2963db6d264"}}'
+    headers:
+      User-Agent:
+      - openfoodnetwork_webhook/1.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 14 Dec 2023 01:52:55 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '35'
+      Connection:
+      - keep-alive
+      Etag:
+      - W/"23-GW39X6dSljjgz4GPY7ICa+eNupE"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"link":"https://example.net/edit"}'
+  recorded_at: Thu, 14 Dec 2023 01:52:55 GMT
+recorded_with: VCR 6.2.0

--- a/spec/jobs/connect_app_job_spec.rb
+++ b/spec/jobs/connect_app_job_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ConnectAppJob, type: :job, vcr: true do
+  subject { ConnectAppJob.new(app, token) }
+
+  let(:app) { ConnectedApp.create!(enterprise: ) }
+  let(:enterprise) { create(:enterprise) }
+  let(:token) { enterprise.owner.spree_api_key }
+
+  before { enterprise.owner.generate_api_key }
+
+  it "stores connection data on the app" do
+    subject.perform_now
+
+    expect(app.data).to eq({ "link" => "https://example.net/edit" })
+  end
+end

--- a/spec/models/connected_app_spec.rb
+++ b/spec/models/connected_app_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ConnectedApp, type: :model do
+  it { is_expected.to belong_to :enterprise }
+
+  it "stores data as json hash" do
+    # This functionality is just Rails and would usually not warrant a spec but
+    # it's the first time we use the json datatype in this codebase and
+    # therefore it's a nice example to see how it works.
+    expect(subject.data).to eq nil
+
+    subject.enterprise = create(:enterprise)
+    subject.data = { link: "https://example.net" }
+    subject.save!
+    subject.reload
+
+    expect(subject.data).to eq({ "link" => "https://example.net" })
+  end
+end

--- a/spec/system/admin/enterprises/connected_apps_spec.rb
+++ b/spec/system/admin/enterprises/connected_apps_spec.rb
@@ -40,7 +40,7 @@ describe "Connected Apps", feature: :connected_apps, vcr: true do
     expect(page).to have_content "Saving changes"
 
     perform_enqueued_jobs(only: ConnectAppJob)
-    page.refresh # TODO: update via cable_ready
+    expect(page).to_not have_content "Saving changes"
     expect(page).to have_content "include regenerative details"
     expect(page).to have_link "Update details"
   end

--- a/spec/system/admin/enterprises/connected_apps_spec.rb
+++ b/spec/system/admin/enterprises/connected_apps_spec.rb
@@ -9,7 +9,7 @@ describe "Connected Apps", feature: :connected_apps do
     login_as enterprise.owner
   end
 
-  it "is not visible by default" do
+  it "is only visible when enabled" do
     # Assuming that this feature will be the default one day, I'm treating this
     # as special case and disable the feature. I don't want to wrap all other
     # test cases in a context block for the feature toggle which will need
@@ -17,6 +17,15 @@ describe "Connected Apps", feature: :connected_apps do
     Flipper.disable(:connected_apps)
     visit edit_admin_enterprise_path(enterprise)
     expect(page).to_not have_content "CONNECTED APPS"
+
+    Flipper.enable(:connected_apps, enterprise.owner)
+    visit edit_admin_enterprise_path(enterprise)
+    expect(page).to have_content "CONNECTED APPS"
+
+    Flipper.disable(:connected_apps)
+    Flipper.enable(:connected_apps, enterprise)
+    visit edit_admin_enterprise_path(enterprise)
+    expect(page).to have_content "CONNECTED APPS"
   end
 
   it "is visible" do

--- a/spec/system/admin/enterprises/connected_apps_spec.rb
+++ b/spec/system/admin/enterprises/connected_apps_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+describe "Connected Apps", feature: :connected_apps do
+  let(:enterprise) { create(:enterprise) }
+
+  before do
+    login_as enterprise.owner
+  end
+
+  it "is not visible by default" do
+    # Assuming that this feature will be the default one day, I'm treating this
+    # as special case and disable the feature. I don't want to wrap all other
+    # test cases in a context block for the feature toggle which will need
+    # removing one day.
+    Flipper.disable(:connected_apps)
+    visit edit_admin_enterprise_path(enterprise)
+    expect(page).to_not have_content "CONNECTED APPS"
+  end
+
+  it "is visible" do
+    visit edit_admin_enterprise_path(enterprise)
+    expect(page).to have_content "CONNECTED APPS"
+
+    scroll_to :bottom
+    click_link "Connected apps"
+    expect(page).to have_content "in progress"
+  end
+end

--- a/spec/system/admin/enterprises/connected_apps_spec.rb
+++ b/spec/system/admin/enterprises/connected_apps_spec.rb
@@ -28,12 +28,15 @@ describe "Connected Apps", feature: :connected_apps do
     expect(page).to have_content "CONNECTED APPS"
   end
 
-  it "is visible" do
+  it "can be enabled" do
     visit edit_admin_enterprise_path(enterprise)
 
     scroll_to :bottom
     click_link "Connected apps"
     expect(page).to have_content "Discover Regenerative"
-    expect(page).to have_button "Share data"
+
+    click_button "Share data"
+    expect(page).to_not have_button "Share data"
+    expect(page).to have_content "include regenerative details"
   end
 end

--- a/spec/system/admin/enterprises/connected_apps_spec.rb
+++ b/spec/system/admin/enterprises/connected_apps_spec.rb
@@ -30,10 +30,10 @@ describe "Connected Apps", feature: :connected_apps do
 
   it "is visible" do
     visit edit_admin_enterprise_path(enterprise)
-    expect(page).to have_content "CONNECTED APPS"
 
     scroll_to :bottom
     click_link "Connected apps"
-    expect(page).to have_content "in progress"
+    expect(page).to have_content "Discover Regenerative"
+    expect(page).to have_button "Share data"
   end
 end

--- a/spec/system/admin/enterprises/connected_apps_spec.rb
+++ b/spec/system/admin/enterprises/connected_apps_spec.rb
@@ -2,7 +2,7 @@
 
 require "system_helper"
 
-describe "Connected Apps", feature: :connected_apps do
+describe "Connected Apps", feature: :connected_apps, vcr: true do
   let(:enterprise) { create(:enterprise) }
 
   before do
@@ -37,6 +37,11 @@ describe "Connected Apps", feature: :connected_apps do
 
     click_button "Share data"
     expect(page).to_not have_button "Share data"
+    expect(page).to have_content "Saving changes"
+
+    perform_enqueued_jobs(only: ConnectAppJob)
+    page.refresh # TODO: update via cable_ready
     expect(page).to have_content "include regenerative details"
+    expect(page).to have_link "Update details"
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #11718 <!-- Insert issue number here. -->

[Screencast from 2023-12-15 16-31-13.webm](https://github.com/openfoodfoundation/openfoodnetwork/assets/3524483/cc8a90fc-73aa-4dd7-9076-0aa5de33ea72)



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Testing requirement: the last step of testing needs the n8n workflow:

- [ ] n8n workflow finished

**Production test only**

I realised that the n8n workflows are all tied to the Australian production server and therefore we can't test it in staging. We may change that but for now, we can just merge this. It's feature-toggled.

Testing steps:
- Activate feature `connected_apps` for user, enterprise or instance.
- Visit enterprise settings.
- Select tab Connected apps
- Click on Share data.
- Maybe observe a loading message.
- Then observe a notice to finish the setup.
- Press on that button and see a form containing your enterprise details.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

This depends on a certain n8n workflow. The webhook URL is hardcoded.


#### Documentation updates

