### PR TITLE
Send semantic id when connecting enterprise to app

### DIFF
--- a/app/jobs/connect_app_job.rb
+++ b/app/jobs/connect_app_job.rb
@@ -8,7 +8,7 @@ class ConnectAppJob < ApplicationJob
     event = "connect-app"
     enterprise = app.enterprise
     payload = {
-      enterprise_id: enterprise.id,
+      '@id': DfcBuilder.urls.enterprise_url(enterprise.id),
       access_token: token,
     }
 

--- a/spec/fixtures/vcr_cassettes/ConnectAppJob/stores_connection_data_on_the_app.yml
+++ b/spec/fixtures/vcr_cassettes/ConnectAppJob/stores_connection_data_on_the_app.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://n8n.openfoodnetwork.org.uk/webhook/regen/connect-enterprise
     body:
       encoding: UTF-8
-      string: '{"id":"6efbbeea-4078-4bb5-88b1-c8dbf599c520","at":"2023-12-14 12:13:39
-        +1100","event":"connect-app","data":{"enterprise_id":23,"access_token":"b5fa8c7fa1dd5331a2111fcc907040d842c5eb928c512e43"}}'
+      string: '{"id":"27bc9d0a-d95c-4a36-9b16-01fdd8a82b51","at":"2023-12-21 14:54:28
+        +1100","event":"connect-app","data":{"@id":"http://test.host/api/dfc/enterprises/3","access_token":"12345"}}'
     headers:
       User-Agent:
       - openfoodnetwork_webhook/1.0
@@ -24,15 +24,15 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 14 Dec 2023 01:13:41 GMT
+      - Thu, 21 Dec 2023 03:54:33 GMT
       Content-Type:
-      - text/html; charset=utf-8
+      - application/json; charset=utf-8
       Content-Length:
-      - '35'
+      - '141'
       Connection:
       - keep-alive
       Etag:
-      - W/"23-GW39X6dSljjgz4GPY7ICa+eNupE"
+      - W/"8d-Lz10bce6zwT2C429xIkj52OBWyk"
       Vary:
       - Accept-Encoding
       Strict-Transport-Security:
@@ -49,6 +49,6 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"link":"https://example.net/edit"}'
-  recorded_at: Thu, 14 Dec 2023 01:13:40 GMT
+      string: '{"link":"https://example.net/update","destroy":"https://n8n.openfoodnetwork.org.uk/webhook/remove-enterprise?id=recjBXXXXXXXXXXXX&key=12345"}'
+  recorded_at: Thu, 21 Dec 2023 03:54:33 GMT
 recorded_with: VCR 6.2.0

--- a/spec/jobs/connect_app_job_spec.rb
+++ b/spec/jobs/connect_app_job_spec.rb
@@ -2,18 +2,40 @@
 
 require 'spec_helper'
 
-RSpec.describe ConnectAppJob, type: :job, vcr: true do
-  subject { ConnectAppJob.new(app, token) }
+RSpec.describe ConnectAppJob, type: :job do
+  subject { ConnectAppJob.new(app, user.spree_api_key) }
 
-  let(:app) { ConnectedApp.create!(enterprise: ) }
-  let(:enterprise) { create(:enterprise) }
-  let(:token) { enterprise.owner.spree_api_key }
+  let(:app) { ConnectedApp.new(enterprise: ) }
+  let(:enterprise) { build(:enterprise, id: 3, owner: user) }
+  let(:user) { build(:user, spree_api_key: "12345") }
+  let(:url) { "https://n8n.openfoodnetwork.org.uk/webhook/regen/connect-enterprise" }
 
-  before { enterprise.owner.generate_api_key }
+  it "sends a semantic id and access token" do
+    stub_request(:post, url).to_return(body: '{}')
 
-  it "stores connection data on the app" do
     subject.perform_now
 
-    expect(app.data).to eq({ "link" => "https://example.net/edit" })
+    request = a_request(:post, url).with(
+      body: hash_including(
+        {
+          data: {
+            '@id': "http://test.host/api/dfc/enterprises/3",
+            access_token: "12345",
+          }
+        }
+      )
+    )
+    expect(request).to have_been_made.once
+  end
+
+  it "stores connection data on the app", vcr: true do
+    subject.perform_now
+
+    expect(app.data).to eq(
+      {
+        "link" => "https://example.net/update",
+        "destroy" => "https://n8n.openfoodnetwork.org.uk/webhook/remove-enterprise?id=recjBXXXXXXXXXXXX&key=12345",
+      }
+    )
   end
 end


### PR DESCRIPTION
#### What? Why?

Follow up from:

- #11937

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
I realised that we can't test this functionality in staging while our Discover app is hardcoded to au-prod. We can open this up by providing the full URL to the enterprise data.

It allows us to list enterprises from any OFN server, not just ofn-au. The app could even accept any enterprise on any server providing its data in the DFC format.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


-   Activate feature connected_apps for user, enterprise or instance.
-   Visit enterprise settings.
-   Select tab Connected apps
-   Click on Share data.
-   Maybe observe a loading message.
-   Then observe a notice to finish the setup.
-   Press on that button and see a form containing your enterprise details.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

- [x] The n8n workflow needs updating.


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
