### PR TITLE
Update Swagger config to new naming

### DIFF
--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -5,7 +5,7 @@ Rswag::Api.configure do |config|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  config.swagger_root = Rails.root.join("swagger").to_s
+  config.openapi_root = Rails.root.join("swagger").to_s
 
   # Inject a lamda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -9,8 +9,8 @@ Rswag::Ui.configure do |config|
   # (under swagger_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  config.swagger_endpoint 'v1.yaml', 'API V1 Docs'
-  config.swagger_endpoint 'dfc.yaml', 'OFN DFC API Docs'
+  config.openapi_endpoint 'v1.yaml', 'API V1 Docs'
+  config.openapi_endpoint 'dfc.yaml', 'OFN DFC API Docs'
 
   # Add Basic Auth in case your API is private
   # config.basic_auth_enabled = true


### PR DESCRIPTION

#### What? Why?

Avoids deprecation warnings:

```
DEPRECATION WARNING: swagger_root= is deprecated and will be removed from rswag-api 3.0 (use openapi_root= instead) (called from block in <main> at config/initializers/rswag_api.rb:8)
DEPRECATION WARNING: Rswag::Ui: WARNING: The method will be renamed to "openapi_endpoint" in v3.0 (called from block in <main> at config/initializers/rswag_ui.rb:12)
DEPRECATION WARNING: Rswag::Ui: WARNING: The method will be renamed to "openapi_endpoint" in v3.0 (called from block in <main> at config/initializers/rswag_ui.rb:13)
```


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test, specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
