### PR TITLE
Moves test introduced by #11799 to avoid non-explicit modal acceptance

### DIFF
--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -101,6 +101,7 @@ describe '
     # expect(page).to have_checked_field "enterprise_enable_subscriptions_false"
 
     accept_alert do
+      scroll_to(:bottom)
       within(".side_menu") { click_link "Users" }
     end
     select2_select user.email, from: 'enterprise_owner_id'
@@ -116,14 +117,6 @@ describe '
     description_input.native.send_keys('This is an interesting long description')
 
     # Check StimulusJs switching of sidebar elements
-    accept_alert do
-      click_link "Primary Details"
-    end
-
-    # Back navigation loads the tab content
-    page.execute_script('window.history.back()')
-    expect(page).to have_selector '#enterprise_description'
-
     accept_alert do
       click_link "Primary Details"
     end
@@ -255,6 +248,14 @@ describe '
     )
     expect(page).to have_checked_field "enterprise_require_login_true"
     expect(page).to have_checked_field "enterprise_enable_subscriptions_true"
+
+    # Back navigation loads the tab content
+    page.execute_script('window.history.back()')
+    expect(page).to have_selector '#enterprise_description'
+
+    # Forward navigation brings back the previous tab
+    page.execute_script('window.history.forward()')
+    expect(page).to have_content 'This is my shopfront message.'
 
     # Test that the right input alert text is displayed
     accept_alert('Please enter a URL to insert') do


### PR DESCRIPTION

#### What? Why?

- Closes #11970.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

On #11799 a fix was introduced to account for "memory" of the selected sections, within the enterprise dashboard. A test was added which was triggering a modal (due to unsaved changes in the forms), without explicitly accepting it.

While default acceptance of the modal is the usual behavior, it often timed out, while running in the CI.

The PR moves the test to a section in the spec where there are no unsaved changes: doing so prevents having to accept the modal.

The PR also adds some minor changes (scrolling down the page to find the Users section - somehow failing locally) and adds a test to account for forward navigation as well.



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
