### PR TITLE
Make hint for logo size translatable and adjust to 300 px

### DIFF
--- a/app/views/admin/enterprises/form/_images.html.haml
+++ b/app/views/admin/enterprises/form/_images.html.haml
@@ -2,7 +2,7 @@
   .alpha.three.columns
     = f.label :logo
     %br
-    100 x 100 pixels
+    = t('.logo_size')
   .omega.eight.columns
     %img{ class: 'image-field-group__preview-image', ng: { src: '{{ Enterprise.logo.thumb }}', if: 'Enterprise.logo' } }
     %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1102,6 +1102,7 @@ en:
         images:
           legend: "Images"
           logo: Logo
+          logo_size: "300 x 300 pixels"
           promo_image_placeholder: 'This image is displayed in "About Us"'
           promo_image_note1: 'PLEASE NOTE:'
           promo_image_note2: Any promo image uploaded here will be cropped to 1200 x 260.


### PR DESCRIPTION
#### What? Why?
The hint for logo size was hard coded and recommended a size of 100 px x 100 px.
However, during registration process of an enterprise we are recommending 300 px x 300 px.

Instead of only adjusting the number I thought it would be better to make this editable in Transifex anyways.

During registration:
![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/1790176/7986eca3-c199-458d-95cb-032ad44af4f2)

Before the PR:
![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/1790176/4b43ff04-6408-483c-b520-bd6f5f780cee)

After the PR:
![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/1790176/8f32253d-240b-4bbf-8181-c17d4c7f919b)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit page /admin/enterprises/<enterprise_name>/edit#/images_panel.
- Check that the hint is displayed correctly.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
