### PR TITLE
Improve `admin/enterprise_roles` page performance

### DIFF
--- a/app/controllers/admin/enterprise_roles_controller.rb
+++ b/app/controllers/admin/enterprise_roles_controller.rb
@@ -3,9 +3,8 @@
 module Admin
   class EnterpriseRolesController < Admin::ResourceController
     def index
-      @enterprise_roles = EnterpriseRole.by_user_email
-      @users = Spree::User.order('spree_users.email')
-      @my_enterprises = @all_enterprises = Enterprise.by_name
+      @enterprise_roles, @users, @all_enterprises = Admin::EnterpriseRolesQuery.query
+      @my_enterprises = @all_enterprises
     end
 
     def create

--- a/app/helpers/admin/injection_helper.rb
+++ b/app/helpers/admin/injection_helper.rb
@@ -27,13 +27,6 @@ module Admin
                                   Api::Admin::EnterpriseRelationshipSerializer
     end
 
-    def admin_inject_enterprise_roles(enterprise_roles)
-      admin_inject_json_ams_array "ofn.admin",
-                                  "enterpriseRoles",
-                                  enterprise_roles,
-                                  Api::Admin::EnterpriseRoleSerializer
-    end
-
     def admin_inject_payment_methods(payment_methods)
       admin_inject_json_ams_array "admin.paymentMethods",
                                   "paymentMethods",
@@ -135,13 +128,6 @@ module Admin
                                   "taxons",
                                   taxons,
                                   Api::Admin::TaxonSerializer
-    end
-
-    def admin_inject_users(users)
-      admin_inject_json_ams_array "ofn.admin",
-                                  "users",
-                                  users,
-                                  Api::Admin::UserSerializer
     end
 
     def admin_inject_variant_overrides(variant_overrides)

--- a/app/queries/admin/enterprise_roles_query.rb
+++ b/app/queries/admin/enterprise_roles_query.rb
@@ -2,10 +2,6 @@
 
 module Admin
   class EnterpriseRolesQuery
-    EnterpriseRoleStruct = Struct.new(:id, :user_id, :enterprise_id, :user_, :enterprise_name)
-    UserStruct = Struct.new(:id, :email)
-    EnterpriseStruct = Struct.new(:id, :name)
-
     class << self
       def query
         enterprise_roles = query_enterprice_roles

--- a/app/queries/admin/enterprise_roles_query.rb
+++ b/app/queries/admin/enterprise_roles_query.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Admin
+  class EnterpriseRolesQuery
+    EnterpriseRoleStruct = Struct.new(:id, :user_id, :enterprise_id, :user_, :enterprise_name)
+    UserStruct = Struct.new(:id, :email)
+    EnterpriseStruct = Struct.new(:id, :name)
+
+    class << self
+      def query
+        enterprise_roles = query_enterprice_roles
+        users = query_users
+        enterprises = query_enterprises
+
+        [enterprise_roles, users, enterprises]
+      end
+
+      private
+
+      def query_enterprice_roles
+        EnterpriseRole.joins(:user, :enterprise).order('spree_users.email ASC').
+          pluck(:id, :user_id, :enterprise_id, 'spree_users.email', 'enterprises.name').
+          map do |data|
+            id, user_id, enterprise_id, user_email, enterprise_name = data
+
+            { id:, user_id:, enterprise_id:, user_email:, enterprise_name: }
+          end
+      end
+
+      def query_users
+        Spree::User.order(:email).pluck(:id, :email).map do |data|
+          id, email = data
+
+          { id:, email: }
+        end
+      end
+
+      def query_enterprises
+        Enterprise.order(:name).pluck(:id, :name).map do |data|
+          id, name = data
+
+          { id:, name: }
+        end
+      end
+    end
+  end
+end

--- a/app/queries/admin/enterprise_roles_query.rb
+++ b/app/queries/admin/enterprise_roles_query.rb
@@ -4,7 +4,7 @@ module Admin
   class EnterpriseRolesQuery
     class << self
       def query
-        enterprise_roles = query_enterprice_roles
+        enterprise_roles = query_enterprise_roles
         users = query_users
         enterprises = query_enterprises
 
@@ -13,7 +13,7 @@ module Admin
 
       private
 
-      def query_enterprice_roles
+      def query_enterprise_roles
         EnterpriseRole.joins(:user, :enterprise).order('spree_users.email ASC').
           pluck(:id, :user_id, :enterprise_id, 'spree_users.email', 'enterprises.name').
           map do |data|

--- a/app/views/admin/enterprise_roles/_data.html.haml
+++ b/app/views/admin/enterprise_roles/_data.html.haml
@@ -1,4 +1,3 @@
-= admin_inject_enterprise_roles(@enterprise_roles)
-= admin_inject_users(@users)
-= admin_inject_enterprises(@my_enterprises, @all_enterprises)
-
+= admin_inject_json('ofn.admin', 'enterpriseRoles', @enterprise_roles)
+= admin_inject_json('ofn.admin', 'users', @users)
+= admin_inject_json('ofn.admin', 'my_enterprises', @my_enterprises) + admin_inject_json('ofn.admin', 'all_enterprises', @all_enterprises)


### PR DESCRIPTION
#### What? Why?

- Closes #11976

- The page is returning 504 error when there is too many enterprise roles to display
- Solution:
  - Reduce loaded data
  - Use `.joins` to reduce N+1 queries
  - Use `.plucks` to avoid initializing models
- Benchmark result:
![Screenshot from 2023-12-26 23-07-46](https://github.com/openfoodfoundation/openfoodnetwork/assets/8463633/1f939320-0081-477b-93c7-f633a153ba47)
- roughly 80x time faster

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Log in as super admin.
- Visit /admin/enterprise_roles.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Improve `admin/enterprise_roles` page performance
