### PR TITLE
remove unnecessary require instructions

### DIFF
--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'open_food_network/permissions'
-require 'order_management/subscriptions/proxy_order_syncer'
 
 module Admin
   class SchedulesController < Admin::ResourceController

--- a/app/controllers/api/v0/enterprise_attachment_controller.rb
+++ b/app/controllers/api/v0/enterprise_attachment_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'api/admin/enterprise_serializer'
-
 module Api
   module V0
     class EnterpriseAttachmentController < Api::V0::BaseController

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'order_management/subscriptions/summarizer'
-
 # Confirms orders of unconfirmed proxy orders in recently closed Order Cycles
 class SubscriptionConfirmJob < ApplicationJob
   def perform

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'order_management/subscriptions/summarizer'
-
 class SubscriptionPlacementJob < ApplicationJob
   def perform
     proxy_orders.each do |proxy_order|

--- a/app/models/spree/adjustment.rb
+++ b/app/models/spree/adjustment.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spree/localized_number'
-require 'concerns/adjustment_scopes'
 
 # Adjustments represent a change to the +item_total+ of an Order. Each adjustment
 # has an +amount+ that can be either positive or negative.

--- a/app/models/spree/gateway.rb
+++ b/app/models/spree/gateway.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'concerns/payment_method_distributors'
-
 module Spree
   class Gateway < PaymentMethod
     acts_as_taggable

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'open_food_network/scope_variant_to_hub'
-require 'variant_units/variant_and_line_item_naming'
 
 module Spree
   class LineItem < ApplicationRecord

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require 'spree/order/checkout'
-require 'open_food_network/enterprise_fee_calculator'
-require 'open_food_network/feature_toggle'
-require 'open_food_network/tag_rule_applicator'
-
 module Spree
   class Order < ApplicationRecord
     include OrderShipment

--- a/app/models/spree/payment_method.rb
+++ b/app/models/spree/payment_method.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'concerns/payment_method_distributors'
-
 module Spree
   class PaymentMethod < ApplicationRecord
     include CalculatedAdjustments

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'open_food_network/property_merge'
-require 'concerns/product_stock'
 
 # PRODUCTS
 # Products represent an entity for sale in a store.

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'open_food_network/enterprise_fee_calculator'
-require 'variant_units/variant_and_line_item_naming'
-require 'concerns/variant_stock'
 require 'spree/localized_number'
 
 module Spree

--- a/app/services/order_available_payment_methods.rb
+++ b/app/services/order_available_payment_methods.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open_food_network/tag_rule_applicator'
+
 class OrderAvailablePaymentMethods
   attr_reader :order, :customer
 

--- a/app/services/order_available_shipping_methods.rb
+++ b/app/services/order_available_shipping_methods.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open_food_network/tag_rule_applicator'
+
 class OrderAvailableShippingMethods
   attr_reader :order, :customer
 

--- a/app/services/order_cycle_clone.rb
+++ b/app/services/order_cycle_clone.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'order_management/subscriptions/proxy_order_syncer'
-
 class OrderCycleClone
   def initialize(order_cycle)
     @original_order_cycle = order_cycle

--- a/app/services/order_cycle_form.rb
+++ b/app/services/order_cycle_form.rb
@@ -2,7 +2,6 @@
 
 require 'open_food_network/permissions'
 require 'open_food_network/order_cycle_form_applicator'
-require 'order_management/subscriptions/proxy_order_syncer'
 
 class OrderCycleForm
   def initialize(order_cycle, order_cycle_params, user)

--- a/app/services/shop/order_cycles_list.rb
+++ b/app/services/shop/order_cycles_list.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open_food_network/tag_rule_applicator'
+
 # Lists available order cycles for a given customer in a given distributor
 module Shop
   class OrderCyclesList

--- a/app/services/variant_units/variant_and_line_item_naming.rb
+++ b/app/services/variant_units/variant_and_line_item_naming.rb
@@ -4,8 +4,6 @@
 # It contains all of our logic for creating and naming option values (which are associated
 # with both models) and methods for printing human readable "names" for instances of these models.
 
-require 'variant_units/option_value_namer'
-
 module VariantUnits
   module VariantAndLineItemNaming
     def options_text

--- a/engines/order_management/app/services/order_management/subscriptions/form.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/form.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'order_management/subscriptions/proxy_order_syncer'
-
 module OrderManagement
   module Subscriptions
     class Form

--- a/spec/lib/reports/enterprise_fee_summary/parameters_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/parameters_spec.rb
@@ -2,8 +2,6 @@
 
 require "spec_helper"
 
-require "date_time_string_validator"
-
 module Reporting
   module Reports
     module EnterpriseFeeSummary

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: false
 
 require 'spec_helper'
-require 'variant_units/option_value_namer'
 require 'spree/localized_number'
 
 describe Spree::Variant do

--- a/spec/services/invoice_renderer_spec.rb
+++ b/spec/services/invoice_renderer_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'spree/payment_methods_helper'
 
 describe InvoiceRenderer do
   include Spree::PaymentMethodsHelper

--- a/spec/services/order_cycle_form_spec.rb
+++ b/spec/services/order_cycle_form_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'order_management/subscriptions/proxy_order_syncer'
 
 describe OrderCycleForm do
   describe "save" do


### PR DESCRIPTION
#### What? Why?

unnecessary `require` instruction will cause raising exceptions in Rails 7.1

This is needed for https://github.com/openfoodfoundation/openfoodnetwork/issues/11673



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
