### PR TITLE
replace cached_find_by with find_by_cached on Spree::Country

### DIFF
--- a/app/models/spree/country.rb
+++ b/app/models/spree/country.rb
@@ -6,7 +6,7 @@ module Spree
 
     validates :name, :iso_name, presence: true
 
-    def self.cached_find_by(attrs)
+    def self.find_by_cached(attrs)
       Rails.cache.fetch("countries/#{attrs.hash}", expires_in: 1.hour) do
         find_by(attrs)
       end

--- a/app/services/default_country.rb
+++ b/app/services/default_country.rb
@@ -10,7 +10,7 @@ class DefaultCountry
   end
 
   def self.country
-    Spree::Country.cached_find_by(iso: ENV.fetch("DEFAULT_COUNTRY_CODE",
+    Spree::Country.find_by_cached(iso: ENV.fetch("DEFAULT_COUNTRY_CODE",
                                                  nil)) || Spree::Country.first
   end
 end


### PR DESCRIPTION
#### What? Why?

In version 7.1, find_by (active record method) refers to `cached_find_by`. https://github.com/rails/rails/blob/1ea796d6a887ddb6fd7a2395399ae35871aeb00c/activerecord/lib/active_record/core.rb#L246-L257 
We rename our method to avoid collision


related to #11673 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
