### PR TITLE
Fix ToS Position Issue

### DIFF
--- a/app/webpacker/css/admin_v3/components/messages.scss
+++ b/app/webpacker/css/admin_v3/components/messages.scss
@@ -30,7 +30,7 @@
   left: 0;
   bottom: 0;
   width: 100%;
-  z-index: 1000;
+  z-index: $flash-message-z-index;
   display: flex;
   justify-content: center;
 

--- a/app/webpacker/css/admin_v3/globals/variables.scss
+++ b/app/webpacker/css/admin_v3/globals/variables.scss
@@ -179,4 +179,5 @@ $btn-condensed-height:           26px !default;
 
 // z-index
 //--------------------------------------------------------------
-$tos-banner-z-index: 102;
+$tos-banner-z-index: 1001;
+$flash-message-z-index: 1000;


### PR DESCRIPTION
#### What? Why?

- Closes #11971

- Flash message has a higher z-index than that of the ToS banner.
- This PR ensures that the ToS banner has a higher z-index than the flash message.

**Observation while addressing the issue**
- It has been noticed that the z-index values used for various elements within our application are currently set without a structured approach.
- To enhance clarity and help us compare the expected stacking order based on their positions, I suggest we define these z-index values as meaningful variables in the `variables.scss` file in a separate issue.
- It not only improves readability but also streamlines the process of understanding the stacking order concerning specific elements with each other.

Would love to hear some thoughts on it. Thanks.

#### What should we test?
- Please validate the expected behavior as mentioned in the linked issue
- Along with that please make sure when ToS is being displayed, nothing should be broken on the UI in terms of the elements' position.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled
