### PR TITLE
Add SemanticLink model for variants

### DIFF
--- a/app/models/semantic_link.rb
+++ b/app/models/semantic_link.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Link a Spree::Variant to an external DFC SuppliedProduct.
+#
+# We store an optional quantity to denote how many variant items are contained
+# in an external wholesale product. For example, we may offer cans of beans
+# on OFN and trigger wholesale orders of slabs of cans of beans which contain
+# 12 cans each.
+class SemanticLink < ApplicationRecord
+  belongs_to :variant, class_name: "Spree::Variant"
+
+  validates :semantic_id, presence: true
+  validates :quantity, numericality: { greater_than: 0 }
+end

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -56,6 +56,7 @@ module Spree
     has_many :exchanges, through: :exchange_variants
     has_many :variant_overrides, dependent: :destroy
     has_many :inventory_items, dependent: :destroy
+    has_many :semantic_links, dependent: :delete_all
 
     localize_number :price, :weight
 

--- a/db/migrate/20240105043228_create_semantic_links.rb
+++ b/db/migrate/20240105043228_create_semantic_links.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateSemanticLinks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :semantic_links do |t|
+      t.references :variant, null: false, foreign_key: { to_table: :spree_variants }
+      t.string :semantic_id, null: false
+      t.integer :quantity
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -388,6 +388,15 @@ ActiveRecord::Schema[7.0].define(version: 20231003000823494) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  create_table "semantic_links", force: :cascade do |t|
+    t.bigint "variant_id", null: false
+    t.string "semantic_id", null: false
+    t.integer "quantity"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["variant_id"], name: "index_semantic_links_on_variant_id"
+  end
+
   create_table "sessions", id: :serial, force: :cascade do |t|
     t.string "session_id", limit: 255, null: false
     t.text "data"
@@ -1154,6 +1163,7 @@ ActiveRecord::Schema[7.0].define(version: 20231003000823494) do
   add_foreign_key "proxy_orders", "spree_orders", column: "order_id", name: "order_id_fk"
   add_foreign_key "proxy_orders", "subscriptions", name: "proxy_orders_subscription_id_fk"
   add_foreign_key "report_rendering_options", "spree_users", column: "user_id"
+  add_foreign_key "semantic_links", "spree_variants", column: "variant_id"
   add_foreign_key "spree_addresses", "spree_countries", column: "country_id", name: "spree_addresses_country_id_fk"
   add_foreign_key "spree_addresses", "spree_states", column: "state_id", name: "spree_addresses_state_id_fk"
   add_foreign_key "spree_inventory_units", "spree_orders", column: "order_id", name: "spree_inventory_units_order_id_fk", on_delete: :cascade

--- a/spec/models/semantic_link_spec.rb
+++ b/spec/models/semantic_link_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SemanticLink, type: :model do
+  it { is_expected.to belong_to :variant }
+  it { is_expected.to validate_presence_of(:semantic_id) }
+  it { is_expected.to validate_numericality_of(:quantity).is_greater_than(0) }
+end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -6,6 +6,8 @@ require 'spree/localized_number'
 describe Spree::Variant do
   subject(:variant) { build(:variant) }
 
+  it { is_expected.to have_many :semantic_links }
+
   context "validations" do
     it "should validate price is greater than 0" do
       variant.price = -1


### PR DESCRIPTION
#### What? Why?
- Closes #11946 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We want to link variants/products to external DFC SuppliedProducts to trigger supplier orders when local stock is exhausted. This is the first step to enable the link.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No UX to test yet.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
