### PR TITLE
Backoffice, fix customer search when searching by first name

### DIFF
--- a/app/webpacker/controllers/select_customer_controller.js
+++ b/app/webpacker/controllers/select_customer_controller.js
@@ -11,7 +11,7 @@ export default class extends TomSelectController {
     const options = {
       valueField: "id",
       labelField: "email",
-      searchField: ["email", "full_name", "last_name"],
+      searchField: ["email", "full_name", "first_name", "last_name"],
       load: this.load.bind(this),
       shouldLoad: (query) => query.length > 2,
       render: {
@@ -38,9 +38,7 @@ export default class extends TomSelectController {
       ];
       const attribute_wrapper = "#order_" + address + "_attributes_";
       address_parts.forEach((part) => {
-        document.querySelector(attribute_wrapper + part).value = data
-          ? data[part]
-          : "";
+        document.querySelector(attribute_wrapper + part).value = data ? data[part] : "";
       });
       this.setValueOnTomSelectController(
         document.querySelector(attribute_wrapper + "state_id"),

--- a/app/webpacker/controllers/select_customer_controller.js
+++ b/app/webpacker/controllers/select_customer_controller.js
@@ -49,9 +49,8 @@ export default class extends TomSelectController {
         data ? data.country_id : ""
       );
     });
-    $("#order_email").val(customer.email);
-    $("#user_id").val(customer.user_id);
-    $("#customer_id").val(customer.id);
+    document.querySelector("#order_email").value = customer.email;
+    document.querySelector("#customer_id").value = customer.id;
   }
 
   setValueOnTomSelectController = (element, value) => {


### PR DESCRIPTION
#### What? Why?

Discovered while looking at #11759. Customer search when creating a new order doesn't work with only first name.
Also remove the usage of Jquery.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Login as an admin
- Visit "Orders" page, and click on "+ new order" button
- Choose a distributor and an ordering cycle and click "Next"
- Search a customer by first name :
  => Find a matching customer 

##### Regression testing: 
Follow the scenario above and search by :
- last name
- full name 
- email

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


