### PR TITLE
[BUU] Sticky table header and saving banner - alternate solution

### DIFF
--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -5,17 +5,6 @@
                    'data-bulk-form-error-value': defined?(error_counts),
                   } do |form|
   = render(partial: "admin/shared/flashes", locals: { flashes: }) if defined? flashes
-  %fieldset.form-actions{ class: ("hidden" unless defined?(error_counts)), 'data-bulk-form-target': "actions" }
-    .container
-      .status
-        .modified_summary{ 'data-bulk-form-target': "changedSummary", 'data-translation-key': 'admin.products_v3.table.changed_summary'}
-        - if defined?(error_counts)
-          .error_summary
-            -# X products were saved correctly, but Y products could not be saved correctly. Please review errors and try again
-            = t('.error_summary.saved', count: error_counts[:saved]) + t('.error_summary.invalid', count: error_counts[:invalid])
-      .form-buttons
-        = form.submit t('.reset'), type: :reset, class: "medium", 'data-reflex': 'click->products#fetch'
-        = form.submit t('.save'), class: "medium"
   %table.products
     %col{ width:"15%" }
     %col{ width:"5%", style: "max-width:5em" }
@@ -28,6 +17,20 @@
     %col{ width:"5%", style: "max-width:5em" }
     %col{ width:"5%", style: "max-width:5em" }
     %thead
+      %tr
+        %td.form-actions-wrapper{ colspan: 10 }
+          .form-actions-wrapper2
+            %fieldset.form-actions{ class: ("hidden" unless defined?(error_counts)), 'data-bulk-form-target': "actions" }
+              .container
+                .status
+                  .modified_summary{ 'data-bulk-form-target': "changedSummary", 'data-translation-key': 'admin.products_v3.table.changed_summary'}
+                  - if defined?(error_counts)
+                    .error_summary
+                      -# X products were saved correctly, but Y products could not be saved correctly. Please review errors and try again
+                      = t('.error_summary.saved', count: error_counts[:saved]) + t('.error_summary.invalid', count: error_counts[:invalid])
+                .form-buttons
+                  = form.submit t('.reset'), type: :reset, class: "medium", 'data-reflex': 'click->products#fetch'
+                  = form.submit t('.save'), class: "medium"
       %tr
         %th.align-left.with-input= t('admin.products_page.columns.name')
         %th.align-right= t('admin.products_page.columns.sku')

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -7,13 +7,13 @@
   = render(partial: "admin/shared/flashes", locals: { flashes: }) if defined? flashes
   %fieldset.form-actions{ class: ("hidden" unless defined?(error_counts)), 'data-bulk-form-target': "actions" }
     .container
-      .status.eleven.columns
+      .status
         .modified_summary{ 'data-bulk-form-target': "changedSummary", 'data-translation-key': 'admin.products_v3.table.changed_summary'}
         - if defined?(error_counts)
           .error_summary
             -# X products were saved correctly, but Y products could not be saved correctly. Please review errors and try again
             = t('.error_summary.saved', count: error_counts[:saved]) + t('.error_summary.invalid', count: error_counts[:invalid])
-      .form-buttons.five.columns
+      .form-buttons
         = form.submit t('.reset'), type: :reset, class: "medium", 'data-reflex': 'click->products#fetch'
         = form.submit t('.save'), class: "medium"
   %table.products

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -19,15 +19,8 @@
     position: relative;
   }
 
-  // Form actions floats over other controls when active
   #products-form {
     .form-actions {
-      // position: absolute;
-      // top: -1;
-      left: 0;
-      right: 0;
-      z-index: 1; // Ensure tom-select and .disabled-section are covered
-
       .container {
         .status {
           flex-grow: 1; // Fill space
@@ -46,6 +39,7 @@
 
     background-color: $color-tbl-bg;
     padding: 4px;
+    padding-top: 0; // Hide border because .form-actions is there. It is added with th padding instead.
     border-collapse: separate; // This is needed for the outer padding. Also should be helpful to give more flexibility of borders between rows.
 
     // Additional horizontal padding to align with input contents
@@ -53,6 +47,24 @@
       position: sticky;
       top: 0;
       z-index: 1; // TODO: Cover .popout and .vertical-ellipsis-menu, but only when sticky
+
+      // Form actions replaces other controls when active
+      // It is part of the table header, to allow for sticky stacking when scrolling.
+      .form-actions-wrapper {
+        padding: 0;
+        overflow: visible;
+        background-color: white;
+      }
+      .form-actions-wrapper2 {
+        position: relative;
+        // Stretch to cover table side borders
+        left: -4px;
+        width: calc(100% + 8px);
+        background-color: white;
+
+        padding: 4px 0;
+        z-index: 1; // Ensure tom-select and .disabled-section are covered
+      }
 
       th.with-input {
         padding-left: $padding-tbl-cell + $hpadding-txt;
@@ -93,6 +105,7 @@
     }
 
     th {
+      padding-top: $padding-tbl-cell + 4px; // Increase padding to create a top border
       // Clip long content in headers, but allow wrapping
       overflow: hidden;
       text-overflow: clip; // If colums are so small that headers are clipping, ellipsis are more of a hindrance
@@ -142,7 +155,7 @@
     }
 
     // "Naked" inputs. Row hover helps reveal them.
-    input:not([type="checkbox"]) {
+    tbody input:not([type="checkbox"]) {
       background-color: $color-tbl-cell-bg;
       height: auto;
       font-size: inherit;

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -22,8 +22,8 @@
   // Form actions floats over other controls when active
   #products-form {
     .form-actions {
-      position: absolute;
-      top: -1em;
+      // position: absolute;
+      // top: -1;
       left: 0;
       right: 0;
       z-index: 1; // Ensure tom-select and .disabled-section are covered
@@ -174,7 +174,8 @@
   }
 
   #sort {
-    margin-bottom: 1em;
+    margin-top: 3px; // Helps even up with .form-actions when visible
+    margin-bottom: 1rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -183,6 +184,10 @@
   #sort {
     line-height: $btn-relaxed-height;
     height: $btn-relaxed-height;
+
+    &.disabled-section {
+      display: none;
+    }
 
     .with-dropdown {
       display: flex;
@@ -198,7 +203,7 @@
     grid-template-rows: 1fr;
     grid-column-gap: 20px;
     align-items: end;
-    margin-bottom: 20px;
+    margin-bottom: 1rem;
 
     .query {
       grid-column: 1 / span 3;

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -49,9 +49,15 @@
     border-collapse: separate; // This is needed for the outer padding. Also should be helpful to give more flexibility of borders between rows.
 
     // Additional horizontal padding to align with input contents
-    thead th.with-input {
-      padding-left: $padding-tbl-cell + $hpadding-txt;
-      padding-right: $padding-tbl-cell + $hpadding-txt;
+    thead {
+      position: sticky;
+      top: 0;
+      z-index: 1; // TODO: Cover .popout and .vertical-ellipsis-menu, but only when sticky
+
+      th.with-input {
+        padding-left: $padding-tbl-cell + $hpadding-txt;
+        padding-right: $padding-tbl-cell + $hpadding-txt;
+      }
     }
 
     // Row hover

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -47,6 +47,7 @@
       position: sticky;
       top: 0;
       z-index: 1; // TODO: Cover .popout and .vertical-ellipsis-menu, but only when sticky
+      box-shadow: $box-shadow;
 
       // Form actions replaces other controls when active
       // It is part of the table header, to allow for sticky stacking when scrolling.

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -64,7 +64,6 @@
         background-color: white;
 
         padding: 4px 0;
-        z-index: 1; // Ensure tom-select and .disabled-section are covered
       }
 
       th.with-input {

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -27,6 +27,16 @@
       left: 0;
       right: 0;
       z-index: 1; // Ensure tom-select and .disabled-section are covered
+
+      .container {
+        .status {
+          flex-grow: 1; // Fill space
+        }
+
+        .form-buttons {
+          flex-shrink: 0; // Don't shrink
+        }
+      }
     }
   }
 


### PR DESCRIPTION
#### What? Why?

- Closes #11902
- Closes https://github.com/openfoodfoundation/openfoodnetwork/pull/11935 as alternative solution.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
As per above issue:

- With admin_style_v3 feature enabled, visit `/admin/products` page

**Scenario 1: Scrolling - sticky table header**
Given that I have loaded my product list
When I scroll below the fold
Then the header of the table remains visible
And I can see it as I keep scrolling
![Screenshot 2024-01-10 at 12 37 46 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/04aa1587-2802-4cf2-abc2-01cdf87603c6)

**Scenario 2: Scrolling - sticky message when products have been modified**
Given that I have loaded my product list
And I have edited one or more products
And the message saying that products have been edited is displayed
When I scroll below the fold
Then the message remains visible
And I can see it as I keep scrolling
![Screenshot 2024-01-10 at 12 38 34 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/933c4182-3f17-48e4-8545-8a0cfb8e85e3)

**Scenario 3: Scrolling - sticky message when product save failed, and other products have been modified**
Given that I have loaded my product list
And I have edited one or more products with invalid value (eg empty name)
And I clicked "Save changes"
And then I edited another product.
The message has multiple lines.
When I scroll below the fold
Then the message remains visible
And I can see it as I keep scrolling


![Screenshot 2024-01-10 at 12 38 55 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/eadfa465-89ed-4a21-a4a7-59a52bebbe14)
![Screenshot 2024-01-10 at 12 39 17 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/80506ed7-519c-4b69-b891-7c031eae7bd1)


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
