### PR TITLE
Show Connected Apps only to enterprise managers

### DIFF
--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -21,7 +21,8 @@ module Admin
       show_payment_methods = can?(:manage_payment_methods, enterprise) && is_shop
       show_enterprise_fees = can?(:manage_enterprise_fees,
                                   enterprise) && (is_shop || enterprise.is_primary_producer)
-      show_connected_apps = feature?(:connected_apps, spree_current_user, enterprise)
+      show_connected_apps = can?(:manage_connected_apps, enterprise) &&
+                            feature?(:connected_apps, spree_current_user, enterprise)
 
       build_enterprise_side_menu_items(
         is_shop:,

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -147,7 +147,8 @@ module Spree
       end
       can [:manage_payment_methods,
            :manage_shipping_methods,
-           :manage_enterprise_fees], Enterprise do |enterprise|
+           :manage_enterprise_fees,
+           :manage_connected_apps], Enterprise do |enterprise|
         user.enterprises.include? enterprise
       end
 

--- a/spec/helpers/admin/enterprises_helper_spec.rb
+++ b/spec/helpers/admin/enterprises_helper_spec.rb
@@ -27,7 +27,8 @@ describe Admin::EnterprisesHelper, type: :helper do
       ]
     end
 
-    it "lists enabled features", feature: :connected_apps do
+    it "lists enabled features when allowed", feature: :connected_apps do
+      user.enterprises << enterprise
       expect(visible_items.pluck(:name)).to include "connected_apps"
     end
   end

--- a/spec/helpers/admin/enterprises_helper_spec.rb
+++ b/spec/helpers/admin/enterprises_helper_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Admin::EnterprisesHelper, type: :helper do
+  let(:user) { build(:user) }
+
+  before do
+    # Enable helper to use `#can?` method.
+    # We could extract this when other helper specs need it.
+    allow_any_instance_of(CanCan::ControllerAdditions).to receive(:current_ability) do
+      Spree::Ability.new(user)
+    end
+    allow(helper).to receive(:spree_current_user) { user }
+  end
+
+  describe "#enterprise_side_menu_items" do
+    let(:enterprise) { build(:enterprise) }
+    let(:menu_items) { helper.enterprise_side_menu_items(enterprise) }
+    let(:visible_items) { menu_items.select { |i| i[:show] } }
+
+    it "lists default items" do
+      expect(visible_items.pluck(:name)).to eq %w[
+        primary_details address contact social about business_details images
+        vouchers enterprise_permissions inventory_settings tag_rules
+        shop_preferences users white_label
+      ]
+    end
+
+    it "lists enabled features", feature: :connected_apps do
+      expect(visible_items.pluck(:name)).to include "connected_apps"
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?


Super-admins also saw that tab but connecting an app doesn't work unless you are a manager of that enterprise.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- CI test coverage is good enough.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
