### PR TITLE
Show DFC API first in documentation

### DIFF
--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -6,7 +6,7 @@ Rswag::Ui.configure do |config|
   # host) to the corresponding endpoint and the second is a title that will be
   # displayed in the document selector.
   # NOTE: If you're using rspec-api to expose Swagger files
-  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
   config.openapi_endpoint 'v1.yaml', 'API V1 Docs'

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -9,8 +9,8 @@ Rswag::Ui.configure do |config|
   # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  config.openapi_endpoint 'v1.yaml', 'API V1 Docs'
   config.openapi_endpoint 'dfc.yaml', 'OFN DFC API Docs'
+  config.openapi_endpoint 'v1.yaml', 'API V1 Docs'
 
   # Add Basic Auth in case your API is private
   # config.basic_auth_enabled = true

--- a/engines/dfc_provider/spec/swagger_helper.rb
+++ b/engines/dfc_provider/spec/swagger_helper.rb
@@ -5,7 +5,7 @@ require_relative "spec_helper"
 
 RSpec.configure do |config|
   # Override swagger docs to generate only this file:
-  config.swagger_docs = {
+  config.openapi_specs = {
     'dfc.yaml' => {
       openapi: '3.0.1',
       info: {

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -9,15 +9,15 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join('swagger').to_s
+  config.openapi_root = Rails.root.join('swagger').to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
-  # be generated at the provided relative path under swagger_root
+  # be generated at the provided relative path under openapi_root
   # By default, the operations defined in spec files are added to the first
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
-  config.swagger_docs = {
+  config.openapi_specs = {
     'v1.yaml' => {
       openapi: '3.0.1',
       info: {
@@ -70,7 +70,7 @@ RSpec.configure do |config|
   # The swagger_docs configuration option has the filename including format in
   # the key, this may want to be changed to avoid putting yaml in json files.
   # Defaults to json. Accepts ':json' and ':yaml'.
-  config.swagger_format = :yaml
+  config.openapi_format = :yaml
 end
 
 module RswagExtension


### PR DESCRIPTION
#### What? Why?

The capabilities and documentation for the DFC API are bigger. And since it's in active development, people want to check the DFC API more frequently. They needed to find the switch to select the DFC API in the top right corner but now it's displayed straight away.



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
