### PR TITLE
Removes default selection for User facing changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@
 
 Changelog Category (reviewers may add a label for the release notes):
 
-- [x] User facing changes
+- [ ] User facing changes
 - [ ] API changes (V0, V1, DFC or Webhook)
 - [ ] Technical changes only
 - [ ] Feature toggled

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,9 @@
 changelog:
   # Categorise according to what an instance manager needs to know
   categories:
-    # Posted in advance for #instance-managers
-    - title: "User-facing changes 👀"
+    # Add the right label if anything appears in here.
+    # Then re-generate the release notes.
+    - title: "❓❓❓ Uncategorised ❓❓❓"
       labels:
         - '*'
       exclude:
@@ -11,6 +12,12 @@ changelog:
           - dependencies
           - feature toggled
           - technical changes only
+          - user facing changes
+
+    # Posted in advance for #instance-managers
+    - title: "User-facing changes 👀"
+      labels:
+        - user facing changes
 
     - title: "API changes ⚠️"
       labels:


### PR DESCRIPTION
#### What? Why?

Removes default selection for User facing changes (Changelog Category), from the GH pull request template.

As discussed [here](https://openfoodnetwork.slack.com/archives/C01T75H6G0Z/p1704976260806189?thread_ts=1704976103.458449&cid=C01T75H6G0Z).

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build.
- creating a PR should have no selected option for the Changelog Category (changes should only take effect after merging).

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
