### PR TITLE
Fix/text overlay with long unit name

### DIFF
--- a/app/views/shop/products/_shop_variant.html.haml
+++ b/app/views/shop/products/_shop_variant.html.haml
@@ -14,7 +14,8 @@
       "question-mark-with-tooltip-placement" => "top",
       "question-mark-with-tooltip-animation" => true,
       key: "'js.shopfront.unit_price_tooltip'"}
-      {{ variant.unit_price_price | localizeCurrency }}&nbsp;/&nbsp;{{ variant.unit_price_unit }}
+      %span.unit_price_unit
+        {{ variant.unit_price_price | localizeCurrency }}&nbsp;/&nbsp;{{ variant.unit_price_unit }}
 
   .medium-2.large-2.columns.total-price
     %span{"ng-class" => "{filled: variant.line_item.total_price}"}

--- a/app/webpacker/css/darkswarm/_shop-inputs.scss
+++ b/app/webpacker/css/darkswarm/_shop-inputs.scss
@@ -5,6 +5,12 @@
   .row .columns.variant-quantity-column {
     padding-left: 0;
   }
+
+  @media screen and (max-width: 425px) {
+    .row .columns.variant-quantity-column {
+      width: fit-content;
+    }
+  }
 }
 
 .reveal-modal.product-bulk-modal {

--- a/app/webpacker/css/darkswarm/_shop-product-rows.scss
+++ b/app/webpacker/css/darkswarm/_shop-product-rows.scss
@@ -22,6 +22,8 @@
 
       // ROW VARIANTS
       .row.variants {
+        display: flex;
+
         margin: 0 0 1em 0;
 
         &.out-of-stock {
@@ -33,6 +35,7 @@
           padding-top: .74em;
         }
         .variant-price {
+          flex: 1;
           padding-top: .65em;
         }
 
@@ -67,12 +70,21 @@
           margin-top: 15px;
           position: relative;
           left: -1px;
+
+          span.unit_price_unit {
+            width: 100%;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+          }
+
         }
 
         // Total price
         .total-price {
           padding-left: 0rem;
           color: $disabled-med;
+          width: fit-content;
 
           .filled {
             color: $med-drk-grey;
@@ -80,6 +92,20 @@
 
           @include breakpoint(phablet) {
             display: none;
+          }
+        }
+
+        @media screen and (max-width: 425px) {
+          .variant-price {
+            flex: 1;
+          }
+
+          .variant-unit-price span.unit_price_unit { // creates an ellipsis when text overflow div size
+              width: 100%;
+              line-height: 1;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+              overflow: hidden;
           }
         }
       }


### PR DESCRIPTION
#### What? Why?

- Closes #11967 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
Long item unit names was overlaying with added quantity in shop making both labels illegible. I fixed this with CSS by hiding part of the long text with ellipsis so it does not clash with added quantity in shop label.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

(Same as to reproduce the initial bug)
- Set up a product with items as unit.
- Enter a very long unit name like in the screenshot.
- Visit the shop with a small screen, like mobile.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Long unit name no longer overlays added quantity in shop