### PR TITLE
Update variant name, price and stock through the DFC API

### DIFF
--- a/engines/dfc_provider/app/controllers/dfc_provider/application_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/application_controller.rb
@@ -59,5 +59,9 @@ module DfcProvider
     def current_ability
       @current_ability ||= Spree::Ability.new(current_user)
     end
+
+    def import
+      DfcIo.import(request.body)
+    end
   end
 end

--- a/engines/dfc_provider/app/controllers/dfc_provider/offers_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/offers_controller.rb
@@ -5,7 +5,7 @@ module DfcProvider
     before_action :check_enterprise
 
     def show
-      subject = DfcBuilder.offer(variant)
+      subject = OfferBuilder.build(variant)
       render json: DfcIo.export(subject)
     end
 

--- a/engines/dfc_provider/app/controllers/dfc_provider/offers_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/offers_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DfcProvider
+  class OffersController < DfcProvider::ApplicationController
+    before_action :check_enterprise
+
+    def show
+      subject = DfcBuilder.offer(variant)
+      render json: DfcIo.export(subject)
+    end
+
+    private
+
+    def variant
+      @variant ||= current_enterprise.supplied_variants.find(params[:id])
+    end
+  end
+end

--- a/engines/dfc_provider/app/controllers/dfc_provider/offers_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/offers_controller.rb
@@ -9,6 +9,16 @@ module DfcProvider
       render json: DfcIo.export(subject)
     end
 
+    def update
+      offer = import
+
+      return head :bad_request unless offer
+
+      OfferBuilder.apply(offer, variant)
+
+      variant.save!
+    end
+
     private
 
     def variant

--- a/engines/dfc_provider/app/controllers/dfc_provider/supplied_products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/supplied_products_controller.rb
@@ -48,10 +48,6 @@ module DfcProvider
 
     private
 
-    def import
-      DfcIo.import(request.body)
-    end
-
     def variant
       @variant ||= current_enterprise.supplied_variants.find(params[:id])
     end

--- a/engines/dfc_provider/app/services/dfc_builder.rb
+++ b/engines/dfc_provider/app/services/dfc_builder.rb
@@ -22,12 +22,6 @@ class DfcBuilder
     variant.on_demand ? nil : variant.total_on_hand
   end
 
-  # OFN product categories (taxons) are currently not standardised.
-  # This is just a dummy value for demos.
-  def self.product_type
-    DfcLoader.connector.PRODUCT_TYPES.VEGETABLE.NON_LOCAL_VEGETABLE
-  end
-
   def self.urls
     DfcProvider::Engine.routes.url_helpers
   end

--- a/engines/dfc_provider/app/services/dfc_builder.rb
+++ b/engines/dfc_provider/app/services/dfc_builder.rb
@@ -12,22 +12,7 @@ class DfcBuilder
       id, product:,
           sku: variant.sku,
           stockLimitation: stock_limitation(variant),
-          offers: [offer(variant)],
-    )
-  end
-
-  def self.offer(variant)
-    # We don't have an endpoint for offers yet and this URL is only a
-    # placeholder for now. The offer is actually affected by order cycle and
-    # customer tags. We'll solve that at a later stage.
-    enterprise_url = urls.enterprise_url(id: variant.product.supplier_id)
-    id = "#{enterprise_url}/offers/#{variant.id}"
-    offered_to = []
-
-    DataFoodConsortium::Connector::Offer.new(
-      id, offeredTo: offered_to,
-          price: variant.price.to_f,
-          stockLimitation: stock_limitation(variant),
+          offers: [OfferBuilder.build(variant)],
     )
   end
 

--- a/engines/dfc_provider/app/services/offer_builder.rb
+++ b/engines/dfc_provider/app/services/offer_builder.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class OfferBuilder < DfcBuilder
+  def self.build(variant)
+    id = urls.enterprise_offer_url(
+      enterprise_id: variant.product.supplier_id,
+      id: variant.id,
+    )
+
+    DataFoodConsortium::Connector::Offer.new(
+      id,
+      price: variant.price.to_f,
+      stockLimitation: stock_limitation(variant),
+    )
+  end
+
   def self.apply(offer, variant)
     variant.on_hand = offer.stockLimitation
     variant.price = offer.price

--- a/engines/dfc_provider/app/services/offer_builder.rb
+++ b/engines/dfc_provider/app/services/offer_builder.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class OfferBuilder < DfcBuilder
+  def self.apply(offer, variant)
+    variant.on_hand = offer.stockLimitation
+    variant.price = offer.price
+  end
+end

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -18,6 +18,12 @@ class SuppliedProductBuilder < DfcBuilder
     )
   end
 
+  # OFN product categories (taxons) are currently not standardised.
+  # This is just a dummy value for demos.
+  def self.product_type
+    DfcLoader.connector.PRODUCT_TYPES.VEGETABLE.NON_LOCAL_VEGETABLE
+  end
+
   def self.import_variant(supplied_product)
     product_id = supplied_product.spree_product_id
 

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -49,10 +49,10 @@ class SuppliedProductBuilder < DfcBuilder
 
   def self.apply(supplied_product, variant)
     variant.product.assign_attributes(
-      name: supplied_product.name,
       description: supplied_product.description,
     )
 
+    variant.display_name = supplied_product.name
     QuantitativeValueBuilder.apply(supplied_product.quantity, variant.product)
     variant.unit_value = variant.product.unit_value
   end

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -4,6 +4,7 @@ DfcProvider::Engine.routes.draw do
   resources :addresses, only: [:show]
   resources :enterprises, only: [:show] do
     resources :catalog_items, only: [:index, :show, :update]
+    resources :offers, only: [:show]
     resources :supplied_products, only: [:create, :show, :update]
     resources :social_medias, only: [:show]
   end

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -4,7 +4,7 @@ DfcProvider::Engine.routes.draw do
   resources :addresses, only: [:show]
   resources :enterprises, only: [:show] do
     resources :catalog_items, only: [:index, :show, :update]
-    resources :offers, only: [:show]
+    resources :offers, only: [:show, :update]
     resources :supplied_products, only: [:create, :show, :update]
     resources :social_medias, only: [:show]
   end

--- a/engines/dfc_provider/spec/requests/offers_spec.rb
+++ b/engines/dfc_provider/spec/requests/offers_spec.rb
@@ -32,5 +32,34 @@ describe "Offers", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: true 
         run_test!
       end
     end
+
+    put "Update Offer" do
+      consumes "application/json"
+
+      parameter name: :offer, in: :body, schema: {
+        example: {
+          '@context': "https://www.datafoodconsortium.org",
+          '@id': "http://test.host/api/dfc/enterprises/10000/offers/10001",
+          '@type': "dfc-b:Offer",
+          'dfc-b:hasPrice': 9.99,
+          'dfc-b:stockLimitation': 7
+        }
+      }
+
+      let(:id) { variant.id }
+      let(:offer) { |example|
+        example.metadata[:operation][:parameters].first[:schema][:example]
+      }
+
+      response "204", "success" do
+        it "updates a variant" do |example|
+          expect {
+            submit_request(example.metadata)
+            variant.reload
+          }.to change { variant.price }.to(9.99)
+            .and change { variant.on_hand }.to(7)
+        end
+      end
+    end
   end
 end

--- a/engines/dfc_provider/spec/requests/offers_spec.rb
+++ b/engines/dfc_provider/spec/requests/offers_spec.rb
@@ -47,11 +47,30 @@ describe "Offers", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: true 
       }
 
       let(:id) { variant.id }
-      let(:offer) { |example|
+      let(:offer) { offer_example }
+      let(:offer_example) { |example|
         example.metadata[:operation][:parameters].first[:schema][:example]
       }
 
       response "204", "success" do
+        context "with missing stockLimitation" do
+          let(:offer) {
+            offer_example.dup.tap do |o|
+              o.delete(:'dfc-b:stockLimitation')
+            end
+          }
+
+          it "sets the variant to on demand" do |example|
+            pending "DFC Connector needs to support unset values."
+
+            expect {
+              submit_request(example.metadata)
+              variant.reload
+            }.to change { variant.on_demand }.to(true)
+              .and change { variant.on_hand }.by(0)
+          end
+        end
+
         it "updates a variant" do |example|
           expect {
             submit_request(example.metadata)

--- a/engines/dfc_provider/spec/requests/offers_spec.rb
+++ b/engines/dfc_provider/spec/requests/offers_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "../swagger_helper"
+
+describe "Offers", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: true do
+  let!(:user) { create(:oidc_user) }
+  let!(:enterprise) { create(:distributor_enterprise, id: 10_000, owner: user) }
+  let!(:product) {
+    create(
+      :product,
+      id: 90_000,
+      supplier: enterprise, name: "Pesto", description: "Basil Pesto",
+      variants: [variant],
+    )
+  }
+  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1) }
+
+  before { login_as user }
+
+  path "/api/dfc/enterprises/{enterprise_id}/offers/{id}" do
+    parameter name: :enterprise_id, in: :path, type: :string
+    parameter name: :id, in: :path, type: :string
+
+    let(:enterprise_id) { enterprise.id }
+
+    get "Show Offer" do
+      produces "application/json"
+
+      response "200", "success" do
+        let(:id) { variant.id }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -188,7 +188,7 @@ describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml", rswag_auto
             submit_request(example.metadata)
             variant.reload
           }.to change { variant.description }.to("DFC-Pesto updated")
-            .and change { variant.name }.to("Pesto novo")
+            .and change { variant.display_name }.to("Pesto novo")
             .and change { variant.unit_value }.to(17)
         end
       end

--- a/engines/dfc_provider/spec/services/offer_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/offer_builder_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../spec_helper"
 
-describe DfcBuilder do
+describe OfferBuilder do
   let(:variant) { build(:variant) }
 
   describe ".offer" do
@@ -11,7 +11,7 @@ describe DfcBuilder do
       variant.save!
       variant.on_hand = 5
 
-      offer = DfcBuilder.offer(variant)
+      offer = OfferBuilder.build(variant)
 
       expect(offer.stockLimitation).to eq 5
     end
@@ -22,7 +22,7 @@ describe DfcBuilder do
       variant.on_hand = 5
       variant.on_demand = true
 
-      offer = DfcBuilder.offer(variant)
+      offer = OfferBuilder.build(variant)
 
       expect(offer.stockLimitation).to eq nil
     end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -489,7 +489,7 @@ paths:
                     "@context": https://www.datafoodconsortium.org
                     "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
                     "@type": dfc-b:SuppliedProduct
-                    dfc-b:name: Apple - 6g
+                    dfc-b:name: Apple (6g)
                     dfc-b:description: A delicious heritage apple
                     dfc-b:hasType: dfc-pt:non-local-vegetable
                     dfc-b:hasQuantity:

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -409,6 +409,35 @@ paths:
                       dfc-b:URL: https://facebook.com/user
         '404':
           description: not found
+  "/api/dfc/enterprises/{enterprise_id}/offers/{id}":
+    parameters:
+    - name: enterprise_id
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Show Offer
+      tags:
+      - Offers
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@context": https://www.datafoodconsortium.org
+                    "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
+                    "@type": dfc-b:Offer
+                    dfc-b:hasPrice: 19.99
+                    dfc-b:stockLimitation: 5
   "/api/dfc/persons/{id}":
     get:
       summary: Show person

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -438,6 +438,24 @@ paths:
                     "@type": dfc-b:Offer
                     dfc-b:hasPrice: 19.99
                     dfc-b:stockLimitation: 5
+    put:
+      summary: Update Offer
+      parameters: []
+      tags:
+      - Offers
+      responses:
+        '204':
+          description: success
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                "@context": https://www.datafoodconsortium.org
+                "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
+                "@type": dfc-b:Offer
+                dfc-b:hasPrice: 9.99
+                dfc-b:stockLimitation: 7
   "/api/dfc/persons/{id}":
     get:
       summary: Show person


### PR DESCRIPTION
#### What? Why?

- Closes #10826 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

There were a few remaining fields left to import products via the DFC API. These have now been added with one exception. The issue also listed setting `on_demand` but that's currently not possible with the DFC Connector:

* https://github.com/datafoodconsortium/connector-codegen/issues/13

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
