### PR TITLE
Include Tax on enterprise fees on the invoice

### DIFF
--- a/app/helpers/tax_helper.rb
+++ b/app/helpers/tax_helper.rb
@@ -14,9 +14,11 @@ module TaxHelper
 
   def display_line_items_taxes(line_item, display_zero: true)
     if line_item.included_tax.positive?
-      Spree::Money.new(line_item.included_tax, currency: line_item.currency)
+      tax = line_item.included_tax + enterprise_fee_tax(line_item)
+      Spree::Money.new(tax, currency: line_item.currency)
     elsif line_item.added_tax.positive?
-      Spree::Money.new(line_item.added_tax, currency: line_item.currency)
+      tax = line_item.added_tax + enterprise_fee_tax(line_item)
+      Spree::Money.new(tax, currency: line_item.currency)
     elsif display_zero
       Spree::Money.new(0.00, currency: line_item.currency)
     end
@@ -25,5 +27,11 @@ module TaxHelper
   def display_total_with_tax(taxable)
     total = taxable.amount + taxable.additional_tax_total
     Spree::Money.new(total, currency: taxable.currency)
+  end
+
+  private
+
+  def enterprise_fee_tax(line_item)
+    EnterpriseFeeAdjustments.new(line_item.enterprise_fee_adjustments).total_tax
   end
 end

--- a/app/helpers/tax_helper.rb
+++ b/app/helpers/tax_helper.rb
@@ -14,10 +14,10 @@ module TaxHelper
 
   def display_line_items_taxes(line_item, display_zero: true)
     if line_item.included_tax.positive?
-      tax = line_item.included_tax + enterprise_fee_tax(line_item)
+      tax = line_item.included_tax + enterprise_fee_adjustments(line_item).total_included_tax
       Spree::Money.new(tax, currency: line_item.currency)
     elsif line_item.added_tax.positive?
-      tax = line_item.added_tax + enterprise_fee_tax(line_item)
+      tax = line_item.added_tax + enterprise_fee_adjustments(line_item).total_additional_tax
       Spree::Money.new(tax, currency: line_item.currency)
     elsif display_zero
       Spree::Money.new(0.00, currency: line_item.currency)
@@ -31,7 +31,7 @@ module TaxHelper
 
   private
 
-  def enterprise_fee_tax(line_item)
-    EnterpriseFeeAdjustments.new(line_item.enterprise_fee_adjustments).total_tax
+  def enterprise_fee_adjustments(line_item)
+    EnterpriseFeeAdjustments.new(line_item.enterprise_fee_adjustments)
   end
 end

--- a/app/models/enterprise_fee_adjustments.rb
+++ b/app/models/enterprise_fee_adjustments.rb
@@ -8,18 +8,10 @@ class EnterpriseFeeAdjustments
   end
 
   def total_additional_tax
-    @adjustments.reduce(0.0) do |sum, enterprise_fee|
-      sum += enterprise_fee.additional_tax_total if enterprise_fee&.adjustments
-
-      sum
-    end
+    @adjustments.sum { |enterprise_fee| enterprise_fee.additional_tax_total.to_f }
   end
 
   def total_included_tax
-    @adjustments.reduce(0.0) do |sum, enterprise_fee|
-      sum += enterprise_fee.included_tax_total if enterprise_fee&.adjustments
-
-      sum
-    end
+    @adjustments.sum { |enterprise_fee| enterprise_fee.included_tax_total.to_f }
   end
 end

--- a/app/models/enterprise_fee_adjustments.rb
+++ b/app/models/enterprise_fee_adjustments.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# EnterpriseFeeAdjustments represent a collection of enterprise fee adjustments
+#
+class EnterpriseFeeAdjustments
+  def initialize(adjustments)
+    @adjustments = adjustments
+  end
+
+  # Calculate the tax portion of enterprise fee when tax excluded from price
+  def total_tax
+    @adjustments.reduce(0.0) do |sum, enterprise_fee|
+      sum += enterprise_fee.adjustments.tax.additional.sum(:amount) if enterprise_fee&.adjustments
+
+      sum
+    end
+  end
+end

--- a/app/models/enterprise_fee_adjustments.rb
+++ b/app/models/enterprise_fee_adjustments.rb
@@ -7,10 +7,17 @@ class EnterpriseFeeAdjustments
     @adjustments = adjustments
   end
 
-  # Calculate the tax portion of enterprise fee when tax excluded from price
-  def total_tax
+  def total_additional_tax
     @adjustments.reduce(0.0) do |sum, enterprise_fee|
-      sum += enterprise_fee.adjustments.tax.additional.sum(:amount) if enterprise_fee&.adjustments
+      sum += enterprise_fee.additional_tax_total if enterprise_fee&.adjustments
+
+      sum
+    end
+  end
+
+  def total_included_tax
+    @adjustments.reduce(0.0) do |sum, enterprise_fee|
+      sum += enterprise_fee.included_tax_total if enterprise_fee&.adjustments
 
       sum
     end

--- a/app/models/invoice/data_presenter/line_item.rb
+++ b/app/models/invoice/data_presenter/line_item.rb
@@ -4,7 +4,8 @@ class Invoice
   class DataPresenter
     class LineItem < Invoice::DataPresenter::Base
       attributes :added_tax, :currency, :included_tax, :price_with_adjustments, :quantity,
-                 :variant_id, :unit_price_price_and_unit, :unit_presentation, :enterprise_fee_tax
+                 :variant_id, :unit_price_price_and_unit, :unit_presentation,
+                 :enterprise_fee_additional_tax, :enterprise_fee_included_tax
       attributes_with_presenter :variant
       array_attribute :tax_rates, class_name: 'TaxRate'
       invoice_generation_attributes :added_tax, :included_tax, :price_with_adjustments,
@@ -13,11 +14,12 @@ class Invoice
       delegate :name_to_display, :options_text, to: :variant
 
       def amount_with_adjustments_without_taxes
-        (price_with_adjustments * quantity) - included_tax
+        fee_tax = enterprise_fee_included_tax || 0.0
+        (price_with_adjustments * quantity) - included_tax - fee_tax
       end
 
       def amount_with_adjustments_and_with_taxes
-        fee_tax = enterprise_fee_tax || 0.00
+        fee_tax = enterprise_fee_additional_tax || 0.0
         ( price_with_adjustments * quantity) + added_tax + fee_tax
       end
 
@@ -30,9 +32,11 @@ class Invoice
       end
 
       def single_display_amount_with_adjustments
-        Spree::Money.new(price_with_adjustments - (included_tax / quantity), currency:)
+        fee_tax = enterprise_fee_included_tax || 0.0
+        Spree::Money.new(price_with_adjustments - ((included_tax + fee_tax) / quantity), currency:)
       end
 
+      # TODO seems useless
       def display_line_items_taxes(display_zero: true)
         if included_tax.positive?
           Spree::Money.new( included_tax, currency:)

--- a/app/models/invoice/data_presenter/line_item.rb
+++ b/app/models/invoice/data_presenter/line_item.rb
@@ -36,17 +36,6 @@ class Invoice
         Spree::Money.new(price_with_adjustments - ((included_tax + fee_tax) / quantity), currency:)
       end
 
-      # TODO seems useless
-      def display_line_items_taxes(display_zero: true)
-        if included_tax.positive?
-          Spree::Money.new( included_tax, currency:)
-        elsif added_tax.positive?
-          Spree::Money.new( added_tax, currency:)
-        elsif display_zero
-          Spree::Money.new(0.00, currency:)
-        end
-      end
-
       def display_line_item_tax_rates
         tax_rates.map { |tr| number_to_percentage(tr.amount * 100, precision: 1) }.join(", ")
       end

--- a/app/models/invoice/data_presenter/line_item.rb
+++ b/app/models/invoice/data_presenter/line_item.rb
@@ -4,7 +4,7 @@ class Invoice
   class DataPresenter
     class LineItem < Invoice::DataPresenter::Base
       attributes :added_tax, :currency, :included_tax, :price_with_adjustments, :quantity,
-                 :variant_id, :unit_price_price_and_unit, :unit_presentation
+                 :variant_id, :unit_price_price_and_unit, :unit_presentation, :enterprise_fee_tax
       attributes_with_presenter :variant
       array_attribute :tax_rates, class_name: 'TaxRate'
       invoice_generation_attributes :added_tax, :included_tax, :price_with_adjustments,
@@ -17,7 +17,8 @@ class Invoice
       end
 
       def amount_with_adjustments_and_with_taxes
-        ( price_with_adjustments * quantity) + added_tax
+        fee_tax = enterprise_fee_tax || 0.00
+        ( price_with_adjustments * quantity) + added_tax + fee_tax
       end
 
       def display_amount_with_adjustments_without_taxes

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -202,7 +202,7 @@ module Spree
       # so line_item.adjustments returns an empty array
       return 0 if quantity.zero?
 
-      fees = adjustments.enterprise_fee.sum(:amount)
+      fees = enterprise_fee_adjustments.sum(:amount)
 
       (price + (fees / quantity)).round(2)
     end
@@ -239,6 +239,10 @@ module Spree
 
     def scoper
       @scoper ||= OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)
+    end
+
+    def enterprise_fee_adjustments
+      adjustments.enterprise_fee
     end
 
     private

--- a/app/serializers/invoice/line_item_serializer.rb
+++ b/app/serializers/invoice/line_item_serializer.rb
@@ -3,8 +3,12 @@
 class Invoice
   class LineItemSerializer < ActiveModel::Serializer
     attributes :id, :added_tax, :currency, :included_tax, :price_with_adjustments, :quantity,
-               :variant_id, :unit_price_price_and_unit, :unit_presentation
+               :variant_id, :unit_price_price_and_unit, :unit_presentation, :enterprise_fee_tax
     has_one :variant, serializer: Invoice::VariantSerializer
     has_many :tax_rates, serializer: Invoice::TaxRateSerializer
+
+    def enterprise_fee_tax
+      EnterpriseFeeAdjustments.new(object.enterprise_fee_adjustments).total_tax
+    end
   end
 end

--- a/app/serializers/invoice/line_item_serializer.rb
+++ b/app/serializers/invoice/line_item_serializer.rb
@@ -3,12 +3,17 @@
 class Invoice
   class LineItemSerializer < ActiveModel::Serializer
     attributes :id, :added_tax, :currency, :included_tax, :price_with_adjustments, :quantity,
-               :variant_id, :unit_price_price_and_unit, :unit_presentation, :enterprise_fee_tax
+               :variant_id, :unit_price_price_and_unit, :unit_presentation,
+               :enterprise_fee_additional_tax, :enterprise_fee_included_tax
     has_one :variant, serializer: Invoice::VariantSerializer
     has_many :tax_rates, serializer: Invoice::TaxRateSerializer
 
-    def enterprise_fee_tax
-      EnterpriseFeeAdjustments.new(object.enterprise_fee_adjustments).total_tax
+    def enterprise_fee_additional_tax
+      EnterpriseFeeAdjustments.new(object.enterprise_fee_adjustments).total_additional_tax
+    end
+
+    def enterprise_fee_included_tax
+      EnterpriseFeeAdjustments.new(object.enterprise_fee_adjustments).total_included_tax
     end
   end
 end

--- a/spec/helpers/tax_helper_spec.rb
+++ b/spec/helpers/tax_helper_spec.rb
@@ -73,10 +73,11 @@ describe TaxHelper, type: :helper do
           )
         }
 
-        it "doesn't add enterprise fee tax, it is already included in the line item tax" do
+        it "includes enterprise fee tax" do
+          expected_tax = line_item.included_tax + fee_tax_adjustment.amount
           expect(
             helper.display_line_items_taxes(line_item)
-          ).to eq Spree::Money.new(line_item.included_tax, currency: line_item.currency)
+          ).to eq Spree::Money.new(expected_tax, currency: line_item.currency)
         end
       end
     end

--- a/spec/helpers/tax_helper_spec.rb
+++ b/spec/helpers/tax_helper_spec.rb
@@ -49,22 +49,79 @@ describe TaxHelper, type: :helper do
   end
 
   describe "#display_line_items_taxes" do
-    it "displays included tax" do
-      expect(
-        helper.display_line_items_taxes(line_item)
-      ).to eq Spree::Money.new(line_item.included_tax, currency: line_item.currency)
+    let(:enterprise_fee) { create(:enterprise_fee, tax_category: tax_rate.tax_category) }
+
+    context "with included tax" do
+      it "displays included tax" do
+        expect(
+          helper.display_line_items_taxes(line_item)
+        ).to eq Spree::Money.new(line_item.included_tax, currency: line_item.currency)
+      end
+
+      context "with enterprise fee incuring tax" do
+        let(:fee_adjustment) {
+          create( :adjustment, originator: enterprise_fee, adjustable: line_item, state: "closed")
+        }
+        let!(:fee_tax_adjustment) {
+          create(
+            :adjustment,
+            originator: tax_rate,
+            adjustable: fee_adjustment,
+            amount: 10,
+            state: "closed",
+            included: true
+          )
+        }
+
+        it "doesn't add enterprise fee tax, it is already included in the line item tax" do
+          expect(
+            helper.display_line_items_taxes(line_item)
+          ).to eq Spree::Money.new(line_item.included_tax, currency: line_item.currency)
+        end
+      end
     end
 
-    it "displays additional tax" do
-      expect(
-        helper.display_line_items_taxes(line_item2)
-      ).to eq Spree::Money.new(line_item2.added_tax, currency: line_item2.currency)
+    context "with additional tax (tax exluded from price)" do
+      it "displays additional tax" do
+        expect(
+          helper.display_line_items_taxes(line_item2)
+        ).to eq Spree::Money.new(line_item2.added_tax, currency: line_item2.currency)
+      end
+
+      context "with enterprise fee incuring tax" do
+        let(:fee_adjustment) {
+          create( :adjustment, originator: enterprise_fee, adjustable: line_item2, state: "closed")
+        }
+        let(:fee_tax_adjustment) {
+          create(
+            :adjustment,
+            originator: tax_rate,
+            adjustable: fee_adjustment,
+            amount: 10,
+            state: "closed",
+            included: false
+          )
+        }
+
+        it "includes enterprise fee tax" do
+          expected_tax = line_item2.added_tax + fee_tax_adjustment.amount
+          expect(
+            helper.display_line_items_taxes(line_item2)
+          ).to eq Spree::Money.new(expected_tax, currency: line_item2.currency)
+        end
+      end
     end
 
     it "displays formatted 0.00 amount when amount is zero" do
       expect(
         helper.display_line_items_taxes(line_item3)
-      ).to eq Spree::Money.new(0.00,)
+      ).to eq Spree::Money.new(0.00)
+    end
+
+    it "optionally displays nothing when amount is zero" do
+      expect(
+        helper.display_line_items_taxes(line_item3, display_zero: false)
+      ).to be_nil
     end
   end
 

--- a/spec/models/enterprise_fee_adjustments_spec.rb
+++ b/spec/models/enterprise_fee_adjustments_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe EnterpriseFeeAdjustments do
+  describe "#tax" do
+    let(:tax_rate) { create(:tax_rate, amount: 0.1) }
+    let(:line_item) { create(:line_item) }
+    let(:enterprise_fee) { create(:enterprise_fee, tax_category: tax_rate.tax_category) }
+    let(:fee_adjustment) {
+      create( :adjustment, originator: enterprise_fee, adjustable: line_item, state: "closed")
+    }
+
+    it "calculates total tax" do
+      create(
+        :adjustment, originator: tax_rate, adjustable: fee_adjustment, amount: 10.0, state: "closed"
+      )
+
+      enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment])
+
+      expect(enterprise_fee_adjustments.total_tax).to eq(10.0)
+    end
+
+    context "with tax included in price" do
+      it "returns 0.0" do
+        create(
+          :adjustment,
+          originator: tax_rate,
+          adjustable: fee_adjustment,
+          amount: 10.0,
+          state: "closed",
+          included: true
+        )
+
+        enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment])
+
+        expect(enterprise_fee_adjustments.total_tax).to eq(0.0)
+      end
+    end
+  end
+end

--- a/spec/models/enterprise_fee_adjustments_spec.rb
+++ b/spec/models/enterprise_fee_adjustments_spec.rb
@@ -5,8 +5,12 @@ require 'spec_helper'
 describe EnterpriseFeeAdjustments do
   let(:tax_rate) { create(:tax_rate, amount: 0.1) }
   let(:line_item) { create(:line_item) }
+  let(:line_item2) { create(:line_item) }
   let(:enterprise_fee) { create(:enterprise_fee, tax_category: tax_rate.tax_category) }
   let(:fee_adjustment) {
+    create( :adjustment, originator: enterprise_fee, adjustable: line_item, state: "closed")
+  }
+  let(:fee_adjustment2) {
     create( :adjustment, originator: enterprise_fee, adjustable: line_item, state: "closed")
   }
 
@@ -20,10 +24,26 @@ describe EnterpriseFeeAdjustments do
         state: "closed",
         included: false
       )
+      create(
+        :adjustment,
+        originator: tax_rate,
+        adjustable: fee_adjustment2,
+        amount: 5.0,
+        state: "closed",
+        included: false
+      )
 
-      enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment])
+      enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment, fee_adjustment2])
 
-      expect(enterprise_fee_adjustments.total_additional_tax).to eq(10.0)
+      expect(enterprise_fee_adjustments.total_additional_tax).to eq(15.0)
+    end
+
+    context "with no tax adjustment" do
+      it "returns 0.0" do
+        enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment])
+
+        expect(enterprise_fee_adjustments.total_additional_tax).to eq(0.0)
+      end
     end
 
     context "with tax included in price" do
@@ -54,10 +74,26 @@ describe EnterpriseFeeAdjustments do
         state: "closed",
         included: true
       )
+      create(
+        :adjustment,
+        originator: tax_rate,
+        adjustable: fee_adjustment2,
+        amount: 5.0,
+        state: "closed",
+        included: true
+      )
 
-      enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment])
+      enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment, fee_adjustment2])
 
-      expect(enterprise_fee_adjustments.total_included_tax).to eq(10.0)
+      expect(enterprise_fee_adjustments.total_included_tax).to eq(15.0)
+    end
+
+    context "with no tax adjustment" do
+      it "returns 0.0" do
+        enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment])
+
+        expect(enterprise_fee_adjustments.total_additional_tax).to eq(0.0)
+      end
     end
 
     context "with tax excluded from price" do

--- a/spec/models/enterprise_fee_adjustments_spec.rb
+++ b/spec/models/enterprise_fee_adjustments_spec.rb
@@ -3,22 +3,27 @@
 require 'spec_helper'
 
 describe EnterpriseFeeAdjustments do
-  describe "#tax" do
-    let(:tax_rate) { create(:tax_rate, amount: 0.1) }
-    let(:line_item) { create(:line_item) }
-    let(:enterprise_fee) { create(:enterprise_fee, tax_category: tax_rate.tax_category) }
-    let(:fee_adjustment) {
-      create( :adjustment, originator: enterprise_fee, adjustable: line_item, state: "closed")
-    }
+  let(:tax_rate) { create(:tax_rate, amount: 0.1) }
+  let(:line_item) { create(:line_item) }
+  let(:enterprise_fee) { create(:enterprise_fee, tax_category: tax_rate.tax_category) }
+  let(:fee_adjustment) {
+    create( :adjustment, originator: enterprise_fee, adjustable: line_item, state: "closed")
+  }
 
+  describe "#total_additional_tax" do
     it "calculates total tax" do
       create(
-        :adjustment, originator: tax_rate, adjustable: fee_adjustment, amount: 10.0, state: "closed"
+        :adjustment,
+        originator: tax_rate,
+        adjustable: fee_adjustment,
+        amount: 10.0,
+        state: "closed",
+        included: false
       )
 
       enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment])
 
-      expect(enterprise_fee_adjustments.total_tax).to eq(10.0)
+      expect(enterprise_fee_adjustments.total_additional_tax).to eq(10.0)
     end
 
     context "with tax included in price" do
@@ -34,7 +39,41 @@ describe EnterpriseFeeAdjustments do
 
         enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment])
 
-        expect(enterprise_fee_adjustments.total_tax).to eq(0.0)
+        expect(enterprise_fee_adjustments.total_additional_tax).to eq(0.0)
+      end
+    end
+  end
+
+  describe "total_included_tax" do
+    it "calculates total tax" do
+      create(
+        :adjustment,
+        originator: tax_rate,
+        adjustable: fee_adjustment,
+        amount: 10.0,
+        state: "closed",
+        included: true
+      )
+
+      enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment])
+
+      expect(enterprise_fee_adjustments.total_included_tax).to eq(10.0)
+    end
+
+    context "with tax excluded from price" do
+      it "returns 0.0" do
+        create(
+          :adjustment,
+          originator: tax_rate,
+          adjustable: fee_adjustment,
+          amount: 10.0,
+          state: "closed",
+          included: false
+        )
+
+        enterprise_fee_adjustments = EnterpriseFeeAdjustments.new([fee_adjustment])
+
+        expect(enterprise_fee_adjustments.total_included_tax).to eq(0.0)
       end
     end
   end

--- a/spec/models/invoice/data_presenter/line_item_spec.rb
+++ b/spec/models/invoice/data_presenter/line_item_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Invoice::DataPresenter::LineItem do
+  subject(:presenter) { described_class.new(data) }
+
+  describe "#amount_with_adjustments_without_taxes" do
+    let(:data) do
+      {
+        price_with_adjustments: 10.0,
+        quantity: 2,
+        included_tax: 0.0,
+        enterprise_fee_included_tax: nil
+      }
+    end
+
+    it "calculated line item price" do
+      expect(presenter.amount_with_adjustments_without_taxes).to eq(20.00)
+    end
+
+    context "with tax included in price" do
+      let(:data) do
+        {
+          price_with_adjustments: 10.0,
+          quantity: 2,
+          included_tax: 1.0,
+          enterprise_fee_included_tax: nil
+        }
+      end
+
+      it "removes the included tax" do
+        expect(presenter.amount_with_adjustments_without_taxes).to eq(19)
+      end
+
+      context "with enterprise fee" do
+        let(:data) do
+          {
+            price_with_adjustments: 10.0,
+            quantity: 2,
+            included_tax: 0.0,
+            enterprise_fee_included_tax: 0.5
+          }
+        end
+
+        it "removes the enterpise fee tax" do
+          expect(presenter.amount_with_adjustments_without_taxes).to eq(19.5)
+        end
+      end
+    end
+  end
+
+  describe "#amount_with_adjustments_and_with_taxes" do
+    let(:data) do
+      {
+        price_with_adjustments: 10.0,
+        quantity: 2,
+        added_tax: 0.0,
+        enterprise_fee_additional_tax: nil
+      }
+    end
+
+    it "cacluated the line item price with tax" do
+      expect(presenter.amount_with_adjustments_and_with_taxes).to eq(20.00)
+    end
+
+    context "with tax excluded from price" do
+      let(:data) do
+        {
+          price_with_adjustments: 10.0,
+          quantity: 2,
+          added_tax: 1.0,
+          enterprise_fee_additional_tax: nil
+        }
+      end
+
+      it "includes the added tax" do
+        expect(presenter.amount_with_adjustments_and_with_taxes).to eq(21.00)
+      end
+
+      context "with enterprise fee" do
+        let(:data) do
+          {
+            price_with_adjustments: 10.0,
+            quantity: 2,
+            added_tax: 0.0,
+            enterprise_fee_additional_tax: 0.5
+          }
+        end
+
+        it "adds the enterpise fee tax" do
+          expect(presenter.amount_with_adjustments_and_with_taxes).to eq(20.50)
+        end
+      end
+    end
+  end
+
+  # TODO
+  describe "#single_display_amount_with_adjustments" do
+    let(:data) do
+      {
+        price_with_adjustments: 10.0,
+        quantity: 2,
+        included_tax: 0.0,
+        enterprise_fee_included_tax: nil,
+        currency: "AUD"
+      }
+    end
+
+    it "displays single price with adjustments" do
+      expect(presenter.single_display_amount_with_adjustments).to eq(Spree::Money.new(10.0))
+    end
+
+    context "with included tax" do
+      let(:data) do
+        {
+          price_with_adjustments: 10.0,
+          quantity: 2,
+          included_tax: 1.0,
+          enterprise_fee_included_tax: nil
+        }
+      end
+
+      it "excludes the included tax" do
+        expect(presenter.single_display_amount_with_adjustments).to eq(Spree::Money.new(9.5))
+      end
+
+      context "with enterpise fee" do
+        let(:data) do
+          {
+            price_with_adjustments: 10.0,
+            quantity: 2,
+            included_tax: 1.0,
+            enterprise_fee_included_tax: 0.5
+          }
+        end
+
+        it "includes fee but remove tax portion of the fee" do
+          expect(presenter.single_display_amount_with_adjustments).to eq(Spree::Money.new(9.25))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Closes #12021 

In the case of tax not included in the price, when a Enterprise Fee incurs a tax, currently it's not included in the line item tax column on the invoice. This fix the issue, by adding the tax portion of the fee to the line item tax.
It also fix a range of issue where the enterprise fee tax was wrongly added to some total, or missing from the tax total, see testing notes for more information.

NOTE TO REVIEWERS:  the git history could be cleaner but I already spent too long on this. I can clean it up if it necessary.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

#### Tax excluded from price

In the backend:
- Make sure you have a tax rate setup with tax excluded from price, see Configuration -> Tax rates
- Set up an Enterprise fee for your testing enterprise, see Configuration -> Enterprise Fees or Enterprise Fees from the enterprise setting page
- Create a product with a per product enterprise fee
- Ensure both the product, and the enterprise fee have a tax category assigned

##### With old invoice (invoices feature disable)

- Place an order with said produce
- Go to the order in the back office, and click on actions -> Print Invoice
- Check the GST (could also be named "Sales tax" depending on your configuration) include the Enterprise Fee tax. Enterprise fee tax are not shown in the backoffice, but you should be able to calculate/infer the value from the Enterprise Fee line item adjustment and your configuration

![old_invoice](https://github.com/openfoodfoundation/openfoodnetwork/assets/40413322/4f5cfa9e-754f-473d-a6ee-4d288bfb5c62)

##### With new invoice (invoices feature enable)
- As above, place an order and click print invoice
- Check the Line Item Total Price (Incl. Tax) includes the Enterprise Fee Tax

![new_invoice](https://github.com/openfoodfoundation/openfoodnetwork/assets/40413322/86124846-305b-4f24-8cbb-681b9047f27e)

#### Tax included in price
Use the setup described above but switch to price included in tax.

##### With old invoice (invoices feature disable)

- Place an order with said produce
- Go to the order in the back office, and click on actions -> Print Invoice
- Check the GST (could also be named "Sales tax" depending on your configuration) include the Enterprise Fee tax. Enterprise fee tax are not shown in the backoffice, but you should be able to calculate/infer the value from the Enterprise Fee line item adjustment and your configuration

![old_invoice_incl_tax](https://github.com/openfoodfoundation/openfoodnetwork/assets/40413322/55e484b4-99bc-4582-97ee-9039828722eb)

##### With new invoice (invoices feature enable)
- As above, place an order and click print invoice
- Check the Price Per Unit ( Excl. Tax ) does not include the enterprise fee tax
- Check the Total ( Excl. Tax ) does not include the enterprise fee tax

![new_invoice_incl_tax](https://github.com/openfoodfoundation/openfoodnetwork/assets/40413322/b0f9c34a-f3a7-46b8-93e3-6055d5fb3ade)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.