### PR TITLE
Hotkey fix

### DIFF
--- a/app/webpacker/controllers/tom_select_controller.js
+++ b/app/webpacker/controllers/tom_select_controller.js
@@ -5,7 +5,6 @@ export default class extends Controller {
   static values = { options: Object, placeholder: String };
 
   connect(options = {}) {
-    console.log(this.element, this.placeholderValue);
     this.control = new TomSelect(this.element, {
       maxItems: 1,
       maxOptions: null,

--- a/app/webpacker/js/hotkeys.js
+++ b/app/webpacker/js/hotkeys.js
@@ -13,8 +13,9 @@ hotkeys.filter = function (event) {
 hotkeys("ctrl+enter, command+enter", function (event, handler) {
   const form = event.target.form;
 
-  // If element has a non-angular form
-  if (form && !form.classList.contains("ng")) {
-    form.submit();
-  }
+  // Simulate a click on the first available submit button. This seems to be the most robust option,
+  // ensuring that event handlers are handled first (eg for StimulusReflex). If there's no submit
+  // button, nothing happens (eg for Angular forms).
+  const submit = form && form.querySelector('input[type="submit"], button[type="submit"]');
+  submit && submit.click();
 });


### PR DESCRIPTION
#### What? Why?

I found an issue with the `ctrl+enter` keyboard shortcut on a StimulusReflex form, and fixed it.



#### What should we test?
With admin_style_v3 enabled,
1. visit `/admin/products`
2. Edit a product
3. press `ctrl+enter` (or `cmd+enter` on mac)

The change should be saved successfully.

Before, it would ask if you want to leave the site, and if you click yes, you got an error "Not found".

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
