### PR TITLE
Silently fail when tax_category has been deleted

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -209,6 +209,13 @@ module Spree
       Spree::Stock::Quantifier.new(self).total_on_hand
     end
 
+    # Silently fail when tax_category has been deleted
+    def tax_category
+      super
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+
     private
 
     def check_currency

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -121,7 +121,7 @@
                 %td.align-left
                   -# empty
                 %td.align-left
-                  .content= variant.tax_category&.name || "None" # TODO: convert to dropdown, else translate hardcoded string.
+                  .content= variant.tax_category&.name || "Deleted" # TODO: convert to dropdown, else translate hardcoded string
                 %td.align-left
                   -# empty
                 %td.align-right

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -6,6 +6,23 @@ require 'spree/localized_number'
 describe Spree::Variant do
   subject(:variant) { build(:variant) }
 
+  describe "associations" do
+    describe "tax_category" do
+      before do
+        variant.tax_category = build(:tax_category)
+        variant.save!
+      end
+
+      it "returns nil without error when soft-deleted" do
+        variant.tax_category.destroy # soft-deleted with acts_as_paranoid
+        variant.reload
+
+        expect(variant.tax_category).to be_nil
+        expect{ variant.tax_category }.not_to raise_error
+      end
+    end
+  end
+
   context "validations" do
     it "should validate price is greater than 0" do
       variant.price = -1


### PR DESCRIPTION
#### What? Why?
* OFN CA have raised [an issue](https://openfoodnetwork.slack.com/archives/C01CXQNJ1J6/p1705527604203799) where the new bulk edit products screen crashes on products that have a deleted tax category.
* Discussed in [#product-circle](https://openfoodnetwork.slack.com/archives/C018S101R4J/p1705531338497929)
* https://github.com/openfoodfoundation/openfoodnetwork/issues/12356

I guess all existing product screens handle this gracefully, though to be honest I'm not sure how. Apparently the new bulk edit products screen, and some old reports can't handle it.
Instead of investigating further, I decided it could be fixed in the model. This fixes the bulk edit products screen, and might fix the old reports that were mentioned.

https://openfoodnetwork.slack.com/archives/C018S101R4J/p1705531338497929

- Closes # <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
With `admin_style_v3` enabled,

- Create a new tax category
- Create a new product with this tax category
- Delete the tax category
- Visit `/admin/products/` and view the product.
  - No errors
  - Tax category column should say "deleted".

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
