### PR TITLE
 Prevent delete of tax category if variants are still using it 

### DIFF
--- a/app/models/spree/tax_category.rb
+++ b/app/models/spree/tax_category.rb
@@ -6,6 +6,7 @@ module Spree
     validates :name, presence: true, uniqueness: { scope: :deleted_at }
 
     has_many :tax_rates, dependent: :destroy, inverse_of: :tax_category
+    has_many :variants, dependent: :restrict_with_error
 
     before_save :set_default_category
 

--- a/db/migrate/20240119005345_nullify_tax_category_on_variants.rb
+++ b/db/migrate/20240119005345_nullify_tax_category_on_variants.rb
@@ -1,0 +1,17 @@
+class NullifyTaxCategoryOnVariants < ActiveRecord::Migration[7.0]
+  def up
+    say "Clearing any variant tax categories that have been deleted..."
+    result = execute(<<-SQL
+      UPDATE spree_variants
+      SET tax_category_id = NULL
+      WHERE tax_category_id IS NOT NULL
+        AND tax_category_id NOT IN(
+          SELECT id
+          FROM spree_tax_categories
+          WHERE deleted_at IS NULL
+      )
+    SQL
+    )
+    say "Done: #{result.cmd_status}"
+  end
+end

--- a/spec/models/spree/tax_category_spec.rb
+++ b/spec/models/spree/tax_category_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 describe Spree::TaxCategory do
+  describe "associations" do
+    it { is_expected.to have_many(:tax_rates).dependent(:destroy) }
+  end
+
   context 'default tax category' do
     let(:tax_category) { create(:tax_category) }
     let(:new_tax_category) { create(:tax_category) }

--- a/spec/models/spree/tax_category_spec.rb
+++ b/spec/models/spree/tax_category_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe Spree::TaxCategory do
   describe "associations" do
     it { is_expected.to have_many(:tax_rates).dependent(:destroy) }
+    it { is_expected.to have_many(:variants).dependent(:restrict_with_error) }
   end
 
   context 'default tax category' do


### PR DESCRIPTION
#### What? Why?

Proposed fix to prevent the case where product variants can have a deleted tax category. This was raised here: 
https://openfoodnetwork.slack.com/archives/C01CXQNJ1J6/p1705527604203799

This update will stop you from being able to delete tax category until all related variants have been changed. 
But.. that could be a very slow and painful task.

- Replaces and closes https://github.com/openfoodfoundation/openfoodnetwork/pull/12057


I've not tested this yet, it was more an exploration of how we should fix it.

#### What should we test?
- Create a tax category
- Create a product +variant with this tax category
- Try to delete the tax category: an error should appear.



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
