### PR TITLE
Add promo image to DFC Enterprise API

### DIFF
--- a/engines/dfc_provider/app/services/enterprise_builder.rb
+++ b/engines/dfc_provider/app/services/enterprise_builder.rb
@@ -27,6 +27,7 @@ class EnterpriseBuilder < DfcBuilder
       add_ofn_property(e, "ofn:contact_name", enterprise.contact_name)
 
       add_ofn_property(e, "ofn:logo_url", enterprise.logo.url)
+      add_ofn_property(e, "ofn:promo_image_url", enterprise.promo_image.url)
     end
   end
 

--- a/engines/dfc_provider/app/services/enterprise_builder.rb
+++ b/engines/dfc_provider/app/services/enterprise_builder.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class EnterpriseBuilder < DfcBuilder
-  def self.enterprise(enterprise)
+  def self.enterprise(enterprise) # rubocop:disable Metrics/AbcSize
+    # The ABC size of this method should shrink when our custom attributes are
+    # in the DFC standard.
+
     variants = enterprise.supplied_variants.to_a
     catalog_items = variants.map(&method(:catalog_item))
     supplied_products = catalog_items.map(&:product)

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -72,10 +72,6 @@ describe "Enterprises", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: 
             ).gsub!(
               %r{active_storage/[0-9A-Za-z/=-]*/logo.png},
               "active_storage/url/logo.png",
-            )
-            response.body.gsub!(
-              %r{active_storage/[0-9A-Za-z/=-]*/promo.png},
-              "active_storage/url/promo.png",
             ).gsub!(
               %r{active_storage/[0-9A-Za-z/=-]*/promo.png},
               "active_storage/url/promo.png",

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -6,7 +6,7 @@ describe "Enterprises", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: 
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) do
     create(
-      :distributor_enterprise, :with_logo_image,
+      :distributor_enterprise, :with_logo_image, :with_promo_image,
       id: 10_000, owner: user, abn: "123 456", name: "Fred's Farm",
       description: "This is an awesome enterprise",
       contact_name: "Fred Farmer",
@@ -72,6 +72,13 @@ describe "Enterprises", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: 
             ).gsub!(
               %r{active_storage/[0-9A-Za-z/=-]*/logo.png},
               "active_storage/url/logo.png",
+            )
+            response.body.gsub!(
+              %r{active_storage/[0-9A-Za-z/=-]*/promo.png},
+              "active_storage/url/promo.png",
+            ).gsub!(
+              %r{active_storage/[0-9A-Za-z/=-]*/promo.png},
+              "active_storage/url/promo.png",
             )
           end
         end

--- a/spec/factories/enterprise_factory.rb
+++ b/spec/factories/enterprise_factory.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
   end
 
   trait :with_promo_image do
-    logo { Rack::Test::UploadedFile.new('spec/fixtures/files/promo.png', 'image/png') }
+    promo_image { Rack::Test::UploadedFile.new('spec/fixtures/files/promo.png', 'image/png') }
   end
 
   factory :supplier_enterprise, parent: :enterprise do

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -375,6 +375,7 @@ paths:
                       ofn:long_description: "<p>Hello, world!</p><p>This is a paragraph.</p>"
                       ofn:contact_name: Fred Farmer
                       ofn:logo_url: http://www.example.com/rails/active_storage/url/logo.png
+                      ofn:promo_image_url: http://www.example.com/rails/active_storage/url/promo.png
                       dfc-b:affiliates: http://test.host/api/dfc/enterprise_groups/60000
                     - "@id": http://test.host/api/dfc/addresses/40000
                       "@type": dfc-b:Address


### PR DESCRIPTION

#### What? Why?


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We want to use the promo image in the Discover Regenerative portal in Australia. The property is read-only and the API doesn't support the upload of a new file.

The enterprise factory needed fixing as well. This trait hadn't been used anywhere else.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test required.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
