### PR TITLE
Add invisible captcha to registration screen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,7 @@ gem "faraday"
 gem "private_address_check"
 
 gem 'newrelic_rpm'
+gem 'invisible_captcha'
 
 group :production, :staging do
   gem 'sd_notify' # For better Systemd process management. Used by Puma.

--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,7 @@ gem "faraday"
 gem "private_address_check"
 
 gem 'newrelic_rpm'
+
 gem 'invisible_captcha'
 
 group :production, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,8 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     immigrant (0.3.6)
       activerecord (>= 3.0)
+    invisible_captcha (2.1.0)
+      rails (>= 5.2)
     io-console (0.7.1)
     ipaddress (0.8.3)
     irb (1.11.0)
@@ -857,6 +859,7 @@ DEPENDENCIES
   i18n-js (~> 3.9.0)
   image_processing
   immigrant
+  invisible_captcha
   jquery-rails (= 4.4.0)
   jquery-ui-rails (~> 4.2)
   json

--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -8,6 +8,7 @@ module Spree
 
     layout 'darkswarm'
 
+    invisible_captcha only: [:create], on_timestamp_spam: :render_alert_timestamp_error_message
     skip_before_action :set_current_order, only: :show
     prepend_before_action :load_object, only: [:show, :edit, :update]
     prepend_before_action :authorize_actions, only: :new
@@ -100,6 +101,17 @@ module Spree
 
     def user_params
       ::PermittedAttributes::User.new(params).call
+    end
+
+    def render_alert_timestamp_error_message
+      render cable_ready: cable_car.inner_html(
+        "#signup-feedback",
+        partial("layouts/alert",
+                locals: {
+                  type: "alert",
+                  message: InvisibleCaptcha.timestamp_error_message
+                })
+      )
     end
   end
 end

--- a/app/views/layouts/_signup_tab.html.haml
+++ b/app/views/layouts/_signup_tab.html.haml
@@ -23,3 +23,4 @@
     .row
       .large-12.columns
         = form.submit t(:action_signup), { class: "button primary", tabindex: 4 }
+        = form.invisible_captcha 

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+InvisibleCaptcha.setup do |config|
+  # Disable timestamp check for test environment
+  config.timestamp_enabled = !Rails.env.test?
+end

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-InvisibleCaptcha.setup do |config|
-  # Disable timestamp check for test environment
-  config.timestamp_enabled = !Rails.env.test?
-end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4774,3 +4774,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     pagination:
       next: Next
       previous: Previous
+
+
+  # Gem to prevent bot form submissions
+  invisible_captcha:
+    sentence_for_humans: "If you are human, ignore this field"
+    timestamp_error_message: "Sorry, that was too quick! Please resubmit."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4778,5 +4778,5 @@ See the %{link} to find out more about %{sitename}'s features and to start using
 
   # Gem to prevent bot form submissions
   invisible_captcha:
-    sentence_for_humans: "If you are human, ignore this field"
-    timestamp_error_message: "Sorry, that was too quick! Please resubmit."
+    sentence_for_humans: "Please leave empty"
+    timestamp_error_message: "Please try again after 5 seconds."

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -55,6 +55,9 @@ I18n.exception_handler = proc do |exception, *_|
   raise exception.to_exception
 end
 
+# Disable timestamp check for test environment
+InvisibleCaptcha.timestamp_enabled = false
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{Rails.root.join('spec/fixtures')}"

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -7,7 +7,7 @@ describe Spree::UsersController, type: :controller do
 
   include AuthenticationHelper
 
-  describe "show" do
+  describe "#show" do
     let!(:u1) { create(:user) }
     let!(:u2) { create(:user) }
     let!(:distributor1) { create(:distributor_enterprise) }
@@ -55,7 +55,7 @@ describe Spree::UsersController, type: :controller do
     end
   end
 
-  describe "registered_email" do
+  describe "#registered_email" do
     routes { Openfoodnetwork::Application.routes }
 
     let!(:user) { create(:user) }
@@ -71,16 +71,16 @@ describe Spree::UsersController, type: :controller do
     end
   end
 
-  context '#load_object' do
-    it 'should redirect to signup path if user is not found' do
+  describe '#load_object' do
+    it 'redirects to signup path if user is not found' do
       allow(controller).to receive_messages(spree_current_user: nil)
       put :update, params: { user: { email: 'foobar@example.com' } }
       expect(response).to redirect_to('/login')
     end
   end
 
-  context '#create' do
-    it 'should create a new user' do
+  describe '#create' do
+    it 'creates a new user' do
       post :create,
            params: { user: { email: 'foobar@example.com', password: 'foobar123',
                              password_confirmation: 'foobar123', locale: 'es' } }

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -108,21 +108,6 @@ describe "Authentication" do
             expect(page).to have_content "doesn't match"
           end
 
-          it "Failing to sign up because the user is too quick" do
-            InvisibleCaptcha.timestamp_enabled = true
-            InvisibleCaptcha.timestamp_threshold = 30
-
-            fill_in "Your email", with: "test@foo.com"
-            fill_in "Choose a password", with: "test12345"
-            fill_in "Confirm password", with: "test12345"
-            click_signup_button
-
-            expect(page).to have_content "Sorry, that was too quick! Please resubmit."
-
-            InvisibleCaptcha.timestamp_enabled = false
-            InvisibleCaptcha.timestamp_threshold = 30
-          end
-
           it "Signing up successfully" do
             fill_in "Your email", with: "test@foo.com"
             fill_in "Choose a password", with: "test12345"
@@ -134,6 +119,35 @@ describe "Authentication" do
                                            'your email address. Please open the link to activate ' \
                                            'your account.'
             end.to enqueue_job ActionMailer::MailDeliveryJob
+          end
+
+          describe "invisible_captcha gem" do
+            around do |example|
+              InvisibleCaptcha.timestamp_enabled = true
+              InvisibleCaptcha.timestamp_threshold = 30
+              example.run
+              InvisibleCaptcha.timestamp_enabled = false
+            end
+
+            it "Failing to sign up because the user is too quick" do
+              fill_in "Your email", with: "test@foo.com"
+              fill_in "Choose a password", with: "test12345"
+              fill_in "Confirm password", with: "test12345"
+              click_signup_button
+
+              expect(page).to have_content "Sorry, that was too quick! Please resubmit."
+            end
+
+            it "succeeding after time threshold" do
+              Timecop.travel(30.seconds.from_now) do
+                fill_in "Your email", with: "test@foo.com"
+                fill_in "Choose a password", with: "test12345"
+                fill_in "Confirm password", with: "test12345"
+                click_signup_button
+
+                expect(page).to have_content 'A message with a confirmation link has been sent'
+              end
+            end
           end
         end
 

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -102,7 +102,7 @@ describe "Authentication" do
           end
 
           it "Failing to sign up because password confirmation doesn't match or is blank" do
-            fill_in "Your email", with: user.email
+            fill_in "Your email", with: "test@foo.com"
             fill_in "Choose a password", with: "ForgotToRetype"
             click_signup_button
             expect(page).to have_content "doesn't match"
@@ -112,7 +112,7 @@ describe "Authentication" do
             InvisibleCaptcha.timestamp_enabled = true
             InvisibleCaptcha.timestamp_threshold = 30
 
-            fill_in "Your email", with: user.email
+            fill_in "Your email", with: "test@foo.com"
             fill_in "Choose a password", with: "test12345"
             fill_in "Confirm password", with: "test12345"
             click_signup_button

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -135,7 +135,7 @@ describe "Authentication" do
               fill_in "Confirm password", with: "test12345"
               click_signup_button
 
-              expect(page).to have_content "Sorry, that was too quick! Please resubmit."
+              expect(page).to have_content "Please try again after 5 seconds."
             end
 
             it "succeeding after time threshold" do

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -108,6 +108,21 @@ describe "Authentication" do
             expect(page).to have_content "doesn't match"
           end
 
+          it "Failing to sign up because the user is too quick" do
+            InvisibleCaptcha.timestamp_enabled = true
+            InvisibleCaptcha.timestamp_threshold = 30
+
+            fill_in "Your email", with: user.email
+            fill_in "Choose a password", with: "test12345"
+            fill_in "Confirm password", with: "test12345"
+            click_signup_button
+
+            expect(page).to have_content "Sorry, that was too quick! Please resubmit."
+
+            InvisibleCaptcha.timestamp_enabled = false
+            InvisibleCaptcha.timestamp_threshold = 30
+          end
+
           it "Signing up successfully" do
             fill_in "Your email", with: "test@foo.com"
             fill_in "Choose a password", with: "test12345"

--- a/spec/system/consumer/multilingual_spec.rb
+++ b/spec/system/consumer/multilingual_spec.rb
@@ -27,7 +27,7 @@ describe 'Multilingual' do
       visit root_path
       expect(get_i18n_locale).to eq 'en'
       expect(get_i18n_translation('label_shops')).to eq 'Shops'
-      expect(cookies).to be_empty
+      expect(cookies_name).not_to include('locale')
       expect(page).to have_content 'SHOPS'
 
       visit root_path(locale: 'es')


### PR DESCRIPTION
#### What? Why?

- Closes #12045  <!-- Insert issue number here. -->

Add [invisible captcha](https://github.com/markets/invisible_captcha) as an anti-spam protection.
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit the login page and click on "Sign up" tab
- Register a new user
  --> New user registered without error
- Register a new user under 4s 
  --> You should see an error message : "Sorry, that was too quick! Please resubmit."
- Pretend to be a bot :
   * Inspect the "Sign up now" button and find the "div" with a random name below
   * disable `height` and `width` style, you should now see an input with a label : "If you are a human, ignore this field"
   
![bot_input](https://github.com/openfoodfoundation/openfoodnetwork/assets/40413322/bad44522-3276-4c31-acba-d6338250e5ec)

   * Fill up email, password and the newly revealed input 
   * click on "Sign up now"
     --> Nothing seems to happen, check the user isn't register  

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
