### PR TITLE
Actions dropdown should stay closed after shipping order

### DIFF
--- a/app/views/spree/admin/shared/_order_links.html.haml
+++ b/app/views/spree/admin/shared/_order_links.html.haml
@@ -4,7 +4,7 @@
       %i.icon-check
       = I18n.t 'admin.actions'
       %i{ "data-dropdown-target": "arrow", "data-expanded-class": "icon-caret-up", "data-collapsed-class": "icon-caret-down" }
-    %div.menu{"data-dropdown-target": "menu"}
+    %div.menu.hidden{"data-dropdown-target": "menu"}
       - order_links(@order).each do |link|
         - if link[:name] == t(:ship_order)
           %a.menu_item{ href: link[:url], target: link[:target] || "_self", data: { "modal-link-target-value": dom_id(@order, :ship), "action":  "click->modal-link#open", "controller": "modal-link" } }


### PR DESCRIPTION
A hidden css class for the actions dropdown to stay closed.

#### What? Why?

- Closes #12063 

I looked at the code and I do not know Stimulus and its quirks enough to know exactly why
the dropdown opens itself after the confirmation modal closes itself.

But, from what I have seen in the code and in the test, the component at creation add lines and only then hides itself.
It can be best viewed when testing `rspec spec/system/admin/order_spec.rb:926` ( by putting a binding.pry before click_button 'Ship') : for a short time  actions dropdown is open then almost immediately closes itself).

So, by adding a hidden class, by default the list is closed, therefore even after the confirmation model closes itself, 
it is still closed :)


#### What should we test?
Setup cuprite with headless false
Put a binding.pry before line 929 (click_button 'Ship')
`rspec spec/system/admin/order_spec.rb:926`
By clicking the button Ship then the confirm, the Actions dropdown will now stay closed.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
