### PR TITLE
Remove automatic pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
- yarn pretty-quick --check --staged

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "license": "AGPL-3.0",
   "scripts": {
-    "prepare": "husky install",
     "pretty-quick": "pretty-quick"
   },
   "jest": {
@@ -41,7 +40,6 @@
     "webpack": "~4"
   },
   "devDependencies": {
-    "husky": "^8.0.0",
     "jasmine-core": "~5.1.1",
     "jest": "^27.4.7",
     "karma": "~6.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4542,11 +4542,6 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-husky@^8.0.0:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
-
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION

#### What? Why?

This has been annoying me for a while. It slows down the `git commit` command even when you don't edit any CSS or JS files. It also restricts you when committing work in progress. Most recently, I was just preparing a release on a laptop which wasn't completely set up yet. I had to use `git commit --no-verify` until I installed Ruby, Nodenv, Yarn etc.

In my opinion, the linting should happen in your IDE, not when committing. But you can install your own pre-commit hook if you like.

We still have CI to check all contributions.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
