### PR TITLE
Display a warning when clicking the generate invoice button if an ABN is required but not present

### DIFF
--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -10,6 +10,17 @@ module Spree
         links.join('&nbsp;').html_safe # rubocop:disable Rails/OutputSafety
       end
 
+      def generate_invoice_button(order)
+        if order.distributor.can_invoice?
+          button_link_to t(:create_or_update_invoice), generate_admin_order_invoices_path(@order),
+                         data: { method: 'post' }, icon: 'icon-plus'
+        else
+          button_link_to t(:create_or_update_invoice), "#", data: {
+            confirm: t(:must_have_valid_business_number, enterprise_name: @order.distributor.name)
+          }, icon: 'icon-plus'
+        end
+      end
+
       def line_item_shipment_price(line_item, quantity)
         Spree::Money.new(line_item.price * quantity, currency: line_item.currency)
       end

--- a/app/views/spree/admin/invoices/index.html.haml
+++ b/app/views/spree/admin/invoices/index.html.haml
@@ -11,7 +11,7 @@
 
 - content_for :page_actions do
   - if show_generate_invoice_button?(@order)
-    %li= button_link_to t(:create_or_update_invoice), generate_admin_order_invoices_path(@order), :icon => 'icon-plus', data: { method: 'post' }
+    %li= generate_invoice_button(@order)
   = render partial: 'spree/admin/shared/order_links'
   %li= button_link_to t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,7 +437,7 @@ en:
   cancel_order: "Cancel Order"
   confirm_send_invoice: "An invoice for this order will be sent to the customer. Are you sure you want to continue?"
   confirm_resend_order_confirmation: "Are you sure you want to resend the order confirmation email?"
-  must_have_valid_business_number: "%{enterprise_name} must have a valid ABN before invoices can be sent."
+  must_have_valid_business_number: "%{enterprise_name} must have a valid ABN before invoices can be used."
   invoice: "Invoice"
   invoices: "Invoices"
   file: "File"

--- a/spec/controllers/spree/admin/orders/invoices_spec.rb
+++ b/spec/controllers/spree/admin/orders/invoices_spec.rb
@@ -43,7 +43,7 @@ describe Spree::Admin::OrdersController, type: :controller do
             end.to_not change{ Spree::OrderMailer.deliveries.count }
             expect(response).to redirect_to spree.edit_admin_order_path(order)
             expect(flash[:error])
-              .to eq "#{distributor.name} must have a valid ABN before invoices can be sent."
+              .to eq "#{distributor.name} must have a valid ABN before invoices can be used."
           end
         end
 

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -727,14 +727,14 @@ describe '
                 click_link "Print Invoice"
               end
               expect(message)
-                .to eq "#{distributor1.name} must have a valid ABN before invoices can be sent."
+                .to eq "#{distributor1.name} must have a valid ABN before invoices can be used."
 
               find("#links-dropdown .ofn-drop-down").click
               message = accept_prompt do
                 click_link "Send Invoice"
               end
               expect(message)
-                .to eq "#{distributor1.name} must have a valid ABN before invoices can be sent."
+                .to eq "#{distributor1.name} must have a valid ABN before invoices can be used."
             end
           end
         end
@@ -1172,6 +1172,7 @@ describe '
           }
 
           before do
+            Spree::Config[:enterprise_number_required_on_invoices?] = false
             visit spree.admin_order_invoices_path(order1)
           end
 
@@ -1196,6 +1197,22 @@ describe '
             # with a valid invoice download link
             expect(page).to have_link("Download",
                                       href: download_href)
+          end
+
+          context "the Create or Update Invoice button" do
+            context "when an ABN number is mandatory for invoices but not present" do
+              before do
+                Spree::Config[:enterprise_number_required_on_invoices?] = true
+              end
+
+              it "displays a warning that an ABN is required when it's clicked" do
+                visit spree.admin_order_invoices_path(order1)
+                message = accept_prompt { click_link "Create or Update Invoice" }
+                distributor = order1.distributor
+                expect(message)
+                  .to eq "#{distributor.name} must have a valid ABN before invoices can be used."
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
#### What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/11940

#### What should we test?

See #11940

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled (under `invoices`)