### PR TITLE
Force start date before end date with range mode flatpickr

### DIFF
--- a/app/views/admin/reports/_date_range_form.html.haml
+++ b/app/views/admin/reports/_date_range_form.html.haml
@@ -6,7 +6,7 @@
 
 .row.date-range-filter
   .alpha.two.columns= label_tag nil, t(:date_range)
-  .omega.fourteen.columns{ data: { controller: "flatpickr", "flatpickr-mode-value": "range" } }
+  .omega.fourteen.columns{ data: { controller: "flatpickr", "flatpickr-mode-value": "range", "flatpickr-enable-time-value": true , "flatpickr-default-hour": 0 } }
     = text_field_tag nil, nil, class: "datepicker", data: { "flatpickr-target": "instance", action: "flatpickr_clear@window->flatpickr#clear" }
     = text_field_tag "q[#{field}_gt]", nil, data: { "flatpickr-target": "start" }, style: "display: none", value: start_date
     = text_field_tag "q[#{field}_lt]", nil, data: { "flatpickr-target": "end" }, style: "display: none", value: end_date

--- a/app/views/admin/reports/_date_range_form.html.haml
+++ b/app/views/admin/reports/_date_range_form.html.haml
@@ -6,8 +6,7 @@
 
 .row.date-range-filter
   .alpha.two.columns= label_tag nil, t(:date_range)
-  .omega.fourteen.columns
-    = f.text_field "#{field}_gt", :class => 'datetimepicker datepicker-from', :placeholder => t(:start), data: { controller: "flatpickr", "flatpickr-enable-time-value": true, "flatpickr-default-date-value": "startOfDay" }, value: start_date 
-    %span.range-divider
-      %i.icon-arrow-right
-    = f.text_field "#{field}_lt", :class => 'datetimepicker datepicker-to', :placeholder => t(:stop), data: { controller: "flatpickr", "flatpickr-enable-time-value": true, "flatpickr-default-date-value": "endOfDay" }, value: end_date 
+  .omega.fourteen.columns{ data: { controller: "flatpickr", "flatpickr-mode-value": "range" } }
+    = text_field_tag nil, nil, class: "datepicker", data: { "flatpickr-target": "instance", action: "flatpickr_clear@window->flatpickr#clear" }
+    = text_field_tag "q[#{field}_gt]", nil, data: { "flatpickr-target": "start" }, style: "display: none", value: start_date
+    = text_field_tag "q[#{field}_lt]", nil, data: { "flatpickr-target": "end" }, style: "display: none", value: end_date

--- a/app/views/admin/reports/_date_range_form.html.haml
+++ b/app/views/admin/reports/_date_range_form.html.haml
@@ -6,7 +6,9 @@
 
 .row.date-range-filter
   .alpha.two.columns= label_tag nil, t(:date_range)
-  .omega.fourteen.columns{ data: { controller: "flatpickr", "flatpickr-mode-value": "range", "flatpickr-enable-time-value": true , "flatpickr-default-hour": 0 } }
-    = text_field_tag nil, nil, class: "datepicker", data: { "flatpickr-target": "instance", action: "flatpickr_clear@window->flatpickr#clear" }
-    = text_field_tag "q[#{field}_gt]", nil, data: { "flatpickr-target": "start" }, style: "display: none", value: start_date
-    = text_field_tag "q[#{field}_lt]", nil, data: { "flatpickr-target": "end" }, style: "display: none", value: end_date
+  .omega.fourteen.columns
+    .field-block.omega.four.columns
+      .date-range-fields{ data: { controller: "flatpickr", "flatpickr-mode-value": "range", "flatpickr-enable-time-value": true , "flatpickr-default-hour": 0 } }
+        = text_field_tag nil, nil, class: "datepicker fullwidth", data: { "flatpickr-target": "instance", action: "flatpickr_clear@window->flatpickr#clear" }
+        = text_field_tag "q[#{field}_gt]", nil, data: { "flatpickr-target": "start" }, style: "display: none", value: start_date
+        = text_field_tag "q[#{field}_lt]", nil, data: { "flatpickr-target": "end" }, style: "display: none", value: end_date

--- a/spec/system/admin/reports/orders_and_fulfillment_spec.rb
+++ b/spec/system/admin/reports/orders_and_fulfillment_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe "Orders And Fulfillment" do
           # with a timeframe that includes one order but not the other
           find("input.datepicker").click
           select_dates_from_daterangepicker datetime_start1, datetime_end
+          find(".shortcut-buttons-flatpickr-button").click # closes flatpickr
 
           find("#display_summary_row").set(false) # hides the summary rows
           run_report

--- a/spec/system/admin/reports/orders_and_fulfillment_spec.rb
+++ b/spec/system/admin/reports/orders_and_fulfillment_spec.rb
@@ -125,8 +125,8 @@ RSpec.describe "Orders And Fulfillment" do
         it "is precise to time of day, not just date" do
           # When I generate a customer report
           # with a timeframe that includes one order but not the other
-          pick_datetime "#q_completed_at_gt", datetime_start1
-          pick_datetime "#q_completed_at_lt", datetime_end
+          find("input.datepicker").click
+          select_dates_from_daterangepicker datetime_start1, datetime_end
 
           find("#display_summary_row").set(false) # hides the summary rows
           run_report
@@ -141,7 +141,8 @@ RSpec.describe "Orders And Fulfillment" do
           # 2 rows for order1 + 1 summary row
 
           # setting a time interval to include both orders
-          pick_datetime "#q_completed_at_gt", datetime_start2
+          find("input.datepicker").click
+          select_dates_from_daterangepicker datetime_start2, Time.zone.now
           run_report
           # Then I should see the rows for both orders
           expect(all('table.report__table tbody tr').count).to eq(5)


### PR DESCRIPTION
  - modify view to get a flatpickr component in range mode
  - modify spec to take into account range mode

#### What? Why?

- Closes #11424 

By using the `flatpickr` component(node module + stimulus), to execute in range mode, we force the user to use consecutive dates. That is: a start date, then an end date.
This mode is already in use in the orders part of the admin.
The change is also effective to every reports since the datepickr is shared between all report views.

#### What should we test?

- Visit any report page, and see the datepicker is now only one input and pop-up component that compels to chose a range of date in proper order.
- also, the automated spec `orders_and_fulfillment_spec.rb` simulate the picking of dates in this new mode.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
