### PR TITLE
Modify default hash tabs controller to redirect users to shopping panel when an OC is selected.

### DIFF
--- a/app/helpers/shop_helper.rb
+++ b/app/helpers/shop_helper.rb
@@ -22,7 +22,7 @@ module ShopHelper
       { name: 'home', title: t(:shopping_tabs_home), show: show_home_tab?,
         default: show_home_tab? },
       { name: 'shop', title: t(:shopping_tabs_shop), show: !require_customer?,
-        default: !show_home_tab? },
+        default: !show_home_tab?, shop: true },
       { name: 'about', title: t(:shopping_tabs_about), show: true },
       { name: 'producers', title: t(:shopping_tabs_producers), show: true },
       { name: 'contact', title: t(:shopping_tabs_contact), show: true },

--- a/app/views/shopping_shared/_tabs.html.haml
+++ b/app/views/shopping_shared/_tabs.html.haml
@@ -1,6 +1,6 @@
 - if (@order&.distributor || current_distributor) == current_distributor
 
-  #shop-tabs{"data-controller": "tabs-and-panels", "data-action": "orderCycleSelected@window->tabs-and-panels#activateDefaultPanel", "data-tabs-and-panels-class-name-value": "selected"}
+  #shop-tabs{"data-controller": "tabs-and-panels", "data-action": "orderCycleSelected@window->tabs-and-panels#activateShopPanel", "data-tabs-and-panels-class-name-value": "selected"}
     .tab-buttons
       .flex.row
         .columns.small-12.large-8
@@ -10,7 +10,7 @@
         .columns.large-4.show-for-large-up
           = render partial: "shopping_shared/order_cycles"
     - shop_tabs.each do |tab|
-      %div{id: "#{tab[:name]}_panel", "data-tabs-and-panels-target": "panel #{'default' if tab[:default]}" } 
+      %div{id: "#{tab[:name]}_panel", "data-tabs-and-panels-target": "panel #{'default' if tab[:default]} #{'shop' if tab[:shop]}" } 
         .page-view
           - if tab[:custom]
             = render "shopping_shared/tabs/custom"

--- a/app/webpacker/controllers/tabs_and_panels_controller.js
+++ b/app/webpacker/controllers/tabs_and_panels_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "stimulus";
 
 export default class extends Controller {
-  static targets = ["tab", "panel", "default"];
+  static targets = ["tab", "panel", "default", "shop"];
   static values = { className: String };
 
   connect() {
@@ -29,6 +29,10 @@ export default class extends Controller {
 
   activateDefaultPanel() {
     this._activateByHash(`#${this.defaultTarget.id}`);
+  }
+
+  activateShopPanel() {
+    this._activateByHash(`#${this.shopTarget.id}`);
   }
 
   _activateByHash(hash) {

--- a/spec/system/consumer/shopping/shopping_spec.rb
+++ b/spec/system/consumer/shopping/shopping_spec.rb
@@ -165,7 +165,6 @@ describe "As a consumer I want to shop with a distributor" do
         let(:exchange2) { oc2.exchanges.to_enterprises(distributor).outgoing.first }
 
         before do
-          pending("Issue #12076")
           exchange1.update_attribute :pickup_time, "frogs"
           exchange2.update_attribute :pickup_time, "turtles"
           distributor.update!(preferred_shopfront_message: "Hello!")
@@ -176,7 +175,7 @@ describe "As a consumer I want to shop with a distributor" do
 
           expect(page).to have_selector "option", text: 'frogs'
           expect(page).to have_selector "option", text: 'turtles'
-          expect(page).to have_content "choose when you want your order"
+          expect(page).to have_content "Choose when you want your order:"
           expect(page).not_to have_selector("input.button.right")
         end
 


### PR DESCRIPTION
#### What? Why?

- Closes #12076  

The activateDefaultPanel function takes the user to the default page, when a home_panel is added, it is set as the default page instead of the shop_panel.

#### What should we test?
see #12076 



