### PR TITLE
Optimise stock

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -154,6 +154,6 @@ module VariantStock
   # There shouldn't be any other stock items, because we should
   # have only one stock location.
   def stock_item
-    @stock_item ||= stock_items.first
+    stock_items.first
   end
 end

--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -154,6 +154,6 @@ module VariantStock
   # There shouldn't be any other stock items, because we should
   # have only one stock location.
   def stock_item
-    stock_items.first
+    @stock_item ||= stock_items.first
   end
 end

--- a/app/models/spree/stock/quantifier.rb
+++ b/app/models/spree/stock/quantifier.rb
@@ -15,7 +15,7 @@ module Spree
         # may still be in an active cart after it's deleted, so this will mark it as out of stock.
         return 0 if @variant.deleted?
 
-        stock_items.sum(:count_on_hand)
+        @total_on_hand ||= stock_items.sum(:count_on_hand)
       end
 
       def backorderable?

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -202,7 +202,7 @@ module Spree
     end
 
     def total_on_hand
-      Spree::Stock::Quantifier.new(self).total_on_hand
+      quantifier.total_on_hand
     end
 
     private
@@ -255,6 +255,10 @@ module Spree
 
     def convert_variant_weight_to_decimal
       self.weight = weight.to_d
+    end
+
+    def quantifier
+      @quantifier ||= Spree::Stock::Quantifier.new(self)
     end
   end
 end

--- a/spec/models/spree/stock/quantifier_spec.rb
+++ b/spec/models/spree/stock/quantifier_spec.rb
@@ -5,6 +5,8 @@ require 'spec_helper'
 module Spree
   module Stock
     describe Quantifier do
+      include DatabaseHelper
+
       let(:quantifier) { Spree::Stock::Quantifier.new(variant) }
       let(:variant) { create(:variant, on_hand: 99) }
 
@@ -16,6 +18,17 @@ module Spree
 
           it "returns zero stock for the variant" do
             expect(quantifier.total_on_hand).to eq 0
+          end
+        end
+      end
+
+      describe "#backorderable" do
+        describe "eager-loading stock_items" do
+          it "doesn't create extra query for stock_items" do
+            variant_loaded = Variant.where(id: variant).includes(:stock_items).first
+            expect do
+              Spree::Stock::Quantifier.new(variant_loaded).backorderable?
+            end.to query_database []
           end
         end
       end

--- a/spec/models/spree/stock/quantifier_spec.rb
+++ b/spec/models/spree/stock/quantifier_spec.rb
@@ -20,6 +20,16 @@ module Spree
             expect(quantifier.total_on_hand).to eq 0
           end
         end
+
+        it "doesn't create extra query on subsequent calls" do
+          quantifier
+          expect do
+            quantifier.total_on_hand
+            quantifier.total_on_hand
+          end.to query_database [
+            "Spree::StockItem Sum"
+          ]
+        end
       end
 
       describe "#backorderable" do

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 require 'spree/localized_number'
 
 describe Spree::Variant do
+  include DatabaseHelper
+
   subject(:variant) { build(:variant) }
 
   context "validations" do
@@ -244,9 +246,20 @@ describe Spree::Variant do
   end
 
   describe '#total_on_hand' do
+    let!(:variant){ build :variant }
+
     it 'matches quantifier total_on_hand' do
-      variant = build(:variant)
       expect(variant.total_on_hand).to eq(Spree::Stock::Quantifier.new(variant).total_on_hand)
+    end
+
+    it "minimises database queries for subsequent calls" do
+      expect do
+        variant.total_on_hand
+        pending "it generates a query for each call"
+        variant.total_on_hand
+      end.to query_database [
+        "Spree::StockItem Sum"
+      ]
     end
   end
 

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -252,7 +252,7 @@ describe Spree::Variant do
       expect(variant.total_on_hand).to eq(Spree::Stock::Quantifier.new(variant).total_on_hand)
     end
 
-    it "minimises database queries for subsequent calls" do
+    it "doesn't make additional db queries for subsequent calls" do
       expect do
         variant.total_on_hand
         pending "it generates a query for each call"

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -255,7 +255,6 @@ describe Spree::Variant do
     it "doesn't make additional db queries for subsequent calls" do
       expect do
         variant.total_on_hand
-        pending "it generates a query for each call"
         variant.total_on_hand
       end.to query_database [
         "Spree::StockItem Sum"

--- a/spec/support/database_helper.rb
+++ b/spec/support/database_helper.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module DatabaseHelper
+  extend RSpec::Matchers::DSL
+
+  matcher :query_database do |expected = nil| # rubocop:disable Metrics/BlockLength
+    match do |block|
+      @queries = scribe_queries(&block)
+
+      if expected.nil?
+        !@queries.empty?
+      elsif expected.is_a?(Integer)
+        @queries.size == expected
+      elsif expected.is_a?(Array)
+        query_names == expected
+      else
+        raise "What are you expecting?"
+      end
+    end
+
+    failure_message do |_block|
+      <<~MESSAGE
+        Expected database queries: #{expected}
+        Actual database queries:   #{query_names}
+
+        Diff: #{RSpec::Expectations.differ.diff_as_object(query_names, expected)}
+
+        Full query log:
+
+        #{query_descriptions.join("\n")}
+      MESSAGE
+    end
+
+    failure_message_when_negated do |_block|
+      "Expected no database queries but observed:\n\n#{query_descriptions.join("\n")}"
+    end
+
+    def supports_block_expectations?
+      true
+    end
+
+    def query_names
+      @queries.map { |q| q[:name] || q[:sql].split.take(2).join(" ") }
+    end
+
+    def query_descriptions
+      @queries.map { |q| "#{q[:name]}  #{q[:sql]}" }
+    end
+
+    def scribe_queries(&)
+      queries = []
+
+      logger = ->(_name, _started, _finished, _unique_id, payload) {
+        queries << payload unless payload[:name].in? %w[CACHE SCHEMA]
+      }
+
+      ActiveSupport::Notifications.subscribed(logger, "sql.active_record", &)
+
+      queries
+    end
+  end
+
+  def expect_query_count(&)
+    expect(count_db_queries(&))
+  end
+
+  def count_db_queries(&)
+    count = 0
+
+    counter_f = ->(_name, _started, _finished, _unique_id, payload) {
+      count += 1 unless payload[:name].in? %w[CACHE SCHEMA]
+    }
+
+    ActiveSupport::Notifications.subscribed(counter_f, "sql.active_record", &)
+
+    count
+  end
+end


### PR DESCRIPTION
#### What? Why?
While trying to replicate a performance issue, I noticed a lot of repeated queries when loading the v3 admin products list.

So I thought I'd try optimising these, and specced an existing optimisation. 

Is it over-optimising? Maybe. The queries were cached by AR already, but I think this still reduces unnecessary processing.
Is it safe to cache? I'm confident that specs would raise any issues. And they did...
 * Caching the result of the count_on_hand `sum` was a bad idea so I reverted it, but left in the history to share my learnings.
 * Caching the `stock_item` only caused a couple of spec failures, so I wondered if maybe those cases could be updated (eg with a `reload`). But that might be fruitless and I shouldn't waste anymore time!


Do other devs agrees that automated specs are enough for testing?

#### What should we test?

Green specs.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
