### PR TITLE
Fix Customer Search Autofill Issue

### DIFF
--- a/app/webpacker/controllers/mixins/useSearchCustomer.js
+++ b/app/webpacker/controllers/mixins/useSearchCustomer.js
@@ -9,7 +9,7 @@ export const useSearchCustomer = (controller) => {
       fetch("/admin/search/customers.json?" + new URLSearchParams(params))
         .then((response) => response.json())
         .then((json) => {
-          this.items = json;
+          this.items = [...this.items, ...json];
           callback(json);
         })
         .catch((error) => {

--- a/app/webpacker/controllers/select_customer_controller.js
+++ b/app/webpacker/controllers/select_customer_controller.js
@@ -6,6 +6,7 @@ export default class extends TomSelectController {
   static values = { options: Object, distributor: Number };
 
   connect() {
+    this.items = [];
     useSearchCustomer(this);
     useRenderCustomer(this);
     const options = {
@@ -20,7 +21,6 @@ export default class extends TomSelectController {
     };
     super.connect(options);
     this.control.on("item_add", this.onItemSelect.bind(this));
-    this.items = [];
   }
 
   onItemSelect(id, item) {


### PR DESCRIPTION
#### What? Why?

- Closes #12085

**Issue**
- There's an edge case where `this.items `might not have the selected customer
https://github.com/openfoodfoundation/openfoodnetwork/blob/a6431bdec62b016f2c2a010d0e6a115aa8a44ffc/app/webpacker/controllers/select_customer_controller.js#L27
- This is because we are always replacing `this.items` with the latest search results.
- As shown in the [repro steps]( https://github.com/openfoodfoundation/openfoodnetwork/issues/12085#issuecomment-1922102301
), if no value is being searched, then the dropdown displays all the previous search results as well
- This PR merges the latest search results into `this.items` so that we always have all the searched items in `this.items` hence mitigates the case where the selected customer might not be present in `this.items`
#### What should we test?
- Steps as explained here:
  - https://github.com/openfoodfoundation/openfoodnetwork/issues/12085#issuecomment-1922102301

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
