### PR TITLE
Make sure fees are applied when adding the first item to a back office order

### DIFF
--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -23,6 +23,8 @@ module Api
 
         OrderWorkflow.new(@order).advance_to_payment if @order.line_items.any?
 
+        @order.recreate_all_fees!
+
         render json: @shipment, serializer: Api::ShipmentSerializer, status: :ok
       end
 

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -91,6 +91,18 @@ describe Api::V0::ShipmentsController, type: :controller do
 
         expect_error_response
       end
+
+      it "applies any enterprise fees that are present" do
+        order_cycle = create(:simple_order_cycle,
+                             coordinator: order.distributor,
+                             coordinator_fees: [create(:enterprise_fee, amount: 20)],
+                             distributors: [order.distributor],
+                             variants: [variant])
+        order.update!(order_cycle_id: order_cycle.id)
+        spree_post :create, params
+
+        expect(order.line_item_adjustments.where(originator_type: "EnterpriseFee")).to be_present
+      end
     end
 
     it "can make a shipment ready" do


### PR DESCRIPTION
#### What? Why?

- Closes #5567 

#### What should we test?

1. Go to _Admin > Orders > New order_
2. Create an order for an enterprise which has an enterprise fee and press _Next_
3. Click the _Order Details_ link
4. Add the first line item and notice that no fees are added. The fees are only added when you add a second line item.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled