### PR TITLE
Fix gem dependency declaration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'rswag-ui'
 
 gem 'omniauth_openid_connect'
 gem 'omniauth-rails_csrf_protection'
-gem 'openid_connect', '~> 1.3'
+gem 'openid_connect'
 
 gem 'angularjs-rails', '1.8.0'
 gem 'bugsnag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -882,7 +882,7 @@ DEPENDENCIES
   oauth2 (~> 1.4.7)
   omniauth-rails_csrf_protection
   omniauth_openid_connect
-  openid_connect (~> 1.3)
+  openid_connect
   order_management!
   pagy (~> 5.1)
   paper_trail


### PR DESCRIPTION


#### What? Why?

Dependabot updated openid_connect despite this being restricted in our Gemfile. Now, all future updates downgrade openid_connect again to satisfy our requested version.

I couldn't find any good reason not to upgrade openid_connect though and since that's the version we already have, let's keep it and just remove the restriction. Then bundler doesn't downgrade any more and updates are performed well.

* Addresses https://github.com/openfoodfoundation/openfoodnetwork/pull/12113#pullrequestreview-1864122816
#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
