### PR TITLE
Fix capturing order payment ignore order changes

### DIFF
--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -38,13 +38,6 @@ module OrderManagement
         update_pending_payment
       end
 
-      def update_pending_payment
-        return unless order.state.in? ["payment", "confirmation"]
-        return unless order.pending_payments.any?
-
-        order.pending_payments.first.update_attribute :amount, order.total
-      end
-
       # Updates the following Order total values:
       #
       # - payment_total - total value of all finalized Payments (excludes non-finalized Payments)
@@ -238,6 +231,13 @@ module OrderManagement
 
       def requires_authorization?
         payments.requires_authorization.any? && payments.completed.empty?
+      end
+
+      def update_pending_payment
+        return unless order.state.in? ["payment", "confirmation"]
+        return unless order.pending_payments.any?
+
+        order.pending_payments.first.update_attribute :amount, order.total
       end
     end
   end

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -234,7 +234,10 @@ module OrderManagement
       end
 
       def update_pending_payment
-        return unless order.state.in? ["payment", "confirmation"]
+        # We only want to update complete order pending payment when it's a cash payment. We assume
+        # that if the payment was a credit card it would alread have been processed, so we don't
+        # bother checking the payment type
+        return unless order.state.in? ["payment", "confirmation", "complete"]
         return unless order.pending_payments.any?
 
         order.pending_payments.first.update_attribute :amount, order.total

--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -8,7 +8,7 @@ module OrderManagement
       let(:order) { create(:order) }
       let(:updater) { OrderManagement::Order::Updater.new(order) }
 
-      context "updating order totals" do
+      describe "#update_totals" do
         before do
           2.times { create(:line_item, order:, price: 10) }
         end
@@ -19,10 +19,22 @@ module OrderManagement
           updater.update_totals
           expect(order.payment_total).to eq(10)
         end
+      end
+
+      describe "#update_item_total" do
+        before do
+          2.times { create(:line_item, order:, price: 10) }
+        end
 
         it "updates item total" do
           updater.update_item_total
           expect(order.item_total).to eq(20)
+        end
+      end
+
+      describe "#update_adjustment_total" do
+        before do
+          2.times { create(:line_item, order:, price: 10) }
         end
 
         it "updates adjustment totals" do
@@ -40,7 +52,7 @@ module OrderManagement
         end
       end
 
-      context "updating shipment state" do
+      describe "#update_shipment_state" do
         let(:shipment) { build(:shipment) }
 
         before do
@@ -85,18 +97,110 @@ module OrderManagement
         order.state_changed('shipment')
       end
 
-      context "completed order" do
+      describe "#update" do
+        it "updates totals once" do
+          expect(updater).to receive(:update_totals).once
+          updater.update
+        end
+
+        it "updates all adjustments" do
+          expect(updater).to receive(:update_all_adjustments)
+          updater.update
+        end
+
+        context "completed order" do
+          before { allow(order).to receive(:completed?) { true } }
+
+          it "updates payment state" do
+            expect(updater).to receive(:update_payment_state)
+            updater.update
+          end
+
+          it "updates shipment state" do
+            expect(updater).to receive(:update_shipment_state)
+            updater.update
+          end
+
+          context "whith pending payments" do
+            let(:order) { create(:completed_order_with_totals) }
+
+            it "updates pending payments" do
+              payment = create(:payment, order:, amount: order.total)
+
+              # update order so the order total will change
+              update_order_quantity(order)
+              order.payments.reload
+
+              expect { updater.update }.to change { payment.reload.amount }.from(50).to(60)
+            end
+          end
+        end
+
+        context "incompleted order" do
+          before { allow(order).to receive_messages completed?: false }
+
+          it "doesnt update payment state" do
+            expect(updater).not_to receive(:update_payment_state)
+            updater.update
+          end
+
+          it "doesnt update shipment state" do
+            expect(updater).not_to receive(:update_shipment_state)
+            updater.update
+          end
+
+          it "doesnt update the order shipment" do
+            shipment = build(:shipment)
+            allow(order).to receive_messages shipments: [shipment]
+
+            expect(shipment).not_to receive(:update!).with(order)
+            expect(updater).not_to receive(:update_shipments).with(order)
+            updater.update
+          end
+
+          context "with pending payments" do
+            let!(:payment) { create(:payment, order:, amount: order.total) }
+
+            context "with order in payment state" do
+              let(:order) { create(:order_with_totals, state: "payment") }
+
+              it "updates pending payments" do
+                # update order so the order total will change
+                update_order_quantity(order)
+                order.payments.reload
+
+                expect { updater.update }.to change { payment.reload.amount }.from(10).to(20)
+              end
+            end
+
+            context "with order in confirmation state" do
+              let(:order) { create(:order_with_totals, state: "confirmation") }
+
+              it "updates pending payments" do
+                # update order so the order total will change
+                update_order_quantity(order)
+                order.payments.reload
+
+                expect { updater.update }.to change { payment.reload.amount }.from(10).to(20)
+              end
+            end
+
+            context "with order in cart" do
+              let(:order) { create(:order_with_totals) }
+
+              it "doesn't update pending payments" do
+                # update order so the order total will change
+                update_order_quantity(order)
+
+                expect { updater.update }.not_to change { payment.reload.amount }
+              end
+            end
+          end
+        end
+      end
+
+      describe "#update_shipments" do
         before { allow(order).to receive(:completed?) { true } }
-
-        it "updates payment state" do
-          expect(updater).to receive(:update_payment_state)
-          updater.update
-        end
-
-        it "updates shipment state" do
-          expect(updater).to receive(:update_shipment_state)
-          updater.update
-        end
 
         it "updates the order shipment" do
           shipment = build(:shipment)
@@ -105,93 +209,6 @@ module OrderManagement
           expect(shipment).to receive(:update!).with(order)
           updater.update_shipments
         end
-
-        context "whith pending payments" do
-          let(:order) { create(:completed_order_with_totals) }
-
-          it "updates pending payments" do
-            payment = create(:payment, order: , amount: order.total)
-
-            # update order so the order total will change
-            update_order_quantity(order)
-            order.payments.reload
-
-            expect { updater.update }.to change { payment.reload.amount }.from(50).to(60)
-          end
-        end
-      end
-
-      context "incompleted order" do
-        before { allow(order).to receive_messages completed?: false }
-
-        it "doesnt update payment state" do
-          expect(updater).not_to receive(:update_payment_state)
-          updater.update
-        end
-
-        it "doesnt update shipment state" do
-          expect(updater).not_to receive(:update_shipment_state)
-          updater.update
-        end
-
-        it "doesnt update the order shipment" do
-          shipment = build(:shipment)
-          allow(order).to receive_messages shipments: [shipment]
-
-          expect(shipment).not_to receive(:update!).with(order)
-          expect(updater).not_to receive(:update_shipments).with(order)
-          updater.update
-        end
-
-        context "with pending payments" do
-          let!(:payment) { create(:payment, order: , amount: order.total) }
-
-          context "with order in payment state" do
-            let(:order) { create(:order_with_totals, state: "payment") }
-
-            it "updates pending payments" do
-              # update order so the order total will change
-              update_order_quantity(order)
-              order.payments.reload
-
-              expect { updater.update }.to change { payment.reload.amount }.from(10).to(20)
-            end
-          end
-
-          context "with order in confirmation state" do
-            let(:order) { create(:order_with_totals, state: "confirmation") }
-
-            it "updates pending payments" do
-              # update order so the order total will change
-              update_order_quantity(order)
-              order.payments.reload
-
-              expect { updater.update }.to change { payment.reload.amount }.from(10).to(20)
-            end
-
-          end
-
-          context "with order in cart" do
-            let(:order) { create(:order_with_totals) }
-
-            it "doesn't update pending payments" do
-              # update order so the order total will change
-              update_order_quantity(order)
-
-              expect { updater.update }.not_to change { payment.reload.amount }
-            end
-          end
-        end
-      end
-
-      it "updates totals once" do
-        expect(updater).to receive(:update_totals).once
-        updater.update
-      end
-
-      it "updates all adjustments" do
-        expect(updater).to receive(:update_all_adjustments)
-        updater.update
       end
 
       describe "#update_payment_state" do
@@ -331,9 +348,28 @@ module OrderManagement
             end
           end
         end
+
+        context "when unused payments records exist which require authorization, " \
+                "but the order is fully paid" do
+          let!(:cash_payment) {
+            build(:payment, state: "completed", amount: order.new_outstanding_balance)
+          }
+          let!(:stripe_payment) { build(:payment, state: "requires_authorization") }
+          before do
+            order.payments << cash_payment
+            order.payments << stripe_payment
+          end
+
+          it "cancels unused payments requiring authorization" do
+            expect(stripe_payment).to receive(:void_transaction!)
+            expect(cash_payment).to_not receive(:void_transaction!)
+
+            order.updater.update_payment_state
+          end
+        end
       end
 
-      context '#shipping_address_from_distributor' do
+      describe '#shipping_address_from_distributor' do
         let(:distributor) { build(:distributor_enterprise) }
         let(:shipment) {
           create(:shipment_with, :shipping_method, shipping_method:)
@@ -367,68 +403,47 @@ module OrderManagement
         end
       end
 
-      describe "updating order totals" do
-        describe "#update_totals_and_states" do
-          it "deals with legacy taxes" do
-            expect(updater).to receive(:handle_legacy_taxes)
+      describe "#update_totals_and_states" do
+        it "deals with legacy taxes" do
+          expect(updater).to receive(:handle_legacy_taxes)
 
-            updater.update_totals_and_states
+          updater.update_totals_and_states
+        end
+      end
+
+      describe "#handle_legacy_taxes" do
+        context "when the order is incomplete" do
+          it "doesn't touch taxes" do
+            allow(order).to receive(:completed?) { false }
+
+            expect(order).to_not receive(:create_tax_charge!)
+            updater.__send__(:handle_legacy_taxes)
           end
         end
 
-        describe "#handle_legacy_taxes" do
-          context "when the order is incomplete" do
-            it "doesn't touch taxes" do
-              allow(order).to receive(:completed?) { false }
+        context "when the order is complete" do
+          before { allow(order).to receive(:completed?) { true } }
 
-              expect(order).to_not receive(:create_tax_charge!)
+          context "and the order has legacy taxes" do
+            let!(:legacy_tax_adjustment) {
+              create(:adjustment, order:, adjustable: order, included: false,
+                                  originator_type: "Spree::TaxRate")
+            }
+
+            it "re-applies order taxes" do
+              expect(order).to receive(:create_tax_charge!)
+
               updater.__send__(:handle_legacy_taxes)
             end
           end
 
-          context "when the order is complete" do
-            before { allow(order).to receive(:completed?) { true } }
+          context "and the order has no legacy taxes" do
+            it "leaves taxes untouched" do
+              expect(order).to_not receive(:create_tax_charge!)
 
-            context "and the order has legacy taxes" do
-              let!(:legacy_tax_adjustment) {
-                create(:adjustment, order:, adjustable: order, included: false,
-                                    originator_type: "Spree::TaxRate")
-              }
-
-              it "re-applies order taxes" do
-                expect(order).to receive(:create_tax_charge!)
-
-                updater.__send__(:handle_legacy_taxes)
-              end
-            end
-
-            context "and the order has no legacy taxes" do
-              it "leaves taxes untouched" do
-                expect(order).to_not receive(:create_tax_charge!)
-
-                updater.__send__(:handle_legacy_taxes)
-              end
+              updater.__send__(:handle_legacy_taxes)
             end
           end
-        end
-      end
-
-      context "when unused payments records exist which require authorization, " \
-              "but the order is fully paid" do
-        let!(:cash_payment) {
-          build(:payment, state: "completed", amount: order.new_outstanding_balance)
-        }
-        let!(:stripe_payment) { build(:payment, state: "requires_authorization") }
-        before do
-          order.payments << cash_payment
-          order.payments << stripe_payment
-        end
-
-        it "cancels unused payments requiring authorization" do
-          expect(stripe_payment).to receive(:void_transaction!)
-          expect(cash_payment).to_not receive(:void_transaction!)
-
-          order.updater.update_payment_state
         end
       end
 

--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -105,6 +105,20 @@ module OrderManagement
           expect(shipment).to receive(:update!).with(order)
           updater.update_shipments
         end
+
+        context "whith pending payments" do
+          let(:order) { create(:completed_order_with_totals) }
+
+          it "updates pending payments" do
+            payment = create(:payment, order: , amount: order.total)
+
+            # update order so the order total will change
+            update_order_quantity(order)
+            order.payments.reload
+
+            expect { updater.update }.to change { payment.reload.amount }.from(50).to(60)
+          end
+        end
       end
 
       context "incompleted order" do

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -239,8 +239,11 @@ describe SubscriptionConfirmJob do
 
         context "when payments are processed without error" do
           before do
-            expect(payment).to receive(:process_offline!) { true }
-            expect(payment).to receive(:completed?) { true }
+            allow(payment).to receive(:process_offline!) do
+              # Mark payment as complete like it would be if sucessfully processed offline
+              payment.state = "complete"
+              true
+            end
           end
 
           it "sends only a subscription confirm email, no regular confirmation emails" do


### PR DESCRIPTION
#### What? Why?

- Closes #9290

Previously only non completed order would have their pending payment updated when `OrderManagement::Order::Updater#update` was called. That means if a completed order was updated, the pending payment wasn't getting updated, resulting in the issue. Now we allow updating pending payment for completed order as well.
It is assumed that credit card order would already have been processed at checkout, to this should fix the issue for cash payment only.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


- As a customer place an order.
- As enterprise user edit that order, i.e. change the shipping method to a method with a different fee.
- As enterprise user capture the payment on the orders listing page.
- The payment state should now be "Paid ($0.00)"

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
The User guide should be updated to reflect this change : https://guide.openfoodnetwork.org/basic-features/orders/view-orders#capturing-a-payment

<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
