### PR TITLE
[DFC] Add state to address 

### DIFF
--- a/engines/dfc_provider/app/services/address_builder.rb
+++ b/engines/dfc_provider/app/services/address_builder.rb
@@ -2,12 +2,13 @@
 
 class AddressBuilder < DfcBuilder
   def self.address(address)
-    DataFoodConsortium::Connector::Address.new(
+    DfcProvider::Address.new(
       urls.address_url(address),
       street: address.address1,
       postalCode: address.zipcode,
       city: address.city,
-      country: address.country.name
+      country: address.country.name,
+      region: address.state.name
     )
   end
 end

--- a/engines/dfc_provider/lib/dfc_provider.rb
+++ b/engines/dfc_provider/lib/dfc_provider.rb
@@ -8,6 +8,7 @@ require "dfc_provider/engine"
 
 # Custom data types
 require "dfc_provider/supplied_product"
+require "dfc_provider/address"
 
 module DfcProvider
   DataFoodConsortium::Connector::Importer.register_type(SuppliedProduct)

--- a/engines/dfc_provider/lib/dfc_provider/address.rb
+++ b/engines/dfc_provider/lib/dfc_provider/address.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Temporary solution to add `region` to Address, to be removed once the DFC connector supports it
+
+module DfcProvider
+  class Address < DataFoodConsortium::Connector::Address
+    # @return [String]
+    attr_accessor :region
+
+    def initialize(semantic_id, region: "", **properties)
+      super(semantic_id, **properties)
+      @region = region
+
+      registerSemanticProperty("dfc-b:region", &method("region")).valueSetter = method("region=")
+    end
+  end
+end

--- a/engines/dfc_provider/spec/services/address_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/address_builder_spec.rb
@@ -8,6 +8,7 @@ describe AddressBuilder do
     build(
       :address,
       id: 1, address1: "Paradise 15", zipcode: "0001", city: "Goosnargh",
+      state: build(:state, name: "Victoria")
     )
   }
 
@@ -32,6 +33,10 @@ describe AddressBuilder do
 
     it "assigns a country" do
       expect(result.country).to eq "Australia"
+    end
+
+    it "assigns a region" do
+      expect(result.region).to eq "Victoria"
     end
   end
 end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -64,6 +64,7 @@ paths:
                     dfc-b:hasPostalCode: '20170'
                     dfc-b:hasCity: Herndon
                     dfc-b:hasCountry: Australia
+                    dfc-b:region: Victoria
         '404':
           description: not found
   "/api/dfc/enterprises/{enterprise_id}/catalog_items":
@@ -339,6 +340,7 @@ paths:
                       dfc-b:hasPostalCode: '20170'
                       dfc-b:hasCity: Herndon
                       dfc-b:hasCountry: Australia
+                      dfc-b:region: Victoria
   "/api/dfc/enterprises/{id}":
     get:
       summary: Show enterprise
@@ -383,6 +385,7 @@ paths:
                       dfc-b:hasPostalCode: '20170'
                       dfc-b:hasCity: Herndon
                       dfc-b:hasCountry: Australia
+                      dfc-b:region: Victoria
                     - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
                       "@type": dfc-b:SuppliedProduct
                       dfc-b:name: Apple - 1g


### PR DESCRIPTION
#### What? Why?

- Closes #12150  <!-- Insert issue number here. -->

Add support for `state` to address DFC API, it is modelled by `region` in the onthology.

We subclassed `DataFoodConsortium::Connector::Address` to add the `region` as it is not currently supported by the connector.
It's included in the next branch of the `data model` : https://github.com/datafoodconsortium/data-model-uml/commit/729eba31a5e551736a18d263531291a5811919c5
Once that's been merged and the connector has been updated, we will be able to remove `DfcProvider::Address`
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
Green Build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
