### PR TITLE
Improve random name generation in factories related to tax_rate_factory

### DIFF
--- a/spec/factories/tax_category_factory.rb
+++ b/spec/factories/tax_category_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :tax_category, class: Spree::TaxCategory do
-    name { "TaxCategory - #{rand(999_999)}" }
+    sequence(:name) { |n| "TaxCategory - #{n}" }
     description { generate(:random_string) }
   end
 end

--- a/spec/factories/zone_factory.rb
+++ b/spec/factories/zone_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :zone, class: Spree::Zone do
-    name { generate(:random_string) }
+    sequence(:name) { |n| "#{generate(:random_string)}#{n}" }
     description { generate(:random_string) }
   end
 


### PR DESCRIPTION
#### What? Why?

- Closes #12062
Failure occurred in specs:
```
1) TaxRateFinder getting the corresponding tax rate finds the tax rate of a shipping fee
     Failure/Error: create(:tax_rate, amount: 0.05, calculator: Calculator::DefaultTax.new, zone:)
     
     ActiveRecord::RecordInvalid:
       Validation failed: Name has already been taken
     # ./spec/services/tax_rate_finder_spec.rb:12:in `block (3 levels) in <top (required)>'
```
The hypothesis is that random name generator sometimes returns the same value twice.
Increase randomness should solve the issue.



#### What should we test?
- all automated tests should pass

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
