### PR TITLE
Reduce Capybara wait time during development

### DIFF
--- a/spec/system/support/capybara_setup.rb
+++ b/spec/system/support/capybara_setup.rb
@@ -4,10 +4,9 @@
 # This allows us to find <input aria-label="Name"> with `expect(page).to have_field "Name"`
 Capybara.enable_aria_label = true
 
-# Usually, especially when using Selenium, developers tend to increase the max wait time.
-# With Cuprite, there is no need for that.
-# We use a Capybara default value here explicitly.
-Capybara.default_max_wait_time = 10
+# The default wait time is 2 seconds. Small is good for test-driven development
+# ensuring efficient code but CI can be a bit slow. We want to avoid flakiness.
+Capybara.default_max_wait_time = 10 if ENV["CI"]
 
 # Normalize whitespaces when using `has_text?` and similar matchers,
 # i.e., ignore newlines, trailing spaces, etc.


### PR DESCRIPTION
#### What? Why?

In test-driven development, you run tests and expect them to fail. Waiting for the results unnecessarily long just slows down development.

And even though CI can be slow, we should aim for good performance of our code. Long wait times can hide performance bottle necks.

If anyone struggles with the default value, we can add an environment variable to adjust the wait time to your machine in .env.test.local. But this may just work for everyone.



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Tests pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
