### PR TITLE
Simplify user factory around admin role

### DIFF
--- a/spec/controllers/api/v0/reports_controller_spec.rb
+++ b/spec/controllers/api/v0/reports_controller_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Api::V0::ReportsController, type: :controller do
-  let(:enterprise_user) { create(:user, enterprises: create(:enterprise)) }
+  let(:enterprise_user) { create(:user, enterprises: [create(:enterprise)]) }
   let(:params) {
     {
       report_type: 'packing',

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -35,17 +35,11 @@ FactoryBot.define do
     end
 
     after(:create) do |user, proxy|
-      user.spree_roles.clear # Remove admin role
-
       user.enterprises << proxy.enterprises
     end
 
     factory :admin_user do
       spree_roles { [Spree::Role.find_or_create_by!(name: 'admin')] }
-
-      after(:create) do |user|
-        user.spree_roles << Spree::Role.find_or_create_by!(name: 'admin')
-      end
     end
 
     factory :oidc_user do

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -6,10 +6,6 @@ FactoryBot.define do
   end
 
   factory :user, class: Spree::User do
-    transient do
-      enterprises { [] }
-    end
-
     email { generate(:random_email) }
     login { email }
     password { 'secret' }
@@ -32,10 +28,6 @@ FactoryBot.define do
           user.skip_confirmation_notification!
         end
       end
-    end
-
-    after(:create) do |user, proxy|
-      user.enterprises << proxy.enterprises
     end
 
     factory :admin_user do


### PR DESCRIPTION

#### What? Why?

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The original Spree user factory was adding the admin role by default. Since we don't do that anymore, we don't need to remove it for normal users. We also need to add it only once to admin users.

Assigning enterprises was also overcomplicated.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
