### PR TITLE
Add rubocop binstub for spring support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -188,6 +188,7 @@ group :development do
   gem 'rubocop-rails'
   gem 'spring'
   gem 'spring-commands-rspec'
+  gem 'spring-commands-rubocop'
   gem 'web-console'
 
   gem 'rack-mini-profiler', '< 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -704,6 +704,8 @@ GEM
     spring (4.1.3)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
+    spring-commands-rubocop (0.4.0)
+      spring (>= 1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -925,6 +927,7 @@ DEPENDENCIES
   spreadsheet_architect
   spring
   spring-commands-rspec
+  spring-commands-rubocop
   state_machines-activerecord
   stimulus_reflex (= 3.5.0.rc3)
   stimulus_reflex_testing

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
+require 'bundler/setup'
+load Gem.bin_path('rubocop', 'rubocop')

--- a/bin/spring
+++ b/bin/spring
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# This file loads Spring without using loading other gems in the Gemfile, in order to be fast.
+# This file loads Spring without loading other gems in the Gemfile in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
 if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])


### PR DESCRIPTION
#### What? Why?

I observed a significant speed-up on the second run. The first run seems to be a lot slower though. Additional output suggests that it's now loading the Rails environment which it doesn't do without spring.

```
time bundle exec rubocop Gemfile
0m2.496s

time rubocop Gemfile # not always right version
0m1.999s

time ./bin/rubocop Gemfile
0m7.543s

time ./bin/rubocop Gemfile
0m0.670s
```

I would like to use this speed-up for a git pre-commit hook.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Nothing.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
