### PR TITLE
hide alternative invoice checkbox if invoices feature is enabled

### DIFF
--- a/app/views/admin/invoice_settings/edit.html.haml
+++ b/app/views/admin/invoice_settings/edit.html.haml
@@ -10,10 +10,11 @@
     = check_box_tag 'preferences[enable_invoices?]', '1',  Spree::Config[:enable_invoices?]
     = label_tag nil, t('.enable_invoices?')
 
-  .field.align-center
-    = hidden_field_tag 'preferences[invoice_style2?]', '0'
-    = check_box_tag 'preferences[invoice_style2?]', '1',  Spree::Config[:invoice_style2?]
-    = label_tag nil, t('.invoice_style2?')
+  - if ! OpenFoodNetwork::FeatureToggle.enabled?(:invoices, spree_current_user)
+    .field.align-center
+      = hidden_field_tag 'preferences[invoice_style2?]', '0'
+      = check_box_tag 'preferences[invoice_style2?]', '1',  Spree::Config[:invoice_style2?]
+      = label_tag nil, t('.invoice_style2?')
 
   .field.align-center
     = hidden_field_tag 'preferences[enterprise_number_required_on_invoices?]', '0'


### PR DESCRIPTION
#### What? Why?

- Closes #11829

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- visit page:/admin/invoice_settings/edit 
- in a different tab, disable the invoices feature
- you should see the "alternative invoice model" checkbox
- enable the feature again
- you should not see that checkbox
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
