### PR TITLE
Fix github action linter

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,9 +18,7 @@ jobs:
         uses: reviewdog/action-rubocop@v2
         with:
           rubocop_version: gemfile
-          rubocop_extensions:
-            - rubocop-rails:gemfile
-            - rubocop-rspec:gemfile
+          rubocop_extensions: rubocop-rails:gemfile rubocop-rspec:gemfile
           reporter: github-pr-check
           level: error
           fail_on_error: true


### PR DESCRIPTION

#### What? Why?

The PR https://github.com/openfoodfoundation/openfoodnetwork/pull/11500  adding rspec extension to rubocop introduced a change that breaks github actions 

This fixes reviewdog configuration with the correct format for the list of extensions to be used
We need to use a string list of extensions as shown in the doc: https://github.com/reviewdog/action-rubocop?tab=readme-ov-file#example-usage

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build :green_circle: 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
