### PR TITLE
Fix incorrect results for multiple tax rates in report

### DIFF
--- a/lib/reporting/reports/sales_tax/sales_tax_totals_by_producer.rb
+++ b/lib/reporting/reports/sales_tax/sales_tax_totals_by_producer.rb
@@ -125,8 +125,14 @@ module Reporting
         end
 
         def total_excl_tax(query_result_row)
-          line_items(query_result_row).sum(&:amount) -
-            line_items(query_result_row).sum(&:included_tax)
+          line_items(query_result_row)&.map do |line_item|
+            if line_item.adjustments.eligible.tax
+                .where(originator_id: tax_rate_id(query_result_row)).empty?
+              0
+            else
+              (line_item.amount - line_item.included_tax)
+            end
+          end&.sum
         end
 
         def tax(query_result_row)

--- a/spec/system/admin/reports/sales_tax/sales_tax_totals_by_producer_spec.rb
+++ b/spec/system/admin/reports/sales_tax/sales_tax_totals_by_producer_spec.rb
@@ -70,9 +70,7 @@ describe "Sales Tax Totals By Producer" do
                       ship_address_id: ship_address.id
                     })
 
-      while !order.completed?
-        break unless order.next!
-      end
+      OrderWorkflow.new(order).complete!
     end
 
     it "generates the report" do
@@ -130,9 +128,7 @@ describe "Sales Tax Totals By Producer" do
                       ship_address_id: ship_address.id
                     })
 
-      while !order.completed?
-        break unless order.next!
-      end
+      OrderWorkflow.new(order).complete!
     end
 
     it 'generates the report' do
@@ -191,9 +187,7 @@ describe "Sales Tax Totals By Producer" do
                       ship_address_id: ship_address.id
                     })
 
-      while !order.completed?
-        break unless order.next!
-      end
+      OrderWorkflow.new(order).complete!
     end
     it "generates the report" do
       login_as admin
@@ -369,9 +363,7 @@ describe "Sales Tax Totals By Producer" do
                       ship_address_id: customer1.bill_address_id,
                       customer_id: customer1.id
                     })
-      while !order.completed?
-        break unless order.next!
-      end
+      OrderWorkflow.new(order).complete!
 
       order2.line_items.create({ variant:, quantity: 1, price: 200 })
       order2.update!({
@@ -379,9 +371,7 @@ describe "Sales Tax Totals By Producer" do
                        ship_address_id: customer2.bill_address_id,
                        customer_id: customer2.id
                      })
-      while !order2.completed?
-        break unless order2.next!
-      end
+      OrderWorkflow.new(order2).complete!
       login_as admin
       visit admin_reports_path
       click_on 'Sales Tax Totals By Producer'

--- a/spec/system/admin/reports/sales_tax/sales_tax_totals_by_producer_spec.rb
+++ b/spec/system/admin/reports/sales_tax/sales_tax_totals_by_producer_spec.rb
@@ -146,20 +146,6 @@ describe "Sales Tax Totals By Producer" do
         "Yes",
         "oc1",
         "tax_category",
-        "State",
-        "1.5 %",
-        "0",
-        "0",
-        "0"
-      ].join(" "))
-
-      expect(page.find("table.report__table tbody").text).to have_content([
-        "Distributor",
-        "Yes",
-        "Supplier",
-        "Yes",
-        "oc1",
-        "tax_category",
         "Country",
         "2.5 %",
         "100.0",
@@ -173,6 +159,10 @@ describe "Sales Tax Totals By Producer" do
         "2.5",
         "102.5"
       ].join(" "))
+
+      # Even though 2 tax rates exist (but only one has been applied), we should get only 2 lines:
+      # one line item + total
+      expect(page.all("table.report__table tbody tr").count).to eq(2)
     end
   end
 


### PR DESCRIPTION
#### What? Why?

- Closes #12066 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
The issue lied in the `total_excl_tax` method that did not take into account which `tax_rates` were really used.
The method would apply taxes if they were defined, even though they were not used.
An example would be a customer in a country which mandates a tax, but not in a state that requires one.
But as the 2 taxes are in the same category, they would both be applied in the report. 

One can also use the following use case(the one I have used): for a same tax category, 1 tax rate for Europe, one for Australia. It would be applied the 2 tax rates even though address can only be in one country.


#### What should we test?
Cf. § Steps to Reproduce in #12066
Repeat this procedure.
One can use the use case described above for the order.
Going to `localhost:3000/admin/reports`, clicking `Sales Tax Totals By Producer` should show an order with 2 lines.
There should be a line of 0 for non applicable tax rates


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
