### PR TITLE
Add Rubocop negation matcher

### DIFF
--- a/.rubocop_rspec_styleguide.yml
+++ b/.rubocop_rspec_styleguide.yml
@@ -10,12 +10,12 @@ RSpec:
 FactoryBot:
   Enabled: false
 
+# Enabled rules
+
+Capybara/NegationMatcher:
+  Enabled: true
+  EnforcedStyle: not_to
+
 RSpec/ExpectChange:
   Enabled: true
   EnforcedStyle: block
-
-RSpec/MultipleExpectations:
-  Max: 5 # Default 1
-
-RSpec/MultipleMemoizedHelpers:
-  Max: 10 # Default 5

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,6 +6,58 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+# Offense count: 229
+# This cop supports safe autocorrection (--autocorrect).
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: have_no, not_to
+Capybara/NegationMatcher:
+  Exclude:
+    - 'spec/mailers/producer_mailer_spec.rb'
+    - 'spec/support/reports_helper.rb'
+    - 'spec/system/admin/authentication_spec.rb'
+    - 'spec/system/admin/bulk_order_management_spec.rb'
+    - 'spec/system/admin/bulk_product_update_spec.rb'
+    - 'spec/system/admin/customers_spec.rb'
+    - 'spec/system/admin/enterprise_fees_spec.rb'
+    - 'spec/system/admin/enterprise_groups_spec.rb'
+    - 'spec/system/admin/enterprise_roles_spec.rb'
+    - 'spec/system/admin/enterprises/images_spec.rb'
+    - 'spec/system/admin/enterprises/index_spec.rb'
+    - 'spec/system/admin/enterprises_spec.rb'
+    - 'spec/system/admin/invoice_print_spec.rb'
+    - 'spec/system/admin/order_cycles/list_spec.rb'
+    - 'spec/system/admin/order_spec.rb'
+    - 'spec/system/admin/orders/invoices_spec.rb'
+    - 'spec/system/admin/orders_spec.rb'
+    - 'spec/system/admin/overview_spec.rb'
+    - 'spec/system/admin/product_import_spec.rb'
+    - 'spec/system/admin/reports/enterprise_fee_summaries_spec.rb'
+    - 'spec/system/admin/reports_spec.rb'
+    - 'spec/system/admin/schedules_spec.rb'
+    - 'spec/system/admin/shipping_methods_spec.rb'
+    - 'spec/system/admin/subscriptions/crud_spec.rb'
+    - 'spec/system/admin/tag_rules_spec.rb'
+    - 'spec/system/admin/users_spec.rb'
+    - 'spec/system/admin/variant_overrides_spec.rb'
+    - 'spec/system/consumer/account/cards_spec.rb'
+    - 'spec/system/consumer/account_spec.rb'
+    - 'spec/system/consumer/checkout/guest_spec.rb'
+    - 'spec/system/consumer/cookies_spec.rb'
+    - 'spec/system/consumer/footer_links_spec.rb'
+    - 'spec/system/consumer/multilingual_spec.rb'
+    - 'spec/system/consumer/registration_spec.rb'
+    - 'spec/system/consumer/shopping/cart_spec.rb'
+    - 'spec/system/consumer/shopping/checkout_auth_spec.rb'
+    - 'spec/system/consumer/shopping/checkout_spec.rb'
+    - 'spec/system/consumer/shopping/embedded_groups_spec.rb'
+    - 'spec/system/consumer/shopping/orders_spec.rb'
+    - 'spec/system/consumer/shopping/shopping_spec.rb'
+    - 'spec/system/consumer/shopping/unit_price_spec.rb'
+    - 'spec/system/consumer/shops_spec.rb'
+    - 'spec/system/consumer/user_password_spec.rb'
+    - 'spec/system/consumer/white_label_spec.rb'
+    - 'spec/views/admin/products_v3/_filters.html.haml_spec.rb'
+
 # Offense count: 16
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: enums

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,58 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 229
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: have_no, not_to
-Capybara/NegationMatcher:
-  Exclude:
-    - 'spec/mailers/producer_mailer_spec.rb'
-    - 'spec/support/reports_helper.rb'
-    - 'spec/system/admin/authentication_spec.rb'
-    - 'spec/system/admin/bulk_order_management_spec.rb'
-    - 'spec/system/admin/bulk_product_update_spec.rb'
-    - 'spec/system/admin/customers_spec.rb'
-    - 'spec/system/admin/enterprise_fees_spec.rb'
-    - 'spec/system/admin/enterprise_groups_spec.rb'
-    - 'spec/system/admin/enterprise_roles_spec.rb'
-    - 'spec/system/admin/enterprises/images_spec.rb'
-    - 'spec/system/admin/enterprises/index_spec.rb'
-    - 'spec/system/admin/enterprises_spec.rb'
-    - 'spec/system/admin/invoice_print_spec.rb'
-    - 'spec/system/admin/order_cycles/list_spec.rb'
-    - 'spec/system/admin/order_spec.rb'
-    - 'spec/system/admin/orders/invoices_spec.rb'
-    - 'spec/system/admin/orders_spec.rb'
-    - 'spec/system/admin/overview_spec.rb'
-    - 'spec/system/admin/product_import_spec.rb'
-    - 'spec/system/admin/reports/enterprise_fee_summaries_spec.rb'
-    - 'spec/system/admin/reports_spec.rb'
-    - 'spec/system/admin/schedules_spec.rb'
-    - 'spec/system/admin/shipping_methods_spec.rb'
-    - 'spec/system/admin/subscriptions/crud_spec.rb'
-    - 'spec/system/admin/tag_rules_spec.rb'
-    - 'spec/system/admin/users_spec.rb'
-    - 'spec/system/admin/variant_overrides_spec.rb'
-    - 'spec/system/consumer/account/cards_spec.rb'
-    - 'spec/system/consumer/account_spec.rb'
-    - 'spec/system/consumer/checkout/guest_spec.rb'
-    - 'spec/system/consumer/cookies_spec.rb'
-    - 'spec/system/consumer/footer_links_spec.rb'
-    - 'spec/system/consumer/multilingual_spec.rb'
-    - 'spec/system/consumer/registration_spec.rb'
-    - 'spec/system/consumer/shopping/cart_spec.rb'
-    - 'spec/system/consumer/shopping/checkout_auth_spec.rb'
-    - 'spec/system/consumer/shopping/checkout_spec.rb'
-    - 'spec/system/consumer/shopping/embedded_groups_spec.rb'
-    - 'spec/system/consumer/shopping/orders_spec.rb'
-    - 'spec/system/consumer/shopping/shopping_spec.rb'
-    - 'spec/system/consumer/shopping/unit_price_spec.rb'
-    - 'spec/system/consumer/shops_spec.rb'
-    - 'spec/system/consumer/user_password_spec.rb'
-    - 'spec/system/consumer/white_label_spec.rb'
-    - 'spec/views/admin/products_v3/_filters.html.haml_spec.rb'
-
 # Offense count: 16
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: enums

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -215,7 +215,7 @@ describe ProducerMailer, type: :mailer do
   context "products from only one supplier" do
     it "doesn't display a supplier column" do
       expect(body_as_html(mail).find(".order-summary"))
-        .to have_no_selector("th", text: "Supplier")
+        .not_to have_selector("th", text: "Supplier")
     end
 
     context "when the show customer names to suppliers setting is enabled" do
@@ -223,7 +223,7 @@ describe ProducerMailer, type: :mailer do
 
       it "doesn't display a supplier column in the summary of orders grouped by customer" do
         expect(body_as_html(mail).find(".customer-order"))
-          .to have_no_selector("th", text: "Supplier")
+          .not_to have_selector("th", text: "Supplier")
       end
     end
   end

--- a/spec/support/reports_helper.rb
+++ b/spec/support/reports_helper.rb
@@ -5,6 +5,6 @@ module ReportsHelper
     click_on "Go"
     expect(page).to have_selector ".loading"
     perform_enqueued_jobs(only: ReportJob)
-    expect(page).to have_no_selector ".loading"
+    expect(page).not_to have_selector ".loading"
   end
 end

--- a/spec/system/admin/authentication_spec.rb
+++ b/spec/system/admin/authentication_spec.rb
@@ -18,7 +18,7 @@ describe "Authentication" do
     click_login_button
     expect(page).to have_content "DASHBOARD"
     expect(page).to have_current_path spree.admin_dashboard_path
-    expect(page).to have_no_content "CONFIGURATION"
+    expect(page).not_to have_content "CONFIGURATION"
   end
 
   it "viewing my account" do

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -58,14 +58,14 @@ describe '
       it "displays a list of line items" do
         expect(page).to have_selector "tr#li_#{li1.id}"
         expect(page).to have_selector "tr#li_#{li2.id}"
-        expect(page).to have_no_selector "tr#li_#{li3.id}"
+        expect(page).not_to have_selector "tr#li_#{li3.id}"
       end
 
       it "displays only line items that are not shipped" do
         expect(page).to have_selector "tr#li_#{li1.id}"
         expect(page).to have_selector "tr#li_#{li2.id}"
-        expect(page).to have_no_selector "tr#li_#{li4.id}"
-        expect(page).to have_no_selector "tr#li_#{li5.id}"
+        expect(page).not_to have_selector "tr#li_#{li4.id}"
+        expect(page).not_to have_selector "tr#li_#{li5.id}"
       end
 
       it "orders by completion date" do
@@ -437,7 +437,7 @@ describe '
       end
 
       it "adds the class 'ng-dirty' to input elements when value is altered" do
-        expect(page).to have_no_css "input[name='quantity'].ng-dirty"
+        expect(page).not_to have_css "input[name='quantity'].ng-dirty"
         fill_in "quantity", with: 2
         expect(page).to have_css "input[name='quantity'].ng-dirty"
       end
@@ -453,19 +453,19 @@ describe '
 
       context "when acceptable data is sent to the server" do
         it "displays an update button which submits pending changes" do
-          expect(page).to have_no_selector "#save-bar"
+          expect(page).not_to have_selector "#save-bar"
           fill_in "quantity", with: 2
           expect(page).to have_selector "input[name='quantity'].ng-dirty"
           expect(page).to have_selector "#save-bar", text: "You have unsaved changes"
           click_button "Save Changes"
           expect(page).to have_selector "#save-bar", text: "All changes saved"
-          expect(page).to have_no_selector "input[name='quantity'].ng-dirty"
+          expect(page).not_to have_selector "input[name='quantity'].ng-dirty"
         end
       end
 
       context "when unacceptable data is sent to the server" do
         it "displays an update button which submits pending changes" do
-          expect(page).to have_no_selector "#save-bar"
+          expect(page).not_to have_selector "#save-bar"
           line_item = order.line_items.first
           fill_in "quantity", with: line_item.variant.on_hand + line_item.quantity + 10
           expect(page).to have_selector "input[name='quantity'].ng-dirty"
@@ -565,7 +565,7 @@ describe '
         end
 
         it "shows all default columns, except the de-selected column" do
-          expect(page).to have_no_selector "th", text: "PRODUCER"
+          expect(page).not_to have_selector "th", text: "PRODUCER"
           expect(page).to have_selector "th", text: "NAME"
           expect(page).to have_selector "th",
                                         text: 'Completed at'.upcase
@@ -608,7 +608,7 @@ describe '
           select2_select s1.name, from: "supplier_filter"
           page.find('.filter-actions .button.icon-search').click
           expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
         end
 
         it "displays all line items when 'All' is selected from supplier filter" do
@@ -617,7 +617,7 @@ describe '
           select2_select s1.name, from: "supplier_filter"
           page.find('.filter-actions .button.icon-search').click
           expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
           select2_select "All", from: "supplier_filter"
           page.find('.filter-actions .button.icon-search').click
           expect(page).to have_selector "tr#li_#{li1.id}"
@@ -657,7 +657,7 @@ describe '
           find(".select2-result-label", text: d1.name.to_s).click
           page.find('.filter-actions .button.icon-search').click
           expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
         end
 
         it "displays all line items when 'All' is selected from distributor filter", retry: 3 do
@@ -666,7 +666,7 @@ describe '
           find("#s2id_distributor_filter .select2-chosen").click
           find(".select2-result-label", text: d1.name.to_s).click
           page.find('.filter-actions .button.icon-search').click
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
           # displays orders from all enterprises
           find("#s2id_distributor_filter .select2-chosen").click
           find(".select2-result-label", text: "All").click
@@ -719,9 +719,9 @@ describe '
                                        with_options: OrderCycle.pluck(:name).unshift("All")
           select2_select oc1.name, from: "order_cycle_filter"
           page.find('.filter-actions .button.icon-search').click
-          expect(page).to have_no_selector "#loading i"
+          expect(page).not_to have_selector "#loading i"
           expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
         end
 
         it "displays all line items when 'All' is selected from order_cycle filter", retry: 3 do
@@ -729,7 +729,7 @@ describe '
           select2_select oc1.name, from: "order_cycle_filter"
           page.find('.filter-actions .button.icon-search').click
           expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
           select2_select "All", from: "order_cycle_filter"
           page.find('.filter-actions .button.icon-search').click
           displays_default_orders
@@ -768,20 +768,20 @@ describe '
           click_on_select2 oc1.name, from: "order_cycle_filter"
           page.find('.filter-actions .button.icon-search').click
           expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
           click_on_select2 d1.name, from: "distributor_filter"
           click_on_select2 s1.name, from: "supplier_filter"
           page.find('.filter-actions .button.icon-search').click
           expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
           click_on_select2 d2.name, from: "distributor_filter"
           click_on_select2 s2.name, from: "supplier_filter"
           page.find('.filter-actions .button.icon-search').click
-          expect(page).to have_no_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li1.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
           click_on_select2 oc2.name, from: "order_cycle_filter"
           page.find('.filter-actions .button.icon-search').click
-          expect(page).to have_no_selector "tr#li_#{li1.id}"
+          expect(page).not_to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
         end
 
@@ -793,7 +793,7 @@ describe '
           click_on_select2 s1.name, from: "supplier_filter"
           page.find('.filter-actions .button.icon-search').click
           expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
           page.find('.filter-actions #clear_filters_button').click
           expect(page).to have_selector "div#s2id_order_cycle_filter a.select2-choice", text: "All"
           expect(page).to have_selector "div#s2id_supplier_filter a.select2-choice", text: "All"
@@ -850,7 +850,7 @@ describe '
         expect(page).to have_selector "tr#li_#{li1.id}"
         expect(page).to have_selector "tr#li_#{li2.id}"
         expect(page).to have_selector "tr#li_#{li3.id}"
-        expect(page).to have_no_selector "tr#li_#{li4.id}"
+        expect(page).not_to have_selector "tr#li_#{li4.id}"
 
         find("input.datepicker").click
         select_dates_from_daterangepicker(from, to)
@@ -878,9 +878,9 @@ describe '
           # daterange picker should have changed
           expect(find("input.datepicker").value)
             .to eq "#{today.prev_day(9).strftime('%F')} to #{today.strftime('%F')}"
-          expect(page).to have_no_selector "#save-bar"
+          expect(page).not_to have_selector "#save-bar"
           within("tr#li_#{li2.id} td.quantity") do
-            expect(page).to have_no_selector "input[name=quantity].ng-dirty"
+            expect(page).not_to have_selector "input[name=quantity].ng-dirty"
           end
         end
 
@@ -967,8 +967,8 @@ describe '
                 click_on("OK")
               end
               # order 1 should be canceled
-              expect(page).to have_no_selector "tr#li_#{li1.id}"
-              expect(page).to have_no_selector "tr#li_#{li11.id}"
+              expect(page).not_to have_selector "tr#li_#{li1.id}"
+              expect(page).not_to have_selector "tr#li_#{li11.id}"
               expect(o1.reload.state).to eq("canceled")
               # order 2 should not be canceled
               expect(page).to have_selector "tr#li_#{li2.id}"
@@ -992,8 +992,8 @@ describe '
               click_on "OK"
             end
 
-            expect(page).to have_no_selector ".modal"
-            expect(page).to have_no_selector "tr#li_#{li1.id}"
+            expect(page).not_to have_selector ".modal"
+            expect(page).not_to have_selector "tr#li_#{li1.id}"
             expect(page).to have_selector "tr#li_#{li11.id}"
             expect(o1.reload.state).to eq("complete")
           end
@@ -1195,8 +1195,8 @@ describe '
         end
 
         it "all line items of the same variant" do
-          expect(page).to have_no_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li1.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
           expect(page).to have_selector "tr#li_#{li3.id}"
           expect(page).to have_selector "tr#li_#{li4.id}"
           expect(page).to have_css("table#listing_orders tbody tr", count: 2)
@@ -1211,7 +1211,7 @@ describe '
         end
 
         it "shows all products and clears group buy box" do
-          expect(page).to have_no_selector "div#group_buy_calculation"
+          expect(page).not_to have_selector "div#group_buy_calculation"
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
           expect(page).to have_selector "tr#li_#{li3.id}"
@@ -1226,10 +1226,10 @@ describe '
         end
 
         it "shows only variant filtering by email" do
-          expect(page).to have_no_selector "tr#li_#{li1.id}"
-          expect(page).to have_no_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li1.id}"
+          expect(page).not_to have_selector "tr#li_#{li2.id}"
           expect(page).to have_selector "tr#li_#{li3.id}"
-          expect(page).to have_no_selector "tr#li_#{li4.id}"
+          expect(page).not_to have_selector "tr#li_#{li4.id}"
         end
 
         context "clicking 'Clear Filters' button" do
@@ -1285,13 +1285,13 @@ describe '
       visit_bulk_order_management
 
       expect(page).to have_selector "tr#li_#{line_item_distributed.id}"
-      expect(page).to have_no_selector "tr#li_#{line_item_not_distributed.id}"
+      expect(page).not_to have_selector "tr#li_#{line_item_not_distributed.id}"
     end
   end
 
   def visit_bulk_order_management
     visit spree.admin_bulk_order_management_path
-    expect(page).to have_no_text 'Loading orders'
+    expect(page).not_to have_text 'Loading orders'
   end
 
   def displays_default_orders
@@ -1304,7 +1304,7 @@ describe '
       expect(page).to have_selector "tr#li_#{li.id}"
     end
     excluded_line_items.each do |li|
-      expect(page).to have_no_selector "tr#li_#{li.id}"
+      expect(page).not_to have_selector "tr#li_#{li.id}"
     end
   end
 end

--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -68,9 +68,9 @@ describe '
       expect(page).to have_selector "a.view-variants", count: 1
       find("a.view-variants").click
 
-      expect(page).to have_no_selector "span[name='on_hand']", text: "On demand"
+      expect(page).not_to have_selector "span[name='on_hand']", text: "On demand"
       expect(page).to have_field "variant_on_hand", with: "4"
-      expect(page).to have_no_field "variant_on_hand", with: ""
+      expect(page).not_to have_field "variant_on_hand", with: ""
       expect(page).to have_selector "span[name='variant_on_hand']", text: "On demand"
     end
 
@@ -527,7 +527,7 @@ describe '
 
     sleep 2 # wait for page to initialise
 
-    expect(page).to have_no_field "product_name", with: p2.name
+    expect(page).not_to have_field "product_name", with: p2.name
     fill_in "product_name", with: "new product1"
 
     within "#save-bar" do
@@ -708,7 +708,7 @@ describe '
 
         toggle_columns /^.{0,1}Producer$/i
 
-        expect(page).to have_no_selector "th", text: "PRODUCER"
+        expect(page).not_to have_selector "th", text: "PRODUCER"
         expect(page).to have_selector "th", text: "NAME"
         expect(page).to have_selector "th", text: "PRICE"
         expect(page).to have_selector "th", text: "ON HAND"
@@ -739,7 +739,7 @@ describe '
 
         # Products are hidden when filtered out
         expect(page).to have_field "product_name", with: p1.name
-        expect(page).to have_no_field "product_name", with: p2.name
+        expect(page).not_to have_field "product_name", with: p2.name
 
         # Clearing filters
         click_button "Clear Filters"
@@ -787,7 +787,7 @@ describe '
 
       expect(page).to have_field 'product_name', with: product_supplied.name
       expect(page).to have_field 'product_name', with: product_supplied_permitted.name
-      expect(page).to have_no_field 'product_name', with: product_not_supplied.name
+      expect(page).not_to have_field 'product_name', with: product_not_supplied.name
     end
 
     it "shows only suppliers that I manage or have permission to" do
@@ -799,7 +799,7 @@ describe '
           with_options: [supplier_managed1.name, supplier_managed2.name, supplier_permitted.name],
           selected: supplier_managed1.name,
         )
-      expect(page).to have_no_select 'producer_id', with_options: [supplier_unmanaged.name]
+      expect(page).not_to have_select 'producer_id', with_options: [supplier_unmanaged.name]
     end
 
     it "shows inactive products that I supply" do
@@ -910,8 +910,8 @@ describe '
         expect(page).to have_css ".spinner"
       end
 
-      expect(page).to have_no_css ".spinner"
-      expect(page).to have_no_selector "div.reveal-modal"
+      expect(page).not_to have_css ".spinner"
+      expect(page).not_to have_selector "div.reveal-modal"
 
       within "table#listing_products tr#p_#{product.id}" do
         # New thumbnail is shown in image column

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -45,9 +45,9 @@ describe 'Customers' do
 
         # Loads the right customers; positive assertion first, so DOM content is loaded
         expect(page).to have_selector "tr#c_#{customer4.id}"
-        expect(page).to have_no_selector "tr#c_#{customer1.id}"
-        expect(page).to have_no_selector "tr#c_#{customer2.id}"
-        expect(page).to have_no_selector "tr#c_#{customer3.id}"
+        expect(page).not_to have_selector "tr#c_#{customer1.id}"
+        expect(page).not_to have_selector "tr#c_#{customer2.id}"
+        expect(page).not_to have_selector "tr#c_#{customer3.id}"
 
         # Changing Shops
         select2_select managed_distributor1.name, from: "shop_id"
@@ -55,12 +55,12 @@ describe 'Customers' do
         # Loads the right customers
         expect(page).to have_selector "tr#c_#{customer1.id}"
         expect(page).to have_selector "tr#c_#{customer2.id}"
-        expect(page).to have_no_selector "tr#c_#{customer3.id}"
-        expect(page).to have_no_selector "tr#c_#{customer4.id}"
+        expect(page).not_to have_selector "tr#c_#{customer3.id}"
+        expect(page).not_to have_selector "tr#c_#{customer4.id}"
 
         # Searching
         fill_in "quick_search", with: customer2.email
-        expect(page).to have_no_selector "tr#c_#{customer1.id}"
+        expect(page).not_to have_selector "tr#c_#{customer1.id}"
         expect(page).to have_selector "tr#c_#{customer2.id}"
         fill_in "quick_search", with: ""
 
@@ -87,8 +87,8 @@ describe 'Customers' do
         expect(page).to have_selector "th.email"
         expect(page).to have_content customer1.email
         toggle_columns "Email"
-        expect(page).to have_no_selector "th.email"
-        expect(page).to have_no_content customer1.email
+        expect(page).not_to have_selector "th.email"
+        expect(page).not_to have_content customer1.email
 
         # Deleting
         create(:subscription, customer: customer1)
@@ -110,7 +110,7 @@ describe 'Customers' do
               find("a.delete-customer").click
             end
           end
-          expect(page).to have_no_selector "tr#c_#{customer2.id}"
+          expect(page).not_to have_selector "tr#c_#{customer2.id}"
         }.to change{ Customer.count }.by(-1)
       end
 

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -250,7 +250,7 @@ describe '
 
     # Then my enterprise fee should have been deleted
     visit admin_enterprise_fees_path
-    expect(page).to have_no_selector "input[value='#{fee.name}']"
+    expect(page).not_to have_selector "input[value='#{fee.name}']"
   end
 
   context "as an enterprise manager" do

--- a/spec/system/admin/enterprise_groups_spec.rb
+++ b/spec/system/admin/enterprise_groups_spec.rb
@@ -103,7 +103,7 @@ describe '
       first("a.delete-resource").click
     end
 
-    expect(page).to have_no_content 'EGEGEG'
+    expect(page).not_to have_content 'EGEGEG'
 
     expect(EnterpriseGroup.all).not_to include eg
   end

--- a/spec/system/admin/enterprise_roles_spec.rb
+++ b/spec/system/admin/enterprise_roles_spec.rb
@@ -140,7 +140,7 @@ create(:enterprise)
         within 'table.managers' do
           within "tr#manager-#{user1.id}" do
             expect(page).to have_css 'i.owner'
-            expect(page).to have_no_css 'i.contact'
+            expect(page).not_to have_css 'i.contact'
           end
           within "tr#manager-#{user2.id}" do
             expect(page).to have_css 'i.contact'

--- a/spec/system/admin/enterprises/images_spec.rb
+++ b/spec/system/admin/enterprises/images_spec.rb
@@ -123,6 +123,6 @@ describe "Managing enterprise images" do
   end
 
   def expect_no_preview_image
-    expect(page).to have_no_selector(".image-field-group__preview-image")
+    expect(page).not_to have_selector(".image-field-group__preview-image")
   end
 end

--- a/spec/system/admin/enterprises/index_spec.rb
+++ b/spec/system/admin/enterprises/index_spec.rb
@@ -19,8 +19,8 @@ describe 'Enterprises Index' do
         expect(page).to have_select "sets_enterprise_set_collection_attributes_1_sells"
         expect(page).to have_content "Settings"
         expect(page).to have_content "Delete"
-        expect(page).to have_no_content "Payment Methods"
-        expect(page).to have_no_content "Shipping Methods"
+        expect(page).not_to have_content "Payment Methods"
+        expect(page).not_to have_content "Shipping Methods"
         expect(page).to have_content "Enterprise Fees"
       end
 
@@ -149,8 +149,8 @@ describe 'Enterprises Index' do
           expect(page).to have_selector "td.package", text: 'Profile'
         end
 
-        expect(page).to have_no_content "supplier2.name"
-        expect(page).to have_no_content "distributor2.name"
+        expect(page).not_to have_content "supplier2.name"
+        expect(page).not_to have_content "distributor2.name"
 
         expect(find('.js-admin-section-header')).to have_link "New Enterprise"
       end
@@ -164,12 +164,12 @@ describe 'Enterprises Index' do
           expect(page).to have_selector "a.selector.producer.disabled"
           find("a.selector.producer.disabled").click
           expect(page).to have_selector "a.selector.non-producer.selected.disabled"
-          expect(page).to have_no_selector "a.update"
+          expect(page).not_to have_selector "a.update"
           find("td.package").click
           expect(page).to have_selector "a.selector.hub-profile.disabled"
           find("a.selector.hub-profile.disabled").click
           expect(page).to have_selector "a.selector.hub.selected.disabled"
-          expect(page).to have_no_selector "a.update"
+          expect(page).not_to have_selector "a.update"
         end
       end
     end
@@ -194,13 +194,13 @@ describe 'Enterprises Index' do
           # Open the producer panel
           find("td.producer").click
 
-          expect(page).to have_no_selector "a.selector.producer.selected"
+          expect(page).not_to have_selector "a.selector.producer.selected"
           expect(page).to have_selector "a.selector.non-producer.selected"
 
           # Change to a producer
           find("a.selector.producer").click
 
-          expect(page).to have_no_selector "a.selector.non-producer.selected"
+          expect(page).not_to have_selector "a.selector.non-producer.selected"
           expect(page).to have_selector "a.selector.producer.selected"
           expect(page).to have_selector "a.update", text: "SAVE"
 
@@ -212,16 +212,16 @@ describe 'Enterprises Index' do
           # Open the package panel
           find("td.package").click
 
-          expect(page).to have_no_selector "a.selector.producer-profile.selected"
-          expect(page).to have_no_selector "a.selector.producer-shop.selected"
+          expect(page).not_to have_selector "a.selector.producer-profile.selected"
+          expect(page).not_to have_selector "a.selector.producer-shop.selected"
           expect(page).to have_selector "a.selector.producer-hub.selected"
 
           # Change to a producer-shop
           find("a.selector.producer-shop").click
 
-          expect(page).to have_no_selector "a.selector.producer-profile.selected"
+          expect(page).not_to have_selector "a.selector.producer-profile.selected"
           expect(page).to have_selector "a.selector.producer-shop.selected"
-          expect(page).to have_no_selector "a.selector.producer-hub.selected"
+          expect(page).not_to have_selector "a.selector.producer-hub.selected"
           expect(page).to have_selector "a.update", text: "SAVE"
 
           # Save selection

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -97,7 +97,7 @@ describe '
     expect(page).to have_checked_field "enterprise_require_login_false"
     expect(page).to have_checked_field "enterprise_allow_guest_orders_true"
     find(:xpath, '//*[@id="enterprise_require_login_true"]').trigger("click")
-    expect(page).to have_no_checked_field "enterprise_require_login_false"
+    expect(page).not_to have_checked_field "enterprise_require_login_false"
     # expect(page).to have_checked_field "enterprise_enable_subscriptions_false"
 
     accept_alert do
@@ -105,7 +105,7 @@ describe '
       within(".side_menu") { click_link "Users" }
     end
     select2_select user.email, from: 'enterprise_owner_id'
-    expect(page).to have_no_selector '.select2-drop-mask' # Ensure select2 has finished
+    expect(page).not_to have_selector '.select2-drop-mask' # Ensure select2 has finished
 
     accept_alert do
       click_link "About"
@@ -413,7 +413,7 @@ describe '
           click_button 'Create'
 
           # Then it should show me an error
-          expect(page).to have_no_content 'Enterprise "zzz" has been successfully created!'
+          expect(page).not_to have_content 'Enterprise "zzz" has been successfully created!'
           expect(page).to have_content "#{enterprise_user.email} is not permitted " \
                                        "to own any more enterprises (limit is 1)."
         end

--- a/spec/system/admin/invoice_print_spec.rb
+++ b/spec/system/admin/invoice_print_spec.rb
@@ -56,7 +56,7 @@ describe '
         login_as_admin
         visit spree.print_admin_order_path(order, params: url_params)
         convert_pdf_to_page
-        expect(page).to have_no_content 'Payment Description at Checkout'
+        expect(page).not_to have_content 'Payment Description at Checkout'
       end
     end
 

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -72,7 +72,7 @@ describe '
     end
 
     # I can load more order_cycles
-    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc7.id}"
+    expect(page).not_to have_selector "#listing_order_cycles tr.order-cycle-#{oc7.id}"
     click_button "Show 30 more days"
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc7.id}"
 
@@ -81,9 +81,9 @@ describe '
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     select2_select oc1.suppliers.first.name, from: "involving_filter"
-    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).not_to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).not_to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     select2_select "Any Enterprise", from: "involving_filter"
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
@@ -95,8 +95,8 @@ describe '
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     fill_in "query", with: oc0.name
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
-    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).not_to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    expect(page).not_to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     fill_in "query", with: ''
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
@@ -108,9 +108,9 @@ describe '
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
     select2_select schedule1.name, from: "schedule_filter"
-    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).not_to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).not_to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
     select2_select 'Any Schedule', from: "schedule_filter"
     expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -1188,7 +1188,7 @@ describe '
             click_link "Create or Update Invoice"
 
             # and disappear after clicking
-            expect(page).to have_no_link "Create or Update Invoice"
+            expect(page).not_to have_link "Create or Update Invoice"
             expect(page).to_not have_content "The order has changed since the last invoice update."
 
             # creating an invoice, displays a second row

--- a/spec/system/admin/orders/invoices_spec.rb
+++ b/spec/system/admin/orders/invoices_spec.rb
@@ -40,7 +40,7 @@ describe '
 
         expect {
           click_link "Create or Update Invoice"
-          expect(page).to have_no_link "Create or Update Invoice"
+          expect(page).not_to have_link "Create or Update Invoice"
         }.to change { order.invoices.count }.by(1)
 
         invoice = order.invoices.first
@@ -72,7 +72,7 @@ describe '
             click_link 'Invoices'
             expect {
               click_link "Create or Update Invoice"
-              expect(page).to have_no_link "Create or Update Invoice"
+              expect(page).not_to have_link "Create or Update Invoice"
             }.to change { order.reload.invoices.count }.by(0)
               .and change { latest_invoice.reload.presenter.note }.from("").to(new_note)
 
@@ -89,7 +89,7 @@ describe '
             click_link 'Invoices'
             expect {
               click_link "Create or Update Invoice"
-              expect(page).to have_no_link "Create or Update Invoice"
+              expect(page).not_to have_link "Create or Update Invoice"
             }.to change { order.reload.invoices.count }.by(1)
 
             expect(latest_invoice.reload.cancelled).to eq true

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -281,7 +281,7 @@ describe '
         # And the same orders are displayed when sorting by name:
         find("th a", text: "NAME").click
 
-        expect(page).to have_no_content order_empty.number
+        expect(page).not_to have_content order_empty.number
         expect(page).to have_content order_not_empty.number
         expect(page).to have_content order_not_empty_no_address.number
       end
@@ -899,15 +899,15 @@ describe '
       visit spree.admin_orders_path
       expect(page).to have_content complete_order.number
       expect(page).to have_content empty_complete_order.number
-      expect(page).to have_no_content incomplete_order.number
-      expect(page).to have_no_content empty_order.number
+      expect(page).not_to have_content incomplete_order.number
+      expect(page).not_to have_content empty_order.number
 
       uncheck 'Only show complete orders'
       page.find('button[type=submit]').click
 
       expect(page).to have_content complete_order.number
       expect(page).to have_content incomplete_order.number
-      expect(page).to have_no_content empty_order.number
+      expect(page).not_to have_content empty_order.number
     end
   end
 

--- a/spec/system/admin/overview_spec.rb
+++ b/spec/system/admin/overview_spec.rb
@@ -53,7 +53,7 @@ describe '
 
         it "does not show a products item" do
           visit '/admin'
-          expect(page).to have_no_selector "#products"
+          expect(page).not_to have_selector "#products"
         end
       end
     end

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -78,14 +78,14 @@ describe "Product Import" do
       proceed_to_validation
 
       expect(page).to have_selector '.item-count', text: "2"
-      expect(page).to have_no_selector '.invalid-count'
+      expect(page).not_to have_selector '.invalid-count'
       expect(page).to have_selector '.create-count', text: "2"
-      expect(page).to have_no_selector '.update-count'
+      expect(page).not_to have_selector '.update-count'
 
       save_data
 
       expect(page).to have_selector '.created-count', text: '2'
-      expect(page).to have_no_selector '.updated-count'
+      expect(page).not_to have_selector '.updated-count'
 
       carrots = Spree::Product.find_by(name: 'Carrots')
       potatoes = Spree::Product.find_by(name: 'Potatoes')
@@ -126,9 +126,9 @@ describe "Product Import" do
       expect(page).to have_selector '.item-count', text: "4"
       expect(page).to have_selector '.invalid-count', text: "3"
       expect(page).to have_selector ".create-count", text: "1"
-      expect(page).to have_no_selector '.update-count'
+      expect(page).not_to have_selector '.update-count'
 
-      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
     end
 
     it "displays info about inconsistent variant unit names, within the same product" do
@@ -152,7 +152,7 @@ describe "Product Import" do
                                    "with the same name"
       expect(page).to have_content "Imported file contains invalid entries"
 
-      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
     end
 
     it "handles saving of named tax and shipping categories" do
@@ -173,12 +173,12 @@ describe "Product Import" do
 
       expect(page).to have_selector '.item-count', text: "1"
       expect(page).to have_selector '.create-count', text: "1"
-      expect(page).to have_no_selector '.update-count'
+      expect(page).not_to have_selector '.update-count'
 
       save_data
 
       expect(page).to have_selector '.created-count', text: '1'
-      expect(page).to have_no_selector '.updated-count'
+      expect(page).not_to have_selector '.updated-count'
 
       carrots = Spree::Product.find_by(name: 'Carrots')
       expect(carrots.variants.first.tax_category).to eq tax_category
@@ -227,8 +227,8 @@ describe "Product Import" do
 
       expect(page).to have_field "product_name", with: carrots.name
       expect(page).to have_field "product_name", with: potatoes.name
-      expect(page).to have_no_field "product_name", with: product.name
-      expect(page).to have_no_field "product_name", with: product2.name
+      expect(page).not_to have_field "product_name", with: product.name
+      expect(page).not_to have_field "product_name", with: product2.name
     end
 
     it "can reset product stock to zero for products not present in the CSV" do
@@ -316,16 +316,16 @@ describe "Product Import" do
       proceed_to_validation
 
       expect(page).to have_selector '.item-count', text: "3"
-      expect(page).to have_no_selector '.invalid-count'
-      expect(page).to have_no_selector '.create-count'
-      expect(page).to have_no_selector '.update-count'
+      expect(page).not_to have_selector '.invalid-count'
+      expect(page).not_to have_selector '.create-count'
+      expect(page).not_to have_selector '.update-count'
       expect(page).to have_selector '.inv-create-count', text: "2"
       expect(page).to have_selector '.inv-update-count', text: "1"
 
       save_data
 
-      expect(page).to have_no_selector '.created-count'
-      expect(page).to have_no_selector '.updated-count'
+      expect(page).not_to have_selector '.created-count'
+      expect(page).not_to have_selector '.updated-count'
       expect(page).to have_selector '.inv-created-count', text: '2'
       expect(page).to have_selector '.inv-updated-count', text: '1'
 
@@ -374,7 +374,7 @@ describe "Product Import" do
       proceed_to_validation
 
       expect(page).to have_selector '.item-count', text: "1"
-      expect(page).to have_no_selector '.invalid-count'
+      expect(page).not_to have_selector '.invalid-count'
       expect(page).to have_selector '.inv-create-count', text: '1'
 
       save_data
@@ -414,7 +414,7 @@ describe "Product Import" do
         click_button 'Upload'
         proceed_to_validation
         expect(page).to have_selector '.item-count', text: "1"
-        expect(page).to have_no_selector '.invalid-count'
+        expect(page).not_to have_selector '.invalid-count'
         expect(page).to have_selector '.inv-create-count', text: '1'
         save_data
 
@@ -452,7 +452,7 @@ describe "Product Import" do
         expect(page).to have_content "Variant_unit_name must be the same for products " \
                                      "with the same name"
         expect(page).to have_content "Imported file contains invalid entries"
-        expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+        expect(page).not_to have_selector 'input[type=submit][value="Save"]'
 
         visit main_app.admin_inventory_path
 
@@ -482,7 +482,7 @@ describe "Product Import" do
         expect(page).to have_content "line 4: Cabbage - Units incorrect value"
         expect(page).to have_content "line 3: Beans - Units incorrect value"
         expect(page).to have_content "Imported file contains invalid entries"
-        expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+        expect(page).not_to have_selector 'input[type=submit][value="Save"]'
         expect(page).not_to have_content "line 2: Aubergine"
       end
 
@@ -509,7 +509,7 @@ describe "Product Import" do
         expect(page).to have_content "line 4: Cabbage - Price incorrect value"
         expect(page).to have_content "line 3: Beans - Price can't be blank"
         expect(page).to have_content "Imported file contains invalid entries"
-        expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+        expect(page).not_to have_selector 'input[type=submit][value="Save"]'
         expect(page).not_to have_content "line 2: Aubergine"
       end
     end
@@ -541,7 +541,7 @@ describe "Product Import" do
       expect(page)
         .to have_content "line 5: Aubergine - On_hand incorrect value - On_demand incorrect value"
       expect(page).to have_content "Imported file contains invalid entries"
-      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
       expect(page).not_to have_content "line 2: Beans"
       expect(page).not_to have_content "line 3: Sprouts"
     end
@@ -577,7 +577,7 @@ describe "Product Import" do
       expect(page).to have_content "line 5: Aubergine ( Bag ) - On_hand incorrect value - " \
                                    "On_demand incorrect value"
       expect(page).to have_content "Imported file contains invalid entries"
-      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
       expect(page).not_to have_content "line 2: Beans"
       expect(page).not_to have_content "line 3: Potatoes"
     end
@@ -611,7 +611,7 @@ describe "Product Import" do
       expect(page).to have_content "line 5: Aubergine ( Bag ) - On_hand incorrect value - " \
                                    "On_demand incorrect value"
       expect(page).to have_content "Imported file contains invalid entries"
-      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
       expect(page).not_to have_content "line 2: Beans"
       expect(page).not_to have_content "line 3: Sprouts"
     end
@@ -640,7 +640,7 @@ describe "Product Import" do
       expect(page).to have_content "line 3: Sprouts - Count_on_hand must be blank if on demand"
       expect(page).to have_content "line 4: Cabbage - Count_on_hand must be blank if on demand"
       expect(page).to have_content "Imported file contains invalid entries"
-      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
     end
 
     it "imports lines with all allowed units" do
@@ -663,14 +663,14 @@ describe "Product Import" do
       proceed_to_validation
 
       expect(page).to have_selector '.item-count', text: "2"
-      expect(page).to have_no_selector '.invalid-count'
+      expect(page).not_to have_selector '.invalid-count'
       expect(page).to have_selector '.create-count', text: "2"
-      expect(page).to have_no_selector '.update-count'
+      expect(page).not_to have_selector '.update-count'
 
       save_data
 
       expect(page).to have_selector '.created-count', text: '2'
-      expect(page).to have_no_selector '.updated-count'
+      expect(page).not_to have_selector '.updated-count'
 
       visit spree.admin_products_path
 
@@ -699,14 +699,14 @@ describe "Product Import" do
       proceed_to_validation
 
       expect(page).to have_selector '.item-count', text: "1"
-      expect(page).to have_no_selector '.invalid-count'
+      expect(page).not_to have_selector '.invalid-count'
       expect(page).to have_selector '.create-count', text: "1"
-      expect(page).to have_no_selector '.update-count'
+      expect(page).not_to have_selector '.update-count'
 
       save_data
 
       expect(page).to have_selector '.created-count', text: '1'
-      expect(page).to have_no_selector '.updated-count'
+      expect(page).not_to have_selector '.updated-count'
       expect(page).to have_content "GO TO PRODUCTS PAGE"
       expect(page).to have_content "UPLOAD ANOTHER FILE"
 
@@ -739,10 +739,10 @@ describe "Product Import" do
 
       expect(page).to have_selector '.item-count', text: "1"
       expect(page).to have_selector '.invalid-count', text: "1"
-      expect(page).to have_no_selector ".create-count"
-      expect(page).to have_no_selector '.update-count'
+      expect(page).not_to have_selector ".create-count"
+      expect(page).not_to have_selector '.update-count'
 
-      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
     end
 
     context 'when using other language than English' do
@@ -800,7 +800,7 @@ describe "Product Import" do
       click_button 'Upload'
 
       expect(page).to have_content "Importer could not process file: invalid filetype"
-      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
       expect(page).to have_content "Select a spreadsheet to upload"
       File.delete('/tmp/test.txt')
     end
@@ -820,9 +820,9 @@ describe "Product Import" do
       attach_file 'file', '/tmp/test.csv'
       click_button 'Upload'
 
-      expect(page).to have_no_selector '.create-count'
-      expect(page).to have_no_selector '.update-count'
-      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+      expect(page).not_to have_selector '.create-count'
+      expect(page).not_to have_selector '.update-count'
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
       File.delete('/tmp/test.csv')
     end
 
@@ -837,9 +837,9 @@ describe "Product Import" do
       attach_file 'file', '/tmp/test.csv'
       click_button 'Upload'
 
-      expect(page).to have_no_selector '.create-count'
-      expect(page).to have_no_selector '.update-count'
-      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
+      expect(page).not_to have_selector '.create-count'
+      expect(page).not_to have_selector '.update-count'
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
       expect(flash_message).to match("Product Import encountered a malformed CSV: %s" % '')
 
       File.delete('/tmp/test.csv')
@@ -874,7 +874,7 @@ describe "Product Import" do
       expect(page).to have_selector '.create-count', text: "1"
 
       expect(page.body).to have_content 'you do not have permission'
-      expect(page).to have_no_selector 'a.button.proceed'
+      expect(page).not_to have_selector 'a.button.proceed'
     end
   end
 

--- a/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
@@ -44,7 +44,7 @@ describe "enterprise fee summaries" do
         let(:current_user) { create(:user) }
 
         it "does not allow access to the report" do
-          expect(page).to have_no_link('Enterprise Fee Summary')
+          expect(page).not_to have_link('Enterprise Fee Summary')
           visit main_app.admin_report_path(report_type: 'enterprise_fee_summary')
           expect(page).to have_content('Unauthorized')
         end

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -122,7 +122,7 @@ describe '
         page.has_selector? ".loading"
       end
 
-      expect(page).to have_no_selector ".loading"
+      expect(page).not_to have_selector ".loading"
     end
   end
 

--- a/spec/system/admin/schedules_spec.rb
+++ b/spec/system/admin/schedules_spec.rb
@@ -39,13 +39,13 @@ describe 'Schedules' do
           expect(page).to have_selector '#available-order-cycles .order-cycle', text: oc1.name
           expect(page).to have_selector '#available-order-cycles .order-cycle', text: oc2.name
           expect(page).to have_selector '#available-order-cycles .order-cycle', text: oc3.name
-          expect(page).to have_no_selector '#available-order-cycles .order-cycle', text: oc4.name
+          expect(page).not_to have_selector '#available-order-cycles .order-cycle', text: oc4.name
           expect(page).to have_selector '#available-order-cycles .order-cycle', text: oc5.name
           fill_in 'name', with: "Fortnightly"
           find("#available-order-cycles .order-cycle", text: oc1.name).click
           find("#add-remove-buttons a.add").click
           # Selection of an order cycles limits available options to those with the same coordinator
-          expect(page).to have_no_selector '#available-order-cycles .order-cycle', text: oc5.name
+          expect(page).not_to have_selector '#available-order-cycles .order-cycle', text: oc5.name
           find("#available-order-cycles .order-cycle", text: oc3.name).click
           find("#add-remove-buttons a.add").click
           click_button "Create Schedule"
@@ -61,7 +61,7 @@ describe 'Schedules' do
 
         within ".order-cycle-#{oc2.id} td.schedules" do
           expect(page).to have_selector "a", text: "Weekly"
-          expect(page).to have_no_selector "a", text: "Fortnightly"
+          expect(page).not_to have_selector "a", text: "Fortnightly"
         end
 
         within ".order-cycle-#{oc3.id} td.schedules" do
@@ -100,11 +100,11 @@ describe 'Schedules' do
 
         within ".order-cycle-#{oc2.id} td.schedules" do
           expect(page).to have_selector "a", text: "Weekly"
-          expect(page).to have_no_selector "a", text: "Fortnightly"
+          expect(page).not_to have_selector "a", text: "Fortnightly"
         end
 
         within ".order-cycle-#{oc3.id} td.schedules" do
-          expect(page).to have_no_selector "a", text: "Weekly"
+          expect(page).not_to have_selector "a", text: "Weekly"
           expect(page).to have_selector "a", text: "Fortnightly"
         end
       end
@@ -128,15 +128,15 @@ describe 'Schedules' do
         expect(save_bar).to have_content "Deleted schedule: 'Weekly'"
 
         within ".order-cycle-#{oc1.id} td.schedules" do
-          expect(page).to have_no_selector "a", text: "Weekly"
+          expect(page).not_to have_selector "a", text: "Weekly"
         end
 
         within ".order-cycle-#{oc2.id} td.schedules" do
-          expect(page).to have_no_selector "a", text: "Weekly"
+          expect(page).not_to have_selector "a", text: "Weekly"
         end
 
         within ".order-cycle-#{oc3.id} td.schedules" do
-          expect(page).to have_no_selector "a", text: "Weekly"
+          expect(page).not_to have_selector "a", text: "Weekly"
         end
 
         expect(Schedule.find_by(id: weekly_schedule.id)).to be_nil

--- a/spec/system/admin/shipping_methods_spec.rb
+++ b/spec/system/admin/shipping_methods_spec.rb
@@ -35,7 +35,7 @@ describe 'shipping methods' do
       check "shipping_method_shipping_categories_"
       click_button 'Create'
 
-      expect(page).to have_no_button 'Create'
+      expect(page).not_to have_button 'Create'
 
       # Then the shipping method should have its distributor set
       expect(flash_message).to include "Carrier Pidgeon", "successfully created!"

--- a/spec/system/admin/subscriptions/crud_spec.rb
+++ b/spec/system/admin/subscriptions/crud_spec.rb
@@ -49,8 +49,8 @@ describe 'Subscriptions' do
 
           # Loads the right subscriptions
           expect(page).to have_selector "tr#so_#{subscription2.id}"
-          expect(page).to have_no_selector "tr#so_#{subscription.id}"
-          expect(page).to have_no_selector "tr#so_#{subscription_unmanaged.id}"
+          expect(page).not_to have_selector "tr#so_#{subscription.id}"
+          expect(page).not_to have_selector "tr#so_#{subscription_unmanaged.id}"
           within "tr#so_#{subscription2.id}" do
             expect(page).to have_selector "td.customer", text: subscription2.customer.email
           end
@@ -60,8 +60,8 @@ describe 'Subscriptions' do
 
           # Loads the right subscriptions
           expect(page).to have_selector "tr#so_#{subscription.id}"
-          expect(page).to have_no_selector "tr#so_#{subscription2.id}"
-          expect(page).to have_no_selector "tr#so_#{subscription_unmanaged.id}"
+          expect(page).not_to have_selector "tr#so_#{subscription2.id}"
+          expect(page).not_to have_selector "tr#so_#{subscription_unmanaged.id}"
           within "tr#so_#{subscription.id}" do
             expect(page).to have_selector "td.customer", text: subscription.customer.email
           end
@@ -72,23 +72,23 @@ describe 'Subscriptions' do
 
           # Using the Quick Search: no result
           fill_in 'query', with: 'blah blah blah'
-          expect(page).to have_no_selector "tr#so_#{subscription.id}"
-          expect(page).to have_no_selector "tr#so_#{other_subscription.id}"
+          expect(page).not_to have_selector "tr#so_#{subscription.id}"
+          expect(page).not_to have_selector "tr#so_#{other_subscription.id}"
 
           # Using the Quick Search: filter by email
           fill_in 'query', with: other_subscription.customer.email
           expect(page).to have_selector "tr#so_#{other_subscription.id}"
-          expect(page).to have_no_selector "tr#so_#{subscription.id}"
+          expect(page).not_to have_selector "tr#so_#{subscription.id}"
 
           # Using the Quick Search: filter by first_name
           fill_in 'query', with: other_subscription.customer.first_name
           expect(page).to have_selector "tr#so_#{other_subscription.id}"
-          expect(page).to have_no_selector "tr#so_#{subscription.id}"
+          expect(page).not_to have_selector "tr#so_#{subscription.id}"
 
           # Using the Quick Search: filter by last_name
           fill_in 'query', with: other_subscription.customer.last_name
           expect(page).to have_selector "tr#so_#{other_subscription.id}"
-          expect(page).to have_no_selector "tr#so_#{subscription.id}"
+          expect(page).not_to have_selector "tr#so_#{subscription.id}"
 
           # Using the Quick Search: reset filter
           fill_in 'query', with: ''
@@ -99,8 +99,8 @@ describe 'Subscriptions' do
           expect(page).to have_selector "th.customer"
           expect(page).to have_content subscription.customer.email
           toggle_columns "Customer"
-          expect(page).to have_no_selector "th.customer"
-          expect(page).to have_no_content subscription.customer.email
+          expect(page).not_to have_selector "th.customer"
+          expect(page).not_to have_content subscription.customer.email
 
           # Viewing Products
           open_subscription_products_panel
@@ -124,7 +124,7 @@ describe 'Subscriptions' do
 
             proxy_order = subscription.proxy_orders.first
             within "tr#po_#{proxy_order.id}" do
-              expect(page).to have_no_content 'CANCELLED'
+              expect(page).not_to have_content 'CANCELLED'
               accept_alert 'Are you sure?' do
                 find("a.cancel-order").click
               end

--- a/spec/system/admin/tag_rules_spec.rb
+++ b/spec/system/admin/tag_rules_spec.rb
@@ -16,7 +16,7 @@ describe 'Tag Rules' do
     it "allows creation of rules of each type" do
       # Creating a new tag
       expect(page).to have_content 'No tags apply to this enterprise yet'
-      expect(page).to have_no_selector '.customer_tag'
+      expect(page).not_to have_selector '.customer_tag'
       click_button '+ Add A New Tag'
       fill_in_tag "volunteer"
 
@@ -271,13 +271,13 @@ describe 'Tag Rules' do
             first("a.delete-tag-rule").click
           end
         end
-        expect(page).to have_no_selector "#tr_1"
+        expect(page).not_to have_selector "#tr_1"
         accept_alert do
           within "#tr_0" do
             first("a.delete-tag-rule").click
           end
         end
-        expect(page).to have_no_selector "#tr_0"
+        expect(page).not_to have_selector "#tr_0"
       end.to change{ TagRule.count }.by(-2)
 
       # After deleting tags, the form is dirty and we need to confirm leaving

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -135,7 +135,7 @@ describe "Managing users" do
         visit spree.new_admin_user_path
 
         # shows no confirmation message to start with
-        expect(page).to have_no_text "Email confirmation is pending"
+        expect(page).not_to have_text "Email confirmation is pending"
 
         fill_in "Email", with: "user1@example.org"
         fill_in "Password", with: "user1Secret"

--- a/spec/system/admin/variant_overrides_spec.rb
+++ b/spec/system/admin/variant_overrides_spec.rb
@@ -105,7 +105,7 @@ describe "
             expect(page).to have_selector "#v_#{variant_related.id}"
             select2_select producer.name, from: 'producer_filter'
             expect(page).to have_selector "#v_#{variant.id}"
-            expect(page).to have_no_selector "#v_#{variant_related.id}"
+            expect(page).not_to have_selector "#v_#{variant_related.id}"
             select2_select 'All', from: 'producer_filter'
 
             # Filters based on the quick search box
@@ -113,7 +113,7 @@ describe "
             expect(page).to have_selector "#v_#{variant_related.id}"
             fill_in 'query', with: product.name
             expect(page).to have_selector "#v_#{variant.id}"
-            expect(page).to have_no_selector "#v_#{variant_related.id}"
+            expect(page).not_to have_selector "#v_#{variant_related.id}"
             fill_in 'query', with: ''
 
             # Clears the filters
@@ -121,8 +121,8 @@ describe "
             expect(page).to have_selector "tr#v_#{variant_related.id}"
             select2_select producer.name, from: 'producer_filter'
             fill_in 'query', with: product_related.name
-            expect(page).to have_no_selector "tr#v_#{variant.id}"
-            expect(page).to have_no_selector "tr#v_#{variant_related.id}"
+            expect(page).not_to have_selector "tr#v_#{variant.id}"
+            expect(page).not_to have_selector "tr#v_#{variant_related.id}"
             click_button 'Clear All'
             expect(page).to have_selector "tr#v_#{variant.id}"
             expect(page).to have_selector "tr#v_#{variant_related.id}"
@@ -134,17 +134,17 @@ describe "
             within "tr#v_#{variant.id}" do
               click_button 'Hide'
             end
-            expect(page).to have_no_selector "tr#v_#{variant.id}"
+            expect(page).not_to have_selector "tr#v_#{variant.id}"
             expect(page).to have_selector "tr#v_#{variant_related.id}"
             first("div#views-dropdown").click
             first("div#views-dropdown div.menu div.menu_item", text: "Hidden Products").click
             expect(page).to have_selector "tr#v_#{variant.id}"
-            expect(page).to have_no_selector "tr#v_#{variant_related.id}"
+            expect(page).not_to have_selector "tr#v_#{variant_related.id}"
             within "tr#v_#{variant.id}" do
               click_button 'Add'
             end
-            expect(page).to have_no_selector "tr#v_#{variant.id}"
-            expect(page).to have_no_selector "tr#v_#{variant_related.id}"
+            expect(page).not_to have_selector "tr#v_#{variant.id}"
+            expect(page).not_to have_selector "tr#v_#{variant_related.id}"
             first("div#views-dropdown").click
             first("div#views-dropdown div.menu div.menu_item", text: "Inventory Products").click
             expect(page).to have_selector "tr#v_#{variant.id}"
@@ -434,7 +434,7 @@ describe "
               # It does not save the changes.
               click_button 'Save Changes'
               expect(page).to have_content 'must be specified because forcing limited stock'
-              expect(page).to have_no_content 'Changes saved.'
+              expect(page).not_to have_content 'Changes saved.'
 
               vo.reload
               expect(vo.count_on_hand).to eq(1111)
@@ -485,8 +485,8 @@ describe "
 
         it "alerts the user to the presence of new products, and allows them to be added " \
            "or hidden" do
-          expect(page).to have_no_selector "table#variant-overrides tr#v_#{variant1.id}"
-          expect(page).to have_no_selector "table#variant-overrides tr#v_#{variant2.id}"
+          expect(page).not_to have_selector "table#variant-overrides tr#v_#{variant1.id}"
+          expect(page).not_to have_selector "table#variant-overrides tr#v_#{variant2.id}"
 
           expect(page).to have_selector '.alert-row span.message',
                                         text: "There are 1 new products available to add to your " \
@@ -502,17 +502,17 @@ describe "
           within "table#new-products tr#v_#{variant2.id}" do
             click_button 'Hide'
           end
-          expect(page).to have_no_selector "table#new-products tr#v_#{variant1.id}"
-          expect(page).to have_no_selector "table#new-products tr#v_#{variant2.id}"
+          expect(page).not_to have_selector "table#new-products tr#v_#{variant1.id}"
+          expect(page).not_to have_selector "table#new-products tr#v_#{variant2.id}"
           click_button "Back to my inventory"
 
           expect(page).to have_selector "table#variant-overrides tr#v_#{variant1.id}"
-          expect(page).to have_no_selector "table#variant-overrides tr#v_#{variant2.id}"
+          expect(page).not_to have_selector "table#variant-overrides tr#v_#{variant2.id}"
 
           first("div#views-dropdown").click
           first("div#views-dropdown div.menu div.menu_item", text: "Hidden Products").click
 
-          expect(page).to have_no_selector "table#hidden-products tr#v_#{variant1.id}"
+          expect(page).not_to have_selector "table#hidden-products tr#v_#{variant1.id}"
           expect(page).to have_selector "table#hidden-products tr#v_#{variant2.id}"
         end
       end

--- a/spec/system/consumer/account/cards_spec.rb
+++ b/spec/system/consumer/account/cards_spec.rb
@@ -90,7 +90,7 @@ describe "Credit Cards" do
       expect(page).to have_content(
         format("Your card has been removed (number: %s)", "x-#{default_card.last_digits}")
       )
-      expect(page).to have_no_selector ".card#card#{default_card.id}"
+      expect(page).not_to have_selector ".card#card#{default_card.id}"
 
       # Allows authorisation of card use by shops
       within "tr#customer#{customer.id}" do

--- a/spec/system/consumer/account_spec.rb
+++ b/spec/system/consumer/account_spec.rb
@@ -45,7 +45,7 @@ describe '
         visit "/account"
 
         # No distributors allow changes to orders
-        expect(page).to have_no_content 'Open Orders'
+        expect(page).not_to have_content 'Open Orders'
 
         expect(page).to have_content 'Past Orders'
 

--- a/spec/system/consumer/checkout/guest_spec.rb
+++ b/spec/system/consumer/checkout/guest_spec.rb
@@ -79,7 +79,7 @@ describe "As a consumer, I want to checkout my order" do
     it "should display the checkout login page" do
       expect(page).to have_content("Ok, ready to checkout?")
       expect(page).to have_content("Login")
-      expect(page).to have_no_content("Checkout as guest")
+      expect(page).not_to have_content("Checkout as guest")
     end
 
     it "should show the login modal when clicking the login button" do

--- a/spec/system/consumer/cookies_spec.rb
+++ b/spec/system/consumer/cookies_spec.rb
@@ -64,9 +64,11 @@ describe "Cookies", caching: true do
       scenario "it is not showing" do
         Spree::Config[:cookies_consent_banner_toggle] = false
         visit root_path
-        expect(page).not_to have_content 'This site uses cookies in order to make your navigation ' \
-                                         'frictionless and secure, and to help us understand how ' \
-                                         'you use it in order to improve the features we offer.'
+        expect(page).not_to have_content(
+          'This site uses cookies in order to make your navigation ' \
+          'frictionless and secure, and to help us understand how ' \
+          'you use it in order to improve the features we offer.'
+        )
       end
     end
   end

--- a/spec/system/consumer/cookies_spec.rb
+++ b/spec/system/consumer/cookies_spec.rb
@@ -64,9 +64,9 @@ describe "Cookies", caching: true do
       scenario "it is not showing" do
         Spree::Config[:cookies_consent_banner_toggle] = false
         visit root_path
-        expect(page).to have_no_content 'This site uses cookies in order to make your navigation ' \
-                                        'frictionless and secure, and to help us understand how ' \
-                                        'you use it in order to improve the features we offer.'
+        expect(page).not_to have_content 'This site uses cookies in order to make your navigation ' \
+                                         'frictionless and secure, and to help us understand how ' \
+                                         'you use it in order to improve the features we offer.'
       end
     end
   end
@@ -91,8 +91,8 @@ describe "Cookies", caching: true do
       scenario "does not show Matomo cookies details and does not show Matomo optout text" do
         Spree::Config[:cookies_policy_matomo_section] = false
         visit_cookies_policy_page
-        expect(page).to have_no_content matomo_description_text
-        expect(page).to have_no_content matomo_opt_out_iframe
+        expect(page).not_to have_content matomo_description_text
+        expect(page).not_to have_content matomo_opt_out_iframe
       end
     end
 
@@ -120,8 +120,8 @@ describe "Cookies", caching: true do
           Spree::Config[:cookies_policy_matomo_section] = true
           Spree::Config[:matomo_url] = ""
           visit_cookies_policy_page
-          expect(page).to have_no_content matomo_opt_out_iframe
-          expect(page).to have_no_selector("iframe")
+          expect(page).not_to have_content matomo_opt_out_iframe
+          expect(page).not_to have_selector("iframe")
         end
       end
     end
@@ -136,7 +136,7 @@ describe "Cookies", caching: true do
   end
 
   def expect_not_visible_cookies_banner
-    expect(page).to have_no_css("button", text: accept_cookies_button_text)
+    expect(page).not_to have_css("button", text: accept_cookies_button_text)
   end
 
   def accept_cookies_button_text

--- a/spec/system/consumer/footer_links_spec.rb
+++ b/spec/system/consumer/footer_links_spec.rb
@@ -44,7 +44,7 @@ describe "Footer Links" do
     it "not showing if it is empty" do
       Spree::Config[:privacy_policy_url] = nil
       visit root_path
-      expect(page).to have_no_link "privacy policy"
+      expect(page).not_to have_link "privacy policy"
     end
 
     it "showing configured privacy policy link" do

--- a/spec/system/consumer/multilingual_spec.rb
+++ b/spec/system/consumer/multilingual_spec.rb
@@ -102,7 +102,7 @@ describe 'Multilingual' do
 
       it "hides the dropdown language menu" do
         visit root_path
-        expect(page).to have_no_css 'ul.right li.language-switcher.has-dropdown'
+        expect(page).not_to have_css 'ul.right li.language-switcher.has-dropdown'
       end
     end
 

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -101,7 +101,7 @@ describe "Registration" do
       # Images
       # Upload logo image
       attach_file "image-select", Rails.root.join("spec/fixtures/files/logo.png"), visible: false
-      expect(page).to have_no_css('#image-placeholder .loading')
+      expect(page).not_to have_css('#image-placeholder .loading')
       expect(page.find('#image-placeholder img')['src']).to_not be_empty
 
       # Move from logo page
@@ -110,7 +110,7 @@ describe "Registration" do
 
       # Upload promo image
       attach_file "image-select", Rails.root.join("spec/fixtures/files/promo.png"), visible: false
-      expect(page).to have_no_css('#image-placeholder .loading')
+      expect(page).not_to have_css('#image-placeholder .loading')
       expect(page.find('#image-placeholder img')['src']).to_not be_empty
 
       # Move from promo page
@@ -255,7 +255,7 @@ describe "Registration" do
         expect(page).to have_selector "input.button.primary[disabled]"
 
         check "accept_terms"
-        expect(page).to have_no_selector "input.button.primary[disabled]"
+        expect(page).not_to have_selector "input.button.primary[disabled]"
 
         click_button "Let's get started!"
         expect(find("div#progress-bar")).to be_visible

--- a/spec/system/consumer/shopping/cart_spec.rb
+++ b/spec/system/consumer/shopping/cart_spec.rb
@@ -49,9 +49,9 @@ describe "full-page cart" do
 
         click_link "Continue shopping"
 
-        expect(page).to have_no_link "Continue shopping"
+        expect(page).not_to have_link "Continue shopping"
         expect(page).to have_link "Shop"
-        expect(page).to have_no_content distributor.preferred_shopfront_message
+        expect(page).not_to have_content distributor.preferred_shopfront_message
       end
     end
 
@@ -59,7 +59,7 @@ describe "full-page cart" do
       it "does not link to the product page" do
         add_product_to_cart order, product_with_fee, quantity: 2
         visit main_app.cart_path
-        expect(page).to have_no_selector '.item-thumb-image a'
+        expect(page).not_to have_selector '.item-thumb-image a'
       end
     end
 
@@ -132,7 +132,7 @@ describe "full-page cart" do
 
         it "hides admin and handlings row" do
           expect(page).to have_selector('#cart-detail')
-          expect(page).to have_no_content('Admin & Handling')
+          expect(page).not_to have_content('Admin & Handling')
           expect(page).to have_selector '.cart-item-price', text: with_currency(0.86)
           expect(page).to have_selector '.order-total.grand-total',
                                         text: with_currency(1.72) # price * 3
@@ -293,8 +293,8 @@ describe "full-page cart" do
         item1 = prev_order1.line_items.first
         item2 = prev_order2.line_items.first
 
-        expect(page).to have_no_content item1.variant.name
-        expect(page).to have_no_content item2.variant.name
+        expect(page).not_to have_content item1.variant.name
+        expect(page).not_to have_content item2.variant.name
 
         expect(page).to have_link 'Edit confirmed items', href: spree.account_path
         find("td.toggle-bought").click
@@ -302,13 +302,13 @@ describe "full-page cart" do
         expect(page).to have_content item1.variant.name
         expect(page).to have_content item2.variant.name
         page.find(".line-item-#{item1.id} td.bought-item-delete a").click
-        expect(page).to have_no_content item1.variant.name
+        expect(page).not_to have_content item1.variant.name
         expect(page).to have_content item2.variant.name
 
         visit main_app.cart_path
 
         find("td.toggle-bought").click
-        expect(page).to have_no_content item1.variant.name
+        expect(page).not_to have_content item1.variant.name
         expect(page).to have_content item2.variant.name
       end
 

--- a/spec/system/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/system/consumer/shopping/checkout_auth_spec.rb
@@ -34,7 +34,7 @@ describe "As a consumer I want to check out my cart" do
         login_as user
         visit checkout_path
         within "section[role='main']" do
-          expect(page).to have_no_content "Login"
+          expect(page).not_to have_content "Login"
           expect(page).to have_checkout_details
         end
       end

--- a/spec/system/consumer/shopping/checkout_spec.rb
+++ b/spec/system/consumer/shopping/checkout_spec.rb
@@ -148,13 +148,13 @@ describe "As a consumer I want to check out my cart" do
       end
 
       it "shows only applicable content" do
-        expect(page).to have_no_content("You have an order for this order cycle already.")
+        expect(page).not_to have_content("You have an order for this order cycle already.")
 
-        expect(page).to have_no_link("Terms and Conditions")
+        expect(page).not_to have_link("Terms and Conditions")
 
         # We always have this link in the footer.
         within "#checkout_form" do
-          expect(page).to have_no_link("Terms of service")
+          expect(page).not_to have_link("Terms of service")
         end
       end
     end

--- a/spec/system/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/system/consumer/shopping/embedded_groups_spec.rb
@@ -49,8 +49,8 @@ describe "Using embedded shopfront functionality" do
     it "doesn't display contact details when embedded" do
       on_embedded_page do
         within 'div#group-page' do
-          expect(page).to have_no_selector 'div.contact-container'
-          expect(page).to have_no_content group.address.address1.to_s
+          expect(page).not_to have_selector 'div.contact-container'
+          expect(page).not_to have_content group.address.address1.to_s
         end
       end
     end
@@ -58,9 +58,9 @@ describe "Using embedded shopfront functionality" do
     it "does not display the header when embedded" do
       on_embedded_page do
         within 'div#group-page' do
-          expect(page).to have_no_selector 'header'
-          expect(page).to have_no_selector 'img.group-logo'
-          expect(page).to have_no_selector 'h2.group-name'
+          expect(page).not_to have_selector 'header'
+          expect(page).not_to have_selector 'img.group-logo'
+          expect(page).not_to have_selector 'h2.group-name'
         end
       end
     end

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -142,7 +142,7 @@ describe "Order Management" do
         expect(find("tr.variant-#{item1.variant.id}")).to have_content item1.product.name
         expect(find("tr.variant-#{item2.variant.id}")).to have_content item2.product.name
         expect(find("tr.variant-#{item3.variant.id}")).to have_content item3.product.name
-        expect(page).to have_no_button 'Save Changes'
+        expect(page).not_to have_button 'Save Changes'
       end
     end
 
@@ -155,7 +155,7 @@ describe "Order Management" do
         visit order_path(order)
 
         expect(page).to have_button 'Order Saved', disabled: true
-        expect(page).to have_no_button 'Save Changes'
+        expect(page).not_to have_button 'Save Changes'
 
         # Changing the quantity of an item
         within "tr.variant-#{item1.variant.id}" do

--- a/spec/system/consumer/shopping/shopping_spec.rb
+++ b/spec/system/consumer/shopping/shopping_spec.rb
@@ -531,7 +531,7 @@ describe "As a consumer I want to shop with a distributor" do
           # Update amount in cart
           within_variant(variant) do
             expect(page).to have_button "Add", disabled: true
-            expect(page).to have_no_content "in cart"
+            expect(page).not_to have_content "in cart"
           end
           within_variant(variant2) do
             expect(page).to have_button "Add", disabled: false
@@ -578,7 +578,7 @@ describe "As a consumer I want to shop with a distributor" do
             # Update amount in cart
             within_variant(variant) do
               expect(page).to have_button "Add", disabled: true
-              expect(page).to have_no_content "in cart"
+              expect(page).not_to have_content "in cart"
             end
 
             # Update amount available in product list
@@ -703,7 +703,7 @@ describe "As a consumer I want to shop with a distributor" do
           visit shop_path
           expect(page).to have_content "Only approved customers can access this shop."
           expect(page).to have_content "login to proceed"
-          expect(page).to have_no_content product.name
+          expect(page).not_to have_content product.name
           expect(page).not_to have_selector "ordercycle"
         end
       end
@@ -721,7 +721,7 @@ describe "As a consumer I want to shop with a distributor" do
             visit shop_path
             expect(page).to have_content "Only approved customers can access this shop."
             expect(page).to have_content "please contact #{distributor.name}"
-            expect(page).to have_no_content product.name
+            expect(page).not_to have_content product.name
             expect(page).not_to have_selector "ordercycle"
           end
         end
@@ -773,7 +773,7 @@ describe "As a consumer I want to shop with a distributor" do
   end
 
   def shows_products_without_customer_warning
-    expect(page).to have_no_content "This shop is for customers only."
+    expect(page).not_to have_content "This shop is for customers only."
     expect(page).to have_content product.name
   end
 
@@ -789,7 +789,7 @@ describe "As a consumer I want to shop with a distributor" do
     expect(page).to have_selector "#variant-#{variant.id}.out-of-stock"
     within_variant(variant) do
       expect(page).to have_button "Add", disabled: true
-      expect(page).to have_no_content "in cart"
+      expect(page).not_to have_content "in cart"
     end
   end
 end

--- a/spec/system/consumer/shopping/unit_price_spec.rb
+++ b/spec/system/consumer/shopping/unit_price_spec.rb
@@ -48,9 +48,9 @@ describe "As a consumer, I want to check unit price information for a product" d
 
       page.find("body").click
       expect(page).not_to have_selector '.joyride-tip-guide.question-mark-tooltip'
-      expect(page).to have_no_content('This is the unit price of this product. ' \
-                                      'It allows you to compare the price of products ' \
-                                      'independent of packaging sizes & weights.')
+      expect(page).not_to have_content('This is the unit price of this product. ' \
+                                       'It allows you to compare the price of products ' \
+                                       'independent of packaging sizes & weights.')
     end
   end
 
@@ -72,9 +72,9 @@ describe "As a consumer, I want to check unit price information for a product" d
       end
       page.find("body").click
       expect(page).not_to have_selector '.joyride-tip-guide.question-mark-tooltip'
-      expect(page).to have_no_content('This is the unit price of this product. ' \
-                                      'It allows you to compare the price of products ' \
-                                      'independent of packaging sizes & weights.')
+      expect(page).not_to have_content('This is the unit price of this product. ' \
+                                       'It allows you to compare the price of products ' \
+                                       'independent of packaging sizes & weights.')
     end
   end
 end

--- a/spec/system/consumer/shops_spec.rb
+++ b/spec/system/consumer/shops_spec.rb
@@ -74,8 +74,8 @@ describe 'Shops' do
     end
 
     it "does not show hubs that are not in an order cycle" do
-      expect(page).to have_no_selector 'hub.inactive'
-      expect(page).to have_no_selector 'hub', text: d2.name
+      expect(page).not_to have_selector 'hub.inactive'
+      expect(page).not_to have_selector 'hub', text: d2.name
     end
 
     it "does not show profiles" do

--- a/spec/system/consumer/user_password_spec.rb
+++ b/spec/system/consumer/user_password_spec.rb
@@ -25,7 +25,7 @@ describe "User password confirm/reset page" do
       fill_in "Password Confirmation", with: "my secret"
       click_button
 
-      expect(page).to have_no_text "Reset password token has expired"
+      expect(page).not_to have_text "Reset password token has expired"
       expect(page).to be_logged_in_as user
     end
 

--- a/spec/system/consumer/white_label_spec.rb
+++ b/spec/system/consumer/white_label_spec.rb
@@ -115,7 +115,7 @@ describe 'White label setting' do
           end
 
           it "hides the OFN navigation" do
-            expect(page).to have_no_selector ofn_navigation
+            expect(page).not_to have_selector ofn_navigation
           end
 
           it_behaves_like "hides the OFN navigation for mobile view as well"
@@ -153,7 +153,7 @@ describe 'White label setting' do
           end
 
           it "hides the OFN navigation" do
-            expect(page).to have_no_selector ofn_navigation
+            expect(page).not_to have_selector ofn_navigation
           end
 
           it_behaves_like "hides the OFN navigation for mobile view as well"
@@ -167,7 +167,7 @@ describe 'White label setting' do
           it "hides the OFN navigation" do
             expect(page).to have_content "Checkout now"
             expect(page).to have_content "Order ready for "
-            expect(page).to have_no_selector ofn_navigation
+            expect(page).not_to have_selector ofn_navigation
           end
 
           it_behaves_like "hides the OFN navigation for mobile view as well"
@@ -186,7 +186,7 @@ describe 'White label setting' do
             end
 
             it "hides the OFN navigation" do
-              expect(page).to have_no_selector ofn_navigation
+              expect(page).not_to have_selector ofn_navigation
             end
           end
         end
@@ -247,7 +247,7 @@ describe 'White label setting' do
 
         it "hides the groups tab" do
           visit main_app.enterprise_shop_path(distributor)
-          expect(page).to have_no_selector "a[href='#groups']"
+          expect(page).not_to have_selector "a[href='#groups']"
         end
       end
 

--- a/spec/views/admin/products_v3/_filters.html.haml_spec.rb
+++ b/spec/views/admin/products_v3/_filters.html.haml_spec.rb
@@ -38,7 +38,7 @@ describe "admin/products_v3/_filters.html.haml" do
       ],
     )
 
-    is_expected.to have_no_content "Producers"
-    is_expected.to have_no_select "producer_id"
+    is_expected.not_to have_content "Producers"
+    is_expected.not_to have_select "producer_id"
   end
 end


### PR DESCRIPTION
#### What? Why?

I am trying to avoid distractions, really, but this came up and I prefer to take the opportunity to increase our code consistency when possible.

Discussed here: https://openfoodnetwork.slack.com/archives/GK2T38QPJ/p1709507064073809

I timed one spec file just in case, and found that it took the same amount of time before/after.

#### What should we test?
specs pass


#### Documentation updates
Old wiki comment has already been removed: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Code-Conventions/_history
