### PR TITLE
[BO Orders] Update Entreprise fees when decreasing quantity

### DIFF
--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -85,6 +85,8 @@ module Api
         @order.contents.remove(variant, quantity, @shipment, restock_item)
         @shipment.reload if @shipment.persisted?
 
+        @order.recreate_all_fees!
+
         render json: @shipment, serializer: Api::ShipmentSerializer, status: :ok
       end
 

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -367,19 +367,29 @@ describe Api::V0::ShipmentsController, type: :controller do
             instance_double(Spree::Order, number: "123", distributor: variant.product.supplier)
           }
           let(:contents) { instance_double(Spree::OrderContents) }
+          let(:fee_order_shipment) {
+            instance_double(Spree::Shipment)
+          }
 
           before do
             allow(Spree::Order).to receive(:find_by!) { fee_order }
-            allow(controller).to receive(:find_and_update_shipment) {}
             allow(controller).to receive(:refuse_changing_cancelled_orders) {}
             allow(fee_order).to receive(:contents) { contents }
-            allow(contents).to receive(:add) {}
+            allow(contents).to receive_messages(add: {}, remove: {})
+            allow(fee_order).to receive_message_chain(:shipments, :find_by!) { fee_order_shipment }
+            allow(fee_order_shipment).to receive_messages(update: nil, reload: nil, persisted?: nil)
             allow(fee_order).to receive(:recreate_all_fees!)
           end
 
           it "recalculates fees for the line item" do
             params[:order_id] = fee_order.number
             spree_put :add, params
+            expect(fee_order).to have_received(:recreate_all_fees!)
+          end
+
+          it "recalculates fees for the line item when qty is decreased" do
+            params[:order_id] = fee_order.number
+            spree_put :remove, params
             expect(fee_order).to have_received(:recreate_all_fees!)
           end
         end


### PR DESCRIPTION
#### What? Why?

- Closes #12158 

The order used to not update when decreasing quantity of a line item in a BO order. 

#### What should we test?
- Log as hub owner/admin
- Click 'Administration'  
- Set up an order cycle with an enterprise fee per line item or check that the order cycle 
    your are testing has Enterprise fees (Cf. https://guide.openfoodnetwork.org/basic-features/shopfront/enterprise-fees )
- Create a back office order for this order cycle.
- Decrease the quantity of line item (Edit icon, increase, then save icon)
- Fee value is updated

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [X] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
