### PR TITLE
Bump stimulus_reflex to 3.5.0-rc4 and cable_ready to 5.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ gem 'redis'
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
 
-gem "cable_ready", "5.0.1"
+gem "cable_ready", "5.0.2"
 gem "stimulus_reflex", "3.5.0.rc4"
 
 gem 'combine_pdf'

--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ gem 'sidekiq'
 gem 'sidekiq-scheduler'
 
 gem "cable_ready", "5.0.1"
-gem "stimulus_reflex", "3.5.0.rc3"
+gem "stimulus_reflex", "3.5.0.rc4"
 
 gem 'combine_pdf'
 gem 'wicked_pdf'

--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ gem 'redis'
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
 
-gem "cable_ready", "5.0.2"
+gem "cable_ready", "5.0.3"
 gem "stimulus_reflex", "3.5.0.rc4"
 
 gem 'combine_pdf'

--- a/Gemfile
+++ b/Gemfile
@@ -164,7 +164,7 @@ group :test, :development do
   gem 'rspec-sql'
   gem 'rswag'
   gem 'shoulda-matchers'
-  gem 'stimulus_reflex_testing'
+  gem 'stimulus_reflex_testing', github: "podia/stimulus_reflex_testing", branch: :main
   gem 'timecop'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -740,7 +740,7 @@ GEM
     state_machines-activerecord (0.9.0)
       activerecord (>= 6.0)
       state_machines-activemodel (>= 0.9.0)
-    stimulus_reflex (3.5.0.rc3)
+    stimulus_reflex (3.5.0.rc4)
       actioncable (>= 5.2, < 8)
       actionpack (>= 5.2, < 8)
       actionview (>= 5.2, < 8)
@@ -951,7 +951,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-commands-rubocop
   state_machines-activerecord
-  stimulus_reflex (= 3.5.0.rc3)
+  stimulus_reflex (= 3.5.0.rc4)
   stimulus_reflex_testing
   stringex (~> 2.8.5)
   stripe

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,14 @@ GIT
       sass-rails
       thor (>= 0.14)
 
+GIT
+  remote: https://github.com/podia/stimulus_reflex_testing.git
+  revision: abac2ee34de347c589795b4d1a8e83e0baafb201
+  branch: main
+  specs:
+    stimulus_reflex_testing (0.3.1)
+      stimulus_reflex (>= 3.3.0)
+
 PATH
   remote: engines/catalog
   specs:
@@ -750,8 +758,6 @@ GEM
       rack (>= 2, < 4)
       railties (>= 5.2, < 8)
       redis (>= 4.0, < 6.0)
-    stimulus_reflex_testing (0.3.0)
-      stimulus_reflex (>= 3.3.0)
     stringex (2.8.6)
     stringio (3.1.0)
     stripe (11.1.0)
@@ -952,7 +958,7 @@ DEPENDENCIES
   spring-commands-rubocop
   state_machines-activerecord
   stimulus_reflex (= 3.5.0.rc4)
-  stimulus_reflex_testing
+  stimulus_reflex_testing!
   stringex (~> 2.8.5)
   stripe
   timecop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
     bullet (7.1.6)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    cable_ready (5.0.1)
+    cable_ready (5.0.2)
       actionpack (>= 5.2)
       actionview (>= 5.2)
       activesupport (>= 5.2)
@@ -855,7 +855,7 @@ DEPENDENCIES
   bootsnap
   bugsnag
   bullet
-  cable_ready (= 5.0.1)
+  cable_ready (= 5.0.2)
   cancancan (~> 1.15.0)
   capybara
   catalog!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
     bullet (7.1.6)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    cable_ready (5.0.2)
+    cable_ready (5.0.3)
       actionpack (>= 5.2)
       actionview (>= 5.2)
       activesupport (>= 5.2)
@@ -855,7 +855,7 @@ DEPENDENCIES
   bootsnap
   bugsnag
   bullet
-  cable_ready (= 5.0.2)
+  cable_ready (= 5.0.3)
   cancancan (~> 1.15.0)
   capybara
   catalog!

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@hotwired/turbo": "^8.0.4",
     "@rails/webpacker": "5.4.4",
     "@stimulus-components/rails-nested-form": "^5.0.0",
-    "cable_ready": "5.0.1",
+    "cable_ready": "5.0.3",
     "debounced": "^0.0.5",
     "flatpickr": "^4.6.9",
     "foundation-sites": "^5.5.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "shortcut-buttons-flatpickr": "^0.4.0",
     "stimulus": "^3.2.2",
     "stimulus-flatpickr": "^1.4.0",
-    "stimulus_reflex": "3.5.0-rc3",
+    "stimulus_reflex": "3.5.0-rc4",
     "tom-select": "^2.3.1",
     "trix": "^2.1.1",
     "webpack": "~4"

--- a/spec/reflexes/products_reflex_spec.rb
+++ b/spec/reflexes/products_reflex_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ProductsReflex, type: :reflex, feature: :admin_style_v3 do
   let(:flash) { {} }
 
   before do
+    pending "https://github.com/podia/stimulus_reflex_testing/issues/21"
     # Mock flash, because stimulus_reflex_testing doesn't support sessions
     allow_any_instance_of(described_class).to receive(:flash).and_return(flash)
   end

--- a/spec/reflexes/products_reflex_spec.rb
+++ b/spec/reflexes/products_reflex_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ProductsReflex, type: :reflex, feature: :admin_style_v3 do
   let(:flash) { {} }
 
   before do
-    pending "https://github.com/podia/stimulus_reflex_testing/issues/21"
+    pending "fix spec"
     # Mock flash, because stimulus_reflex_testing doesn't support sessions
     allow_any_instance_of(described_class).to receive(:flash).and_return(flash)
   end

--- a/spec/reflexes/user_reflex_spec.rb
+++ b/spec/reflexes/user_reflex_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe UserReflex, type: :reflex do
   let(:current_user) { create(:user) }
   let(:context) { { url: spree.admin_dashboard_url, connection: { current_user: } } }
 
+  before { pending "https://github.com/podia/stimulus_reflex_testing/issues/21" }
+
   describe "#accept_terms_of_services" do
     subject(:reflex) { build_reflex(method_name: :accept_terms_of_services, **context) }
 

--- a/spec/reflexes/user_reflex_spec.rb
+++ b/spec/reflexes/user_reflex_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe UserReflex, type: :reflex do
   let(:current_user) { create(:user) }
   let(:context) { { url: spree.admin_dashboard_url, connection: { current_user: } } }
 
-  before { pending "https://github.com/podia/stimulus_reflex_testing/issues/21" }
-
   describe "#accept_terms_of_services" do
     subject(:reflex) { build_reflex(method_name: :accept_terms_of_services, **context) }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2444,17 +2444,10 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-cable_ready@5.0.3:
+cable_ready@5.0.3, cable_ready@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-5.0.3.tgz#99e621005246d846b4ee5fb34cbfb773c88a019a"
   integrity sha512-0WcXRSwNw6p4SQmcAPk/APkqgfN3MlLCg6N6SUV+xJECWcdPPRIF8bQ7CLZBrch7Q8Fv7NZiokJpQShuSv+yNw==
-  dependencies:
-    morphdom "2.6.1"
-
-cable_ready@^5.0.0:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-5.0.2.tgz#9042bddce487c25710492d9d4b27f01ce0f8f90e"
-  integrity sha512-2NUDYACXZuLmnw9q32lGwRQqJaAGU+X/XTLS9lQHojw19l4Py7F2HyeJD6nZ1Rucv96oSlrVQr5kAL/jOB+CpQ==
   dependencies:
     morphdom "2.6.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2444,10 +2444,17 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-cable_ready@5.0.1, cable_ready@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-5.0.1.tgz#1cef5991cf7a064d09971ed7d87c614dec2ee1e1"
-  integrity sha512-+t9rKTgYwW5XBx113y97qC8MNEtBZZL84Isdec23HWvjMx0icOQsMzHJE75ycjevgjACTeWZqjRcCdtCHxgZ9g==
+cable_ready@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-5.0.3.tgz#99e621005246d846b4ee5fb34cbfb773c88a019a"
+  integrity sha512-0WcXRSwNw6p4SQmcAPk/APkqgfN3MlLCg6N6SUV+xJECWcdPPRIF8bQ7CLZBrch7Q8Fv7NZiokJpQShuSv+yNw==
+  dependencies:
+    morphdom "2.6.1"
+
+cable_ready@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-5.0.2.tgz#9042bddce487c25710492d9d4b27f01ce0f8f90e"
+  integrity sha512-2NUDYACXZuLmnw9q32lGwRQqJaAGU+X/XTLS9lQHojw19l4Py7F2HyeJD6nZ1Rucv96oSlrVQr5kAL/jOB+CpQ==
   dependencies:
     morphdom "2.6.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8373,10 +8373,10 @@ stimulus@^3.2.2:
     "@hotwired/stimulus" "^3.2.2"
     "@hotwired/stimulus-webpack-helpers" "^1.0.0"
 
-stimulus_reflex@3.5.0-rc3:
-  version "3.5.0-rc3"
-  resolved "https://registry.yarnpkg.com/stimulus_reflex/-/stimulus_reflex-3.5.0-rc3.tgz#21196b2a42f48ea7f1fad54f8443d09a95c320a5"
-  integrity sha512-KSRDgGkU4aA77yw1b0W0oP7Ag+SB6Aa36BdcBJTpacU2W0bm9Fz1a0o9ynD+YAWK6AUyJ0gR20wXLvBvBGpnpg==
+stimulus_reflex@3.5.0-rc4:
+  version "3.5.0-rc4"
+  resolved "https://registry.yarnpkg.com/stimulus_reflex/-/stimulus_reflex-3.5.0-rc4.tgz#fb5135a810b8f5fd3c3bcb7e13c29b1f5ea81316"
+  integrity sha512-Oh+ywKP/HvCOHXvsSKqWqKcFENA+SYt8krDG/Z+2jQG0VJZ1UxLe6oEdSXCdkbjj6lDZ4BPiytPm39kQvcDqNA==
   dependencies:
     "@hotwired/stimulus" "^3"
     "@rails/actioncable" "^6 || ^7"


### PR DESCRIPTION
* Bumps [stimulus_reflex](https://github.com/stimulusreflex/stimulus_reflex) **ruby gem and JS package** from 3.5.0-rc3 to [3.5.0-rc4](https://github.com/stimulusreflex/stimulus_reflex/releases/tag/v3.5.0.rc4).
* Bumps [cable_ready](https://github.com/stimulusreflex/cable_ready/releases/)  **ruby gem and JS package**  from 5.0.1 to [5.0.3](https://github.com/stimulusreflex/cable_ready/releases/tag/v5.0.3)
* Bumps [stimulus_reflex_testing](https://github.com/podia/stimulus_reflex_testing) to `main` (because latest fixes haven't been released yet).


### What should we test?
These are underlying frameworks used for the dynamic functionality on the below pages. Simply checking that they work as usual, with no errors in the dev console should be sufficient.
* BUU Bulk Edit Products - Delete (`/admin/products` with `admin_style_v3`)
* A report, eg `/admin/reports/packing/customer` (old or new design, doesn't matter)
* Admin Enterprise > Connected app
* Admin Orders > Any bulk action


### Dependencies
- Supersedes and closes https://github.com/openfoodfoundation/openfoodnetwork/pull/12260
