### PR TITLE
Downgrade cable_ready JS to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@floating-ui/dom": "^1.6.3",
     "@hotwired/turbo": "^8.0.3",
     "@rails/webpacker": "5.4.4",
-    "cable_ready": "5.0.2",
+    "cable_ready": "5.0.1",
     "debounced": "^0.0.5",
     "flatpickr": "^4.6.9",
     "foundation-sites": "^5.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,10 +2421,10 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-cable_ready@5.0.2, cable_ready@^5.0.0:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-5.0.2.tgz#9042bddce487c25710492d9d4b27f01ce0f8f90e"
-  integrity sha512-2NUDYACXZuLmnw9q32lGwRQqJaAGU+X/XTLS9lQHojw19l4Py7F2HyeJD6nZ1Rucv96oSlrVQr5kAL/jOB+CpQ==
+cable_ready@5.0.1, cable_ready@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-5.0.1.tgz#1cef5991cf7a064d09971ed7d87c614dec2ee1e1"
+  integrity sha512-+t9rKTgYwW5XBx113y97qC8MNEtBZZL84Isdec23HWvjMx0icOQsMzHJE75ycjevgjACTeWZqjRcCdtCHxgZ9g==
   dependencies:
     morphdom "2.6.1"
 


### PR DESCRIPTION
### What? Why?
In order to match the gem version.
Who knows, this might help with:
- #11752
- #12020

I tried to [Bump cable_ready to 5.0.3](https://github.com/openfoodfoundation/openfoodnetwork/pull/12235), but it didn't work, so let's try this instead. It's still compatible with the [current version](https://github.com/stimulusreflex/stimulus_reflex/blob/v3.5.0.rc3/package.json#L60) of StimulusReflex.

I don't know if I'm using yarn wrong, but it wanted to install a newer version alongside this version, in order to resolve `cable_ready@^5.0.0`. I manually edited the lockfile and yarn install now works as expected.


### What should we test?
Functions that use StimulusReflex, which includes:
* Bulk edit products  (admin_style_v3)
* Bulk orders actions (send invoice etc)

### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
