### PR TITLE
[BUU] Enqueue actions to perform at end of reflex

### DIFF
--- a/app/reflexes/products_reflex.rb
+++ b/app/reflexes/products_reflex.rb
@@ -116,11 +116,11 @@ class ProductsReflex < ApplicationReflex
                              producer_options: producers, producer_id: @producer_id,
                              category_options: categories, category_id: @category_id,
                              flashes: flash })
-    ).broadcast
+    )
 
     cable_ready.replace_state(
       url: current_url,
-    ).broadcast_later
+    )
 
     morph :nothing
   end
@@ -133,7 +133,7 @@ class ProductsReflex < ApplicationReflex
     cable_ready.replace(
       selector: "#products-form",
       html: render(partial: "admin/products_v3/table", locals:)
-    ).broadcast
+    )
     morph :nothing
 
     # dunno why this doesn't work.

--- a/app/reflexes/products_reflex.rb
+++ b/app/reflexes/products_reflex.rb
@@ -136,9 +136,8 @@ class ProductsReflex < ApplicationReflex
     )
     morph :nothing
 
-    # dunno why this doesn't work.
-    # morph "#products-form", render(partial: "admin/products_v3/table",
-    #                locals: { products: products })
+    # dunno why this doesn't work. The HTML stops after the first `<col>` element, wtf?!
+    # morph "#products-form", render(partial: "admin/products_v3/table", locals:)
   end
 
   def producers


### PR DESCRIPTION
#### What? Why?
I'm trying to better understand StimulusReflex and doing sort of a health check.

I don't think this will fix<!----> https://github.com/openfoodfoundation/openfoodnetwork/issues/12020, but it means sticking a bit closer to convention, and I think things will run slightly smoother.

#### What should we test?
Just a quick run through of the v3 Bulk Edit Products screen, to test the responsiveness:

- Using filters 
- Using different page sizes
- Updating a product

Previously, the success message would sometimes appear before the loading spinner had finished. Now I think it should all happen at the same time.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
