### PR TITLE
Add dev script to run rubocop on changed files

### DIFF
--- a/script/rubocop-diff.sh
+++ b/script/rubocop-diff.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# While you are developing, you can call this script to check all
+# changed files. And then you can also tell Git to check before every
+# commit by adding this line to your `.git/hooks/pre-commit` file:
+#
+#   ./script/rubocop-diff.sh --cached || exit 1
+#
+
+rubocop="`dirname $0`/../bin/rubocop"
+cached="$1" # may be empty
+
+if git diff $cached --diff-filter=ACMR HEAD --quiet; then
+	# nothing changed
+	exit 0
+fi
+
+exec git diff $cached --name-only --relative --diff-filter=ACMR HEAD |\
+	xargs \
+	$rubocop --force-exclusion \
+                 --fail-level A \
+                 --format simple \
+                 --parallel --cache true


### PR DESCRIPTION
#### What? Why?

Sometimes when I create a pull request or add commits our linters pick up style violations which I forgot to check locally. Adding a Rubocop check to my workflow, especially a pre-commit hook guards against this and avoids unnecessary CI runs.

On my laptop, this adds 0.6 seconds to the commit action. It's noticeable and I would like to integrate Rubocop into my IDE instead but I haven't achieved that yet. So for now this is better than nothing.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Nothing.
- Devs can try this out by running the script but that's not necessary.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
