### PR TITLE
Enforce RSpec expect(..).not_to over to_not

### DIFF
--- a/.rubocop_rspec_styleguide.yml
+++ b/.rubocop_rspec_styleguide.yml
@@ -19,3 +19,6 @@ Capybara/NegationMatcher:
 RSpec/ExpectChange:
   Enabled: true
   EnforcedStyle: block
+
+RSpec/NotToNot:
+  Enabled: true

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -182,7 +182,7 @@ module Admin
                                customer: { email: 'new.email@gmail.com' }
             expect(response).to redirect_to unauthorized_path
             expect(assigns(:customer)).to eq nil
-            expect(customer.email).to_not eq 'new.email@gmail.com'
+            expect(customer.email).not_to eq 'new.email@gmail.com'
           end
         end
       end

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -168,7 +168,7 @@ describe Admin::EnterprisesController, type: :controller do
         spree_post :update, update_params
 
         distributor.reload
-        expect(distributor.users).to_not include user
+        expect(distributor.users).not_to include user
       end
 
       it "updates the contact for notifications" do
@@ -190,7 +190,7 @@ describe Admin::EnterprisesController, type: :controller do
         }
 
         expect { spree_post :update, params }.
-          to_not change { distributor.contact }
+          not_to change { distributor.contact }
       end
 
       it "updates enterprise preferences" do
@@ -223,7 +223,7 @@ describe Admin::EnterprisesController, type: :controller do
             expect(Spree::Property.count).to be 1
             expect(ProducerProperty.count).to be 0
             property_names = producer.reload.properties.map(&:name)
-            expect(property_names).to_not include 'a different name'
+            expect(property_names).not_to include 'a different name'
           end
         end
 
@@ -721,7 +721,7 @@ describe Admin::EnterprisesController, type: :controller do
         it "scopes @collection to enterprises editable by the user" do
           get :index, format: :json
           expect(assigns(:collection)).to include enterprise1, enterprise2
-          expect(assigns(:collection)).to_not include enterprise3
+          expect(assigns(:collection)).not_to include enterprise3
         end
       end
     end

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -37,7 +37,7 @@ module Admin
           context "where ransack conditions are specified" do
             it "loads order cycles closed within past month, and orders w/o a close_at date" do
               get :index, as: :json
-              expect(assigns(:collection)).to_not include oc1, oc2
+              expect(assigns(:collection)).not_to include oc1, oc2
               expect(assigns(:collection)).to include oc3, oc4
             end
           end
@@ -47,7 +47,7 @@ module Admin
 
             it "loads order cycles closed after specified date, and orders w/o a close_at date" do
               get :index, as: :json, params: { q: }
-              expect(assigns(:collection)).to_not include oc1
+              expect(assigns(:collection)).not_to include oc1
               expect(assigns(:collection)).to include oc2, oc3, oc4
             end
 
@@ -56,7 +56,7 @@ module Admin
 
               it "loads order cycles that meet all conditions" do
                 get :index, format: :json, params: { q: }
-                expect(assigns(:collection)).to_not include oc1, oc2, oc4
+                expect(assigns(:collection)).not_to include oc1, oc2, oc4
                 expect(assigns(:collection)).to include oc3
               end
             end
@@ -415,9 +415,9 @@ module Admin
                     } } }
 
           oc.reload
-          expect(oc.name).to_not eq "Updated Order Cycle"
-          expect(oc.orders_open_at.to_date).to_not eq Date.current - 21.days
-          expect(oc.orders_close_at.to_date).to_not eq Date.current + 21.days
+          expect(oc.name).not_to eq "Updated Order Cycle"
+          expect(oc.orders_open_at.to_date).not_to eq Date.current - 21.days
+          expect(oc.orders_close_at.to_date).not_to eq Date.current + 21.days
         end
       end
     end
@@ -505,8 +505,8 @@ module Admin
             get :destroy, params: { id: cloned.id }
 
             expect(OrderCycle.find_by(id: cloned.id)).to be nil
-            expect(OrderCycle.find_by(id: oc.id)).to_not be nil
-            expect(EnterpriseFee.find_by(id: enterprise_fee1.id)).to_not be nil
+            expect(OrderCycle.find_by(id: oc.id)).not_to be nil
+            expect(EnterpriseFee.find_by(id: enterprise_fee1.id)).not_to be nil
             expect(response).to redirect_to admin_order_cycles_path
           end
         end

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -162,7 +162,7 @@ describe Admin::ReportsController, type: :controller do
         report_types = assigns(:reports).keys
         expect(report_types).to include :orders_and_fulfillment,
                                         :products_and_inventory, :packing # and others
-        expect(report_types).to_not include :sales_tax
+        expect(report_types).not_to include :sales_tax
       end
     end
 
@@ -365,7 +365,7 @@ describe Admin::ReportsController, type: :controller do
         spree_get :show, report_type: :sales_tax, report_subtype: report_type
         expect(response).to have_http_status(:ok)
         expect(resulting_orders_prelim).to include(orderA1, orderB1)
-        expect(resulting_orders_prelim).to_not include(orderA2, orderB2)
+        expect(resulting_orders_prelim).not_to include(orderA2, orderB2)
       end
     end
   end

--- a/spec/controllers/admin/schedules_controller_spec.rb
+++ b/spec/controllers/admin/schedules_controller_spec.rb
@@ -115,7 +115,7 @@ describe Admin::SchedulesController, type: :controller do
                                                                       uncoordinated_order_cycle,
                                                                       uncoordinated_order_cycle3
           # coordinated_order_cycle is removed, uncoordinated_order_cycle2 is NOT added
-          expect(coordinated_schedule.reload.order_cycles).to_not include coordinated_order_cycle,
+          expect(coordinated_schedule.reload.order_cycles).not_to include coordinated_order_cycle,
                                                                           uncoordinated_order_cycle2
         end
 
@@ -145,7 +145,7 @@ describe Admin::SchedulesController, type: :controller do
                              schedule: { name: "my awesome schedule" }
           expect(response).to redirect_to unauthorized_path
           expect(assigns(:schedule)).to eq nil
-          expect(coordinated_schedule.name).to_not eq "my awesome schedule"
+          expect(coordinated_schedule.name).not_to eq "my awesome schedule"
         end
       end
     end
@@ -173,7 +173,7 @@ describe Admin::SchedulesController, type: :controller do
 
         context "where no order cycles ids are provided" do
           it "does not allow me to create the schedule" do
-            expect { create_schedule params }.to_not change { Schedule.count }
+            expect { create_schedule params }.not_to change { Schedule.count }
           end
         end
 
@@ -187,7 +187,7 @@ describe Admin::SchedulesController, type: :controller do
             expect { create_schedule params }.to change { Schedule.count }.by(1)
             schedule = Schedule.last
             expect(schedule.order_cycles).to include coordinated_order_cycle
-            expect(schedule.order_cycles).to_not include uncoordinated_order_cycle
+            expect(schedule.order_cycles).not_to include uncoordinated_order_cycle
           end
 
           it "sync proxy orders" do
@@ -205,7 +205,7 @@ describe Admin::SchedulesController, type: :controller do
           end
 
           it "prevents me from creating the schedule" do
-            expect { create_schedule params }.to_not change { Schedule.count }
+            expect { create_schedule params }.not_to change { Schedule.count }
           end
         end
       end
@@ -257,7 +257,7 @@ describe Admin::SchedulesController, type: :controller do
             let!(:subscription) { create(:subscription, schedule: coordinated_schedule) }
 
             it "returns an error message and prevents me from deleting the schedule" do
-              expect { spree_delete :destroy, params }.to_not change { Schedule.count }
+              expect { spree_delete :destroy, params }.not_to change { Schedule.count }
               json_response = JSON.parse(response.body)
               expect(json_response["errors"])
                 .to include 'This schedule cannot be deleted ' \
@@ -270,7 +270,7 @@ describe Admin::SchedulesController, type: :controller do
           before { params.merge!(id: uncoordinated_schedule.id) }
 
           it "prevents me from destroying the schedule" do
-            expect { spree_delete :destroy, params }.to_not change { Schedule.count }
+            expect { spree_delete :destroy, params }.not_to change { Schedule.count }
           end
         end
       end

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -81,7 +81,7 @@ describe Admin::SubscriptionsController, type: :controller do
             expect(json_response.count).to be 1
             ids = json_response.map{ |so| so['id'] }
             expect(ids).to include subscription2.id
-            expect(ids).to_not include subscription.id
+            expect(ids).not_to include subscription.id
           end
         end
       end
@@ -134,7 +134,7 @@ describe Admin::SubscriptionsController, type: :controller do
 
       context 'when I submit insufficient params' do
         it 'returns errors' do
-          expect{ spree_post :create, params }.to_not change{ Subscription.count }
+          expect{ spree_post :create, params }.not_to change{ Subscription.count }
           json_response = JSON.parse(response.body)
           expect(json_response['errors'].keys).to include 'schedule', 'customer', 'payment_method',
                                                           'shipping_method', 'begins_at'
@@ -168,7 +168,7 @@ describe Admin::SubscriptionsController, type: :controller do
         end
 
         it 'returns errors' do
-          expect{ spree_post :create, params }.to_not change{ Subscription.count }
+          expect{ spree_post :create, params }.not_to change{ Subscription.count }
           json_response = JSON.parse(response.body)
           expect(json_response['errors'].keys).to include 'schedule', 'customer', 'payment_method',
                                                           'shipping_method', 'ends_at'
@@ -197,7 +197,7 @@ describe Admin::SubscriptionsController, type: :controller do
 
         context 'where the specified variants are not available from the shop' do
           it 'returns an error' do
-            expect{ spree_post :create, params }.to_not change{ Subscription.count }
+            expect{ spree_post :create, params }.not_to change{ Subscription.count }
             json_response = JSON.parse(response.body)
             expect(json_response['errors']['subscription_line_items'])
               .to eq ["#{variant.product.name} - #{variant.full_name} " \
@@ -343,7 +343,7 @@ describe Admin::SubscriptionsController, type: :controller do
         end
 
         it 'returns errors' do
-          expect{ spree_post :update, params }.to_not change{ Subscription.count }
+          expect{ spree_post :update, params }.not_to change{ Subscription.count }
           json_response = JSON.parse(response.body)
           expect(json_response['errors'].keys).to include 'payment_method', 'shipping_method'
           subscription.reload
@@ -387,7 +387,7 @@ describe Admin::SubscriptionsController, type: :controller do
           context 'where the specified variants are not available from the shop' do
             it 'returns an error' do
               expect{ spree_post :update, params }
-                .to_not change{ subscription.subscription_line_items.count }
+                .not_to change{ subscription.subscription_line_items.count }
               json_response = JSON.parse(response.body)
               expect(json_response['errors']['subscription_line_items'])
                 .to eq ["#{product2.name} - #{variant2.full_name} " \
@@ -478,7 +478,7 @@ describe Admin::SubscriptionsController, type: :controller do
               it 'renders the cancelled subscription as json, and does not cancel the open order' do
                 spree_put :cancel, params
                 json_response = JSON.parse(response.body)
-                expect(json_response['canceled_at']).to_not be nil
+                expect(json_response['canceled_at']).not_to be nil
                 expect(json_response['id']).to eq subscription.id
                 expect(subscription.reload.canceled_at).to be_within(5.seconds).of Time.zone.now
                 expect(order.reload.state).to eq 'complete'
@@ -498,7 +498,7 @@ describe Admin::SubscriptionsController, type: :controller do
               it 'renders the cancelled subscription as json, and cancels the open order' do
                 spree_put :cancel, params
                 json_response = JSON.parse(response.body)
-                expect(json_response['canceled_at']).to_not be nil
+                expect(json_response['canceled_at']).not_to be nil
                 expect(json_response['id']).to eq subscription.id
                 expect(subscription.reload.canceled_at).to be_within(5.seconds).of Time.zone.now
                 expect(order.reload.state).to eq 'canceled'
@@ -512,7 +512,7 @@ describe Admin::SubscriptionsController, type: :controller do
             it 'renders the cancelled subscription as json' do
               spree_put :cancel, params
               json_response = JSON.parse(response.body)
-              expect(json_response['canceled_at']).to_not be nil
+              expect(json_response['canceled_at']).not_to be nil
               expect(json_response['id']).to eq subscription.id
               expect(subscription.reload.canceled_at).to be_within(5.seconds).of Time.zone.now
             end
@@ -582,7 +582,7 @@ describe Admin::SubscriptionsController, type: :controller do
               it 'renders the paused subscription as json, and does not cancel the open order' do
                 spree_put :pause, params
                 json_response = JSON.parse(response.body)
-                expect(json_response['paused_at']).to_not be nil
+                expect(json_response['paused_at']).not_to be nil
                 expect(json_response['id']).to eq subscription.id
                 expect(subscription.reload.paused_at).to be_within(5.seconds).of Time.zone.now
                 expect(order.reload.state).to eq 'complete'
@@ -602,7 +602,7 @@ describe Admin::SubscriptionsController, type: :controller do
               it 'renders the paused subscription as json, and cancels the open order' do
                 spree_put :pause, params
                 json_response = JSON.parse(response.body)
-                expect(json_response['paused_at']).to_not be nil
+                expect(json_response['paused_at']).not_to be nil
                 expect(json_response['id']).to eq subscription.id
                 expect(subscription.reload.paused_at).to be_within(5.seconds).of Time.zone.now
                 expect(order.reload.state).to eq 'canceled'
@@ -616,7 +616,7 @@ describe Admin::SubscriptionsController, type: :controller do
             it 'renders the paused subscription as json' do
               spree_put :pause, params
               json_response = JSON.parse(response.body)
-              expect(json_response['paused_at']).to_not be nil
+              expect(json_response['paused_at']).not_to be nil
               expect(json_response['id']).to eq subscription.id
               expect(subscription.reload.paused_at).to be_within(5.seconds).of Time.zone.now
             end
@@ -708,7 +708,7 @@ describe Admin::SubscriptionsController, type: :controller do
                   expect(json_response['id']).to eq subscription.id
                   expect(subscription.reload.paused_at).to be nil
                   expect(order.reload.state).to eq 'canceled'
-                  expect(proxy_order.reload.canceled_at).to_not be nil
+                  expect(proxy_order.reload.canceled_at).not_to be nil
                 end
               end
             end
@@ -771,7 +771,7 @@ describe Admin::SubscriptionsController, type: :controller do
       it "only loads Stripe and Cash payment methods" do
         controller.send(:load_form_data)
         expect(assigns(:payment_methods)).to include payment_method, stripe
-        expect(assigns(:payment_methods)).to_not include paypal
+        expect(assigns(:payment_methods)).not_to include paypal
       end
     end
   end

--- a/spec/controllers/admin/terms_of_service_files_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service_files_controller_spec.rb
@@ -12,12 +12,12 @@ describe Admin::TermsOfServiceFilesController, type: :controller do
 
     it "does not allow deletion" do
       post :destroy
-      expect(TermsOfServiceFile).to_not receive(:current)
+      expect(TermsOfServiceFile).not_to receive(:current)
     end
 
     it "does not allow creation" do
       post :create
-      expect(TermsOfServiceFile).to_not receive(:create!)
+      expect(TermsOfServiceFile).not_to receive(:create!)
     end
   end
 

--- a/spec/controllers/admin/variant_overrides_controller_spec.rb
+++ b/spec/controllers/admin/variant_overrides_controller_spec.rb
@@ -97,7 +97,7 @@ describe Admin::VariantOverridesController, type: :controller do
             it "allows to update other variant overrides" do
               put :bulk_update, as: format, params: { variant_overrides: variant_override_params }
 
-              expect(response).to_not redirect_to unauthorized_path
+              expect(response).not_to redirect_to unauthorized_path
               variant_override.reload
               expect(variant_override.price).to eq 123.45
             end
@@ -193,7 +193,7 @@ describe Admin::VariantOverridesController, type: :controller do
             it "does not reset count_on_hand for variant_overrides not in params" do
               expect {
                 put :bulk_reset, params:
-              }.to_not change{ variant_override3.reload.count_on_hand }
+              }.not_to change{ variant_override3.reload.count_on_hand }
             end
           end
         end

--- a/spec/controllers/api/v0/logos_controller_spec.rb
+++ b/spec/controllers/api/v0/logos_controller_spec.rb
@@ -35,7 +35,7 @@ module Api
           expect(response.status).to eq 200
           expect(json_response["id"]).to eq enterprise.id
           enterprise.reload
-          expect(enterprise.logo).to_not be_attached
+          expect(enterprise.logo).not_to be_attached
         end
 
         context "when logo does not exist" do

--- a/spec/controllers/api/v0/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/v0/order_cycles_controller_spec.rb
@@ -57,7 +57,7 @@ module Api
                            q: { ransack_param => "Kangaroo" }
 
         expect(product_ids).to include product1.id
-        expect(product_ids).to_not include product2.id
+        expect(product_ids).not_to include product2.id
       end
 
       context "with variant overrides" do
@@ -84,7 +84,7 @@ module Api
         it "does not return products where the variant overrides are out of stock" do
           api_get :products, id: order_cycle.id, distributor: distributor.id
 
-          expect(product_ids).to_not include product2.id
+          expect(product_ids).not_to include product2.id
         end
       end
 
@@ -99,7 +99,7 @@ module Api
 
           expect(response.status).to eq 200
           expect(product_ids).to eq [product1.id, product2.id]
-          expect(product_ids).to_not include product3.id
+          expect(product_ids).not_to include product3.id
         end
 
         context "with supplier properties" do
@@ -118,7 +118,7 @@ module Api
 
             expect(response.status).to eq 200
             expect(product_ids).to match_array [product1.id, product2.id]
-            expect(product_ids).to_not include product3.id
+            expect(product_ids).not_to include product3.id
           end
         end
       end
@@ -129,7 +129,7 @@ module Api
                              q: { primary_taxon_id_in_any: [taxon2.id] }
 
           expect(product_ids).to include product2.id, product3.id
-          expect(product_ids).to_not include product1.id, product4.id
+          expect(product_ids).not_to include product1.id, product4.id
         end
       end
 
@@ -176,7 +176,7 @@ module Api
 
           api_get :products, id: order_cycle.id, distributor: distributor.id
 
-          expect(product_ids).to_not include product1.id
+          expect(product_ids).not_to include product1.id
         end
 
         it "does not return variants hidden for this specific customer" do
@@ -185,7 +185,7 @@ module Api
 
           api_get :products, id: order_cycle.id, distributor: distributor.id
 
-          expect(product_ids).to_not include product2.id
+          expect(product_ids).not_to include product2.id
         end
 
         it "returns hidden variants made visible for this specific customer" do
@@ -197,7 +197,7 @@ module Api
 
           api_get :products, id: order_cycle.id, distributor: distributor.id
 
-          expect(product_ids).to_not include product1.id
+          expect(product_ids).not_to include product1.id
           expect(product_ids).to include product3.id
         end
       end

--- a/spec/controllers/api/v0/promo_images_controller_spec.rb
+++ b/spec/controllers/api/v0/promo_images_controller_spec.rb
@@ -35,7 +35,7 @@ module Api
           expect(response.status).to eq 200
           expect(json_response["id"]).to eq enterprise.id
           enterprise.reload
-          expect(enterprise.promo_image).to_not be_attached
+          expect(enterprise.promo_image).not_to be_attached
         end
 
         context "when promo image does not exist" do

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -194,14 +194,14 @@ describe Api::V0::ShipmentsController, type: :controller do
           expect {
             api_put :add, params.merge(variant_id: existing_variant.to_param)
             expect(response.status).to eq(422)
-          }.to_not change { existing_variant.reload.on_hand }
+          }.not_to change { existing_variant.reload.on_hand }
         end
 
         it "doesn't adjust stock when removing a variant" do
           expect {
             api_put :remove, params.merge(variant_id: existing_variant.to_param)
             expect(response.status).to eq(422)
-          }.to_not change { existing_variant.reload.on_hand }
+          }.not_to change { existing_variant.reload.on_hand }
         end
       end
 

--- a/spec/controllers/api/v0/terms_and_conditions_controller_spec.rb
+++ b/spec/controllers/api/v0/terms_and_conditions_controller_spec.rb
@@ -29,7 +29,7 @@ module Api
           expect(response.status).to eq 200
           expect(json_response["id"]).to eq enterprise.id
           enterprise.reload
-          expect(enterprise.terms_and_conditions).to_not be_attached
+          expect(enterprise.terms_and_conditions).not_to be_attached
         end
 
         context "when terms and conditions file does not exist" do

--- a/spec/controllers/api/v0/variants_controller_spec.rb
+++ b/spec/controllers/api/v0/variants_controller_spec.rb
@@ -172,7 +172,7 @@ describe Api::V0::VariantsController, type: :controller do
       variant = product.variants.first
       spree_delete :destroy, id: variant.to_param
 
-      expect(variant.reload).to_not be_deleted
+      expect(variant.reload).not_to be_deleted
       expect(assigns(:variant).errors[:product]).to include "must have at least one variant"
     end
   end

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -17,7 +17,7 @@ describe BaseController, type: :controller do
     it "doesn't change anything without a user" do
       expect {
         get :index
-      }.to_not change { Spree::Order.count }
+      }.not_to change { Spree::Order.count }
     end
 
     it "creates a new order" do
@@ -36,7 +36,7 @@ describe BaseController, type: :controller do
 
       expect {
         get :index
-      }.to_not change { Spree::Order.count }
+      }.not_to change { Spree::Order.count }
 
       expect(session[:order_id]).to eq last_cart.id
     end
@@ -63,7 +63,7 @@ describe BaseController, type: :controller do
 
       expect {
         get :index
-      }.to_not change { Spree::Order.count }
+      }.not_to change { Spree::Order.count }
 
       expect(current_cart.line_items.count).to eq 0
     end
@@ -89,13 +89,13 @@ describe BaseController, type: :controller do
         get :index
       }.to change { Spree::Order.count }.by(1)
 
-      expect(session[:order_id]).to_not eq just_completed_order.id
-      expect(session[:order_id]).to_not eq last_cart.id
+      expect(session[:order_id]).not_to eq just_completed_order.id
+      expect(session[:order_id]).not_to eq last_cart.id
       expect(controller.current_order.line_items.count).to eq 0
     end
 
     it "doesn't load variant overrides without line items" do
-      expect(VariantOverride).to_not receive(:indexed)
+      expect(VariantOverride).not_to receive(:indexed)
       controller.current_order(true)
     end
   end

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -148,7 +148,7 @@ describe CheckoutController, type: :controller do
           it "doesn't update default bill address on user" do
             expect {
               put :update, params: params.merge(order: { save_bill_address: "0" })
-            }.to_not change {
+            }.not_to change {
               order.user.reload.bill_address
             }
           end
@@ -163,7 +163,7 @@ describe CheckoutController, type: :controller do
           it "doesn't update default ship address on user" do
             expect {
               put :update, params: params.merge(order: { save_ship_address: "0" })
-            }.to_not change {
+            }.not_to change {
               order.user.reload.ship_address
             }
           end
@@ -196,7 +196,7 @@ describe CheckoutController, type: :controller do
           end
 
           it "doesn't recalculate the voucher adjustment" do
-            expect(service).to_not receive(:update)
+            expect(service).not_to receive(:update)
 
             put(:update, params:)
 

--- a/spec/controllers/concerns/raising_parameters_spec.rb
+++ b/spec/controllers/concerns/raising_parameters_spec.rb
@@ -26,7 +26,7 @@ describe RaisingParameters do
     it "raises no error when all parameters are permitted" do
       expect {
         params.require(:data).permit(:id, :admin)
-      }.to_not raise_error
+      }.not_to raise_error
     end
 
     it "doesn't change standard parameter objects" do
@@ -34,7 +34,7 @@ describe RaisingParameters do
 
       expect {
         original_params.permit(:one)
-      }.to_not raise_error
+      }.not_to raise_error
     end
   end
 end

--- a/spec/controllers/spree/admin/adjustments_controller_spec.rb
+++ b/spec/controllers/spree/admin/adjustments_controller_spec.rb
@@ -27,7 +27,7 @@ module Spree
         spree_get :index, order_id: order.number
 
         expect(assigns(:collection)).to include adjustment1, adjustment2
-        expect(assigns(:collection)).to_not include adjustment3
+        expect(assigns(:collection)).not_to include adjustment3
       end
 
       it "displays admin adjustments" do
@@ -39,7 +39,7 @@ module Spree
       it "does not display enterprise fee adjustments" do
         spree_get :index, order_id: order.number
 
-        expect(assigns(:collection)).to_not include adjustment4
+        expect(assigns(:collection)).not_to include adjustment4
       end
     end
 
@@ -237,7 +237,7 @@ module Spree
         expect {
           spree_post :create, order_id: order.number,
                               adjustment: { label: "Testing", amount: "110" }
-        }.to_not change { [Adjustment.count, order.reload.total] }
+        }.not_to change { [Adjustment.count, order.reload.total] }
 
         expect(response).to redirect_to spree.admin_order_adjustments_path(order)
       end
@@ -246,7 +246,7 @@ module Spree
         expect {
           spree_put :update, order_id: order.number, id: adjustment.id,
                              adjustment: { label: "Testing", amount: "110" }
-        }.to_not change { [adjustment.reload.amount, order.reload.total] }
+        }.not_to change { [adjustment.reload.amount, order.reload.total] }
 
         expect(response).to redirect_to spree.admin_order_adjustments_path(order)
       end

--- a/spec/controllers/spree/admin/general_settings_controller_spec.rb
+++ b/spec/controllers/spree/admin/general_settings_controller_spec.rb
@@ -13,7 +13,7 @@ describe Spree::Admin::GeneralSettingsController, type: :controller do
     end
 
     it "updates available units" do
-      expect(Spree::Config.available_units).to_not include("lb")
+      expect(Spree::Config.available_units).not_to include("lb")
       settings_params = { available_units: { lb: "1" } }
       spree_put :update, settings_params
       expect(Spree::Config.available_units).to include("lb")

--- a/spec/controllers/spree/admin/orders/invoices_spec.rb
+++ b/spec/controllers/spree/admin/orders/invoices_spec.rb
@@ -40,7 +40,7 @@ describe Spree::Admin::OrdersController, type: :controller do
           it "should allow me to send order invoices" do
             expect do
               spree_get :invoice, params
-            end.to_not change{ Spree::OrderMailer.deliveries.count }
+            end.not_to change{ Spree::OrderMailer.deliveries.count }
             expect(response).to redirect_to spree.edit_admin_order_path(order)
             expect(flash[:error])
               .to eq "#{distributor.name} must have a valid ABN before invoices can be used."

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
@@ -49,13 +49,13 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
             it "voids the payment" do
               order.reload
-              expect(order.payment_total).to_not eq 0
+              expect(order.payment_total).not_to eq 0
               expect(order.outstanding_balance.to_f).to eq 0
               spree_put :fire, params
               expect(payment.reload.state).to eq 'void'
               order.reload
               expect(order.payment_total).to eq 0
-              expect(order.outstanding_balance.to_f).to_not eq 0
+              expect(order.outstanding_balance.to_f).not_to eq 0
             end
           end
 
@@ -69,12 +69,12 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
             it "does not void the payment" do
               order.reload
-              expect(order.payment_total).to_not eq 0
+              expect(order.payment_total).not_to eq 0
               expect(order.outstanding_balance.to_f).to eq 0
               spree_put :fire, params
               expect(payment.reload.state).to eq 'completed'
               order.reload
-              expect(order.payment_total).to_not eq 0
+              expect(order.payment_total).not_to eq 0
               expect(order.outstanding_balance.to_f).to eq 0
               expect(flash[:error]).to eq "Bup-bow!"
             end
@@ -92,13 +92,13 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
             it "can still void the payment" do
               order.reload
-              expect(order.payment_total).to_not eq 0
+              expect(order.payment_total).not_to eq 0
               expect(order.outstanding_balance.to_f).to eq 0
               spree_put :fire, params
               expect(payment.reload.state).to eq 'void'
               order.reload
               expect(order.payment_total).to eq 0
-              expect(order.outstanding_balance.to_f).to_not eq 0
+              expect(order.outstanding_balance.to_f).not_to eq 0
             end
           end
         end
@@ -115,13 +115,13 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
           it "voids the payment" do
             order.reload
-            expect(order.payment_total).to_not eq 0
+            expect(order.payment_total).not_to eq 0
             expect(order.outstanding_balance.to_f).to eq 0
             spree_put :fire, params
             expect(payment.reload.state).to eq 'void'
             order.reload
             expect(order.payment_total).to eq 0
-            expect(order.outstanding_balance.to_f).to_not eq 0
+            expect(order.outstanding_balance.to_f).not_to eq 0
           end
         end
       end

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -258,7 +258,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
       it 'does not process the event' do
         spree_put :fire, params
 
-        expect(payment).to_not receive(:unrecognized_event)
+        expect(payment).not_to receive(:unrecognized_event)
         expect(flash[:error]).to eq('Could not update the payment')
       end
     end

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -24,7 +24,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
         spree_get :edit, id: order
 
-        expect(response.body).to_not match adjustment.label
+        expect(response.body).not_to match adjustment.label
       end
     end
   end
@@ -204,7 +204,7 @@ describe Spree::Admin::OrdersController, type: :controller do
                 order.reload
 
                 expect(order.all_adjustments.tax.count).to eq 2
-                expect(order.all_adjustments.tax).to_not include legacy_tax_adjustment
+                expect(order.all_adjustments.tax).not_to include legacy_tax_adjustment
                 expect(order.additional_tax_total).to eq 0.5
               end
             end

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -190,7 +190,7 @@ describe Spree::Admin::ProductsController, type: :controller do
         spree_put :update, id: product, product: { supplier_id: new_producer.id }
 
         expect(product.reload.supplier.id).to eq new_producer.id
-        expect(order_cycle.reload.distributed_variants).to_not include product.variants.first
+        expect(order_cycle.reload.distributed_variants).not_to include product.variants.first
       end
     end
 
@@ -227,7 +227,7 @@ describe Spree::Admin::ProductsController, type: :controller do
             expect(Spree::Property.count).to be 1
             expect(Spree::ProductProperty.count).to be 0
             property_names = product.reload.properties.map(&:name)
-            expect(property_names).to_not include 'a different name'
+            expect(property_names).not_to include 'a different name'
           end
         end
 

--- a/spec/controllers/spree/admin/search_controller_spec.rb
+++ b/spec/controllers/spree/admin/search_controller_spec.rb
@@ -18,7 +18,7 @@ describe Spree::Admin::SearchController, type: :controller do
 
         it "returns a list of users that I share management of enteprises with" do
           expect(assigns(:users)).to include owner, manager
-          expect(assigns(:users)).to_not include random
+          expect(assigns(:users)).not_to include random
         end
       end
 

--- a/spec/controllers/spree/admin/tax_rates_controller_spec.rb
+++ b/spec/controllers/spree/admin/tax_rates_controller_spec.rb
@@ -27,7 +27,7 @@ module Spree
             it "updates the record" do
               expect {
                 spree_put :update, id: tax_rate.id, tax_rate: params
-              }.to_not change{ Spree::TaxRate.with_deleted.count }
+              }.not_to change{ Spree::TaxRate.with_deleted.count }
 
               expect(response).to redirect_to spree.admin_tax_rates_url
               expect(tax_rate.reload.name).to eq "Updated Rate"

--- a/spec/controllers/spree/api_keys_controller_spec.rb
+++ b/spec/controllers/spree/api_keys_controller_spec.rb
@@ -26,7 +26,7 @@ describe Spree::ApiKeysController, type: :controller, performance: true do
       expect {
         spree_post :create, id: other_user.id
         other_user.reload
-      }.to_not change {
+      }.not_to change {
         other_user.spree_api_key
       }
     end

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -94,7 +94,7 @@ describe Spree::CreditCardsController, type: :controller do
           { status: 402, body: JSON.generate(error: { message: "Bup-bow..." }) }
         }
         it "doesn't save the card locally, and renders a flash error" do
-          expect{ spree_post :new_from_token, params }.to_not change { Spree::CreditCard.count }
+          expect{ spree_post :new_from_token, params }.not_to change { Spree::CreditCard.count }
 
           json_response = JSON.parse(response.body)
           flash_message = "There was a problem with your payment information: %s" % 'Bup-bow...'
@@ -172,7 +172,7 @@ describe Spree::CreditCardsController, type: :controller do
         let(:params) { { id: 123 } }
 
         it "redirects to /account with a flash error, does not request deletion with Stripe" do
-          expect(controller).to_not receive(:destroy_at_stripe)
+          expect(controller).not_to receive(:destroy_at_stripe)
           spree_delete :destroy, params
           expect(flash[:error]).to eq 'Sorry, the card could not be removed'
           expect(response.status).to eq 200
@@ -205,7 +205,7 @@ describe Spree::CreditCardsController, type: :controller do
             end
 
             it "doesn't delete the card" do
-              expect{ spree_delete :destroy, params }.to_not change { Spree::CreditCard.count }
+              expect{ spree_delete :destroy, params }.not_to change { Spree::CreditCard.count }
               expect(flash[:error]).to eq 'Sorry, the card could not be removed'
               expect(response.status).to eq 422
             end

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -150,7 +150,7 @@ describe Spree::OrdersController, type: :controller do
           spree_registration_path = '/signup'
           ofn_registration_path = '/register'
           get :edit
-          expect(response.body).to_not match spree_registration_path
+          expect(response.body).not_to match spree_registration_path
           expect(response.body).to match ofn_registration_path
         end
       end

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -33,7 +33,7 @@ describe Spree::UsersController, type: :controller do
       get :show
 
       expect(orders).to include d1o1, d1o2
-      expect(orders).to_not include d1_order_for_u2, d1o3, d2o1
+      expect(orders).not_to include d1_order_for_u2, d1o3, d2o1
       expect(shops).to include distributor1
 
       # Doesn't return orders for irrelevant distributors" do

--- a/spec/controllers/webhook_endpoints_controller_spec.rb
+++ b/spec/controllers/webhook_endpoints_controller_spec.rb
@@ -24,7 +24,7 @@ describe WebhookEndpointsController, type: :controller do
     it "shows error if parameters not specified" do
       expect {
         spree_post :create, { url: "" }
-      }.to_not change {
+      }.not_to change {
         user.webhook_endpoints.count
       }
 

--- a/spec/helpers/bulk_form_builder_spec.rb
+++ b/spec/helpers/bulk_form_builder_spec.rb
@@ -9,7 +9,7 @@ describe BulkFormBuilder do
     let(:product) { create(:product) }
     let(:form) { BulkFormBuilder.new(:product, product, self, {}) }
 
-    it { expect(form.text_field(:name)).to_not include "changed" }
+    it { expect(form.text_field(:name)).not_to include "changed" }
 
     context "attribute has been changed" do
       before { product.assign_attributes name: "updated name" }
@@ -19,7 +19,7 @@ describe BulkFormBuilder do
       context "and saved" do
         before { product.save }
 
-        it { expect(form.text_field(:name)).to_not include "changed" }
+        it { expect(form.text_field(:name)).not_to include "changed" }
       end
     end
   end

--- a/spec/helpers/injection_helper_spec.rb
+++ b/spec/helpers/injection_helper_spec.rb
@@ -78,6 +78,6 @@ describe InjectionHelper, type: :helper do
                                  gateway_customer_profile_id: nil)
     injected_cards = helper.inject_saved_credit_cards
     expect(injected_cards).to match "1234"
-    expect(injected_cards).to_not match "4321"
+    expect(injected_cards).not_to match "4321"
   end
 end

--- a/spec/helpers/shop_helper_spec.rb
+++ b/spec/helpers/shop_helper_spec.rb
@@ -24,7 +24,7 @@ describe ShopHelper, type: :helper do
       end
 
       it "should not return the groups tab" do
-        expect(helper.shop_tabs).to_not include(name: "groups", show: true, title: "Groups")
+        expect(helper.shop_tabs).not_to include(name: "groups", show: true, title: "Groups")
       end
     end
 

--- a/spec/jobs/order_cycle_closing_job_spec.rb
+++ b/spec/jobs/order_cycle_closing_job_spec.rb
@@ -15,8 +15,8 @@ describe OrderCycleClosingJob do
 
   it "sends notifications for recently closed order cycles with automatic notifications enabled" do
     expect(OrderCycleNotificationJob).to receive(:perform_later).with(order_cycle1.id)
-    expect(OrderCycleNotificationJob).to_not receive(:perform_later).with(order_cycle2.id)
-    expect(OrderCycleNotificationJob).to_not receive(:perform_later).with(order_cycle3.id)
+    expect(OrderCycleNotificationJob).not_to receive(:perform_later).with(order_cycle2.id)
+    expect(OrderCycleNotificationJob).not_to receive(:perform_later).with(order_cycle3.id)
 
     OrderCycleClosingJob.perform_now
   end

--- a/spec/jobs/order_cycle_opened_job_spec.rb
+++ b/spec/jobs/order_cycle_opened_job_spec.rb
@@ -18,10 +18,10 @@ describe OrderCycleOpenedJob do
       .to receive(:create_webhook_job).with(oc_opened_now, 'order_cycle.opened')
 
     expect(OrderCycleWebhookService)
-      .to_not receive(:create_webhook_job).with(oc_opened_before, 'order_cycle.opened')
+      .not_to receive(:create_webhook_job).with(oc_opened_before, 'order_cycle.opened')
 
     expect(OrderCycleWebhookService)
-      .to_not receive(:create_webhook_job).with(oc_opening_soon, 'order_cycle.opened')
+      .not_to receive(:create_webhook_job).with(oc_opening_soon, 'order_cycle.opened')
 
     OrderCycleOpenedJob.perform_now
   end

--- a/spec/jobs/report_job_spec.rb
+++ b/spec/jobs/report_job_spec.rb
@@ -25,7 +25,7 @@ describe ReportJob do
   it "enqueues a job for async processing" do
     expect {
       ReportJob.perform_later(**report_args)
-    }.to_not change { ActiveStorage::Blob.count }
+    }.not_to change { ActiveStorage::Blob.count }
 
     expect {
       perform_enqueued_jobs(only: ReportJob)
@@ -76,7 +76,7 @@ describe ReportJob do
       # rspec-rails: https://github.com/rspec/rspec-rails/issues/2668
       ReportJob.perform_later(**report_args)
       perform_enqueued_jobs(only: ReportJob)
-    }.to_not enqueue_mail
+    }.not_to enqueue_mail
   end
 
   it "rescues errors" do
@@ -87,7 +87,7 @@ describe ReportJob do
 
     expect {
       perform_enqueued_jobs(only: ReportJob)
-    }.to_not raise_error
+    }.not_to raise_error
   end
 
   def expect_csv_report

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -44,38 +44,38 @@ describe SubscriptionConfirmJob do
 
     it "ignores proxy orders where the OC closed more than 1 hour ago" do
       proxy_order.update!(order_cycle_id: order_cycle2.id)
-      expect(proxy_orders).to_not include proxy_order
+      expect(proxy_orders).not_to include proxy_order
     end
 
     it "ignores cancelled proxy orders" do
       proxy_order.update!(canceled_at: 5.minutes.ago)
-      expect(proxy_orders).to_not include proxy_order
+      expect(proxy_orders).not_to include proxy_order
     end
 
     it "ignores proxy orders without a completed order" do
       proxy_order.order.completed_at = nil
       proxy_order.order.save!
-      expect(proxy_orders).to_not include proxy_order
+      expect(proxy_orders).not_to include proxy_order
     end
 
     it "ignores proxy orders without an associated order" do
       proxy_order.update!(order_id: nil)
-      expect(proxy_orders).to_not include proxy_order
+      expect(proxy_orders).not_to include proxy_order
     end
 
     it "ignores proxy orders that haven't been placed yet" do
       proxy_order.update!(placed_at: nil)
-      expect(proxy_orders).to_not include proxy_order
+      expect(proxy_orders).not_to include proxy_order
     end
 
     it "ignores proxy orders that have already been confirmed" do
       proxy_order.update!(confirmed_at: 1.second.ago)
-      expect(proxy_orders).to_not include proxy_order
+      expect(proxy_orders).not_to include proxy_order
     end
 
     it "ignores orders that have been cancelled" do
       proxy_order.order.cancel!
-      expect(proxy_orders).to_not include proxy_order
+      expect(proxy_orders).not_to include proxy_order
     end
   end
 
@@ -126,7 +126,7 @@ describe SubscriptionConfirmJob do
        "or updated_at date is within the last hour" do
       order_cycles = job.send(:recently_closed_order_cycles)
       expect(order_cycles).to include order_cycle3, order_cycle4
-      expect(order_cycles).to_not include order_cycle1, order_cycle2, order_cycle5
+      expect(order_cycles).not_to include order_cycle1, order_cycle2, order_cycle5
     end
   end
 
@@ -215,7 +215,7 @@ describe SubscriptionConfirmJob do
 
         it "sends a failed payment email" do
           expect(job).to receive(:send_failed_payment_email)
-          expect(job).to_not receive(:send_confirmation_email)
+          expect(job).not_to receive(:send_confirmation_email)
           job.send(:confirm_order!, order)
         end
       end
@@ -231,8 +231,8 @@ describe SubscriptionConfirmJob do
 
           it "sends a failed payment email" do
             expect(job).to receive(:send_failed_payment_email)
-            expect(job).to_not receive(:send_confirmation_email)
-            expect(job).to_not receive(:send_payment_authorization_emails)
+            expect(job).not_to receive(:send_confirmation_email)
+            expect(job).not_to receive(:send_payment_authorization_emails)
             job.send(:confirm_order!, order)
           end
         end
@@ -248,7 +248,7 @@ describe SubscriptionConfirmJob do
 
           it "sends only a subscription confirm email, no regular confirmation emails" do
             expect{ job.send(:confirm_order!, order) }
-              .to_not have_enqueued_mail(Spree::OrderMailer, :confirm_email_for_customer)
+              .not_to have_enqueued_mail(Spree::OrderMailer, :confirm_email_for_customer)
 
             expect(job).to have_received(:send_confirmation_email).once
           end

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -27,27 +27,27 @@ describe SubscriptionPlacementJob do
     it "ignores proxy orders where the OC has closed" do
       expect(job.send(:proxy_orders)).to include proxy_order
       proxy_order.update!(order_cycle_id: order_cycle2.id)
-      expect(job.send(:proxy_orders)).to_not include proxy_order
+      expect(job.send(:proxy_orders)).not_to include proxy_order
     end
 
     it "ignores proxy orders for paused or cancelled subscriptions" do
       expect(job.send(:proxy_orders)).to include proxy_order
       subscription.update!(paused_at: 1.minute.ago)
-      expect(job.send(:proxy_orders)).to_not include proxy_order
+      expect(job.send(:proxy_orders)).not_to include proxy_order
       subscription.update!(paused_at: nil)
       expect(job.send(:proxy_orders)).to include proxy_order
       subscription.update!(canceled_at: 1.minute.ago)
-      expect(job.send(:proxy_orders)).to_not include proxy_order
+      expect(job.send(:proxy_orders)).not_to include proxy_order
     end
 
     it "ignores proxy orders that have been marked as cancelled or placed" do
       expect(job.send(:proxy_orders)).to include proxy_order
       proxy_order.update!(canceled_at: 5.minutes.ago)
-      expect(job.send(:proxy_orders)).to_not include proxy_order
+      expect(job.send(:proxy_orders)).not_to include proxy_order
       proxy_order.update!(canceled_at: nil)
       expect(job.send(:proxy_orders)).to include proxy_order
       proxy_order.update!(placed_at: 5.minutes.ago)
-      expect(job.send(:proxy_orders)).to_not include proxy_order
+      expect(job.send(:proxy_orders)).not_to include proxy_order
     end
   end
 
@@ -108,7 +108,7 @@ describe SubscriptionPlacementJob do
     let!(:exchange_fee) { ExchangeFee.create!(exchange: ex, enterprise_fee: fee) }
 
     before do
-      expect_any_instance_of(Spree::Payment).to_not receive(:process!)
+      expect_any_instance_of(Spree::Payment).not_to receive(:process!)
       allow_any_instance_of(PlaceProxyOrder).to receive(:send_placement_email)
       allow_any_instance_of(PlaceProxyOrder).to receive(:send_empty_email)
     end
@@ -136,7 +136,7 @@ describe SubscriptionPlacementJob do
           expect(proxy_order.order.total).to eq 0
           expect(proxy_order.order.adjustment_total).to eq 0
 
-          expect(service).to_not have_received(:send_placement_email)
+          expect(service).not_to have_received(:send_placement_email)
           expect(service).to have_received(:send_empty_email)
         end
       end
@@ -162,7 +162,7 @@ describe SubscriptionPlacementJob do
 
         it "does not enqueue confirmation emails" do
           expect{ service.call }
-            .to_not have_enqueued_mail(Spree::OrderMailer, :confirm_email_for_customer)
+            .not_to have_enqueued_mail(Spree::OrderMailer, :confirm_email_for_customer)
 
           expect(service).to have_received(:send_placement_email).once
         end
@@ -171,7 +171,7 @@ describe SubscriptionPlacementJob do
           before { allow(service).to receive(:move_to_completion).and_raise(StandardError) }
 
           it "records an error and does not attempt to send an email" do
-            expect(service).to_not receive(:send_placement_email)
+            expect(service).not_to receive(:send_placement_email)
             expect(summarizer).to receive(:record_and_log_error).once
             service.call
           end

--- a/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
@@ -185,7 +185,7 @@ module OpenFoodNetwork
           before { allow(applicator).to receive(:manages_coordinator?) { false } }
 
           it "does not destroy any exchanges" do
-            expect(applicator).to_not receive(:with_permission)
+            expect(applicator).not_to receive(:with_permission)
             applicator.send(:destroy_untouched_exchanges)
           end
         end
@@ -238,26 +238,26 @@ module OpenFoodNetwork
           expect(ids).to include v1.id
 
           # Does not add variants that are not editable
-          expect(ids).to_not include v2.id
+          expect(ids).not_to include v2.id
 
           # Keeps existing variants, when they are explicitly mentioned in the request
           expect(ids).to include v3.id
 
           # Removes existing variants that are editable, when they are not mentioned in the request
-          expect(ids).to_not include v4.id
+          expect(ids).not_to include v4.id
 
           # Removes existing variants that are editable, when the request explicitly removes them
-          expect(ids).to_not include v5.id
+          expect(ids).not_to include v5.id
 
           # Keeps existing variants that are not editable
           expect(ids).to include v6.id
 
           # Removes existing variants that are not in an incoming exchange,
           # regardless of whether they are not editable
-          expect(ids).to_not include v7.id, v8.id
+          expect(ids).not_to include v7.id, v8.id
 
           # Does not add variants that are not in an incoming exchange
-          expect(ids).to_not include v9.id
+          expect(ids).not_to include v9.id
         end
       end
 
@@ -300,7 +300,7 @@ module OpenFoodNetwork
           expect(ids).to include v1.id
 
           # Does not add variants that are not editable
-          expect(ids).to_not include v2.id
+          expect(ids).not_to include v2.id
 
           # Keeps existing variants, if they are editable and requested
           expect(ids).to include v3.id
@@ -309,13 +309,13 @@ module OpenFoodNetwork
           expect(ids).to include v4.id
 
           # Removes existing variants that are editable, when the request explicitly removes them
-          expect(ids).to_not include v5.id
+          expect(ids).not_to include v5.id
 
           # Keeps existing variants that are not editable
           expect(ids).to include v6.id
 
           # Removes existing variants that are editable, when they are not mentioned in the request
-          expect(ids).to_not include v7.id
+          expect(ids).not_to include v7.id
         end
       end
 
@@ -500,8 +500,8 @@ module OpenFoodNetwork
             exchange.reload
             expect(exchange.variants).to match_array [variant1, variant3]
             expect(exchange.enterprise_fees).to match_array [enterprise_fee1, enterprise_fee2]
-            expect(exchange.pickup_time).to_not eq 'New Pickup Time'
-            expect(exchange.pickup_instructions).to_not eq 'New Pickup Instructions'
+            expect(exchange.pickup_time).not_to eq 'New Pickup Time'
+            expect(exchange.pickup_instructions).not_to eq 'New Pickup Instructions'
             expect(exchange.tag_list).to eq []
             expect(applicator.send(:touched_exchanges)).to eq [exchange]
           end

--- a/spec/lib/open_food_network/order_cycle_permissions_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_permissions_spec.rb
@@ -48,7 +48,7 @@ module OpenFoodNetwork
             it "returns enterprises which have granted P-OC to the coordinator" do
               enterprises = permissions.visible_enterprises
               expect(enterprises).to include hub
-              expect(enterprises).to_not include producer
+              expect(enterprises).not_to include producer
             end
           end
 
@@ -56,7 +56,7 @@ module OpenFoodNetwork
             before { allow(coordinator).to receive(:sells) { 'own' } }
             it "returns just the coordinator" do
               enterprises = permissions.visible_enterprises
-              expect(enterprises).to_not include hub, producer
+              expect(enterprises).not_to include hub, producer
             end
           end
         end
@@ -83,7 +83,7 @@ module OpenFoodNetwork
               before { allow(coordinator).to receive(:sells) { 'own' } }
               it "returns just the coordinator" do
                 enterprises = permissions.visible_enterprises
-                expect(enterprises).to_not include hub, producer
+                expect(enterprises).not_to include hub, producer
               end
             end
           end
@@ -91,7 +91,7 @@ module OpenFoodNetwork
           context "where the other enterprises are not in the order cycle" do
             it "returns just the coordinator" do
               enterprises = permissions.visible_enterprises
-              expect(enterprises).to_not include hub, producer
+              expect(enterprises).not_to include hub, producer
             end
           end
         end
@@ -117,7 +117,7 @@ module OpenFoodNetwork
             it "returns my hub" do
               enterprises = permissions.visible_enterprises
               expect(enterprises).to include hub
-              expect(enterprises).to_not include producer, coordinator
+              expect(enterprises).not_to include producer, coordinator
             end
 
             context "and has been granted P-OC by a producer" do
@@ -143,7 +143,7 @@ module OpenFoodNetwork
 
                 it "does not return the producer" do
                   enterprises = permissions.visible_enterprises
-                  expect(enterprises).to_not include producer
+                  expect(enterprises).not_to include producer
                 end
               end
             end
@@ -171,7 +171,7 @@ module OpenFoodNetwork
 
                 it "does not return the producer" do
                   enterprises = permissions.visible_enterprises
-                  expect(enterprises).to_not include producer
+                  expect(enterprises).not_to include producer
                 end
               end
             end
@@ -182,7 +182,7 @@ module OpenFoodNetwork
 
             it "does not return my hub" do
               enterprises = permissions.visible_enterprises
-              expect(enterprises).to_not include hub, producer, coordinator
+              expect(enterprises).not_to include hub, producer, coordinator
             end
           end
         end
@@ -190,7 +190,7 @@ module OpenFoodNetwork
         context "that has not granted P-OC to the coordinator" do
           it "does not return my hub" do
             enterprises = permissions.visible_enterprises
-            expect(enterprises).to_not include hub, producer, coordinator
+            expect(enterprises).not_to include hub, producer, coordinator
           end
 
           context "but is already in the order cycle" do
@@ -202,7 +202,7 @@ module OpenFoodNetwork
             it "returns my hub" do
               enterprises = permissions.visible_enterprises
               expect(enterprises).to include hub
-              expect(enterprises).to_not include producer, coordinator
+              expect(enterprises).not_to include producer, coordinator
             end
 
             context "and distributes variants distributed by an unmanaged & unpermitted producer" do
@@ -214,7 +214,7 @@ module OpenFoodNetwork
               it "returns that producer as well" do
                 enterprises = permissions.visible_enterprises
                 expect(enterprises).to include producer, hub
-                expect(enterprises).to_not include coordinator
+                expect(enterprises).not_to include coordinator
               end
             end
           end
@@ -241,7 +241,7 @@ module OpenFoodNetwork
             it "returns my producer" do
               enterprises = permissions.visible_enterprises
               expect(enterprises).to include producer
-              expect(enterprises).to_not include hub, coordinator
+              expect(enterprises).not_to include hub, coordinator
             end
 
             context "and has been granted P-OC by a hub" do
@@ -259,7 +259,7 @@ module OpenFoodNetwork
                 it "returns the hub as well" do
                   enterprises = permissions.visible_enterprises
                   expect(enterprises).to include producer, hub
-                  expect(enterprises).to_not include coordinator
+                  expect(enterprises).not_to include coordinator
                 end
               end
 
@@ -268,7 +268,7 @@ module OpenFoodNetwork
 
                 it "does not return the hub" do
                   enterprises = permissions.visible_enterprises
-                  expect(enterprises).to_not include hub
+                  expect(enterprises).not_to include hub
                 end
               end
             end
@@ -288,7 +288,7 @@ module OpenFoodNetwork
                 it "returns the hub as well" do
                   enterprises = permissions.visible_enterprises
                   expect(enterprises).to include producer, hub
-                  expect(enterprises).to_not include coordinator
+                  expect(enterprises).not_to include coordinator
                 end
               end
 
@@ -297,7 +297,7 @@ module OpenFoodNetwork
 
                 it "does not return the hub" do
                   enterprises = permissions.visible_enterprises
-                  expect(enterprises).to_not include hub
+                  expect(enterprises).not_to include hub
                 end
               end
             end
@@ -308,7 +308,7 @@ module OpenFoodNetwork
 
             it "does not return my producer" do
               enterprises = permissions.visible_enterprises
-              expect(enterprises).to_not include hub, producer, coordinator
+              expect(enterprises).not_to include hub, producer, coordinator
             end
           end
         end
@@ -316,7 +316,7 @@ module OpenFoodNetwork
         context "which has not granted P-OC to the coordinator" do
           it "does not return my producer" do
             enterprises = permissions.visible_enterprises
-            expect(enterprises).to_not include producer
+            expect(enterprises).not_to include producer
           end
 
           context "but is already in the order cycle" do
@@ -329,7 +329,7 @@ module OpenFoodNetwork
             it "returns my producer" do
               enterprises = permissions.visible_enterprises
               expect(enterprises).to include producer
-              expect(enterprises).to_not include hub, coordinator
+              expect(enterprises).not_to include hub, coordinator
             end
 
             context "and has variants distributed by an outgoing hub" do
@@ -346,7 +346,7 @@ module OpenFoodNetwork
               it "returns that hub as well" do
                 enterprises = permissions.visible_enterprises
                 expect(enterprises).to include producer, hub
-                expect(enterprises).to_not include coordinator
+                expect(enterprises).not_to include coordinator
               end
             end
           end
@@ -527,7 +527,7 @@ module OpenFoodNetwork
           it "returns all variants belonging to the sending producer" do
             visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
             expect(visible).to include v1
-            expect(visible).to_not include v2
+            expect(visible).not_to include v2
           end
         end
 
@@ -541,7 +541,7 @@ module OpenFoodNetwork
           it "returns all variants belonging to the sending producer" do
             visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
             expect(visible).to include v1
-            expect(visible).to_not include v2
+            expect(visible).not_to include v2
           end
         end
 
@@ -561,7 +561,7 @@ module OpenFoodNetwork
             it "returns variants produced by that producer only" do
               visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
               expect(visible).to include v1
-              expect(visible).to_not include v2
+              expect(visible).not_to include v2
             end
           end
 
@@ -570,7 +570,7 @@ module OpenFoodNetwork
 
             it "does not return variants produced by that producer" do
               visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
-              expect(visible).to_not include v1, v2
+              expect(visible).not_to include v1, v2
             end
           end
         end
@@ -589,7 +589,7 @@ module OpenFoodNetwork
           it "returns all variants of any producer which has granted the outgoing hub P-OC" do
             visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
             expect(visible).to include v1
-            expect(visible).to_not include v2
+            expect(visible).not_to include v2
           end
 
           context "where the coordinator produces products" do
@@ -598,14 +598,14 @@ module OpenFoodNetwork
             it "returns any variants produced by the coordinator itself for exchanges w/ 'self'" do
               visible = permissions.visible_variants_for_outgoing_exchanges_to(coordinator)
               expect(visible).to include v3
-              expect(visible).to_not include v1, v2
+              expect(visible).not_to include v1, v2
             end
 
             it "does not return coordinator's variants for exchanges with other hubs, " \
                "when permission has not been granted" do
               visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
               expect(visible).to include v1
-              expect(visible).to_not include v2, v3
+              expect(visible).not_to include v2, v3
             end
           end
 
@@ -637,7 +637,7 @@ module OpenFoodNetwork
           it "returns all variants of any producer which has granted the outgoing hub P-OC" do
             visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
             expect(visible).to include v1
-            expect(visible).to_not include v2
+            expect(visible).not_to include v2
           end
 
           context "where the hub produces products" do
@@ -686,7 +686,7 @@ module OpenFoodNetwork
             it "returns all of my produced variants" do
               visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
               expect(visible).to include v1
-              expect(visible).to_not include v2
+              expect(visible).not_to include v2
             end
           end
 
@@ -695,7 +695,7 @@ module OpenFoodNetwork
 
             it "does not return my variants" do
               visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to_not include v1, v2
+              expect(visible).not_to include v1, v2
             end
           end
         end
@@ -726,7 +726,7 @@ module OpenFoodNetwork
 
             it "returns those variants that are in the exchange" do
               visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to_not include v1, v3
+              expect(visible).not_to include v1, v3
               expect(visible).to include v2
             end
           end
@@ -752,7 +752,7 @@ module OpenFoodNetwork
           it "returns all variants belonging to the sending producer" do
             visible = permissions.editable_variants_for_incoming_exchanges_from(producer1)
             expect(visible).to include v1
-            expect(visible).to_not include v2
+            expect(visible).not_to include v2
           end
         end
 
@@ -766,7 +766,7 @@ module OpenFoodNetwork
           it "returns all variants belonging to the sending producer" do
             visible = permissions.editable_variants_for_incoming_exchanges_from(producer1)
             expect(visible).to include v1
-            expect(visible).to_not include v2
+            expect(visible).not_to include v2
           end
         end
 
@@ -779,7 +779,7 @@ module OpenFoodNetwork
 
           it "does not return variants produced by that producer" do
             visible = permissions.editable_variants_for_incoming_exchanges_from(producer1)
-            expect(visible).to_not include v1, v2
+            expect(visible).not_to include v1, v2
           end
         end
       end
@@ -797,7 +797,7 @@ module OpenFoodNetwork
           it "returns all variants of any producer which has granted the outgoing hub P-OC" do
             visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
             expect(visible).to include v1
-            expect(visible).to_not include v2
+            expect(visible).not_to include v2
           end
 
           context "where the coordinator produces products" do
@@ -806,14 +806,14 @@ module OpenFoodNetwork
             it "returns any variants produced by the coordinator itself for exchanges w/ 'self'" do
               visible = permissions.editable_variants_for_outgoing_exchanges_to(coordinator)
               expect(visible).to include v3
-              expect(visible).to_not include v1, v2
+              expect(visible).not_to include v1, v2
             end
 
             it "does not return coordinator's variants for exchanges with other hubs, " \
                "when permission has not been granted" do
               visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
               expect(visible).to include v1
-              expect(visible).to_not include v2, v3
+              expect(visible).not_to include v2, v3
             end
           end
 
@@ -844,7 +844,7 @@ module OpenFoodNetwork
           it "returns all variants of any producer which has granted the outgoing hub P-OC" do
             visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
             expect(visible).to include v1
-            expect(visible).to_not include v2
+            expect(visible).not_to include v2
           end
 
           context "where the hub produces products" do
@@ -899,7 +899,7 @@ module OpenFoodNetwork
               it "returns all of my produced variants" do
                 visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
                 expect(visible).to include v1
-                expect(visible).to_not include v2
+                expect(visible).not_to include v2
               end
             end
 
@@ -908,7 +908,7 @@ module OpenFoodNetwork
 
               it "does not return my variants" do
                 visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
-                expect(visible).to_not include v1, v2
+                expect(visible).not_to include v1, v2
               end
             end
           end
@@ -918,7 +918,7 @@ module OpenFoodNetwork
 
             it "does not return my variants" do
               visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to_not include v1, v2
+              expect(visible).not_to include v1, v2
             end
           end
         end
@@ -949,7 +949,7 @@ module OpenFoodNetwork
 
             it "does not return my variants" do
               visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to_not include v1, v2, v3
+              expect(visible).not_to include v1, v2, v3
             end
           end
         end

--- a/spec/lib/open_food_network/permissions_spec.rb
+++ b/spec/lib/open_food_network/permissions_spec.rb
@@ -178,7 +178,7 @@ module OpenFoodNetwork
                                 Enterprise.where(id: [hub, producer2])
                               }
 
-        expect(permissions.variant_override_enterprises_per_hub[hub.id]).to_not include producer2.id
+        expect(permissions.variant_override_enterprises_per_hub[hub.id]).not_to include producer2.id
       end
 
       it "returns itself if self is also a primary producer " \

--- a/spec/lib/open_food_network/scope_variants_to_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_to_search_spec.rb
@@ -31,7 +31,7 @@ describe OpenFoodNetwork::ScopeVariantsForSearch do
 
       it "returns all products whose names or SKUs match the query" do
         expect(result).to include v1, v2
-        expect(result).to_not include v3, v4
+        expect(result).not_to include v3, v4
       end
 
       context "matching both product SKUs and variant SKUs" do
@@ -39,7 +39,7 @@ describe OpenFoodNetwork::ScopeVariantsForSearch do
 
         it "returns all variants whose SKU or product's SKU match the query" do
           expect(result).to include v1, v2, v5
-          expect(result).to_not include v3, v4
+          expect(result).not_to include v3, v4
         end
       end
     end
@@ -49,7 +49,7 @@ describe OpenFoodNetwork::ScopeVariantsForSearch do
 
       it "returns all products distributed through that schedule" do
         expect(result).to include v1, v3
-        expect(result).to_not include v2, v4
+        expect(result).not_to include v2, v4
       end
     end
 
@@ -58,7 +58,7 @@ describe OpenFoodNetwork::ScopeVariantsForSearch do
 
       it "returns all products distributed through that order cycle" do
         expect(result).to include v2
-        expect(result).to_not include v1, v3, v4
+        expect(result).not_to include v1, v3, v4
       end
     end
 
@@ -67,7 +67,7 @@ describe OpenFoodNetwork::ScopeVariantsForSearch do
 
       it "returns all products distributed through that distributor" do
         expect(result).to include v4
-        expect(result).to_not include v1, v2, v3
+        expect(result).not_to include v1, v2, v3
       end
 
       context "filtering by stock availability" do
@@ -127,7 +127,7 @@ describe OpenFoodNetwork::ScopeVariantsForSearch do
               distributor1_variant_with_override_on_hand_but_not_on_demand,
               distributor1_variant_with_override_without_stock_level_set_but_producer_in_stock
             )
-            expect(result).to_not include(
+            expect(result).not_to include(
               distributor1_variant_not_backorderable_and_not_on_hand,
               distributor1_variant_with_override_not_on_demand_and_not_on_hand,
               distributor1_variant_with_override_not_in_stock_but_producer_in_stock,
@@ -152,7 +152,7 @@ describe OpenFoodNetwork::ScopeVariantsForSearch do
               distributor1_variant_with_override_not_on_demand_and_not_on_hand,
               distributor1_variant_with_override_not_in_stock_but_producer_in_stock
             )
-            expect(result).to_not include(
+            expect(result).not_to include(
               distributor2_variant_with_override_in_stock
             )
           end

--- a/spec/lib/reports/packing/packing_report_spec.rb
+++ b/spec/lib/reports/packing/packing_report_spec.rb
@@ -42,7 +42,7 @@ describe "Packing Reports" do
       end
 
       it "does not fetch line items for cancelled orders" do
-        expect(report_contents).to_not include line_item2.product.name
+        expect(report_contents).not_to include line_item2.product.name
       end
     end
 
@@ -103,7 +103,7 @@ describe "Packing Reports" do
         context "where an order contains items from multiple suppliers" do
           it "only shows line items the current user supplies" do
             expect(report_contents).to include line_item2.product.name
-            expect(report_contents).to_not include line_item3.product.name
+            expect(report_contents).not_to include line_item3.product.name
           end
         end
       end
@@ -126,7 +126,7 @@ describe "Packing Reports" do
 
       it "only shows line items distributed by enterprises managed by the current user" do
         expect(report_contents).to include line_item.product.name
-        expect(report_contents).to_not include line_item3.product.name
+        expect(report_contents).not_to include line_item3.product.name
       end
 
       context "filtering results" do
@@ -148,7 +148,7 @@ describe "Packing Reports" do
 
           it "only shows results from the selected order cycle" do
             expect(report_contents).to include line_item.product.name
-            expect(report_contents).to_not include line_item4.product.name
+            expect(report_contents).not_to include line_item4.product.name
           end
         end
 
@@ -157,7 +157,7 @@ describe "Packing Reports" do
 
           it "only shows results from the selected supplier" do
             expect(report_contents).to include line_item.product.name
-            expect(report_contents).to_not include line_item4.product.name
+            expect(report_contents).not_to include line_item4.product.name
           end
         end
       end

--- a/spec/lib/reports/users_and_enterprises_report_spec.rb
+++ b/spec/lib/reports/users_and_enterprises_report_spec.rb
@@ -84,7 +84,7 @@ module Reporting
               it "excludes enterprises that are not explicitly requested" do
                 results = subject.owners_and_enterprises.to_a.map{ |oae| oae["name"] }
                 expect(results).to include enterprise1.name
-                expect(results).to_not include enterprise2.name
+                expect(results).not_to include enterprise2.name
               end
             end
 
@@ -95,7 +95,7 @@ module Reporting
               it "excludes enterprises that are not explicitly requested" do
                 results = subject.owners_and_enterprises.to_a.map{ |oae| oae["name"] }
                 expect(results).to include enterprise1.name
-                expect(results).to_not include enterprise2.name
+                expect(results).not_to include enterprise2.name
               end
             end
           end
@@ -108,7 +108,7 @@ module Reporting
               it "excludes enterprises that are not explicitly requested" do
                 results = subject.managers_and_enterprises.to_a.map{ |mae| mae["name"] }
                 expect(results).to include enterprise1.name
-                expect(results).to_not include enterprise2.name
+                expect(results).not_to include enterprise2.name
               end
             end
 
@@ -126,7 +126,7 @@ module Reporting
               it "excludes enterprises whose managers are not explicitly requested" do
                 results = subject.managers_and_enterprises.to_a.map{ |mae| mae["name"] }
                 expect(results).to include enterprise1.name
-                expect(results).to_not include enterprise2.name
+                expect(results).not_to include enterprise2.name
               end
             end
           end

--- a/spec/lib/stripe/account_connector_spec.rb
+++ b/spec/lib/stripe/account_connector_spec.rb
@@ -27,7 +27,7 @@ module Stripe
         it "returns false and does not create a new StripeAccount" do
           expect do
             expect(connector.create_account).to be false
-          end.to_not change { StripeAccount.count }
+          end.not_to change { StripeAccount.count }
         end
       end
 
@@ -36,7 +36,7 @@ module Stripe
           it "raises a StripeError" do
             expect do
               expect{ connector.create_account }.to raise_error StripeError
-            end.to_not change { StripeAccount.count }
+            end.not_to change { StripeAccount.count }
           end
         end
 
@@ -47,7 +47,7 @@ module Stripe
             it "raises an AccessDenied error" do
               expect do
                 expect{ connector.create_account }.to raise_error CanCan::AccessDenied
-              end.to_not change { StripeAccount.count }
+              end.not_to change { StripeAccount.count }
             end
           end
 
@@ -68,7 +68,7 @@ module Stripe
                 expect(OAuth).to receive(:deauthorize).with(stripe_user_id: "some_user_id")
                 expect do
                   expect{ connector.create_account }.to raise_error CanCan::AccessDenied
-                end.to_not change { StripeAccount.count }
+                end.not_to change { StripeAccount.count }
               end
             end
 
@@ -78,7 +78,7 @@ module Stripe
               end
 
               it "raises no errors" do
-                expect(OAuth).to_not receive(:deauthorize)
+                expect(OAuth).not_to receive(:deauthorize)
                 connector.create_account
               end
 
@@ -94,7 +94,7 @@ module Stripe
               let(:user) { enterprise.owner }
 
               it "raises no errors" do
-                expect(OAuth).to_not receive(:deauthorize)
+                expect(OAuth).not_to receive(:deauthorize)
                 connector.create_account
               end
 

--- a/spec/lib/stripe/payment_intent_validator_spec.rb
+++ b/spec/lib/stripe/payment_intent_validator_spec.rb
@@ -52,7 +52,7 @@ describe Stripe::PaymentIntentValidator do
             expect {
               result = validator.call
               expect(result).to eq payment_intent_response_body
-            }.to_not raise_error Stripe::StripeError
+            }.not_to raise_error Stripe::StripeError
           end
 
           it "captures the payment" do

--- a/spec/lib/stripe/webhook_handler_spec.rb
+++ b/spec/lib/stripe/webhook_handler_spec.rb
@@ -48,7 +48,7 @@ module Stripe
         end
 
         it "does not call the handler method, and returns :unknown" do
-          expect(handler).to_not receive(:some_method)
+          expect(handler).not_to receive(:some_method)
           expect(handler.handle).to be :unknown
         end
       end
@@ -57,7 +57,7 @@ module Stripe
     describe "deauthorize" do
       context "when the event has no 'account' attribute" do
         it "does destroy stripe accounts, returns :ignored" do
-          expect(handler).to_not receive(:destroy_stripe_accounts_linked_to)
+          expect(handler).not_to receive(:destroy_stripe_accounts_linked_to)
           expect(handler.send(:deauthorize)).to be :ignored
         end
       end

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -55,9 +55,9 @@ describe RemoveTransientData do
       it 'deletes cart orders and related objects older than retention_period' do
         RemoveTransientData.new.call
 
-        expect{ cart.reload }.to_not raise_error
-        expect{ line_item.reload }.to_not raise_error
-        expect{ adjustment.reload }.to_not raise_error
+        expect{ cart.reload }.not_to raise_error
+        expect{ line_item.reload }.not_to raise_error
+        expect{ adjustment.reload }.not_to raise_error
 
         expect{ old_cart.reload }.to raise_error ActiveRecord::RecordNotFound
         expect{ old_line_item.reload }.to raise_error ActiveRecord::RecordNotFound

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -35,14 +35,14 @@ describe Spree::OrderMailer do
     end
 
     it "doesn't aggressively escape double quotes body" do
-      expect(email.body).to_not include("&quot;")
+      expect(email.body).not_to include("&quot;")
     end
 
     it "accepts an order id as an alternative to an Order object" do
       expect(Spree::Order).to receive(:find).with(order.id).and_return(order)
       expect {
         described_class.confirm_email_for_customer(order.id).deliver_now
-      }.to_not raise_error
+      }.not_to raise_error
     end
 
     it "display the OFN header by default" do
@@ -55,7 +55,7 @@ describe Spree::OrderMailer do
       end
 
       it 'does not display the OFN navigation' do
-        expect(email.body).to_not include(ContentConfig.url_for(:footer_logo))
+        expect(email.body).not_to include(ContentConfig.url_for(:footer_logo))
       end
     end
   end
@@ -91,7 +91,7 @@ describe Spree::OrderMailer do
       expect(Spree::Order).to receive(:find).with(order.id).and_return(order)
       expect {
         Spree::OrderMailer.cancel_email(order.id).deliver_now
-      }.to_not raise_error
+      }.not_to raise_error
     end
   end
 
@@ -115,11 +115,11 @@ describe Spree::OrderMailer do
     let!(:cancel_email) { Spree::OrderMailer.cancel_email(order) }
 
     specify do
-      expect(confirmation_email.body).to_not include("Ineligible Adjustment")
+      expect(confirmation_email.body).not_to include("Ineligible Adjustment")
     end
 
     specify do
-      expect(cancel_email.body).to_not include("Ineligible Adjustment")
+      expect(cancel_email.body).not_to include("Ineligible Adjustment")
     end
   end
 
@@ -241,7 +241,7 @@ describe Spree::OrderMailer do
         expect(renderer).to receive(:render_to_string).with(order, nil).and_return("invoice")
         expect {
           email.deliver_now
-        }.to_not raise_error
+        }.not_to raise_error
         expect(deliveries.count).to eq(1)
         expect(deliveries.first.attachments.count).to eq(1)
         expect(deliveries.first.attachments.first.filename).to eq(attachment_filename)

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -147,7 +147,7 @@ describe ProducerMailer, type: :mailer do
     end
 
     it "adds customer names table" do
-      expect(body_as_html(mail).find(".order-summary.customer-order")).to_not be_nil
+      expect(body_as_html(mail).find(".order-summary.customer-order")).not_to be_nil
     end
 
     it "displays last name for each order" do

--- a/spec/mailers/shipment_mailer_spec.rb
+++ b/spec/mailers/shipment_mailer_spec.rb
@@ -25,14 +25,14 @@ describe Spree::ShipmentMailer do
   # Regression test for #2196
   it "doesn't include out of stock in the email body" do
     shipment_email = Spree::ShipmentMailer.shipped_email(shipment, delivery: true)
-    expect(shipment_email.body).to_not include(%{Out of Stock})
+    expect(shipment_email.body).not_to include(%{Out of Stock})
   end
 
   it "shipment_email accepts an shipment id as an alternative to an Shipment object" do
     expect(Spree::Shipment).to receive(:find).with(shipment.id).and_return(shipment)
     expect {
       Spree::ShipmentMailer.shipped_email(shipment.id, delivery: true).deliver_now
-    }.to_not raise_error
+    }.not_to raise_error
   end
 
   it "includes the distributor's name in the subject" do

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -35,7 +35,7 @@ describe SubscriptionMailer, type: :mailer do
         body = SubscriptionMailer.deliveries.last.body.encoded
 
         expect(body).to include "This order was automatically created for you."
-        expect(body).to_not include "Unfortunately, not all products " \
+        expect(body).not_to include "Unfortunately, not all products " \
                                     "that you requested were available."
       end
     end
@@ -55,7 +55,7 @@ describe SubscriptionMailer, type: :mailer do
 
         it "provides link to make changes" do
           expect(body).to match %r{<a #{order_link_href} #{order_link_style}>make changes</a>}
-          expect(body).to_not match %r{
+          expect(body).not_to match %r{
             <a #{order_link_href} #{order_link_style}>view details of this order</a>
           }
         end
@@ -64,7 +64,7 @@ describe SubscriptionMailer, type: :mailer do
           let(:shop) { create(:enterprise, allow_order_changes: false) }
 
           it "provides link to view details" do
-            expect(body).to_not match %r{<a #{order_link_href} #{order_link_style}>make changes</a>}
+            expect(body).not_to match %r{<a #{order_link_href} #{order_link_style}>make changes</a>}
             expect(body)
               .to match %r{<a #{order_link_href} #{order_link_style}>view details of this order</a>}
           end
@@ -75,14 +75,14 @@ describe SubscriptionMailer, type: :mailer do
         let(:customer) { create(:customer, enterprise: shop, user: nil) }
 
         it "does not provide link" do
-          expect(body).to_not match /#{order_link_href}/
+          expect(body).not_to match /#{order_link_href}/
         end
 
         context "when the distributor does not allow changes to the order" do
           let(:shop) { create(:enterprise, allow_order_changes: false) }
 
           it "does not provide link" do
-            expect(body).to_not match /#{order_link_href}/
+            expect(body).not_to match /#{order_link_href}/
           end
         end
       end
@@ -140,7 +140,7 @@ describe SubscriptionMailer, type: :mailer do
         let(:customer) { create(:customer, user: nil) }
 
         it "does not provide link" do
-          expect(email.body).to_not match /#{order_link_href}/
+          expect(email.body).not_to match /#{order_link_href}/
         end
       end
     end
@@ -167,7 +167,7 @@ describe SubscriptionMailer, type: :mailer do
       end
 
       it 'does not display the OFN navigation' do
-        expect(email.body).to_not include(ContentConfig.url_for(:footer_logo))
+        expect(email.body).not_to include(ContentConfig.url_for(:footer_logo))
       end
     end
   end
@@ -236,7 +236,7 @@ describe SubscriptionMailer, type: :mailer do
         let(:customer) { create(:customer, user: nil) }
 
         it "does not provide link" do
-          expect(body).to_not match /#{order_link_href}/
+          expect(body).not_to match /#{order_link_href}/
         end
       end
     end
@@ -269,7 +269,7 @@ describe SubscriptionMailer, type: :mailer do
         expect(body).to include("A total of %d subscriptions were marked " \
                                 "for automatic processing." % 37)
         expect(body).to include 'All were processed successfully.'
-        expect(body).to_not include 'Details of the issues encountered are provided below.'
+        expect(body).not_to include 'Details of the issues encountered are provided below.'
       end
 
       it "renders the shop's logo" do
@@ -370,7 +370,7 @@ describe SubscriptionMailer, type: :mailer do
         expect(body).to include order2.number
 
         # No error messages reported when non provided
-        expect(body).to_not include 'No error message provided'
+        expect(body).not_to include 'No error message provided'
       end
     end
   end
@@ -401,7 +401,7 @@ describe SubscriptionMailer, type: :mailer do
         expect(body).to include("A total of %d subscriptions were marked " \
                                 "for automatic processing." % 37)
         expect(body).to include 'All were processed successfully.'
-        expect(body).to_not include 'Details of the issues encountered are provided below.'
+        expect(body).not_to include 'Details of the issues encountered are provided below.'
       end
     end
 
@@ -497,7 +497,7 @@ describe SubscriptionMailer, type: :mailer do
         expect(body).to include order2.number
 
         # No error messages reported when non provided
-        expect(body).to_not include 'No error message provided'
+        expect(body).not_to include 'No error message provided'
       end
     end
   end

--- a/spec/mailers/test_mailer_spec.rb
+++ b/spec/mailers/test_mailer_spec.rb
@@ -16,6 +16,6 @@ describe Spree::TestMailer do
     expect(Spree::User).to receive(:find).with(user.id).and_return(user)
     expect {
       Spree::TestMailer.test_email(user.id).deliver_now
-    }.to_not raise_error
+    }.not_to raise_error
   end
 end

--- a/spec/migrations/convert_stripe_connect_to_stripe_sca_spec.rb
+++ b/spec/migrations/convert_stripe_connect_to_stripe_sca_spec.rb
@@ -89,7 +89,7 @@ describe ConvertStripeConnectToStripeSca do
       distributor_ids: [owner.id]
     )
 
-    expect { subject.up }.to_not change { stripe.reload.attributes }
+    expect { subject.up }.not_to change { stripe.reload.attributes }
   end
 
   it "doesn't mess with other payment methods" do
@@ -99,6 +99,6 @@ describe ConvertStripeConnectToStripeSca do
       distributor_ids: [owner.id]
     )
 
-    expect { subject.up }.to_not change { cash.reload.attributes }
+    expect { subject.up }.not_to change { cash.reload.attributes }
   end
 end

--- a/spec/migrations/migrate_admin_tax_amounts_spec.rb
+++ b/spec/migrations/migrate_admin_tax_amounts_spec.rb
@@ -18,7 +18,7 @@ describe MigrateAdminTaxAmounts do
       let!(:adjustment_without_tax) { create(:adjustment, included_tax: 0) }
 
       it "doesn't move the tax to an adjustment" do
-        expect { subject.migrate_admin_taxes! }.to_not change {
+        expect { subject.migrate_admin_taxes! }.not_to change {
           Spree::Adjustment.count
         }
       end
@@ -85,7 +85,7 @@ describe MigrateAdminTaxAmounts do
       let(:order) { nil }
 
       it "returns an empty array" do
-        expect(Spree::TaxRate).to_not receive(:match)
+        expect(Spree::TaxRate).not_to receive(:match)
 
         expect(subject.applicable_rates(adjustment)).to eq []
       end
@@ -95,7 +95,7 @@ describe MigrateAdminTaxAmounts do
       let(:distributor) { nil }
 
       it "returns an empty array" do
-        expect(Spree::TaxRate).to_not receive(:match)
+        expect(Spree::TaxRate).not_to receive(:match)
 
         expect(subject.applicable_rates(adjustment)).to eq []
       end

--- a/spec/models/concerns/order_shipment_spec.rb
+++ b/spec/models/concerns/order_shipment_spec.rb
@@ -43,7 +43,7 @@ describe OrderShipment do
 
         it "returns nil for empty shipping_method_id" do
           empty_shipping_method_id = ' '
-          expect(shipment.shipping_rates).to_not receive(:find_by)
+          expect(shipment.shipping_rates).not_to receive(:find_by)
             .with(shipping_method_id: empty_shipping_method_id)
 
           expect(order.select_shipping_method(empty_shipping_method_id)).to be_nil

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -63,7 +63,7 @@ describe Customer, type: :model do
       c1 = Customer.create(enterprise:, email: non_existing_email, user: user1)
       expect(c1.user).to eq user1
       expect(c1.email).to eq non_existing_email
-      expect(c1.email).to_not eq user1.email
+      expect(c1.email).not_to eq user1.email
 
       c2 = Customer.create(enterprise:, email: user2.email)
       expect(c2.user).to eq user2

--- a/spec/models/enterprise_fee_spec.rb
+++ b/spec/models/enterprise_fee_spec.rb
@@ -196,7 +196,7 @@ describe EnterpriseFee do
     end
 
     it "soft-deletes the enterprise fee" do
-      expect(enterprise_fee.deleted_at).to_not be_nil
+      expect(enterprise_fee.deleted_at).not_to be_nil
     end
 
     it "can be accessed by old adjustments" do

--- a/spec/models/enterprise_relationship_spec.rb
+++ b/spec/models/enterprise_relationship_spec.rb
@@ -196,9 +196,9 @@ describe EnterpriseRelationship do
             before { er.destroy }
             it "should set permission_revoked_at to the current time " \
                "for all variant overrides of the relationship" do
-              expect(vo1.reload.permission_revoked_at).to_not be_nil
-              expect(vo2.reload.permission_revoked_at).to_not be_nil
-              expect(vo2.reload.permission_revoked_at).to_not be_nil
+              expect(vo1.reload.permission_revoked_at).not_to be_nil
+              expect(vo2.reload.permission_revoked_at).not_to be_nil
+              expect(vo2.reload.permission_revoked_at).not_to be_nil
             end
           end
         end
@@ -207,8 +207,8 @@ describe EnterpriseRelationship do
           before { er.permissions_list = [:add_to_order_cycles]; er.save! }
           it "should set permission_revoked_at to the current time " \
              "for all relevant variant overrides" do
-            expect(vo1.reload.permission_revoked_at).to_not be_nil
-            expect(vo2.reload.permission_revoked_at).to_not be_nil
+            expect(vo1.reload.permission_revoked_at).not_to be_nil
+            expect(vo2.reload.permission_revoked_at).not_to be_nil
           end
 
           it "should not affect other variant overrides" do
@@ -277,7 +277,7 @@ describe EnterpriseRelationship do
           end
 
           it "should not affect other variant overrides" do
-            expect(vo3.reload.permission_revoked_at).to_not be_nil
+            expect(vo3.reload.permission_revoked_at).not_to be_nil
           end
         end
 
@@ -285,9 +285,9 @@ describe EnterpriseRelationship do
           before { er.permissions_list = [:add_to_order_cycles, :manage_products]; er.save! }
 
           it "should have no effect on existing variant_overrides" do
-            expect(vo1.reload.permission_revoked_at).to_not be_nil
-            expect(vo2.reload.permission_revoked_at).to_not be_nil
-            expect(vo3.reload.permission_revoked_at).to_not be_nil
+            expect(vo1.reload.permission_revoked_at).not_to be_nil
+            expect(vo2.reload.permission_revoked_at).not_to be_nil
+            expect(vo3.reload.permission_revoked_at).not_to be_nil
           end
         end
       end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -96,7 +96,7 @@ describe Enterprise do
       it "adds new owner to list of managers" do
         expect(e.owner).to eq u1
         expect(e.users).to include u1
-        expect(e.users).to_not include u2
+        expect(e.users).not_to include u2
         e.owner = u2
         e.save!
         e.reload
@@ -132,14 +132,14 @@ describe Enterprise do
 
       it "prevents duplicate names for new records" do
         e = Enterprise.new name: enterprise.name
-        expect(e).to_not be_valid
+        expect(e).not_to be_valid
         expect(e.errors[:name].first).to include enterprise_name_error(owner.email)
       end
 
       it "prevents duplicate names for existing records" do
         e = create(:enterprise, name: 'foo')
         e.name = enterprise.name
-        expect(e).to_not be_valid
+        expect(e).not_to be_valid
         expect(e.errors[:name].first).to include enterprise_name_error(owner.email)
       end
 
@@ -155,27 +155,27 @@ describe Enterprise do
     describe "prevent a wrong instagram link pattern" do
       it "invalidates the instagram attribute https://facebook.com/user" do
         e = build(:enterprise, instagram: 'https://facebook.com/user')
-        expect(e).to_not be_valid
+        expect(e).not_to be_valid
       end
 
       it "invalidates the instagram attribute tagram.com/user" do
         e = build(:enterprise, instagram: 'tagram.com/user')
-        expect(e).to_not be_valid
+        expect(e).not_to be_valid
       end
 
       it "invalidates the instagram attribute https://instagram.com/user/preferences" do
         e = build(:enterprise, instagram: 'https://instagram.com/user/preferences')
-        expect(e).to_not be_valid
+        expect(e).not_to be_valid
       end
 
       it "invalidates the instagram attribute https://www.instagram.com/p/Cpg4McNPyJA/" do
         e = build(:enterprise, instagram: 'https://www.instagram.com/p/Cpg4McNPyJA/')
-        expect(e).to_not be_valid
+        expect(e).not_to be_valid
       end
 
       it "invalidates the instagram attribute https://instagram.com/user-user" do
         e = build(:enterprise, instagram: 'https://instagram.com/user-user')
-        expect(e).to_not be_valid
+        expect(e).not_to be_valid
       end
     end
 
@@ -368,7 +368,7 @@ describe Enterprise do
       it "finds enterprises that have a sells property other than 'unspecified'" do
         activated_enterprises = Enterprise.activated
         expect(activated_enterprises).to include active_enterprise
-        expect(activated_enterprises).to_not include inactive_enterprise
+        expect(activated_enterprises).not_to include inactive_enterprise
       end
     end
 

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -15,7 +15,7 @@ describe OrderCycle do
 
   it 'should not be valid when open date is after close date' do
     oc = build(:simple_order_cycle, orders_open_at: Time.zone.now, orders_close_at: 1.minute.ago)
-    expect(oc).to_not be_valid
+    expect(oc).not_to be_valid
   end
 
   it "has a coordinator and associated fees" do
@@ -246,7 +246,7 @@ describe OrderCycle do
           it "does not consider soft-deleted variants to be currently distributed in the oc" do
             p2_v.delete
 
-            expect(oc.variants_distributed_by(d1)).to_not include p2_v
+            expect(oc.variants_distributed_by(d1)).not_to include p2_v
           end
         end
       end
@@ -564,12 +564,12 @@ describe OrderCycle do
 
     it "it does not reset opened_at if open date is changed to be earlier" do
       expect{ oc.update!(orders_open_at: 3.days.ago) }
-        .to_not change { oc.opened_at }
+        .not_to change { oc.opened_at }
     end
 
     it "it does not reset opened_at if open date does not change" do
       expect{ oc.update!(orders_close_at: 1.day.from_now) }
-        .to_not change { oc.opened_at }
+        .not_to change { oc.opened_at }
     end
   end
 
@@ -580,21 +580,21 @@ describe OrderCycle do
     }
 
     it "reset processed_at if close date change in future" do
-      expect(oc.processed_at).to_not be_nil
+      expect(oc.processed_at).not_to be_nil
       oc.update!(orders_close_at: 1.week.from_now)
       expect(oc.processed_at).to be_nil
     end
 
     it "it does not reset processed_at if close date is changed to be earlier" do
-      expect(oc.processed_at).to_not be_nil
+      expect(oc.processed_at).not_to be_nil
       oc.update!(orders_close_at: 2.days.ago)
-      expect(oc.processed_at).to_not be_nil
+      expect(oc.processed_at).not_to be_nil
     end
 
     it "it does not reset processed_at if close date does not change" do
-      expect(oc.processed_at).to_not be_nil
+      expect(oc.processed_at).not_to be_nil
       oc.update!(orders_open_at: 2.weeks.ago)
-      expect(oc.processed_at).to_not be_nil
+      expect(oc.processed_at).not_to be_nil
     end
   end
 

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -161,7 +161,7 @@ describe ProductImport::ProductImporter do
       expect(carrots.variants.first.unit_value).to eq 500
       expect(carrots.variant_unit).to eq 'weight'
       expect(carrots.variant_unit_scale).to eq 1
-      expect(carrots.variants.first.on_demand).to_not eq true
+      expect(carrots.variants.first.on_demand).not_to eq true
       expect(carrots.variants.first.import_date).to be_within(1.minute).of Time.zone.now
 
       potatoes = Spree::Product.find_by(name: 'Potatoes')
@@ -171,7 +171,7 @@ describe ProductImport::ProductImporter do
       expect(potatoes.variants.first.unit_value).to eq 2000
       expect(potatoes.variant_unit).to eq 'weight'
       expect(potatoes.variant_unit_scale).to eq 1000
-      expect(potatoes.variants.first.on_demand).to_not eq true
+      expect(potatoes.variants.first.on_demand).not_to eq true
       expect(potatoes.variants.first.import_date).to be_within(1.minute).of Time.zone.now
 
       pea_soup = Spree::Product.find_by(name: 'Pea Soup')
@@ -181,7 +181,7 @@ describe ProductImport::ProductImporter do
       expect(pea_soup.variants.first.unit_value).to eq 0.75
       expect(pea_soup.variant_unit).to eq 'volume'
       expect(pea_soup.variant_unit_scale).to eq 0.001
-      expect(pea_soup.variants.first.on_demand).to_not eq true
+      expect(pea_soup.variants.first.on_demand).not_to eq true
       expect(pea_soup.variants.first.import_date).to be_within(1.minute).of Time.zone.now
 
       salad = Spree::Product.find_by(name: 'Salad')
@@ -191,7 +191,7 @@ describe ProductImport::ProductImporter do
       expect(salad.variants.first.unit_value).to eq 1
       expect(salad.variant_unit).to eq 'items'
       expect(salad.variant_unit_scale).to eq nil
-      expect(salad.variants.first.on_demand).to_not eq true
+      expect(salad.variants.first.on_demand).not_to eq true
       expect(salad.variants.first.import_date).to be_within(1.minute).of Time.zone.now
 
       buns = Spree::Product.find_by(name: 'Hot Cross Buns')
@@ -550,7 +550,7 @@ describe ProductImport::ProductImporter do
 
       beetroot = Spree::Product.find_by(name: 'Beetroot').variants.first
       expect(beetroot.price).to eq 3.50
-      expect(beetroot.on_demand).to_not eq true
+      expect(beetroot.on_demand).not_to eq true
 
       tomato = Spree::Product.find_by(name: 'Tomato').variants.first
       expect(tomato.price).to eq 5.50

--- a/spec/models/proxy_order_spec.rb
+++ b/spec/models/proxy_order_spec.rb
@@ -205,8 +205,8 @@ describe ProxyOrder, type: :model do
       end
 
       it "returns the existing order" do
-        expect(OrderFactory).to_not receive(:new)
-        expect(proxy_order).to_not receive(:save!)
+        expect(OrderFactory).not_to receive(:new)
+        expect(proxy_order).not_to receive(:save!)
         expect(proxy_order.initialise_order!).to eq existing_order
       end
     end

--- a/spec/models/report_blob_spec.rb
+++ b/spec/models/report_blob_spec.rb
@@ -9,6 +9,6 @@ describe ReportBlob, type: :model do
     expect do
       blob = ReportBlob.create!("customers.html", content)
       content = blob.result
-    end.to_not change { content.encoding }.from(Encoding::UTF_8)
+    end.not_to change { content.encoding }.from(Encoding::UTF_8)
   end
 end

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -55,10 +55,10 @@ describe Spree::Ability do
 
     context 'with customer' do
       it 'should not be able to admin' do
-        expect(subject).to_not be_able_to :admin, resource
-        expect(subject).to_not be_able_to :admin, resource_order
-        expect(subject).to_not be_able_to :admin, resource_product
-        expect(subject).to_not be_able_to :admin, resource_user
+        expect(subject).not_to be_able_to :admin, resource
+        expect(subject).not_to be_able_to :admin, resource_order
+        expect(subject).not_to be_able_to :admin, resource_product
+        expect(subject).not_to be_able_to :admin, resource_user
       end
     end
   end

--- a/spec/models/spree/address_spec.rb
+++ b/spec/models/spree/address_spec.rb
@@ -36,9 +36,9 @@ describe Spree::Address do
       expect(cloned.state_name).to eq original.state_name
       expect(cloned.zipcode).to eq original.zipcode
 
-      expect(cloned.id).to_not eq original.id
-      expect(cloned.created_at).to_not eq original.created_at
-      expect(cloned.updated_at).to_not eq original.updated_at
+      expect(cloned.id).not_to eq original.id
+      expect(cloned.created_at).not_to eq original.created_at
+      expect(cloned.updated_at).not_to eq original.updated_at
     end
   end
 
@@ -74,7 +74,7 @@ describe Spree::Address do
     it "errors when state_name is nil" do
       address.state_name = nil
       address.state = nil
-      expect(address).to_not be_valid
+      expect(address).not_to be_valid
     end
 
     it "full state name is in state_name and country does contain that state" do

--- a/spec/models/spree/addresses_spec.rb
+++ b/spec/models/spree/addresses_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Address do
 
   describe "destroy" do
     it "can be deleted" do
-      expect { address.destroy }.to_not raise_error
+      expect { address.destroy }.not_to raise_error
     end
 
     it "cannot be deleted with associated enterprise" do

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -107,7 +107,7 @@ module Spree
 
         it "is false when adjustment state is open" do
           adjustment.state = "open"
-          expect(adjustment).to_not be_immutable
+          expect(adjustment).not_to be_immutable
         end
       end
 
@@ -119,9 +119,9 @@ module Spree
 
         it "is false when adjustment state isn't finalized" do
           adjustment.state = "closed"
-          expect(adjustment).to_not be_finalized
+          expect(adjustment).not_to be_finalized
           adjustment.state = "open"
-          expect(adjustment).to_not be_finalized
+          expect(adjustment).not_to be_finalized
         end
       end
     end

--- a/spec/models/spree/credit_card_spec.rb
+++ b/spec/models/spree/credit_card_spec.rb
@@ -74,41 +74,41 @@ module Spree
       context "#valid?" do
         it "should validate presence of number" do
           credit_card.attributes = valid_credit_card_attributes.except(:number)
-          expect(credit_card).to_not be_valid
+          expect(credit_card).not_to be_valid
           expect(credit_card.errors[:number]).to eq ["can't be blank"]
         end
 
         it "should validate presence of security code" do
           credit_card.attributes = valid_credit_card_attributes.except(:verification_value)
-          expect(credit_card).to_not be_valid
+          expect(credit_card).not_to be_valid
           expect(credit_card.errors[:verification_value]).to eq ["can't be blank"]
         end
 
         it "should validate expiration is not in the past" do
           credit_card.month = 1.month.ago.month
           credit_card.year = 1.month.ago.year
-          expect(credit_card).to_not be_valid
+          expect(credit_card).not_to be_valid
           expect(credit_card.errors[:base]).to eq ["has expired"]
         end
 
         it "does not run expiration in the past validation if month is not set" do
           credit_card.month = nil
           credit_card.year = Time.zone.now.year
-          expect(credit_card).to_not be_valid
+          expect(credit_card).not_to be_valid
           expect(credit_card.errors[:base]).to be_blank
         end
 
         it "does not run expiration in the past validation if year is not set" do
           credit_card.month = Time.zone.now.month
           credit_card.year = nil
-          expect(credit_card).to_not be_valid
+          expect(credit_card).not_to be_valid
           expect(credit_card.errors[:base]).to be_blank
         end
 
         it "does not run expiration in the past validation if year and month are empty" do
           credit_card.year = ""
           credit_card.month = ""
-          expect(credit_card).to_not be_valid
+          expect(credit_card).not_to be_valid
           expect(credit_card.errors[:card]).to be_blank
         end
 

--- a/spec/models/spree/inventory_unit_spec.rb
+++ b/spec/models/spree/inventory_unit_spec.rb
@@ -29,7 +29,7 @@ describe Spree::InventoryUnit do
     # Regression for Spree #3066
     it "returns modifiable objects" do
       units = Spree::InventoryUnit.backordered_for_stock_item(stock_item)
-      expect { units.first.save! }.to_not raise_error
+      expect { units.first.save! }.not_to raise_error
     end
 
     it "finds inventory units from its stock location " \
@@ -44,7 +44,7 @@ describe Spree::InventoryUnit do
       other_variant_unit.save!
 
       expect(Spree::InventoryUnit.backordered_for_stock_item(stock_item))
-        .to_not include(other_variant_unit)
+        .not_to include(other_variant_unit)
     end
   end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -200,7 +200,7 @@ module Spree
           li3.variant.product.destroy
 
           expect(o.line_items.reload.sorted_by_name_and_unit_value).to eq([li6, li5, li4, li3])
-          expect(o.line_items.sorted_by_name_and_unit_value.to_sql).to_not match "deleted_at"
+          expect(o.line_items.sorted_by_name_and_unit_value.to_sql).not_to match "deleted_at"
         end
       end
 
@@ -340,7 +340,7 @@ module Spree
           it "draws stock from the variant override" do
             expect(vo.reload.count_on_hand).to eq 3
             expect{ line_item.increment!(:quantity) }
-              .to_not change{ Spree::Variant.find(variant.id).on_hand }
+              .not_to change{ Spree::Variant.find(variant.id).on_hand }
             expect(vo.reload.count_on_hand).to eq 2
           end
         end
@@ -367,7 +367,7 @@ module Spree
 
           it "restores stock to the variant override" do
             expect(vo.reload.count_on_hand).to eq 3
-            expect{ line_item.destroy }.to_not change{ Spree::Variant.find(variant.id).on_hand }
+            expect{ line_item.destroy }.not_to change{ Spree::Variant.find(variant.id).on_hand }
             expect(vo.reload.count_on_hand).to eq 4
           end
         end
@@ -458,7 +458,7 @@ module Spree
         end
 
         it "returns false otherwise" do
-          expect(li_no_tax).to_not have_tax
+          expect(li_no_tax).not_to have_tax
         end
       end
 

--- a/spec/models/spree/order/payment_spec.rb
+++ b/spec/models/spree/order/payment_spec.rb
@@ -87,7 +87,7 @@ module Spree
 
         expect(zero_order.payment_state).to eq "paid"
         expect(zero_payment.reload.state).to eq "completed"
-        expect(zero_payment.captured_at).to_not be_nil
+        expect(zero_payment.captured_at).not_to be_nil
       end
     end
 

--- a/spec/models/spree/order/tax_spec.rb
+++ b/spec/models/spree/order/tax_spec.rb
@@ -159,7 +159,7 @@ module Spree
           it "removes any legacy tax adjustments on order" do
             order.create_tax_charge!
 
-            expect(order.reload.adjustments).to_not include legacy_tax_adjustment
+            expect(order.reload.adjustments).not_to include legacy_tax_adjustment
           end
 
           it "re-applies taxes on individual items" do

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -146,7 +146,7 @@ describe Spree::OrderContents do
       end
 
       it "does not update the order's enterprise fees if not complete" do
-        expect(order).to_not receive(:update_order_fees!)
+        expect(order).not_to receive(:update_order_fees!)
 
         subject.update_item(line_item, { quantity: 3 })
       end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -34,7 +34,7 @@ describe Spree::Order do
     end
 
     it "can find a line item matching a given variant" do
-      expect(order.find_line_item_by_variant(order.line_items.third.variant)).to_not be_nil
+      expect(order.find_line_item_by_variant(order.line_items.third.variant)).not_to be_nil
       expect(order.find_line_item_by_variant(build(:variant))).to be_nil
     end
   end
@@ -107,7 +107,7 @@ describe Spree::Order do
   context "#create" do
     it "should assign an order number" do
       order = Spree::Order.create
-      expect(order.number).to_not be_nil
+      expect(order.number).not_to be_nil
     end
   end
 
@@ -1012,7 +1012,7 @@ describe Spree::Order do
 
       it "returns only orders which have line items" do
         expect(Spree::Order.not_empty).to include order_with_line_items
-        expect(Spree::Order.not_empty).to_not include order_without_line_items
+        expect(Spree::Order.not_empty).not_to include order_without_line_items
       end
     end
   end
@@ -1041,19 +1041,19 @@ describe Spree::Order do
 
   describe "#customer" do
     it "is not required for new records" do
-      is_expected.to_not validate_presence_of(:customer)
+      is_expected.not_to validate_presence_of(:customer)
     end
 
     it "is not required for new complete orders" do
       order = Spree::Order.new(state: "complete")
 
-      expect(order).to_not validate_presence_of(:customer)
+      expect(order).not_to validate_presence_of(:customer)
     end
 
     it "is not required for existing orders in cart state" do
       order = create(:order)
 
-      expect(order).to_not validate_presence_of(:customer)
+      expect(order).not_to validate_presence_of(:customer)
     end
 
     it "is created for existing orders in complete state" do
@@ -1070,7 +1070,7 @@ describe Spree::Order do
       it "does not create a customer" do
         expect {
           create(:order, distributor:)
-        }.to_not change {
+        }.not_to change {
           Customer.count
         }
       end
@@ -1130,7 +1130,7 @@ describe Spree::Order do
 
         expect {
           other_order.update!(state: "complete")
-        }.to_not change { Customer.count }
+        }.not_to change { Customer.count }
 
         expect(other_order.customer.email).to eq "new@email.org"
         expect(order.customer).to eq other_order.customer
@@ -1334,7 +1334,7 @@ describe Spree::Order do
     let!(:payment) { create(:payment, order:, payment_method:) }
 
     it "does not include the :confirm step" do
-      expect(order.checkout_steps).to_not include "confirm"
+      expect(order.checkout_steps).not_to include "confirm"
     end
   end
 

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -145,7 +145,7 @@ describe Spree::Payment do
 
         it "should call capture if the payment is already authorized" do
           expect(payment).to receive(:capture!)
-          expect(payment).to_not receive(:purchase!)
+          expect(payment).not_to receive(:purchase!)
           payment.process_offline!
         end
       end
@@ -222,7 +222,7 @@ describe Spree::Payment do
           it "should mark payment as failed" do
             allow(payment_method).to receive(:authorize).and_return(failed_response)
             expect(payment).to receive(:failure)
-            expect(payment).to_not receive(:pend)
+            expect(payment).not_to receive(:pend)
             expect {
               payment.authorize!
             }.to raise_error(Spree::Core::GatewayError)
@@ -313,7 +313,7 @@ describe Spree::Payment do
             it "should not make payment complete" do
               allow(payment_method).to receive(:capture).and_return(failed_response)
               expect(payment).to receive(:failure)
-              expect(payment).to_not receive(:complete)
+              expect(payment).not_to receive(:complete)
               expect { payment.capture! }.to raise_error(Spree::Core::GatewayError)
             end
           end
@@ -323,9 +323,9 @@ describe Spree::Payment do
         context "when payment is completed" do
           it "should do nothing" do
             payment = build_stubbed(:payment, :completed)
-            expect(payment).to_not receive(:complete)
-            expect(payment.payment_method).to_not receive(:capture)
-            expect(payment.log_entries).to_not receive(:create)
+            expect(payment).not_to receive(:complete)
+            expect(payment.payment_method).not_to receive(:capture)
+            expect(payment.log_entries).not_to receive(:create)
             payment.capture!
           end
         end
@@ -382,7 +382,7 @@ describe Spree::Payment do
         context "if unsuccessful" do
           it "should not void the payment" do
             allow(payment_method).to receive(:void).and_return(failed_response)
-            expect(payment).to_not receive(:void)
+            expect(payment).not_to receive(:void)
             expect { payment.void_transaction! }.to raise_error(Spree::Core::GatewayError)
           end
         end
@@ -391,7 +391,7 @@ describe Spree::Payment do
         context "if payment is already voided" do
           it "should not void the payment" do
             payment = build_stubbed(:payment, payment_method:, state: 'void')
-            expect(payment.payment_method).to_not receive(:void)
+            expect(payment.payment_method).not_to receive(:void)
             payment.void_transaction!
           end
         end
@@ -570,8 +570,8 @@ describe Spree::Payment do
         payment = build_stubbed(:payment)
         payment.state = 'processing'
 
-        expect(payment).to_not receive(:authorize!)
-        expect(payment).to_not receive(:purchase!)
+        expect(payment).not_to receive(:authorize!)
+        expect(payment).not_to receive(:purchase!)
         expect(payment.process!).to be_nil
       end
     end
@@ -717,7 +717,7 @@ describe Spree::Payment do
           payment_method.distributors << create(:distributor_enterprise)
           payment_method.save!
 
-          expect(payment_method).to_not receive :create_profile
+          expect(payment_method).not_to receive :create_profile
           payment = Spree::Payment.create(
             amount: 100,
             order: create(:order),
@@ -1012,7 +1012,7 @@ describe Spree::Payment do
             expect(payment.adjustment.eligible?).to be false
             expect(payment.adjustment.finalized?).to be true
             expect(order.all_adjustments.payment_fee.count).to eq 1
-            expect(order.all_adjustments.payment_fee.eligible).to_not include payment.adjustment
+            expect(order.all_adjustments.payment_fee.eligible).not_to include payment.adjustment
           end
         end
 
@@ -1031,7 +1031,7 @@ describe Spree::Payment do
             expect(payment.adjustment.eligible?).to be false
             expect(payment.adjustment.finalized?).to be true
             expect(order.all_adjustments.payment_fee.count).to eq 1
-            expect(order.all_adjustments.payment_fee.eligible).to_not include payment.adjustment
+            expect(order.all_adjustments.payment_fee.eligible).not_to include payment.adjustment
           end
         end
 

--- a/spec/models/spree/preferences/preferable_spec.rb
+++ b/spec/models/spree/preferences/preferable_spec.rb
@@ -284,7 +284,7 @@ describe Spree::Preferences::Preferable do
         expect(pref_test.preference_cache_key(:pref_test_pref)).to be_nil
 
         pref_test.save
-        expect(pref_test.preference_cache_key(:pref_test_pref)).to_not be_nil
+        expect(pref_test.preference_cache_key(:pref_test_pref)).not_to be_nil
       end
 
       it "but returns default values" do
@@ -314,7 +314,7 @@ describe Spree::Preferences::Preferable do
       @pt1 = PrefTest.new(col: 'aaaa')
       @pt1.id = @pt.id
       @pt1.save!
-      expect(@pt1.get_preference(:pref_test_pref)).to_not eq 'lmn'
+      expect(@pt1.get_preference(:pref_test_pref)).not_to eq 'lmn'
       expect(@pt1.get_preference(:pref_test_pref)).to eq 'abc'
     end
   end

--- a/spec/models/spree/price_spec.rb
+++ b/spec/models/spree/price_spec.rb
@@ -21,7 +21,7 @@ module Spree
       let(:expensive_variant) { build(:variant, price: 10_000_000) }
 
       it "saves without error" do
-        expect{ expensive_variant.save }.to_not raise_error
+        expect{ expensive_variant.save }.not_to raise_error
         expect(expensive_variant.persisted?).to be true
       end
     end

--- a/spec/models/spree/product_property_spec.rb
+++ b/spec/models/spree/product_property_spec.rb
@@ -7,7 +7,7 @@ describe Spree::ProductProperty do
     it "should validate length of value" do
       pp = create(:product_property)
       pp.value = "x" * 256
-      expect(pp).to_not be_valid
+      expect(pp).not_to be_valid
     end
   end
 end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -25,7 +25,7 @@ module Spree
         context "#destroy" do
           it "should set deleted_at value" do
             product.destroy
-            expect(product.deleted_at).to_not be_nil
+            expect(product.deleted_at).not_to be_nil
             expect(product.variants.all? { |v| !v.deleted_at.nil? }).to be_truthy
           end
         end
@@ -441,14 +441,14 @@ module Spree
           distributors = Enterprise.where(id: [distributor1.id, distributor2.id]).to_a
 
           expect(Product.in_distributors(distributors)).to include product1, product2, product3
-          expect(Product.in_distributors(distributors)).to_not include product4
+          expect(Product.in_distributors(distributors)).not_to include product4
         end
 
         it "returns distributed products for a given array of enterprise ids" do
           distributors_ids = [distributor1.id, distributor2.id]
 
           expect(Product.in_distributors(distributors_ids)).to include product1, product2, product3
-          expect(Product.in_distributors(distributors_ids)).to_not include product4
+          expect(Product.in_distributors(distributors_ids)).not_to include product4
         end
       end
 
@@ -569,7 +569,7 @@ module Spree
         it "lists any products with variants that are listed as visible=true" do
           expect(products.length).to eq(1)
           expect(products).to include product
-          expect(products).to_not include new_variant.product, hidden_variant.product
+          expect(products).not_to include new_variant.product, hidden_variant.product
         end
       end
 
@@ -591,7 +591,7 @@ module Spree
         it 'shows products produced by the enterprise and any producers granting P-OC' do
           stockable_products = Spree::Product.stockable_by(shop)
           expect(stockable_products).to include p1, p2
-          expect(stockable_products).to_not include p3
+          expect(stockable_products).not_to include p3
         end
       end
 

--- a/spec/models/spree/return_authorization_spec.rb
+++ b/spec/models/spree/return_authorization_spec.rb
@@ -49,7 +49,7 @@ describe Spree::ReturnAuthorization do
       end
 
       it "should not update order state" do
-        expect{ return_authorization.add_variant(variant.id, 1) }.to_not change{ order.state }
+        expect{ return_authorization.add_variant(variant.id, 1) }.not_to change{ order.state }
       end
     end
   end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -124,7 +124,7 @@ describe Spree::Shipment do
           to receive(:new).with(shipment.order).and_return(mock_estimator)
         allow(shipment).to receive_messages(shipping_method: nil)
         expect(shipment.refresh_rates).to eq shipping_rates
-        expect(shipment.reload.selected_shipping_rate).to_not be_nil
+        expect(shipment.reload.selected_shipping_rate).not_to be_nil
       end
 
       it 'should not refresh if shipment is shipped' do
@@ -347,10 +347,10 @@ describe Spree::Shipment do
     it "should update shipped_at timestamp" do
       allow(shipment).to receive(:send_shipped_email)
       shipment.ship!
-      expect(shipment.shipped_at).to_not be_nil
+      expect(shipment.shipped_at).not_to be_nil
       # Ensure value is persisted
       shipment.reload
-      expect(shipment.shipped_at).to_not be_nil
+      expect(shipment.shipped_at).not_to be_nil
     end
 
     it "should send a shipment email if order.send_shipment_email is true" do

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -191,7 +191,7 @@ module Spree
 
       it "soft-deletes when destroy is called" do
         shipping_method.destroy
-        expect(shipping_method.deleted_at).to_not be_blank
+        expect(shipping_method.deleted_at).not_to be_blank
       end
     end
 

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -75,7 +75,7 @@ module Spree
             it "is not valid" do
               line_item.quantity = 999
               validator.validate(line_item)
-              expect(line_item).to_not be_valid
+              expect(line_item).not_to be_valid
             end
           end
         end

--- a/spec/models/spree/tax_rate_spec.rb
+++ b/spec/models/spree/tax_rate_spec.rb
@@ -218,7 +218,7 @@ module Spree
 
           it "should apply adjustments for two tax rates to the order" do
             expect(rate_1).to receive(:adjust)
-            expect(rate_2).to_not receive(:adjust)
+            expect(rate_2).not_to receive(:adjust)
             Spree::TaxRate.adjust(order, line_items)
           end
         end
@@ -234,7 +234,7 @@ module Spree
 
           it "should apply adjustments for two tax rates to the order" do
             expect(rate_1).to receive(:adjust)
-            expect(rate_2).to_not receive(:adjust)
+            expect(rate_2).not_to receive(:adjust)
             Spree::TaxRate.adjust(order, shipments)
           end
         end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -52,7 +52,7 @@ describe Spree::User do
       it "enforces the limit on the number of enterprise owned" do
         expect(u2.owned_enterprises.reload).to eq []
         u2.owned_enterprises << e1
-        expect { u2.save! }.to_not raise_error
+        expect { u2.save! }.not_to raise_error
         expect do
           u2.owned_enterprises << e2
           u2.save!
@@ -92,13 +92,13 @@ describe Spree::User do
 
     it "detects emails without @" do
       user.email = "examplemail.com"
-      expect(user).to_not be_valid
+      expect(user).not_to be_valid
       expect(user.errors.messages[:email]).to include "is invalid"
     end
 
     it "detects backslashes at the end" do
       user.email = "example@gmail.com\\\\"
-      expect(user).to_not be_valid
+      expect(user).not_to be_valid
     end
 
     it "is okay with numbers before the @" do
@@ -111,7 +111,7 @@ describe Spree::User do
       # valid, the network requests slow down tests and could make them flaky.
       expect_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?).and_call_original
       user.email = "example@ho020tmail.com"
-      expect(user).to_not be_valid
+      expect(user).not_to be_valid
     end
   end
 
@@ -164,10 +164,10 @@ describe Spree::User do
     describe "as an enterprise user" do
       it "returns a list of users which manage shared enterprises" do
         expect(u1.known_users).to include u1, u2
-        expect(u1.known_users).to_not include u3
+        expect(u1.known_users).not_to include u3
         expect(u2.known_users).to include u1, u2
-        expect(u2.known_users).to_not include u3
-        expect(u3.known_users).to_not include u1, u2, u3
+        expect(u2.known_users).not_to include u3
+        expect(u3.known_users).not_to include u1, u2, u3
       end
     end
 

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -37,7 +37,7 @@ describe Spree::Variant do
         expect(variant.tax_category).to eq default
         expect {
           variant.tax_category = nil
-        }.to_not change {
+        }.not_to change {
           variant.tax_category
         }
         expect(variant).to be_valid
@@ -358,7 +358,7 @@ describe Spree::Variant do
 
           it "lists any variants that are not listed as visible=false" do
             expect(variants).to include new_variant, visible_variant
-            expect(variants).to_not include hidden_variant
+            expect(variants).not_to include hidden_variant
           end
 
           context "when inventory items exist for other enterprises" do
@@ -379,7 +379,7 @@ describe Spree::Variant do
 
             it "lists any variants not listed as visible=false only for the relevant enterprise" do
               expect(variants).to include new_variant, visible_variant
-              expect(variants).to_not include hidden_variant
+              expect(variants).not_to include hidden_variant
             end
           end
         end
@@ -390,7 +390,7 @@ describe Spree::Variant do
 
         it "lists any variants that are listed as visible=true" do
           expect(variants).to include visible_variant
-          expect(variants).to_not include new_variant, hidden_variant
+          expect(variants).not_to include new_variant, hidden_variant
         end
       end
     end
@@ -415,7 +415,7 @@ describe Spree::Variant do
       it 'shows variants produced by the enterprise and any producers granting P-OC' do
         stockable_variants = Spree::Variant.stockable_by(shop)
         expect(stockable_variants).to include v1, v2
-        expect(stockable_variants).to_not include v3
+        expect(stockable_variants).not_to include v3
       end
     end
   end

--- a/spec/models/stripe_account_spec.rb
+++ b/spec/models/stripe_account_spec.rb
@@ -43,7 +43,7 @@ describe StripeAccount do
 
       it "destroys the record" do
         # returns status 200
-        expect(Bugsnag).to_not receive(:notify) # and does not receive Bugsnag notification
+        expect(Bugsnag).not_to receive(:notify) # and does not receive Bugsnag notification
         expect {
           stripe_account.deauthorize_and_destroy
         }.to change {
@@ -58,7 +58,7 @@ describe StripeAccount do
       }
 
       it "Doesn't make a Stripe API disconnection request " do
-        expect(Stripe::OAuth).to_not receive(:deauthorize)
+        expect(Stripe::OAuth).not_to receive(:deauthorize)
         stripe_account.deauthorize_and_destroy
         expect(StripeAccount.all).not_to include(stripe_account)
       end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -47,7 +47,7 @@ describe Subscription, type: :model do
         expect{ subscription.cancel }.to raise_error "Some error"
         expect(subscription.reload.canceled_at).to be nil
         expect(proxy_order1).to have_received(:cancel)
-        expect(proxy_order2).to_not have_received(:cancel)
+        expect(proxy_order2).not_to have_received(:cancel)
       end
     end
   end

--- a/spec/models/variant_override_spec.rb
+++ b/spec/models/variant_override_spec.rb
@@ -20,7 +20,7 @@ describe VariantOverride do
     }
 
     it "ignores variant_overrides with revoked_permissions by default" do
-      expect(VariantOverride.all).to_not include vo3
+      expect(VariantOverride.all).not_to include vo3
       expect(VariantOverride.unscoped).to include vo3
     end
 
@@ -141,7 +141,7 @@ describe VariantOverride do
       end
 
       it "soft-deletes the price" do
-        expect(price_object.reload.deleted_at).to_not be_nil
+        expect(price_object.reload.deleted_at).not_to be_nil
       end
 
       it "can access the soft-deleted price" do

--- a/spec/reflexes/products_reflex_spec.rb
+++ b/spec/reflexes/products_reflex_spec.rb
@@ -206,7 +206,7 @@ describe ProductsReflex, type: :reflex, feature: :admin_style_v3 do
 
         reflex = run_reflex(:bulk_update, params:)
         expect(reflex.get(:error_counts)).to eq({ saved: 1, invalid: 2 })
-        expect(flash).to_not include success: "Changes saved"
+        expect(flash).not_to include success: "Changes saved"
 
         # # WTF
         # expect{ reflex(:bulk_update, params:) }.to broadcast(

--- a/spec/requests/admin/images_spec.rb
+++ b/spec/requests/admin/images_spec.rb
@@ -47,7 +47,7 @@ describe "/admin/products/:product_id/images", type: :request do
         expect {
           subject
           product.reload
-        }.to_not change{ product.image&.attachment&.filename.to_s }
+        }.not_to change{ product.image&.attachment&.filename.to_s }
 
         pending "error status code"
         expect(response).to be_unprocessable

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -43,7 +43,7 @@ describe '/user/spree_user/auth/openid_connect/callback', type: :request do
     end
 
     it 'fails with bad auth data' do
-      expect { request! }.to_not change { OidcAccount.count }
+      expect { request! }.not_to change { OidcAccount.count }
 
       expect(response.status).to eq(302)
     end

--- a/spec/requests/spree/admin/overview_spec.rb
+++ b/spec/requests/spree/admin/overview_spec.rb
@@ -45,7 +45,7 @@ describe "/admin", type: :request do
 
             get "/admin"
 
-            expect(response.body).to_not include("Terms of Service have been updated")
+            expect(response.body).not_to include("Terms of Service have been updated")
           end
         end
 
@@ -66,7 +66,7 @@ describe "/admin", type: :request do
 
             get "/admin"
 
-            expect(response.body).to_not include("Terms of Service have been updated")
+            expect(response.body).not_to include("Terms of Service have been updated")
           end
         end
 
@@ -79,7 +79,7 @@ describe "/admin", type: :request do
           it "doesn't show accept new ToS banner" do
             get "/admin"
 
-            expect(response.body).to_not include("Terms of Service have been updated")
+            expect(response.body).not_to include("Terms of Service have been updated")
           end
         end
       end

--- a/spec/serializers/api/admin/enterprise_serializer_spec.rb
+++ b/spec/serializers/api/admin/enterprise_serializer_spec.rb
@@ -21,7 +21,7 @@ describe Api::Admin::EnterpriseSerializer do
 
       it "includes URLs of image versions" do
         serializer = Api::Admin::EnterpriseSerializer.new(enterprise)
-        expect(serializer.as_json[:logo]).to_not be_blank
+        expect(serializer.as_json[:logo]).not_to be_blank
         expect(serializer.as_json[:logo][:medium]).to match(/logo-black.png/)
       end
     end
@@ -46,7 +46,7 @@ describe Api::Admin::EnterpriseSerializer do
 
       it "includes URLs of image versions" do
         serializer = Api::Admin::EnterpriseSerializer.new(enterprise)
-        expect(serializer.as_json[:promo_image]).to_not be_blank
+        expect(serializer.as_json[:promo_image]).not_to be_blank
         expect(serializer.as_json[:promo_image][:medium]).to match(/logo-black\.png$/)
       end
     end

--- a/spec/serializers/api/admin/exchange_serializer_spec.rb
+++ b/spec/serializers/api/admin/exchange_serializer_spec.rb
@@ -40,7 +40,7 @@ describe Api::Admin::ExchangeSerializer do
           .with(exchange.order_cycle.coordinator)
         expect(exchange.variants).to include v1, v2, v3
         expect(visible_variants.keys).to include v1.id
-        expect(visible_variants.keys).to_not include v2.id, v3.id
+        expect(visible_variants.keys).not_to include v2.id, v3.id
       end
     end
 
@@ -54,10 +54,10 @@ describe Api::Admin::ExchangeSerializer do
         visible_variants = serializer.variants
         expect(permissions_mock).to have_received(:visible_variants_for_incoming_exchanges_from)
           .with(exchange.sender)
-        expect(permitted_variants).to_not have_received(:visible_for)
+        expect(permitted_variants).not_to have_received(:visible_for)
         expect(exchange.variants).to include v1, v2, v3
         expect(visible_variants.keys).to include v1.id, v2.id
-        expect(visible_variants.keys).to_not include v3.id
+        expect(visible_variants.keys).not_to include v3.id
       end
     end
   end
@@ -88,10 +88,10 @@ describe Api::Admin::ExchangeSerializer do
         expect(permissions_mock).to have_received(:visible_variants_for_outgoing_exchanges_to)
           .with(exchange.receiver)
         expect(permitted_variants).to have_received(:not_hidden_for).with(exchange.receiver)
-        expect(permitted_variants).to_not have_received(:visible_for)
+        expect(permitted_variants).not_to have_received(:visible_for)
         expect(exchange.variants).to include v1, v2, v3
         expect(visible_variants.keys).to include v1.id, v2.id
-        expect(visible_variants.keys).to_not include v3.id
+        expect(visible_variants.keys).not_to include v3.id
       end
     end
 
@@ -107,10 +107,10 @@ describe Api::Admin::ExchangeSerializer do
         expect(permissions_mock).to have_received(:visible_variants_for_outgoing_exchanges_to)
           .with(exchange.receiver)
         expect(permitted_variants).to have_received(:visible_for).with(exchange.receiver)
-        expect(permitted_variants).to_not have_received(:not_hidden_for)
+        expect(permitted_variants).not_to have_received(:not_hidden_for)
         expect(exchange.variants).to include v1, v2, v3
         expect(visible_variants.keys).to include v1.id
-        expect(visible_variants.keys).to_not include v2.id, v3.id
+        expect(visible_variants.keys).not_to include v2.id, v3.id
       end
     end
   end

--- a/spec/serializers/api/admin/order_cycle_serializer_spec.rb
+++ b/spec/serializers/api/admin/order_cycle_serializer_spec.rb
@@ -22,7 +22,7 @@ describe Api::Admin::OrderCycleSerializer do
     variant_ids = from_json(serializer.editable_variants_for_incoming_exchanges).values.flatten
 
     expect(variant_ids).to include order_cycle.variants.first.id
-    expect(distributor_ids).to_not include order_cycle.distributors.first.id.to_s
+    expect(distributor_ids).not_to include order_cycle.distributors.first.id.to_s
   end
 
   it "serializes the order cycle with editable_variants_for_outgoing_exchanges" do

--- a/spec/services/checkout/post_checkout_actions_spec.rb
+++ b/spec/services/checkout/post_checkout_actions_spec.rb
@@ -22,7 +22,7 @@ describe Checkout::PostCheckoutActions do
       it "sets customer's terms_and_conditions to the current time if terms have been accepted" do
         params = { order: { terms_and_conditions_accepted: true } }
         postCheckoutActions.success(params, current_user)
-        expect(order.customer.terms_and_conditions_accepted_at).to_not be_nil
+        expect(order.customer.terms_and_conditions_accepted_at).not_to be_nil
       end
     end
 

--- a/spec/services/customer_order_cancellation_spec.rb
+++ b/spec/services/customer_order_cancellation_spec.rb
@@ -25,7 +25,7 @@ describe CustomerOrderCancellation do
 
       CustomerOrderCancellation.new(order).call
 
-      expect(Spree::OrderMailer).to_not have_received(:cancel_email_for_shop)
+      expect(Spree::OrderMailer).not_to have_received(:cancel_email_for_shop)
     end
   end
 end

--- a/spec/services/image_importer_spec.rb
+++ b/spec/services/image_importer_spec.rb
@@ -14,7 +14,7 @@ describe ImageImporter do
         Spree::Image.count
       }.by(1)
 
-      expect(product.image).to_not be_nil
+      expect(product.image).not_to be_nil
       expect(product.reload.image.attachment_blob.byte_size).to eq 6274
     end
   end

--- a/spec/services/order_available_payment_methods_spec.rb
+++ b/spec/services/order_available_payment_methods_spec.rb
@@ -129,7 +129,7 @@ describe OrderAvailablePaymentMethods do
 
         it "applies default action (hide)" do
           expect(available_payment_methods).to include untagged_payment_method
-          expect(available_payment_methods).to_not include tagged_payment_method
+          expect(available_payment_methods).not_to include tagged_payment_method
         end
       end
 
@@ -156,7 +156,7 @@ describe OrderAvailablePaymentMethods do
 
           it "applies the default action (hide)" do
             expect(available_payment_methods).to include untagged_payment_method
-            expect(available_payment_methods).to_not include tagged_payment_method
+            expect(available_payment_methods).not_to include tagged_payment_method
           end
         end
       end
@@ -195,7 +195,7 @@ describe OrderAvailablePaymentMethods do
 
           it "applies the action (hide)" do
             expect(available_payment_methods).to include untagged_payment_method
-            expect(available_payment_methods).to_not include tagged_payment_method
+            expect(available_payment_methods).not_to include tagged_payment_method
           end
         end
 

--- a/spec/services/order_available_shipping_methods_spec.rb
+++ b/spec/services/order_available_shipping_methods_spec.rb
@@ -114,7 +114,7 @@ describe OrderAvailableShippingMethods do
 
         it "applies default action (hide)" do
           expect(available_shipping_methods).to include untagged_sm
-          expect(available_shipping_methods).to_not include tagged_sm
+          expect(available_shipping_methods).not_to include tagged_sm
         end
       end
 
@@ -138,7 +138,7 @@ describe OrderAvailableShippingMethods do
 
           it "applies the default action (hide)" do
             expect(available_shipping_methods).to include untagged_sm
-            expect(available_shipping_methods).to_not include tagged_sm
+            expect(available_shipping_methods).not_to include tagged_sm
           end
         end
       end
@@ -174,7 +174,7 @@ describe OrderAvailableShippingMethods do
 
           it "applies the action (hide)" do
             expect(available_shipping_methods).to include untagged_sm
-            expect(available_shipping_methods).to_not include tagged_sm
+            expect(available_shipping_methods).not_to include tagged_sm
           end
         end
 

--- a/spec/services/order_checkout_restart_spec.rb
+++ b/spec/services/order_checkout_restart_spec.rb
@@ -8,7 +8,7 @@ describe OrderCheckoutRestart do
   describe "#call" do
     context "when the order is already in the 'cart' state" do
       it "does nothing" do
-        expect(order).to_not receive(:restart_checkout!)
+        expect(order).not_to receive(:restart_checkout!)
         OrderCheckoutRestart.new(order).call
       end
     end

--- a/spec/services/order_cycle_distributed_products_spec.rb
+++ b/spec/services/order_cycle_distributed_products_spec.rb
@@ -30,7 +30,7 @@ describe OrderCycleDistributedProducts do
 
       it "does not return product" do
         expect(described_class.new(distributor, order_cycle,
-                                   customer).products_relation).to_not include product
+                                   customer).products_relation).not_to include product
       end
     end
 
@@ -42,7 +42,7 @@ describe OrderCycleDistributedProducts do
 
       it "does not return product" do
         expect(described_class.new(distributor, order_cycle,
-                                   customer).products_relation).to_not include product
+                                   customer).products_relation).not_to include product
       end
     end
 
@@ -56,7 +56,7 @@ describe OrderCycleDistributedProducts do
         it "does not return product when variant is out of stock" do
           variant.update_attribute(:on_hand, 0)
           expect(described_class.new(distributor, order_cycle,
-                                     customer).products_relation).to_not include product
+                                     customer).products_relation).not_to include product
         end
       end
 
@@ -67,7 +67,7 @@ describe OrderCycleDistributedProducts do
 
         it "does not return product when an override is out of stock" do
           expect(described_class.new(distributor, order_cycle,
-                                     customer).products_relation).to_not include product
+                                     customer).products_relation).not_to include product
         end
 
         it "returns product when an override is in stock" do
@@ -93,11 +93,11 @@ describe OrderCycleDistributedProducts do
 
     it "returns variants in the oc" do
       expect(variants).to include v1
-      expect(variants).to_not include v2
+      expect(variants).not_to include v2
     end
 
     it "does not return variants where override is out of stock" do
-      expect(variants).to_not include v3
+      expect(variants).not_to include v3
     end
   end
 end

--- a/spec/services/order_cycle_form_spec.rb
+++ b/spec/services/order_cycle_form_spec.rb
@@ -25,7 +25,7 @@ describe OrderCycleForm do
         it "returns false" do
           expect do
             expect(form.save).to be false
-          end.to_not change { OrderCycle.count }
+          end.not_to change { OrderCycle.count }
         end
       end
     end
@@ -51,7 +51,7 @@ describe OrderCycleForm do
         it "returns false" do
           expect do
             expect(form.save).to be false
-          end.to_not change{ order_cycle.reload.name }
+          end.not_to change{ order_cycle.reload.name }
         end
       end
 
@@ -101,7 +101,7 @@ describe OrderCycleForm do
         it "associates the order cycle to the schedule" do
           expect(form.save).to be true
           expect(coordinated_order_cycle.reload.schedules).to include coordinated_schedule2
-          expect(coordinated_order_cycle.reload.schedules).to_not include coordinated_schedule
+          expect(coordinated_order_cycle.reload.schedules).not_to include coordinated_schedule
           expect(syncer_mock).to have_received(:sync!)
         end
       end
@@ -112,8 +112,8 @@ describe OrderCycleForm do
         it "ignores the schedule that I don't own" do
           expect(form.save).to be true
           expect(coordinated_order_cycle.reload.schedules).to include coordinated_schedule
-          expect(coordinated_order_cycle.reload.schedules).to_not include uncoordinated_schedule
-          expect(syncer_mock).to_not have_received(:sync!)
+          expect(coordinated_order_cycle.reload.schedules).not_to include uncoordinated_schedule
+          expect(syncer_mock).not_to have_received(:sync!)
         end
       end
 
@@ -123,7 +123,7 @@ describe OrderCycleForm do
         it "ignores the schedule that I don't own" do
           expect(form.save).to be true
           expect(coordinated_order_cycle.reload.schedules).to include coordinated_schedule
-          expect(syncer_mock).to_not have_received(:sync!)
+          expect(syncer_mock).not_to have_received(:sync!)
         end
       end
     end
@@ -256,7 +256,7 @@ describe OrderCycleForm do
               supplier.users.first
             )
 
-            expect{ form.save }.to_not change{ order_cycle.distributor_payment_methods.pluck(:id) }
+            expect{ form.save }.not_to change{ order_cycle.distributor_payment_methods.pluck(:id) }
           end
         end
 
@@ -306,7 +306,7 @@ describe OrderCycleForm do
                 distributor2.users.first
               )
 
-              expect{ form.save }.to_not change{
+              expect{ form.save }.not_to change{
                                            order_cycle.distributor_payment_methods.pluck(:id)
                                          }
             end

--- a/spec/services/order_cycle_webhook_service_spec.rb
+++ b/spec/services/order_cycle_webhook_service_spec.rb
@@ -22,7 +22,7 @@ describe OrderCycleWebhookService do
       coordinator_user.webhook_endpoints.create!(url: "http://coordinator_user_url")
 
       expect{ OrderCycleWebhookService.create_webhook_job(order_cycle, "order_cycle.opened") }
-        .to_not enqueue_job(WebhookDeliveryJob).with("http://coordinator_user_url", any_args)
+        .not_to enqueue_job(WebhookDeliveryJob).with("http://coordinator_user_url", any_args)
     end
 
     context "coordinator owner has endpoint configured" do
@@ -128,7 +128,7 @@ describe OrderCycleWebhookService do
 
         it "doesn't create a webhook payload for supplier owner" do
           expect{ OrderCycleWebhookService.create_webhook_job(order_cycle, "order_cycle.opened") }
-            .to_not enqueue_job(WebhookDeliveryJob).with("http://supplier_owner_url", any_args)
+            .not_to enqueue_job(WebhookDeliveryJob).with("http://supplier_owner_url", any_args)
         end
       end
     end

--- a/spec/services/order_fees_handler_spec.rb
+++ b/spec/services/order_fees_handler_spec.rb
@@ -33,7 +33,7 @@ describe OrderFeesHandler do
 
     it "skips per-order fee adjustments for orders that don't have an order cycle" do
       allow(service).to receive(:order_cycle) { nil }
-      expect(calculator).to_not receive(:create_order_adjustments_for)
+      expect(calculator).not_to receive(:create_order_adjustments_for)
 
       service.create_order_fees!
     end

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -171,7 +171,7 @@ describe OrderSyncer do
         it "updates all bill_address attrs and ship_address names + phone" do
           subscription.assign_attributes(params)
           expect(syncer.sync!).to be true
-          expect(syncer.order_update_issues.keys).to_not include order.id
+          expect(syncer.order_update_issues.keys).not_to include order.id
           order.reload;
           expect(order.bill_address.firstname).to eq "Bill"
           expect(order.bill_address.lastname).to eq bill_address_attrs["lastname"]
@@ -216,7 +216,7 @@ describe OrderSyncer do
         it "only updates bill_address attrs" do
           subscription.assign_attributes(params)
           expect(syncer.sync!).to be true
-          expect(syncer.order_update_issues.keys).to_not include order.id
+          expect(syncer.order_update_issues.keys).not_to include order.id
           order.reload;
           expect(order.bill_address.firstname).to eq "Bill"
           expect(order.bill_address.lastname).to eq bill_address_attrs["lastname"]
@@ -278,7 +278,7 @@ describe OrderSyncer do
       it "does not change the ship address" do
         subscription.assign_attributes(params)
         expect(syncer.sync!).to be true
-        expect(syncer.order_update_issues.keys).to_not include order.id
+        expect(syncer.order_update_issues.keys).not_to include order.id
         order.reload;
         expect(order.ship_address.firstname).to eq bill_address_attrs["firstname"]
         expect(order.ship_address.lastname).to eq bill_address_attrs["lastname"]
@@ -355,7 +355,7 @@ describe OrderSyncer do
         it "updates ship_address attrs" do
           subscription.assign_attributes(params)
           expect(syncer.sync!).to be true
-          expect(syncer.order_update_issues.keys).to_not include order.id
+          expect(syncer.order_update_issues.keys).not_to include order.id
           order.reload;
           expect(order.ship_address.firstname).to eq "Ship"
           expect(order.ship_address.lastname).to eq ship_address_attrs["lastname"]

--- a/spec/services/permissions/order_spec.rb
+++ b/spec/services/permissions/order_spec.rb
@@ -70,9 +70,9 @@ module Permissions
 
           it "only returns completed, non-cancelled orders within search filter range" do
             expect(permissions.visible_orders).to include order_completed
-            expect(permissions.visible_orders).to_not include order_cancelled
-            expect(permissions.visible_orders).to_not include order_cart
-            expect(permissions.visible_orders).to_not include order_from_last_year
+            expect(permissions.visible_orders).not_to include order_cancelled
+            expect(permissions.visible_orders).not_to include order_cart
+            expect(permissions.visible_orders).not_to include order_from_last_year
           end
         end
       end
@@ -99,7 +99,7 @@ module Permissions
 
         context "which does not contain my products" do
           it "should not let me see the order" do
-            expect(permissions.visible_orders).to_not include order
+            expect(permissions.visible_orders).not_to include order
           end
         end
       end
@@ -113,7 +113,7 @@ module Permissions
         end
 
         it "should not let me see the order" do
-          expect(permissions.visible_orders).to_not include order
+          expect(permissions.visible_orders).not_to include order
         end
       end
     end
@@ -172,7 +172,7 @@ module Permissions
         it "should let me see the line_items pertaining to variants I produce" do
           ps = permissions.visible_line_items
           expect(ps).to include line_item1
-          expect(ps).to_not include line_item2
+          expect(ps).not_to include line_item2
         end
       end
 
@@ -185,7 +185,7 @@ module Permissions
         end
 
         it "should not let me see the line_items" do
-          expect(permissions.visible_line_items).to_not include line_item1, line_item2
+          expect(permissions.visible_line_items).not_to include line_item1, line_item2
         end
       end
 
@@ -205,10 +205,10 @@ module Permissions
         it "only returns line items from completed, " \
            "non-cancelled orders within search filter range" do
           expect(permissions.visible_line_items).to include order_completed.line_items.first
-          expect(permissions.visible_line_items).to_not include order_cancelled.line_items.first
-          expect(permissions.visible_line_items).to_not include order_cart.line_items.first
+          expect(permissions.visible_line_items).not_to include order_cancelled.line_items.first
+          expect(permissions.visible_line_items).not_to include order_cart.line_items.first
           expect(permissions.visible_line_items)
-            .to_not include order_from_last_year.line_items.first
+            .not_to include order_from_last_year.line_items.first
         end
       end
     end

--- a/spec/services/place_proxy_order_spec.rb
+++ b/spec/services/place_proxy_order_spec.rb
@@ -57,7 +57,7 @@ describe PlaceProxyOrder do
 
       it "records an issue and ignores it" do
         expect(summarizer).to receive(:record_issue).with(:complete, order).once
-        expect { subject.call }.to_not change { order.reload.state }
+        expect { subject.call }.not_to change { order.reload.state }
         expect(order.payments.first.state).to eq "checkout"
         expect(ActionMailer::Base.deliveries.count).to be 0
       end

--- a/spec/services/products_renderer_spec.rb
+++ b/spec/services/products_renderer_spec.rb
@@ -195,13 +195,13 @@ describe ProductsRenderer do
 
     it "scopes variants to distribution" do
       expect(variants[p.id]).to include v1
-      expect(variants[p.id]).to_not include v2
+      expect(variants[p.id]).not_to include v2
     end
 
     it "does not render variants that have been hidden by the hub" do
       # but does render 'new' variants, ie. v1
       expect(variants[p.id]).to include v1, v3
-      expect(variants[p.id]).to_not include v4
+      expect(variants[p.id]).not_to include v4
     end
 
     context "when hub opts to only see variants in its inventory" do
@@ -212,7 +212,7 @@ describe ProductsRenderer do
       it "doesn't render variants that haven't been explicitly added to inventory for the hub" do
         # but does render 'new' variants, ie. v1
         expect(variants[p.id]).to include v3
-        expect(variants[p.id]).to_not include v1, v4
+        expect(variants[p.id]).not_to include v1, v4
       end
     end
   end

--- a/spec/services/sets/model_set_spec.rb
+++ b/spec/services/sets/model_set_spec.rb
@@ -79,7 +79,7 @@ describe Sets::ModelSet do
         expect(subject.errors.full_messages).to eq ["Product Name can't be blank"]
 
         expect(subject.invalid).to     include product_a
-        expect(subject.invalid).to_not include product_b
+        expect(subject.invalid).not_to include product_b
       end
     end
   end

--- a/spec/services/sets/product_set_spec.rb
+++ b/spec/services/sets/product_set_spec.rb
@@ -130,7 +130,7 @@ describe Sets::ProductSet do
             }.to change { product.supplier }.to(producer).
               and change { order_cycle.distributed_variants.count }.by(-1)
 
-            expect(order_cycle.distributed_variants).to_not include product.variants.first
+            expect(order_cycle.distributed_variants).not_to include product.variants.first
           end
         end
       end
@@ -163,7 +163,7 @@ describe Sets::ProductSet do
           expect {
             product_set.save
             product.reload
-          }.to_not change { product.sku }
+          }.not_to change { product.sku }
 
           expect(product_set.saved_count).to be_zero
           expect(product_set.invalid.count).to be_positive
@@ -173,7 +173,7 @@ describe Sets::ProductSet do
           expect {
             product_set.save
             variant.reload
-          }.to_not change { variant.sku }
+          }.not_to change { variant.sku }
         end
 
         it 'assigns the in-memory attributes of the variant' do
@@ -239,7 +239,7 @@ describe Sets::ProductSet do
           let(:variant_attributes) { { sku: "var_sku", display_name: "A" * 256 } } # maximum length
 
           include_examples "nothing saved" do
-            after { expect(variant2.reload.sku).to_not eq "var_sku2" }
+            after { expect(variant2.reload.sku).not_to eq "var_sku2" }
           end
         end
       end

--- a/spec/services/tax_rate_updater_spec.rb
+++ b/spec/services/tax_rate_updater_spec.rb
@@ -12,7 +12,7 @@ describe TaxRateUpdater do
 
   describe "#updated_rate" do
     it "returns a cloned (unsaved) tax rate with the new attributes assigned" do
-      expect(new_tax_rate).to_not be old_tax_rate
+      expect(new_tax_rate).not_to be old_tax_rate
       expect(new_tax_rate.amount).to eq params[:amount]
       expect(new_tax_rate.id).to be_nil
       expect(new_tax_rate.calculator.class).to eq old_tax_rate.calculator.class
@@ -34,9 +34,9 @@ describe TaxRateUpdater do
     context "when saving the new tax_rate fails" do
       it "does not delete the old tax_rate and returns a falsey value" do
         expect(new_tax_rate).to receive(:save) { false }
-        expect(old_tax_rate).to_not receive(:destroy)
+        expect(old_tax_rate).not_to receive(:destroy)
 
-        expect(service.transition_rate!).to_not be_truthy
+        expect(service.transition_rate!).not_to be_truthy
       end
     end
   end

--- a/spec/services/terms_of_service_spec.rb
+++ b/spec/services/terms_of_service_spec.rb
@@ -37,7 +37,7 @@ describe TermsOfService do
       it "should always return true" do
         expect {
           allow(TermsOfServiceFile).to receive(:exists?) { false }
-        }.to_not change {
+        }.not_to change {
           TermsOfService.tos_accepted?(customer)
         }.from(true)
       end

--- a/spec/services/voucher_adjustments_service_spec.rb
+++ b/spec/services/voucher_adjustments_service_spec.rb
@@ -264,7 +264,7 @@ describe VoucherAdjustmentsService do
 
     context 'when no order given' do
       it "doesn't blow up" do
-        expect { VoucherAdjustmentsService.new(nil).update }.to_not raise_error
+        expect { VoucherAdjustmentsService.new(nil).update }.not_to raise_error
       end
     end
 
@@ -272,7 +272,7 @@ describe VoucherAdjustmentsService do
       let(:order) { create(:order_with_line_items, line_items_count: 1, distributor: enterprise) }
 
       it "doesn't blow up" do
-        expect { VoucherAdjustmentsService.new(order).update }.to_not raise_error
+        expect { VoucherAdjustmentsService.new(order).update }.not_to raise_error
       end
     end
   end

--- a/spec/support/ability_helpers.rb
+++ b/spec/support/ability_helpers.rb
@@ -19,15 +19,15 @@ end
 
 shared_examples_for 'access denied' do
   it 'should not allow read' do
-    expect(subject).to_not be_able_to(:read, resource)
+    expect(subject).not_to be_able_to(:read, resource)
   end
 
   it 'should not allow create' do
-    expect(subject).to_not be_able_to(:create, resource)
+    expect(subject).not_to be_able_to(:create, resource)
   end
 
   it 'should not allow update' do
-    expect(subject).to_not be_able_to(:update, resource)
+    expect(subject).not_to be_able_to(:update, resource)
   end
 end
 
@@ -40,7 +40,7 @@ end
 
 shared_examples_for 'admin denied' do
   it 'should not allow admin' do
-    expect(subject).to_not be_able_to(:admin, resource)
+    expect(subject).not_to be_able_to(:admin, resource)
   end
 end
 
@@ -52,7 +52,7 @@ end
 
 shared_examples_for 'no index allowed' do
   it 'should not allow index' do
-    expect(subject).to_not be_able_to(:index, resource)
+    expect(subject).not_to be_able_to(:index, resource)
   end
 end
 
@@ -62,25 +62,25 @@ shared_examples_for 'create only' do
   end
 
   it 'should not allow read' do
-    expect(subject).to_not be_able_to(:read, resource)
+    expect(subject).not_to be_able_to(:read, resource)
   end
 
   it 'should not allow update' do
-    expect(subject).to_not be_able_to(:update, resource)
+    expect(subject).not_to be_able_to(:update, resource)
   end
 
   it 'should not allow index' do
-    expect(subject).to_not be_able_to(:index, resource)
+    expect(subject).not_to be_able_to(:index, resource)
   end
 end
 
 shared_examples_for 'read only' do
   it 'should not allow create' do
-    expect(subject).to_not be_able_to(:create, resource)
+    expect(subject).not_to be_able_to(:create, resource)
   end
 
   it 'should not allow update' do
-    expect(subject).to_not be_able_to(:update, resource)
+    expect(subject).not_to be_able_to(:update, resource)
   end
 
   it 'should allow index' do
@@ -90,11 +90,11 @@ end
 
 shared_examples_for 'update only' do
   it 'should not allow create' do
-    expect(subject).to_not be_able_to(:create, resource)
+    expect(subject).not_to be_able_to(:create, resource)
   end
 
   it 'should not allow read' do
-    expect(subject).to_not be_able_to(:read, resource)
+    expect(subject).not_to be_able_to(:read, resource)
   end
 
   it 'should allow update' do
@@ -102,7 +102,7 @@ shared_examples_for 'update only' do
   end
 
   it 'should not allow index' do
-    expect(subject).to_not be_able_to(:index, resource)
+    expect(subject).not_to be_able_to(:index, resource)
   end
 end
 

--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -20,7 +20,7 @@ module AuthenticationHelper
 
   def expect_logged_in
     # Ensure page has been reloaded after submitting login form
-    expect(page).to_not have_selector ".menu #login-link"
-    expect(page).to_not have_content "Login"
+    expect(page).not_to have_selector ".menu #login-link"
+    expect(page).not_to have_content "Login"
   end
 end

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -11,7 +11,7 @@ module ShopWorkflow
     within find_body do
       # We ignore visibility in case the cart dropdown is not open.
       within '.cart-sidebar', visible: false do
-        expect(page).to_not have_link "Updating cart...", visible: false
+        expect(page).not_to have_link "Updating cart...", visible: false
       end
     end
   end

--- a/spec/system/admin/adjustments_spec.rb
+++ b/spec/system/admin/adjustments_spec.rb
@@ -178,8 +178,8 @@ describe '
     it "displays adjustments" do
       click_link 'Adjustments'
 
-      expect(page).to_not have_selector 'tr a.icon-edit'
-      expect(page).to_not have_selector 'a.icon-plus', text: 'New Adjustment'
+      expect(page).not_to have_selector 'tr a.icon-edit'
+      expect(page).not_to have_selector 'a.icon-plus', text: 'New Adjustment'
     end
   end
 end

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -139,7 +139,7 @@ describe '
         expect(page).to have_button("« First", disabled: true)
         expect(page).to have_button("Previous", disabled: true)
         expect(page).to have_button("1", disabled: true)
-        expect(page).to_not have_button("2")
+        expect(page).not_to have_button("2")
         expect(page).to have_button("Next", disabled: true)
         expect(page).to have_button("Last »", disabled: true)
         select2_select "100 per page", from: "autogen4" # should display all 20 line items
@@ -1105,7 +1105,7 @@ describe '
               end
               expect(page).to have_selector "a.delete-line-item", count: 1
               expect(o2.reload.state).to eq("canceled")
-            end.to_not have_enqueued_mail(Spree::OrderMailer, :cancel_email)
+            end.not_to have_enqueued_mail(Spree::OrderMailer, :cancel_email)
           end
 
           it "the user can confirm + wants to send email confirmation : line item is " \
@@ -1123,7 +1123,7 @@ describe '
 
           it "the user can confirm + uncheck the restock option: line item is then deleted and " \
              "order is canceled without retocking" do
-            expect_any_instance_of(Spree::StockLocation).to_not receive(:restock)
+            expect_any_instance_of(Spree::StockLocation).not_to receive(:restock)
             expect do
               within(".modal") do
                 uncheck("Restock Items: return all items to stock")

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -102,7 +102,7 @@ describe 'Customers' do
                                         text: 'Delete failed: This customer has ' \
                                               'active subscriptions. Cancel them first.'
           click_button "OK"
-        }.to_not change{ Customer.count }
+        }.not_to change{ Customer.count }
 
         expect{
           within "tr#c_#{customer2.id}" do
@@ -153,8 +153,8 @@ describe 'Customers' do
               expect(page).to have_content "$-99.00"
             end
             within "tr#c_#{customer4.id}" do
-              expect(page).to_not have_content "CREDIT OWED"
-              expect(page).to_not have_content "BALANCE DUE"
+              expect(page).not_to have_content "CREDIT OWED"
+              expect(page).not_to have_content "BALANCE DUE"
               expect(page).to have_content "$0.00"
             end
           end
@@ -370,7 +370,7 @@ describe 'Customers' do
           first('#bill-address-link').click
 
           expect(page).to have_content 'Edit Billing Address'
-          expect(page).to_not have_content 'Please input all of the required fields'
+          expect(page).not_to have_content 'Please input all of the required fields'
         end
 
         it 'creates a new shipping address' do
@@ -436,7 +436,7 @@ describe 'Customers' do
               click_button 'Add Customer'
               expect(page).to have_selector "#new-customer-dialog .error",
                                             text: "Please enter a valid email address"
-            }.to_not change{ Customer.of(managed_distributor1).count }
+            }.not_to change{ Customer.of(managed_distributor1).count }
 
             # When an invalid email with domain is used it's checked by "valid_email2" gem #7886
             expect{
@@ -444,7 +444,7 @@ describe 'Customers' do
               click_button 'Add Customer'
               expect(page).to have_selector "#new-customer-dialog .error",
                                             text: "Email is invalid"
-            }.to_not change{ Customer.of(managed_distributor1).count }
+            }.not_to change{ Customer.of(managed_distributor1).count }
 
             # When a new valid email is used
             expect{

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -153,7 +153,7 @@ describe '
 
       # editing to an invalid combination
       select 'Flat Rate (per order)', from: "#{prefix}_calculator_type"
-      expect{ click_button 'Update' }.to_not change { fee.reload.calculator_type }
+      expect{ click_button 'Update' }.not_to change { fee.reload.calculator_type }
       expect(page).to have_content "Inheriting the tax categeory requires a per-item calculator."
     end
   end

--- a/spec/system/admin/enterprises/connected_apps_spec.rb
+++ b/spec/system/admin/enterprises/connected_apps_spec.rb
@@ -16,7 +16,7 @@ describe "Connected Apps", feature: :connected_apps, vcr: true do
     # removing one day.
     Flipper.disable(:connected_apps)
     visit edit_admin_enterprise_path(enterprise)
-    expect(page).to_not have_content "CONNECTED APPS"
+    expect(page).not_to have_content "CONNECTED APPS"
 
     Flipper.enable(:connected_apps, enterprise.owner)
     visit edit_admin_enterprise_path(enterprise)
@@ -36,18 +36,18 @@ describe "Connected Apps", feature: :connected_apps, vcr: true do
     expect(page).to have_content "Discover Regenerative"
 
     click_button "Allow data sharing"
-    expect(page).to_not have_button "Allow data sharing"
+    expect(page).not_to have_button "Allow data sharing"
     expect(page).to have_button "Loading", disabled: true
 
     perform_enqueued_jobs(only: ConnectAppJob)
-    expect(page).to_not have_button "Loading", disabled: true
+    expect(page).not_to have_button "Loading", disabled: true
     expect(page).to have_content "account is connected"
     expect(page).to have_link "Manage listing"
 
     click_button "Stop sharing"
     expect(page).to have_button "Allow data sharing"
-    expect(page).to_not have_button "Stop sharing"
-    expect(page).to_not have_content "account is connected"
-    expect(page).to_not have_link "Manage listing"
+    expect(page).not_to have_button "Stop sharing"
+    expect(page).not_to have_content "account is connected"
+    expect(page).not_to have_link "Manage listing"
   end
 end

--- a/spec/system/admin/enterprises/index_spec.rb
+++ b/spec/system/admin/enterprises/index_spec.rb
@@ -93,9 +93,9 @@ describe 'Enterprises Index' do
               "#{manager.email} is not permitted to own any more enterprises (limit is 1)."
             )
             second_distributor.reload
-          }.to_not change { second_distributor.owner }
+          }.not_to change { second_distributor.owner }
 
-          expect(second_distributor.owner).to_not eq manager
+          expect(second_distributor.owner).not_to eq manager
         end
 
         def select_new_owner(user, enterprise)

--- a/spec/system/admin/enterprises/terms_and_conditions_spec.rb
+++ b/spec/system/admin/enterprises/terms_and_conditions_spec.rb
@@ -50,7 +50,7 @@ describe "Uploading Terms and Conditions PDF" do
         click_button "Update"
         expect(page).
           to have_content "Enterprise \"#{distributor.name}\" has been successfully updated!"
-        expect(distributor.reload.terms_and_conditions_blob.created_at).to_not eq run_time
+        expect(distributor.reload.terms_and_conditions_blob.created_at).not_to eq run_time
 
         go_to_business_details
         expect(page).to have_selector "a[href*='Terms-of-ServiceUK.pdf']"

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -588,7 +588,7 @@ describe '
             expect do
               click_button "Invite"
               expect(page).to have_content "Email is invalid"
-            end.to_not enqueue_job ActionMailer::MailDeliveryJob
+            end.not_to enqueue_job ActionMailer::MailDeliveryJob
           end
         end
 
@@ -600,7 +600,7 @@ describe '
             expect do
               click_button "Invite"
               expect(page).to have_content "User already exists"
-            end.to_not enqueue_job ActionMailer::MailDeliveryJob
+            end.not_to enqueue_job ActionMailer::MailDeliveryJob
           end
         end
 
@@ -698,7 +698,7 @@ describe '
             end
             expect(flash_message).to match(/Logo removed/)
             distributor1.reload
-            expect(distributor1.white_label_logo).to_not be_attached
+            expect(distributor1.white_label_logo).not_to be_attached
           end
 
           shared_examples "edit link with" do |url, result|

--- a/spec/system/admin/oidc_settings_spec.rb
+++ b/spec/system/admin/oidc_settings_spec.rb
@@ -6,7 +6,7 @@ describe "OIDC Settings" do
   it "requires login" do
     visit admin_oidc_settings_path
     expect(page).to have_button "Login"
-    expect(page).to_not have_button "Link your Les Communs OIDC Account"
+    expect(page).not_to have_button "Link your Les Communs OIDC Account"
   end
 
   describe "with valid login" do
@@ -36,7 +36,7 @@ describe "OIDC Settings" do
 
       expect(page).to have_content "Tokens to access connected apps have expired"
       click_button "Refresh authorisation"
-      expect(page).to_not have_content "Tokens to access connected apps have expired"
+      expect(page).not_to have_content "Tokens to access connected apps have expired"
     end
   end
 end

--- a/spec/system/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
+++ b/spec/system/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
@@ -26,7 +26,7 @@ describe '
       expect(page).to have_selector ".exchange-product-details"
 
       expect(page).to have_content "1 of 2 Variants Loaded"
-      expect(page).to_not have_content new_product.name
+      expect(page).not_to have_content new_product.name
     end
 
     it "load all products" do

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -207,7 +207,7 @@ describe '
 
         # I should see only the order cycle I am coordinating
         expect(page).to have_selector "tr.order-cycle-#{oc_user_coordinating.id}"
-        expect(page).to_not have_selector "tr.order-cycle-#{oc_for_other_user.id}"
+        expect(page).not_to have_selector "tr.order-cycle-#{oc_for_other_user.id}"
 
         toggle_columns "Producers", "Shops"
 
@@ -263,7 +263,7 @@ describe '
 
         click_button 'Save and Next'
         expect(page).to have_content 'Your order cycle has been updated.'
-        expect(page).to_not have_content "Loading..."
+        expect(page).not_to have_content "Loading..."
 
         expect(page).to have_select 'new_distributor_id'
         expect(page).not_to have_select 'new_distributor_id',
@@ -578,7 +578,7 @@ describe '
         expect(page).to have_selector "tr.supplier-#{supplier_managed.id}"
         expect(page).to have_selector 'tr.supplier', count: 1
 
-        expect(page).to_not have_content "Loading..."
+        expect(page).not_to have_content "Loading..."
 
         # Open the products list for managed_supplier's incoming exchange
         within "tr.supplier-#{supplier_managed.id}" do
@@ -847,7 +847,7 @@ describe '
     accept_alert do
       first('a.delete-order-cycle').click
     end
-    expect(page).to_not have_selector "tr.order-cycle-#{order_cycle.id}"
+    expect(page).not_to have_selector "tr.order-cycle-#{order_cycle.id}"
   end
 
   private

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -210,7 +210,7 @@ describe '
           end
           expect(page).to have_content "Cannot add item to canceled order"
           expect(order.reload.state).to eq("canceled")
-        end.to_not have_enqueued_mail(Spree::OrderMailer, :cancel_email)
+        end.not_to have_enqueued_mail(Spree::OrderMailer, :cancel_email)
       end
 
       it "and the items are not restocked when the user uncheck the checkbox to restock items" do
@@ -359,7 +359,7 @@ describe '
     within("tr.stock-item", text: order.products.first.name) do
       expect(page).to have_field :quantity, with: max_quantity.to_s
     end
-    expect { item.reload }.to_not change { item.quantity }
+    expect { item.reload }.not_to change { item.quantity }
   end
 
   it "there are infinite items available (variant is on demand)" do
@@ -430,7 +430,7 @@ describe '
         find("button.add_variant").click
       end
 
-      expect(page).to_not have_selector("table.stock-levels")
+      expect(page).not_to have_selector("table.stock-levels")
       expect(page).to have_selector("table.stock-contents")
 
       within("tr.stock-item") do
@@ -752,7 +752,7 @@ describe '
         it "can edit shipping method" do
           visit spree.edit_admin_order_path(order)
 
-          expect(page).to_not have_content different_shipping_method_for_distributor1.name
+          expect(page).not_to have_content different_shipping_method_for_distributor1.name
 
           find('.edit-method').click
           expect(page).to have_select2('selected_shipping_rate_id',
@@ -857,7 +857,7 @@ describe '
 
       it "can edit and delete tracking number" do
         test_tracking_number = "ABCCBA"
-        expect(page).to_not have_content test_tracking_number
+        expect(page).not_to have_content test_tracking_number
 
         find('.edit-tracking').click
         fill_in "tracking", with: test_tracking_number
@@ -871,18 +871,18 @@ describe '
         # the alert box vanishes and tracking num is still present
         expect(page).to have_content 'Are you sure?'
         find('.cancel').click
-        expect(page).to_not have_content 'Are you sure?'
+        expect(page).not_to have_content 'Are you sure?'
         expect(page).to have_content test_tracking_number
 
         find('.delete-tracking.icon-trash').click
         expect(page).to have_content 'Are you sure?'
         find('.confirm').click
-        expect(page).to_not have_content test_tracking_number
+        expect(page).not_to have_content test_tracking_number
       end
 
       it "can edit and delete note" do
         test_note = "this is a note"
-        expect(page).to_not have_content test_note
+        expect(page).not_to have_content test_note
 
         find('.edit-note.icon-edit').click
         fill_in "note", with: test_note
@@ -896,13 +896,13 @@ describe '
         # the alert box vanishes and note is still present
         expect(page).to have_content 'Are you sure?'
         find('.cancel').click
-        expect(page).to_not have_content 'Are you sure?'
+        expect(page).not_to have_content 'Are you sure?'
         expect(page).to have_content test_note
 
         find('.delete-note.icon-trash').click
         expect(page).to have_content 'Are you sure?'
         find('.confirm').click
-        expect(page).to_not have_content test_note
+        expect(page).not_to have_content test_note
       end
 
       it "viewing shipping fees" do
@@ -949,7 +949,7 @@ describe '
             uncheck 'Send a shipment/pick up notification email to the customer.'
             expect {
               find_button("Confirm").click
-            }.to_not enqueue_job(ActionMailer::MailDeliveryJob)
+            }.not_to enqueue_job(ActionMailer::MailDeliveryJob)
           end
 
           save_screenshot('~/hello.png')
@@ -986,7 +986,7 @@ describe '
               uncheck 'Send a shipment/pick up notification email to the customer.'
               expect {
                 find_button("Confirm").click
-              }.to_not enqueue_job(ActionMailer::MailDeliveryJob)
+              }.not_to enqueue_job(ActionMailer::MailDeliveryJob)
             end
 
             expect(order.reload.shipped?).to be true
@@ -1012,7 +1012,7 @@ describe '
           order.cancel!
           visit spree.edit_admin_order_path(order)
           within("tr.stock-item", text: order.products.first.name) do
-            expect(page).to_not have_selector("a.edit-item")
+            expect(page).not_to have_selector("a.edit-item")
           end
         end
       end
@@ -1035,12 +1035,12 @@ describe '
             accept_alert 'Are you sure?' do
               find("a.delete-resource").click
             end
-            expect(page).to_not have_content incomplete_order.products.first.name
+            expect(page).not_to have_content incomplete_order.products.first.name
           end
 
           # updates the order and verifies the warning disappears
           click_button 'Update And Recalculate Fees'
-          expect(page).to_not have_content "Out of Stock".upcase
+          expect(page).not_to have_content "Out of Stock".upcase
         end
       end
     end
@@ -1058,11 +1058,11 @@ describe '
       expect(page).to have_selector 'td', text: product.name
 
       expect(page).to have_select2 'order_distributor_id', with_options: [distributor1.name]
-      expect(page).to_not have_select2 'order_distributor_id', with_options: [distributor2.name]
+      expect(page).not_to have_select2 'order_distributor_id', with_options: [distributor2.name]
 
       expect(page).to have_select2 'order_order_cycle_id',
                                    with_options: ["#{order_cycle1.name} (open)"]
-      expect(page).to_not have_select2 'order_order_cycle_id',
+      expect(page).not_to have_select2 'order_order_cycle_id',
                                        with_options: ["#{order_cycle2.name} (open)"]
 
       click_button 'Update'
@@ -1189,7 +1189,7 @@ describe '
 
             # and disappear after clicking
             expect(page).not_to have_link "Create or Update Invoice"
-            expect(page).to_not have_content "The order has changed since the last invoice update."
+            expect(page).not_to have_content "The order has changed since the last invoice update."
 
             # creating an invoice, displays a second row
             expect(page.find("table").text).to have_content(table_contents)

--- a/spec/system/admin/orders/invoices_spec.rb
+++ b/spec/system/admin/orders/invoices_spec.rb
@@ -55,7 +55,7 @@ describe '
       context 'order not updated since latest invoice' do
         it 'should not render new invoice button' do
           click_link 'Invoices'
-          expect(page).to_not have_link "Create or Update Invoice"
+          expect(page).not_to have_link "Create or Update Invoice"
         end
       end
 

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -115,7 +115,7 @@ describe '
         # Order 2 and 3 should show, but not 4
         expect(page).to have_content order2.number
         expect(page).to have_content order3.number
-        expect(page).to_not have_content order4.number
+        expect(page).not_to have_content order4.number
       end
 
       it "filter by distributors" do
@@ -126,7 +126,7 @@ describe '
 
         # Order 2 and 4 should show, but not 3
         expect(page).to have_content order2.number
-        expect(page).to_not have_content order3.number
+        expect(page).not_to have_content order3.number
         expect(page).to have_content order4.number
       end
 
@@ -138,7 +138,7 @@ describe '
         page.find('.filter-actions .button[type=submit]').click
 
         # Order 3 and 4 should show, but not 2
-        expect(page).to_not have_content order2.number
+        expect(page).not_to have_content order2.number
         expect(page).to have_content order3.number
         expect(page).to have_content order4.number
       end
@@ -149,9 +149,9 @@ describe '
         page.find('.filter-actions .button[type=submit]').click
 
         # Order 3 should show, but not 2 and 4
-        expect(page).to_not have_content order2.number
+        expect(page).not_to have_content order2.number
         expect(page).to have_content order3.number
-        expect(page).to_not have_content order4.number
+        expect(page).not_to have_content order4.number
       end
 
       it "filter by customer first and last names" do
@@ -161,8 +161,8 @@ describe '
         page.find('.filter-actions .button[type=submit]').click
         # Order 2 should show, but not 3 and 4
         expect(page).to have_content order2.number
-        expect(page).to_not have_content order3.number
-        expect(page).to_not have_content order4.number
+        expect(page).not_to have_content order3.number
+        expect(page).not_to have_content order4.number
 
         find("#clear_filters_button").click
         # filtering by last name
@@ -170,8 +170,8 @@ describe '
         fill_in "Last name begins with", with: billing_address4.lastname
         page.find('.filter-actions .button[type=submit]').click
         # Order 4 should show, but not 2 and 3
-        expect(page).to_not have_content order2.number
-        expect(page).to_not have_content order3.number
+        expect(page).not_to have_content order2.number
+        expect(page).not_to have_content order3.number
         expect(page).to have_content order4.number
 
         find("#clear_filters_button").click
@@ -194,16 +194,16 @@ describe '
         page.find('.filter-actions .button[type=submit]').click
         # Order 2 should show, but not 3 and 5
         expect(page).to have_content order2.number
-        expect(page).to_not have_content order3.number
-        expect(page).to_not have_content order4.number
+        expect(page).not_to have_content order3.number
+        expect(page).not_to have_content order4.number
 
         find("#clear_filters_button").click
 
         tomselect_search_and_select "Signed, sealed, delivered", from: 'shipping_method_id'
         page.find('.filter-actions .button[type=submit]').click
         # Order 4 should show, but not 2 and 3
-        expect(page).to_not have_content order2.number
-        expect(page).to_not have_content order3.number
+        expect(page).not_to have_content order2.number
+        expect(page).not_to have_content order3.number
         expect(page).to have_content order4.number
       end
 
@@ -214,8 +214,8 @@ describe '
 
         # Order 2 should show, but not 3 and 4
         expect(page).to have_content order2.number
-        expect(page).to_not have_content order3.number
-        expect(page).to_not have_content order4.number
+        expect(page).not_to have_content order3.number
+        expect(page).not_to have_content order4.number
       end
 
       it "filter by order state" do
@@ -236,10 +236,10 @@ describe '
 
         # Order 2 should show, but not 3 and 4
         expect(page).to have_content order.number
-        expect(page).to_not have_content order2.number
-        expect(page).to_not have_content order3.number
-        expect(page).to_not have_content order4.number
-        expect(page).to_not have_content order5.number
+        expect(page).not_to have_content order2.number
+        expect(page).not_to have_content order3.number
+        expect(page).not_to have_content order4.number
+        expect(page).not_to have_content order5.number
       end
     end
 
@@ -496,11 +496,11 @@ describe '
         page.find("#listing_orders thead th:first-child input[type=checkbox]").trigger("click")
         expect(page.find(
                  "#listing_orders tbody tr td:first-child input[type=checkbox]"
-               )).to_not be_checked
+               )).not_to be_checked
         # disables print invoices button not clickable
         expect { find("span.icon-reorder", text: "ACTIONS").click }
           .to raise_error(Capybara::Cuprite::MouseEventFailed)
-        expect(page).to_not have_content "Print Invoices"
+        expect(page).not_to have_content "Print Invoices"
       end
     end
 
@@ -645,7 +645,7 @@ describe '
             uncheck "Send a cancellation email to the customer"
             expect {
               find_button("Cancel").click # Cancels the cancel action
-            }.to_not enqueue_job(ActionMailer::MailDeliveryJob).exactly(:twice)
+            }.not_to enqueue_job(ActionMailer::MailDeliveryJob).exactly(:twice)
           end
 
           page.find("span.icon-reorder", text: "ACTIONS").click
@@ -656,7 +656,7 @@ describe '
           within ".reveal-modal" do
             expect {
               find_button("Confirm").click # Confirms the cancel action
-            }.to_not enqueue_job(ActionMailer::MailDeliveryJob).exactly(:twice)
+            }.not_to enqueue_job(ActionMailer::MailDeliveryJob).exactly(:twice)
           end
 
           expect(page).to have_content("CANCELLED", count: 2)
@@ -697,7 +697,7 @@ describe '
           within ".reveal-modal" do
             expect {
               find_button("Confirm").click
-            }.to_not enqueue_job(ActionMailer::MailDeliveryJob)
+            }.not_to enqueue_job(ActionMailer::MailDeliveryJob)
           end
         end
       end

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -278,11 +278,11 @@ describe "Product Import" do
       proceed_to_validation
 
       expect(page).to have_selector '.item-count', text: "3"
-      expect(page).to_not have_selector '.invalid-count'
+      expect(page).not_to have_selector '.invalid-count'
       expect(page).to have_selector '.create-count', text: "3"
-      expect(page).to_not have_selector '.update-count'
-      expect(page).to_not have_selector '.inv-create-count'
-      expect(page).to_not have_selector '.inv-update-count'
+      expect(page).not_to have_selector '.update-count'
+      expect(page).not_to have_selector '.inv-create-count'
+      expect(page).not_to have_selector '.inv-update-count'
 
       save_data
 

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -714,13 +714,13 @@ describe '
 
       visit spree.admin_product_images_path(product)
       expect(page).to have_selector "table.index td img"
-      expect(product.reload.image).to_not be_nil
+      expect(product.reload.image).not_to be_nil
 
       accept_alert do
         page.find('a.delete-resource').click
       end
 
-      expect(page).to_not have_selector "table.index td img"
+      expect(page).not_to have_selector "table.index td img"
       expect(product.reload.image).to be_nil
     end
 

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -258,7 +258,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
       expect {
         click_button "Discard changes"
         product_a.reload
-      }.to_not change { product_a.name }
+      }.not_to change { product_a.name }
 
       within row_containing_name("Apples") do
         expect(page).to have_field "Name", with: "Apples" # Changed value wasn't saved
@@ -295,7 +295,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
           expect(page).to have_content "1 product could not be saved"
           expect(page).to have_content "Please review the errors and try again"
           product_a.reload
-        }.to_not change { product_a.name }
+        }.not_to change { product_a.name }
 
         # (there's no identifier displayed, so the user must remember which product it is..)
         within row_containing_name("") do
@@ -320,7 +320,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
 
           expect(page).to have_content("1 product could not be saved")
           product_a.reload
-        }.to_not change { product_a.name }
+        }.not_to change { product_a.name }
 
         within row_containing_name("") do
           fill_in "Name", with: "Pommes"
@@ -408,7 +408,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
             expect(page).to have_content "1 product could not be saved"
             expect(page).to have_content "Please review the errors and try again"
             variant_a1.reload
-          }.to_not change { variant_a1.display_name }
+          }.not_to change { variant_a1.display_name }
 
           # New variant
           within row_containing_name("N" * 256) do
@@ -433,7 +433,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
             click_button "Save changes"
 
             variant_a1.reload
-          }.to_not change { variant_a1.display_name }
+          }.not_to change { variant_a1.display_name }
 
           within row_containing_name("N" * 256) do
             fill_in "Name", with: "Nice box"
@@ -527,7 +527,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
             expect(page).to have_content "1 product could not be saved"
             expect(page).to have_content "Please review the errors and try again"
             variant_a1.reload
-          }.to_not change { variant_a1.display_name }
+          }.not_to change { variant_a1.display_name }
 
           # New variant
           within row_containing_name("N" * 256) do
@@ -552,7 +552,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
             click_button "Save changes"
 
             variant_a1.reload
-          }.to_not change { variant_a1.display_name }
+          }.not_to change { variant_a1.display_name }
 
           within row_containing_name("N" * 256) do
             fill_in "Name", with: "Nice box"
@@ -595,7 +595,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
         expect {
           click_button "Save changes"
           product_a.reload
-        }.to_not change { product_a.name }
+        }.not_to change { product_a.name }
 
         expect(page).not_to have_content("0 product was saved correctly, but")
         expect(page).to have_content("1 product could not be saved")
@@ -699,7 +699,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
 
           within row_containing_name("Medium box") do
             page.find(".vertical-ellipsis-menu").click
-            expect(page).to_not have_link "Clone", href: spree.clone_admin_product_path(product_a)
+            expect(page).not_to have_link "Clone", href: spree.clone_admin_product_path(product_a)
           end
         end
       end
@@ -711,7 +711,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
             input_content = page.find_all('input[type=text]').map(&:value).join
 
             # Products does not include the cloned product.
-            expect(input_content).to_not match /COPY OF Apples/
+            expect(input_content).not_to match /COPY OF Apples/
           end
 
           within row_containing_name("Apples") do
@@ -757,7 +757,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
           # to select the default variant
           within default_variant_selector do
             page.find(".vertical-ellipsis-menu").click
-            expect(page).to_not have_css(delete_option_selector)
+            expect(page).not_to have_css(delete_option_selector)
           end
         end
 
@@ -806,7 +806,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
               page.find(keep_button_selector).click
             end
 
-            expect(page).to_not have_selector(modal_selector)
+            expect(page).not_to have_selector(modal_selector)
             expect(page).to have_selector(product_selector)
 
             # Keep Variant
@@ -819,7 +819,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
               page.find(keep_button_selector).click
             end
 
-            expect(page).to_not have_selector(modal_selector)
+            expect(page).not_to have_selector(modal_selector)
             expect(page).to have_selector(variant_selector)
           end
         end
@@ -839,10 +839,10 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
               page.find(delete_button_selector).click
             end
 
-            expect(page).to_not have_selector(modal_selector)
+            expect(page).not_to have_selector(modal_selector)
             # Make sure the products loading spinner is hidden
             wait_for_class('.spinner-overlay', 'hidden')
-            expect(page).to_not have_selector(variant_selector)
+            expect(page).not_to have_selector(variant_selector)
             within success_flash_message_selector do
               expect(page).to have_content("Successfully deleted the variant")
               page.find(dismiss_button_selector).click
@@ -857,10 +857,10 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
             within modal_selector do
               page.find(delete_button_selector).click
             end
-            expect(page).to_not have_selector(modal_selector)
+            expect(page).not_to have_selector(modal_selector)
             # Make sure the products loading spinner is hidden
             wait_for_class('.spinner-overlay', 'hidden')
-            expect(page).to_not have_selector(product_selector)
+            expect(page).not_to have_selector(product_selector)
             within success_flash_message_selector do
               expect(page).to have_content("Successfully deleted the product")
             end
@@ -881,7 +881,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
               page.find(delete_button_selector).click
             end
 
-            expect(page).to_not have_selector(modal_selector)
+            expect(page).not_to have_selector(modal_selector)
             sleep(0.5) # delay for loading spinner to complete
             expect(page).to have_selector(variant_selector)
             within error_flash_message_selector do
@@ -898,7 +898,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
             within modal_selector do
               page.find(delete_button_selector).click
             end
-            expect(page).to_not have_selector(modal_selector)
+            expect(page).not_to have_selector(modal_selector)
             sleep(0.5) # delay for loading spinner to complete
             expect(page).to have_selector(product_selector)
             within error_flash_message_selector do

--- a/spec/system/admin/reports/enterprise_summary_fees/enterprise_summary_fee_with_tax_report_by_producer_spec.rb
+++ b/spec/system/admin/reports/enterprise_summary_fees/enterprise_summary_fee_with_tax_report_by_producer_spec.rb
@@ -532,10 +532,10 @@ describe "Enterprise Summary Fee with Tax Report By Producer" do
             expect(table).to have_content(cost_of_produce2)
             expect(table).to have_content(summary_row2)
 
-            expect(table).to_not have_content(supplier_state_tax1)
-            expect(table).to_not have_content(supplier_country_tax1)
-            expect(table).to_not have_content(cost_of_produce1)
-            expect(table).to_not have_content(summary_row1)
+            expect(table).not_to have_content(supplier_state_tax1)
+            expect(table).not_to have_content(supplier_country_tax1)
+            expect(table).not_to have_content(cost_of_produce1)
+            expect(table).not_to have_content(summary_row1)
           end
 
           it "should filter by fee name" do
@@ -550,19 +550,19 @@ describe "Enterprise Summary Fee with Tax Report By Producer" do
 
             expect(table).to have_content(supplier_state_tax1)
             expect(table).to have_content(supplier_country_tax1)
-            expect(table).to_not have_content(distributor_state_tax1)
-            expect(table).to_not have_content(distributor_country_tax1)
-            expect(table).to_not have_content(coordinator_state_tax1)
-            expect(table).to_not have_content(coordinator_country_tax1)
+            expect(table).not_to have_content(distributor_state_tax1)
+            expect(table).not_to have_content(distributor_country_tax1)
+            expect(table).not_to have_content(coordinator_state_tax1)
+            expect(table).not_to have_content(coordinator_country_tax1)
             expect(table).to have_content(cost_of_produce1)
             expect(table).to have_content(summary_row1)
 
             expect(table).to have_content(supplier_state_tax3)
             expect(table).to have_content(supplier_country_tax3)
-            expect(table).to_not have_content(distributor_state_tax3)
-            expect(table).to_not have_content(distributor_country_tax3)
-            expect(table).to_not have_content(coordinator_state_tax3)
-            expect(table).to_not have_content(coordinator_country_tax3)
+            expect(table).not_to have_content(distributor_state_tax3)
+            expect(table).not_to have_content(distributor_country_tax3)
+            expect(table).not_to have_content(coordinator_state_tax3)
+            expect(table).not_to have_content(coordinator_country_tax3)
             expect(table).to have_content(cost_of_produce3)
             expect(table).to have_content(summary_row3)
           end
@@ -577,10 +577,10 @@ describe "Enterprise Summary Fee with Tax Report By Producer" do
             table = page.find("table.report__table tbody")
             expect(table).to have_content(supplier_state_tax1)
             expect(table).to have_content(supplier_country_tax1)
-            expect(table).to_not have_content(distributor_state_tax1)
-            expect(table).to_not have_content(distributor_country_tax1)
-            expect(table).to_not have_content(coordinator_state_tax1)
-            expect(table).to_not have_content(coordinator_country_tax1)
+            expect(table).not_to have_content(distributor_state_tax1)
+            expect(table).not_to have_content(distributor_country_tax1)
+            expect(table).not_to have_content(coordinator_state_tax1)
+            expect(table).not_to have_content(coordinator_country_tax1)
             expect(table).to have_content(cost_of_produce1)
             expect(table).to have_content(summary_row_after_filtering_by_fee_owner)
           end

--- a/spec/system/admin/subscriptions/crud_spec.rb
+++ b/spec/system/admin/subscriptions/crud_spec.rb
@@ -371,7 +371,7 @@ describe 'Subscriptions' do
               expect{
                 click_button('Create Subscription')
                 expect(page).to have_content 'Please add at least one product'
-              }.to_not change { Subscription.count }
+              }.not_to change { Subscription.count }
             end
 
             context 'and adding a new product' do

--- a/spec/system/admin/subscriptions/smoke_tests_spec.rb
+++ b/spec/system/admin/subscriptions/smoke_tests_spec.rb
@@ -33,7 +33,7 @@ describe 'Subscriptions' do
           expect(page).to have_content "Just a few more steps before you can begin"
 
           # subscriptions are enabled, instructions are not displayed
-          expect(page).to_not have_content 'Under "Shop Preferences", /
+          expect(page).not_to have_content 'Under "Shop Preferences", /
           enable the Subscriptions option'
 
           # other relevant instructions are displayed
@@ -54,7 +54,7 @@ describe 'Subscriptions' do
         end
         it "the subscriptions tab is not visible" do
           expect(page).to have_current_path "/admin/orders"
-          expect(page).to_not have_link "Subscriptions", href: "/admin/subscriptions"
+          expect(page).not_to have_link "Subscriptions", href: "/admin/subscriptions"
         end
       end
     end

--- a/spec/system/admin/tos_banner_spec.rb
+++ b/spec/system/admin/tos_banner_spec.rb
@@ -26,11 +26,11 @@ describe 'Terms of Service banner' do
         click_button "Accept Terms of Service"
         admin_user.reload
       end.to change { admin_user.terms_of_service_accepted_at }
-      expect(page).to_not have_content("Terms of Service have been updated")
+      expect(page).not_to have_content("Terms of Service have been updated")
 
       # Check the banner doesn't show again once ToS has been accepted
       page.refresh
-      expect(page).to_not have_content("Terms of Service have been updated")
+      expect(page).not_to have_content("Terms of Service have been updated")
     end
   end
 

--- a/spec/system/admin/variants_spec.rb
+++ b/spec/system/admin/variants_spec.rb
@@ -167,7 +167,7 @@ describe '
       login_as_admin
       visit spree.edit_admin_product_variant_path(product, variant)
 
-      expect(page).to_not have_field "unit_value_human"
+      expect(page).not_to have_field "unit_value_human"
       expect(page).to have_field "variant_weight"
       expect(page).to have_field "variant_unit_description", with: "foo"
 

--- a/spec/system/consumer/account/cards_spec.rb
+++ b/spec/system/consumer/account/cards_spec.rb
@@ -53,7 +53,7 @@ describe "Credit Cards" do
       within(".card#card#{non_default_card.id}") do
         expect(page).to have_content non_default_card.cc_type.capitalize
         expect(page).to have_content non_default_card.last_digits
-        expect(find_field('default_card')).to_not be_checked
+        expect(find_field('default_card')).not_to be_checked
       end
 
       # Allows switching of default card
@@ -73,7 +73,7 @@ describe "Credit Cards" do
 
       expect(default_card.reload.is_default).to be false
       within(".card#card#{default_card.id}") do
-        expect(find_field('default_card')).to_not be_checked
+        expect(find_field('default_card')).not_to be_checked
       end
       expect(non_default_card.reload.is_default).to be true
 
@@ -94,7 +94,7 @@ describe "Credit Cards" do
 
       # Allows authorisation of card use by shops
       within "tr#customer#{customer.id}" do
-        expect(find_field('allow_charges')).to_not be_checked
+        expect(find_field('allow_charges')).not_to be_checked
         find_field('allow_charges').click
       end
       expect(page).to have_content 'Changes saved.'

--- a/spec/system/consumer/account/developer_settings_spec.rb
+++ b/spec/system/consumer/account/developer_settings_spec.rb
@@ -47,7 +47,7 @@ describe "Developer Settings" do
 
               click_button I18n.t(:delete)
               expect(page.document).to have_content I18n.t('webhook_endpoints.destroy.success')
-              expect(page).to_not have_content "https://url"
+              expect(page).not_to have_content "https://url"
             end
           end
         end
@@ -59,7 +59,7 @@ describe "Developer Settings" do
 
       it "does not show the developer settings tab" do
         within("#account-tabs") do
-          expect(page).to_not have_selector("a", text: "DEVELOPER SETTINGS")
+          expect(page).not_to have_selector("a", text: "DEVELOPER SETTINGS")
         end
       end
     end

--- a/spec/system/consumer/account/payments_spec.rb
+++ b/spec/system/consumer/account/payments_spec.rb
@@ -38,7 +38,7 @@ describe "Payments requiring action" do
         visit "/account"
 
         find("a", text: /Transactions/i).click
-        expect(page).to_not have_content 'Authorisation Required'
+        expect(page).not_to have_content 'Authorisation Required'
       end
     end
   end

--- a/spec/system/consumer/account/settings_spec.rb
+++ b/spec/system/consumer/account/settings_spec.rb
@@ -47,7 +47,7 @@ Your email address will be updated once the new email is confirmed." % 'new@emai
       click_button 'Update'
       expect(find(".alert-box.success").text.strip).to eq "Account updated!\n×"
 
-      expect(user.reload.encrypted_password).to_not eq initial_password
+      expect(user.reload.encrypted_password).not_to eq initial_password
     end
   end
 end

--- a/spec/system/consumer/caching/darkswarm_caching_spec.rb
+++ b/spec/system/consumer/caching/darkswarm_caching_spec.rb
@@ -35,8 +35,8 @@ describe "Darkswarm data caching", caching: true do
 
       visit shops_path
 
-      expect(Spree::Taxon).to_not receive(:all)
-      expect(Spree::Property).to_not receive(:all)
+      expect(Spree::Taxon).not_to receive(:all)
+      expect(Spree::Property).not_to receive(:all)
 
       visit shops_path
     end
@@ -66,7 +66,7 @@ describe "Darkswarm data caching", caching: true do
       visit shops_path
 
       # Wait for /shops page to load properly before checking for new timestamps
-      expect(page).to_not have_selector ".row.filter-box"
+      expect(page).not_to have_selector ".row.filter-box"
 
       taxon_timestamp2 = CacheService.latest_timestamp_by_class(Spree::Taxon)
       expect_cached "views/#{CacheService::FragmentCaching.ams_all_taxons[0]}"
@@ -74,8 +74,8 @@ describe "Darkswarm data caching", caching: true do
       property_timestamp2 = CacheService.latest_timestamp_by_class(Spree::Property)
       expect_cached "views/#{CacheService::FragmentCaching.ams_all_properties[0]}"
 
-      expect(taxon_timestamp1).to_not eq taxon_timestamp2
-      expect(property_timestamp1).to_not eq property_timestamp2
+      expect(taxon_timestamp1).not_to eq taxon_timestamp2
+      expect(property_timestamp1).not_to eq property_timestamp2
 
       toggle_filters
 

--- a/spec/system/consumer/caching/shops_caching_spec.rb
+++ b/spec/system/consumer/caching/shops_caching_spec.rb
@@ -38,7 +38,7 @@ describe "Shops caching", caching: true do
 
         visit shops_path
 
-        expect(page).to_not have_content "New Name" # Displayed name is unchanged
+        expect(page).not_to have_content "New Name" # Displayed name is unchanged
       end
 
       # A while later...

--- a/spec/system/consumer/checkout/details_spec.rb
+++ b/spec/system/consumer/checkout/details_spec.rb
@@ -152,7 +152,7 @@ describe "As a consumer, I want to checkout my order" do
               before do
                 expect {
                   proceed_to_payment
-                }.to_not change {
+                }.not_to change {
                   user.reload.bill_address
                 }
               end
@@ -206,7 +206,7 @@ describe "As a consumer, I want to checkout my order" do
               before do
                 expect {
                   proceed_to_payment
-                }.to_not change {
+                }.not_to change {
                            user.reload.ship_address
                          }
               end

--- a/spec/system/consumer/checkout/summary_spec.rb
+++ b/spec/system/consumer/checkout/summary_spec.rb
@@ -131,9 +131,9 @@ describe "As a consumer, I want to checkout my order" do
             visit checkout_step_path(:summary)
 
             within "#checkout" do
-              expect(page).to_not have_field "order_accept_terms"
-              expect(page).to_not have_link "Terms and Conditions"
-              expect(page).to_not have_link "Terms of service"
+              expect(page).not_to have_field "order_accept_terms"
+              expect(page).not_to have_link "Terms and Conditions"
+              expect(page).not_to have_link "Terms of service"
             end
           end
         end
@@ -347,7 +347,7 @@ describe "As a consumer, I want to checkout my order" do
         order.distributor.save
         visit checkout_step_path(:summary)
 
-        expect(page).to_not have_content("You have an order for this order cycle already.")
+        expect(page).not_to have_content("You have an order for this order cycle already.")
       end
     end
 
@@ -393,8 +393,8 @@ describe "As a consumer, I want to checkout my order" do
 
         it_behaves_like "order confirmation page", "PAID", "50" do
           before do
-            expect(page).to_not have_selector('h5', text: "Credit Owed")
-            expect(page).to_not have_selector('h5', text: "Balance Due")
+            expect(page).not_to have_selector('h5', text: "Credit Owed")
+            expect(page).not_to have_selector('h5', text: "Balance Due")
           end
         end
       end

--- a/spec/system/consumer/groups_spec.rb
+++ b/spec/system/consumer/groups_spec.rb
@@ -110,10 +110,10 @@ describe 'Groups' do
 
       it "adjusts visibilities of enterprises depending on their status" do
         expect(page).to     have_css('hub', text: d1.name)
-        expect(page).to_not have_css('hub.inactive', text: d1.name)
+        expect(page).not_to have_css('hub.inactive', text: d1.name)
         expect(page).to     have_css('hub', text: d2.name)
-        expect(page).to_not have_css('hub.inactive', text: d2.name)
-        expect(page).to_not have_text d3.name
+        expect(page).not_to have_css('hub.inactive', text: d2.name)
+        expect(page).not_to have_text d3.name
         expect(page).to     have_css('hub.inactive', text: d4.name)
       end
 

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -102,7 +102,7 @@ describe "Registration" do
       # Upload logo image
       attach_file "image-select", Rails.root.join("spec/fixtures/files/logo.png"), visible: false
       expect(page).not_to have_css('#image-placeholder .loading')
-      expect(page.find('#image-placeholder img')['src']).to_not be_empty
+      expect(page.find('#image-placeholder img')['src']).not_to be_empty
 
       # Move from logo page
       click_button "Continue"
@@ -111,7 +111,7 @@ describe "Registration" do
       # Upload promo image
       attach_file "image-select", Rails.root.join("spec/fixtures/files/promo.png"), visible: false
       expect(page).not_to have_css('#image-placeholder .loading')
-      expect(page.find('#image-placeholder img')['src']).to_not be_empty
+      expect(page.find('#image-placeholder img')['src']).not_to be_empty
 
       # Move from promo page
       click_button "Continue"

--- a/spec/system/consumer/shopping/cart_spec.rb
+++ b/spec/system/consumer/shopping/cart_spec.rb
@@ -246,13 +246,13 @@ describe "full-page cart" do
 
             # Quantity field clearly marked as invalid and "Update" button is not highlighted
             expect(page).to have_selector "#order_line_items_attributes_0_quantity.ng-invalid-stock"
-            expect(page).to_not have_selector "#update-button.alert"
+            expect(page).not_to have_selector "#update-button.alert"
 
             fill_in "order_line_items_attributes_0_quantity", with: 4
 
             # Quantity field not marked as invalid and "Update" button is
             # highlighted after correction
-            expect(page).to_not have_selector(
+            expect(page).not_to have_selector(
               "#order_line_items_attributes_0_quantity.ng-invalid-stock"
             )
             expect(page).to have_selector "#update-button.alert"
@@ -260,8 +260,8 @@ describe "full-page cart" do
             click_button 'Update'
 
             # "Continue Shopping" and "Checkout" buttons are not disabled after cart is updated
-            expect(page).to_not have_selector "a.continue-shopping[disabled=disabled]"
-            expect(page).to_not have_selector "a#checkout-link[disabled=disabled]"
+            expect(page).not_to have_selector "a.continue-shopping[disabled=disabled]"
+            expect(page).not_to have_selector "a#checkout-link[disabled=disabled]"
           end
         end
       end
@@ -318,7 +318,7 @@ describe "full-page cart" do
         end
 
         it "doesn't throw an error" do
-          expect{ visit main_app.cart_path }.to_not raise_error
+          expect{ visit main_app.cart_path }.not_to raise_error
         end
       end
     end

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -44,7 +44,7 @@ describe "Order Management" do
       it "allows the user to see the details" do
         # Cannot load the page without token
         visit order_path(order)
-        expect(page).to_not be_confirmed_order_page
+        expect(page).not_to be_confirmed_order_page
 
         # Can load the page with token
         visit order_path(order, order_token: order.token)
@@ -87,7 +87,7 @@ describe "Order Management" do
       it "allows the user to see order details after login" do
         # Cannot load the page without signing in
         visit order_path(order)
-        expect(page).to_not be_confirmed_order_page
+        expect(page).not_to be_confirmed_order_page
 
         # Can load the page after signing in
         fill_in_and_submit_login_form user

--- a/spec/system/consumer/shopping/shopping_spec.rb
+++ b/spec/system/consumer/shopping/shopping_spec.rb
@@ -62,7 +62,7 @@ describe "As a consumer I want to shop with a distributor" do
         (all_tabs - tabs).each do |tab|
           it "does not show the #{tab} tab" do
             within ".tab-buttons" do
-              expect(page).to_not have_content tab
+              expect(page).not_to have_content tab
             end
           end
         end
@@ -132,8 +132,8 @@ describe "As a consumer I want to shop with a distributor" do
         end
 
         it "does not show the producer modal" do
-          expect(page).to_not have_link supplier.name
-          expect(page).to_not have_selector ".reveal-modal"
+          expect(page).not_to have_link supplier.name
+          expect(page).not_to have_selector ".reveal-modal"
         end
       end
     end
@@ -549,7 +549,7 @@ describe "As a consumer I want to shop with a distributor" do
 
           click_add_to_cart variant
 
-          expect(page).to_not have_selector '.out-of-stock-modal'
+          expect(page).not_to have_selector '.out-of-stock-modal'
         end
 
         context "group buy products" do

--- a/spec/system/consumer/shops_spec.rb
+++ b/spec/system/consumer/shops_spec.rb
@@ -246,7 +246,7 @@ describe 'Shops' do
 
       it "does not show the producer modal" do
         open_enterprise_modal producer
-        expect(page).to_not have_selector(".reveal-modal")
+        expect(page).not_to have_selector(".reveal-modal")
       end
     end
   end

--- a/spec/system/consumer/user_password_spec.rb
+++ b/spec/system/consumer/user_password_spec.rb
@@ -40,7 +40,7 @@ describe "User password confirm/reset page" do
       click_button
 
       expect(page).to have_text "User password cannot be blank. Please enter a password."
-      expect(page).to_not be_logged_in_as user
+      expect(page).not_to be_logged_in_as user
     end
   end
 

--- a/spec/system/consumer/white_label_spec.rb
+++ b/spec/system/consumer/white_label_spec.rb
@@ -381,7 +381,7 @@ describe 'White label setting' do
         shared_examples "shows the right link on the logo" do
           it "shows the white label logo link" do
             within ".nav-logo .ofn-logo" do
-              expect(page).to_not have_selector "a[href='/']"
+              expect(page).not_to have_selector "a[href='/']"
               expect(page).to have_selector "a[href*='https://www.example.com']"
             end
           end

--- a/spec/views/checkout/_voucher_section.html.haml_spec.rb
+++ b/spec/views/checkout/_voucher_section.html.haml_spec.rb
@@ -40,7 +40,7 @@ describe "checkout/_voucher_section.html.haml" do
     assign(:order, order)
 
     render
-    expect(rendered).to_not have_content(note)
+    expect(rendered).not_to have_content(note)
   end
 
   def add_voucher(voucher, order)

--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -54,8 +54,8 @@ describe "spree/admin/orders/edit.html.haml" do
       it "doesn't display a table of out of stock line items" do
         render
 
-        expect(rendered).to_not have_content "Out of Stock"
-        expect(rendered).to_not have_selector ".insufficient-stock-items",
+        expect(rendered).not_to have_content "Out of Stock"
+        expect(rendered).not_to have_selector ".insufficient-stock-items",
                                               text: out_of_stock_line_item.variant.display_name
       end
     end
@@ -63,7 +63,7 @@ describe "spree/admin/orders/edit.html.haml" do
     it "doesn't display closed associated adjustments" do
       render
 
-      expect(rendered).to_not have_content "Associated adjustment closed"
+      expect(rendered).not_to have_content "Associated adjustment closed"
     end
   end
 
@@ -96,14 +96,14 @@ describe "spree/admin/orders/edit.html.haml" do
       it "doesn't display a table of out of stock line items" do
         render
 
-        expect(rendered).to_not have_content "Out of Stock"
+        expect(rendered).not_to have_content "Out of Stock"
       end
     end
 
     it "doesn't display closed associated adjustments" do
       render
 
-      expect(rendered).to_not have_content "Associated adjustment closed"
+      expect(rendered).not_to have_content "Associated adjustment closed"
     end
   end
 end

--- a/spec/views/spree/admin/orders/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/index.html.haml_spec.rb
@@ -38,7 +38,7 @@ describe "spree/admin/orders/index.html.haml" do
 
       render
 
-      expect(rendered).to_not have_content("Print Invoices")
+      expect(rendered).not_to have_content("Print Invoices")
       expect(rendered).to have_content("Resend Confirmation")
       expect(rendered).to have_content("Cancel Orders")
     end

--- a/spec/views/spree/admin/orders/invoice.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/invoice.html.haml_spec.rb
@@ -82,7 +82,7 @@ describe "spree/admin/orders/invoice.html.haml" do
 
     render
     expect(rendered).to have_content "Shipping: Pickup"
-    expect(rendered).to_not have_content adas_address_display
+    expect(rendered).not_to have_content adas_address_display
   end
 
   it "displays order note on invoice when note is given" do


### PR DESCRIPTION
#### What? Why?

The style is the opposite of what I would prefer but it's the default. Period.

The [RSpec Matcher docs](https://rspec.info/documentation/3.13/rspec-expectations/RSpec/Matchers.html) mention `not_to` 38 times but `to_not` only twice (both in the same example block).

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
