### PR TITLE
set variant_processor to mini_magick

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -249,6 +249,7 @@ module Openfoodnetwork
     config.active_storage.content_types_to_serve_as_binary -= ["image/svg+xml"]
     config.active_storage.variable_content_types += ["image/svg+xml"]
     config.active_storage.url_options = config.action_controller.default_url_options
+    config.active_storage.variant_processor = :mini_magick
 
     config.exceptions_app = self.routes
 


### PR DESCRIPTION
#### What? Why?

- related #11673 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

It looks like the default variant processor becomes "vips" on Rails7.1.

* https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/8280341472/job/22656656944?pr=12209 * https://github.com/rails/rails/issues/44211

The comment on the source code doesn't seem to be updated https://github.com/rails/rails/blob/4bb73233413f30fd7217bd7f08af44963f5832b1/activestorage/app/models/active_storage/variant.rb#L11

#### What should we test?

- I think it's used for enterprise logos, white label and promo_image

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
