### PR TITLE
Limit enterprise image sizes on DFC API

### DIFF
--- a/engines/dfc_provider/app/services/enterprise_builder.rb
+++ b/engines/dfc_provider/app/services/enterprise_builder.rb
@@ -29,8 +29,8 @@ class EnterpriseBuilder < DfcBuilder
       # But that would require a new endpoint for a single string.
       add_ofn_property(e, "ofn:contact_name", enterprise.contact_name)
 
-      add_ofn_property(e, "ofn:logo_url", enterprise.logo.url)
-      add_ofn_property(e, "ofn:promo_image_url", enterprise.promo_image.url)
+      add_ofn_property(e, "ofn:logo_url", enterprise.logo_url(:small))
+      add_ofn_property(e, "ofn:promo_image_url", enterprise.promo_image_url(:large))
     end
   end
 

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -377,8 +377,8 @@ paths:
                       dfc-b:supplies: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
                       ofn:long_description: "<p>Hello, world!</p><p>This is a paragraph.</p>"
                       ofn:contact_name: Fred Farmer
-                      ofn:logo_url: http://www.example.com/rails/active_storage/url/logo.png
-                      ofn:promo_image_url: http://www.example.com/rails/active_storage/url/promo.png
+                      ofn:logo_url: http://test.host/rails/active_storage/url/logo.png
+                      ofn:promo_image_url: http://test.host/rails/active_storage/url/promo.png
                       dfc-b:affiliates: http://test.host/api/dfc/enterprise_groups/60000
                     - "@id": http://test.host/api/dfc/addresses/40000
                       "@type": dfc-b:Address


### PR DESCRIPTION

#### What? Why?

Uploaded images can be several MB in size. While offering the big size would enable other apps to resize it and store the image size they need, we have only one app using it in practice and it's using the image directly. It's much simpler and if a default size will work for others in the future then why not just serve that.

We can revise this in the future. There is a DFC discussion about publishing several sizes which I started:
* https://github.com/datafoodconsortium/ontology/discussions/77#discussioncomment-8228094

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
