### PR TITLE
Fix Rubocop Rails issue: Rails/FindEach

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -391,21 +391,6 @@ Naming/VariableNumber:
     - 'spec/requests/api/orders_spec.rb'
 
 # Offense count: 11
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowedMethods, AllowedPatterns.
-# AllowedMethods: order, limit, select, lock
-Rails/FindEach:
-  Exclude:
-    - 'app/controllers/admin/order_cycles_controller.rb'
-    - 'app/jobs/subscription_confirm_job.rb'
-    - 'app/services/orders/bulk_cancel_service.rb'
-    - 'app/services/products_renderer.rb'
-    - 'lib/tasks/data.rake'
-    - 'lib/tasks/subscriptions/debug.rake'
-    - 'spec/system/admin/bulk_order_management_spec.rb'
-    - 'spec/system/admin/enterprise_relationships_spec.rb'
-
-# Offense count: 11
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb
 Rails/HasManyOrHasOneDependent:

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -100,7 +100,7 @@ module Admin
 
     def update_nil_subscription_line_items_price_estimate(order_cycle)
       order_cycle.schedules.each do |schedule|
-        Subscription.where(schedule_id: schedule.id).each do |subscription|
+        Subscription.where(schedule_id: schedule.id).find_each do |subscription|
           shop = Enterprise.managed_by(spree_current_user).find_by(id: subscription.shop_id)
           fee_calculator = OpenFoodNetwork::EnterpriseFeeCalculator.new(shop, order_cycle)
           subscription.subscription_line_items.nil_price_estimate.each do |line_item|

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -23,7 +23,7 @@ class SubscriptionConfirmJob < ApplicationJob
     unconfirmed_proxy_orders.update_all(confirmed_at: Time.zone.now)
 
     # Confirm these proxy orders
-    ProxyOrder.where(id: unconfirmed_proxy_orders_ids).each do |proxy_order|
+    ProxyOrder.where(id: unconfirmed_proxy_orders_ids).find_each do |proxy_order|
       JobLogger.logger.info "Confirming Order for Proxy Order #{proxy_order.id}"
       confirm_order!(proxy_order.order)
     end

--- a/app/services/orders/bulk_cancel_service.rb
+++ b/app/services/orders/bulk_cancel_service.rb
@@ -10,11 +10,13 @@ module Orders
     end
 
     def call
+      # rubocop:disable Rails/FindEach # .each returns an array, .find_each returns nil
       editable_orders.where(id: @order_ids).each do |order|
         order.send_cancellation_email = @send_cancellation_email
         order.restock_items = @restock_items
         order.cancel
       end
+      # rubocop:enable Rails/FindEach
     end
 
     private

--- a/app/services/products_renderer.rb
+++ b/app/services/products_renderer.rb
@@ -89,10 +89,12 @@ class ProductsRenderer
     @variants_for_shop ||= begin
       scoper = OpenFoodNetwork::ScopeVariantToHub.new(distributor)
 
+      # rubocop:disable Rails/FindEach # .each returns an array, .find_each returns nil
       distributed_products.variants_relation.
         includes(:default_price, :stock_locations, :product).
         where(product_id: products).
         each { |v| scoper.scope(v) } # Scope results with variant_overrides
+      # rubocop:enable Rails/FindEach
     end
   end
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -7,7 +7,7 @@ namespace :ofn do
       input = request_months
 
       # For each order cycle which was modified within the past 3 months
-      OrderCycle.where('updated_at > ?', Date.current - input.months).each do |order_cycle|
+      OrderCycle.where('updated_at > ?', Date.current - input.months).find_each do |order_cycle|
         # Cycle through the incoming exchanges
         order_cycle.exchanges.incoming.each do |exchange|
           next if exchange.sender == exchange.receiver

--- a/lib/tasks/subscriptions/debug.rake
+++ b/lib/tasks/subscriptions/debug.rake
@@ -12,7 +12,7 @@ namespace :ofn do
         puts "Order Cycle #{order_cycle.name}"
         order_cycle.schedules.each do |schedule|
           puts "Schedule #{schedule.name}"
-          Subscription.where(schedule_id: schedule.id).each do |subscription|
+          Subscription.where(schedule_id: schedule.id).find_each do |subscription|
             puts
             puts "Subscription #{subscription.id}"
             puts subscription.shop.name
@@ -23,7 +23,7 @@ namespace :ofn do
             puts "Canceled at #{subscription.canceled_at} and paused at #{subscription.paused_at}"
 
             ProxyOrder.where(order_cycle_id:,
-                             subscription_id: subscription.id).each do |proxy_order|
+                             subscription_id: subscription.id).find_each do |proxy_order|
               puts
               puts "Proxy Order #{proxy_order.id}"
               puts "Canceled at #{proxy_order.canceled_at}"
@@ -42,7 +42,7 @@ namespace :ofn do
                   puts "Source #{payment.source.to_json}"
                 end
                 Spree::LogEntry.where(source_type: "Spree::Payment",
-                                      source_id: payment.id).each do |log_entry|
+                                      source_id: payment.id).find_each do |log_entry|
                   puts "Log Entries found"
                   puts log_entry.details
                 end

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -921,6 +921,7 @@ describe '
         expect(page).to have_selector "tr#li_#{li2.id} input[type='checkbox'][name='bulk']"
       end
 
+      # rubocop:disable Rails/FindEach. # These are Capybara finders
       it "displays a checkbox to which toggles the 'checked' state of all checkboxes" do
         check "toggle_bulk"
         page.all("input[type='checkbox'][name='bulk']").each{ |checkbox|
@@ -931,6 +932,7 @@ describe '
           expect(checkbox.checked?).to be false
         }
       end
+      # rubocop:enable Rails/FindEach
 
       it "displays a bulk action select box with a list of actions" do
         list_of_actions = ['Delete Selected']

--- a/spec/system/admin/enterprise_relationships_spec.rb
+++ b/spec/system/admin/enterprise_relationships_spec.rb
@@ -138,6 +138,7 @@ create(:enterprise)
     end
   end
 
+  # rubocop:disable Rails/FindEach. # These are Capybara finders
   def find_relationship(parent, child)
     page.all('tr').each do |tr|
       return tr if tr.find('td:first-child').text == parent.name &&
@@ -146,4 +147,5 @@ create(:enterprise)
     end
     raise "relationship not found"
   end
+  # rubocop:enable Rails/FindEach.
 end


### PR DESCRIPTION
#### What? Why?

Closes #12290 

Fix all violations of the Rails/FindEach cop.

- Part of #11482 

[Rubocop](https://www.rubydoc.info/gems/rubocop/0.41.2/RuboCop/Cop/Rails/FindEach) recommends using `find_each` in place of `each` whenever the call is chained to a `where`, `all` or `not`.

This PR is one of many PR's addressing issue #11482.

#### What should we test?
N/A

#### Release notes
Fix all violations of the Rails/FindEach cop.

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

#### Dependencies
N/A

#### Documentation updates
N/A
