### PR TITLE
Publish full URLs of social media links on DFC API

### DIFF
--- a/engines/dfc_provider/app/services/social_media_builder.rb
+++ b/engines/dfc_provider/app/services/social_media_builder.rb
@@ -12,9 +12,15 @@ class SocialMediaBuilder < DfcBuilder
   def self.social_media(enterprise, name)
     return nil unless name.in?(NAMES)
 
-    url =  enterprise.attributes[name]
+    url = enterprise.public_send(name)
 
     return nil if url.blank?
+
+    if name == "instagram"
+      url = "https://www.instagram.com/#{url}/"
+    end
+
+    url = "https://#{url}" unless url.starts_with?(%r{https?://})
 
     DataFoodConsortium::Connector::SocialMedia.new(
       urls.enterprise_social_media_url(enterprise.id, name),

--- a/engines/dfc_provider/spec/services/social_media_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/social_media_builder_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+describe SocialMediaBuilder do
+  let(:enterprise) do
+    create(
+      :enterprise,
+      id: 10_000,
+
+      # These formats are requested by our UI:
+      facebook: "www.facebook.com/user",
+      instagram: "handle",
+      linkedin: "www.linkedin.com/company/name",
+    )
+  end
+
+  describe ".social_media" do
+    it "links to Facebook" do
+      result = SocialMediaBuilder.social_media(enterprise, "facebook")
+      expect(result.url).to eq "https://www.facebook.com/user"
+    end
+
+    it "links to Instagram" do
+      result = SocialMediaBuilder.social_media(enterprise, "instagram")
+      expect(result.url).to eq "https://www.instagram.com/handle/"
+    end
+
+    it "links to Linkedin" do
+      result = SocialMediaBuilder.social_media(enterprise, "linkedin")
+      expect(result.url).to eq "https://www.linkedin.com/company/name"
+    end
+  end
+end


### PR DESCRIPTION


#### What? Why?

- Closes https://github.com/openfoodfoundation/sib-discovery-components/issues/9

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We have a quirky way of storing social media links in our database. The saved format results from the UI, validations and overridden getter methods. We want URLs on the API though.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
