### PR TITLE
Remove unnecessary method checkout_steps

### DIFF
--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -82,7 +82,7 @@ module Spree
           format.html do
             if params.key?(:checkout)
               @order.next_transition.run_callbacks if @order.cart?
-              redirect_to main_app.checkout_step_path(@order.checkout_steps.first)
+              redirect_to main_app.checkout_step_path("address")
             elsif @order.complete?
               redirect_to main_app.order_path(@order)
             else

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -8,7 +8,6 @@ module Spree
           class_attribute :next_event_transitions
           class_attribute :previous_states
           class_attribute :checkout_flow
-          class_attribute :checkout_steps
 
           def self.checkout_flow(&block)
             if block_given?
@@ -20,7 +19,6 @@ module Spree
           end
 
           def self.define_state_machine!
-            self.checkout_steps = {}
             self.next_event_transitions = []
             self.previous_states = [:cart]
 
@@ -97,7 +95,6 @@ module Spree
           end
 
           def self.go_to_state(name, options = {})
-            checkout_steps[name] = options
             previous_states.each do |state|
               add_transition({ from: state, to: name }.merge(options))
             end
@@ -112,30 +109,14 @@ module Spree
             @next_event_transitions ||= []
           end
 
-          def self.checkout_steps
-            @checkout_steps ||= {}
-          end
-
           def self.add_transition(options)
             next_event_transitions << { options.delete(:from) => options.delete(:to) }.
               merge(options)
           end
 
-          def checkout_steps
-            steps = self.class.checkout_steps.
-              each_with_object([]) { |(step, options), checkout_steps|
-              next if options.include?(:if) && !options[:if].call(self)
-
-              checkout_steps << step
-            }.map(&:to_s)
-            # Ensure there is always a complete step
-            steps << "complete" unless steps.include?("complete")
-            steps
-          end
-
           def restart_checkout_flow
             update_columns(
-              state: checkout_steps.first,
+              state: "address",
               updated_at: Time.zone.now,
             )
           end

--- a/spec/models/spree/order/checkout_spec.rb
+++ b/spec/models/spree/order/checkout_spec.rb
@@ -6,22 +6,6 @@ describe Spree::Order::Checkout do
   let(:order) { Spree::Order.new }
 
   context "with default state machine" do
-    context "#checkout_steps" do
-      context "when payment not required" do
-        before { allow(order).to receive_messages payment_required?: false }
-        specify do
-          expect(order.checkout_steps).to eq %w(address delivery confirmation complete)
-        end
-      end
-
-      context "when payment required" do
-        before { allow(order).to receive_messages payment_required?: true }
-        specify do
-          expect(order.checkout_steps).to eq %w(address delivery payment confirmation complete)
-        end
-      end
-    end
-
     it "starts out at cart" do
       expect(order.state).to eq "cart"
     end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1325,19 +1325,6 @@ describe Spree::Order do
     end
   end
 
-  describe "determining checkout steps for an order" do
-    let!(:enterprise) { create(:enterprise) }
-    let!(:order) { create(:order, distributor: enterprise) }
-    let!(:payment_method) {
-      create(:stripe_sca_payment_method, distributor_ids: [enterprise.id])
-    }
-    let!(:payment) { create(:payment, order:, payment_method:) }
-
-    it "does not include the :confirm step" do
-      expect(order.checkout_steps).not_to include "confirm"
-    end
-  end
-
   describe "payments" do
     let(:payment_method) { create(:payment_method) }
     let(:shipping_method) { create(:shipping_method) }


### PR DESCRIPTION

#### What? Why?

Random refactor while reading our code.

The method `checkout_steps` allowed introspection of a dynamic state machine. But the only two usages of this method only referred to the first state which is always the same. Our complicated checkout logic needs more clarity and introducing some hardcoded state names here can only help.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Checkout fail, e.g. payment fail.
- Checkout success.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
