### PR TITLE
Don't generate packing reports twice just to show the form

### DIFF
--- a/lib/reporting/report_headers_builder.rb
+++ b/lib/reporting/report_headers_builder.rb
@@ -11,13 +11,13 @@ module Reporting
 
     def table_headers
       filter = proc { |key| key.to_sym.in?(fields_to_show) }
-      report.columns.keys.filter { |key| filter.call(key) }.map do |key|
+      report.table_columns.keys.filter { |key| filter.call(key) }.map do |key|
         translate_header(key)
       end
     end
 
     def available_headers
-      report.columns.keys.map { |key| [translate_header(key), key] }
+      report.table_columns.keys.map { |key| [translate_header(key), key] }
     end
 
     def fields_to_hide

--- a/lib/reporting/report_template.rb
+++ b/lib/reporting/report_template.rb
@@ -54,6 +54,10 @@ module Reporting
       raise NotImplementedError
     end
 
+    def table_columns
+      columns
+    end
+
     # Exple { total_price: :currency }
     def columns_format
       {}

--- a/lib/reporting/reports/packing/customer.rb
+++ b/lib/reporting/reports/packing/customer.rb
@@ -4,11 +4,16 @@ module Reporting
   module Reports
     module Packing
       class Customer < Base
+        def table_columns
+          Struct.new(:keys).new(
+            [:hub, :customer_code, :first_name, :last_name, :phone, :supplier, :product,
+             :variant, :weight, :height, :width, :depth, :quantity, :price, :temp_controlled]
+          )
+        end
+
         def columns
           # Reorder default columns
-          super.slice(:hub, :customer_code, :first_name, :last_name, :phone,
-                      :supplier, :product, :variant, :weight, :height, :width, :depth, :quantity,
-                      :price, :temp_controlled)
+          super.slice(*table_columns.keys)
         end
 
         def rules

--- a/lib/reporting/reports/packing/product.rb
+++ b/lib/reporting/reports/packing/product.rb
@@ -4,11 +4,16 @@ module Reporting
   module Reports
     module Packing
       class Product < Base
+        def table_columns
+          Struct.new(:keys).new(
+            [:hub, :supplier, :product, :variant, :customer_code, :first_name,
+             :last_name, :phone, :quantity, :price, :temp_controlled]
+          )
+        end
+
         def columns
           # Reorder default columns
-          super.slice(:hub, :supplier, :product, :variant,
-                      :customer_code, :first_name, :last_name, :phone,
-                      :quantity, :price, :temp_controlled)
+          super.slice(*table_columns.keys)
         end
 
         def rules

--- a/lib/reporting/reports/packing/supplier.rb
+++ b/lib/reporting/reports/packing/supplier.rb
@@ -4,10 +4,16 @@ module Reporting
   module Reports
     module Packing
       class Supplier < Base
+        def table_columns
+          Struct.new(:keys).new(
+            [:hub, :supplier, :customer_code, :first_name, :last_name, :phone,
+             :product, :variant, :quantity, :price, :temp_controlled]
+          )
+        end
+
         def columns
           # Reorder default columns
-          super.slice(:hub, :supplier, :customer_code, :first_name, :last_name, :phone,
-                      :product, :variant, :quantity, :price, :temp_controlled)
+          super.slice(*table_columns.keys)
         end
 
         def rules


### PR DESCRIPTION
#### What? Why?

Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/11752, comment: https://github.com/openfoodfoundation/openfoodnetwork/issues/11752#issuecomment-2015174810

Packing reports pages currently are generating an entire report when the page first loads (before the form has even been submitted) just to get the column headers so it can list them in the dropdown in the form (which lets you choose report columns to show or hide), and this is incredibly expensive. The generated report doesn't even get used at that point and just gets discarded, and another one gets generated when you click the submit button. In production this means the page to just show the form can take 30 seconds to load (as superadmin). It should be around 0.3 seconds...

#### What should we test?

- Packing reports pages load quickly and generating reports works correctly.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
