### PR TITLE
Removes Stripe accounts created for testing purposes

### DIFF
--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_credit/refunds_the_payment.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_credit/refunds_the_payment.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_dQEqJkCMMFVHEu","request_duration_ms":305}}'
+      - '{"last_request_metrics":{"request_id":"req_kMqUEhudX1xjNZ","request_duration_ms":956}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:46 GMT
+      - Mon, 01 Apr 2024 10:17:46 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -58,15 +58,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - ea5ce2ab-65b7-42b5-b6ae-eb2864297b4c
+      - d054f866-a1e5-4afe-9ad2-aa1c319d4497
       Original-Request:
-      - req_xHZMFlYae6NH9Q
+      - req_Dfi6gcZKlVoQOx
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_xHZMFlYae6NH9Q
+      - req_Dfi6gcZKlVoQOx
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -81,7 +81,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1Oy1yv4F5rkj3PEw",
+          "id": "acct_1P0hvxQKJsxyg7Xm",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -103,7 +103,7 @@ http_interactions:
             "type": "application"
           },
           "country": "AU",
-          "created": 1711328746,
+          "created": 1711966666,
           "default_currency": "aud",
           "details_submitted": false,
           "email": "carrot.producer@example.com",
@@ -112,7 +112,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1Oy1yv4F5rkj3PEw/external_accounts"
+            "url": "/v1/accounts/acct_1P0hvxQKJsxyg7Xm/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -209,7 +209,7 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:46 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:46 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
@@ -224,13 +224,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_xHZMFlYae6NH9Q","request_duration_ms":1621}}'
+      - '{"last_request_metrics":{"request_id":"req_Dfi6gcZKlVoQOx","request_duration_ms":1594}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1yv4F5rkj3PEw
+      - acct_1P0hvxQKJsxyg7Xm
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -243,7 +243,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:48 GMT
+      - Mon, 01 Apr 2024 10:17:48 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -270,17 +270,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 607f3369-b61d-42ab-b148-13d8029bda8a
+      - 46b0b9e2-a61f-4e6d-a217-de0eeadd9736
       Original-Request:
-      - req_pRlYz5pzWyveLX
+      - req_dBgFusE0TKXqtN
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_pRlYz5pzWyveLX
+      - req_dBgFusE0TKXqtN
       Stripe-Account:
-      - acct_1Oy1yv4F5rkj3PEw
+      - acct_1P0hvxQKJsxyg7Xm
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -295,7 +295,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yx4F5rkj3PEw1YhbcT0d",
+          "id": "pi_3P0hvzQKJsxyg7Xm1F7SlEaz",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -311,18 +311,18 @@ http_interactions:
           "capture_method": "automatic",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328747,
+          "created": 1711966667,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1yx4F5rkj3PEw1Vhf3wWk",
+          "latest_charge": "ch_3P0hvzQKJsxyg7Xm1yaStIBm",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yx4F5rkj3PEw261B4212",
+          "payment_method": "pm_1P0hvzQKJsxyg7Xmcm9nKHkF",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -347,10 +347,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:48 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:47 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1yx4F5rkj3PEw1YhbcT0d
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0hvzQKJsxyg7Xm1F7SlEaz
     body:
       encoding: US-ASCII
       string: ''
@@ -366,7 +366,7 @@ http_interactions:
       X-Stripe-Client-User-Metadata:
       - '{"ip":null}'
       Stripe-Account:
-      - acct_1Oy1yv4F5rkj3PEw
+      - acct_1P0hvxQKJsxyg7Xm
       Connection:
       - close
       Accept-Encoding:
@@ -381,7 +381,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:48 GMT
+      - Mon, 01 Apr 2024 10:17:48 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -413,9 +413,9 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_shCZFnlUQwEcYZ
+      - req_OzWVOd5Hl9GDRa
       Stripe-Account:
-      - acct_1Oy1yv4F5rkj3PEw
+      - acct_1P0hvxQKJsxyg7Xm
       Stripe-Version:
       - '2020-08-27'
       Vary:
@@ -428,7 +428,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yx4F5rkj3PEw1YhbcT0d",
+          "id": "pi_3P0hvzQKJsxyg7Xm1F7SlEaz",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -446,7 +446,7 @@ http_interactions:
             "object": "list",
             "data": [
               {
-                "id": "ch_3Oy1yx4F5rkj3PEw1Vhf3wWk",
+                "id": "ch_3P0hvzQKJsxyg7Xm1yaStIBm",
                 "object": "charge",
                 "amount": 1000,
                 "amount_captured": 1000,
@@ -454,7 +454,7 @@ http_interactions:
                 "application": "<HIDDEN-STRIPE_CLIENT_ID>",
                 "application_fee": null,
                 "application_fee_amount": null,
-                "balance_transaction": "txn_3Oy1yx4F5rkj3PEw1RJEP4W1",
+                "balance_transaction": "txn_3P0hvzQKJsxyg7Xm1XuyTg59",
                 "billing_details": {
                   "address": {
                     "city": null,
@@ -470,7 +470,7 @@ http_interactions:
                 },
                 "calculated_statement_descriptor": "OFNOFNOFN",
                 "captured": true,
-                "created": 1711328747,
+                "created": 1711966667,
                 "currency": "aud",
                 "customer": null,
                 "description": null,
@@ -490,13 +490,13 @@ http_interactions:
                   "network_status": "approved_by_network",
                   "reason": null,
                   "risk_level": "normal",
-                  "risk_score": 23,
+                  "risk_score": 27,
                   "seller_message": "Payment complete.",
                   "type": "authorized"
                 },
                 "paid": true,
-                "payment_intent": "pi_3Oy1yx4F5rkj3PEw1YhbcT0d",
-                "payment_method": "pm_1Oy1yx4F5rkj3PEw261B4212",
+                "payment_intent": "pi_3P0hvzQKJsxyg7Xm1F7SlEaz",
+                "payment_method": "pm_1P0hvzQKJsxyg7Xmcm9nKHkF",
                 "payment_method_details": {
                   "card": {
                     "amount_authorized": 1000,
@@ -507,7 +507,7 @@ http_interactions:
                       "cvc_check": "pass"
                     },
                     "country": "US",
-                    "exp_month": 3,
+                    "exp_month": 4,
                     "exp_year": 2025,
                     "extended_authorization": {
                       "status": "disabled"
@@ -539,14 +539,14 @@ http_interactions:
                 "radar_options": {},
                 "receipt_email": null,
                 "receipt_number": null,
-                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xT3kxeXY0RjVya2ozUEV3KOybg7AGMgaMaiL5f1M6LBZ2TPdfjQZaJju4Svv3eQ2CAa-uzyn94c8BQ_w3LTF76p1LiyHr0_r8sLqu",
+                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xUDBodnhRS0pzeHlnN1htKMyTqrAGMgagIC1dC4g6LBa_RnE4t8Z6RFw7z5iNrtCxFgz1qsdSgfljLtBrigjEcUqEye-Ykf5_ujwB",
                 "refunded": false,
                 "refunds": {
                   "object": "list",
                   "data": [],
                   "has_more": false,
                   "total_count": 0,
-                  "url": "/v1/charges/ch_3Oy1yx4F5rkj3PEw1Vhf3wWk/refunds"
+                  "url": "/v1/charges/ch_3P0hvzQKJsxyg7Xm1yaStIBm/refunds"
                 },
                 "review": null,
                 "shipping": null,
@@ -561,22 +561,22 @@ http_interactions:
             ],
             "has_more": false,
             "total_count": 1,
-            "url": "/v1/charges?payment_intent=pi_3Oy1yx4F5rkj3PEw1YhbcT0d"
+            "url": "/v1/charges?payment_intent=pi_3P0hvzQKJsxyg7Xm1F7SlEaz"
           },
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328747,
+          "created": 1711966667,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1yx4F5rkj3PEw1Vhf3wWk",
+          "latest_charge": "ch_3P0hvzQKJsxyg7Xm1yaStIBm",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yx4F5rkj3PEw261B4212",
+          "payment_method": "pm_1P0hvzQKJsxyg7Xmcm9nKHkF",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -601,10 +601,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:48 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:48 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/charges/ch_3Oy1yx4F5rkj3PEw1Vhf3wWk/refunds
+    uri: https://api.stripe.com/v1/charges/ch_3P0hvzQKJsxyg7Xm1yaStIBm/refunds
     body:
       encoding: UTF-8
       string: amount=1000&expand[0]=charge
@@ -622,7 +622,7 @@ http_interactions:
       X-Stripe-Client-User-Metadata:
       - '{"ip":null}'
       Stripe-Account:
-      - acct_1Oy1yv4F5rkj3PEw
+      - acct_1P0hvxQKJsxyg7Xm
       Connection:
       - close
       Accept-Encoding:
@@ -637,7 +637,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:49 GMT
+      - Mon, 01 Apr 2024 10:17:50 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -665,17 +665,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 25ab8e5d-7c88-4922-808b-5ae9f8599b9e
+      - f3a27053-08a2-48a4-9365-8be0a2640a99
       Original-Request:
-      - req_pu08Uov3va360O
+      - req_HsA2oPctvXOzHJ
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_pu08Uov3va360O
+      - req_HsA2oPctvXOzHJ
       Stripe-Account:
-      - acct_1Oy1yv4F5rkj3PEw
+      - acct_1P0hvxQKJsxyg7Xm
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -690,12 +690,12 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "re_3Oy1yx4F5rkj3PEw1pr5QKNw",
+          "id": "re_3P0hvzQKJsxyg7Xm1vh5ClXr",
           "object": "refund",
           "amount": 1000,
-          "balance_transaction": "txn_3Oy1yx4F5rkj3PEw1sPm1vqA",
+          "balance_transaction": "txn_3P0hvzQKJsxyg7Xm1X7XsjkF",
           "charge": {
-            "id": "ch_3Oy1yx4F5rkj3PEw1Vhf3wWk",
+            "id": "ch_3P0hvzQKJsxyg7Xm1yaStIBm",
             "object": "charge",
             "amount": 1000,
             "amount_captured": 1000,
@@ -703,7 +703,7 @@ http_interactions:
             "application": "<HIDDEN-STRIPE_CLIENT_ID>",
             "application_fee": null,
             "application_fee_amount": null,
-            "balance_transaction": "txn_3Oy1yx4F5rkj3PEw1RJEP4W1",
+            "balance_transaction": "txn_3P0hvzQKJsxyg7Xm1XuyTg59",
             "billing_details": {
               "address": {
                 "city": null,
@@ -719,7 +719,7 @@ http_interactions:
             },
             "calculated_statement_descriptor": "OFNOFNOFN",
             "captured": true,
-            "created": 1711328747,
+            "created": 1711966667,
             "currency": "aud",
             "customer": null,
             "description": null,
@@ -739,13 +739,13 @@ http_interactions:
               "network_status": "approved_by_network",
               "reason": null,
               "risk_level": "normal",
-              "risk_score": 23,
+              "risk_score": 27,
               "seller_message": "Payment complete.",
               "type": "authorized"
             },
             "paid": true,
-            "payment_intent": "pi_3Oy1yx4F5rkj3PEw1YhbcT0d",
-            "payment_method": "pm_1Oy1yx4F5rkj3PEw261B4212",
+            "payment_intent": "pi_3P0hvzQKJsxyg7Xm1F7SlEaz",
+            "payment_method": "pm_1P0hvzQKJsxyg7Xmcm9nKHkF",
             "payment_method_details": {
               "card": {
                 "amount_authorized": 1000,
@@ -756,7 +756,7 @@ http_interactions:
                   "cvc_check": "pass"
                 },
                 "country": "US",
-                "exp_month": 3,
+                "exp_month": 4,
                 "exp_year": 2025,
                 "extended_authorization": {
                   "status": "disabled"
@@ -788,18 +788,18 @@ http_interactions:
             "radar_options": {},
             "receipt_email": null,
             "receipt_number": null,
-            "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xT3kxeXY0RjVya2ozUEV3KO2bg7AGMgaJ23TFQt46LBZayXOJnAJj1AORS9kJ4pQz9jm6LgdQlAVDoKDuAeQsLO335SflS3n6K1ac",
+            "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xUDBodnhRS0pzeHlnN1htKM2TqrAGMgYOp7ktBPI6LBa3drlCvWCNQIXREBHiFbU5feoRc9WpEoK6xto6d5jvytb__krblV-onUHu",
             "refunded": true,
             "refunds": {
               "object": "list",
               "data": [
                 {
-                  "id": "re_3Oy1yx4F5rkj3PEw1pr5QKNw",
+                  "id": "re_3P0hvzQKJsxyg7Xm1vh5ClXr",
                   "object": "refund",
                   "amount": 1000,
-                  "balance_transaction": "txn_3Oy1yx4F5rkj3PEw1sPm1vqA",
-                  "charge": "ch_3Oy1yx4F5rkj3PEw1Vhf3wWk",
-                  "created": 1711328749,
+                  "balance_transaction": "txn_3P0hvzQKJsxyg7Xm1X7XsjkF",
+                  "charge": "ch_3P0hvzQKJsxyg7Xm1yaStIBm",
+                  "created": 1711966669,
                   "currency": "aud",
                   "destination_details": {
                     "card": {
@@ -810,7 +810,7 @@ http_interactions:
                     "type": "card"
                   },
                   "metadata": {},
-                  "payment_intent": "pi_3Oy1yx4F5rkj3PEw1YhbcT0d",
+                  "payment_intent": "pi_3P0hvzQKJsxyg7Xm1F7SlEaz",
                   "reason": null,
                   "receipt_number": null,
                   "source_transfer_reversal": null,
@@ -820,7 +820,7 @@ http_interactions:
               ],
               "has_more": false,
               "total_count": 1,
-              "url": "/v1/charges/ch_3Oy1yx4F5rkj3PEw1Vhf3wWk/refunds"
+              "url": "/v1/charges/ch_3P0hvzQKJsxyg7Xm1yaStIBm/refunds"
             },
             "review": null,
             "shipping": null,
@@ -832,7 +832,7 @@ http_interactions:
             "transfer_data": null,
             "transfer_group": null
           },
-          "created": 1711328749,
+          "created": 1711966669,
           "currency": "aud",
           "destination_details": {
             "card": {
@@ -843,12 +843,94 @@ http_interactions:
             "type": "card"
           },
           "metadata": {},
-          "payment_intent": "pi_3Oy1yx4F5rkj3PEw1YhbcT0d",
+          "payment_intent": "pi_3P0hvzQKJsxyg7Xm1F7SlEaz",
           "reason": null,
           "receipt_number": null,
           "source_transfer_reversal": null,
           "status": "succeeded",
           "transfer_reversal": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:50 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:49 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0hvxQKJsxyg7Xm
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_dBgFusE0TKXqtN","request_duration_ms":1488}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_Vxcx1VoZ2gIpT7
+      Stripe-Account:
+      - acct_1P0hvxQKJsxyg7Xm
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hvxQKJsxyg7Xm",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:50 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_error_message/when_payment_intent_state_is_not_in_requires_capture_state/does_not_succeed_if_payment_intent_state_is_not_requires_capture.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_error_message/when_payment_intent_state_is_not_in_requires_capture_state/does_not_succeed_if_payment_intent_state_is_not_requires_capture.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_pRlYz5pzWyveLX","request_duration_ms":1291}}'
+      - '{"last_request_metrics":{"request_id":"req_Vxcx1VoZ2gIpT7","request_duration_ms":1065}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:50 GMT
+      - Mon, 01 Apr 2024 10:17:52 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -63,7 +63,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_iMg6LHEnZ3xXaK
+      - req_9uqqs0dhQujm9Z
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -76,7 +76,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1z0KuuB1fWySnpjyW7Sjh",
+          "id": "pm_1P0hw4KuuB1fWySntDFvCnCW",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -100,7 +100,7 @@ http_interactions:
             },
             "country": "US",
             "display_brand": "mastercard",
-            "exp_month": 3,
+            "exp_month": 4,
             "exp_year": 2025,
             "fingerprint": "BL35fEFVcTTS5wpE",
             "funding": "credit",
@@ -117,19 +117,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328750,
+          "created": 1711966672,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:50 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:52 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=1000&currency=aud&payment_method=pm_1Oy1z0KuuB1fWySnpjyW7Sjh&payment_method_types[0]=card&capture_method=manual
+      string: amount=1000&currency=aud&payment_method=pm_1P0hw4KuuB1fWySntDFvCnCW&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.13.0
@@ -138,7 +138,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_iMg6LHEnZ3xXaK","request_duration_ms":404}}'
+      - '{"last_request_metrics":{"request_id":"req_9uqqs0dhQujm9Z","request_duration_ms":360}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -155,7 +155,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:51 GMT
+      - Mon, 01 Apr 2024 10:17:53 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,15 +182,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 2e298eb3-1328-4573-a56a-e5d9958af72c
+      - 4ecbe95a-3ec0-4337-b19e-7e175451cfd1
       Original-Request:
-      - req_Zoer1zzHRH2OxX
+      - req_d7SbxDw4JbGPV6
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_Zoer1zzHRH2OxX
+      - req_d7SbxDw4JbGPV6
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -205,7 +205,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1z1KuuB1fWySn0TuzQTHS",
+          "id": "pi_3P0hw5KuuB1fWySn2nvrAGCL",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -221,7 +221,7 @@ http_interactions:
           "capture_method": "manual",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328751,
+          "created": 1711966673,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -232,7 +232,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1z0KuuB1fWySnpjyW7Sjh",
+          "payment_method": "pm_1P0hw4KuuB1fWySntDFvCnCW",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -257,10 +257,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:51 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:52 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1z1KuuB1fWySn0TuzQTHS
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0hw5KuuB1fWySn2nvrAGCL
     body:
       encoding: US-ASCII
       string: ''
@@ -272,7 +272,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_Zoer1zzHRH2OxX","request_duration_ms":426}}'
+      - '{"last_request_metrics":{"request_id":"req_d7SbxDw4JbGPV6","request_duration_ms":512}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -289,7 +289,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:51 GMT
+      - Mon, 01 Apr 2024 10:17:53 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -321,7 +321,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_YyXcj9K9FRIiNe
+      - req_DqIecKV3qULNG7
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -334,7 +334,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1z1KuuB1fWySn0TuzQTHS",
+          "id": "pi_3P0hw5KuuB1fWySn2nvrAGCL",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -350,7 +350,7 @@ http_interactions:
           "capture_method": "manual",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328751,
+          "created": 1711966673,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -361,7 +361,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1z0KuuB1fWySnpjyW7Sjh",
+          "payment_method": "pm_1P0hw4KuuB1fWySntDFvCnCW",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -386,5 +386,297 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:51 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:53 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=standard&country=AU&email=carrot.producer%40example.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_DqIecKV3qULNG7","request_duration_ms":304}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3046'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - e81ed6ab-996f-42b6-9da3-4682aead8558
+      Original-Request:
+      - req_EDPibXlowchAvO
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_EDPibXlowchAvO
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hw5QT9u0FYInb",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "name": null,
+            "product_description": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": null
+          },
+          "business_type": null,
+          "capabilities": {},
+          "charges_enabled": false,
+          "controller": {
+            "is_controller": true,
+            "type": "application"
+          },
+          "country": "AU",
+          "created": 1711966674,
+          "default_currency": "aud",
+          "details_submitted": false,
+          "email": "carrot.producer@example.com",
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1P0hw5QT9u0FYInb/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {},
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "past_due": [
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": null,
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": null,
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null
+            },
+            "payments": {
+              "statement_descriptor": null,
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "type": "standard"
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:54 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0hw5QT9u0FYInb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_EDPibXlowchAvO","request_duration_ms":1590}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_THI2PVqc1ZJrFQ
+      Stripe-Account:
+      - acct_1P0hw5QT9u0FYInb
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hw5QT9u0FYInb",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:55 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_external_payment_url/calls_Checkout_StripeRedirect.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_external_payment_url/calls_Checkout_StripeRedirect.yml
@@ -1,0 +1,295 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=standard&country=AU&email=carrot.producer%40example.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_qGbRhQRLinAVWB","request_duration_ms":900}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:18:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3046'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 94670b1e-5595-43bd-8cc3-1b099c613d59
+      Original-Request:
+      - req_sZR0zGRpMmvqd6
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_sZR0zGRpMmvqd6
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hwD4EE19S9Esd",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "name": null,
+            "product_description": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": null
+          },
+          "business_type": null,
+          "capabilities": {},
+          "charges_enabled": false,
+          "controller": {
+            "is_controller": true,
+            "type": "application"
+          },
+          "country": "AU",
+          "created": 1711966681,
+          "default_currency": "aud",
+          "details_submitted": false,
+          "email": "carrot.producer@example.com",
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1P0hwD4EE19S9Esd/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {},
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "past_due": [
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": null,
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": null,
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null
+            },
+            "payments": {
+              "statement_descriptor": null,
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "type": "standard"
+        }
+  recorded_at: Mon, 01 Apr 2024 10:18:02 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0hwD4EE19S9Esd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_sZR0zGRpMmvqd6","request_duration_ms":1798}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:18:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_6J3hXuJ4aUNNqR
+      Stripe-Account:
+      - acct_1P0hwD4EE19S9Esd
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hwD4EE19S9Esd",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:18:03 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_external_payment_url/returns_nil_when_an_order_is_not_supplied.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_external_payment_url/returns_nil_when_an_order_is_not_supplied.yml
@@ -1,0 +1,295 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=standard&country=AU&email=carrot.producer%40example.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_THI2PVqc1ZJrFQ","request_duration_ms":925}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3046'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - f82c1fbd-6ae1-4f50-88d9-fe10d7cba328
+      Original-Request:
+      - req_utR5hUFKEPNNWO
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_utR5hUFKEPNNWO
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hw8QLyaBty4VB",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "name": null,
+            "product_description": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": null
+          },
+          "business_type": null,
+          "capabilities": {},
+          "charges_enabled": false,
+          "controller": {
+            "is_controller": true,
+            "type": "application"
+          },
+          "country": "AU",
+          "created": 1711966677,
+          "default_currency": "aud",
+          "details_submitted": false,
+          "email": "carrot.producer@example.com",
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1P0hw8QLyaBty4VB/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {},
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "past_due": [
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": null,
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": null,
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null
+            },
+            "payments": {
+              "statement_descriptor": null,
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "type": "standard"
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:57 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0hw8QLyaBty4VB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_utR5hUFKEPNNWO","request_duration_ms":1921}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_qGbRhQRLinAVWB
+      Stripe-Account:
+      - acct_1P0hw8QLyaBty4VB
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hw8QLyaBty4VB",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:58 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_purchase/completes_the_purchase.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_purchase/completes_the_purchase.yml
@@ -13,8 +13,6 @@ http_interactions:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       Content-Type:
       - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_TY7Hi7GZqE85NM","request_duration_ms":613}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:29 GMT
+      - Mon, 01 Apr 2024 10:17:14 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -63,7 +61,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_eZZ7HmOnmCs18p
+      - req_NROkvnMh04rWQN
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -76,7 +74,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1yfKuuB1fWySnmSknGVrY",
+          "id": "pm_1P0hvSKuuB1fWySnJ7tz7AJK",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -100,7 +98,7 @@ http_interactions:
             },
             "country": "US",
             "display_brand": "mastercard",
-            "exp_month": 3,
+            "exp_month": 4,
             "exp_year": 2025,
             "fingerprint": "BL35fEFVcTTS5wpE",
             "funding": "credit",
@@ -117,19 +115,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328729,
+          "created": 1711966634,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:29 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:13 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=1000&currency=aud&payment_method=pm_1Oy1yfKuuB1fWySnmSknGVrY&payment_method_types[0]=card&capture_method=manual
+      string: amount=1000&currency=aud&payment_method=pm_1P0hvSKuuB1fWySnJ7tz7AJK&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.13.0
@@ -138,7 +136,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_eZZ7HmOnmCs18p","request_duration_ms":331}}'
+      - '{"last_request_metrics":{"request_id":"req_NROkvnMh04rWQN","request_duration_ms":654}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -155,7 +153,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:30 GMT
+      - Mon, 01 Apr 2024 10:17:14 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,15 +180,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - f9dff413-6eeb-427c-b053-375ee1ba6348
+      - cba76d31-80ee-43f3-8ed7-82050651941a
       Original-Request:
-      - req_2BnlYiEOCRE4wl
+      - req_KE257bfb4pCgy9
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_2BnlYiEOCRE4wl
+      - req_KE257bfb4pCgy9
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -205,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yfKuuB1fWySn07fsNcfd",
+          "id": "pi_3P0hvSKuuB1fWySn0RNbGSBR",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -221,7 +219,7 @@ http_interactions:
           "capture_method": "manual",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328729,
+          "created": 1711966634,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -232,7 +230,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yfKuuB1fWySnmSknGVrY",
+          "payment_method": "pm_1P0hvSKuuB1fWySnJ7tz7AJK",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -257,10 +255,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:30 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:14 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1yfKuuB1fWySn07fsNcfd/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0hvSKuuB1fWySn0RNbGSBR/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -272,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_2BnlYiEOCRE4wl","request_duration_ms":437}}'
+      - '{"last_request_metrics":{"request_id":"req_KE257bfb4pCgy9","request_duration_ms":611}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -289,7 +287,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:31 GMT
+      - Mon, 01 Apr 2024 10:17:15 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -317,15 +315,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - aad0cb30-9cbb-405b-8575-361f1512e6dc
+      - df6fa1d7-7c63-4c89-8482-e6a3c7b761d5
       Original-Request:
-      - req_SIi15R2Jjn8PLO
+      - req_hZkVWHrm7BBut4
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_SIi15R2Jjn8PLO
+      - req_hZkVWHrm7BBut4
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -340,7 +338,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yfKuuB1fWySn07fsNcfd",
+          "id": "pi_3P0hvSKuuB1fWySn0RNbGSBR",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 1000,
@@ -356,18 +354,18 @@ http_interactions:
           "capture_method": "manual",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328729,
+          "created": 1711966634,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1yfKuuB1fWySn0iqzx5ZJ",
+          "latest_charge": "ch_3P0hvSKuuB1fWySn01aUEw8a",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yfKuuB1fWySnmSknGVrY",
+          "payment_method": "pm_1P0hvSKuuB1fWySnJ7tz7AJK",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -392,10 +390,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:31 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:15 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1yfKuuB1fWySn07fsNcfd
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0hvSKuuB1fWySn0RNbGSBR
     body:
       encoding: US-ASCII
       string: ''
@@ -407,7 +405,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_SIi15R2Jjn8PLO","request_duration_ms":984}}'
+      - '{"last_request_metrics":{"request_id":"req_hZkVWHrm7BBut4","request_duration_ms":1040}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -424,7 +422,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:32 GMT
+      - Mon, 01 Apr 2024 10:17:19 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -456,7 +454,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_3bg3h4Aj4t7cN6
+      - req_jzjgc37xM2CuNm
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -469,7 +467,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yfKuuB1fWySn07fsNcfd",
+          "id": "pi_3P0hvSKuuB1fWySn0RNbGSBR",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 1000,
@@ -485,18 +483,18 @@ http_interactions:
           "capture_method": "manual",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328729,
+          "created": 1711966634,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1yfKuuB1fWySn0iqzx5ZJ",
+          "latest_charge": "ch_3P0hvSKuuB1fWySn01aUEw8a",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yfKuuB1fWySnmSknGVrY",
+          "payment_method": "pm_1P0hvSKuuB1fWySnJ7tz7AJK",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -521,10 +519,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:32 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:18 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1yfKuuB1fWySn07fsNcfd/capture
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0hvSKuuB1fWySn0RNbGSBR/capture
     body:
       encoding: UTF-8
       string: amount_to_capture=1000
@@ -555,7 +553,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:33 GMT
+      - Mon, 01 Apr 2024 10:17:20 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -583,15 +581,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 70b9bfad-b75e-4ecf-a3fb-7ba5d0ba4e06
+      - cf45fd92-6c39-4ba7-8fda-da00040a35e6
       Original-Request:
-      - req_zUqaIRoXLSvLQG
+      - req_1PGTPM2HKB09cZ
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_zUqaIRoXLSvLQG
+      - req_1PGTPM2HKB09cZ
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -606,7 +604,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yfKuuB1fWySn07fsNcfd",
+          "id": "pi_3P0hvSKuuB1fWySn0RNbGSBR",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -624,7 +622,7 @@ http_interactions:
             "object": "list",
             "data": [
               {
-                "id": "ch_3Oy1yfKuuB1fWySn0iqzx5ZJ",
+                "id": "ch_3P0hvSKuuB1fWySn01aUEw8a",
                 "object": "charge",
                 "amount": 1000,
                 "amount_captured": 1000,
@@ -633,7 +631,7 @@ http_interactions:
                 "application": null,
                 "application_fee": null,
                 "application_fee_amount": null,
-                "balance_transaction": "txn_3Oy1yfKuuB1fWySn0Bq9IJSm",
+                "balance_transaction": "txn_3P0hvSKuuB1fWySn01bU7GoR",
                 "billing_details": {
                   "address": {
                     "city": null,
@@ -649,7 +647,7 @@ http_interactions:
                 },
                 "calculated_statement_descriptor": "OFNOFNOFN",
                 "captured": true,
-                "created": 1711328730,
+                "created": 1711966635,
                 "currency": "aud",
                 "customer": null,
                 "description": null,
@@ -669,25 +667,25 @@ http_interactions:
                   "network_status": "approved_by_network",
                   "reason": null,
                   "risk_level": "normal",
-                  "risk_score": 49,
+                  "risk_score": 31,
                   "seller_message": "Payment complete.",
                   "type": "authorized"
                 },
                 "paid": true,
-                "payment_intent": "pi_3Oy1yfKuuB1fWySn07fsNcfd",
-                "payment_method": "pm_1Oy1yfKuuB1fWySnmSknGVrY",
+                "payment_intent": "pi_3P0hvSKuuB1fWySn0RNbGSBR",
+                "payment_method": "pm_1P0hvSKuuB1fWySnJ7tz7AJK",
                 "payment_method_details": {
                   "card": {
                     "amount_authorized": 1000,
                     "brand": "mastercard",
-                    "capture_before": 1711933530,
+                    "capture_before": 1712571435,
                     "checks": {
                       "address_line1_check": null,
                       "address_postal_code_check": null,
                       "cvc_check": "pass"
                     },
                     "country": "US",
-                    "exp_month": 3,
+                    "exp_month": 4,
                     "exp_year": 2025,
                     "extended_authorization": {
                       "status": "disabled"
@@ -719,14 +717,14 @@ http_interactions:
                 "radar_options": {},
                 "receipt_email": null,
                 "receipt_number": null,
-                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xRmlxRXNLdXVCMWZXeVNuKN2bg7AGMgarRMEgGRE6LBbWYlBvobC-RPCaTfg6H-aGjj1IIBnFsdXk9cGG0Q6VTECF5RDLFsMxptpV",
+                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xRmlxRXNLdXVCMWZXeVNuKLCTqrAGMgbNvCvIw0g6LBbGTJrRbRYLZ-ydAl2URON7Lqf2q67mw5SMB1ivr6qOAp-39SKNVncDs0Xh",
                 "refunded": false,
                 "refunds": {
                   "object": "list",
                   "data": [],
                   "has_more": false,
                   "total_count": 0,
-                  "url": "/v1/charges/ch_3Oy1yfKuuB1fWySn0iqzx5ZJ/refunds"
+                  "url": "/v1/charges/ch_3P0hvSKuuB1fWySn01aUEw8a/refunds"
                 },
                 "review": null,
                 "shipping": null,
@@ -741,22 +739,22 @@ http_interactions:
             ],
             "has_more": false,
             "total_count": 1,
-            "url": "/v1/charges?payment_intent=pi_3Oy1yfKuuB1fWySn07fsNcfd"
+            "url": "/v1/charges?payment_intent=pi_3P0hvSKuuB1fWySn0RNbGSBR"
           },
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328729,
+          "created": 1711966634,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1yfKuuB1fWySn0iqzx5ZJ",
+          "latest_charge": "ch_3P0hvSKuuB1fWySn01aUEw8a",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yfKuuB1fWySnmSknGVrY",
+          "payment_method": "pm_1P0hvSKuuB1fWySnJ7tz7AJK",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -781,5 +779,297 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:33 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:19 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=standard&country=AU&email=carrot.producer%40example.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_jzjgc37xM2CuNm","request_duration_ms":329}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3046'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - f08fb11b-d34f-43bc-bb7c-6d8d14817f85
+      Original-Request:
+      - req_LtIyyQ5lUErcOZ
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_LtIyyQ5lUErcOZ
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hvY4KTZpW5r5h",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "name": null,
+            "product_description": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": null
+          },
+          "business_type": null,
+          "capabilities": {},
+          "charges_enabled": false,
+          "controller": {
+            "is_controller": true,
+            "type": "application"
+          },
+          "country": "AU",
+          "created": 1711966641,
+          "default_currency": "aud",
+          "details_submitted": false,
+          "email": "carrot.producer@example.com",
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1P0hvY4KTZpW5r5h/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {},
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "past_due": [
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": null,
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": null,
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null
+            },
+            "payments": {
+              "statement_descriptor": null,
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "type": "standard"
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:21 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0hvY4KTZpW5r5h
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_LtIyyQ5lUErcOZ","request_duration_ms":1634}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_FFbh4TJnQI3ZW8
+      Stripe-Account:
+      - acct_1P0hvY4KTZpW5r5h
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hvY4KTZpW5r5h",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:22 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_purchase/provides_an_error_message_to_help_developer_debug.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_purchase/provides_an_error_message_to_help_developer_debug.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_3bg3h4Aj4t7cN6","request_duration_ms":311}}'
+      - '{"last_request_metrics":{"request_id":"req_FFbh4TJnQI3ZW8","request_duration_ms":1118}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:33 GMT
+      - Mon, 01 Apr 2024 10:17:23 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -63,7 +63,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_NVFewBpDrTVLXp
+      - req_Dxle6ambnNzGMR
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -76,7 +76,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1yjKuuB1fWySnumy35WlL",
+          "id": "pm_1P0hvbKuuB1fWySnphwbA46F",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -100,7 +100,7 @@ http_interactions:
             },
             "country": "US",
             "display_brand": "mastercard",
-            "exp_month": 3,
+            "exp_month": 4,
             "exp_year": 2025,
             "fingerprint": "BL35fEFVcTTS5wpE",
             "funding": "credit",
@@ -117,19 +117,19 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328733,
+          "created": 1711966643,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:33 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:23 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=1000&currency=aud&payment_method=pm_1Oy1yjKuuB1fWySnumy35WlL&payment_method_types[0]=card&capture_method=manual
+      string: amount=1000&currency=aud&payment_method=pm_1P0hvbKuuB1fWySnphwbA46F&payment_method_types[0]=card&capture_method=manual
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.13.0
@@ -138,7 +138,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_NVFewBpDrTVLXp","request_duration_ms":436}}'
+      - '{"last_request_metrics":{"request_id":"req_Dxle6ambnNzGMR","request_duration_ms":471}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -155,7 +155,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:34 GMT
+      - Mon, 01 Apr 2024 10:17:24 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -182,15 +182,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - cd07ba15-aa17-4cae-b02d-3b03646f7c8e
+      - 3221df62-1efa-4f68-bc9a-481084dbc0d5
       Original-Request:
-      - req_B7pqiSH8Ga1rGi
+      - req_IFPoshfyuzAtNV
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_B7pqiSH8Ga1rGi
+      - req_IFPoshfyuzAtNV
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -205,7 +205,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1ykKuuB1fWySn2Y4njm2Y",
+          "id": "pi_3P0hvcKuuB1fWySn2qMAW4Pl",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -221,7 +221,7 @@ http_interactions:
           "capture_method": "manual",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328734,
+          "created": 1711966644,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -232,7 +232,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yjKuuB1fWySnumy35WlL",
+          "payment_method": "pm_1P0hvbKuuB1fWySnphwbA46F",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -257,10 +257,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:34 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:23 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1ykKuuB1fWySn2Y4njm2Y/confirm
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0hvcKuuB1fWySn2qMAW4Pl/confirm
     body:
       encoding: US-ASCII
       string: ''
@@ -272,7 +272,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_B7pqiSH8Ga1rGi","request_duration_ms":406}}'
+      - '{"last_request_metrics":{"request_id":"req_IFPoshfyuzAtNV","request_duration_ms":508}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -289,7 +289,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:35 GMT
+      - Mon, 01 Apr 2024 10:17:25 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -317,15 +317,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 024f19c8-d5dd-41f8-989b-d2e44cc8d558
+      - 955a38d6-f683-4ec9-ae3e-745e1aee014c
       Original-Request:
-      - req_nFUn2E3zDuLnka
+      - req_yTVJzIu4xzBdz1
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_nFUn2E3zDuLnka
+      - req_yTVJzIu4xzBdz1
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -340,7 +340,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1ykKuuB1fWySn2Y4njm2Y",
+          "id": "pi_3P0hvcKuuB1fWySn2qMAW4Pl",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 1000,
@@ -356,18 +356,18 @@ http_interactions:
           "capture_method": "manual",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328734,
+          "created": 1711966644,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1ykKuuB1fWySn2b3yc3OQ",
+          "latest_charge": "ch_3P0hvcKuuB1fWySn21gozvRO",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yjKuuB1fWySnumy35WlL",
+          "payment_method": "pm_1P0hvbKuuB1fWySnphwbA46F",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -392,5 +392,297 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:35 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:24 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=standard&country=AU&email=carrot.producer%40example.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yTVJzIu4xzBdz1","request_duration_ms":918}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3046'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 7bf68c6c-e10c-4c16-be41-5223aa78b9f8
+      Original-Request:
+      - req_JIxGPj3qSK72eE
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_JIxGPj3qSK72eE
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hveQMn01RU0IH",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "name": null,
+            "product_description": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": null
+          },
+          "business_type": null,
+          "capabilities": {},
+          "charges_enabled": false,
+          "controller": {
+            "is_controller": true,
+            "type": "application"
+          },
+          "country": "AU",
+          "created": 1711966647,
+          "default_currency": "aud",
+          "details_submitted": false,
+          "email": "carrot.producer@example.com",
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1P0hveQMn01RU0IH/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {},
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "past_due": [
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": null,
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": null,
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null
+            },
+            "payments": {
+              "statement_descriptor": null,
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "type": "standard"
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:27 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0hveQMn01RU0IH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_JIxGPj3qSK72eE","request_duration_ms":1761}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_OR1ot4mPDCrtpe
+      Stripe-Account:
+      - acct_1P0hveQMn01RU0IH
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hveQMn01RU0IH",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:28 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_void/with_a_confirmed_payment/refunds_the_payment.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_void/with_a_confirmed_payment/refunds_the_payment.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_nFUn2E3zDuLnka","request_duration_ms":937}}'
+      - '{"last_request_metrics":{"request_id":"req_OR1ot4mPDCrtpe","request_duration_ms":1014}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:37 GMT
+      - Mon, 01 Apr 2024 10:17:31 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -58,15 +58,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 0b04a96a-3534-43ae-92d5-00c1259d7e11
+      - 3a486fc8-7081-42e5-9448-12eaaab21320
       Original-Request:
-      - req_fbiCnbwzgahDp8
+      - req_JlcagkGgFmf09l
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_fbiCnbwzgahDp8
+      - req_JlcagkGgFmf09l
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -81,7 +81,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1Oy1ylQQBQboho8d",
+          "id": "acct_1P0hvhQOtfYFz63d",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -103,7 +103,7 @@ http_interactions:
             "type": "application"
           },
           "country": "AU",
-          "created": 1711328736,
+          "created": 1711966650,
           "default_currency": "aud",
           "details_submitted": false,
           "email": "carrot.producer@example.com",
@@ -112,7 +112,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1Oy1ylQQBQboho8d/external_accounts"
+            "url": "/v1/accounts/acct_1P0hvhQOtfYFz63d/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -209,7 +209,7 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:37 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:30 GMT
 - request:
     method: get
     uri: https://api.stripe.com/v1/payment_methods/pm_card_mastercard
@@ -224,7 +224,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_fbiCnbwzgahDp8","request_duration_ms":1520}}'
+      - '{"last_request_metrics":{"request_id":"req_JlcagkGgFmf09l","request_duration_ms":1812}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -241,7 +241,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:38 GMT
+      - Mon, 01 Apr 2024 10:17:33 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -273,7 +273,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_jzrkwjOjdTRGXl
+      - req_SD6TmRQwlO8i9h
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -286,7 +286,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1ynKuuB1fWySntoarRMNc",
+          "id": "pm_1P0hvkKuuB1fWySnHhJwKNp0",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -310,7 +310,7 @@ http_interactions:
             },
             "country": "US",
             "display_brand": "mastercard",
-            "exp_month": 3,
+            "exp_month": 4,
             "exp_year": 2025,
             "fingerprint": "BL35fEFVcTTS5wpE",
             "funding": "credit",
@@ -327,13 +327,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328737,
+          "created": 1711966653,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:38 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:32 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
@@ -348,13 +348,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jzrkwjOjdTRGXl","request_duration_ms":366}}'
+      - '{"last_request_metrics":{"request_id":"req_SD6TmRQwlO8i9h","request_duration_ms":395}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1ylQQBQboho8d
+      - acct_1P0hvhQOtfYFz63d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -367,7 +367,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:39 GMT
+      - Mon, 01 Apr 2024 10:17:34 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -394,17 +394,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - fd896ded-8114-4db7-8ae9-7521f6de7207
+      - 8929364e-fcee-4841-bf21-90286e78e8cf
       Original-Request:
-      - req_YcdwGwp3R1roTq
+      - req_Jooh4BEh09MmaC
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_YcdwGwp3R1roTq
+      - req_Jooh4BEh09MmaC
       Stripe-Account:
-      - acct_1Oy1ylQQBQboho8d
+      - acct_1P0hvhQOtfYFz63d
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -419,7 +419,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yoQQBQboho8d1GzK0RmL",
+          "id": "pi_3P0hvlQOtfYFz63d1S3oHL1K",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -435,18 +435,18 @@ http_interactions:
           "capture_method": "automatic",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328738,
+          "created": 1711966653,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1yoQQBQboho8d1P02xOfr",
+          "latest_charge": "ch_3P0hvlQOtfYFz63d17W6Uk5o",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yoQQBQboho8dX6fOZSS0",
+          "payment_method": "pm_1P0hvlQOtfYFz63d4BUPS5Hy",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -471,10 +471,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:39 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:33 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1yoQQBQboho8d1GzK0RmL
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0hvlQOtfYFz63d1S3oHL1K
     body:
       encoding: US-ASCII
       string: ''
@@ -486,13 +486,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_YcdwGwp3R1roTq","request_duration_ms":1425}}'
+      - '{"last_request_metrics":{"request_id":"req_Jooh4BEh09MmaC","request_duration_ms":1489}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1ylQQBQboho8d
+      - acct_1P0hvhQOtfYFz63d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -505,7 +505,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:39 GMT
+      - Mon, 01 Apr 2024 10:17:35 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -537,9 +537,9 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_B8HQtwXofAuAud
+      - req_TjPcCKrV0d7ymx
       Stripe-Account:
-      - acct_1Oy1ylQQBQboho8d
+      - acct_1P0hvhQOtfYFz63d
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -552,7 +552,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yoQQBQboho8d1GzK0RmL",
+          "id": "pi_3P0hvlQOtfYFz63d1S3oHL1K",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -568,18 +568,18 @@ http_interactions:
           "capture_method": "automatic",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328738,
+          "created": 1711966653,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1yoQQBQboho8d1P02xOfr",
+          "latest_charge": "ch_3P0hvlQOtfYFz63d17W6Uk5o",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yoQQBQboho8dX6fOZSS0",
+          "payment_method": "pm_1P0hvlQOtfYFz63d4BUPS5Hy",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -604,10 +604,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:39 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:34 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1yoQQBQboho8d1GzK0RmL
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0hvlQOtfYFz63d1S3oHL1K
     body:
       encoding: US-ASCII
       string: ''
@@ -623,7 +623,7 @@ http_interactions:
       X-Stripe-Client-User-Metadata:
       - '{"ip":null}'
       Stripe-Account:
-      - acct_1Oy1ylQQBQboho8d
+      - acct_1P0hvhQOtfYFz63d
       Connection:
       - close
       Accept-Encoding:
@@ -638,11 +638,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:40 GMT
+      - Mon, 01 Apr 2024 10:17:35 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '5159'
+      - '5160'
       Connection:
       - close
       Access-Control-Allow-Credentials:
@@ -670,9 +670,9 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_CSd4rWimSuXsi1
+      - req_KPSoGkE7nvNfqA
       Stripe-Account:
-      - acct_1Oy1ylQQBQboho8d
+      - acct_1P0hvhQOtfYFz63d
       Stripe-Version:
       - '2020-08-27'
       Vary:
@@ -685,7 +685,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yoQQBQboho8d1GzK0RmL",
+          "id": "pi_3P0hvlQOtfYFz63d1S3oHL1K",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -703,7 +703,7 @@ http_interactions:
             "object": "list",
             "data": [
               {
-                "id": "ch_3Oy1yoQQBQboho8d1P02xOfr",
+                "id": "ch_3P0hvlQOtfYFz63d17W6Uk5o",
                 "object": "charge",
                 "amount": 1000,
                 "amount_captured": 1000,
@@ -711,7 +711,7 @@ http_interactions:
                 "application": "<HIDDEN-STRIPE_CLIENT_ID>",
                 "application_fee": null,
                 "application_fee_amount": null,
-                "balance_transaction": "txn_3Oy1yoQQBQboho8d1aY0Geov",
+                "balance_transaction": "txn_3P0hvlQOtfYFz63d14KNEbJT",
                 "billing_details": {
                   "address": {
                     "city": null,
@@ -727,7 +727,7 @@ http_interactions:
                 },
                 "calculated_statement_descriptor": "OFNOFNOFN",
                 "captured": true,
-                "created": 1711328738,
+                "created": 1711966653,
                 "currency": "aud",
                 "customer": null,
                 "description": null,
@@ -747,13 +747,13 @@ http_interactions:
                   "network_status": "approved_by_network",
                   "reason": null,
                   "risk_level": "normal",
-                  "risk_score": 2,
+                  "risk_score": 51,
                   "seller_message": "Payment complete.",
                   "type": "authorized"
                 },
                 "paid": true,
-                "payment_intent": "pi_3Oy1yoQQBQboho8d1GzK0RmL",
-                "payment_method": "pm_1Oy1yoQQBQboho8dX6fOZSS0",
+                "payment_intent": "pi_3P0hvlQOtfYFz63d1S3oHL1K",
+                "payment_method": "pm_1P0hvlQOtfYFz63d4BUPS5Hy",
                 "payment_method_details": {
                   "card": {
                     "amount_authorized": 1000,
@@ -764,7 +764,7 @@ http_interactions:
                       "cvc_check": "pass"
                     },
                     "country": "US",
-                    "exp_month": 3,
+                    "exp_month": 4,
                     "exp_year": 2025,
                     "extended_authorization": {
                       "status": "disabled"
@@ -796,14 +796,14 @@ http_interactions:
                 "radar_options": {},
                 "receipt_email": null,
                 "receipt_number": null,
-                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xT3kxeWxRUUJRYm9obzhkKOSbg7AGMgYWZlW4LmE6LBaCWIdCdCzIKdxrS5MSExre106gKftLKUN-aiDzhCA03iHuNiBaMnIN2AfB",
+                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xUDBodmhRT3RmWUZ6NjNkKL-TqrAGMgb4Lds_0ZM6LBbjEEGODjni8tWktObzq-jhec7I_Q_T-kMGRTOWbdfl6e3_dhFPfEzDinAN",
                 "refunded": false,
                 "refunds": {
                   "object": "list",
                   "data": [],
                   "has_more": false,
                   "total_count": 0,
-                  "url": "/v1/charges/ch_3Oy1yoQQBQboho8d1P02xOfr/refunds"
+                  "url": "/v1/charges/ch_3P0hvlQOtfYFz63d17W6Uk5o/refunds"
                 },
                 "review": null,
                 "shipping": null,
@@ -818,22 +818,22 @@ http_interactions:
             ],
             "has_more": false,
             "total_count": 1,
-            "url": "/v1/charges?payment_intent=pi_3Oy1yoQQBQboho8d1GzK0RmL"
+            "url": "/v1/charges?payment_intent=pi_3P0hvlQOtfYFz63d1S3oHL1K"
           },
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328738,
+          "created": 1711966653,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1yoQQBQboho8d1P02xOfr",
+          "latest_charge": "ch_3P0hvlQOtfYFz63d17W6Uk5o",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yoQQBQboho8dX6fOZSS0",
+          "payment_method": "pm_1P0hvlQOtfYFz63d4BUPS5Hy",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -858,10 +858,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:40 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:34 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/charges/ch_3Oy1yoQQBQboho8d1P02xOfr/refunds
+    uri: https://api.stripe.com/v1/charges/ch_3P0hvlQOtfYFz63d17W6Uk5o/refunds
     body:
       encoding: UTF-8
       string: amount=1000&expand[0]=charge
@@ -879,7 +879,7 @@ http_interactions:
       X-Stripe-Client-User-Metadata:
       - '{"ip":null}'
       Stripe-Account:
-      - acct_1Oy1ylQQBQboho8d
+      - acct_1P0hvhQOtfYFz63d
       Connection:
       - close
       Accept-Encoding:
@@ -894,11 +894,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:41 GMT
+      - Mon, 01 Apr 2024 10:17:36 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '4535'
+      - '4536'
       Connection:
       - close
       Access-Control-Allow-Credentials:
@@ -922,17 +922,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 1ee8c9cd-d52a-4415-9d08-341e29679f82
+      - 9405517c-b17a-403c-8ad0-0f46c69764f4
       Original-Request:
-      - req_iGUFWRqGFSqPnf
+      - req_0VkhDqHi0ceRgK
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_iGUFWRqGFSqPnf
+      - req_0VkhDqHi0ceRgK
       Stripe-Account:
-      - acct_1Oy1ylQQBQboho8d
+      - acct_1P0hvhQOtfYFz63d
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -947,12 +947,12 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "re_3Oy1yoQQBQboho8d19AcpLS8",
+          "id": "re_3P0hvlQOtfYFz63d1RyMfZ9w",
           "object": "refund",
           "amount": 1000,
-          "balance_transaction": "txn_3Oy1yoQQBQboho8d1ObNoNSy",
+          "balance_transaction": "txn_3P0hvlQOtfYFz63d1ZPMfDM4",
           "charge": {
-            "id": "ch_3Oy1yoQQBQboho8d1P02xOfr",
+            "id": "ch_3P0hvlQOtfYFz63d17W6Uk5o",
             "object": "charge",
             "amount": 1000,
             "amount_captured": 1000,
@@ -960,7 +960,7 @@ http_interactions:
             "application": "<HIDDEN-STRIPE_CLIENT_ID>",
             "application_fee": null,
             "application_fee_amount": null,
-            "balance_transaction": "txn_3Oy1yoQQBQboho8d1aY0Geov",
+            "balance_transaction": "txn_3P0hvlQOtfYFz63d14KNEbJT",
             "billing_details": {
               "address": {
                 "city": null,
@@ -976,7 +976,7 @@ http_interactions:
             },
             "calculated_statement_descriptor": "OFNOFNOFN",
             "captured": true,
-            "created": 1711328738,
+            "created": 1711966653,
             "currency": "aud",
             "customer": null,
             "description": null,
@@ -996,13 +996,13 @@ http_interactions:
               "network_status": "approved_by_network",
               "reason": null,
               "risk_level": "normal",
-              "risk_score": 2,
+              "risk_score": 51,
               "seller_message": "Payment complete.",
               "type": "authorized"
             },
             "paid": true,
-            "payment_intent": "pi_3Oy1yoQQBQboho8d1GzK0RmL",
-            "payment_method": "pm_1Oy1yoQQBQboho8dX6fOZSS0",
+            "payment_intent": "pi_3P0hvlQOtfYFz63d1S3oHL1K",
+            "payment_method": "pm_1P0hvlQOtfYFz63d4BUPS5Hy",
             "payment_method_details": {
               "card": {
                 "amount_authorized": 1000,
@@ -1013,7 +1013,7 @@ http_interactions:
                   "cvc_check": "pass"
                 },
                 "country": "US",
-                "exp_month": 3,
+                "exp_month": 4,
                 "exp_year": 2025,
                 "extended_authorization": {
                   "status": "disabled"
@@ -1045,18 +1045,18 @@ http_interactions:
             "radar_options": {},
             "receipt_email": null,
             "receipt_number": null,
-            "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xT3kxeWxRUUJRYm9obzhkKOWbg7AGMgbrN7C25Bw6LBZsWKcrRKE1SQAGSnUvwwx9RlR5zavtd_dD_C0rb-R5ddUmv4GzOFn_NcG1",
+            "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xUDBodmhRT3RmWUZ6NjNkKMCTqrAGMgbyY5RUFRk6LBaT3wmNFdytmSSbdRYuUMdycJATyR94mCeZ-emUTnJlAObM_RmUJl9XBnk_",
             "refunded": true,
             "refunds": {
               "object": "list",
               "data": [
                 {
-                  "id": "re_3Oy1yoQQBQboho8d19AcpLS8",
+                  "id": "re_3P0hvlQOtfYFz63d1RyMfZ9w",
                   "object": "refund",
                   "amount": 1000,
-                  "balance_transaction": "txn_3Oy1yoQQBQboho8d1ObNoNSy",
-                  "charge": "ch_3Oy1yoQQBQboho8d1P02xOfr",
-                  "created": 1711328740,
+                  "balance_transaction": "txn_3P0hvlQOtfYFz63d1ZPMfDM4",
+                  "charge": "ch_3P0hvlQOtfYFz63d17W6Uk5o",
+                  "created": 1711966656,
                   "currency": "aud",
                   "destination_details": {
                     "card": {
@@ -1067,7 +1067,7 @@ http_interactions:
                     "type": "card"
                   },
                   "metadata": {},
-                  "payment_intent": "pi_3Oy1yoQQBQboho8d1GzK0RmL",
+                  "payment_intent": "pi_3P0hvlQOtfYFz63d1S3oHL1K",
                   "reason": null,
                   "receipt_number": null,
                   "source_transfer_reversal": null,
@@ -1077,7 +1077,7 @@ http_interactions:
               ],
               "has_more": false,
               "total_count": 1,
-              "url": "/v1/charges/ch_3Oy1yoQQBQboho8d1P02xOfr/refunds"
+              "url": "/v1/charges/ch_3P0hvlQOtfYFz63d17W6Uk5o/refunds"
             },
             "review": null,
             "shipping": null,
@@ -1089,7 +1089,7 @@ http_interactions:
             "transfer_data": null,
             "transfer_group": null
           },
-          "created": 1711328740,
+          "created": 1711966656,
           "currency": "aud",
           "destination_details": {
             "card": {
@@ -1100,12 +1100,94 @@ http_interactions:
             "type": "card"
           },
           "metadata": {},
-          "payment_intent": "pi_3Oy1yoQQBQboho8d1GzK0RmL",
+          "payment_intent": "pi_3P0hvlQOtfYFz63d1S3oHL1K",
           "reason": null,
           "receipt_number": null,
           "source_transfer_reversal": null,
           "status": "succeeded",
           "transfer_reversal": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:41 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:36 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0hvhQOtfYFz63d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_TjPcCKrV0d7ymx","request_duration_ms":304}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_hKiCpXqUl16Kl8
+      Stripe-Account:
+      - acct_1P0hvhQOtfYFz63d
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hvhQOtfYFz63d",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:37 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_void/with_a_voidable_payment/void_the_payment.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Spree_Gateway_StripeSCA/_void/with_a_voidable_payment/void_the_payment.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_B8HQtwXofAuAud","request_duration_ms":315}}'
+      - '{"last_request_metrics":{"request_id":"req_hKiCpXqUl16Kl8","request_duration_ms":1787}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:43 GMT
+      - Mon, 01 Apr 2024 10:17:40 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -58,15 +58,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - e0d95ab9-e759-44f9-953b-42a1b5039ee5
+      - 14264278-d788-4d2e-ad3d-0117eb363c3c
       Original-Request:
-      - req_phH4XQSJYj98Br
+      - req_LHu8cqhZqgQMUJ
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_phH4XQSJYj98Br
+      - req_LHu8cqhZqgQMUJ
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -81,7 +81,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1Oy1yr4JZbvxnQxx",
+          "id": "acct_1P0hvqQNl7gNJ86k",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -103,7 +103,7 @@ http_interactions:
             "type": "application"
           },
           "country": "AU",
-          "created": 1711328742,
+          "created": 1711966659,
           "default_currency": "aud",
           "details_submitted": false,
           "email": "carrot.producer@example.com",
@@ -112,7 +112,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1Oy1yr4JZbvxnQxx/external_accounts"
+            "url": "/v1/accounts/acct_1P0hvqQNl7gNJ86k/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -209,7 +209,7 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:43 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:39 GMT
 - request:
     method: get
     uri: https://api.stripe.com/v1/payment_methods/pm_card_mastercard
@@ -224,7 +224,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_phH4XQSJYj98Br","request_duration_ms":1624}}'
+      - '{"last_request_metrics":{"request_id":"req_LHu8cqhZqgQMUJ","request_duration_ms":1883}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -241,7 +241,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:44 GMT
+      - Mon, 01 Apr 2024 10:17:42 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -273,7 +273,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_VjTDKDraib3x5n
+      - req_bo7V71DzluzpfV
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -286,7 +286,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1ytKuuB1fWySnTGPUUZ9W",
+          "id": "pm_1P0hvuKuuB1fWySnyv0hrI42",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -310,7 +310,7 @@ http_interactions:
             },
             "country": "US",
             "display_brand": "mastercard",
-            "exp_month": 3,
+            "exp_month": 4,
             "exp_year": 2025,
             "fingerprint": "BL35fEFVcTTS5wpE",
             "funding": "credit",
@@ -327,13 +327,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328743,
+          "created": 1711966662,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:44 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:41 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
@@ -348,13 +348,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_VjTDKDraib3x5n","request_duration_ms":348}}'
+      - '{"last_request_metrics":{"request_id":"req_bo7V71DzluzpfV","request_duration_ms":439}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1yr4JZbvxnQxx
+      - acct_1P0hvqQNl7gNJ86k
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -367,7 +367,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:44 GMT
+      - Mon, 01 Apr 2024 10:17:43 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -394,17 +394,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 448a3754-ff2d-4c7a-932a-6ecbed368de5
+      - c184a160-d9d4-4966-a5fb-c6c60af56c00
       Original-Request:
-      - req_VCNskqLWVYXBwm
+      - req_UuTjMZxNofXIzO
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_VCNskqLWVYXBwm
+      - req_UuTjMZxNofXIzO
       Stripe-Account:
-      - acct_1Oy1yr4JZbvxnQxx
+      - acct_1P0hvqQNl7gNJ86k
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -419,7 +419,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yu4JZbvxnQxx1GZfkvyC",
+          "id": "pi_3P0hvuQNl7gNJ86k0Jhc01Pm",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -435,7 +435,7 @@ http_interactions:
           "capture_method": "manual",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328744,
+          "created": 1711966662,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -446,7 +446,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yu4JZbvxnQxx237loiZv",
+          "payment_method": "pm_1P0hvuQNl7gNJ86k2HsxqojU",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -471,10 +471,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:44 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:42 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1yu4JZbvxnQxx1GZfkvyC
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0hvuQNl7gNJ86k0Jhc01Pm
     body:
       encoding: US-ASCII
       string: ''
@@ -486,13 +486,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_VCNskqLWVYXBwm","request_duration_ms":494}}'
+      - '{"last_request_metrics":{"request_id":"req_UuTjMZxNofXIzO","request_duration_ms":500}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1yr4JZbvxnQxx
+      - acct_1P0hvqQNl7gNJ86k
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -505,7 +505,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:44 GMT
+      - Mon, 01 Apr 2024 10:17:43 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -537,9 +537,9 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_dQEqJkCMMFVHEu
+      - req_AdmbOgLvCvz3We
       Stripe-Account:
-      - acct_1Oy1yr4JZbvxnQxx
+      - acct_1P0hvqQNl7gNJ86k
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -552,7 +552,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yu4JZbvxnQxx1GZfkvyC",
+          "id": "pi_3P0hvuQNl7gNJ86k0Jhc01Pm",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -568,7 +568,7 @@ http_interactions:
           "capture_method": "manual",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328744,
+          "created": 1711966662,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -579,7 +579,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yu4JZbvxnQxx237loiZv",
+          "payment_method": "pm_1P0hvuQNl7gNJ86k2HsxqojU",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -604,10 +604,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:44 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:42 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1yu4JZbvxnQxx1GZfkvyC/cancel
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0hvuQNl7gNJ86k0Jhc01Pm/cancel
     body:
       encoding: US-ASCII
       string: ''
@@ -625,7 +625,7 @@ http_interactions:
       X-Stripe-Client-User-Metadata:
       - '{"ip":null}'
       Stripe-Account:
-      - acct_1Oy1yr4JZbvxnQxx
+      - acct_1P0hvqQNl7gNJ86k
       Connection:
       - close
       Accept-Encoding:
@@ -640,7 +640,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:05:45 GMT
+      - Mon, 01 Apr 2024 10:17:44 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -668,17 +668,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 16ccfd33-7b9f-4f3c-8c3c-2e646c07a3bc
+      - d9fddcbb-0ac1-4977-9c95-c29e88d0babf
       Original-Request:
-      - req_dCuFJRf1qmi5jG
+      - req_E5g5IXvjv9h9Gb
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_dCuFJRf1qmi5jG
+      - req_E5g5IXvjv9h9Gb
       Stripe-Account:
-      - acct_1Oy1yr4JZbvxnQxx
+      - acct_1P0hvqQNl7gNJ86k
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -693,7 +693,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1yu4JZbvxnQxx1GZfkvyC",
+          "id": "pi_3P0hvuQNl7gNJ86k0Jhc01Pm",
           "object": "payment_intent",
           "amount": 1000,
           "amount_capturable": 0,
@@ -704,7 +704,7 @@ http_interactions:
           "application": "<HIDDEN-STRIPE_CLIENT_ID>",
           "application_fee_amount": null,
           "automatic_payment_methods": null,
-          "canceled_at": 1711328745,
+          "canceled_at": 1711966663,
           "cancellation_reason": null,
           "capture_method": "manual",
           "charges": {
@@ -712,11 +712,11 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/charges?payment_intent=pi_3Oy1yu4JZbvxnQxx1GZfkvyC"
+            "url": "/v1/charges?payment_intent=pi_3P0hvuQNl7gNJ86k0Jhc01Pm"
           },
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328744,
+          "created": 1711966662,
           "currency": "aud",
           "customer": null,
           "description": null,
@@ -727,7 +727,7 @@ http_interactions:
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1yu4JZbvxnQxx237loiZv",
+          "payment_method": "pm_1P0hvuQNl7gNJ86k2HsxqojU",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -752,5 +752,87 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:05:45 GMT
+  recorded_at: Mon, 01 Apr 2024 10:17:43 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0hvqQNl7gNJ86k
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_AdmbOgLvCvz3We","request_duration_ms":308}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:17:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_kMqUEhudX1xjNZ
+      Stripe-Account:
+      - acct_1P0hvqQNl7gNJ86k
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0hvqQNl7gNJ86k",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:17:44 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Stripe_CreditCardCloner/_find_or_clone/when_called_with_a_card_without_a_customer_one_time_usage_card_/clones_the_payment_method_only.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Stripe_CreditCardCloner/_find_or_clone/when_called_with_a_card_without_a_customer_one_time_usage_card_/clones_the_payment_method_only.yml
@@ -13,8 +13,6 @@ http_interactions:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       Content-Type:
       - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_h7L3ebMIxfrBQA","request_duration_ms":362}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:35 GMT
+      - Mon, 01 Apr 2024 10:34:10 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -58,15 +56,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - ecfdc1e4-77a6-4669-b1b8-7a37913beba7
+      - 87abc46e-2d05-4378-8119-4f411499c4f6
       Original-Request:
-      - req_9mpqKboIjyqAGD
+      - req_mMCwnyftaTO0A9
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_9mpqKboIjyqAGD
+      - req_mMCwnyftaTO0A9
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -81,7 +79,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1wpKuuB1fWySnHsMWSPCR",
+          "id": "pm_1P0iBqKuuB1fWySnELWe8IYX",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -122,13 +120,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328615,
+          "created": 1711967650,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:35 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:10 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/accounts
@@ -143,7 +141,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_9mpqKboIjyqAGD","request_duration_ms":407}}'
+      - '{"last_request_metrics":{"request_id":"req_mMCwnyftaTO0A9","request_duration_ms":791}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -160,7 +158,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:37 GMT
+      - Mon, 01 Apr 2024 10:34:12 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -187,15 +185,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 5e191396-cf24-4d67-81ae-e5d0ec55b30d
+      - b16226ad-7fa4-473f-a888-b5b6c0fec934
       Original-Request:
-      - req_mLpF77c6BWNKSm
+      - req_KlLE3OrUB0oItW
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_mLpF77c6BWNKSm
+      - req_KlLE3OrUB0oItW
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -210,7 +208,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1Oy1wpQMiDmkXbIR",
+          "id": "acct_1P0iBrQQQ2czqbXz",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -232,7 +230,7 @@ http_interactions:
             "type": "application"
           },
           "country": "AU",
-          "created": 1711328616,
+          "created": 1711967651,
           "default_currency": "aud",
           "details_submitted": false,
           "email": "apple.producer@example.com",
@@ -241,7 +239,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1Oy1wpQMiDmkXbIR/external_accounts"
+            "url": "/v1/accounts/acct_1P0iBrQQQ2czqbXz/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -338,10 +336,10 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:37 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:12 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_methods/pm_1Oy1wpKuuB1fWySnHsMWSPCR
+    uri: https://api.stripe.com/v1/payment_methods/pm_1P0iBqKuuB1fWySnELWe8IYX
     body:
       encoding: US-ASCII
       string: ''
@@ -353,7 +351,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_mLpF77c6BWNKSm","request_duration_ms":1809}}'
+      - '{"last_request_metrics":{"request_id":"req_KlLE3OrUB0oItW","request_duration_ms":1783}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -370,7 +368,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:37 GMT
+      - Mon, 01 Apr 2024 10:34:12 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -402,7 +400,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_2rMmDQMsy6xjXh
+      - req_xntwL32OdFuHO2
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -415,7 +413,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1wpKuuB1fWySnHsMWSPCR",
+          "id": "pm_1P0iBqKuuB1fWySnELWe8IYX",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -456,13 +454,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328615,
+          "created": 1711967650,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:37 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:13 GMT
 - request:
     method: get
     uri: https://api.stripe.com/v1/customers?email=apple.customer@example.com&limit=100
@@ -477,13 +475,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_2rMmDQMsy6xjXh","request_duration_ms":306}}'
+      - '{"last_request_metrics":{"request_id":"req_xntwL32OdFuHO2","request_duration_ms":383}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1wpQMiDmkXbIR
+      - acct_1P0iBrQQQ2czqbXz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -496,7 +494,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:37 GMT
+      - Mon, 01 Apr 2024 10:34:13 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -527,9 +525,9 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_dBDo3yV3pFGETO
+      - req_T0KGhMK82XR0nv
       Stripe-Account:
-      - acct_1Oy1wpQMiDmkXbIR
+      - acct_1P0iBrQQQ2czqbXz
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -547,13 +545,13 @@ http_interactions:
           "has_more": false,
           "url": "/v1/customers"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:37 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:13 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: payment_method=pm_1Oy1wpKuuB1fWySnHsMWSPCR
+      string: payment_method=pm_1P0iBqKuuB1fWySnELWe8IYX
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.13.0
@@ -562,13 +560,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_dBDo3yV3pFGETO","request_duration_ms":305}}'
+      - '{"last_request_metrics":{"request_id":"req_T0KGhMK82XR0nv","request_duration_ms":304}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1wpQMiDmkXbIR
+      - acct_1P0iBrQQQ2czqbXz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -581,7 +579,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:38 GMT
+      - Mon, 01 Apr 2024 10:34:13 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -608,17 +606,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 634f582c-c186-4ee1-8864-d664334d659c
+      - 9b36e664-fbf7-467a-9985-9f27f375ff75
       Original-Request:
-      - req_9NBLynkvOr45hN
+      - req_BlhoEtliLzNeTN
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_9NBLynkvOr45hN
+      - req_BlhoEtliLzNeTN
       Stripe-Account:
-      - acct_1Oy1wpQMiDmkXbIR
+      - acct_1P0iBrQQQ2czqbXz
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -633,7 +631,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1wsQMiDmkXbIR6HISdqXF",
+          "id": "pm_1P0iBtQQQ2czqbXzXRQy4xCv",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -674,11 +672,93 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328618,
+          "created": 1711967653,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:38 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:13 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0iBrQQQ2czqbXz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_BlhoEtliLzNeTN","request_duration_ms":408}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:34:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_I9EbXGMXci58JH
+      Stripe-Account:
+      - acct_1P0iBrQQQ2czqbXz
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0iBrQQQ2czqbXz",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:34:14 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Stripe_CreditCardCloner/_find_or_clone/when_called_with_a_valid_customer_and_payment_method/clones_both_the_payment_method_and_the_customer.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Stripe_CreditCardCloner/_find_or_clone/when_called_with_a_valid_customer_and_payment_method/clones_both_the_payment_method_and_the_customer.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_9NBLynkvOr45hN","request_duration_ms":408}}'
+      - '{"last_request_metrics":{"request_id":"req_I9EbXGMXci58JH","request_duration_ms":1014}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:38 GMT
+      - Mon, 01 Apr 2024 10:34:15 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -58,15 +58,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 1ebc592c-4b16-4cb7-8df4-4dd1788222a9
+      - 9a9b78cb-d5b2-4607-8647-b3b0b7164d7f
       Original-Request:
-      - req_9ZbnxtNGCEVoja
+      - req_mtxlbfRKrdqbTe
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_9ZbnxtNGCEVoja
+      - req_mtxlbfRKrdqbTe
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -81,7 +81,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1wsKuuB1fWySnbqRLfT73",
+          "id": "pm_1P0iBvKuuB1fWySnQ3GGNr5D",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -122,13 +122,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328618,
+          "created": 1711967655,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:38 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:15 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/customers
@@ -143,7 +143,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_9ZbnxtNGCEVoja","request_duration_ms":409}}'
+      - '{"last_request_metrics":{"request_id":"req_mtxlbfRKrdqbTe","request_duration_ms":510}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -160,7 +160,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:39 GMT
+      - Mon, 01 Apr 2024 10:34:15 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -187,15 +187,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 1ac9d6b1-6a60-41d6-94fb-2a258a60c9c0
+      - a9a252ea-ff33-4041-824e-47536ea82dec
       Original-Request:
-      - req_1lra1WO2HyTCqc
+      - req_8PyoP9fCUiGRLY
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_1lra1WO2HyTCqc
+      - req_8PyoP9fCUiGRLY
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -210,18 +210,18 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_PndDSAnsdBuHx2",
+          "id": "cus_PqOzU8qAZYbzy8",
           "object": "customer",
           "address": null,
           "balance": 0,
-          "created": 1711328618,
+          "created": 1711967655,
           "currency": null,
           "default_source": null,
           "delinquent": false,
           "description": null,
           "discount": null,
           "email": "apple.customer@example.com",
-          "invoice_prefix": "6A074CDE",
+          "invoice_prefix": "740F2A2E",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -238,13 +238,13 @@ http_interactions:
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:39 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:15 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_methods/pm_1Oy1wsKuuB1fWySnbqRLfT73/attach
+    uri: https://api.stripe.com/v1/payment_methods/pm_1P0iBvKuuB1fWySnQ3GGNr5D/attach
     body:
       encoding: UTF-8
-      string: customer=cus_PndDSAnsdBuHx2
+      string: customer=cus_PqOzU8qAZYbzy8
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.13.0
@@ -253,7 +253,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_1lra1WO2HyTCqc","request_duration_ms":409}}'
+      - '{"last_request_metrics":{"request_id":"req_8PyoP9fCUiGRLY","request_duration_ms":486}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -270,7 +270,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:39 GMT
+      - Mon, 01 Apr 2024 10:34:16 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -298,15 +298,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 4e49d6bb-3682-4f97-85ed-a7a597a3efcb
+      - ff5f81e9-99f8-4ae0-adb2-b7ad3c8be4f4
       Original-Request:
-      - req_0SDRGxyjoieP2E
+      - req_gyMt4WsKnRnDh9
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_0SDRGxyjoieP2E
+      - req_gyMt4WsKnRnDh9
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -321,7 +321,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1wsKuuB1fWySnbqRLfT73",
+          "id": "pm_1P0iBvKuuB1fWySnQ3GGNr5D",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -362,13 +362,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328618,
-          "customer": "cus_PndDSAnsdBuHx2",
+          "created": 1711967655,
+          "customer": "cus_PqOzU8qAZYbzy8",
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:39 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:16 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/accounts
@@ -383,7 +383,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_0SDRGxyjoieP2E","request_duration_ms":664}}'
+      - '{"last_request_metrics":{"request_id":"req_gyMt4WsKnRnDh9","request_duration_ms":671}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -400,7 +400,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:41 GMT
+      - Mon, 01 Apr 2024 10:34:18 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -427,15 +427,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 7fbb557e-39c4-491d-a46f-2d74839c3e8a
+      - 38b82023-270d-4b5f-ad08-e879dc0c8497
       Original-Request:
-      - req_1nx9WrJrOSnMH1
+      - req_rFlG6EIzTsn5Gc
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_1nx9WrJrOSnMH1
+      - req_rFlG6EIzTsn5Gc
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -450,7 +450,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1Oy1wt4IGiN56LfX",
+          "id": "acct_1P0iBw4CpUvfJTwy",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -472,7 +472,7 @@ http_interactions:
             "type": "application"
           },
           "country": "AU",
-          "created": 1711328620,
+          "created": 1711967657,
           "default_currency": "aud",
           "details_submitted": false,
           "email": "apple.producer@example.com",
@@ -481,7 +481,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1Oy1wt4IGiN56LfX/external_accounts"
+            "url": "/v1/accounts/acct_1P0iBw4CpUvfJTwy/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -578,10 +578,10 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:41 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:18 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_methods/pm_1Oy1wsKuuB1fWySnbqRLfT73
+    uri: https://api.stripe.com/v1/payment_methods/pm_1P0iBvKuuB1fWySnQ3GGNr5D
     body:
       encoding: US-ASCII
       string: ''
@@ -593,7 +593,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_1nx9WrJrOSnMH1","request_duration_ms":1734}}'
+      - '{"last_request_metrics":{"request_id":"req_rFlG6EIzTsn5Gc","request_duration_ms":1881}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -610,7 +610,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:41 GMT
+      - Mon, 01 Apr 2024 10:34:18 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -642,7 +642,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_x6yAn3Hq3u7YDv
+      - req_GpP9PQR8v2I8Az
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -655,7 +655,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1wsKuuB1fWySnbqRLfT73",
+          "id": "pm_1P0iBvKuuB1fWySnQ3GGNr5D",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -696,13 +696,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328618,
-          "customer": "cus_PndDSAnsdBuHx2",
+          "created": 1711967655,
+          "customer": "cus_PqOzU8qAZYbzy8",
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:41 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:18 GMT
 - request:
     method: get
     uri: https://api.stripe.com/v1/customers?email=apple.customer@example.com&limit=100
@@ -717,13 +717,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_x6yAn3Hq3u7YDv","request_duration_ms":305}}'
+      - '{"last_request_metrics":{"request_id":"req_GpP9PQR8v2I8Az","request_duration_ms":300}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1wt4IGiN56LfX
+      - acct_1P0iBw4CpUvfJTwy
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -736,7 +736,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:42 GMT
+      - Mon, 01 Apr 2024 10:34:19 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -767,9 +767,9 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_IzhyvvtaMkwora
+      - req_dwhyzLrV4PAdEw
       Stripe-Account:
-      - acct_1Oy1wt4IGiN56LfX
+      - acct_1P0iBw4CpUvfJTwy
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -787,13 +787,13 @@ http_interactions:
           "has_more": false,
           "url": "/v1/customers"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:42 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:19 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: customer=cus_PndDSAnsdBuHx2&payment_method=pm_1Oy1wsKuuB1fWySnbqRLfT73
+      string: customer=cus_PqOzU8qAZYbzy8&payment_method=pm_1P0iBvKuuB1fWySnQ3GGNr5D
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.13.0
@@ -802,13 +802,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_IzhyvvtaMkwora","request_duration_ms":261}}'
+      - '{"last_request_metrics":{"request_id":"req_dwhyzLrV4PAdEw","request_duration_ms":302}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1wt4IGiN56LfX
+      - acct_1P0iBw4CpUvfJTwy
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -821,7 +821,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:42 GMT
+      - Mon, 01 Apr 2024 10:34:19 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -848,17 +848,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 106ec4d0-9064-49b6-9118-70dfbc4e9ace
+      - 2baba894-5b00-48e3-809e-723a1b3ec676
       Original-Request:
-      - req_8vK1arSR0BpLR7
+      - req_DjC1KNG9qo16Kz
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_8vK1arSR0BpLR7
+      - req_DjC1KNG9qo16Kz
       Stripe-Account:
-      - acct_1Oy1wt4IGiN56LfX
+      - acct_1P0iBw4CpUvfJTwy
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -873,7 +873,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1ww4IGiN56LfX2a74y9Ke",
+          "id": "pm_1P0iBz4CpUvfJTwynAKpfkxH",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -914,13 +914,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328622,
+          "created": 1711967659,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:42 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:19 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/customers
@@ -935,13 +935,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_8vK1arSR0BpLR7","request_duration_ms":362}}'
+      - '{"last_request_metrics":{"request_id":"req_DjC1KNG9qo16Kz","request_duration_ms":368}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1wt4IGiN56LfX
+      - acct_1P0iBw4CpUvfJTwy
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -954,7 +954,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:42 GMT
+      - Mon, 01 Apr 2024 10:34:19 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -981,17 +981,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 494b0a67-cb48-4e8a-b905-da36321263d0
+      - dfcff075-66c2-44fc-bbf1-97b38b3b1cbb
       Original-Request:
-      - req_Sj7FrzoHYrusKV
+      - req_QR3OH50gGiSl9Q
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_Sj7FrzoHYrusKV
+      - req_QR3OH50gGiSl9Q
       Stripe-Account:
-      - acct_1Oy1wt4IGiN56LfX
+      - acct_1P0iBw4CpUvfJTwy
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -1006,18 +1006,18 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_PndDs7hHSPI3Bw",
+          "id": "cus_PqOzZM1X9o7ikr",
           "object": "customer",
           "address": null,
           "balance": 0,
-          "created": 1711328622,
+          "created": 1711967659,
           "currency": null,
           "default_source": null,
           "delinquent": false,
           "description": null,
           "discount": null,
           "email": "apple.customer@example.com",
-          "invoice_prefix": "EA365F4D",
+          "invoice_prefix": "CD31A87F",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -1034,13 +1034,13 @@ http_interactions:
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:42 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:19 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_methods/pm_1Oy1ww4IGiN56LfX2a74y9Ke/attach
+    uri: https://api.stripe.com/v1/payment_methods/pm_1P0iBz4CpUvfJTwynAKpfkxH/attach
     body:
       encoding: UTF-8
-      string: customer=cus_PndDs7hHSPI3Bw
+      string: customer=cus_PqOzZM1X9o7ikr
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.13.0
@@ -1049,13 +1049,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_Sj7FrzoHYrusKV","request_duration_ms":368}}'
+      - '{"last_request_metrics":{"request_id":"req_QR3OH50gGiSl9Q","request_duration_ms":366}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1wt4IGiN56LfX
+      - acct_1P0iBw4CpUvfJTwy
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1068,7 +1068,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:43 GMT
+      - Mon, 01 Apr 2024 10:34:20 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1096,17 +1096,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 62e5d7b3-e27e-4700-993a-a481bd42c7ec
+      - 74a3d5eb-4048-44d0-bf50-27156c0a8b99
       Original-Request:
-      - req_navOBsghMcbvY0
+      - req_8TLFIETtz2WBeV
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_navOBsghMcbvY0
+      - req_8TLFIETtz2WBeV
       Stripe-Account:
-      - acct_1Oy1wt4IGiN56LfX
+      - acct_1P0iBw4CpUvfJTwy
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -1121,7 +1121,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1ww4IGiN56LfX2a74y9Ke",
+          "id": "pm_1P0iBz4CpUvfJTwynAKpfkxH",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -1162,16 +1162,16 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328622,
-          "customer": "cus_PndDs7hHSPI3Bw",
+          "created": 1711967659,
+          "customer": "cus_PqOzZM1X9o7ikr",
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:43 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:20 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_methods/pm_1Oy1ww4IGiN56LfX2a74y9Ke
+    uri: https://api.stripe.com/v1/payment_methods/pm_1P0iBz4CpUvfJTwynAKpfkxH
     body:
       encoding: UTF-8
       string: metadata[ofn-clone]=true
@@ -1183,13 +1183,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_navOBsghMcbvY0","request_duration_ms":437}}'
+      - '{"last_request_metrics":{"request_id":"req_8TLFIETtz2WBeV","request_duration_ms":488}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1wt4IGiN56LfX
+      - acct_1P0iBw4CpUvfJTwy
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1202,7 +1202,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:43 GMT
+      - Mon, 01 Apr 2024 10:34:20 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1230,17 +1230,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 1f0a7951-2716-4642-a491-c8d823a68d1f
+      - 27b0d1b6-86f1-4b3b-80fa-dfd9421bc924
       Original-Request:
-      - req_8rbpP0dWyISBhg
+      - req_h0hBgne589Kk9w
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_8rbpP0dWyISBhg
+      - req_h0hBgne589Kk9w
       Stripe-Account:
-      - acct_1Oy1wt4IGiN56LfX
+      - acct_1P0iBw4CpUvfJTwy
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -1255,7 +1255,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1ww4IGiN56LfX2a74y9Ke",
+          "id": "pm_1P0iBz4CpUvfJTwynAKpfkxH",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -1296,13 +1296,95 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328622,
-          "customer": "cus_PndDs7hHSPI3Bw",
+          "created": 1711967659,
+          "customer": "cus_PqOzZM1X9o7ikr",
           "livemode": false,
           "metadata": {
             "ofn-clone": "true"
           },
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:43 GMT
+  recorded_at: Mon, 01 Apr 2024 10:34:20 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0iBw4CpUvfJTwy
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_h0hBgne589Kk9w","request_duration_ms":507}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:34:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_wwjHzXaFDsM2tY
+      Stripe-Account:
+      - acct_1P0iBw4CpUvfJTwy
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0iBw4CpUvfJTwy",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:34:22 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Stripe_CreditCardRemover/_remove/Stripe_customer_does_not_exist/raises_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Stripe_CreditCardRemover/_remove/Stripe_customer_does_not_exist/raises_an_error.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_f4uKDNQoWEHZAO","request_duration_ms":716}}'
+      - '{"last_request_metrics":{"request_id":"req_CYs5cyIYrDtms1","request_duration_ms":912}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:48 GMT
+      - Mon, 01 Apr 2024 10:29:55 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -58,15 +58,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 152331f8-291c-4868-9982-b11126d0185c
+      - d1e06c14-a4a9-4ece-a1c7-2d1d82b4ce87
       Original-Request:
-      - req_xinDj3jks15YZe
+      - req_ydZEGvejtkVfYi
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_xinDj3jks15YZe
+      - req_ydZEGvejtkVfYi
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -81,7 +81,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1x2KuuB1fWySnybrNr9sw",
+          "id": "pm_1P0i7jKuuB1fWySn7ueU6TCh",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -122,13 +122,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328628,
+          "created": 1711967395,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:48 GMT
+  recorded_at: Mon, 01 Apr 2024 10:29:55 GMT
 - request:
     method: get
     uri: https://api.stripe.com/v1/customers/non_existing_customer_id
@@ -143,7 +143,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_xinDj3jks15YZe","request_duration_ms":421}}'
+      - '{"last_request_metrics":{"request_id":"req_ydZEGvejtkVfYi","request_duration_ms":478}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -160,7 +160,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:48 GMT
+      - Mon, 01 Apr 2024 10:29:56 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -192,7 +192,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_vbYhhjl7RaarHT
+      - req_kaJToof4XVcxfw
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -210,9 +210,301 @@ http_interactions:
             "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
             "message": "No such customer: 'non_existing_customer_id'",
             "param": "id",
-            "request_log_url": "https://dashboard.stripe.com/test/logs/req_vbYhhjl7RaarHT?t=1711328628",
+            "request_log_url": "https://dashboard.stripe.com/test/logs/req_kaJToof4XVcxfw?t=1711967395",
             "type": "invalid_request_error"
           }
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:48 GMT
+  recorded_at: Mon, 01 Apr 2024 10:29:56 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=standard&country=AU&email=apple.producer%40example.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ydZEGvejtkVfYi","request_duration_ms":478}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:29:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3045'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 16ba19c4-5895-4831-90f7-1f0020b6d2c7
+      Original-Request:
+      - req_zZAtmDqAXjBliZ
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_zZAtmDqAXjBliZ
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0i7kQN6BspgMVl",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "name": null,
+            "product_description": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": null
+          },
+          "business_type": null,
+          "capabilities": {},
+          "charges_enabled": false,
+          "controller": {
+            "is_controller": true,
+            "type": "application"
+          },
+          "country": "AU",
+          "created": 1711967397,
+          "default_currency": "aud",
+          "details_submitted": false,
+          "email": "apple.producer@example.com",
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1P0i7kQN6BspgMVl/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {},
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "past_due": [
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": null,
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": null,
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null
+            },
+            "payments": {
+              "statement_descriptor": null,
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "type": "standard"
+        }
+  recorded_at: Mon, 01 Apr 2024 10:29:57 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0i7kQN6BspgMVl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_zZAtmDqAXjBliZ","request_duration_ms":1647}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:29:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_1T12HskzQnA7vD
+      Stripe-Account:
+      - acct_1P0i7kQN6BspgMVl
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0i7kQN6BspgMVl",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:29:58 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Stripe_CreditCardRemover/_remove/Stripe_customer_exists/and_is_deleted/deletes_the_credit_card_clone.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Stripe_CreditCardRemover/_remove/Stripe_customer_exists/and_is_deleted/deletes_the_credit_card_clone.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_dhqez2Z135e7g2","request_duration_ms":409}}'
+      - '{"last_request_metrics":{"request_id":"req_rbpTKQEa57sHfG","request_duration_ms":912}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:46 GMT
+      - Mon, 01 Apr 2024 10:29:51 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -58,15 +58,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - a8630c1c-3eac-4d74-b3ca-b70e86513927
+      - 9a9bca93-d831-4d81-b47a-bd05f4f61b04
       Original-Request:
-      - req_tt7EbIbRXg52u5
+      - req_0DyzOk2iA0A0ij
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_tt7EbIbRXg52u5
+      - req_0DyzOk2iA0A0ij
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -81,7 +81,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1x0KuuB1fWySngOngDsAy",
+          "id": "pm_1P0i7eKuuB1fWySn0BtsXTu8",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -122,13 +122,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328626,
+          "created": 1711967390,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:46 GMT
+  recorded_at: Mon, 01 Apr 2024 10:29:51 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/customers
@@ -143,7 +143,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_tt7EbIbRXg52u5","request_duration_ms":460}}'
+      - '{"last_request_metrics":{"request_id":"req_0DyzOk2iA0A0ij","request_duration_ms":533}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -160,7 +160,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:47 GMT
+      - Mon, 01 Apr 2024 10:29:51 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -187,15 +187,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 55f0d6f9-f0d8-4a88-91f5-9b95b6d1b1a3
+      - ba70c906-f630-4092-8a61-0bec6183a748
       Original-Request:
-      - req_LfQoCioNArL3X3
+      - req_kIz5bfnc11jwVI
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_LfQoCioNArL3X3
+      - req_kIz5bfnc11jwVI
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -210,18 +210,18 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_PndDefpSdaBAvE",
+          "id": "cus_PqOvluNCLAk1mM",
           "object": "customer",
           "address": null,
           "balance": 0,
-          "created": 1711328626,
+          "created": 1711967391,
           "currency": null,
           "default_source": null,
           "delinquent": false,
           "description": null,
           "discount": null,
           "email": "applecustomer@example.com",
-          "invoice_prefix": "16CD447C",
+          "invoice_prefix": "B8CF2444",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -238,13 +238,13 @@ http_interactions:
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:47 GMT
+  recorded_at: Mon, 01 Apr 2024 10:29:51 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_methods/pm_1Oy1x0KuuB1fWySngOngDsAy/attach
+    uri: https://api.stripe.com/v1/payment_methods/pm_1P0i7eKuuB1fWySn0BtsXTu8/attach
     body:
       encoding: UTF-8
-      string: customer=cus_PndDefpSdaBAvE
+      string: customer=cus_PqOvluNCLAk1mM
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.13.0
@@ -253,7 +253,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_LfQoCioNArL3X3","request_duration_ms":511}}'
+      - '{"last_request_metrics":{"request_id":"req_kIz5bfnc11jwVI","request_duration_ms":507}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -270,7 +270,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:47 GMT
+      - Mon, 01 Apr 2024 10:29:52 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -298,15 +298,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 313281d3-a159-4da7-8472-6c89595c1d02
+      - 634f6e95-0f90-4807-8a16-a94d49760538
       Original-Request:
-      - req_f4uKDNQoWEHZAO
+      - req_GDtfjLPuzWtuQH
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_f4uKDNQoWEHZAO
+      - req_GDtfjLPuzWtuQH
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -321,7 +321,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1x0KuuB1fWySngOngDsAy",
+          "id": "pm_1P0i7eKuuB1fWySn0BtsXTu8",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -362,11 +362,303 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328626,
-          "customer": "cus_PndDefpSdaBAvE",
+          "created": 1711967390,
+          "customer": "cus_PqOvluNCLAk1mM",
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:47 GMT
+  recorded_at: Mon, 01 Apr 2024 10:29:52 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=standard&country=AU&email=apple.producer%40example.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_GDtfjLPuzWtuQH","request_duration_ms":706}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:29:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3045'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 890a33be-a4bd-4760-85c4-14e2e0842cce
+      Original-Request:
+      - req_smWHmdll7twdoW
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_smWHmdll7twdoW
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0i7gQOcsMRPuMj",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "name": null,
+            "product_description": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": null
+          },
+          "business_type": null,
+          "capabilities": {},
+          "charges_enabled": false,
+          "controller": {
+            "is_controller": true,
+            "type": "application"
+          },
+          "country": "AU",
+          "created": 1711967393,
+          "default_currency": "aud",
+          "details_submitted": false,
+          "email": "apple.producer@example.com",
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1P0i7gQOcsMRPuMj/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {},
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "past_due": [
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": null,
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": null,
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null
+            },
+            "payments": {
+              "statement_descriptor": null,
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "type": "standard"
+        }
+  recorded_at: Mon, 01 Apr 2024 10:29:54 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0i7gQOcsMRPuMj
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_smWHmdll7twdoW","request_duration_ms":1717}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:29:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_CYs5cyIYrDtms1
+      Stripe-Account:
+      - acct_1P0i7gQOcsMRPuMj
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0i7gQOcsMRPuMj",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:29:55 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Stripe_CreditCardRemover/_remove/Stripe_customer_exists/and_is_not_deleted/deletes_the_credit_card_clone_and_the_customer.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/Stripe_CreditCardRemover/_remove/Stripe_customer_exists/and_is_not_deleted/deletes_the_credit_card_clone_and_the_customer.yml
@@ -13,8 +13,6 @@ http_interactions:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       Content-Type:
       - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_8rbpP0dWyISBhg","request_duration_ms":511}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:44 GMT
+      - Mon, 01 Apr 2024 10:29:45 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -58,15 +56,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - ee8d3056-63d4-4c03-9694-700037ee4acf
+      - 7db31cab-1323-4d4f-8c57-356d1df7da68
       Original-Request:
-      - req_nMoIkw0CCwGQAa
+      - req_po05dfR5WTcYjX
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_nMoIkw0CCwGQAa
+      - req_po05dfR5WTcYjX
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -81,7 +79,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1wxKuuB1fWySnP1rS0DJE",
+          "id": "pm_1P0i7ZKuuB1fWySnV4nOcrmM",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -122,13 +120,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328624,
+          "created": 1711967385,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:44 GMT
+  recorded_at: Mon, 01 Apr 2024 10:29:45 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/customers
@@ -143,7 +141,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_nMoIkw0CCwGQAa","request_duration_ms":446}}'
+      - '{"last_request_metrics":{"request_id":"req_po05dfR5WTcYjX","request_duration_ms":709}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -160,7 +158,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:44 GMT
+      - Mon, 01 Apr 2024 10:29:46 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -187,15 +185,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - da3c6a8d-1859-4c3f-b949-e755b6aea586
+      - c5e35cd7-d1f1-4a8e-98c5-0f58e57dd9ff
       Original-Request:
-      - req_igTG24PWT6amPb
+      - req_9Y6oyXcwwZPYk2
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_igTG24PWT6amPb
+      - req_9Y6oyXcwwZPYk2
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -210,18 +208,18 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_PndDIk2HJos3eg",
+          "id": "cus_PqOvbIa0hOWGHx",
           "object": "customer",
           "address": null,
           "balance": 0,
-          "created": 1711328624,
+          "created": 1711967386,
           "currency": null,
           "default_source": null,
           "delinquent": false,
           "description": null,
           "discount": null,
           "email": "applecustomer@example.com",
-          "invoice_prefix": "FDB50758",
+          "invoice_prefix": "42C2AF34",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -238,13 +236,13 @@ http_interactions:
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:44 GMT
+  recorded_at: Mon, 01 Apr 2024 10:29:46 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_methods/pm_1Oy1wxKuuB1fWySnP1rS0DJE/attach
+    uri: https://api.stripe.com/v1/payment_methods/pm_1P0i7ZKuuB1fWySnV4nOcrmM/attach
     body:
       encoding: UTF-8
-      string: customer=cus_PndDIk2HJos3eg
+      string: customer=cus_PqOvbIa0hOWGHx
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/10.13.0
@@ -253,7 +251,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_igTG24PWT6amPb","request_duration_ms":510}}'
+      - '{"last_request_metrics":{"request_id":"req_9Y6oyXcwwZPYk2","request_duration_ms":558}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -270,7 +268,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:45 GMT
+      - Mon, 01 Apr 2024 10:29:46 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -298,15 +296,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 9c49732a-8525-4ef9-8942-fb8642eccf3d
+      - 61de0f6a-0afe-4b87-ae4b-8d11cc6c2cf0
       Original-Request:
-      - req_dGoo5IXZLRKooB
+      - req_MSB1Kdfo0sTpdH
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_dGoo5IXZLRKooB
+      - req_MSB1Kdfo0sTpdH
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -321,7 +319,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1wxKuuB1fWySnP1rS0DJE",
+          "id": "pm_1P0i7ZKuuB1fWySnV4nOcrmM",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -362,16 +360,16 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328624,
-          "customer": "cus_PndDIk2HJos3eg",
+          "created": 1711967385,
+          "customer": "cus_PqOvbIa0hOWGHx",
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:45 GMT
+  recorded_at: Mon, 01 Apr 2024 10:29:47 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/customers/cus_PndDIk2HJos3eg
+    uri: https://api.stripe.com/v1/customers/cus_PqOvbIa0hOWGHx
     body:
       encoding: US-ASCII
       string: ''
@@ -383,7 +381,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_dGoo5IXZLRKooB","request_duration_ms":608}}'
+      - '{"last_request_metrics":{"request_id":"req_MSB1Kdfo0sTpdH","request_duration_ms":702}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -400,7 +398,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:45 GMT
+      - Mon, 01 Apr 2024 10:29:47 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -432,7 +430,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_aBsmD9I20lq0W5
+      - req_v8BRvklpAugSOQ
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -445,18 +443,18 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_PndDIk2HJos3eg",
+          "id": "cus_PqOvbIa0hOWGHx",
           "object": "customer",
           "address": null,
           "balance": 0,
-          "created": 1711328624,
+          "created": 1711967386,
           "currency": null,
           "default_source": null,
           "delinquent": false,
           "description": null,
           "discount": null,
           "email": "applecustomer@example.com",
-          "invoice_prefix": "FDB50758",
+          "invoice_prefix": "42C2AF34",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -473,10 +471,10 @@ http_interactions:
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:45 GMT
+  recorded_at: Mon, 01 Apr 2024 10:29:47 GMT
 - request:
     method: delete
-    uri: https://api.stripe.com/v1/customers/cus_PndDIk2HJos3eg
+    uri: https://api.stripe.com/v1/customers/cus_PqOvbIa0hOWGHx
     body:
       encoding: US-ASCII
       string: ''
@@ -488,7 +486,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_aBsmD9I20lq0W5","request_duration_ms":302}}'
+      - '{"last_request_metrics":{"request_id":"req_v8BRvklpAugSOQ","request_duration_ms":267}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -505,7 +503,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:03:46 GMT
+      - Mon, 01 Apr 2024 10:29:47 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -537,7 +535,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_dhqez2Z135e7g2
+      - req_EzjgtHJg9Lsg8z
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -550,9 +548,301 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_PndDIk2HJos3eg",
+          "id": "cus_PqOvbIa0hOWGHx",
           "object": "customer",
           "deleted": true
         }
-  recorded_at: Mon, 25 Mar 2024 01:03:46 GMT
+  recorded_at: Mon, 01 Apr 2024 10:29:47 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=standard&country=AU&email=apple.producer%40example.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_EzjgtHJg9Lsg8z","request_duration_ms":386}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:29:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3045'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Idempotency-Key:
+      - 805a7508-1b56-4cf7-8e53-3ff26392c3cd
+      Original-Request:
+      - req_XSF73TDvh1uwNG
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_XSF73TDvh1uwNG
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0i7bQQIgNTjlQP",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "name": null,
+            "product_description": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": null
+          },
+          "business_type": null,
+          "capabilities": {},
+          "charges_enabled": false,
+          "controller": {
+            "is_controller": true,
+            "type": "application"
+          },
+          "country": "AU",
+          "created": 1711967388,
+          "default_currency": "aud",
+          "details_submitted": false,
+          "email": "apple.producer@example.com",
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1P0i7bQQIgNTjlQP/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {},
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.product_description",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "past_due": [
+              "external_account",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": null,
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": null,
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null
+            },
+            "payments": {
+              "statement_descriptor": null,
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "type": "standard"
+        }
+  recorded_at: Mon, 01 Apr 2024 10:29:49 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0i7bQQIgNTjlQP
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_XSF73TDvh1uwNG","request_duration_ms":1654}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:29:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_rbpTKQEa57sHfG
+      Stripe-Account:
+      - acct_1P0i7bQQIgNTjlQP
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0i7bQQIgNTjlQP",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:29:50 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/_As_an_hub_manager_I_want_to_make_Stripe_payments_/with_a_payment_using_a_StripeSCA_payment_method/that_is_completed/allows_to_refund_the_payment.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v10.13.0/_As_an_hub_manager_I_want_to_make_Stripe_payments_/with_a_payment_using_a_StripeSCA_payment_method/that_is_completed/allows_to_refund_the_payment.yml
@@ -13,8 +13,6 @@ http_interactions:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       Content-Type:
       - application/x-www-form-urlencoded
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_SIi2VfiKBKwO71","request_duration_ms":307}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:06:07 GMT
+      - Mon, 01 Apr 2024 10:00:07 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -58,15 +56,15 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 5cc51bf3-ba16-45aa-a9c1-45e59aca4e6e
+      - 894d988f-0964-465e-96a4-cbc43d6cff62
       Original-Request:
-      - req_gL2DHHWKEt9WY4
+      - req_L06jsKcXNbzYER
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_gL2DHHWKEt9WY4
+      - req_L06jsKcXNbzYER
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -81,7 +79,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1Oy1zF4Gzo74w4IY",
+          "id": "acct_1P0herQTjBVDfK8a",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -103,7 +101,7 @@ http_interactions:
             "type": "application"
           },
           "country": "AU",
-          "created": 1711328766,
+          "created": 1711965606,
           "default_currency": "aud",
           "details_submitted": false,
           "email": "lettuce.producer@example.com",
@@ -112,7 +110,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1Oy1zF4Gzo74w4IY/external_accounts"
+            "url": "/v1/accounts/acct_1P0herQTjBVDfK8a/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -209,7 +207,7 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Mon, 25 Mar 2024 01:06:07 GMT
+  recorded_at: Mon, 01 Apr 2024 10:00:06 GMT
 - request:
     method: get
     uri: https://api.stripe.com/v1/payment_methods/pm_card_mastercard
@@ -224,7 +222,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_gL2DHHWKEt9WY4","request_duration_ms":1585}}'
+      - '{"last_request_metrics":{"request_id":"req_L06jsKcXNbzYER","request_duration_ms":1991}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -241,7 +239,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:06:07 GMT
+      - Mon, 01 Apr 2024 10:00:07 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -273,7 +271,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_zb7FA0di3NsMHU
+      - req_vWioO9TiRIjFMJ
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -286,7 +284,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1Oy1zHKuuB1fWySnvptpC3Yy",
+          "id": "pm_1P0hetKuuB1fWySne9uWJYPX",
           "object": "payment_method",
           "billing_details": {
             "address": {
@@ -310,7 +308,7 @@ http_interactions:
             },
             "country": "US",
             "display_brand": "mastercard",
-            "exp_month": 3,
+            "exp_month": 4,
             "exp_year": 2025,
             "fingerprint": "BL35fEFVcTTS5wpE",
             "funding": "credit",
@@ -327,13 +325,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1711328767,
+          "created": 1711965607,
           "customer": null,
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Mon, 25 Mar 2024 01:06:07 GMT
+  recorded_at: Mon, 01 Apr 2024 10:00:07 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
@@ -348,13 +346,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_zb7FA0di3NsMHU","request_duration_ms":388}}'
+      - '{"last_request_metrics":{"request_id":"req_vWioO9TiRIjFMJ","request_duration_ms":495}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1zF4Gzo74w4IY
+      - acct_1P0herQTjBVDfK8a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -367,7 +365,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:06:09 GMT
+      - Mon, 01 Apr 2024 10:00:09 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -394,17 +392,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 13d69ece-7fba-4979-8a6d-d9d385606451
+      - f729fae8-2e8d-4c89-b101-46b2343325aa
       Original-Request:
-      - req_ybAeua31aoGvov
+      - req_gKh9rEHg5FbISS
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_ybAeua31aoGvov
+      - req_gKh9rEHg5FbISS
       Stripe-Account:
-      - acct_1Oy1zF4Gzo74w4IY
+      - acct_1P0herQTjBVDfK8a
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -419,7 +417,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1zH4Gzo74w4IY0Cmzw6Zs",
+          "id": "pi_3P0heuQTjBVDfK8a0gBRJEL6",
           "object": "payment_intent",
           "amount": 2600,
           "amount_capturable": 0,
@@ -435,18 +433,18 @@ http_interactions:
           "capture_method": "automatic",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328767,
+          "created": 1711965608,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1zH4Gzo74w4IY0FgasZx5",
+          "latest_charge": "ch_3P0heuQTjBVDfK8a0a5WwJKV",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1zH4Gzo74w4IY2pn1gAqH",
+          "payment_method": "pm_1P0heuQTjBVDfK8aBSEO0abL",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -471,10 +469,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:06:09 GMT
+  recorded_at: Mon, 01 Apr 2024 10:00:08 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1zH4Gzo74w4IY0Cmzw6Zs
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0heuQTjBVDfK8a0gBRJEL6
     body:
       encoding: US-ASCII
       string: ''
@@ -490,7 +488,7 @@ http_interactions:
       X-Stripe-Client-User-Agent:
       - "<HIDDEN-STRIPE-USER-AGENT>"
       Stripe-Account:
-      - acct_1Oy1zF4Gzo74w4IY
+      - acct_1P0herQTjBVDfK8a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -503,7 +501,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:06:15 GMT
+      - Mon, 01 Apr 2024 10:00:11 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -535,9 +533,9 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_d5isEd1g6f9UMk
+      - req_ddnixS5X4GzrFe
       Stripe-Account:
-      - acct_1Oy1zF4Gzo74w4IY
+      - acct_1P0herQTjBVDfK8a
       Stripe-Version:
       - '2023-10-16'
       Vary:
@@ -550,7 +548,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1zH4Gzo74w4IY0Cmzw6Zs",
+          "id": "pi_3P0heuQTjBVDfK8a0gBRJEL6",
           "object": "payment_intent",
           "amount": 2600,
           "amount_capturable": 0,
@@ -566,18 +564,18 @@ http_interactions:
           "capture_method": "automatic",
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328767,
+          "created": 1711965608,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1zH4Gzo74w4IY0FgasZx5",
+          "latest_charge": "ch_3P0heuQTjBVDfK8a0a5WwJKV",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1zH4Gzo74w4IY2pn1gAqH",
+          "payment_method": "pm_1P0heuQTjBVDfK8aBSEO0abL",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -602,10 +600,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:06:15 GMT
+  recorded_at: Mon, 01 Apr 2024 10:00:10 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_intents/pi_3Oy1zH4Gzo74w4IY0Cmzw6Zs
+    uri: https://api.stripe.com/v1/payment_intents/pi_3P0heuQTjBVDfK8a0gBRJEL6
     body:
       encoding: US-ASCII
       string: ''
@@ -621,7 +619,7 @@ http_interactions:
       X-Stripe-Client-User-Metadata:
       - '{"ip":null}'
       Stripe-Account:
-      - acct_1Oy1zF4Gzo74w4IY
+      - acct_1P0herQTjBVDfK8a
       Connection:
       - close
       Accept-Encoding:
@@ -636,7 +634,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:06:15 GMT
+      - Mon, 01 Apr 2024 10:00:11 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -668,9 +666,9 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_nk97z3InXQ8xRo
+      - req_f5WYRcAhEZFokf
       Stripe-Account:
-      - acct_1Oy1zF4Gzo74w4IY
+      - acct_1P0herQTjBVDfK8a
       Stripe-Version:
       - '2020-08-27'
       Vary:
@@ -683,7 +681,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_3Oy1zH4Gzo74w4IY0Cmzw6Zs",
+          "id": "pi_3P0heuQTjBVDfK8a0gBRJEL6",
           "object": "payment_intent",
           "amount": 2600,
           "amount_capturable": 0,
@@ -701,7 +699,7 @@ http_interactions:
             "object": "list",
             "data": [
               {
-                "id": "ch_3Oy1zH4Gzo74w4IY0FgasZx5",
+                "id": "ch_3P0heuQTjBVDfK8a0a5WwJKV",
                 "object": "charge",
                 "amount": 2600,
                 "amount_captured": 2600,
@@ -709,7 +707,7 @@ http_interactions:
                 "application": "<HIDDEN-STRIPE_CLIENT_ID>",
                 "application_fee": null,
                 "application_fee_amount": null,
-                "balance_transaction": "txn_3Oy1zH4Gzo74w4IY0aZsdH9L",
+                "balance_transaction": "txn_3P0heuQTjBVDfK8a0x7dKX45",
                 "billing_details": {
                   "address": {
                     "city": null,
@@ -725,7 +723,7 @@ http_interactions:
                 },
                 "calculated_statement_descriptor": "OFNOFNOFN",
                 "captured": true,
-                "created": 1711328768,
+                "created": 1711965608,
                 "currency": "aud",
                 "customer": null,
                 "description": null,
@@ -745,13 +743,13 @@ http_interactions:
                   "network_status": "approved_by_network",
                   "reason": null,
                   "risk_level": "normal",
-                  "risk_score": 13,
+                  "risk_score": 10,
                   "seller_message": "Payment complete.",
                   "type": "authorized"
                 },
                 "paid": true,
-                "payment_intent": "pi_3Oy1zH4Gzo74w4IY0Cmzw6Zs",
-                "payment_method": "pm_1Oy1zH4Gzo74w4IY2pn1gAqH",
+                "payment_intent": "pi_3P0heuQTjBVDfK8a0gBRJEL6",
+                "payment_method": "pm_1P0heuQTjBVDfK8aBSEO0abL",
                 "payment_method_details": {
                   "card": {
                     "amount_authorized": 2600,
@@ -762,7 +760,7 @@ http_interactions:
                       "cvc_check": "pass"
                     },
                     "country": "US",
-                    "exp_month": 3,
+                    "exp_month": 4,
                     "exp_year": 2025,
                     "extended_authorization": {
                       "status": "disabled"
@@ -794,14 +792,14 @@ http_interactions:
                 "radar_options": {},
                 "receipt_email": null,
                 "receipt_number": null,
-                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xT3kxekY0R3pvNzR3NElZKIecg7AGMgag_LXvnno6LBZ_5X55Zs33z_qqfq99QavqBCnC_VHntkc6o5E84xzoZhirXFuV0xND3uqO",
+                "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xUDBoZXJRVGpCVkRmSzhhKKuLqrAGMgZl5iBA3Tk6LBah2hXiN2VZVWEI8C03u5ojHBD7WR0LtJ1qOR8waX9LZmiGOtmFJDNtAcIn",
                 "refunded": false,
                 "refunds": {
                   "object": "list",
                   "data": [],
                   "has_more": false,
                   "total_count": 0,
-                  "url": "/v1/charges/ch_3Oy1zH4Gzo74w4IY0FgasZx5/refunds"
+                  "url": "/v1/charges/ch_3P0heuQTjBVDfK8a0a5WwJKV/refunds"
                 },
                 "review": null,
                 "shipping": null,
@@ -816,22 +814,22 @@ http_interactions:
             ],
             "has_more": false,
             "total_count": 1,
-            "url": "/v1/charges?payment_intent=pi_3Oy1zH4Gzo74w4IY0Cmzw6Zs"
+            "url": "/v1/charges?payment_intent=pi_3P0heuQTjBVDfK8a0gBRJEL6"
           },
           "client_secret": "<HIDDEN-CLIENT-SECRET>",
           "confirmation_method": "automatic",
-          "created": 1711328767,
+          "created": 1711965608,
           "currency": "aud",
           "customer": null,
           "description": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_3Oy1zH4Gzo74w4IY0FgasZx5",
+          "latest_charge": "ch_3P0heuQTjBVDfK8a0a5WwJKV",
           "livemode": false,
           "metadata": {},
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_1Oy1zH4Gzo74w4IY2pn1gAqH",
+          "payment_method": "pm_1P0heuQTjBVDfK8aBSEO0abL",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -856,10 +854,10 @@ http_interactions:
           "transfer_data": null,
           "transfer_group": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:06:16 GMT
+  recorded_at: Mon, 01 Apr 2024 10:00:11 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/charges/ch_3Oy1zH4Gzo74w4IY0FgasZx5/refunds
+    uri: https://api.stripe.com/v1/charges/ch_3P0heuQTjBVDfK8a0a5WwJKV/refunds
     body:
       encoding: UTF-8
       string: amount=2600&expand[0]=charge
@@ -877,7 +875,7 @@ http_interactions:
       X-Stripe-Client-User-Metadata:
       - '{"ip":null}'
       Stripe-Account:
-      - acct_1Oy1zF4Gzo74w4IY
+      - acct_1P0herQTjBVDfK8a
       Connection:
       - close
       Accept-Encoding:
@@ -892,7 +890,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 Mar 2024 01:06:17 GMT
+      - Mon, 01 Apr 2024 10:00:13 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -920,17 +918,17 @@ http_interactions:
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Idempotency-Key:
-      - 5df35d88-f54f-4df9-be43-31fdb1e07eca
+      - 4442c923-f666-4f9e-b74c-8d6993bd0347
       Original-Request:
-      - req_o456KUltmvEaJV
+      - req_NxYfZfAEt2L2Rx
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_o456KUltmvEaJV
+      - req_NxYfZfAEt2L2Rx
       Stripe-Account:
-      - acct_1Oy1zF4Gzo74w4IY
+      - acct_1P0herQTjBVDfK8a
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -945,12 +943,12 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "re_3Oy1zH4Gzo74w4IY0vLupviX",
+          "id": "re_3P0heuQTjBVDfK8a00UpmaQ6",
           "object": "refund",
           "amount": 2600,
-          "balance_transaction": "txn_3Oy1zH4Gzo74w4IY0fdc64JK",
+          "balance_transaction": "txn_3P0heuQTjBVDfK8a0TBrCthB",
           "charge": {
-            "id": "ch_3Oy1zH4Gzo74w4IY0FgasZx5",
+            "id": "ch_3P0heuQTjBVDfK8a0a5WwJKV",
             "object": "charge",
             "amount": 2600,
             "amount_captured": 2600,
@@ -958,7 +956,7 @@ http_interactions:
             "application": "<HIDDEN-STRIPE_CLIENT_ID>",
             "application_fee": null,
             "application_fee_amount": null,
-            "balance_transaction": "txn_3Oy1zH4Gzo74w4IY0aZsdH9L",
+            "balance_transaction": "txn_3P0heuQTjBVDfK8a0x7dKX45",
             "billing_details": {
               "address": {
                 "city": null,
@@ -974,7 +972,7 @@ http_interactions:
             },
             "calculated_statement_descriptor": "OFNOFNOFN",
             "captured": true,
-            "created": 1711328768,
+            "created": 1711965608,
             "currency": "aud",
             "customer": null,
             "description": null,
@@ -994,13 +992,13 @@ http_interactions:
               "network_status": "approved_by_network",
               "reason": null,
               "risk_level": "normal",
-              "risk_score": 13,
+              "risk_score": 10,
               "seller_message": "Payment complete.",
               "type": "authorized"
             },
             "paid": true,
-            "payment_intent": "pi_3Oy1zH4Gzo74w4IY0Cmzw6Zs",
-            "payment_method": "pm_1Oy1zH4Gzo74w4IY2pn1gAqH",
+            "payment_intent": "pi_3P0heuQTjBVDfK8a0gBRJEL6",
+            "payment_method": "pm_1P0heuQTjBVDfK8aBSEO0abL",
             "payment_method_details": {
               "card": {
                 "amount_authorized": 2600,
@@ -1011,7 +1009,7 @@ http_interactions:
                   "cvc_check": "pass"
                 },
                 "country": "US",
-                "exp_month": 3,
+                "exp_month": 4,
                 "exp_year": 2025,
                 "extended_authorization": {
                   "status": "disabled"
@@ -1043,18 +1041,18 @@ http_interactions:
             "radar_options": {},
             "receipt_email": null,
             "receipt_number": null,
-            "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xT3kxekY0R3pvNzR3NElZKImcg7AGMgZZta4Xdyo6LBYRvQ1spFAm7rGx_xZxItYb-XK_475iGkG-hUYgMR4ORxVehvhcNSRzdDNK",
+            "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xUDBoZXJRVGpCVkRmSzhhKK2LqrAGMgZFrKZLsbw6LBaxLtTKUnb--xZneOjdSBMJDQz_yksC-OUOmpLLerbi0qPjd6jy3jizBg0t",
             "refunded": true,
             "refunds": {
               "object": "list",
               "data": [
                 {
-                  "id": "re_3Oy1zH4Gzo74w4IY0vLupviX",
+                  "id": "re_3P0heuQTjBVDfK8a00UpmaQ6",
                   "object": "refund",
                   "amount": 2600,
-                  "balance_transaction": "txn_3Oy1zH4Gzo74w4IY0fdc64JK",
-                  "charge": "ch_3Oy1zH4Gzo74w4IY0FgasZx5",
-                  "created": 1711328776,
+                  "balance_transaction": "txn_3P0heuQTjBVDfK8a0TBrCthB",
+                  "charge": "ch_3P0heuQTjBVDfK8a0a5WwJKV",
+                  "created": 1711965612,
                   "currency": "aud",
                   "destination_details": {
                     "card": {
@@ -1065,7 +1063,7 @@ http_interactions:
                     "type": "card"
                   },
                   "metadata": {},
-                  "payment_intent": "pi_3Oy1zH4Gzo74w4IY0Cmzw6Zs",
+                  "payment_intent": "pi_3P0heuQTjBVDfK8a0gBRJEL6",
                   "reason": null,
                   "receipt_number": null,
                   "source_transfer_reversal": null,
@@ -1075,7 +1073,7 @@ http_interactions:
               ],
               "has_more": false,
               "total_count": 1,
-              "url": "/v1/charges/ch_3Oy1zH4Gzo74w4IY0FgasZx5/refunds"
+              "url": "/v1/charges/ch_3P0heuQTjBVDfK8a0a5WwJKV/refunds"
             },
             "review": null,
             "shipping": null,
@@ -1087,7 +1085,7 @@ http_interactions:
             "transfer_data": null,
             "transfer_group": null
           },
-          "created": 1711328776,
+          "created": 1711965612,
           "currency": "aud",
           "destination_details": {
             "card": {
@@ -1098,12 +1096,94 @@ http_interactions:
             "type": "card"
           },
           "metadata": {},
-          "payment_intent": "pi_3Oy1zH4Gzo74w4IY0Cmzw6Zs",
+          "payment_intent": "pi_3P0heuQTjBVDfK8a0gBRJEL6",
           "reason": null,
           "receipt_number": null,
           "source_transfer_reversal": null,
           "status": "succeeded",
           "transfer_reversal": null
         }
-  recorded_at: Mon, 25 Mar 2024 01:06:17 GMT
+  recorded_at: Mon, 01 Apr 2024 10:00:12 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1P0herQTjBVDfK8a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.13.0
+      Authorization:
+      - "<HIDDEN-AUTHORIZATION-HEADER>"
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_gKh9rEHg5FbISS","request_duration_ms":1524}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<HIDDEN-STRIPE-USER-AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Apr 2024 10:00:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts%2F%3Aaccount; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_E52hF9rOGNiT8Q
+      Stripe-Account:
+      - acct_1P0herQTjBVDfK8a
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1P0herQTjBVDfK8a",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 01 Apr 2024 10:00:13 GMT
 recorded_with: VCR 6.2.0

--- a/spec/lib/stripe/credit_card_cloner_spec.rb
+++ b/spec/lib/stripe/credit_card_cloner_spec.rb
@@ -44,6 +44,10 @@ module Stripe
 
       let(:cloner) { Stripe::CreditCardCloner.new(credit_card, connected_account.id) }
 
+      after do
+        Stripe::Account.delete(connected_account.id)
+      end
+
       context "when called with a card without a customer (one time usage card)" do
         let(:payment_method_id) { pm_card.id }
 

--- a/spec/lib/stripe/credit_card_remover_spec.rb
+++ b/spec/lib/stripe/credit_card_remover_spec.rb
@@ -36,6 +36,10 @@ describe Stripe::CreditCardRemover do
 
     let(:cloner) { Stripe::CreditCardCloner.new(credit_card, connected_account.id) }
 
+    after do
+      Stripe::Account.delete(connected_account.id)
+    end
+
     context 'Stripe customer exists' do
       let(:payment_method_id) { pm_card.id }
       let(:customer_id) { customer.id }

--- a/spec/models/spree/gateway/stripe_sca_spec.rb
+++ b/spec/models/spree/gateway/stripe_sca_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Spree::Gateway::StripeSCA, type: :model do
+describe Spree::Gateway::StripeSCA, :vcr, :stripe_version, type: :model do
   let(:order) { create(:order_ready_for_payment) }
 
   let(:year_valid) { Time.zone.now.year.next }
@@ -46,7 +46,11 @@ describe Spree::Gateway::StripeSCA, type: :model do
                            })
   end
 
-  describe "#purchase", :vcr, :stripe_version do
+  after do
+    Stripe::Account.delete(connected_account.id)
+  end
+
+  describe "#purchase" do
     # Stripe acepts amounts as positive integers representing how much to charge
     # in the smallest currency unit
     let(:capture_amount) { order.total.to_i * 100 } # order total is 10 AUD
@@ -71,7 +75,7 @@ describe Spree::Gateway::StripeSCA, type: :model do
     end
   end
 
-  describe "#void", :vcr, :stripe_version do
+  describe "#void" do
     let(:stripe_test_account) { connected_account.id }
 
     before do
@@ -136,7 +140,7 @@ describe Spree::Gateway::StripeSCA, type: :model do
     end
   end
 
-  describe "#credit", :vcr, :stripe_version do
+  describe "#credit" do
     let(:stripe_test_account) { connected_account.id }
 
     before do
@@ -166,7 +170,7 @@ describe Spree::Gateway::StripeSCA, type: :model do
     end
   end
 
-  describe "#error message", :vcr, :stripe_version do
+  describe "#error message" do
     context "when payment intent state is not in 'requires_capture' state" do
       before do
         payment

--- a/spec/system/admin/payments_stripe_spec.rb
+++ b/spec/system/admin/payments_stripe_spec.rb
@@ -192,6 +192,10 @@ describe '
         order.payments << payment
       end
 
+      after do
+        Stripe::Account.delete(connected_account.id)
+      end
+
       it "allows to refund the payment" do
         login_as_admin
         visit spree.admin_order_payments_path order


### PR DESCRIPTION

Follow-up from https://github.com/openfoodfoundation/openfoodnetwork/pull/12262.

As agreed [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/12262#issuecomment-2025091138), we should delete accounts which were created for testing purposes, on Stripe.

#### What? Why?
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


We were accumulating (Stripe-connected)-test accounts, which were created each time specs were running and recording VCR cassettes; we don't need them, as soon as the server reply is recorded.

Adding an `after` block to delete created (Stripe-connected) accounts should delete them.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
