### PR TITLE
[BUU] Fix Wrong Tax Category Display

### DIFF
--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -44,7 +44,7 @@
 %td.align-left
   .content= variant.primary_taxon&.name
 %td.align-left
-  .content= variant.tax_category&.name || "None" # TODO: convert to dropdown, else translate hardcoded string.
+  .content= (variant.tax_category_id ? variant.tax_category&.name : t('.none_tax_category')) # TODO: convert to dropdown
 %td.align-left
   -# empty
 %td.align-right

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -897,6 +897,8 @@ en:
       delete_variant:
         success: Successfully deleted the variant
         error: Unable to delete the variant
+      variant_row:
+        none_tax_category: None
     product_import:
       title: Product Import
       file_not_found: File not found or could not be opened

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -485,6 +485,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
         expect(new_variant.price).to eq 10.25
         expect(new_variant.unit_value).to eq 1000
         expect(new_variant.on_hand).to eq 3
+        expect(new_variant.tax_category_id).to be_nil
 
         within row_containing_name("Large box") do
           expect(page).to have_field "Name", with: "Large box"
@@ -492,6 +493,9 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
           expect(page).to have_field "Price", with: "10.25"
           expect(page).to have_content "1kg"
           expect(page).to have_button "On Hand", text: "3"
+          within tax_category_column do
+            expect(page).to have_content "None"
+          end
         end
       end
 
@@ -961,5 +965,9 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
 
   def expect_page_to_have_image(url)
     expect(page).to have_selector("img[src$='#{url}']")
+  end
+
+  def tax_category_column
+    @tax_category_column ||= 'td:nth-child(10)'
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #12294 

**Issue:**
- `tax_category` is overridden in the variant model here:

https://github.com/openfoodfoundation/openfoodnetwork/blob/0bae5d67c661dae94b5b61e4a14165da1da213d0/app/models/spree/variant.rb#L172-L174

- If the tax category is not present, then return the default tax category (_which may or may not be nil_)
- I'm not sure of the exact business logic for this, but apparently, it's being moved from the [product's code](https://github.com/openfoodfoundation/openfoodnetwork/commit/d33e780411fcd64e76f1db5f5878d19e4cc711b8).
- Moreover, I'm not sure if it's a good practice to override associations like this because it's not working like a typical rails `belongs_to` association i.e. `tax_category` might not be `nil` in case `tax_category_id` is `nil`.

**Fix:**
- Only display the `tax_category` name if the `tax_category_id` is present.
- Otherwise display "None"

#### What should we test?
- Steps mentioned in the attached issue

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled