### PR TITLE
Fix Rubocop Rails/NegateInclude issues

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -668,16 +668,6 @@ Rails/LexicallyScopedActionFilter:
     - 'app/controllers/spree/admin/zones_controller.rb'
     - 'app/controllers/spree/users_controller.rb'
 
-# Offense count: 5
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/NegateInclude:
-  Exclude:
-    - 'app/controllers/admin/resource_controller.rb'
-    - 'app/models/calculator/weight.rb'
-    - 'app/models/product_import/spreadsheet_entry.rb'
-    - 'lib/spree/localized_number.rb'
-    - 'spec/support/matchers/table_matchers.rb'
-
 # Offense count: 32
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/Pluck:

--- a/app/controllers/admin/resource_controller.rb
+++ b/app/controllers/admin/resource_controller.rb
@@ -229,7 +229,7 @@ module Admin
     end
 
     def member_action?
-      !collection_actions.include? action
+      collection_actions.exclude? action
     end
 
     def new_actions

--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -10,7 +10,7 @@ module Calculator
     end
 
     def set_preference(name, value)
-      if name == :unit_from_list && !["kg", "lb"].include?(value)
+      if name == :unit_from_list && ["kg", "lb"].exclude?(value)
         calculable.errors.add(:preferred_unit_from_list, I18n.t(:calculator_preferred_unit_error))
       else
         __send__ self.class.preference_setter_method(name), value

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -94,7 +94,7 @@ module ProductImport
       units = UnitConverter.new(attrs)
 
       units.converted_attributes.each do |attr, value|
-        if respond_to?("#{attr}=") && !NON_PRODUCT_ATTRIBUTES.include?(attr)
+        if respond_to?("#{attr}=") && NON_PRODUCT_ATTRIBUTES.exclude?(attr)
           public_send("#{attr}=", value)
         end
       end

--- a/lib/spree/localized_number.rb
+++ b/lib/spree/localized_number.rb
@@ -77,7 +77,7 @@ module Spree
     private
 
     def non_activerecord_attribute?(attribute)
-      table_exists? && !column_names.include?(attribute.to_s)
+      table_exists? && column_names.exclude?(attribute.to_s)
     rescue ::ActiveRecord::NoDatabaseError
       # This class is now loaded during `rake db:create` (since Rails 5.2), and not only does the
       # table not exist, but the database does not even exist yet, and throws a fatal error.

--- a/spec/support/matchers/table_matchers.rb
+++ b/spec/support/matchers/table_matchers.rb
@@ -8,7 +8,7 @@ RSpec::Matchers.define :have_table_row do |row|
 
   match_when_negated do |node|
     @row = row
-    !rows_under(node).include? row # Robust check of columns
+    rows_under(node).exclude? row # Robust check of columns
   end
 
   failure_message do |text|

--- a/spec/system/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
+++ b/spec/system/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
@@ -36,9 +36,9 @@ describe '
     end
 
     it "select all products" do
-      # replace with scroll_to method when upgrading to Capybara >= 3.13.0
       checkbox_id = "order_cycle_incoming_exchange_0_select_all_variants"
-      page.execute_script("document.getElementById('#{checkbox_id}').scrollIntoView()")
+      elmnt = find_field(id: checkbox_id)
+      scroll_to(elmnt, align: :top)
       check checkbox_id
 
       expect_all_products_loaded


### PR DESCRIPTION
 #### What? Why?

- Contributes to  #11482
- Closes #12338 

Fixes one of many rubocop issues

- cop class: RuboCop::Cop::Rails::NegateInclude
- idea: replacing `!array.include?(2)` with `array.exclude?(2)`
- `.rubocop_todo.yml` updated

#### What should we test?
Nothing: the rubocop should raise no offenses when checking linters at Integration.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
