### PR TITLE
Fix Lint/DuplicateRequire issue

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,12 +28,6 @@ Lint/DuplicateMethods:
   Exclude:
     - 'lib/discourse/single_sign_on.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/DuplicateRequire:
-  Exclude:
-    - 'spec/lib/open_food_network/scope_variants_to_search_spec.rb'
-
 # Offense count: 16
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
 Lint/EmptyBlock:

--- a/spec/lib/open_food_network/scope_variants_to_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_to_search_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 require 'open_food_network/scope_variants_for_search'
-require 'spec_helper'
 
 describe OpenFoodNetwork::ScopeVariantsForSearch do
   let!(:p1) { create(:simple_product, name: 'Product 1') }


### PR DESCRIPTION
#### What? Why?

- Contributes to #11482 

Fixes one of many rubocop issues:
- cop class: RuboCop::Cop::Lint::DuplicateRequire
- that is: some requires are made twice
- `.rubocop_todo.yml` updated


#### What should we test?
Nothing: this is all about syntax linting and how rubocop should raise no offenses on the above cop when checking.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
