### PR TITLE
Fix Rubocop Locale Errors

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -576,11 +576,6 @@ Rails/HasManyOrHasOneDependent:
     - 'app/models/spree/tax_rate.rb'
     - 'app/models/spree/variant.rb'
 
-# Offense count: 3
-Rails/I18nLocaleTexts:
-  Exclude:
-    - 'app/controllers/admin/stripe_accounts_controller.rb'
-
 # Offense count: 22
 # Configuration parameters: IgnoreScopes, Include.
 # Include: app/models/**/*.rb

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -576,16 +576,6 @@ Rails/HasManyOrHasOneDependent:
     - 'app/models/spree/tax_rate.rb'
     - 'app/models/spree/variant.rb'
 
-# Offense count: 8
-# Configuration parameters: Include.
-# Include: spec/**/*.rb, test/**/*.rb
-Rails/I18nLocaleAssignment:
-  Exclude:
-    - 'spec/controllers/user_registrations_controller_spec.rb'
-    - 'spec/helpers/i18n_helper_spec.rb'
-    - 'spec/models/spree/variant_spec.rb'
-    - 'spec/system/admin/order_cycles/list_spec.rb'
-
 # Offense count: 3
 Rails/I18nLocaleTexts:
   Exclude:

--- a/app/controllers/admin/stripe_accounts_controller.rb
+++ b/app/controllers/admin/stripe_accounts_controller.rb
@@ -16,14 +16,14 @@ module Admin
       authorize! :destroy, stripe_account
 
       if stripe_account.deauthorize_and_destroy
-        flash[:success] = "Stripe account disconnected."
+        flash[:success] = I18n.t('stripe.success_code.disconnected')
       else
-        flash[:error] = "Failed to disconnect Stripe."
+        flash[:error] = I18n.t('stripe.error_code.disconnect_failure')
       end
 
       redirect_to main_app.edit_admin_enterprise_path(stripe_account.enterprise)
     rescue ActiveRecord::RecordNotFound
-      flash[:error] = "Failed to disconnect Stripe."
+      flash[:error] = I18n.t('stripe.error_code.disconnect_failure')
       redirect_to spree.admin_dashboard_path
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,6 +235,9 @@ en:
       transaction_not_allowed: "The card has been declined for an unknown reason."
       try_again_later: "The card has been declined for an unknown reason."
       withdrawal_count_limit_exceeded: "The customer has exceeded the balance or credit limit available on their card."
+      disconnect_failure: "Failed to disconnect Stripe."
+    success_code:
+      disconnected: "Stripe account disconnected."
 
   activemodel:
     errors:

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -96,6 +96,11 @@ RSpec.configure do |config|
     expectations.syntax = :expect
   end
 
+  # Reset locale for all specs.
+  config.around(:each) do |example|
+    I18n.with_locale(:en) { example.run }
+  end
+
   # Reset all feature toggles to prevent leaking.
   config.before(:suite) do
     Flipper.features.each(&:remove)

--- a/spec/controllers/user_registrations_controller_spec.rb
+++ b/spec/controllers/user_registrations_controller_spec.rb
@@ -48,16 +48,9 @@ describe UserRegistrationsController, type: :controller do
     end
 
     it "sets user.locale from cookie on create" do
-      original_i18n_locale = I18n.locale
-      original_locale_cookie = cookies[:locale]
-
-      # changes to +I18n.locale+ will only persist within the +with_locale+ block
-      I18n.with_locale(original_i18n_locale) do
-        cookies[:locale] = "pt"
-        post :create, xhr: true, params: { spree_user: user_params, use_route: :spree }
-        expect(assigns[:user].locale).to eq("pt")
-        cookies[:locale] = original_locale_cookie
-      end
+      cookies[:locale] = "pt"
+      post :create, xhr: true, params: { spree_user: user_params, use_route: :spree }
+      expect(assigns[:user].locale).to eq("pt")
     end
   end
 end

--- a/spec/controllers/user_registrations_controller_spec.rb
+++ b/spec/controllers/user_registrations_controller_spec.rb
@@ -51,12 +51,13 @@ describe UserRegistrationsController, type: :controller do
       original_i18n_locale = I18n.locale
       original_locale_cookie = cookies[:locale]
 
-      cookies[:locale] = "pt"
-      post :create, xhr: true, params: { spree_user: user_params, use_route: :spree }
-      expect(assigns[:user].locale).to eq("pt")
-
-      I18n.locale = original_i18n_locale
-      cookies[:locale] = original_locale_cookie
+      # changes to +I18n.locale+ will only persist within the +with_locale+ block
+      I18n.with_locale(original_i18n_locale) do
+        cookies[:locale] = "pt"
+        post :create, xhr: true, params: { spree_user: user_params, use_route: :spree }
+        expect(assigns[:user].locale).to eq("pt")
+        cookies[:locale] = original_locale_cookie
+      end
     end
   end
 end

--- a/spec/helpers/i18n_helper_spec.rb
+++ b/spec/helpers/i18n_helper_spec.rb
@@ -10,17 +10,6 @@ describe I18nHelper, type: :helper do
     allow(helper).to receive(:cookies) { cookies }
   end
 
-  # In the real world, the helper is called in every request and sets
-  # I18n.locale to the chosen locale or the default. For testing purposes we
-  # have to restore I18n.locale for unit tests that don't call the helper, but
-  # rely on translated strings.
-  around do |example|
-    original_locale = I18n.locale
-    I18n.with_locale(original_locale) do
-      example.run
-    end
-  end
-
   context "as guest" do
     before do
       allow(helper).to receive(:spree_current_user) { nil }

--- a/spec/helpers/i18n_helper_spec.rb
+++ b/spec/helpers/i18n_helper_spec.rb
@@ -15,9 +15,10 @@ describe I18nHelper, type: :helper do
   # have to restore I18n.locale for unit tests that don't call the helper, but
   # rely on translated strings.
   around do |example|
-    locale = I18n.locale
-    example.run
-    I18n.locale = locale
+    original_locale = I18n.locale
+    I18n.with_locale(original_locale) do
+      example.run
+    end
   end
 
   context "as guest" do

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -59,16 +59,6 @@ describe Spree::Variant do
   end
 
   context "price parsing" do
-    around(:each) do |spec|
-      default_locale = I18n.default_locale
-      I18n.with_locale(default_locale) do
-        I18n.backend.store_translations(:de,
-                                        { number: { currency: { format: { delimiter: '.',
-                                                                          separator: ',' } } } })
-        spec.run
-      end
-    end
-
     context "price=" do
       context "with decimal point" do
         it "captures the proper amount for a formatted price" do

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -59,12 +59,13 @@ describe Spree::Variant do
   end
 
   context "price parsing" do
-    before(:each) do
+    around(:each) do |spec|
       default_locale = I18n.default_locale
       I18n.with_locale(default_locale) do
         I18n.backend.store_translations(:de,
                                         { number: { currency: { format: { delimiter: '.',
                                                                           separator: ',' } } } })
+        spec.run
       end
     end
 

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -60,14 +60,12 @@ describe Spree::Variant do
 
   context "price parsing" do
     before(:each) do
-      I18n.locale = I18n.default_locale
-      I18n.backend.store_translations(:de,
-                                      { number: { currency: { format: { delimiter: '.',
-                                                                        separator: ',' } } } })
-    end
-
-    after do
-      I18n.locale = I18n.default_locale
+      default_locale = I18n.default_locale
+      I18n.with_locale(default_locale) do
+        I18n.backend.store_translations(:de,
+                                        { number: { currency: { format: { delimiter: '.',
+                                                                          separator: ',' } } } })
+      end
     end
 
     context "price=" do
@@ -80,17 +78,19 @@ describe Spree::Variant do
 
       context "with decimal comma" do
         it "captures the proper amount for a formatted price" do
-          I18n.locale = :es
-          variant.price = '1.599,99'
-          expect(variant.price).to eq 1599.99
+          I18n.with_locale(:es) do
+            variant.price = '1.599,99'
+            expect(variant.price).to eq 1599.99
+          end
         end
       end
 
       context "with a numeric price" do
         it "uses the price as is" do
-          I18n.locale = :es
-          variant.price = 1599.99
-          expect(variant.price).to eq 1599.99
+          I18n.with_locale(:es) do
+            variant.price = 1599.99
+            expect(variant.price).to eq 1599.99
+          end
         end
       end
     end

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -194,15 +194,6 @@ describe '
 
   private
 
-  def wait_for_edit_form_to_load_order_cycle(order_cycle)
-    expect(page).to have_field "order_cycle_name", with: order_cycle.name
-  end
-
-  def select_incoming_variant(supplier, exchange_no, variant)
-    page.find("table.exchanges tr.supplier-#{supplier.id} td.products").click
-    check "order_cycle_incoming_exchange_#{exchange_no}_variants_#{variant.id}"
-  end
-
   def date_warning_msg(nbr = 1)
     "This order cycle is linked to %d open subscription orders. Changing this date now will not " \
     "affect any orders which have already been placed, but should be avoided if possible. " \

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -133,9 +133,9 @@ describe '
     }
 
     around(:each) do |spec|
-      I18n.locale = :pt
-      spec.run
-      I18n.locale = :en
+      I18n.with_locale(:pt) do
+        spec.run
+      end
     end
 
     context 'using datetimepickers' do


### PR DESCRIPTION
#### What? Why?

- Part of #11482
- Closes #12332
- This PR fixes the following Rubocop errors:
  - [Rails/I18nLocaleAssignment](https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/I18nLocaleAssignment)
  - [Rails/I18nLocaleTexts](https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/I18nLocaleTexts)
- It'd help to review the PR commit by commit. Thanks

#### What should we test?
- Build should be green

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category:

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled