### PR TITLE
Fix lint constant definition in block issue

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,7 +11,6 @@
 # AllowedMethods: enums
 Lint/ConstantDefinitionInBlock:
   Exclude:
-    - 'spec/lib/reports/line_items_spec.rb'
     - 'spec/models/spree/ability_spec.rb'
     - 'spec/models/spree/gateway_spec.rb'
     - 'spec/models/spree/preferences/configuration_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,7 +11,6 @@
 # AllowedMethods: enums
 Lint/ConstantDefinitionInBlock:
   Exclude:
-    - 'spec/models/spree/ability_spec.rb'
     - 'spec/models/spree/gateway_spec.rb'
     - 'spec/models/spree/preferences/configuration_spec.rb'
     - 'spec/models/spree/preferences/preferable_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,17 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 16
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: enums
-Lint/ConstantDefinitionInBlock:
-  Exclude:
-    - 'spec/models/spree/gateway_spec.rb'
-    - 'spec/models/spree/preferences/configuration_spec.rb'
-    - 'spec/models/spree/preferences/preferable_spec.rb'
-    - 'spec/validators/date_time_string_validator_spec.rb'
-    - 'spec/validators/integer_array_validator_spec.rb'
-
 # Offense count: 2
 Lint/DuplicateMethods:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,7 +11,6 @@
 # AllowedMethods: enums
 Lint/ConstantDefinitionInBlock:
   Exclude:
-    - 'lib/tasks/import_product_images.rake'
     - 'lib/tasks/users.rake'
     - 'spec/controllers/spree/admin/base_controller_spec.rb'
     - 'spec/helpers/serializer_helper_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,7 +11,6 @@
 # AllowedMethods: enums
 Lint/ConstantDefinitionInBlock:
   Exclude:
-    - 'lib/tasks/users.rake'
     - 'spec/controllers/spree/admin/base_controller_spec.rb'
     - 'spec/helpers/serializer_helper_spec.rb'
     - 'spec/lib/reports/line_items_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,8 +11,6 @@
 # AllowedMethods: enums
 Lint/ConstantDefinitionInBlock:
   Exclude:
-    - 'spec/controllers/spree/admin/base_controller_spec.rb'
-    - 'spec/helpers/serializer_helper_spec.rb'
     - 'spec/lib/reports/line_items_spec.rb'
     - 'spec/models/spree/ability_spec.rb'
     - 'spec/models/spree/gateway_spec.rb'

--- a/lib/tasks/import_product_images.rake
+++ b/lib/tasks/import_product_images.rake
@@ -4,7 +4,7 @@ namespace :ofn do
   namespace :import do
     desc "Importing images for products from CSV"
     task :product_images, [:filename] => [:environment] do |_task, args|
-      COLUMNS = [:producer, :name, :image_url].freeze
+      columns = [:producer, :name, :image_url].freeze
 
       puts "Warning: use only with trusted URLs. This script will download whatever it can, " \
            "including local secrets, and expose the file as an image file."
@@ -12,7 +12,7 @@ namespace :ofn do
       raise "Filename required" if args[:filename].blank?
 
       csv = CSV.read(args[:filename], headers: true, header_converters: :symbol)
-      raise "CSV columns reqired: #{COLUMNS.map(&:to_s)}" if (COLUMNS - csv.headers).present?
+      raise "CSV columns reqired: #{columns.map(&:to_s)}" if (columns - csv.headers).present?
 
       csv.each.with_index do |entry, index|
         puts "#{index} #{entry[:producer]}, #{entry[:name]}"

--- a/lib/tasks/user/remove_enterprise_limit.rb
+++ b/lib/tasks/user/remove_enterprise_limit.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RemoveEnterpriseLimit
+  MAX_INTEGER = 2_147_483_647
+
+  def initialize(user_id)
+    @user_id = user_id
+  end
+
+  def call
+    user = Spree::User.find(user_id)
+    user.update_attribute(:enterprise_limit, MAX_INTEGER)
+  end
+
+  private
+
+  attr_reader :user_id
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -5,23 +5,7 @@ require 'csv'
 namespace :ofn do
   desc 'remove the limit of enterprises a user can create'
   task :remove_enterprise_limit, [:user_id] => :environment do |_task, args|
+    require 'tasks/user/remove_enterprise_limit'
     RemoveEnterpriseLimit.new(args.user_id).call
-  end
-
-  class RemoveEnterpriseLimit
-    MAX_INTEGER = 2_147_483_647
-
-    def initialize(user_id)
-      @user_id = user_id
-    end
-
-    def call
-      user = Spree::User.find(user_id)
-      user.update_attribute(:enterprise_limit, MAX_INTEGER)
-    end
-
-    private
-
-    attr_reader :user_id
   end
 end

--- a/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/spec/controllers/spree/admin/base_controller_spec.rb
@@ -71,9 +71,9 @@ describe Spree::Admin::BaseController, type: :controller do
 
   describe "determining the name of the serializer to be used" do
     before do
-      class Api::Admin::AllowedPrefixBaseSerializer; end;
+      Api::Admin.const_set "AllowedPrefixBaseSerializer", Class.new
 
-      class Api::Admin::BaseSerializer; end;
+      Api::Admin.const_set "BaseSerializer", Class.new
       allow(controller).to receive(:ams_prefix_whitelist) { [:allowed_prefix] }
     end
 

--- a/spec/helpers/serializer_helper_spec.rb
+++ b/spec/helpers/serializer_helper_spec.rb
@@ -4,10 +4,9 @@ require 'spec_helper'
 
 describe SerializerHelper, type: :helper do
   let(:serializer) do
-    class ExampleEnterpriseSerializer < ActiveModel::Serializer
-      attributes :id, :name
-    end
-    ExampleEnterpriseSerializer
+    Object.const_set("ExampleEnterpriseSerializer", Class.new(ActiveModel::Serializer)).tap { |o|
+      o.attributes :id, :name
+    }
   end
 
   describe "#required_attributes" do

--- a/spec/lib/reports/line_items_spec.rb
+++ b/spec/lib/reports/line_items_spec.rb
@@ -8,29 +8,6 @@ describe Reporting::LineItems do
   # This object lets us add some test coverage despite the very deep coupling between the class
   # under test and the various objects it depends on. Other more common moking strategies where very
   # hard.
-  class FakeOrderPermissions
-    def initialize(line_items, orders_relation)
-      @relations = Spree::LineItem.where(id: line_items.map(&:id))
-      @orders_relation = orders_relation
-    end
-
-    def visible_line_items
-      relations
-    end
-
-    def editable_line_items
-      line_item = FactoryBot.create(:line_item)
-      Spree::LineItem.where(id: line_item.id)
-    end
-
-    def visible_orders
-      orders_relation
-    end
-
-    private
-
-    attr_reader :relations, :orders_relation
-  end
 
   describe '#list' do
     let!(:order) do
@@ -76,4 +53,28 @@ describe Reporting::LineItems do
       end
     end
   end
+end
+
+class FakeOrderPermissions
+  def initialize(line_items, orders_relation)
+    @relations = Spree::LineItem.where(id: line_items.map(&:id))
+    @orders_relation = orders_relation
+  end
+
+  def visible_line_items
+    relations
+  end
+
+  def editable_line_items
+    line_item = FactoryBot.create(:line_item)
+    Spree::LineItem.where(id: line_item.id)
+  end
+
+  def visible_orders
+    orders_relation
+  end
+
+  private
+
+  attr_reader :relations, :orders_relation
 end

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -13,8 +13,6 @@ describe Spree::Ability do
     user.spree_roles.clear
   end
 
-  TOKEN = 'token123'
-
   after(:each) {
     user.spree_roles = []
   }

--- a/spec/models/spree/gateway_spec.rb
+++ b/spec/models/spree/gateway_spec.rb
@@ -3,21 +3,21 @@
 require 'spec_helper'
 
 describe Spree::Gateway do
-  class Provider
-    def initialize(options); end
-
-    def imaginary_method; end
-  end
-
-  class TestGateway < Spree::Gateway
-    def provider_class
-      Provider
-    end
-  end
-
   it "passes through all arguments on a method_missing call" do
     gateway = TestGateway.new
     expect(gateway.provider).to receive(:imaginary_method).with('foo')
     gateway.imaginary_method('foo')
+  end
+end
+
+class Provider
+  def initialize(options); end
+
+  def imaginary_method; end
+end
+
+class TestGateway < Spree::Gateway
+  def provider_class
+    Provider
   end
 end

--- a/spec/models/spree/preferences/configuration_spec.rb
+++ b/spec/models/spree/preferences/configuration_spec.rb
@@ -4,9 +4,6 @@ require 'spec_helper'
 
 describe Spree::Preferences::Configuration do
   before :all do
-    class AppConfig < Spree::Preferences::Configuration
-      preference :color, :string, default: :blue
-    end
     @config = AppConfig.new
   end
 
@@ -24,4 +21,8 @@ describe Spree::Preferences::Configuration do
     @config.set :color, 'green'
     expect(@config.get(:color)).to eq 'green'
   end
+end
+
+class AppConfig < Spree::Preferences::Configuration
+  preference :color, :string, default: :blue
 end

--- a/spec/validators/date_time_string_validator_spec.rb
+++ b/spec/validators/date_time_string_validator_spec.rb
@@ -3,14 +3,6 @@
 require "spec_helper"
 
 describe DateTimeStringValidator do
-  class TestModel
-    include ActiveModel::Validations
-
-    attr_accessor :timestamp
-
-    validates :timestamp, date_time_string: true
-  end
-
   describe "internationalization" do
     it "has translation for NOT_STRING_ERROR" do
       expect(described_class.not_string_error).not_to be_blank
@@ -57,4 +49,12 @@ describe DateTimeStringValidator do
       expect(instance.errors[:timestamp]).to eq([described_class.invalid_format_error])
     end
   end
+end
+
+class TestModel
+  include ActiveModel::Validations
+
+  attr_accessor :timestamp
+
+  validates :timestamp, date_time_string: true
 end

--- a/spec/validators/integer_array_validator_spec.rb
+++ b/spec/validators/integer_array_validator_spec.rb
@@ -3,14 +3,6 @@
 require "spec_helper"
 
 describe IntegerArrayValidator do
-  class TestModel
-    include ActiveModel::Validations
-
-    attr_accessor :ids
-
-    validates :ids, integer_array: true
-  end
-
   describe "internationalization" do
     it "has translation for NOT_ARRAY_ERROR" do
       expect(described_class.not_array_error).not_to be_blank
@@ -56,4 +48,12 @@ describe IntegerArrayValidator do
       expect(instance.errors[:ids]).to include(described_class.invalid_element_error)
     end
   end
+end
+
+class TestModel
+  include ActiveModel::Validations
+
+  attr_accessor :ids
+
+  validates :ids, integer_array: true
 end


### PR DESCRIPTION
#### What? Why?

Contributes to #11482 

Fixes one of many rubocop issues

- cop class: `RuboCop::Cop::Lint::ConstantDefinitionInBlock`
- most of the time, object used by the spec are defined in the example group itself. Object definition out of it do not raise an offense.
- some other times, all is needed is a dynamic definition
- at one time, a constant array needs only to be a variable array
- details are in the commit messages
- `.rubocop_todo.yml` updated

#### What should we test?
Nothing: the rubocop should raise no offenses when checking linters at Integration.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
