### PR TITLE
Fix rubocop Lint/DuplicateMethods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,11 +23,6 @@ Lint/ConstantDefinitionInBlock:
     - 'spec/validators/date_time_string_validator_spec.rb'
     - 'spec/validators/integer_array_validator_spec.rb'
 
-# Offense count: 2
-Lint/DuplicateMethods:
-  Exclude:
-    - 'lib/discourse/single_sign_on.rb'
-
 # Offense count: 16
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
 Lint/EmptyBlock:

--- a/lib/discourse/single_sign_on.rb
+++ b/lib/discourse/single_sign_on.rb
@@ -12,7 +12,7 @@ module Discourse
              :suppress_welcome_message].freeze
     NONCE_EXPIRY_TIME = 10.minutes
 
-    attr_accessor(*ACCESSORS, :sso_secret, :sso_url)
+    attr_accessor(*ACCESSORS)
 
     def self.sso_secret
       raise "sso_secret not implemented on class, be sure to set it on instance"


### PR DESCRIPTION
#### What? Why?

- Part of Fix Rubocop Lint issues [#12330](https://github.com/openfoodfoundation/openfoodnetwork/issues/12330)

Fixed the `Lint/DuplicateMethods` offense. 

`sso_secret` is defined at both `attr_accessor` and `lib/discourse/single_sign_on.rb:66`

`sso_url` is defined at both  `attr_accessor`  and `lib/discourse/single_sign_on.rb:70`

#### What should we test?

Fix seems pretty safe since we are just removing duplicate instance methods. But might be worth testing SSO to discourse.

#### Release notes

Changelog Category: Technical changes

#### Dependencies

#### Documentation updates
