### PR TITLE
Fix rubocop FixRailsWhereEquals

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -798,38 +798,6 @@ Rails/UnusedRenderContent:
     - 'app/controllers/api/v0/taxons_controller.rb'
     - 'app/controllers/api/v0/variants_controller.rb'
 
-# Offense count: 54
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/WhereEquals:
-  Exclude:
-    - 'app/controllers/spree/admin/products_controller.rb'
-    - 'app/mailers/producer_mailer.rb'
-    - 'app/models/enterprise.rb'
-    - 'app/models/enterprise_fee.rb'
-    - 'app/models/enterprise_group.rb'
-    - 'app/models/enterprise_relationship.rb'
-    - 'app/models/exchange.rb'
-    - 'app/models/order_cycle.rb'
-    - 'app/models/product_import/entry_processor.rb'
-    - 'app/models/proxy_order.rb'
-    - 'app/models/schedule.rb'
-    - 'app/models/spree/line_item.rb'
-    - 'app/models/spree/order.rb'
-    - 'app/models/spree/payment_method.rb'
-    - 'app/models/spree/product.rb'
-    - 'app/models/spree/shipping_method.rb'
-    - 'app/models/spree/variant.rb'
-    - 'app/models/subscription.rb'
-    - 'app/serializers/api/enterprise_shopfront_serializer.rb'
-    - 'app/serializers/api/order_serializer.rb'
-    - 'lib/open_food_network/enterprise_fee_calculator.rb'
-    - 'lib/open_food_network/order_cycle_permissions.rb'
-    - 'lib/reporting/reports/products_and_inventory/base.rb'
-    - 'lib/tasks/data.rake'
-    - 'lib/tasks/data/anonymize_data.rake'
-    - 'lib/tasks/data/remove_transient_data.rb'
-    - 'spec/services/product_tag_rules_filterer_spec.rb'
-
 # Offense count: 8
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -175,7 +175,7 @@ module Spree
         Spree::Variant.
           select('DISTINCT spree_variants.import_date').
           joins(:product).
-          where('spree_products.supplier_id IN (?)', editable_enterprises.collect(&:id)).
+          where(spree_products: { supplier_id: editable_enterprises.collect(&:id) }).
           where.not(spree_variants: { import_date: nil }).
           where(spree_variants: { deleted_at: nil }).
           order('spree_variants.import_date DESC')

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -52,7 +52,7 @@ class ProducerMailer < ApplicationMailer
   def distributors_pickup_times_for(line_items)
     @order_cycle.distributors.
       joins(:distributed_orders).
-      where("spree_orders.id IN (?)", line_items.map(&:order_id).uniq).
+      where(spree_orders: { id: line_items.map(&:order_id).uniq }).
       map do |distributor|
       [distributor.name, @order_cycle.pickup_time_for(distributor)]
     end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -161,7 +161,7 @@ class Enterprise < ApplicationRecord
   scope :is_hub, -> { where(sells: 'any') }
   scope :supplying_variant_in, lambda { |variants|
     joins(supplied_products: :variants).
-      where('spree_variants.id IN (?)', variants).
+      where(spree_variants: { id: variants }).
       select('DISTINCT enterprises.*')
   }
 
@@ -205,7 +205,7 @@ class Enterprise < ApplicationRecord
       ").
       joins('INNER JOIN exchange_variants ON (exchange_variants.exchange_id = exchanges.id)').
       joins('INNER JOIN spree_variants ON (spree_variants.id = exchange_variants.variant_id)').
-      where('spree_variants.product_id IN (?)', product_ids).select('DISTINCT enterprises.id')
+      where(spree_variants: { product_id: product_ids }).select('DISTINCT enterprises.id')
 
     where(id: exchanges)
   }
@@ -214,7 +214,7 @@ class Enterprise < ApplicationRecord
     if user.has_spree_role?('admin')
       where(nil)
     else
-      joins(:enterprise_roles).where('enterprise_roles.user_id = ?', user.id)
+      joins(:enterprise_roles).where(enterprise_roles: { user_id: user.id })
     end
   }
 
@@ -382,7 +382,7 @@ class Enterprise < ApplicationRecord
   def distributed_taxons
     Spree::Taxon.
       joins(:products).
-      where('spree_products.id IN (?)', Spree::Product.in_distributor(self).select(&:id)).
+      where(spree_products: { id: Spree::Product.in_distributor(self).select(&:id) }).
       select('DISTINCT spree_taxons.*')
   end
 
@@ -398,7 +398,7 @@ class Enterprise < ApplicationRecord
   def supplied_taxons
     Spree::Taxon.
       joins(:products).
-      where('spree_products.id IN (?)', Spree::Product.in_supplier(self).select(&:id)).
+      where(spree_products: { id: Spree::Product.in_supplier(self).select(&:id) }).
       select('DISTINCT spree_taxons.*')
   end
 
@@ -472,7 +472,7 @@ class Enterprise < ApplicationRecord
     ExchangeVariant.joins(exchange: :order_cycle)
       .merge(Exchange.outgoing)
       .select("DISTINCT exchange_variants.variant_id, exchanges.receiver_id AS enterprise_id")
-      .where("exchanges.receiver_id = ?", id)
+      .where(exchanges: { receiver_id: id })
       .merge(OrderCycle.active.with_distributor(id))
   end
 

--- a/app/models/enterprise_fee.rb
+++ b/app/models/enterprise_fee.rb
@@ -32,7 +32,7 @@ class EnterpriseFee < ApplicationRecord
     if user.has_spree_role?('admin')
       where(nil)
     else
-      where('enterprise_id IN (?)', user.enterprises.select(&:id))
+      where(enterprise_id: user.enterprises.select(&:id))
     end
   }
 
@@ -40,7 +40,7 @@ class EnterpriseFee < ApplicationRecord
     joins(:calculator).where.not(spree_calculators: { type: PER_ORDER_CALCULATORS })
   }
   scope :per_order, lambda {
-    joins(:calculator).where('spree_calculators.type IN (?)', PER_ORDER_CALCULATORS)
+    joins(:calculator).where(spree_calculators: { type: PER_ORDER_CALCULATORS })
   }
 
   def self.clear_all_adjustments(order)

--- a/app/models/enterprise_group.rb
+++ b/app/models/enterprise_group.rb
@@ -41,7 +41,7 @@ class EnterpriseGroup < ApplicationRecord
     if user.has_spree_role?('admin')
       where(nil)
     else
-      where('owner_id = ?', user.id)
+      where(owner_id: user.id)
     end
   }
 

--- a/app/models/enterprise_relationship.rb
+++ b/app/models/enterprise_relationship.rb
@@ -27,12 +27,12 @@ class EnterpriseRelationship < ApplicationRecord
     where('parent_id IN (?) OR child_id IN (?)', enterprises.select(&:id), enterprises.select(&:id))
   }
 
-  scope :permitting, ->(enterprise_ids) { where('child_id IN (?)', enterprise_ids) }
-  scope :permitted_by, ->(enterprise_ids) { where('parent_id IN (?)', enterprise_ids) }
+  scope :permitting, ->(enterprise_ids) { where(child_id: enterprise_ids) }
+  scope :permitted_by, ->(enterprise_ids) { where(parent_id: enterprise_ids) }
 
   scope :with_permission, ->(permission) {
     joins(:permissions).
-      where('enterprise_relationship_permissions.name = ?', permission)
+      where(enterprise_relationship_permissions: { name: permission })
   }
 
   scope :by_name, -> { with_enterprises.order('child_enterprises.name, parent_enterprises.name') }
@@ -108,6 +108,6 @@ class EnterpriseRelationship < ApplicationRecord
 
   def child_variant_overrides
     VariantOverride.unscoped.for_hubs(child)
-      .joins(variant: :product).where("spree_products.supplier_id IN (?)", parent)
+      .joins(variant: :product).where(spree_products: { supplier_id: parent })
   end
 end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -38,8 +38,8 @@ class Exchange < ApplicationRecord
   scope :outgoing, -> { where(incoming: false) }
   scope :from_enterprise, lambda { |enterprise| where(sender_id: enterprise) }
   scope :to_enterprise, lambda { |enterprise| where(receiver_id: enterprise) }
-  scope :from_enterprises, lambda { |enterprises| where('exchanges.sender_id IN (?)', enterprises) }
-  scope :to_enterprises, lambda { |enterprises| where('exchanges.receiver_id IN (?)', enterprises) }
+  scope :from_enterprises, lambda { |enterprises| where(exchanges: { sender_id: enterprises }) }
+  scope :to_enterprises, lambda { |enterprises| where(exchanges: { receiver_id: enterprises }) }
   scope :involving, lambda { |enterprises|
     where('exchanges.receiver_id IN (?) OR exchanges.sender_id IN (?)', enterprises, enterprises).
       select('DISTINCT exchanges.*')
@@ -48,7 +48,7 @@ class Exchange < ApplicationRecord
     where('exchanges.incoming OR exchanges.receiver_id = ?', distributor)
   }
   scope :with_variant, lambda { |variant|
-    joins(:exchange_variants).where('exchange_variants.variant_id = ?', variant)
+    joins(:exchange_variants).where(exchange_variants: { variant_id: variant })
   }
   scope :with_any_variant, lambda { |variant_ids|
     joins(:exchange_variants).
@@ -57,7 +57,7 @@ class Exchange < ApplicationRecord
   }
   scope :with_product, lambda { |product|
     joins(:exchange_variants).
-      where('exchange_variants.variant_id IN (?)', product.variants.select(&:id))
+      where(exchange_variants: { variant_id: product.variants.select(&:id) })
   }
   scope :by_enterprise_name, -> {
     joins('INNER JOIN enterprises AS sender   ON (sender.id   = exchanges.sender_id)').

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -165,13 +165,13 @@ class OrderCycle < ApplicationRecord
   def attachable_distributor_payment_methods
     DistributorPaymentMethod.joins(:payment_method).
       merge(Spree::PaymentMethod.available).
-      where("distributor_id IN (?)", distributor_ids)
+      where(distributor_id: distributor_ids)
   end
 
   def attachable_distributor_shipping_methods
     DistributorShippingMethod.joins(:shipping_method).
       merge(Spree::ShippingMethod.frontend).
-      where("distributor_id IN (?)", distributor_ids)
+      where(distributor_id: distributor_ids)
   end
 
   def clone!

--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -56,7 +56,7 @@ module ProductImport
           else
             Spree::Variant.
               joins(:product).
-              where('spree_products.supplier_id IN (?)', enterprise_id).
+              where(spree_products: { supplier_id: enterprise_id }).
               count
           end
 

--- a/app/models/proxy_order.rb
+++ b/app/models/proxy_order.rb
@@ -17,7 +17,7 @@ class ProxyOrder < ApplicationRecord
   scope :closed, -> { joins(:order_cycle).merge(OrderCycle.closed) }
   scope :not_closed, -> { joins(:order_cycle).merge(OrderCycle.not_closed) }
   scope :canceled, -> { where.not(proxy_orders: { canceled_at: nil }) }
-  scope :not_canceled, -> { where('proxy_orders.canceled_at IS NULL') }
+  scope :not_canceled, -> { where(proxy_orders: { canceled_at: nil }) }
   scope :placed_and_open, -> {
                             joins(:order).not_closed
                               .where(spree_orders: { state: ['complete', 'resumed'] })

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -8,7 +8,8 @@ class Schedule < ApplicationRecord
   has_many :coordinators, -> { distinct }, through: :order_cycles
 
   scope :with_coordinator, lambda { |enterprise|
-                             joins(:order_cycles).where('coordinator_id = ?', enterprise.id)
+                             joins(:order_cycles)
+                               .where(order_cycles: { coordinator_id: enterprise.id })
                                .select('DISTINCT schedules.*')
                            }
 

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -85,7 +85,7 @@ module Spree
 
     scope :from_order_cycle, lambda { |order_cycle|
       joins(order: :order_cycle).
-        where('order_cycles.id = ?', order_cycle)
+        where(order_cycles: { id: order_cycle })
     }
 
     # Here we are simply joining the line item to its variant and product
@@ -94,12 +94,12 @@ module Spree
     scope :supplied_by_any, lambda { |enterprises|
       product_ids = Spree::Product.unscoped.where(supplier_id: enterprises).select(:id)
       variant_ids = Spree::Variant.unscoped.where(product_id: product_ids).select(:id)
-      where("spree_line_items.variant_id IN (?)", variant_ids)
+      where(spree_line_items: { variant_id: variant_ids })
     }
 
     scope :with_tax, -> {
       joins(:adjustments).
-        where('spree_adjustments.originator_type = ?', 'Spree::TaxRate').
+        where(spree_adjustments: { originator_type: 'Spree::TaxRate' }).
         select('DISTINCT spree_line_items.*')
     }
 
@@ -110,7 +110,7 @@ module Spree
           ON (spree_adjustments.adjustable_id=spree_line_items.id
             AND spree_adjustments.adjustable_type = 'Spree::LineItem'
             AND spree_adjustments.originator_type='Spree::TaxRate')").
-        where('spree_adjustments.id IS NULL')
+        where(spree_adjustments: { id: nil })
     }
 
     def copy_price

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -141,7 +141,7 @@ module Spree
       if user.has_spree_role?('admin')
         where(nil)
       else
-        where('spree_orders.distributor_id IN (?)', user.enterprises.select(&:id))
+        where(spree_orders: { distributor_id: user.enterprises.select(&:id) })
       end
     }
 

--- a/app/models/spree/payment_method.rb
+++ b/app/models/spree/payment_method.rb
@@ -29,8 +29,7 @@ module Spree
       return where(nil) if user.admin?
 
       joins(:distributors).
-        where('distributors_payment_methods.distributor_id IN (?)',
-              user.enterprises.select(&:id)).
+        where(distributors_payment_methods: { distributor_id: user.enterprises.select(&:id) }).
         select('DISTINCT spree_payment_methods.*')
     }
 
@@ -40,7 +39,7 @@ module Spree
     }
 
     scope :for_distributor, ->(distributor) {
-      joins(:distributors).where('enterprises.id = ?', distributor)
+      joins(:distributors).where(enterprises: { id: distributor })
     }
 
     scope :for_subscriptions, -> { where(type: Subscription::ALLOWED_PAYMENT_METHOD_TYPES) }

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -159,7 +159,7 @@ module Spree
     scope :in_order_cycle, lambda { |order_cycle|
       with_order_cycles_inner.
         merge(Exchange.outgoing).
-        where('order_cycles.id = ?', order_cycle)
+        where(order_cycles: { id: order_cycle })
     }
 
     scope :in_an_active_order_cycle, lambda {
@@ -176,7 +176,7 @@ module Spree
       if user.has_spree_role?('admin')
         where(nil)
       else
-        where('supplier_id IN (?)', user.enterprises.select("enterprises.id"))
+        where(supplier_id: user.enterprises.select("enterprises.id"))
       end
     }
 
@@ -187,10 +187,10 @@ module Spree
         .with_permission(:add_to_order_cycle)
         .where(enterprises: { is_primary_producer: true })
         .pluck(:parent_id)
-      where('spree_products.supplier_id IN (?)', [enterprise.id] | permitted_producer_ids)
+      where(spree_products: { supplier_id: [enterprise.id] | permitted_producer_ids })
     }
 
-    scope :active, lambda { where("spree_products.deleted_at IS NULL") }
+    scope :active, lambda { where(spree_products: { deleted_at: nil }) }
 
     def self.group_by_products_id
       group(column_names.map { |col_name| "#{table_name}.#{col_name}" })
@@ -265,8 +265,8 @@ module Spree
         touch_distributors
 
         ExchangeVariant.
-          where('exchange_variants.variant_id IN (?)', variants.with_deleted.
-          select(:id)).destroy_all
+          where(exchange_variants: { variant_id: variants.with_deleted.
+          select(:id) }).destroy_all
 
         yield
       end

--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -41,8 +41,7 @@ module Spree
         where(nil)
       else
         joins(:distributors).
-          where('distributors_shipping_methods.distributor_id IN (?)',
-                user.enterprises.select(&:id)).
+          where(distributors_shipping_methods: { distributor_id: user.enterprises.select(&:id) }).
           select('DISTINCT spree_shipping_methods.*')
       end
     }
@@ -53,7 +52,7 @@ module Spree
     }
     scope :for_distributor, lambda { |distributor|
       joins(:distributors).
-        where('enterprises.id = ?', distributor)
+        where(enterprises: { id: distributor })
     }
 
     scope :by_name, -> { order('spree_shipping_methods.name ASC') }

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -101,7 +101,7 @@ module Spree
     scope :in_order_cycle, lambda { |order_cycle|
       with_order_cycles_inner.
         merge(Exchange.outgoing).
-        where('order_cycles.id = ?', order_cycle).
+        where(order_cycles: { id: order_cycle }).
         select('DISTINCT spree_variants.*')
     }
 
@@ -113,8 +113,8 @@ module Spree
     }
 
     scope :for_distribution, lambda { |order_cycle, distributor|
-      where('spree_variants.id IN (?)', order_cycle.variants_distributed_by(distributor).
-        select(&:id))
+      where(spree_variants: { id: order_cycle.variants_distributed_by(distributor).
+        select(&:id) })
     }
 
     scope :visible_for, lambda { |enterprise|
@@ -161,12 +161,12 @@ module Spree
     def self.active(currency = nil)
       # "where(id:" is necessary so that the returned relation has no includes
       # The relation without includes will not be readonly and allow updates on it
-      where("spree_variants.id in (?)", joins(:prices).
+      where(spree_variants: { id: joins(:prices).
                                           where(deleted_at: nil).
                                           where('spree_prices.currency' =>
                                             currency || CurrentConfig.get(:currency)).
                                           where.not(spree_prices: { amount: nil }).
-                                          select("spree_variants.id"))
+                                          select("spree_variants.id") })
     end
 
     def tax_category

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -34,8 +34,8 @@ class Subscription < ApplicationRecord
                       where('subscriptions.ends_at > (?) OR subscriptions.ends_at IS NULL',
                             Time.zone.now)
                     }
-  scope :not_canceled, -> { where('subscriptions.canceled_at IS NULL') }
-  scope :not_paused, -> { where('subscriptions.paused_at IS NULL') }
+  scope :not_canceled, -> { where(subscriptions: { canceled_at: nil }) }
+  scope :not_paused, -> { where(subscriptions: { paused_at: nil }) }
   scope :active, -> {
                    not_canceled.not_ended.not_paused.where('subscriptions.begins_at <= (?)',
                                                            Time.zone.now)

--- a/app/serializers/api/enterprise_shopfront_serializer.rb
+++ b/app/serializers/api/enterprise_shopfront_serializer.rb
@@ -145,7 +145,7 @@ module Api
       require_shipping = type == :delivery ? 't' : 'f'
       Spree::ShippingMethod.
         joins(:distributor_shipping_methods).
-        where('distributors_shipping_methods.distributor_id = ?', enterprise.id).
+        where(distributors_shipping_methods: { distributor_id: enterprise.id }).
         where("spree_shipping_methods.require_ship_address = '#{require_shipping}'").exists?
     end
   end

--- a/app/serializers/api/order_serializer.rb
+++ b/app/serializers/api/order_serializer.rb
@@ -16,7 +16,7 @@ module Api
     end
 
     def payments
-      object.payments.joins(:payment_method).where('state IN (?)', %w(completed pending))
+      object.payments.joins(:payment_method).where(state: %w(completed pending))
     end
 
     def shop_id

--- a/lib/open_food_network/enterprise_fee_calculator.rb
+++ b/lib/open_food_network/enterprise_fee_calculator.rb
@@ -111,7 +111,7 @@ module OpenFoodNetwork
       EnterpriseFee.
         per_item.
         joins(exchanges: :exchange_variants).
-        where('exchanges.order_cycle_id = ?', @order_cycle.id).
+        where(exchanges: { order_cycle_id: @order_cycle.id }).
         merge(Exchange.supplying_to(@distributor)).
         select('enterprise_fees.*, exchange_variants.variant_id AS variant_id')
     end

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -99,10 +99,10 @@ module OpenFoodNetwork
             ).pluck(:id).uniq
 
           product_ids = Spree::Product.joins(:variants).
-            where("spree_variants.id IN (?)", variant_ids).pluck(:id).uniq
+            where(spree_variants: { id: variant_ids }).pluck(:id).uniq
 
           producers_active_ids = Enterprise.joins(:supplied_products).
-            where("spree_products.id IN (?)", product_ids).pluck(:id).uniq
+            where(spree_products: { id: product_ids }).pluck(:id).uniq
         end
 
         ids = managed_permitted_ids | hubs_permitted_ids | hubs_permitting_ids |

--- a/lib/reporting/reports/products_and_inventory/base.rb
+++ b/lib/reporting/reports/products_and_inventory/base.rb
@@ -59,7 +59,7 @@ module Reporting
 
         def filter_to_supplier(variants)
           if params[:supplier_id].to_i > 0
-            variants.where("spree_products.supplier_id = ?", params[:supplier_id])
+            variants.where(spree_products: { supplier_id: params[:supplier_id] })
           else
             variants
           end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -46,11 +46,13 @@ namespace :ofn do
           end
 
           # For each variant in the exchange
-          products = Spree::Product.joins(:variants).where(
-            'spree_variants.id IN (?)', exchange.variants
-          ).pluck(:id).uniq
-          producers = Enterprise.joins(:supplied_products).where("spree_products.id IN (?)",
-                                                                 products).distinct
+          products = Spree::Product.joins(:variants)
+            .where(spree_variants: { id: exchange.variants })
+            .pluck(:id)
+            .uniq
+          producers = Enterprise.joins(:supplied_products)
+            .where(spree_products: { id: products })
+            .distinct
           producers.each do |producer|
             next if producer == exchange.receiver
 

--- a/lib/tasks/data/anonymize_data.rake
+++ b/lib/tasks/data/anonymize_data.rake
@@ -44,7 +44,7 @@ namespace :ofn do
       Spree::User.update_all("email = concat(id, '_ofn_user@example.com'),
                               login = concat(id, '_ofn_user@example.com'),
                               unconfirmed_email = concat(id, '_ofn_user@example.com')")
-      Customer.where("user_id IS NULL")
+      Customer.where(user_id: nil)
         .update_all("email = concat(id, '_ofn_customer@example.com'),
                      name = concat('Customer Number ', id, ' (without connected User)')")
       Customer.where.not(user_id: nil)

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -38,6 +38,6 @@ class RemoveTransientData
     # Carts with failed payments are ignored, as they contain potentially useful data
     Spree::Order.
       joins("LEFT OUTER JOIN spree_payments ON spree_orders.id = spree_payments.order_id").
-      where("spree_payments.id IS NULL")
+      where(spree_payments: { id: nil })
   end
 end

--- a/spec/services/product_tag_rules_filterer_spec.rb
+++ b/spec/services/product_tag_rules_filterer_spec.rb
@@ -18,7 +18,7 @@ describe ProductTagRulesFilterer do
     }
     let(:customer) { create(:customer, enterprise: distributor) }
     let(:variants_relation) {
-      Spree::Variant.joins(:product).where("spree_products.supplier_id = ?", distributor.id)
+      Spree::Variant.joins(:product).where(spree_products: { supplier_id: distributor.id })
     }
     let(:default_hide_rule) {
       create(:filter_products_tag_rule,


### PR DESCRIPTION
 #### What? Why?

- Contributes to #11482 

Fixes offenses caused by `RuboCop::Cop::Rails::WhereEquals` cop

I did not chunk corrections by commit, or rather it is a single chunk as the method for removing the offense is the same for each change.
Basically, replace each of `User.where('name IS NULL')` or `User.where('name IN (?)', ['john', 'jane'])` with the like of
`User.where(name: nil)` or `User.where(name: ['john', 'jane'])`

There are a lot of changes, I did the first ones manually and then used the autocorrect option and checked afterwards.
One line, one by one in the todo, so that I have to check one correction at a time.





#### What should we test?
Nothing. All offenses should be corrected and therefore raise nothing.
All tests should pass and so show no sign of regression.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
