### PR TITLE
Fix: preserve order of invoices in bulk print

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -165,6 +165,7 @@ module Spree
     scope :finalized, -> { where(state: FINALIZED_STATES) }
     scope :complete, -> { where.not(completed_at: nil) }
     scope :incomplete, -> { where(completed_at: nil) }
+    scope :invoiceable, -> { where(state: [:complete, :resumed]) }
     scope :by_state, lambda { |state| where(state:) }
     scope :not_state, lambda { |state| where.not(state:) }
 
@@ -211,10 +212,6 @@ module Spree
 
     def completed?
       completed_at.present?
-    end
-
-    def invoiceable?
-      complete? || resumed?
     end
 
     # Indicates whether or not the user is allowed to proceed to checkout.

--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -44,8 +44,13 @@ module Admin
         html: render(partial: "spree/admin/orders/bulk/invoice_modal")
       ).broadcast
 
+      # Preserve order of bulk_ids.
+      # The ids are supplied in the sequence of the orders screen and may be
+      # sorted, for example by last name of the customer.
+      visible_order_ids = params[:bulk_ids].map(&:to_i) & visible_orders.pluck(:id)
+
       BulkInvoiceJob.perform_later(
-        visible_orders.pluck(:id),
+        visible_order_ids,
         "tmp/invoices/#{Time.zone.now.to_i}-#{SecureRandom.hex(2)}.pdf",
         channel: SessionChannel.for_request(request),
         current_user_id: current_user.id

--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -32,7 +32,7 @@ module Admin
     end
 
     def bulk_invoice(params)
-      visible_orders = editable_orders.where(id: params[:bulk_ids]).filter(&:invoiceable?)
+      visible_orders = editable_orders.invoiceable.where(id: params[:bulk_ids])
       if Spree::Config.enterprise_number_required_on_invoices? &&
          !all_distributors_can_invoice?(visible_orders)
         render_business_number_required_error(visible_orders)
@@ -87,8 +87,8 @@ module Admin
 
     def send_invoices(params)
       count = 0
-      editable_orders.where(id: params[:bulk_ids]).find_each do |o|
-        next unless o.distributor.can_invoice? && o.invoiceable?
+      editable_orders.invoiceable.where(id: params[:bulk_ids]).find_each do |o|
+        next unless o.distributor.can_invoice?
 
         Spree::OrderMailer.invoice_email(o.id, current_user_id: current_user.id).deliver_later
         count += 1

--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -126,11 +126,6 @@ module Admin
       params[:id] = @order.number
     end
 
-    def all_distributors_can_invoice?(orders)
-      distributor_ids = orders.map(&:distributor_id)
-      Enterprise.where(id: distributor_ids, abn: nil).empty?
-    end
-
     def render_business_number_required_error(distributors)
       distributor_names = distributors.pluck(:name)
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -140,23 +140,6 @@ describe Spree::Order do
     end
   end
 
-  context "#invoiceable?" do
-    it "should return true if the order is completed" do
-      allow(order).to receive_messages(complete?: true)
-      expect(order.invoiceable?).to be_truthy
-    end
-
-    it "should return true if the order is resumed" do
-      allow(order).to receive_messages(resumed?: true)
-      expect(order.invoiceable?).to be_truthy
-    end
-
-    it "should return false if the order is neither completed nor resumed" do
-      allow(order).to receive_messages(complete?: false, resumed?: false)
-      expect(order.invoiceable?).to be_falsy
-    end
-  end
-
   context '#changes_allowed?' do
     let(:order) { create(:order_ready_for_details) }
     let(:complete) { true }
@@ -997,6 +980,19 @@ describe Spree::Order do
   end
 
   describe "scopes" do
+    describe "invoiceable" do
+      it "finds only active orders" do
+        order_complete = create(:order, state: :complete)
+        order_canceled = create(:order, state: :canceled)
+        order_resumed = create(:order, state: :resumed)
+
+        expect(Spree::Order.invoiceable).to match_array [
+          order_complete,
+          order_resumed,
+        ]
+      end
+    end
+
     describe "not_state" do
       it "finds only orders not in specified state" do
         o = FactoryBot.create(:completed_order_with_totals,

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -686,7 +686,7 @@ describe '
                 invoice_content = extract_pdf_content
 
                 expect(
-                  invoice_content
+                  invoice_content.join
                 ).to match(/#{surnames[0]}.*#{surnames[1]}.*#{surnames[2]}.*#{surnames[3]}/m)
               end
             end

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -710,7 +710,6 @@ describe '
                    order4.name.gsub(/.* /, ""), order5.name.gsub(/.* /, "")].sort
                 }
                 before do
-                  pending("#12340")
                   page.find('a', text: "NAME").click # orders alphabetically (asc)
                   sleep(0.5) # waits for column sorting
                   page.find('#selectAll').click
@@ -723,7 +722,6 @@ describe '
                    order4.name.gsub(/.* /, ""), order5.name.gsub(/.* /, "")].sort.reverse
                 }
                 before do
-                  pending("#12340")
                   page.find('a', text: "NAME").click # orders alphabetically (asc)
                   sleep(0.5) # waits for column sorting
                   page.find('a', text: "NAME").click # orders alphabetically (desc)


### PR DESCRIPTION
#### What? Why?

- Closes #12340 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Preserving the sort order in invoices again and simplifying the code a little.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Bulk print invoices.
- Sort orders in different ways and check the invoice order.
- Repeat with the new invoices feature and without.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
