### PR TITLE
Fix Rails/WhereExists rubocop offenses

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -124,6 +124,9 @@ Rails/SkipsModelValidations:
     - update_column
     - update_columns
 
+Rails/WhereExists:
+  EnforcedStyle: where # Cf. conversion https://github.com/openfoodfoundation/openfoodnetwork/pull/12363
+
 Style/Documentation:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -773,21 +773,6 @@ Rails/UnusedRenderContent:
     - 'app/controllers/api/v0/taxons_controller.rb'
     - 'app/controllers/api/v0/variants_controller.rb'
 
-# Offense count: 8
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: exists, where
-Rails/WhereExists:
-  Exclude:
-    - 'app/controllers/spree/admin/overview_controller.rb'
-    - 'app/controllers/spree/admin/tax_rates_controller.rb'
-    - 'app/controllers/spree/user_sessions_controller.rb'
-    - 'app/models/spree/preferences/store.rb'
-    - 'lib/tasks/sample_data/customer_factory.rb'
-    - 'lib/tasks/sample_data/group_factory.rb'
-    - 'lib/tasks/sample_data/order_cycle_factory.rb'
-    - 'lib/tasks/sample_data/taxon_factory.rb'
-
 # Offense count: 1
 Security/Open:
   Exclude:

--- a/app/models/spree/credit_card.rb
+++ b/app/models/spree/credit_card.rb
@@ -152,7 +152,7 @@ module Spree
     end
 
     def default_missing?
-      !user.credit_cards.exists?(is_default: true)
+      !user.credit_cards.where(is_default: true).exists?
     end
 
     def default_card_needs_updating?

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -694,7 +694,7 @@ module Spree
     end
 
     def registered_email?
-      Spree::User.exists?(email:)
+      Spree::User.where(email:).exists?
     end
 
     def adjustments_fetcher

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -246,7 +246,7 @@ module Spree
     # and this is it. Related to #1998.
     # See https://github.com/spree/spree/issues/1998#issuecomment-12869105
     def set_unique_identifier
-      self.identifier = generate_identifier while self.class.exists?(identifier:)
+      self.identifier = generate_identifier while self.class.where(identifier:).exists?
     end
 
     def generate_identifier

--- a/lib/reporting/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_order.rb
+++ b/lib/reporting/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_order.rb
@@ -66,8 +66,8 @@ module Reporting
 
           enterprise_fee_id = arg.first
 
-          EnterpriseFee.exists?(id: enterprise_fee_id,
-                                enterprise_id: ransack_params[:enterprise_fee_owner_id_in] )
+          EnterpriseFee.where(id: enterprise_fee_id,
+                              enterprise_id: ransack_params[:enterprise_fee_owner_id_in] ).exists?
         end
 
         def filter_enterprise_fee_by_id_active?


### PR DESCRIPTION
Edited:
- no corrections will be made (see conversation below), but instead, the `where` style will be enforced from now on.

#### What? Why?

- Contributes to #11482

- Cop: [RuboCop::Cop::Rails::WhereExists](https://www.rubydoc.info/gems/rubocop-rails/2.8.1/RuboCop/Cop/Rails/WhereExists)
- replaced like of `exists?(…)` with `where(…).exists?`


#### What should we test?
Nothing. All offenses should be corrected and therefore raise nothing.
All tests should pass and so show no sign of regression.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.