### PR TITLE
Fix Ship Order menu choice not working

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -164,6 +164,7 @@ Metrics/ClassLength:
     - 'app/models/spree/user.rb'
     - 'app/models/spree/variant.rb'
     - 'app/models/spree/zone.rb'
+    - 'app/reflexes/admin/orders_reflex.rb'
     - 'app/reflexes/products_reflex.rb'
     - 'app/serializers/api/cached_enterprise_serializer.rb'
     - 'app/serializers/api/enterprise_shopfront_serializer.rb'

--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -34,6 +34,10 @@ module Spree
         links
       end
 
+      def order_shipment_ready?(order)
+        order.ready_to_ship?
+      end
+
       private
 
       def complete_order_links(order)

--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -21,7 +21,8 @@ module Admin
     def ship
       @order.send_shipment_email = false unless params[:send_shipment_email]
       if @order.ship
-        return set_param_for_controller if Regexp.union(Constants::PATHS).match? request.url
+        paths = %w[edit customer payments adjustments invoices return_authorizations].freeze
+        return set_param_for_controller if Regexp.union(paths).match? request.url
 
         morph dom_id(@order), render(partial: "spree/admin/orders/table_row",
                                      locals: { order: @order.reload, success: true })
@@ -133,9 +134,5 @@ module Admin
                              enterprise_name: distributor_names.join(", "))
       morph_admin_flashes
     end
-  end
-
-  module Constants
-    PATHS = %w[edit customer payments adjustments invoices return_authorizations].freeze
   end
 end

--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -21,7 +21,7 @@ module Admin
     def ship
       @order.send_shipment_email = false unless params[:send_shipment_email]
       if @order.ship
-        return set_param_for_controller if request.url.match?('edit')
+        return set_param_for_controller if Regexp.union(Constants::PATHS).match? request.url
 
         morph dom_id(@order), render(partial: "spree/admin/orders/table_row",
                                      locals: { order: @order.reload, success: true })
@@ -133,5 +133,9 @@ module Admin
                              enterprise_name: distributor_names.join(", "))
       morph_admin_flashes
     end
+  end
+
+  module Constants
+    PATHS = %w[edit customer payments adjustments invoices return_authorizations].freeze
   end
 end

--- a/app/views/spree/admin/shared/_order_links.html.haml
+++ b/app/views/spree/admin/shared/_order_links.html.haml
@@ -6,8 +6,10 @@
           %i.icon-check
           = I18n.t 'admin.actions'
       %div.menu{"data-action": "click->dropdown#closeOnMenu"}
+        - shipment_ready = false
         - order_links(@order).each do |link|
           - if link[:name] == t(:ship_order)
+            - shipment_ready = true 
             %a.menu_item{ href: link[:url], target: link[:target] || "_self", data: { "modal-link-target-value": dom_id(@order, :ship), "action":  "click->modal-link#open", "controller": "modal-link" } }
               %span
                 %i{ class: link[:icon] }
@@ -19,3 +21,6 @@
               %span=link[:name]
 
 = render 'spree/admin/shared/custom-confirm'
+- if shipment_ready
+  %form
+    = render ShipOrderComponent.new(order: @order)

--- a/app/views/spree/admin/shared/_order_links.html.haml
+++ b/app/views/spree/admin/shared/_order_links.html.haml
@@ -6,10 +6,8 @@
           %i.icon-check
           = I18n.t 'admin.actions'
       %div.menu{"data-action": "click->dropdown#closeOnMenu"}
-        - shipment_ready = false
         - order_links(@order).each do |link|
           - if link[:name] == t(:ship_order)
-            - shipment_ready = true 
             %a.menu_item{ href: link[:url], target: link[:target] || "_self", data: { "modal-link-target-value": dom_id(@order, :ship), "action":  "click->modal-link#open", "controller": "modal-link" } }
               %span
                 %i{ class: link[:icon] }
@@ -21,6 +19,6 @@
               %span=link[:name]
 
 = render 'spree/admin/shared/custom-confirm'
-- if shipment_ready
+- if order_shipment_ready?(@order)
   %form
     = render ShipOrderComponent.new(order: @order)

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -1006,6 +1006,30 @@ describe '
           it_behaves_like "ship order from dropdown", "Invoices"
           it_behaves_like "ship order from dropdown", "Return Authorizations"
         end
+
+        context 'when not on the Order Details sub section' do
+          before do
+            click_link 'Customer Details'
+          end
+          it 'can ship order too' do
+            find('.ofn-drop-down').click
+            click_link 'Ship Order'
+
+            within ".reveal-modal" do
+              expect(page).to have_checked_field('Send a shipment/pick up ' \
+                                                 'notification email to the customer.')
+              # no test of enqueued job since it can cause failures
+              # if the remainder of the spec is too fasr
+              find_button('Confirm').click
+            end
+
+            # the best & easiest way to close the modal without calling all the JS
+            find_button("Cancel").click
+            expect(order.reload.shipped?).to be true
+            click_link('Order Details')
+            expect(page).to have_text 'SHIPPED'
+          end
+        end
       end
 
       context "when an included variant has been deleted" do

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -971,10 +971,10 @@ describe '
                 find_button("Confirm").click
               end
 
-              find_button("Cancel").click # closes modal as it is not automatic
               expect(page).to have_selector('.reveal-modal', visible: false)
               click_link('Order Details') unless subpage == 'Order Details'
 
+              sleep(0.5) # avoid flakyness
               expect(order.reload.shipped?).to be true
               expect(page).to have_text 'SHIPPED'
               expect(ActionMailer::MailDeliveryJob).to have_been_enqueued
@@ -995,9 +995,10 @@ describe '
                 find_button("Confirm").click
               end
 
-              find_button("Cancel").click # closes modal as it is not automatic
               expect(page).to have_selector('.reveal-modal', visible: false)
               click_link('Order Details') unless subpage == 'Order Details'
+
+              sleep(0.5) # avoir flakyness
               expect(order.reload.shipped?).to be true
               expect(page).to have_text 'SHIPPED'
               expect(ActionMailer::MailDeliveryJob).not_to have_been_enqueued

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -968,13 +968,19 @@ describe '
               within ".reveal-modal" do
                 expect(page).to have_checked_field('Send a shipment/pick up ' \
                                                    'notification email to the customer.')
-                expect {
-                  find_button("Confirm").click
-                }.to enqueue_job(ActionMailer::MailDeliveryJob).exactly(:once)
+                find_button("Confirm").click
               end
+
+              find_button("Cancel").click # closes modal as it is not automatic
+              expect(page).to have_selector('.reveal-modal', visible: false)
+              click_link('Order Details') unless subpage == 'Order Details'
 
               expect(order.reload.shipped?).to be true
               expect(page).to have_text 'SHIPPED'
+              expect(ActionMailer::MailDeliveryJob).to have_been_enqueued
+                .exactly(:once)
+                .with("Spree::ShipmentMailer", "shipped_email", "deliver_now",
+                      { args: [order.shipment.id, { delivery: true }] })
             end
 
             it "ships the order without sending email" do
@@ -986,50 +992,26 @@ describe '
 
               within ".reveal-modal" do
                 uncheck 'Send a shipment/pick up notification email to the customer.'
-                expect {
-                  find_button("Confirm").click
-                }.not_to enqueue_job(ActionMailer::MailDeliveryJob)
+                find_button("Confirm").click
               end
 
+              find_button("Cancel").click # closes modal as it is not automatic
+              expect(page).to have_selector('.reveal-modal', visible: false)
+              click_link('Order Details') unless subpage == 'Order Details'
               expect(order.reload.shipped?).to be true
               expect(page).to have_text 'SHIPPED'
+              expect(ActionMailer::MailDeliveryJob).not_to have_been_enqueued
+                .with(array_including("Spree::ShipmentMailer"))
             end
           end
         end
 
         it_behaves_like "ship order from dropdown", "Order Details"
-        context "pending examples" do
-          before { pending("#12369") }
-          it_behaves_like "ship order from dropdown", "Customer Details"
-          it_behaves_like "ship order from dropdown", "Payments"
-          it_behaves_like "ship order from dropdown", "Adjustments"
-          it_behaves_like "ship order from dropdown", "Invoices"
-          it_behaves_like "ship order from dropdown", "Return Authorizations"
-        end
-
-        context 'when not on the Order Details sub section' do
-          before do
-            click_link 'Customer Details'
-          end
-          it 'can ship order too' do
-            find('.ofn-drop-down').click
-            click_link 'Ship Order'
-
-            within ".reveal-modal" do
-              expect(page).to have_checked_field('Send a shipment/pick up ' \
-                                                 'notification email to the customer.')
-              # no test of enqueued job since it can cause failures
-              # if the remainder of the spec is too fasr
-              find_button('Confirm').click
-            end
-
-            # the best & easiest way to close the modal without calling all the JS
-            find_button("Cancel").click
-            expect(order.reload.shipped?).to be true
-            click_link('Order Details')
-            expect(page).to have_text 'SHIPPED'
-          end
-        end
+        it_behaves_like "ship order from dropdown", "Customer Details"
+        it_behaves_like "ship order from dropdown", "Payments"
+        it_behaves_like "ship order from dropdown", "Adjustments"
+        it_behaves_like "ship order from dropdown", "Invoices"
+        it_behaves_like "ship order from dropdown", "Return Authorizations"
       end
 
       context "when an included variant has been deleted" do


### PR DESCRIPTION
#### What? Why?

- Closes #12369

Error when trying to ship an order when everywhere in `admin/orders/RXX/customer`, `admin/orders/RXXX/payments`, `admin/orders/RXXXX/adjustments`, `admin/orders/RXXXXX/return_authorizations`
Reason: there were not the `ShipOrderComponent` which enables a modal for shipping order. The same component this present when in the `admin/orders/R52384XXX/edit` page

 - added ShipOrderComponent in the view that handles the dropdown (`_order_links.html.haml`)
 - updated spec to test for a specific case


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, visit `admin/orders`.
- Choose an item that has yet to be shipped. (the ones that got to be captured)
- Edit it -> `admin/orders/R52384XXX/edit`
- Click anything a part 'ORDER DETAILS', eg CUSTOMER DETAILS or ADJUSTMENTS
- Select 'Ship Order' from the actions dropdown menu.
- the modal should appear without errors and be functional
- clicking on 'Confirm' should put the item in the shipped state.
- By going/clicking on 'Order Details', it should be displayed 'shipped'

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
