### PR TITLE
Allow Dependabot to open as many PRs as it likes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,8 @@
+# Dependabot configuration
+#
+# The `directory` and `schedule.interval` options are mandatory.
+# Most of the configuration here is not used for security updates though.
+
 version: 2
 updates:
 
@@ -5,7 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
+
     # Only specific requirements are specified in Gemfile, so don't touch it.
     versioning-strategy: lockfile-only
 
@@ -13,5 +18,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
     # All versions are specified in package.json, so please update them.
     versioning-strategy: increase


### PR DESCRIPTION
#### What? Why?

I was just checking our config and had look a few things up. So I added a comment. The pull request limit came from the very early days when Dependabot was created and we tested it out. But I don't think we need that now. I prefer to see the whole picture. It doesn't mean that we have to review all PRs straight away.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Nothing.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
