### PR TITLE
Don't pass invalid auth method "None" to net-smtp

### DIFF
--- a/lib/spree/core/mail_settings.rb
+++ b/lib/spree/core/mail_settings.rb
@@ -20,9 +20,7 @@ module Spree
       private
 
       def mail_server_settings
-        settings = basic_settings.merge(user_credentials)
-
-        settings.merge(enable_starttls_auto: secure_connection?)
+        basic_settings.merge(user_credentials)
       end
 
       def user_credentials
@@ -31,10 +29,13 @@ module Spree
       end
 
       def basic_settings
-        { address: Config.mail_host,
+        {
+          address: Config.mail_host,
           domain: Config.mail_domain,
           port: Config.mail_port,
-          authentication: }
+          authentication:,
+          enable_starttls_auto: secure_connection?,
+        }
       end
 
       def authentication

--- a/lib/spree/core/mail_settings.rb
+++ b/lib/spree/core/mail_settings.rb
@@ -38,7 +38,13 @@ module Spree
         { address: Config.mail_host,
           domain: Config.mail_domain,
           port: Config.mail_port,
-          authentication: Config.mail_auth_type }
+          authentication: }
+      end
+
+      def authentication
+        return unless need_authentication?
+
+        Config.mail_auth_type.presence
       end
 
       def need_authentication?

--- a/lib/spree/core/mail_settings.rb
+++ b/lib/spree/core/mail_settings.rb
@@ -20,18 +20,14 @@ module Spree
       private
 
       def mail_server_settings
-        settings = if need_authentication?
-                     basic_settings.merge(user_credentials)
-                   else
-                     basic_settings
-                   end
+        settings = basic_settings.merge(user_credentials)
 
         settings.merge(enable_starttls_auto: secure_connection?)
       end
 
       def user_credentials
-        { user_name: Config.smtp_username,
-          password: Config.smtp_password }
+        { user_name: Config.smtp_username.presence,
+          password: Config.smtp_password.presence }
       end
 
       def basic_settings
@@ -42,13 +38,10 @@ module Spree
       end
 
       def authentication
-        return unless need_authentication?
-
-        Config.mail_auth_type.presence
-      end
-
-      def need_authentication?
-        Config.mail_auth_type != 'None'
+        # "None" is an option in the UI but not a real authentication type.
+        # We should remove it from our host configurations but I'm keeping
+        # this check for backwards-compatibility for now.
+        Config.mail_auth_type.presence unless Config.mail_auth_type == "None"
       end
 
       def secure_connection?

--- a/lib/spree/core/mail_settings.rb
+++ b/lib/spree/core/mail_settings.rb
@@ -20,21 +20,14 @@ module Spree
       private
 
       def mail_server_settings
-        basic_settings.merge(user_credentials)
-      end
-
-      def user_credentials
-        { user_name: Config.smtp_username.presence,
-          password: Config.smtp_password.presence }
-      end
-
-      def basic_settings
         {
           address: Config.mail_host,
           domain: Config.mail_domain,
           port: Config.mail_port,
           authentication:,
           enable_starttls_auto: secure_connection?,
+          user_name: Config.smtp_username.presence,
+          password: Config.smtp_password.presence,
         }
       end
 

--- a/spec/lib/spree/core/mail_settings_spec.rb
+++ b/spec/lib/spree/core/mail_settings_spec.rb
@@ -8,12 +8,12 @@ module Spree
       let!(:subject) { MailSettings.new }
 
       context "overrides appplication defaults" do
-        context "authentication method is none" do
+        context "authentication method is login" do
           before do
             Config.mail_host = "smtp.example.com"
             Config.mail_domain = "example.com"
             Config.mail_port = 123
-            Config.mail_auth_type = MailSettings::SECURE_CONNECTION_TYPES[0]
+            Config.mail_auth_type = "login"
             Config.smtp_username = "schof"
             Config.smtp_password = "hellospree!"
             Config.secure_connection_type = "TLS"
@@ -23,30 +23,21 @@ module Spree
           it { expect(ActionMailer::Base.smtp_settings[:address]).to eq "smtp.example.com" }
           it { expect(ActionMailer::Base.smtp_settings[:domain]).to eq "example.com" }
           it { expect(ActionMailer::Base.smtp_settings[:port]).to eq 123 }
-          it { expect(ActionMailer::Base.smtp_settings[:authentication]).to eq nil }
+          it { expect(ActionMailer::Base.smtp_settings[:authentication]).to eq "login" }
           it { expect(ActionMailer::Base.smtp_settings[:enable_starttls_auto]).to be_truthy }
-
-          it "doesnt touch user name config" do
-            expect(ActionMailer::Base.smtp_settings[:user_name]).to be_nil
-          end
-
-          it "doesnt touch password config" do
-            expect(ActionMailer::Base.smtp_settings[:password]).to be_nil
-          end
-        end
-      end
-
-      context "when mail_auth_type is other than none" do
-        before do
-          Config.mail_auth_type = "login"
-          Config.smtp_username = "schof"
-          Config.smtp_password = "hellospree!"
-          subject.override!
-        end
-
-        context "overrides user credentials" do
           it { expect(ActionMailer::Base.smtp_settings[:user_name]).to eq "schof" }
           it { expect(ActionMailer::Base.smtp_settings[:password]).to eq "hellospree!" }
+        end
+
+        context "authentication method is none" do
+          before do
+            Config.mail_auth_type = "None"
+            subject.override!
+          end
+
+          it "doesn't store 'None' as auth method" do
+            expect(ActionMailer::Base.smtp_settings[:authentication]).to eq nil
+          end
         end
       end
     end

--- a/spec/lib/spree/core/mail_settings_spec.rb
+++ b/spec/lib/spree/core/mail_settings_spec.rb
@@ -23,7 +23,7 @@ module Spree
           it { expect(ActionMailer::Base.smtp_settings[:address]).to eq "smtp.example.com" }
           it { expect(ActionMailer::Base.smtp_settings[:domain]).to eq "example.com" }
           it { expect(ActionMailer::Base.smtp_settings[:port]).to eq 123 }
-          it { expect(ActionMailer::Base.smtp_settings[:authentication]).to eq "None" }
+          it { expect(ActionMailer::Base.smtp_settings[:authentication]).to eq nil }
           it { expect(ActionMailer::Base.smtp_settings[:enable_starttls_auto]).to be_truthy }
 
           it "doesnt touch user name config" do

--- a/spec/lib/spree/core/mail_settings_spec.rb
+++ b/spec/lib/spree/core/mail_settings_spec.rb
@@ -2,43 +2,37 @@
 
 require 'spec_helper'
 
-module Spree
-  module Core
-    describe MailSettings do
-      let!(:subject) { MailSettings.new }
+describe Spree::Core::MailSettings do
+  context "overrides appplication defaults" do
+    context "authentication method is login" do
+      before do
+        Spree::Config.mail_host = "smtp.example.com"
+        Spree::Config.mail_domain = "example.com"
+        Spree::Config.mail_port = 123
+        Spree::Config.mail_auth_type = "login"
+        Spree::Config.smtp_username = "schof"
+        Spree::Config.smtp_password = "hellospree!"
+        Spree::Config.secure_connection_type = "TLS"
+        subject.override!
+      end
 
-      context "overrides appplication defaults" do
-        context "authentication method is login" do
-          before do
-            Config.mail_host = "smtp.example.com"
-            Config.mail_domain = "example.com"
-            Config.mail_port = 123
-            Config.mail_auth_type = "login"
-            Config.smtp_username = "schof"
-            Config.smtp_password = "hellospree!"
-            Config.secure_connection_type = "TLS"
-            subject.override!
-          end
+      it { expect(ActionMailer::Base.smtp_settings[:address]).to eq "smtp.example.com" }
+      it { expect(ActionMailer::Base.smtp_settings[:domain]).to eq "example.com" }
+      it { expect(ActionMailer::Base.smtp_settings[:port]).to eq 123 }
+      it { expect(ActionMailer::Base.smtp_settings[:authentication]).to eq "login" }
+      it { expect(ActionMailer::Base.smtp_settings[:enable_starttls_auto]).to be_truthy }
+      it { expect(ActionMailer::Base.smtp_settings[:user_name]).to eq "schof" }
+      it { expect(ActionMailer::Base.smtp_settings[:password]).to eq "hellospree!" }
+    end
 
-          it { expect(ActionMailer::Base.smtp_settings[:address]).to eq "smtp.example.com" }
-          it { expect(ActionMailer::Base.smtp_settings[:domain]).to eq "example.com" }
-          it { expect(ActionMailer::Base.smtp_settings[:port]).to eq 123 }
-          it { expect(ActionMailer::Base.smtp_settings[:authentication]).to eq "login" }
-          it { expect(ActionMailer::Base.smtp_settings[:enable_starttls_auto]).to be_truthy }
-          it { expect(ActionMailer::Base.smtp_settings[:user_name]).to eq "schof" }
-          it { expect(ActionMailer::Base.smtp_settings[:password]).to eq "hellospree!" }
-        end
+    context "authentication method is none" do
+      before do
+        Spree::Config.mail_auth_type = "None"
+        subject.override!
+      end
 
-        context "authentication method is none" do
-          before do
-            Config.mail_auth_type = "None"
-            subject.override!
-          end
-
-          it "doesn't store 'None' as auth method" do
-            expect(ActionMailer::Base.smtp_settings[:authentication]).to eq nil
-          end
-        end
+      it "doesn't store 'None' as auth method" do
+        expect(ActionMailer::Base.smtp_settings[:authentication]).to eq nil
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

- Closes #12383 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The indirect dependency net-smtp introduced a [new check on authentication methods](https://github.com/ruby/net-smtp/pull/73). Suddenly it raised an error on our non-standard auth method "None" which indicates not to authenticate.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Send an email on au-staging.
- Send an email on another staging server.
- You should receive both emails and not see anything in Bugsnag.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
