### PR TITLE
Fix Duplicate Language Display on New User Creation

### DIFF
--- a/lib/open_food_network/i18n_config.rb
+++ b/lib/open_food_network/i18n_config.rb
@@ -17,7 +17,7 @@ module OpenFoodNetwork
 
     # All locales that can be accessed by the application, including fallbacks.
     def self.available_locales
-      (selectable_locales + [default_locale, source_locale]).uniq
+      (selectable_locales + [default_locale]).uniq
     end
 
     # The default locale that is used when the user doesn't have a preference.

--- a/spec/lib/open_food_network/i18n_config_spec.rb
+++ b/spec/lib/open_food_network/i18n_config_spec.rb
@@ -77,7 +77,7 @@ module OpenFoodNetwork
       end
 
       it "provides the default available locales" do
-        expect(I18nConfig.available_locales).to eq ["en_GB", "en"]
+        expect(I18nConfig.available_locales).to eq ["en_GB"]
       end
     end
 
@@ -92,7 +92,7 @@ module OpenFoodNetwork
       end
 
       it "provides the default available locales" do
-        expect(I18nConfig.available_locales).to eq ["es", "fr", "de", "en"]
+        expect(I18nConfig.available_locales).to eq ["es", "fr", "de"]
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

- Closes #11513 

There was a bug in user creation where the Base language was displayed twice. Initially, it was thought that this issue occurred due to having two versions of English in the .env file. However, it happened when a locale other than the base English (such as en_AU) was used. The helper would always append the source_locale (en), resulting in duplication.

This appending behavior (for the source_locale) has been removed, and now it no longer duplicates.

![en](https://github.com/openfoodfoundation/openfoodnetwork/assets/80131514/d96e651d-bc5e-4fd6-b8b3-7081b6ed8fdf)

#### What should we test?

Set your .env with somethiing like this:

```
LOCALE="en_AU"
AVAILABLE_LOCALES="en_AU,fr,es"

```
- Visit `http://localhost:3000/admin/users/new`
- Check if any languages are duplicated in the language field.

#### Release notes


#### Dependencies

#### Documentation updates

