### PR TITLE
Publish enterprise website with https://

### DIFF
--- a/engines/dfc_provider/app/services/enterprise_builder.rb
+++ b/engines/dfc_provider/app/services/enterprise_builder.rb
@@ -23,7 +23,7 @@ class EnterpriseBuilder < DfcBuilder
       socialMedias: SocialMediaBuilder.social_medias(enterprise),
 
       # The model strips the protocol and we need to add it:
-      websites: [enterprise.website].compact.map { |url| "https://#{url}" },
+      websites: [enterprise.website].compact_blank.map { |url| "https://#{url}" },
     ).tap do |e|
       add_ofn_property(e, "ofn:long_description", enterprise.long_description)
 

--- a/engines/dfc_provider/app/services/enterprise_builder.rb
+++ b/engines/dfc_provider/app/services/enterprise_builder.rb
@@ -21,11 +21,10 @@ class EnterpriseBuilder < DfcBuilder
       localizations: [address],
       phoneNumbers: [enterprise.phone].compact,
       socialMedias: SocialMediaBuilder.social_medias(enterprise),
-      websites: [enterprise.website].compact,
-    ).tap do |e|
-      # The model strips the protocol and we need to add it:
-      e.websites = e.websites.map { |url| "https://#{url}" }
 
+      # The model strips the protocol and we need to add it:
+      websites: [enterprise.website].compact.map { |url| "https://#{url}" },
+    ).tap do |e|
       add_ofn_property(e, "ofn:long_description", enterprise.long_description)
 
       # This could be expressed as dfc-b:hasMainContact Person with name.

--- a/engines/dfc_provider/app/services/enterprise_builder.rb
+++ b/engines/dfc_provider/app/services/enterprise_builder.rb
@@ -23,6 +23,9 @@ class EnterpriseBuilder < DfcBuilder
       socialMedias: SocialMediaBuilder.social_medias(enterprise),
       websites: [enterprise.website].compact,
     ).tap do |e|
+      # The model strips the protocol and we need to add it:
+      e.websites = e.websites.map { |url| "https://#{url}" }
+
       add_ofn_property(e, "ofn:long_description", enterprise.long_description)
 
       # This could be expressed as dfc-b:hasMainContact Person with name.

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -71,6 +71,7 @@ describe "Enterprises", type: :request, swagger_doc: "dfc.yaml", rswag_autodoc: 
 
             expect(json_response["@graph"][0]).to include(
               "dfc-b:affiliates" => "http://test.host/api/dfc/enterprise_groups/60000",
+              "dfc-b:websitePage" => "https://openfoodnetwork.org",
             )
 
             # Insert static value to keep documentation deterministic:

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -376,7 +376,7 @@ paths:
                       dfc-b:hasAddress: http://test.host/api/dfc/addresses/40000
                       dfc-b:hasPhoneNumber: 0404 444 000 200
                       dfc-b:email: hello@example.org
-                      dfc-b:websitePage: openfoodnetwork.org
+                      dfc-b:websitePage: https://openfoodnetwork.org
                       dfc-b:hasSocialMedia: http://test.host/api/dfc/enterprises/10000/social_medias/facebook
                       dfc-b:logo: ''
                       dfc-b:name: Fred's Farm


### PR DESCRIPTION
#### What? Why?


Related to:

- https://github.com/openfoodfoundation/sib-discovery-components/issues/54

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We strip all `http://` and `https://` from enterprise URLs and add `http://` in the frontend. While we should fix the data model, I added a quick fix to the DFC API to publish the website URL with `https://` so that it can be used in links straight away.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Nothing, specs are enough.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
