### PR TITLE
[BUU] Fix non-admin saving

### DIFF
--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -192,7 +192,7 @@ module Spree
         OpenFoodNetwork::Permissions.new(user).managed_product_enterprises.include? product.supplier
       end
 
-      can [:admin, :index], :products_v3
+      can [:admin, :index, :bulk_update], :products_v3
 
       can [:create], Spree::Variant
       can [:admin, :index, :read, :edit,

--- a/app/webpacker/controllers/application_controller.js
+++ b/app/webpacker/controllers/application_controller.js
@@ -47,7 +47,7 @@ export default class extends Controller {
     console.error(reflex + ":\n " + error);
 
     // show error message
-    alert(I18n.t("errors.stimulus_reflex_error"));
+    alert(I18n.t("errors.general_error.message"));
   }
 
   reflexForbidden(element, reflex, noop, reflexId) {

--- a/app/webpacker/js/turbo.js
+++ b/app/webpacker/js/turbo.js
@@ -1,0 +1,14 @@
+import "@hotwired/turbo";
+
+document.addEventListener("turbo:frame-missing", (event) => {
+  // don't replace frame contents
+  event.preventDefault();
+
+  // show error message instead
+  status = event.detail.response.status;
+  if(status == 401) {
+    alert(I18n.t("errors.unauthorized.message"));
+  } else {
+    alert(I18n.t("errors.general_error.message"));
+  }
+});

--- a/app/webpacker/packs/admin.js
+++ b/app/webpacker/packs/admin.js
@@ -1,6 +1,6 @@
 import "controllers";
 import "channels";
-import "@hotwired/turbo";
+import "../js/turbo";
 import "../js/hotkeys";
 import "../js/mrujs";
 import "../js/matomo";
@@ -17,3 +17,4 @@ import Trix from "trix";
 document.addEventListener("trix-file-accept", (event) => {
   event.preventDefault();
 });
+

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,5 +1,5 @@
 import "controllers";
-import "@hotwired/turbo";
+import "../js/turbo";
 import "../js/hotkeys";
 import "../js/mrujs";
 import "../js/matomo";

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,14 +175,15 @@ en:
       message_html: "<p>The change you wanted was rejected. Maybe you tried to change something you don't have access to.
       <br><h3><a href='/' >Return home</a></h3>
       </p>"
-    stimulus_reflex_error: "We're sorry, but something went wrong.
+    general_error:
+      message: "We're sorry, but something went wrong.
 
 
-      This might be a temporary problem, so please try again or reload the page.
+        This might be a temporary problem, so please try again or reload the page.
 
-      We record all errors and may be working on a fix.
+        We record all errors and may be working on a fix.
 
-      If the problem persists or is urgent, please contact us."
+        If the problem persists or is urgent, please contact us."
   stripe:
     error_code:
       incorrect_number: "The card number is incorrect."

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -2,13 +2,16 @@
 
 require "system_helper"
 
-describe 'As an admin, I can manage products', feature: :admin_style_v3 do
+describe 'As an enterprise user, I can manage my products', feature: :admin_style_v3 do
   include WebHelper
   include AuthenticationHelper
   include FileHelper
 
+  let(:producer) { create(:supplier_enterprise) }
+  let(:user) { create(:user, enterprises: [producer]) }
+
   before do
-    login_as_admin
+    login_as user
   end
 
   it "can see the new product page" do
@@ -129,8 +132,10 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
       before { create_products 1 }
 
       # create a product with a different supplier
-      let!(:producer) { create(:supplier_enterprise, name: "Producer 1") }
-      let!(:product_by_supplier) { create(:simple_product, name: "Apples", supplier: producer) }
+      let!(:producer1) { create(:supplier_enterprise, name: "Producer 1") }
+      let!(:product_by_supplier) { create(:simple_product, name: "Apples", supplier: producer1) }
+
+      before { user.enterprise_roles.create(enterprise: producer1) }
 
       it "can search for and update a product" do
         visit admin_products_url
@@ -145,6 +150,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
           fill_in "Name", with: "Pommes"
         end
 
+        pending "#12403"
         expect {
           click_button "Save changes"
 
@@ -180,7 +186,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
     end
   end
 
-  describe "updating" do
+  xdescribe "updating" do # pending #12403
     let!(:variant_a1) {
       product_a.variants.first.tap{ |v|
         v.update! display_name: "Medium box", sku: "APL-01", price: 5.25, on_hand: 5,
@@ -974,7 +980,7 @@ describe 'As an admin, I can manage products', feature: :admin_style_v3 do
 
   def create_products(amount)
     amount.times do |i|
-      create(:simple_product, name: "product #{i}")
+      create(:simple_product, name: "product #{i}", supplier: producer)
     end
   end
 

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -150,7 +150,6 @@ describe 'As an enterprise user, I can manage my products', feature: :admin_styl
           fill_in "Name", with: "Pommes"
         end
 
-        pending "#12403"
         expect {
           click_button "Save changes"
 
@@ -179,14 +178,14 @@ describe 'As an enterprise user, I can manage my products', feature: :admin_styl
         search_by_category "Category 1"
 
         # expect(page).to have_content "1 product found for your search criteria."
-        expect(page).to have_select "category_id", selected: "Category 1"
+        expect(page).to have_select "category_id", selected: "Category 1" # fails in dev but not CI
         expect_products_count_to_be 1
         expect(page).to have_field "Name", with: product_by_category.name
       end
     end
   end
 
-  xdescribe "updating" do # pending #12403
+  describe "updating" do
     let!(:variant_a1) {
       product_a.variants.first.tap{ |v|
         v.update! display_name: "Medium box", sku: "APL-01", price: 5.25, on_hand: 5,


### PR DESCRIPTION
Project code: #7198 Back Office Uplift (Product): Build

#### What? Why?

- Closes #12403

The `Spree::Admin::BaseController` requires a permission defined for each controller action, so I've now added this.
It wasn't covered by the system spec because it only tested as an admin (which automatically has access to everything). I've updated the spec to always use an enterprise user, which is a better test.

But the error message was pretty disruptive and unhelpful (see issue). So in case it happens again, I've added a general error handler to show a  message, based on the HTTP code (401 - Unauthorized). 
![Screenshot 2024-04-23 at 12 58 16 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/494f7019-f20e-4c8f-a6b2-18cb3cbd9a11)


#### What should we test?
Just a quick validation ideally by Konrad:
* Log in as an enterprise user that doesn't have the 'admin' role. Save a product change on the new products screen.

This also touches the general Turbo code which I think is used in the checkout process. But I believe this change is sufficiently covered by specs.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

