### PR TITLE
Display additional tax total in order - fixes #11680

### DIFF
--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -11,7 +11,23 @@ module Admin
     def order_adjustments_for_display(order)
       order.adjustments +
         voucher_included_tax_representations(order) +
+        additional_tax_total_representation(order) +
         order.all_adjustments.payment_fee.eligible
+    end
+
+    def additional_tax_total_representation(order)
+      adjustment = Spree::Adjustment.additional.tax.where(
+        order_id: order.id, adjustable_type: 'Spree::Adjustment'
+      ).sum(:amount)
+
+      return [] unless adjustment != 0
+
+      [
+        AdjustmentData.new(
+          I18n.t("admin.orders.edit.additional_tax_included_in_price"),
+          adjustment
+        )
+      ]
     end
 
     def voucher_included_tax_representations(order)

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -24,7 +24,7 @@ module Admin
 
       [
         AdjustmentData.new(
-          I18n.t("admin.orders.edit.additional_tax_included_in_price"),
+          I18n.t("admin.orders.edit.tax_on_fees"),
           adjustment
         )
       ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1061,6 +1061,7 @@ en:
       edit:
         order_sure_want_to: Are you sure you want to %{event} this order?
         voucher_tax_included_in_price: "%{label} (tax included in voucher)"
+        additional_tax_included_in_price: "Tax on fees"
       invoice_email_sent: 'Invoice email has been sent'
       order_email_resent: 'Order email has been resent'
       bulk_management:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1061,7 +1061,7 @@ en:
       edit:
         order_sure_want_to: Are you sure you want to %{event} this order?
         voucher_tax_included_in_price: "%{label} (tax included in voucher)"
-        additional_tax_included_in_price: "Tax on fees"
+        tax_on_fees: "Tax on fees"
       invoice_email_sent: 'Invoice email has been sent'
       order_email_resent: 'Order email has been resent'
       bulk_management:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -94,6 +94,11 @@ FactoryBot.define do
       transient { amount { 1 } }
       calculator { build(:calculator_per_item, preferred_amount: amount) }
     end
+
+    trait :flat_percent_per_item do
+      transient { amount { 1 } }
+      calculator { build(:calculator_flat_percent_per_item, preferred_flat_percent: amount) }
+    end
   end
 
   factory :adjustment_metadata, class: AdjustmentMetadata do

--- a/spec/factories/calculator_factory.rb
+++ b/spec/factories/calculator_factory.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
     preferred_amount { generate(:calculator_amount) }
   end
 
+  factory :calculator_flat_percent_per_item, class: Calculator::FlatPercentPerItem do
+    preferred_flat_percent { generate(:calculator_amount) }
+  end
+
   factory :weight_calculator, class: Calculator::Weight do
     after(:build) { |c|
       c.set_preference(:per_unit, 0.5)

--- a/spec/helpers/admin/orders_helper_spec.rb
+++ b/spec/helpers/admin/orders_helper_spec.rb
@@ -55,5 +55,56 @@ RSpec.describe Admin::OrdersHelper, type: :helper do
         expect(fake_adjustment.amount).to eq(-0.5)
       end
     end
+
+    context "with additional tax total" do
+      let!(:shipping_method){ create(:free_shipping_method) }
+      let!(:enterprise){
+        create(:distributor_enterprise_with_tax, name: 'Enterprise', charges_sales_tax: true,
+                                                 shipping_methods: [shipping_method])
+      }
+      let!(:country_zone){ create(:zone_with_member) }
+      let!(:tax_category){ create(:tax_category, name: 'tax_category') }
+      let!(:tax_rate){
+        create(:tax_rate, zone: country_zone, tax_category:, name: 'Tax Rate', amount: 0.13,
+                          included_in_price: false)
+      }
+      let!(:ship_address){ create(:ship_address) }
+      let!(:product) {
+        create(:simple_product, supplier: enterprise, price: 10, tax_category_id: tax_category.id)
+      }
+      let!(:variant){
+        create(:variant, :with_order_cycle, product:, distributor: enterprise, order_cycle:,
+                                            tax_category:)
+      }
+      let!(:coordinator_fees){
+        create(:enterprise_fee, :flat_percent_per_item, enterprise:, amount: 20,
+                                                        name: 'Adminstration',
+                                                        fee_type: 'sales',
+                                                        tax_category:)
+      }
+      let!(:order_cycle){
+        create(:simple_order_cycle, name: "oc1", suppliers: [enterprise],
+                                    distributors: [enterprise],
+                                    coordinator_fees: [coordinator_fees])
+      }
+      let!(:order){
+        create(:order_with_distributor, distributor: enterprise, order_cycle:, ship_address:)
+      }
+      let!(:line_item) { create(:line_item, variant:, quantity: 1, price: 10, order:) }
+
+      before do
+        order_cycle.variants << [product.variants.first]
+        order_cycle.exchanges.outgoing.first.variants << product.variants.first
+
+        order.recreate_all_fees!
+        Orders::WorkflowService.new(order).complete!
+      end
+
+      it "includes additional tax on fees" do
+        adjustment = order_adjustments_for_display(order).first
+        expect(adjustment.label).to eq("Tax on fees")
+        expect(adjustment.amount).to eq(0.26)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #11680
The admin/orders#edit form doesnt display additional tax adjustments

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/23547158/70a2fe88-7332-4127-af27-ac9d3dd753d8)

UNCERTAIN
- Label for the Tax category order adjustment which is currently 'Tax category'

#### What should we test?
- Add new Product with price $10
- Add non-included Tax Rate with 13%
- Add Enterprise Fee with Tax category of the newly added Tax Rate with Flat Percent (per item) of 20%
- Add the newly added Enterprise Fee to the Order Cycle with the new Product
- Create new Order adding 1 Product. The final checkout price will be $13.56 with (included tax) of $0.26

**Tax included in price**
Same scenario as above but with Tax Rate included in the price. Check it's working as before.


#### Release notes
Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

The title of the pull request will be included in the release notes.

