### PR TITLE
Explicitely require all rubocop extensions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,12 @@
 # The configuration is split into three files. Look into those files for more details.
 #
 require:
+  - rubocop-capybara
+  - rubocop-factory_bot
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
+
 inherit_from:
 
   # The automatically generated todo list to ignore all current violations.


### PR DESCRIPTION

#### What? Why?


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I think that rspec-rails loaded the other extensions already but Rubocop was suggesting these extensions to be loaded as well.

The alternative is to disable suggestions of new extensions but that could hide new shiny tools when they become available.

Avoids this message:
```
The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-capybara
  * rubocop-factory_bot
  * rubocop-rspec_rails

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
