### PR TITLE
[BUU] Delete Button missing before saving variant

### DIFF
--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -76,8 +76,8 @@
 
           = form.fields_for("products][#{product_index}][variants_attributes][NEW_RECORD", product.variants.build) do |new_variant_form|
             %template{ 'data-nested-form-target': "template" }
-              %tr.condensed{ 'data-controller': "variant", 'class': "nested-form-wrapper" }
-                = render partial: 'variant_row', locals: { variant: new_variant_form.object, f: new_variant_form, category_options:, tax_category_options: }
+              %tr.condensed{ 'data-controller': "variant", 'class': "nested-form-wrapper", 'data-new-record': "true" }
+                = render partial: 'variant_row', locals: { variant: new_variant_form.object, f: new_variant_form, category_options:, tax_category_options:  }
 
           %tr{ 'data-nested-form-target': "target" }
           %tr.condensed

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -49,7 +49,7 @@
                   = form.submit t('.save'), class: "medium"
       %tr
         %th.align-left= # image
-        = render partial: 'spree/admin/shared/stimulus_sortable_header', 
+        = render partial: 'spree/admin/shared/stimulus_sortable_header',
             locals: { column: :name, sorted: params.dig(:q, :s), default: 'name asc' }
         %th.align-left.with-input= t('admin.products_page.columns.sku')
         %th.align-left.with-input= t('admin.products_page.columns.unit_scale')
@@ -76,7 +76,7 @@
 
           = form.fields_for("products][#{product_index}][variants_attributes][NEW_RECORD", product.variants.build) do |new_variant_form|
             %template{ 'data-nested-form-target': "template" }
-              %tr.condensed{ 'data-controller': "variant" }
+              %tr.condensed{ 'data-controller': "variant", 'class': "nested-form-wrapper" }
                 = render partial: 'variant_row', locals: { variant: new_variant_form.object, f: new_variant_form, category_options:, tax_category_options: }
 
           %tr{ 'data-nested-form-target': "target" }

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -65,7 +65,7 @@
       = form.fields_for("products", product, index: product_index) do |product_form|
         %tbody.relaxed{ data: { 'record-id': product_form.object.id,
                                 controller: "nested-form product",
-                                action: 'rails-nested-form:add->bulk-form#registerElements' } }
+                                action: 'rails-nested-form:add->bulk-form#registerElements rails-nested-form:remove->bulk-form#toggleFormChanged' } }
           %tr
             = render partial: 'product_row', locals: { f: product_form, product:, producer_options: }
 

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -71,7 +71,7 @@
 
           - product.variants.each_with_index do |variant, variant_index|
             = form.fields_for("products][#{product_index}][variants_attributes][", variant, index: variant_index) do |variant_form|
-              %tr.condensed{ 'data-controller': "variant" }
+              %tr.condensed{ 'data-controller': "variant", 'class': "nested-form-wrapper", 'data-new-record': variant.new_record? ? "true" : false }
                 = render partial: 'variant_row', locals: { variant:, f: variant_form, category_options:, tax_category_options: }
 
           = form.fields_for("products][#{product_index}][variants_attributes][NEW_RECORD", product.variants.build) do |new_variant_form|

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -68,6 +68,6 @@
             "data-modal-link-modal-dataset-value": {'data-current-id': variant.id}.to_json }
           = t('admin.products_page.actions.delete')
     - else
+      = f.hidden_field :_destroy
       %a{ 'data-action': "nested-form#remove" }
-        = f.hidden_field :_destroy
         = t('admin.products_page.actions.remove')

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -59,11 +59,15 @@
 %td.align-left
   -# empty
 %td.align-right
-  - if variant.persisted?
-    = render(VerticalEllipsisMenu::Component.new) do
+  = render(VerticalEllipsisMenu::Component.new) do
+    - if variant.persisted?
       = link_to t('admin.products_page.actions.edit'), edit_admin_product_variant_path(variant.product, variant)
       - if variant.product.variants.size > 1
         %a{ "data-controller": "modal-link", "data-action": "click->modal-link#setModalDataSetOnConfirm click->modal-link#open",
             "data-modal-link-target-value": "variant-delete-modal", "class": "delete",
             "data-modal-link-modal-dataset-value": {'data-current-id': variant.id}.to_json }
           = t('admin.products_page.actions.delete')
+    - else
+      %a{ 'data-action': "nested-form#remove" }
+        = f.hidden_field :_destroy
+        = t('admin.products_page.actions.remove')

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -68,6 +68,5 @@
             "data-modal-link-modal-dataset-value": {'data-current-id': variant.id}.to_json }
           = t('admin.products_page.actions.delete')
     - else
-      = f.hidden_field :_destroy
-      %a{ 'data-action': "nested-form#remove bulk-form#remove", class: 'delete', 'data-temp_id': f.field_id(:remove_link) }
+      %a{ 'data-action': "nested-form#remove", class: 'delete' }
         = t('admin.products_page.actions.remove')

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -69,5 +69,5 @@
           = t('admin.products_page.actions.delete')
     - else
       = f.hidden_field :_destroy
-      %a{ 'data-action': "nested-form#remove" }
+      %a{ 'data-action': "nested-form#remove bulk-form#remove", class: 'delete', 'data-temp_id': f.field_id(:remove_link) }
         = t('admin.products_page.actions.remove')

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -91,35 +91,6 @@ export default class BulkFormController extends Controller {
     }
   }
 
-  // Removes tr from DOM as well as corresponding elmnts from recordElement
-  // when clicking on 'Remove' button. For not persisted rows removed by
-  // stimulus components lib.
-  remove(event) {
-    // We need the temp id for the newly non persisted variant
-    let elmnt = event.target;
-    const recordContainer = elmnt.closest("[data-record-id]");
-    let recordId = recordContainer.dataset.recordId;
-    let elmnt_temp_id = elmnt.dataset.temp_id;
-    const re = /([0-9]*)_remove_link/;
-    let temp_id = elmnt_temp_id.match(re)[1]
-
-    // Store indexes and not elements
-    let elmntsToDelete = [];
-    this.recordElements[recordId].forEach((item, index) => {
-      if ((item.id).includes(temp_id)) {
-        elmntsToDelete.push(index);
-      }
-    });
-
-
-    // Want to delete ary.last - ary.first ie from to first up to last index
-    // In this way, we also delete unnecessary elements without reference to temp variant(id)
-    // like buttons but nonetheless part of the elements to be removed.
-    this.recordElements[recordId]
-      .splice(elmntsToDelete[0], elmntsToDelete[elmntsToDelete.length - 1] - elmntsToDelete[0] + 1);
-    this.toggleFormChanged();
-  }
-
   // private
 
   #registerSubmit() {
@@ -161,8 +132,12 @@ export default class BulkFormController extends Controller {
   }
 
   #isChanged(element) {
-    if (element.type == "checkbox") {
+    if(!element.isConnected) {
+      return false;
+
+    } else if (element.type == "checkbox") {
       return element.defaultChecked !== undefined && element.checked != element.defaultChecked;
+
     } else if (element.type == "select-one") {
       // (weird) Behavior of select element's include_blank option in Rails:
       //   If a select field has include_blank option selected (its value will be ''),
@@ -175,6 +150,7 @@ export default class BulkFormController extends Controller {
       const areBothBlank = selectedOption.value === '' && defaultSelected === undefined
 
       return !areBothBlank && selectedOption !== defaultSelected;
+
     } else {
       return element.defaultValue !== undefined && element.value != element.defaultValue;
     }

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -118,11 +118,6 @@ export default class BulkFormController extends Controller {
     this.recordElements[recordId]
       .splice(elmntsToDelete[0], elmntsToDelete[elmntsToDelete.length - 1] - elmntsToDelete[0] + 1);
     this.toggleFormChanged();
-
-    // Otherwise, elements within tr may be re-added to recordElements.
-    // With the nested-form-wrapper(stimulus components) class added to a tr.
-    let tr = document.querySelector('.nested-form-wrapper[style="display: none;"]')
-    tr.remove();
   }
 
   // private

--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -91,6 +91,40 @@ export default class BulkFormController extends Controller {
     }
   }
 
+  // Removes tr from DOM as well as corresponding elmnts from recordElement
+  // when clicking on 'Remove' button. For not persisted rows removed by
+  // stimulus components lib.
+  remove(event) {
+    // We need the temp id for the newly non persisted variant
+    let elmnt = event.target;
+    const recordContainer = elmnt.closest("[data-record-id]");
+    let recordId = recordContainer.dataset.recordId;
+    let elmnt_temp_id = elmnt.dataset.temp_id;
+    const re = /([0-9]*)_remove_link/;
+    let temp_id = elmnt_temp_id.match(re)[1]
+
+    // Store indexes and not elements
+    let elmntsToDelete = [];
+    this.recordElements[recordId].forEach((item, index) => {
+      if ((item.id).includes(temp_id)) {
+        elmntsToDelete.push(index);
+      }
+    });
+
+
+    // Want to delete ary.last - ary.first ie from to first up to last index
+    // In this way, we also delete unnecessary elements without reference to temp variant(id)
+    // like buttons but nonetheless part of the elements to be removed.
+    this.recordElements[recordId]
+      .splice(elmntsToDelete[0], elmntsToDelete[elmntsToDelete.length - 1] - elmntsToDelete[0] + 1);
+    this.toggleFormChanged();
+
+    // Otherwise, elements within tr may be re-added to recordElements.
+    // With the nested-form-wrapper(stimulus components) class added to a tr.
+    let tr = document.querySelector('.nested-form-wrapper[style="display: none;"]')
+    tr.remove();
+  }
+
   // private
 
   #registerSubmit() {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -601,6 +601,7 @@ en:
         edit: Edit
         clone: Clone
         delete: Delete
+        remove: Remove
       image:
         edit: Edit
     adjustments:

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -216,6 +216,16 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       create(:simple_product, name: "Apples", sku: "APL-00",
                               variant_unit: "weight", variant_unit_scale: 1) # Grams
     }
+    let(:variant_b1) {
+      product_b.variants.first.tap{ |v|
+        v.update! display_name: "Medium box", sku: "TMT-01", price: 5, on_hand: 5,
+                  on_demand: false
+      }
+    }
+    let(:product_b) {
+      create(:simple_product, name: "Tomatoes", sku: "TMT-01",
+                              variant_unit: "weight", variant_unit_scale: 1) # Grams
+    }
     before do
       visit admin_products_url
     end
@@ -553,11 +563,98 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
           fill_in "Name", with: "Large box"
           fill_in "SKU", with: "APL-02"
           expect(page).to have_field("Name", placeholder: "Apples", with: "Large box")
+        end
+
+        expect(page).to have_text("1 product modified.")
+        expect(page).to have_css('form.disabled-section#filters') # ie search/sort disabled
+
+        within new_variant_row do
           page.find(".vertical-ellipsis-menu").click
           page.find('a', text: 'Remove').click
         end
 
         expect(page).not_to have_field("Name", placeholder: "Apples", with: "Large box")
+        expect(page).not_to have_text("1 product modified.")
+        expect(page).not_to have_css('form.disabled-section#filters')
+      end
+
+      it "removes newly added not persistent Variants one at a time" do
+        click_on "New variant"
+
+        first_new_variant_row = find_field("Name", placeholder: "Apples", with: "").ancestor("tr")
+        within first_new_variant_row do
+          fill_in "Name", with: "Large box"
+        end
+
+        click_on "New variant"
+        second_new_variant_row = find_field("Name", placeholder: "Apples", with: "").ancestor("tr")
+        within second_new_variant_row do
+          fill_in "Name", with: "Huge box"
+        end
+
+        expect(page).to have_text("1 product modified.")
+        expect(page).to have_css('form.disabled-section#filters')
+
+        within first_new_variant_row do
+          page.find(".vertical-ellipsis-menu").click
+          page.find('a', text: 'Remove').click
+        end
+
+        expect(page).to have_text("1 product modified.")
+
+        within second_new_variant_row do
+          page.find(".vertical-ellipsis-menu").click
+          page.find('a', text: 'Remove').click
+        end
+        # Only when all non persistent variants are gone that product is non modified
+        expect(page).not_to have_text("1 product modified.")
+        expect(page).not_to have_css('form.disabled-section#filters')
+      end
+
+      context "With 2 products" do
+        before do
+          variant_b1
+          # To add 2nd product on page
+          page.refresh
+        end
+
+        it "removes newly added Variants across products" do
+          click_on "New variant"
+          apples_new_variant_row =
+            find_field("Name", placeholder: "Apples", with: "").ancestor("tr")
+          within apples_new_variant_row do
+            fill_in "Name", with: "Large box"
+          end
+
+          tomatoes_part = page.all('tbody')[1]
+          within tomatoes_part do
+            click_on "New variant"
+          end
+          tomatoes_new_variant_row =
+            find_field("Name", placeholder: "Tomatoes", with: "").ancestor("tr")
+          within tomatoes_new_variant_row do
+            fill_in "Name", with: "Huge box"
+          end
+          expect(page).to have_text("2 products modified.")
+          expect(page).to have_css('form.disabled-section#filters') # ie search/sort disabled
+
+          within apples_new_variant_row do
+            page.find(".vertical-ellipsis-menu").click
+            page.find('a', text: 'Remove').click
+          end
+          # New variant for apples is no more, expect only 1 modified product
+          expect(page).to have_text("1 product modified.")
+          # search/sort still disabled
+          expect(page).to have_css('form.disabled-section#filters')
+
+          within tomatoes_new_variant_row do
+            page.find(".vertical-ellipsis-menu").click
+            page.find('a', text: 'Remove').click
+          end
+          # Back to page without any alteration
+          expect(page).not_to have_text("1 product modified.")
+          expect(page).not_to have_css('form.disabled-section#filters')
+        end
       end
 
       context "with invalid data" do

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -735,6 +735,22 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
           expect(new_variant.price).to eq 10.25
           expect(new_variant.unit_value).to eq 200
         end
+
+        it "removes unsaved record" do
+          click_button "Save changes"
+
+          expect(page).to have_text("1 product could not be saved.")
+
+          within row_containing_name("N" * 256) do
+            page.find(".vertical-ellipsis-menu").click
+            page.find('a', text: 'Remove').click
+          end
+
+          # Now that invalid variant is removed, we can proceed to save
+          click_button "Save changes"
+          expect(page).not_to have_text("1 product could not be saved.")
+          expect(page).not_to have_css('form.disabled-section#filters')
+        end
       end
     end
 

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -546,6 +546,20 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
         end
       end
 
+      it 'removes a newly added not persisted variant' do
+        click_on "New variant"
+        new_variant_row = find_field("Name", placeholder: "Apples", with: "").ancestor("tr")
+        within new_variant_row do
+          fill_in "Name", with: "Large box"
+          fill_in "SKU", with: "APL-02"
+          expect(page).to have_field("Name", placeholder: "Apples", with: "Large box")
+          page.find(".vertical-ellipsis-menu").click
+          page.find('a', text: 'Remove').click
+        end
+
+        expect(page).not_to have_field("Name", placeholder: "Apples", with: "Large box")
+      end
+
       context "with invalid data" do
         before do
           click_on "New variant"


### PR DESCRIPTION
#### What? Why?

- Closes #12400 


 I used the remove option of `stimulus-components/rails-nested-form` nodejs lib
I added the Remove option in the menu

#### What should we test?

- Toggle to the v3 admin
- Visit `http://localhost:3000/admin/products`
- Chose some product and click the blue cross under the last variant line
- At the end of line, the three little dots menu should appear
- It should have only one option: 'Remove'
- Clicking 'Remove' should remove the line without confirmation

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [X] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
