### PR TITLE
Bumps knapsack_pro to v7.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ env:
   TIMEZONE: UTC
   COVERAGE: true
   RAILS_ENV: test
-    bundle exec rails webpacker:compile
 
 permissions:
   contents: read
@@ -194,6 +193,10 @@ jobs:
         run: |
           bundle exec rake db:create db:schema:load
 
+      - name: Webpack compilation
+        run: RAILS_ENV=test bundle exec rails webpacker:compile
+
+
       - name: Run tests
 
         env:
@@ -270,6 +273,9 @@ jobs:
       - name: Set up database
         run: |
           bundle exec rake db:create db:schema:load
+
+      - name: Webpack compilation
+        run: RAILS_ENV=test bundle exec rails webpacker:compile
 
       - name: Run tests
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
   TIMEZONE: UTC
   COVERAGE: true
   RAILS_ENV: test
+    bundle exec rails webpacker:compile
 
 permissions:
   contents: read
@@ -203,14 +204,14 @@ jobs:
           # if you use Knapsack Pro Queue Mode you must set below env variable
           # to be able to retry CI build and run previously recorded tests
           # https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node
-          # KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
+          KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           # RSpec split test files by test examples feature - it's optional
           # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it
           #KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/system/admin/**/*_spec.rb}" 
 
         run: |
-          bundle exec rake knapsack_pro:rspec
+          bundle exec rake knapsack_pro:queue:rspec
 
       - name: Archive failed tests screenshots
         if: failure()
@@ -280,14 +281,14 @@ jobs:
           # if you use Knapsack Pro Queue Mode you must set below env variable
           # to be able to retry CI build and run previously recorded tests
           # https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node
-          # KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
+          KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           # RSpec split test files by test examples feature - it's optional
           # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it
           #KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/system/consumer/**/*_spec.rb}" 
 
         run: |
-          bundle exec rake knapsack_pro:rspec
+          bundle exec rake knapsack_pro:queue:rspec
 
       - name: Archive failed tests screenshots
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,14 +203,14 @@ jobs:
           # if you use Knapsack Pro Queue Mode you must set below env variable
           # to be able to retry CI build and run previously recorded tests
           # https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node
-          KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
+          # KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           # RSpec split test files by test examples feature - it's optional
           # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it
           #KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/system/admin/**/*_spec.rb}" 
 
         run: |
-          bundle exec rake knapsack_pro:queue:rspec
+          bundle exec rake knapsack_pro:rspec
 
       - name: Archive failed tests screenshots
         if: failure()
@@ -280,14 +280,14 @@ jobs:
           # if you use Knapsack Pro Queue Mode you must set below env variable
           # to be able to retry CI build and run previously recorded tests
           # https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node
-          KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
+          # KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           # RSpec split test files by test examples feature - it's optional
           # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it
           #KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/system/consumer/**/*_spec.rb}" 
 
         run: |
-          bundle exec rake knapsack_pro:queue:rspec
+          bundle exec rake knapsack_pro:rspec
 
       - name: Archive failed tests screenshots
         if: failure()

--- a/Gemfile
+++ b/Gemfile
@@ -157,7 +157,7 @@ group :test, :development do
   gem "factory_bot_rails", '6.2.0', require: false
   gem 'fuubar', '~> 2.5.1'
   gem 'json_spec', '~> 1.1.4'
-  gem 'knapsack_pro'
+  gem 'knapsack_pro', '7.0.0'
   gem 'letter_opener', '>= 1.4.1'
   gem 'rspec-rails', ">= 3.5.2"
   gem 'rspec-retry', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -157,7 +157,7 @@ group :test, :development do
   gem "factory_bot_rails", '6.2.0', require: false
   gem 'fuubar', '~> 2.5.1'
   gem 'json_spec', '~> 1.1.4'
-  gem 'knapsack_pro', '7.0.0'
+  gem 'knapsack_pro'
   gem 'letter_opener', '>= 1.4.1'
   gem 'rspec-rails', ">= 3.5.2"
   gem 'rspec-retry', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
       activesupport (>= 4.2)
     jwt (2.8.1)
       base64
-    knapsack_pro (6.0.4)
+    knapsack_pro (7.0.0)
       rake
     language_server-protocol (3.17.0.3)
     launchy (3.0.0)
@@ -890,7 +890,7 @@ DEPENDENCIES
   json_spec (~> 1.1.4)
   jsonapi-serializer
   jwt (~> 2.3)
-  knapsack_pro
+  knapsack_pro (= 7.0.0)
   letter_opener (>= 1.4.1)
   listen
   mime-types

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
       activesupport (>= 4.2)
     jwt (2.8.1)
       base64
-    knapsack_pro (7.0.0)
+    knapsack_pro (7.1.0)
       rake
     language_server-protocol (3.17.0.3)
     launchy (3.0.0)
@@ -890,7 +890,7 @@ DEPENDENCIES
   json_spec (~> 1.1.4)
   jsonapi-serializer
   jwt (~> 2.3)
-  knapsack_pro (= 7.0.0)
+  knapsack_pro
   letter_opener (>= 1.4.1)
   listen
   mime-types


### PR DESCRIPTION
#### What? Why?

- replaces #12424

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Context here: https://github.com/openfoodfoundation/openfoodnetwork/pull/12261
This version was superseeded and the context got a but hidden. I'm not sure the issue with webpacker is expected, I've contacted Knapsack support.

Disables Knapsack queue mode and bumps the gem to 7.1.0.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
