### PR TITLE
Remove "ready for" info from shipping method description area at checkout #12395 (solved)

### DIFF
--- a/app/views/checkout/_details.html.haml
+++ b/app/views/checkout/_details.html.haml
@@ -96,11 +96,6 @@
           #distributor_address.panel
             - if shipping_method.description.present?
               %span #{shipping_method.description}
-              %br/
-              %br/
-            - if @order.order_cycle.pickup_time_for(@order.distributor)
-              = t :checkout_ready_for
-            = @order.order_cycle.pickup_time_for(@order.distributor)
 
       = f.error_message_on :shipping_method, standalone: true
 


### PR DESCRIPTION
#### What? Why?
sometimes, some shipping method are not available every day. It can raise a conflict with the content the shop manager puts in the "ready for" field. Therefore, we should remove the display of the field in the shipping method description. (according to the creator of the issue)

- Closes #12395

This change simply comments the code related to the "ready for" info from shipping method description area at checkout/details. Instead of running the code it simply does not execute because it is commented (line 96 until 103 not working).

#### What should we test?


   1) Set up a "ready for" information (=> delivery details at step 3 of the order cycle)
   2) See it shows up in the top right blue corner of the shopfront
   3) See it shows up on the top of the checkout process
   4) See order confirmation and email confirmation still have the info
   5) However, shipping method description in checkout/details does not have the info anymore

 (these steps were done manually to check)

- Visit checkout/details page (first step in buying from cart).
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ X] User facing changes

The title of the pull request will be included in the release notes.
