### PR TITLE
Knapsack pro 7.1.0

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require base_spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
       activesupport (>= 4.2)
     jwt (2.8.1)
       base64
-    knapsack_pro (6.0.4)
+    knapsack_pro (7.1.0)
       rake
     language_server-protocol (3.17.0.3)
     launchy (3.0.0)

--- a/spec/support/precompile_assets.rb
+++ b/spec/support/precompile_assets.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.before(:suite) do
+  config.before(:all) do
     # We can use webpack-dev-server for tests, too!
     # Useful if you working on a frontend code fixes and want to verify them via system tests.
     next if Webpacker.dev_server.running?


### PR DESCRIPTION
#### What? Why?

- Closes #12442
- Closes #12445

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Knapsack Pro 7 changed the timing of calling RSpec's before-suite calls. Since they are, correctly, only called once before the suite, our before-suite call to compile assets when needed failed. In queue mode, there are no examples loaded yet when the before-suite hook is called and therefore we don't know yet if we need to compile assets or not.

Now we load the RSpec hooks early for Knapsack Pro to recognise them and we check for asset compilation before each batch.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
