### PR TITLE
Feature/11058 change products order by name

### DIFF
--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -48,6 +48,7 @@ module Admin
       # prority is given to element dataset (if present) over url params
       @page = params[:page].presence || 1
       @per_page = params[:per_page].presence || 15
+      @q = params.permit(q: {})[:q] || { s: 'name asc' }
     end
 
     def producers
@@ -89,6 +90,8 @@ module Admin
         query.merge!(Spree::Variant::SEARCH_KEY => @search_term)
       end
       query.merge!(variants_primary_taxon_id_in: @category_id) if @category_id.present?
+      query.merge!(@q) if @q
+
       query
     end
 

--- a/app/views/admin/products_v3/_content.html.haml
+++ b/app/views/admin/products_v3/_content.html.haml
@@ -1,5 +1,5 @@
 %turbo-frame#products-content{ target: "_top", refresh: "morph" }
-  .spinner-overlay{ "data-controller": "loading", "data-products-target": "loading", class: "hidden" }
+  .spinner-overlay.hidden
     .spinner-container
       .spinner
       = t('.loading')

--- a/app/views/admin/products_v3/_content.html.haml
+++ b/app/views/admin/products_v3/_content.html.haml
@@ -1,5 +1,5 @@
 %turbo-frame#products-content{ target: "_top", refresh: "morph" }
-  .spinner-overlay.hidden
+  .spinner-overlay{ "data-controller": "loading", "data-products-target": "loading", class: "hidden" }
     .spinner-container
       .spinner
       = t('.loading')

--- a/app/views/admin/products_v3/_filters.html.haml
+++ b/app/views/admin/products_v3/_filters.html.haml
@@ -1,6 +1,7 @@
 = form_with url: admin_products_path, id: "filters", method: :get, data: { "search-target": "form", 'turbo-frame': "_self" } do
   = hidden_field_tag :page, nil, class: "page"
   = hidden_field_tag :per_page, nil, class: "per-page"
+  = hidden_field_tag '[q][s]', params.dig(:q, :s) || 'name asc', class: 'sort', 'data-default': 'name asc'
 
   .query
     .search-input

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -49,7 +49,8 @@
                   = form.submit t('.save'), class: "medium"
       %tr
         %th.align-left= # image
-        %th.align-left.with-input= t('admin.products_page.columns.name')
+        = render partial: 'spree/admin/shared/stimulus_sortable_header', 
+            locals: { column: :name, sorted: params.dig(:q, :s), default: 'name asc' }
         %th.align-left.with-input= t('admin.products_page.columns.sku')
         %th.align-left.with-input= t('admin.products_page.columns.unit_scale')
         %th.align-left.with-input= t('admin.products_page.columns.unit')

--- a/app/views/spree/admin/shared/_stimulus_sortable_header.html.haml
+++ b/app/views/spree/admin/shared/_stimulus_sortable_header.html.haml
@@ -1,5 +1,5 @@
 %th
-  %a{ "data-action": "click->search#changeSorting", "data-column": "#{column}", "data-current": sorted.to_s }
+  %a{ "data-controller": "search", "data-action": "click->search#changeSorting", "data-column": "#{column}", "data-current": (sorted || default).to_s }
     = t("spree.admin.shared.sortable_header.#{column.to_s}")
 
     - if sorted == "#{column} asc" || sorted.blank? && local_assigns[:default] == "#{column} asc"

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -34,11 +34,8 @@ describe 'As an enterprise user, I can manage my products', feature: :admin_styl
 
     it "Should sort products alphabetically by default in ascending order" do
       within products_table do
-        # Gather input values, because page.content doesn't include them.
-        input_content = page.find_all('input[type=text]').map(&:value).join
-
         # Products are in correct order.
-        expect(input_content).to match /Apples.*Bananas/
+        expect(all_input_values).to match /Apples.*Bananas/
       end
     end
 
@@ -50,16 +47,12 @@ describe 'As an enterprise user, I can manage my products', feature: :admin_styl
           # Sort in descending order
           name_header.click
           expect(page).to have_content("Name ▼") # this indicates the re-sorted content has loaded
-
-          input_content = page.find_all('input[type=text]').map(&:value).join
-          expect(input_content).to match /Bananas.*Apples/
+          expect(all_input_values).to match /Bananas.*Apples/
 
           # Sort in ascending order
           name_header.click
           expect(page).to have_content("Name ▲") # this indicates the re-sorted content has loaded
-
-          input_content = page.find_all('input[type=text]').map(&:value).join
-          expect(input_content).to match /Apples.*Bananas/
+          expect(all_input_values).to match /Apples.*Bananas/
         end
       end
     end
@@ -1198,5 +1191,9 @@ describe 'As an enterprise user, I can manage my products', feature: :admin_styl
   def random_tax_category
     Spree::TaxCategory
       .pluck(:name).sample
+  end
+
+  def all_input_values
+    page.find_all('input[type=text]').map(&:value).join
   end
 end

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -26,18 +26,41 @@ describe 'As an enterprise user, I can manage my products', feature: :admin_styl
   describe "sorting" do
     let!(:product_b) { create(:simple_product, name: "Bananas") }
     let!(:product_a) { create(:simple_product, name: "Apples") }
+    let(:products_table) { "table.products" }
 
     before do
       visit admin_products_url
     end
 
-    it "Should sort products alphabetically by default" do
-      within "table.products" do
+    it "Should sort products alphabetically by default in ascending order" do
+      within products_table do
         # Gather input values, because page.content doesn't include them.
         input_content = page.find_all('input[type=text]').map(&:value).join
 
         # Products are in correct order.
         expect(input_content).to match /Apples.*Bananas/
+      end
+    end
+
+    context "when clicked on 'Name' column header" do
+      it "Should sort products alphabetically in descending/ascending order" do
+        within products_table do
+          name_header = page.find('th > a[data-column="name"]')
+
+          # Sort in descending order
+          name_header.click
+          expect(page).to have_content("Name ▼") # this indicates the re-sorted content has loaded
+
+          input_content = page.find_all('input[type=text]').map(&:value).join
+          expect(input_content).to match /Bananas.*Apples/
+
+          # Sort in ascending order
+          name_header.click
+          expect(page).to have_content("Name ▲") # this indicates the re-sorted content has loaded
+
+          input_content = page.find_all('input[type=text]').map(&:value).join
+          expect(input_content).to match /Apples.*Bananas/
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

- Closes #11058
- This PR adds the feature to sort the products by their name on products page

#### What should we test?
- All the scenarios in the attached issue

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled