### PR TITLE
12372-[Admin] Missing translations  page titles

### DIFF
--- a/app/views/spree/admin/shared/_head.html.haml
+++ b/app/views/spree/admin/shared/_head.html.haml
@@ -7,7 +7,7 @@
   - if content_for? :html_title
     = yield :html_title
   - else
-    = t(controller.controller_name, :default => controller.controller_name.titleize)
+    = t("spree.admin.tab.#{controller.controller_name}", :default => controller.controller_name.titleize)
   = " - OFN #{t(:administration)}"
 
 %link{:href => "https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600&subset=latin,cyrillic,greek,vietnamese", :rel => "stylesheet", :type => "text/css"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4174,6 +4174,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         customers: "Customers"
         groups: "Groups"
         oidc_settings: "OIDC Settings"
+        overview: "Overview"
+        product_import: "Import"
+        enterprise_roles: "Roles"
+        payment_methods: "Payment Methods"
       product_properties:
         index:
           inherits_properties_checkbox_hint: "Inherit properties from %{supplier}? (unless overridden above)"


### PR DESCRIPTION
#### What? Why?

- Closes #12372 

#### What should we test?

The page titles of the following admin pages are always shown in English and they are not translated to the selected locale.

1. 'Overview'
2. 'Properties'
3. 'Product Import'
4. 'Subscriptions'
5. 'General Settings'
6. 'Enterprise Roles'

The translation for these are missing in locale file . For now I added the locales in en.yml file.

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

The title of the pull request will be included in the release notes.

