### PR TITLE
Sanitise HTML in long description of enterprise

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -248,11 +248,6 @@ class Enterprise < ApplicationRecord
   end
 
   # Remove any unsupported HTML.
-  def long_description
-    HtmlSanitizer.sanitize(super)
-  end
-
-  # Remove any unsupported HTML.
   def long_description=(html)
     super(HtmlSanitizer.sanitize(html))
   end

--- a/db/migrate/20240510033206_sanitize_enterprise_long_description.rb
+++ b/db/migrate/20240510033206_sanitize_enterprise_long_description.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class SanitizeEnterpriseLongDescription < ActiveRecord::Migration[7.0]
+  class Enterprise < ApplicationRecord
+  end
+
+  # This is a copy from our application code at the time of writing.
+  # We prefer to keep migrations isolated and not affected by changing
+  # application code in the future.
+  # If we need to change the sanitizer in the future we may need a new
+  # migration (not change the old one) to sanitise the data properly.
+  class HtmlSanitizer
+    ALLOWED_TAGS = %w[h1 h2 h3 h4 div p br b i u a strong em del pre blockquote ul ol li hr
+                      figure].freeze
+    ALLOWED_ATTRIBUTES = %w[href target].freeze
+    ALLOWED_TRIX_DATA_ATTRIBUTES = %w[data-trix-attachment].freeze
+
+    def self.sanitize(html)
+      @sanitizer ||= Rails::HTML5::SafeListSanitizer.new
+      @sanitizer.sanitize(
+        html, tags: ALLOWED_TAGS, attributes: (ALLOWED_ATTRIBUTES + ALLOWED_TRIX_DATA_ATTRIBUTES)
+      )
+    end
+  end
+
+  def up
+    Enterprise.where.not(long_description: [nil, ""]).find_each do |enterprise|
+      long_description = HtmlSanitizer.sanitize(enterprise.long_description)
+      enterprise.update!(long_description:)
+    end
+  end
+
+  private
+
+  def sanitize(html)
+    HtmlSanitizer.sanitize(html)
+  end
+end

--- a/spec/migrations/20240510033206_sanitize_enterprise_long_description_spec.rb
+++ b/spec/migrations/20240510033206_sanitize_enterprise_long_description_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../db/migrate/20240510033206_sanitize_enterprise_long_description'
+
+RSpec.describe SanitizeEnterpriseLongDescription do
+  describe "#up" do
+    let!(:enterprise_nil_desc) { create(:enterprise, long_description: nil) }
+    let!(:enterprise_empty_desc) { create(:enterprise, long_description: "") }
+    let!(:enterprise_normal) { create(:enterprise, long_description: normal_desc) }
+    let!(:enterprise_bad) {
+      # The attribute is sanitised at assignment. So we need to inject into the
+      # database differently:
+      create(:enterprise).tap do |enterprise|
+        enterprise.update_columns(long_description: bad_desc)
+      end
+    }
+    let(:normal_desc) {
+      <<~HTML.squish
+        <p>𝐂𝐎̛𝐌 𝐓𝐀̂́𝐌 𝐂𝐇𝐔́ 𝐁𝐄́ is now available in Melbourne, everyone. 😂<br>
+        <>>> The story is this is a person who loves to eat...</p>
+      HTML
+    }
+    let(:normal_desc_sanitised) {
+      <<~HTML.squish
+        <p>𝐂𝐎̛𝐌 𝐓𝐀̂́𝐌 𝐂𝐇𝐔́ 𝐁𝐄́ is now available in Melbourne, everyone. 😂<br>
+        &lt;&gt;&gt;&gt; The story is this is a person who loves to eat...</p>
+      HTML
+    }
+    let(:bad_desc) {
+      <<~HTML.squish
+        <p data-controller="load->payMe">Fred Farmer is a certified organic
+        <script>alert("Gotcha!")</script>...</p>
+      HTML
+    }
+    let(:bad_desc_sanitised) {
+      "<p>Fred Farmer is a certified organic alert(\"Gotcha!\")...</p>"
+    }
+
+    it "sanitises the long description" do
+      expect { subject.up }.to change {
+        enterprise_bad.reload.attributes["long_description"]
+      }.from(bad_desc).to(bad_desc_sanitised)
+
+      expect(enterprise_nil_desc.reload.long_description).to eq nil
+      expect(enterprise_empty_desc.reload.long_description).to eq ""
+      expect(enterprise_normal.reload.attributes["long_description"])
+        .to eq normal_desc_sanitised
+    end
+  end
+end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -404,11 +404,6 @@ RSpec.describe Enterprise do
       subject.long_description = "Hello <script>alert</script> dearest <b>monster</b>."
       expect(subject.long_description).to eq "Hello alert dearest <b>monster</b>."
     end
-
-    it "sanitises existing HTML in long_description" do
-      subject[:long_description] = "Hello <script>alert</script> dearest <b>monster</b>."
-      expect(subject.long_description).to eq "Hello alert dearest <b>monster</b>."
-    end
   end
 
   describe "callbacks" do


### PR DESCRIPTION
:information_source: _Please use project **Discover Regenerative (Macdoch pt 2): 3. Open Source Tech Evolution** to track work on this issue._

#### What? Why?

- Part of #12448

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We are now sanitising attributes on the model level but this pull request introduces the first database migration to migrate existing data. We were holding off because it's destructive but so far everything has been fine. I'm doing it for just one attribute here but if everything is find, we can probably do all other attributes in one migration in the next PR.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit Admin, Enterprise settings, About and edit the long description with the editor.
- Everything you do with the editor should save and show in the frontend.
- Existing descriptions should look the same after deploying this PR.

#### Release notes

Note that this includes potential **un-reversable data deletion**. Seems like a good time for a minor version increment.
<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
