### PR TITLE
Sanitise HTML in long description of enterprise [read-only]

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -247,6 +247,11 @@ class Enterprise < ApplicationRecord
     count(distinct: true)
   end
 
+  # Remove any unsupported HTML.
+  def long_description=(html)
+    super(HtmlSanitizer.sanitize(html))
+  end
+
   def contact
     contact = users.where(enterprise_roles: { receives_notifications: true }).first
     contact || owner

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -248,6 +248,11 @@ class Enterprise < ApplicationRecord
   end
 
   # Remove any unsupported HTML.
+  def long_description
+    HtmlSanitizer.sanitize(super)
+  end
+
+  # Remove any unsupported HTML.
   def long_description=(html)
     super(HtmlSanitizer.sanitize(html))
   end

--- a/app/services/html_sanitizer.rb
+++ b/app/services/html_sanitizer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Keeps only allowed HTML.
+#
+# We store some rich text as HTML in attributes of models like Enterprise.
+# We offer an editor which supports certain tags but you can't insert just any
+# HTML, which would be dangerous.
+class HtmlSanitizer
+  def self.sanitize(html)
+    @sanitizer ||= Rails::HTML5::SafeListSanitizer.new
+    @sanitizer.sanitize(
+      html, tags: %w[h1 h2 h3 h4 p b i u a], attributes: %w[href target],
+    )
+  end
+end

--- a/app/services/html_sanitizer.rb
+++ b/app/services/html_sanitizer.rb
@@ -9,7 +9,7 @@ class HtmlSanitizer
   def self.sanitize(html)
     @sanitizer ||= Rails::HTML5::SafeListSanitizer.new
     @sanitizer.sanitize(
-      html, tags: %w[h1 h2 h3 h4 p b i u a], attributes: %w[href target],
+      html, tags: %w[h1 h2 h3 h4 p br b i u a], attributes: %w[href target],
     )
   end
 end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -403,6 +403,11 @@ RSpec.describe Enterprise do
       subject.long_description = "Hello <script>alert</script> dearest <b>monster</b>."
       expect(subject.long_description).to eq "Hello alert dearest <b>monster</b>."
     end
+
+    it "sanitises existing HTML in long_description" do
+      subject[:long_description] = "Hello <script>alert</script> dearest <b>monster</b>."
+      expect(subject.long_description).to eq "Hello alert dearest <b>monster</b>."
+    end
   end
 
   describe "callbacks" do

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -398,6 +398,13 @@ RSpec.describe Enterprise do
     end
   end
 
+  describe "serialisation" do
+    it "sanitises HTML in long_description" do
+      subject.long_description = "Hello <script>alert</script> dearest <b>monster</b>."
+      expect(subject.long_description).to eq "Hello alert dearest <b>monster</b>."
+    end
+  end
+
   describe "callbacks" do
     it "restores permalink to original value when it is changed and invalid" do
       e1 = create(:enterprise, permalink: "taken")

--- a/spec/services/html_sanitizer_spec.rb
+++ b/spec/services/html_sanitizer_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe HtmlSanitizer do
   end
 
   it "keeps supported tags" do
-    html = "Hello <b>alert</b>!"
+    html = "Hello <b>alert</b>! <br>How are you?"
     expect(subject.sanitize(html))
-      .to eq "Hello <b>alert</b>!"
+      .to eq "Hello <b>alert</b>! <br>How are you?"
   end
 
   it "keeps supported attributes" do

--- a/spec/services/html_sanitizer_spec.rb
+++ b/spec/services/html_sanitizer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe HtmlSanitizer do
+  subject { described_class }
+
+  it "removes dangerous tags" do
+    html = "Hello <script>alert</script>!"
+    expect(subject.sanitize(html))
+      .to eq "Hello alert!"
+  end
+
+  it "keeps supported tags" do
+    html = "Hello <b>alert</b>!"
+    expect(subject.sanitize(html))
+      .to eq "Hello <b>alert</b>!"
+  end
+
+  it "keeps supported attributes" do
+    html = 'Hello <a href="#focus">alert</a>!'
+    expect(subject.sanitize(html))
+      .to eq 'Hello <a href="#focus">alert</a>!'
+  end
+
+  it "removes unsupported attributes" do
+    html = 'Hello <a href="#focus" onclick="alert">alert</a>!'
+    expect(subject.sanitize(html))
+      .to eq 'Hello <a href="#focus">alert</a>!'
+  end
+
+  it "removes dangerous attribute values" do
+    html = 'Hello <a href="javascript:alert(\"boo!\")">you</a>!'
+    expect(subject.sanitize(html))
+      .to eq 'Hello <a>you</a>!'
+  end
+end


### PR DESCRIPTION
:information_source: _Please use project **Discover Regenerative (Macdoch pt 2): 3. Open Source Tech Evolution** to track work on this issue._

#### What? Why?

- Part of #12448
- Prequel of #12459

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We weren't sanitising the HTML of long enterprise descriptions at all. So here's a remedy that sanitises the field before it's reaching the database. All consumers, including API users should now get sanitised HTML.

There are more attributes like this listed in the issue. But I wanted to get this through faster and get a review first before I apply the same approach to the other three fields.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit Admin, Enterprise settings, About and edit the long description with the editor.
- Everything you do with the editor should save and show in the frontend.
- I don't know an easy way to simulate the attacker scenario. But I think that my approach with those unit tests is pretty safe.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
