### PR TITLE
[wip] Don't transform translated values in navigation menu

### DIFF
--- a/app/helpers/spree/admin/navigation_helper.rb
+++ b/app/helpers/spree/admin/navigation_helper.rb
@@ -24,17 +24,17 @@ module Spree
         options[:route] ||= "admin_#{args.first}"
 
         destination_url = options[:url] || spree.public_send("#{options[:route]}_path")
-        titleized_label = Spree.t(options[:label],
-                                  default: options[:label],
-                                  scope: [:admin, :tab]).capitalize
+        label = Spree.t(options[:label],
+                        default: options[:label].humanize,
+                        scope: [:admin, :tab])
 
         css_classes = []
 
         if options[:icon] && !feature?(:admin_style_v3, spree_current_user)
-          link = link_to_with_icon(options[:icon], titleized_label, destination_url)
+          link = link_to_with_icon(options[:icon], label, destination_url)
           css_classes << 'tab-with-icon'
         else
-          link = link_to(titleized_label, destination_url)
+          link = link_to(label, destination_url)
         end
 
         selected = if options[:match_path]

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -34,6 +34,15 @@ module Spree
           expect(helper.klass_for('Inventory')).to eq(VariantOverride)
         end
       end
+
+      describe "tab" do
+        it "includes translated value" do
+          # todo: mock translation?
+          expect(helper.tab(:oidc_settings)).to include "OIDC Settings"
+        end
+
+        it "transforms untranslated value"
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

I was looking to see if it was a good first issue, then I saw the solution so just did it.

- Closes #11023


Eg if :oidc_settings has no translation key:
```
options[:label].humanize
=> "Oidc settings"
```

But if it was translated as "OIDC Settings", then it is unchanged.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

### Work in progress:

- [ ] Fix specs 
- [ ] Check/add a test for the default value
- [ ] remove special handling for missing translations

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

As per issue

#### Release notes
As it can change what shows in the menu, it's probalby worth announcing as user-facing

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
