### PR TITLE
Show any tax category errors when saving variants

### DIFF
--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -56,6 +56,7 @@
       include_blank: t('.none_tax_category'),
       aria_label: t('.tax_category_field_name'),
       placeholder_value: t('.search_for_tax_categories')))
+  = error_message_on variant, :tax_category
 %td.align-left
   -# empty
 %td.align-right

--- a/app/views/spree/admin/tax_settings/edit.html.haml
+++ b/app/views/spree/admin/tax_settings/edit.html.haml
@@ -7,8 +7,9 @@
 
   .field.align-center
     = hidden_field_tag 'preferences[products_require_tax_category]', '0'
-    = check_box_tag 'preferences[products_require_tax_category]', '1',  Spree::Config[:products_require_tax_category]
-    = label_tag nil, t(:products_require_tax_category)
+    %label
+      = check_box_tag 'preferences[products_require_tax_category]', '1',  Spree::Config[:products_require_tax_category]
+      = t(:products_require_tax_category)
 
   .form-buttons
     = button t(:update), 'icon-refresh'

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -65,7 +65,7 @@
       = f.number_field field, value: value, class: 'fullwidth', step: 0.01
 
   .field
-    = f.label :tax_category_id, t(:tax_category)
+    = f.label :tax_category, t(:tax_category), for: :tax_category_id
     = f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: t(:none) }, { class: 'select2 fullwidth' })
 
   .field

--- a/app/webpacker/css/admin_v3/components/tom_select.scss
+++ b/app/webpacker/css/admin_v3/components/tom_select.scss
@@ -194,6 +194,13 @@
   }
 }
 
+// Errors
+.field_with_errors .ts-wrapper {
+  .ts-control {
+    border-color: $color-error;
+  }
+}
+
 // Display as "changed" if sibling select is marked as changed.
 select.changed + .ts-wrapper {
   &.single, &.multi {


### PR DESCRIPTION
### What? Why?

- Closes #12480

If the tax category is required, but not chosen on a variant, the error is now clearer so you know what's wrong:
* on bulk products screen: an error message now appears below the dropdown
* on variant edit screen: the label is highlighted red.

I now realise this was due to bad setup (see below), and would like to update the interface to avoid the root cause. But until then at least we have better error messaging.

![Screenshot 2024-05-16 at 3 19 29 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/623d4ce9-ad8e-4956-b2e7-65daf4afc5bf)

![Screenshot 2024-05-16 at 11 18 49 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/49a43a3b-a4f5-41cc-a223-9472fe705be8)

It would have been nice to highlight the Tomselect and  Select2 dropdowns too, but there's a couple of problems with that..
.. And we'll have to fix unit value another day.

### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected

     by your change. -->

**Setup**
I now realise that this is bad setup, but it's currently possible, and it's not intuitive:
1. Visit `/admin/tax_settings/edit`, select "products require tax category" and save
2. Visit `/admin/tax_categories` and ensure there is no "default"

**Test with `admin_style_v3` enabled**
4. Visit `/admin/products`
5. select "None" for tax category on a variant, and attempt save
6. Error message should explain why it did not save.

**Try both: with `admin_style_v3` enabled, also without.**
7. Visit `/admin/products/x/variants/x/edit` 
8. select "None" for tax category, and attempt save.

#### Release notes
It's only really noticeable on admin_style_v3
<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.



### Documentation updates
The config requirements may already be documented in the guide, I don't know. But we really need to make the app more intuitive anyway.
