### PR TITLE
More realistic test env for translations

### DIFF
--- a/.env
+++ b/.env
@@ -10,10 +10,10 @@ TIMEZONE="Melbourne"
 DEFAULT_COUNTRY_CODE="AU"
 
 # Locale for translation.
-LOCALE="en"
+LOCALE="en_AU"
 
 # For multilingual - ENV doesn't have array so pass it as string with commas
-AVAILABLE_LOCALES="en,es"
+AVAILABLE_LOCALES="en_AU,es"
 
 # Spree zone.
 CHECKOUT_ZONE="Australia"

--- a/.env.development
+++ b/.env.development
@@ -5,6 +5,11 @@
 #
 #     cp .env.development .env.local
 
+# Locale for translation. Using a locale other than `en` tests the
+# successful fallback to `en`. You will also see up-to-date text used
+# in production
+LOCALE="en_AU"
+
 VERBOSE_QUERY_LOGS=true
 
 SECRET_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,9 @@
 # ENV vars for the test environment
 # Override locally with `.env.test.local`
 
+# Locale for translation.
+LOCALE="en_TEST"
+
 OFN_REDIS_JOBS_URL="redis://localhost:6379/2"
 
 SECRET_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/config/locales/en_TEST.yml
+++ b/config/locales/en_TEST.yml
@@ -1,0 +1,12 @@
+# Test language file
+# ---------------------
+#
+# All production environments set their own locale. The source locale `en.yml`
+# is used as a fallback but no server is using it directly.
+#
+# Using this test locale reflects that setup more realistically and means that
+# we include fallback translations in our tests.
+#
+en:
+  # Overridden here due to a bug in spree i18n (Issue #870, and issue #1800)
+  language_name: "English" # Localised name of this language

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -141,7 +141,7 @@ RSpec.configure do |config|
 
   # Reset locale for all specs.
   config.around(:each) do |example|
-    I18n.with_locale(:en) { example.run }
+    I18n.with_locale(:en_AU) { example.run }
   end
 
   # Reset all feature toggles to prevent leaking.


### PR DESCRIPTION

#### What? Why?

Most production servers don't use the source locale `en`. Even if the default language is English, they use a local variant like `en_AU` or `en_GB` to customise some of the translations.

However the environment is configured, the app should always fallback to `en` if no other translation is available.

I was hoping to cover a recent bug with this change:

- #12429

Unfortunately, the missing translation wasn't covered by any spec and this didn't help. But it may prevent other bugs in the future. Fallback translations are now used in tests and dev.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Production and staging servers define their own locale.
- But it doesn't hurt to deploy this and follow steps in #12429.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
