### PR TITLE
Removes deprecation strikethrough from tax report (by producer)

### DIFF
--- a/lib/reporting/reports/list.rb
+++ b/lib/reporting/reports/list.rb
@@ -62,8 +62,7 @@ module Reporting
           ],
           [
             i18n_translate('enterprise_fees_with_tax_report_by_producer'),
-            :enterprise_fees_with_tax_report_by_producer,
-            { deprecated: true }, # Not supported until specific details are finalised.
+            :enterprise_fees_with_tax_report_by_producer
           ],
         ]
       end


### PR DESCRIPTION
 Removes deprecation strikethrough from report enterprise fees with tax report by producer.

#### What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/11531

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Context [here](https://openfoodnetwork.slack.com/archives/C01T75H6G0Z/p1716400836719719).

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- login as a hub manager or superadmin
- visit /admin/reports
- the link for Enterprise Fees With Tax Report By Producer should have the strike-through removed:

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/49817236/dba83219-7ccd-47b4-8916-e4c663eb8a03)

- the Inventory (on hand) should still have the strike-through styling


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
