### PR TITLE
Sanitise HTML in long description of enterprise group [read-only]

### DIFF
--- a/app/models/enterprise_group.rb
+++ b/app/models/enterprise_group.rb
@@ -74,6 +74,16 @@ class EnterpriseGroup < ApplicationRecord
     permalink
   end
 
+  # Remove any unsupported HTML.
+  def long_description
+    HtmlSanitizer.sanitize(super)
+  end
+
+  # Remove any unsupported HTML.
+  def long_description=(html)
+    super(HtmlSanitizer.sanitize(html))
+  end
+
   private
 
   def sanitize_permalink

--- a/spec/models/enterprise_group_spec.rb
+++ b/spec/models/enterprise_group_spec.rb
@@ -118,4 +118,16 @@ RSpec.describe EnterpriseGroup do
       end
     end
   end
+
+  describe "serialisation" do
+    it "sanitises HTML in long_description" do
+      subject.long_description = "Hello <script>alert</script> dearest <b>monster</b>."
+      expect(subject.long_description).to eq "Hello alert dearest <b>monster</b>."
+    end
+
+    it "sanitises existing HTML in long_description" do
+      subject[:long_description] = "Hello <script>alert</script> dearest <b>monster</b>."
+      expect(subject.long_description).to eq "Hello alert dearest <b>monster</b>."
+    end
+  end
 end


### PR DESCRIPTION
:information_source: _Please use project **Discover Regenerative (Macdoch pt 2): #3A. Tech - OFN & OFN/DFC Endpoints** to track work on this issue._

#### What? Why?

- Part of #12448

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Sanitises the HTML of long enterprise group description before reaching the database.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

1. [Editor] Visit Admin, Group settings, About and edit the long description with the editor.

<img width="1422" alt="Screenshot 2024-05-23 at 09 34 33" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/27692541/e7689bc6-794b-43e9-b790-082f00a83484">

2. [Store] Visit Store, Groups, select the group, About us:  everything you do in step 1 (editor) should save and show up here.

<img width="1430" alt="Screenshot 2024-05-23 at 09 33 43" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/27692541/2586748b-711b-4a31-8858-2a7d13ca8938">


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
