### PR TITLE
Allow only enterprise managers to connect apps

### DIFF
--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -14,6 +14,10 @@ module Admin
       producers.size == 1 ? producers.first.id : nil
     end
 
+    def can_connect_apps?(enterprise)
+      enterprise.in?(spree_current_user.enterprises)
+    end
+
     def enterprise_side_menu_items(enterprise)
       is_shop = enterprise.sells != "none"
       show_properties = !!enterprise.is_primary_producer

--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -14,7 +14,7 @@ module Admin
       producers.size == 1 ? producers.first.id : nil
     end
 
-    def can_connect_apps?(enterprise)
+    def managed_by_user?(enterprise)
       enterprise.in?(spree_current_user.enterprises)
     end
 

--- a/app/views/admin/enterprises/form/_connected_apps.html.haml
+++ b/app/views/admin/enterprises/form/_connected_apps.html.haml
@@ -6,7 +6,9 @@
       %p= t ".tagline"
     %div
       - if enterprise.connected_apps.empty?
-        = button_to t(".enable"), admin_enterprise_connected_apps_path(enterprise.id), method: :post
+        = button_to t(".enable"), admin_enterprise_connected_apps_path(enterprise.id), method: :post, disabled: !can_connect_apps?(enterprise)
+        -# This is only seen by super-admins:
+        %em= t(".need_to_be_manager") unless can_connect_apps?(enterprise)
       - elsif enterprise.connected_apps.connecting.present?
         %button{ disabled: true }
           %i.spinner.fa.fa-spin.fa-circle-o-notch

--- a/app/views/admin/enterprises/form/_connected_apps.html.haml
+++ b/app/views/admin/enterprises/form/_connected_apps.html.haml
@@ -6,9 +6,9 @@
       %p= t ".tagline"
     %div
       - if enterprise.connected_apps.empty?
-        = button_to t(".enable"), admin_enterprise_connected_apps_path(enterprise.id), method: :post, disabled: !can_connect_apps?(enterprise)
+        = button_to t(".enable"), admin_enterprise_connected_apps_path(enterprise.id), method: :post, disabled: !managed_by_user?(enterprise)
         -# This is only seen by super-admins:
-        %em= t(".need_to_be_manager") unless can_connect_apps?(enterprise)
+        %em= t(".need_to_be_manager") unless managed_by_user?(enterprise)
       - elsif enterprise.connected_apps.connecting.present?
         %button{ disabled: true }
           %i.spinner.fa.fa-spin.fa-circle-o-notch

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1357,6 +1357,7 @@ en:
           enable: "Allow data sharing"
           disable: "Stop sharing"
           loading: "Loading"
+          need_to_be_manager: "Only managers can connect apps."
           note: |
             Your Open Food Network account is connected to Discover Regenerative.
             Add or update information on your Discover Regenerative listing here.

--- a/spec/system/admin/enterprises/connected_apps_spec.rb
+++ b/spec/system/admin/enterprises/connected_apps_spec.rb
@@ -50,4 +50,14 @@ RSpec.describe "Connected Apps", feature: :connected_apps, vcr: true do
     expect(page).not_to have_content "account is connected"
     expect(page).not_to have_link "Manage listing"
   end
+
+  it "can't be enabled by non-manager" do
+    login_as create(:admin_user)
+
+    visit "#{edit_admin_enterprise_path(enterprise)}#/connected_apps_panel"
+    expect(page).to have_content "Discover Regenerative"
+
+    expect(page).to have_button("Allow data sharing", disabled: true)
+    expect(page).to have_content "Only managers can connect apps."
+  end
 end


### PR DESCRIPTION

#### What? Why?

- Part of #12425 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Connecting apps only works for enterprise managers because non-managers, like super admins, are not authorised to access enterprise data via the DFC API.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Edit an enterprise and go to the connected apps panel (feature toggle on).
- As manager, you see the normal connect button.
- As non-manager (super admin) the button is disabled and a not displays. You can't click that button.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
