### PR TITLE
Fix redundant presence validation on belongs part V

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -650,14 +650,12 @@ Rails/RedundantActiveRecordAllMethod:
     - 'app/models/spree/variant.rb'
     - 'spec/system/admin/product_import_spec.rb'
 
-# Offense count: 7
+# Offense count: 4
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/RedundantPresenceValidationOnBelongsTo:
   Exclude:
     - 'app/models/spree/line_item.rb'
     - 'app/models/spree/order.rb'
-    - 'app/models/subscription_line_item.rb'
-    - 'app/models/tag_rule.rb'
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/app/models/subscription_line_item.rb
+++ b/app/models/subscription_line_item.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 class SubscriptionLineItem < ApplicationRecord
-  self.belongs_to_required_by_default = false
-
   belongs_to :subscription, inverse_of: :subscription_line_items
   belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'
 
-  validates :subscription, presence: true
-  validates :variant, presence: true
   validates :quantity, presence: true, numericality: { only_integer: true }
 
   default_scope { order('id ASC') }

--- a/app/models/tag_rule.rb
+++ b/app/models/tag_rule.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 class TagRule < ApplicationRecord
-  self.belongs_to_required_by_default = false
-
   belongs_to :enterprise
 
   preference :customer_tags, :string, default: ""
-
-  validates :enterprise, presence: true
 
   scope :for, ->(enterprise) { where(enterprise_id: enterprise) }
   scope :prioritised, -> { order('priority ASC') }

--- a/spec/models/subscription_line_item_spec.rb
+++ b/spec/models/subscription_line_item_spec.rb
@@ -5,11 +5,11 @@ require 'spec_helper'
 RSpec.describe SubscriptionLineItem, model: true do
   describe "validations" do
     it "requires a subscription" do
-      expect(subject).to validate_presence_of :subscription
+      expect(subject).to belong_to :subscription
     end
 
     it "requires a variant" do
-      expect(subject).to validate_presence_of :variant
+      expect(subject).to belong_to :variant
     end
 
     it "requires a integer for quantity" do

--- a/spec/models/tag_rule_spec.rb
+++ b/spec/models/tag_rule_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe TagRule, type: :model do
   describe "validations" do
     it "requires a enterprise" do
-      expect(subject).to validate_presence_of(:enterprise)
+      expect(subject).to belong_to(:enterprise)
     end
   end
 end


### PR DESCRIPTION
#### What? Why?
- Contributes to #11482
- First attempt was made by #12380 
-  Continuation of #12493 
- See also #11297 that started the work


#### What should we test?
After migration, all tests should pass and no rubocop offense should be raised.

No migration file here because the null were already enforced at DB level.
Also no need to check for corrupt data.

#### Need to know: May be some of these changes are unnecessary
I had the following message when, after code modifications I ran the
corresponding specs (see end of the thread).

So, I changed the spec accordingly. In the end belonged ids must not be null.
However, since belongs_to enforce validation, testing that a belongs_to is
enforced in specs appears to me redundant.

So, I would delete the 2 first examples in the `spec/models/subscription_line_item_spec.rb` file, 
and the `spec/models/tag_rule_spec.rb` file entirely.

I share the opinion that one not should test what an external lib should do:
https://www.codewithjason.com/dont-use-shoulda-matchers/

But I did the changes in cases reviewers still want to keep the specs.
It is also easy to add a commit to delete those parts.

```
SubscriptionLineItem validations requires a variant
     Failure/Error: expect(subject).to validate_presence_of :variant
     
       Expected SubscriptionLineItem to validate that :variant cannot be
       empty/falsy, but this could not be proved.
         After setting :variant to ‹nil›, the matcher expected the
         SubscriptionLineItem to be invalid and to produce the validation error
         "can't be blank" on :variant. The record was indeed invalid, but it
         produced these validation errors instead:
     
         * subscription: ["must exist"]
         * variant: ["must exist"]
         * quantity: ["can't be blank", "is not a number"]
     
         You're getting this error because ActiveRecord is configured to add a
         presence validation to all `belongs_to` associations, and this
         includes yours. *This* presence validation doesn't use "can't be
         blank", the usual validation message, but "must exist" instead.
     
         With that said, did you know that the `belong_to` matcher can test
         this validation for you? Instead of using `validate_presence_of`, try
         the following instead:
     
             it { should belong_to(:variant) }
```

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
