### PR TITLE
Do not commit to db unchanged products in bulk save

### DIFF
--- a/app/models/spree/price.rb
+++ b/app/models/spree/price.rb
@@ -24,10 +24,6 @@ module Spree
       amount
     end
 
-    def price_changed?
-      amount_changed?
-    end
-
     def price=(price)
       self[:amount] = parse_price(price)
     end

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -199,6 +199,11 @@ module Spree
       price_in(currency).try(:amount)
     end
 
+    def changed?
+      # Changes to price are saved after_save
+      super || default_price.changed?
+    end
+
     # can_supply? is implemented in VariantStock
     def in_stock?(quantity = 1)
       can_supply?(quantity)

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -200,7 +200,7 @@ module Spree
     end
 
     def changed?
-      # Changes to price are saved after_save
+      # We consider the variant changed if associated price is changed (it is saved after_save)
       super || default_price.changed?
     end
 

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -49,7 +49,7 @@ module Spree
     has_many :prices,
              class_name: 'Spree::Price',
              dependent: :destroy
-    delegate :display_price, :display_amount, :price, :price_changed?, :price=,
+    delegate :display_price, :display_amount, :price, :price=,
              :currency, :currency=,
              to: :find_or_build_default_price
 

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -67,11 +67,12 @@ module Sets
 
       product.assign_attributes(product_related_attrs)
 
+      return true unless product.changed?
+
       validate_presence_of_unit_value_in_product(product)
 
-      changed = product.changed?
       success = product.errors.empty? && product.save
-      count_result(success && changed)
+      count_result(success)
       success
     end
 
@@ -104,7 +105,8 @@ module Sets
     def create_or_update_variant(product, variant_attributes)
       variant = find_model(product.variants, variant_attributes[:id])
       if variant.present?
-        variant.update(variant_attributes.except(:id))
+        variant.assign_attributes(variant_attributes.except(:id))
+        variant.update(variant_attributes.except(:id)) if variant.changed?
       else
         variant = create_variant(product, variant_attributes)
       end

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -106,7 +106,7 @@ module Sets
       variant = find_model(product.variants, variant_attributes[:id])
       if variant.present?
         variant.assign_attributes(variant_attributes.except(:id))
-        variant.update(variant_attributes.except(:id)) if variant.changed?
+        variant.save if variant.changed?
       else
         variant = create_variant(product, variant_attributes)
       end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -58,6 +58,28 @@ RSpec.describe Spree::Variant do
     end
   end
 
+  describe "#changed?" do
+    subject(:variant) { create(:variant) }
+
+    it { is_expected.not_to be_changed }
+
+    it "is changed when basic fields are changed" do
+      subject.display_name = "blah"
+      expect(subject).to be_changed
+    end
+
+    describe "default_price" do
+      it "price" do
+        subject.price = 100
+        expect(subject).to be_changed
+      end
+      it "currency" do
+        subject.currency = "USD"
+        expect(subject).to be_changed
+      end
+    end
+  end
+
   context "price parsing" do
     context "price=" do
       context "with decimal point" do

--- a/spec/services/sets/product_set_spec.rb
+++ b/spec/services/sets/product_set_spec.rb
@@ -134,6 +134,27 @@ RSpec.describe Sets::ProductSet do
           end
         end
       end
+
+      context "when product attributes are not changed" do
+        let(:collection_hash) {
+          { 0 => { id: product.id, name: product.name } }
+        }
+
+        it 'returns true' do
+          is_expected.to eq true
+        end
+
+        it 'does not increase saved_count' do
+          subject
+          expect(product_set.saved_count).to eq 0
+        end
+
+        it 'does not update any product by calling save' do
+          expect_any_instance_of(Spree::Product).not_to receive(:save)
+
+          subject
+        end
+      end
     end
 
     describe "updating a product's variants" do
@@ -188,6 +209,23 @@ RSpec.describe Sets::ProductSet do
         let(:variant_attributes) { { sku: "var_sku", display_name: "A" * 256 } } # maximum length
 
         include_examples "nothing saved"
+      end
+
+      context "when attributes are not changed" do
+        let(:variant_attributes) { { sku: variant.sku } }
+
+        before { variant }
+
+        it 'updates product by calling save' do
+          expect_any_instance_of(Spree::Variant).not_to receive(:save)
+
+          subject
+        end
+
+        it 'does not increase saved_count' do
+          subject
+          expect(product_set.saved_count).to eq 0
+        end
       end
 
       context "when products attributes are also updated" do


### PR DESCRIPTION
#### What? Why?

- Closes #12503

It imprves performance.



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- enable feature toggle `admin_style_v3`
- Set up a product with invalid tax category (see https://github.com/openfoodfoundation/openfoodnetwork/pull/12486#issuecomment-2123374715). This will make the product invalid.
- visit `/admin/products`
- saving of other products should work 
   -  unchanged invalid product should be ignored, with no error message.
   - saving time may be improved.
   - (in DEV: in logs should be visible db commit transactions only for updated products )


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
