### PR TITLE
Sanitise HTML in product description [read-only]

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -304,6 +304,16 @@ module Spree
       )
     end
 
+    # Remove any unsupported HTML.
+    def description
+      Rails::HTML::SafeListSanitizer.new.sanitize(super)
+    end
+
+    # # Remove any unsupported HTML.
+    def description=(html)
+      super(Rails::HTML::SafeListSanitizer.new.sanitize(html))
+    end
+
     private
 
     def update_units

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -306,12 +306,12 @@ module Spree
 
     # Remove any unsupported HTML.
     def description
-      Rails::HTML::SafeListSanitizer.new.sanitize(super)
+      HtmlSanitizer.sanitize(super)
     end
 
-    # # Remove any unsupported HTML.
+    # Remove any unsupported HTML.
     def description=(html)
-      super(Rails::HTML::SafeListSanitizer.new.sanitize(html))
+      super(HtmlSanitizer.sanitize(html))
     end
 
     private

--- a/app/services/html_sanitizer.rb
+++ b/app/services/html_sanitizer.rb
@@ -6,7 +6,8 @@
 # We offer an editor which supports certain tags but you can't insert just any
 # HTML, which would be dangerous.
 class HtmlSanitizer
-  ALLOWED_TAGS = %w[h1 h2 h3 h4 p br b i u a strong em del pre blockquote ul ol li hr figure].freeze
+  ALLOWED_TAGS = %w[h1 h2 h3 h4 div p br b i u a strong em del pre blockquote ul ol li hr
+                    figure].freeze
   ALLOWED_ATTRIBUTES = %w[href target].freeze
   ALLOWED_TRIX_DATA_ATTRIBUTES = %w[data-trix-attachment].freeze
 

--- a/app/services/html_sanitizer.rb
+++ b/app/services/html_sanitizer.rb
@@ -6,6 +6,7 @@
 # We offer an editor which supports certain tags but you can't insert just any
 # HTML, which would be dangerous.
 class HtmlSanitizer
+  # div is required by Trix editor
   ALLOWED_TAGS = %w[h1 h2 h3 h4 div p br b i u a strong em del pre blockquote ul ol li hr
                     figure].freeze
   ALLOWED_ATTRIBUTES = %w[href target].freeze

--- a/app/services/html_sanitizer.rb
+++ b/app/services/html_sanitizer.rb
@@ -6,10 +6,14 @@
 # We offer an editor which supports certain tags but you can't insert just any
 # HTML, which would be dangerous.
 class HtmlSanitizer
+  ALLOWED_TAGS = %w[h1 h2 h3 h4 p br b i u a strong em del pre blockquote ul ol li hr figure].freeze
+  ALLOWED_ATTRIBUTES = %w[href target].freeze
+  ALLOWED_TRIX_DATA_ATTRIBUTES = %w[data-trix-attachment].freeze
+
   def self.sanitize(html)
     @sanitizer ||= Rails::HTML5::SafeListSanitizer.new
     @sanitizer.sanitize(
-      html, tags: %w[h1 h2 h3 h4 p br b i u a], attributes: %w[href target],
+      html, tags: ALLOWED_TAGS, attributes: (ALLOWED_ATTRIBUTES + ALLOWED_TRIX_DATA_ATTRIBUTES)
     )
   end
 end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -748,6 +748,18 @@ module Spree
         expect(e.variants.reload).to be_empty
       end
     end
+
+    describe "serialisation" do
+      it "sanitises HTML in description" do
+        subject.description = "Hello <script>alert</script> dearest <b>monster</b>."
+        expect(subject.description).to eq "Hello alert dearest <b>monster</b>."
+      end
+
+      it "sanitises existing HTML in description" do
+        subject[:description] = "Hello <script>alert</script> dearest <b>monster</b>."
+        expect(subject.description).to eq "Hello alert dearest <b>monster</b>."
+      end
+    end
   end
 
   RSpec.describe "product import" do

--- a/spec/services/html_sanitizer_spec.rb
+++ b/spec/services/html_sanitizer_spec.rb
@@ -6,14 +6,26 @@ RSpec.describe HtmlSanitizer do
   subject { described_class }
 
   context "when HTML has supported tags" do
-    it "keeps supported tags" do
-      html = "Hello <b>alert</b>! <br>How are you?"
-      expect(subject.sanitize(html))
-        .to eq "Hello <b>alert</b>! <br>How are you?"
+    it "keeps supported regular tags" do
+      supported_tags = %w[h1 h2 h3 h4 div p b i u a strong em del pre blockquote ul ol li figure]
+      supported_tags.each do |tag|
+        html = "<#{tag}>Content</#{tag}>"
+        sanitized_html = subject.sanitize(html)
+        expect(sanitized_html).to eq(html), "Expected '#{tag}' to be preserved."
+      end
+    end
+
+    it "keeps supported void tags" do
+      supported_tags = %w[br hr]
+      supported_tags.each do |tag|
+        html = "<#{tag}>"
+        sanitized_html = subject.sanitize(html)
+        expect(sanitized_html).to eq(html), "Expected '#{tag}' to be preserved."
+      end
     end
 
     it "handles nested tags" do
-      html = '<ul><li>Item 1</li><li><strong>Item 2</strong></li></ul>'
+      html = '<div><ul><li>Item 1</li><li><strong>Item 2</strong></li></ul></div>'
       expect(subject.sanitize(html)).to eq(html)
     end
   end
@@ -44,7 +56,7 @@ RSpec.describe HtmlSanitizer do
       expect(subject.sanitize(html)).to eq ""
     end
 
-    it "removes link tags" do
+    it "removes base tags" do
       html = "<base href='http://phishing-site.com/'>"
       expect(subject.sanitize(html)).to eq ""
     end

--- a/spec/services/html_sanitizer_spec.rb
+++ b/spec/services/html_sanitizer_spec.rb
@@ -5,33 +5,85 @@ require 'spec_helper'
 RSpec.describe HtmlSanitizer do
   subject { described_class }
 
-  it "removes dangerous tags" do
-    html = "Hello <script>alert</script>!"
-    expect(subject.sanitize(html))
-      .to eq "Hello alert!"
+  context "when HTML has supported tags" do
+    it "keeps supported tags" do
+      html = "Hello <b>alert</b>! <br>How are you?"
+      expect(subject.sanitize(html))
+        .to eq "Hello <b>alert</b>! <br>How are you?"
+    end
+
+    it "handles nested tags" do
+      html = '<ul><li>Item 1</li><li><strong>Item 2</strong></li></ul>'
+      expect(subject.sanitize(html)).to eq(html)
+    end
   end
 
-  it "keeps supported tags" do
-    html = "Hello <b>alert</b>! <br>How are you?"
-    expect(subject.sanitize(html))
-      .to eq "Hello <b>alert</b>! <br>How are you?"
+  context "when HTML has dangerous tags" do
+    it "removes script tags" do
+      html = "Hello <script>alert</script>!"
+      expect(subject.sanitize(html)).to eq "Hello alert!"
+    end
+
+    it "removes iframe tags" do
+      html = "Content <iframe src='http://malicious-site.com'></iframe>"
+      expect(subject.sanitize(html)).to eq "Content "
+    end
+
+    it "removes object tags" do
+      html = "<object data='malicious-file.swf'></object>"
+      expect(subject.sanitize(html)).to eq ""
+    end
+
+    it "removes embed tags" do
+      html = "<embed src='malicious-video.mp4' type='video/mp4'>"
+      expect(subject.sanitize(html)).to eq ""
+    end
+
+    it "removes link tags" do
+      html = "<link rel='stylesheet' href='http://malicious-site.com/style.css'>"
+      expect(subject.sanitize(html)).to eq ""
+    end
+
+    it "removes link tags" do
+      html = "<base href='http://phishing-site.com/'>"
+      expect(subject.sanitize(html)).to eq ""
+    end
+
+    it "removes form tags" do
+      html = "<form action='http://malicious-site.com/submit' method='post'>...</form>"
+      expect(subject.sanitize(html)).to eq "..."
+    end
+
+    it "removes combined dangerous tags" do
+      html = "<script>alert</script><iframe scr='http://malicious-site.com'></iframe>"
+      expect(subject.sanitize(html)).to eq "alert"
+    end
   end
 
-  it "keeps supported attributes" do
-    html = 'Hello <a href="#focus">alert</a>!'
-    expect(subject.sanitize(html))
-      .to eq 'Hello <a href="#focus">alert</a>!'
+  context "when HTML has supported attributes" do
+    it "keeps supported attributes" do
+      html = 'Hello <a href="#focus">alert</a>!'
+      expect(subject.sanitize(html))
+        .to eq 'Hello <a href="#focus">alert</a>!'
+    end
   end
 
-  it "removes unsupported attributes" do
-    html = 'Hello <a href="#focus" onclick="alert">alert</a>!'
-    expect(subject.sanitize(html))
-      .to eq 'Hello <a href="#focus">alert</a>!'
-  end
+  context "when HTML has dangerous attributes" do
+    it "removes unsupported attributes" do
+      html = 'Hello <a href="#focus" onclick="alert">alert</a>!'
+      expect(subject.sanitize(html))
+        .to eq 'Hello <a href="#focus">alert</a>!'
+    end
 
-  it "removes dangerous attribute values" do
-    html = 'Hello <a href="javascript:alert(\"boo!\")">you</a>!'
-    expect(subject.sanitize(html))
-      .to eq 'Hello <a>you</a>!'
+    it "removes dangerous attribute values" do
+      html = 'Hello <a href="javascript:alert(\"boo!\")">you</a>!'
+      expect(subject.sanitize(html))
+        .to eq 'Hello <a>you</a>!'
+    end
+
+    it "keeps only Trix-specific data attributes" do
+      html = '<figure data-trix-attachment="{...}" data-script="">...</figure>'
+      expect(subject.sanitize(html)).to eq('<figure data-trix-attachment="{...}">...</figure>')
+    end
   end
 end


### PR DESCRIPTION
:information_source: _Please use project **Discover Regenerative (Macdoch pt 2): #3A. Tech - OFN & OFN/DFC Endpoints** to track work on this issue._

#### What? Why?

- Part of #12448

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Sanitises the HTML of product description before reaching the database.

**Implementation comments/suggestion:**

Using our custom  `HtmlSanitizer` on `Spree::Product#description` breaks the Action Text editor. That is because Action Text includes tags that we are not allowed in our custom sanitiser. Action Text uses rails' default  `Rails::Html::SafeListSanitizer`.

I might have missed discussions regarding the tags and attributes that we want to allow at OFN but why not use Rails defaults?

For a complete list of the default allowed attributes/tags:
`Rails::Html::WhiteListSanitizer.allowed_attributes`
`Rails::Html::WhiteListSanitizer.allowed_tags`

Tests still pass since the defaults do not allow `<script>` attributes. And this way we don't break the Action Text editor, offering more text editing possibilities.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

1. [Editor] Visit Admin, Products, edit a product description. Make sure you can save the text with editing options provided by the editor.

<img width="953" alt="Screenshot 2024-05-31 at 16 43 35" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/27692541/d41d4b92-8789-4e14-b208-4003a67e0744">


2. [Store] Visit Store, Select a hub and find the product that was edited in the first step. The description of the product should show up as it was edited in step 1.

<img width="1418" alt="Screenshot 2024-05-31 at 16 43 44" src="https://github.com/openfoodfoundation/openfoodnetwork/assets/27692541/19681962-e53a-4514-b0f8-ac4968590bd8">

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
