### PR TITLE
Extracts BUU from branch in #11645

### DIFF
--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1196,6 +1196,9 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       let(:default_variant_selector) {
         "tr:has(input[aria-label=Price][value='#{product_a.price}'])"
       }
+      let(:link_edit_variant) {
+        "/admin/products/#{Spree::Product.first.id}/variants/#{Spree::Variant.first.id}/edit"
+      }
 
       describe "Actions columns (delete)" do
         before do
@@ -1203,6 +1206,7 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
         end
 
         it "shows an actions menu with a delete link when clicking on icon for product. " \
+           "shows link to clone and edit the product;" \
            "doesn't show delete link for the single variant" do
           within product_selector do
             page.find(".vertical-ellipsis-menu").click
@@ -1213,6 +1217,7 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
           # to select the default variant
           within default_variant_selector do
             page.find(".vertical-ellipsis-menu").click
+            expect(page).to have_link "Edit", href: link_edit_variant
             expect(page).not_to have_css(delete_option_selector)
           end
         end
@@ -1224,17 +1229,21 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
                  display_name: "Medium box",
                  sku: "APL-01",
                  price: 5.25)
+          link_edit_variant2 =
+            "/admin/products/#{Spree::Product.first.id}/variants/#{Spree::Variant.second.id}/edit"
           visit admin_products_url
 
           # to select the default variant
           within default_variant_selector do
             page.find(".vertical-ellipsis-menu").click
+            expect(page).to have_link "Edit", href: link_edit_variant
             expect(page).to have_css(delete_option_selector)
           end
           page.find("div#content").click # to close the vertical actions menu
 
           within variant_selector do
             page.find(".vertical-ellipsis-menu").click
+            expect(page).to have_link "Edit", href: link_edit_variant2
             expect(page).to have_css(delete_option_selector)
           end
         end

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -85,22 +85,6 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       end
     end
 
-    it "displays a select box for suppliers, with the appropriate supplier selected" do
-      pending( "[BUU] Change producer, unit type, category and tax category #11060" )
-      s1 = FactoryBot.create(:supplier_enterprise)
-      s2 = FactoryBot.create(:supplier_enterprise)
-      s3 = FactoryBot.create(:supplier_enterprise)
-      p1 = FactoryBot.create(:product, supplier: s2)
-      p2 = FactoryBot.create(:product, supplier: s3)
-
-      visit spree.admin_products_path
-
-      expect(page).to have_select "producer_id", with_options: [s1.name, s2.name, s3.name],
-                                                 selected: s2.name
-      expect(page).to have_select "producer_id", with_options: [s1.name, s2.name, s3.name],
-                                                 selected: s3.name
-    end
-
     context "with several variants" do
       let!(:variant1) { p1.variants.first }
       let!(:variant2) { p2.variants.first }
@@ -397,7 +381,6 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       end
 
       # Unit popout
-      # TODO: prevent empty value
       fill_in "Unit value", with: ""
       click_button "Save changes" # attempt to save or close the popout
       expect(page).to have_field "Unit value", with: "" # popout is still open

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -18,9 +18,128 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
   let(:categories_search_selector) { 'input[placeholder="Search for categories"]' }
   let(:tax_categories_search_selector) { 'input[placeholder="Search for tax categories"]' }
 
-  it "can see the new product page" do
-    visit admin_products_url
-    expect(page).to have_content "Bulk Edit Products"
+  describe "with no products" do
+    before { visit admin_products_url }
+    it "can see the new product page" do
+      expect(page).to have_content "Bulk Edit Products"
+      expect(page).to have_text "No products found"
+      # displays buttons to add products with the correct links
+      expect(page).to have_link(class: "button", text: "New Product", href: "/admin/products/new")
+      expect(page).to have_link(class: "button", text: "Import multiple products",
+                                href: "/admin/products/import")
+    end
+  end
+
+  describe "using the page" do
+    describe "using column display dropdown" do
+      let(:product) { create(:simple_product) }
+
+      before do
+        pending "Pending implementation, issue #11055"
+        login_as_admin
+        visit spree.admin_products_path
+      end
+
+      it "shows a column display dropdown, which shows a list of columns when clicked" do
+        expect(page).to have_selector "th", text: "NAME"
+        expect(page).to have_selector "th", text: "PRODUCER"
+        expect(page).to have_selector "th", text: "PRICE"
+        expect(page).to have_selector "th", text: "ON HAND"
+
+        toggle_columns /^.{0,1}Producer$/i
+
+        expect(page).not_to have_selector "th", text: "PRODUCER"
+        expect(page).to have_selector "th", text: "NAME"
+        expect(page).to have_selector "th", text: "PRICE"
+        expect(page).to have_selector "th", text: "ON HAND"
+      end
+    end
+  end
+
+  describe "listing" do
+    let!(:p1) { create(:product) }
+    let!(:p2) { create(:product) }
+
+    before do
+      visit admin_products_url
+    end
+
+    it "displays a list of products" do
+      within ".products" do
+        # displays table header
+        expect(page).to have_selector "th", text: "Name"
+        expect(page).to have_selector "th", text: "SKU"
+        expect(page).to have_selector "th", text: "Unit scale"
+        expect(page).to have_selector "th", text: "Unit"
+        expect(page).to have_selector "th", text: "Price"
+        expect(page).to have_selector "th", text: "On Hand"
+        expect(page).to have_selector "th", text: "Producer"
+        expect(page).to have_selector "th", text: "Category"
+        expect(page).to have_selector "th", text: "Tax Category"
+        expect(page).to have_selector "th", text: "Inherits Properties?"
+        expect(page).to have_selector "th", text: "Actions"
+
+        # displays product list
+        expect(page).to have_field("_products_0_name", with: p1.name.to_s)
+        expect(page).to have_field("_products_1_name", with: p2.name.to_s)
+      end
+    end
+
+    it "displays a select box for suppliers, with the appropriate supplier selected" do
+      pending( "[BUU] Change producer, unit type, category and tax category #11060" )
+      s1 = FactoryBot.create(:supplier_enterprise)
+      s2 = FactoryBot.create(:supplier_enterprise)
+      s3 = FactoryBot.create(:supplier_enterprise)
+      p1 = FactoryBot.create(:product, supplier: s2)
+      p2 = FactoryBot.create(:product, supplier: s3)
+
+      visit spree.admin_products_path
+
+      expect(page).to have_select "producer_id", with_options: [s1.name, s2.name, s3.name],
+                                                 selected: s2.name
+      expect(page).to have_select "producer_id", with_options: [s1.name, s2.name, s3.name],
+                                                 selected: s3.name
+    end
+
+    context "with several variants" do
+      let!(:variant1) { p1.variants.first }
+      let!(:variant2) { p2.variants.first }
+      let!(:variant3) { create(:variant, product: p2, on_demand: false, on_hand: 4) }
+
+      before do
+        variant1.update!(on_hand: 0, on_demand: true)
+        variant2.update!(on_hand: 16, on_demand: false)
+        visit spree.admin_products_path
+      end
+
+      it "displays an on hand count in a span for each product" do
+        expect(page).to have_content "On demand"
+        expect(page).not_to have_content "20" # does not display the total stock
+        expect(page).to have_content "16" # displays the stock for variant_2
+        expect(page).to have_content "4"  # displays the stock for variant_3
+      end
+    end
+
+    it "displays a select box for the unit of measure for the product's variants" do
+      pending( "[BUU] Change producer, unit type and tax category #11060" )
+      p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1,
+                                      variant_unit_name: '')
+
+      visit spree.admin_products_path
+
+      expect(page).to have_select "variant_unit_with_scale", selected: "Weight (g)"
+    end
+
+    it "displays a text field for the item name when unit is set to 'Items'" do
+      pending( "[BUU] Change producer, unit type and tax category #11060" )
+      p = FactoryBot.create(:product, variant_unit: 'items', variant_unit_scale: nil,
+                                      variant_unit_name: 'packet')
+
+      visit spree.admin_products_path
+
+      expect(page).to have_select "variant_unit_with_scale", selected: "Items"
+      expect(page).to have_field "variant_unit_name", with: "packet"
+    end
   end
 
   describe "sorting" do

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
         expect(page).to have_selector "th", text: "Actions"
 
         # displays product list
-        expect(page).to have_field("_products_0_name", with: p1.name.to_s)
-        expect(page).to have_field("_products_1_name", with: p2.name.to_s)
+        expect(page).to have_selector row_containing_name(p1.name.to_s)
+        expect(page).to have_selector row_containing_name(p2.name.to_s)
       end
     end
 

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -103,27 +103,6 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
         expect(page).to have_content "4"  # displays the stock for variant_3
       end
     end
-
-    it "displays a select box for the unit of measure for the product's variants" do
-      pending( "[BUU] Change producer, unit type and tax category #11060" )
-      p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1,
-                                      variant_unit_name: '')
-
-      visit spree.admin_products_path
-
-      expect(page).to have_select "variant_unit_with_scale", selected: "Weight (g)"
-    end
-
-    it "displays a text field for the item name when unit is set to 'Items'" do
-      pending( "[BUU] Change producer, unit type and tax category #11060" )
-      p = FactoryBot.create(:product, variant_unit: 'items', variant_unit_scale: nil,
-                                      variant_unit_name: 'packet')
-
-      visit spree.admin_products_path
-
-      expect(page).to have_select "variant_unit_with_scale", selected: "Items"
-      expect(page).to have_field "variant_unit_name", with: "packet"
-    end
   end
 
   describe "sorting" do
@@ -1203,7 +1182,6 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
         end
 
         it "shows an actions menu with a delete link when clicking on icon for product. " \
-           "shows link to clone and edit the product;" \
            "doesn't show delete link for the single variant" do
           within product_selector do
             page.find(".vertical-ellipsis-menu").click
@@ -1225,8 +1203,6 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
                  display_name: "Medium box",
                  sku: "APL-01",
                  price: 5.25)
-          link_edit_variant2 =
-            "/admin/products/#{Spree::Product.first.id}/variants/#{Spree::Variant.second.id}/edit"
           visit admin_products_url
 
           # to select the default variant

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1196,9 +1196,6 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       let(:default_variant_selector) {
         "tr:has(input[aria-label=Price][value='#{product_a.price}'])"
       }
-      let(:link_edit_variant) {
-        "/admin/products/#{Spree::Product.first.id}/variants/#{Spree::Variant.first.id}/edit"
-      }
 
       describe "Actions columns (delete)" do
         before do
@@ -1217,7 +1214,6 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
           # to select the default variant
           within default_variant_selector do
             page.find(".vertical-ellipsis-menu").click
-            expect(page).to have_link "Edit", href: link_edit_variant
             expect(page).not_to have_css(delete_option_selector)
           end
         end
@@ -1236,14 +1232,12 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
           # to select the default variant
           within default_variant_selector do
             page.find(".vertical-ellipsis-menu").click
-            expect(page).to have_link "Edit", href: link_edit_variant
             expect(page).to have_css(delete_option_selector)
           end
           page.find("div#content").click # to close the vertical actions menu
 
           within variant_selector do
             page.find(".vertical-ellipsis-menu").click
-            expect(page).to have_link "Edit", href: link_edit_variant2
             expect(page).to have_css(delete_option_selector)
           end
         end


### PR DESCRIPTION
Adds tests around the following scenarios, on the BUU page.

#### What? Why?

- Contributes to feature parity tests between legacy vs. BUU product page

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Covers additional scenarios:
- with no products
- column display dropdown (pending #11055)
- search function: listing products with several variants
- search function: for a non-existing product
- search function: variant search
- search function: with multiple variants

- assures Edit option is displayed for default variants (although the Delete option is not) and non-default variants (where the Delete option should be visible as well)


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green page 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
