### PR TITLE
[BUU] Fix for blank dropdowns

### DIFF
--- a/app/webpacker/controllers/bulk_form_controller.js
+++ b/app/webpacker/controllers/bulk_form_controller.js
@@ -63,7 +63,7 @@ export default class BulkFormController extends Controller {
     // For each record, check if any fields are changed
     // TODO: optimise basd on current state. if field is changed, but form already changed, no need to update (and vice versa)
     const changedRecordCount = Object.values(this.recordElements).filter((elements) =>
-      elements.some(this.#isChanged),
+      elements.some(this.#checkIsChanged.bind(this)),
     ).length;
     this.formChanged = changedRecordCount > 0 || this.errorValue;
 
@@ -131,11 +131,17 @@ export default class BulkFormController extends Controller {
     });
   }
 
-  #isChanged(element) {
-    if(!element.isConnected) {
-      return false;
+  // Check if changed, and mark with class if it is.
+  #checkIsChanged(element) {
+    if(!element.isConnected) return false;
 
-    } else if (element.type == "checkbox") {
+    const changed = this.#isChanged(element);
+    element.classList.toggle("changed", changed);
+    return changed;
+  }
+
+  #isChanged(element) {
+     if (element.type == "checkbox") {
       return element.defaultChecked !== undefined && element.checked != element.defaultChecked;
 
     } else if (element.type == "select-one") {

--- a/spec/javascripts/stimulus/bulk_form_controller_test.js
+++ b/spec/javascripts/stimulus/bulk_form_controller_test.js
@@ -99,6 +99,59 @@ describe("BulkFormController", () => {
         expect(input1b.classList).not.toContain('changed');
         expect(input2.classList).toContain('changed');
       });
+
+      describe("select not include_blank", () => {
+        beforeEach(() => {
+          document.body.innerHTML = `
+            <form data-controller="bulk-form" data-bulk-form-disable-selector-value="#disable1,#disable2">
+              <div data-record-id="1">
+                <select id="select1">
+                  <option value="1">one</option>
+                  <option value="2">two</option>
+                </select>
+              </div>
+              <input type="submit">
+            </form>
+          `;
+        });
+
+        it("shows as changed", () => {
+          // Expect select to show changed (select-one always has something selected)
+          expect(select1.classList).toContain('changed');
+
+          // Change selection
+          select1.options[0].selected = false;
+          select1.options[1].selected = true;
+          select1.dispatchEvent(new Event("input"));
+          expect(select1.classList).toContain('changed');
+        });
+      });
+
+      describe("select-one with include_blank", () => {
+        beforeEach(() => {
+          document.body.innerHTML = `
+            <form data-controller="bulk-form" data-bulk-form-disable-selector-value="#disable1,#disable2">
+              <div data-record-id="1">
+                <select id="select1">
+                  <option value="">blank</option>
+                  <option value="1">one</option>
+                </select>
+              </div>
+              <input type="submit">
+            </form>
+          `;
+        });
+
+        it("does not show as changed", () => {
+          expect(select1.classList).not.toContain('changed');
+
+          // Change selection
+          select1.options[0].selected = false;
+          select1.options[1].selected = true;
+          select1.dispatchEvent(new Event("input"));
+          expect(select1.classList).toContain('changed');
+        });
+      });
     })
 
     describe("activating sections, and showing a summary", () => {


### PR DESCRIPTION


#### What? Why?

- Proposed solution for #12473

It was observed that sometimes the form says "x products updated", even before you've updated anything. This was due to invalid data on staging: the variants has a blank category (probably due to the order the product refactor PR was staged).
A blank category is not valid, and therefore the select dropdowns do not have a "blank" option. In this situation, the browser is forced to select the first option, which is counted as "modified".

I considered different options to solve this, not sure the best way:
1. just fix the data on staging and move on. Ok maybe that would have been fine, but I thought similar cases may arise in the future
2. Always mark 'modified' fields with orange border (even if the user didn't make the selection) <-- I chose this
3. Add a hidden blank option on the dropdowns, so they can be in a blank state, but the user can't select it.
4. Update the rails model to automatically choose a default category when loading the form. Hmm, it does this upon save anyway (`assign_related_taxon`)


I have to admit I didn't think of all the options, before starting down option 2. Options 3 and 4 like good ideas..

#### What should we test?
This can currently be replicated on au_staging page 8: 

- visit  https://staging.openfoodnetwork.org.au/admin/products?page=8
- observe there are products modified. Scroll to find fields that are marked with orange border.
- Select new option, or leave the default. Click save
- Observe that they are no longer marked as modified.
- Please comment if you'd consider the above issue closed or not

![Screenshot 2024-05-27 at 4 43 04 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/99b6066c-413c-469a-ad2b-150ce90d397c)
