### PR TITLE
[BUU] Producers selects are to be populated on focus

### DIFF
--- a/app/views/admin/products_v3/_producer_options_template.html.haml
+++ b/app/views/admin/products_v3/_producer_options_template.html.haml
@@ -1,0 +1,2 @@
+%template{ id: "producer_options"}
+  = options_for_select(producer_options, product.supplier_id)

--- a/app/views/admin/products_v3/_product_row.html.haml
+++ b/app/views/admin/products_v3/_product_row.html.haml
@@ -1,5 +1,3 @@
-%template{ id: "producer_options"}
-  = options_for_select(producer_options, product.supplier_id)
 %td.with-image{ id: "image-#{product.id}" }
   = render partial: "product_image", locals: { product: }
 %td.field.align-left.header.naked_inputs

--- a/app/views/admin/products_v3/_product_row.html.haml
+++ b/app/views/admin/products_v3/_product_row.html.haml
@@ -34,7 +34,8 @@
     class: "fullwidth no-input",
     'aria-label': t('.producer_field_name'),
     data: { "controller": "producers-select",
-      "producers-select-placeholder-value": t('admin.products_v3.filters.search_for_producers')}
+      "producers-select-placeholder-value": t('admin.products_v3.filters.search_for_producers'),
+      "producers-select-template-id-value": "producer_options" }
 %td.align-left
   -# empty
 %td.align-left

--- a/app/views/admin/products_v3/_product_row.html.haml
+++ b/app/views/admin/products_v3/_product_row.html.haml
@@ -1,3 +1,5 @@
+%template{ id: "producer_options"}
+  = options_for_select(producer_options, product.supplier_id)
 %td.with-image{ id: "image-#{product.id}" }
   = render partial: "product_image", locals: { product: }
 %td.field.align-left.header.naked_inputs
@@ -26,12 +28,13 @@
 %td.align-right
   -# empty
 %td.naked_inputs
-  = render(SearchableDropdownComponent.new(form: f,
-      name: :supplier_id,
-      aria_label: t('.producer_field_name'),
-      options: producer_options,
-      selected_option: product.supplier_id,
-      placeholder_value: t('admin.products_v3.filters.search_for_producers')))
+  = f.select :supplier_id,
+    options_for_select([producer_options.find{ |option| option[1] == product.supplier_id }], product.supplier_id),
+    {},
+    class: "fullwidth no-input",
+    'aria-label': t('.producer_field_name'),
+    data: { "controller": "producers-select",
+      "producers-select-placeholder-value": t('admin.products_v3.filters.search_for_producers')}
 %td.align-left
   -# empty
 %td.align-left

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -67,6 +67,7 @@
                                 controller: "nested-form product",
                                 action: 'rails-nested-form:add->bulk-form#registerElements rails-nested-form:remove->bulk-form#toggleFormChanged' } }
           %tr
+            = render partial: 'producer_options_template', locals: { product:, producer_options: }
             = render partial: 'product_row', locals: { f: product_form, product:, producer_options: }
 
           - product.variants.each_with_index do |variant, variant_index|

--- a/app/webpacker/controllers/producers_select_controller.js
+++ b/app/webpacker/controllers/producers_select_controller.js
@@ -1,0 +1,37 @@
+import TomSelect from "./tom_select_controller";
+
+const minimumOptionsForSearchField = 11;
+
+export default class extends TomSelect {
+  static values = { options: Object, placeholder: String };
+
+  connect(options = {}) {
+    const template = this.template();
+    let additional_options = {};
+    const lines_of_option = template.content.children.length; 
+
+    if (lines_of_option < minimumOptionsForSearchField) {
+      additional_options.plugins = [];  
+    }
+
+    super.connect(additional_options);
+    this.control.on('focus', this.fetchProducers.bind(this));
+  }
+
+  disconnect() {
+    if (this.control) this.control.destroy();
+  }
+  
+  fetchProducers() {
+    if ((Object.keys(this.control.options).length) > 1) return false;
+
+    const template = this.template();
+    Array.from(template.content.children).forEach((option) => {
+      this.control.addOption({value: option.value, text: option.text});
+    }); 
+  }
+  
+  template() {
+    return document.querySelector("#producer_options");
+  }
+}

--- a/app/webpacker/controllers/producers_select_controller.js
+++ b/app/webpacker/controllers/producers_select_controller.js
@@ -3,18 +3,20 @@ import TomSelect from "./tom_select_controller";
 const minimumOptionsForSearchField = 11;
 
 export default class extends TomSelect {
-  static values = { options: Object, placeholder: String };
+  static values = { templateId: String, placeholder: String };
 
-  connect(options = {}) {
-    const template = this.template();
+  connect() {
+    const template = this.template(this.templateIdValue );
     let additional_options = {};
     const lines_of_option = template.content.children.length; 
 
+    // Disable search input ("dropdown_input" plugin) from tom-select
     if (lines_of_option < minimumOptionsForSearchField) {
       additional_options.plugins = [];  
     }
 
     super.connect(additional_options);
+    // focus event available on tom-select , not on html select
     this.control.on('focus', this.fetchProducers.bind(this));
   }
 
@@ -25,13 +27,13 @@ export default class extends TomSelect {
   fetchProducers() {
     if ((Object.keys(this.control.options).length) > 1) return false;
 
-    const template = this.template();
+    const template = this.template(this.templateIdValue );
     Array.from(template.content.children).forEach((option) => {
       this.control.addOption({value: option.value, text: option.text});
     }); 
   }
   
-  template() {
-    return document.querySelector("#producer_options");
+  template(id) {
+    return document.querySelector(`#${id}`);
   }
 }


### PR DESCRIPTION
#### What? Why?

- Closes #12482


When visiting page  `admin/products` (in V3 mode), each select is populated via the classical Rails way.

But each select carries the same data, which can be some overload for the producers selects that may carry a lot of data.
My solution is instead to put the producers data once in a html element `template`.
Each select is only populated with its default.
Then, on focus, it is populated.
Therefore, no more copying 10 times the same options for the 10 selects.
Also, it is now the browser job to populate the focused select.
One group of data is written on the page instead of 10, which reduces the server work.

I have created for that a Stimulus controller that inherit from tom-select, and not a StimulusReflex one.

#### What should we test?

- In V3 toggled mode, as an admin or producer
- Visit `admin/products`
- There should be no change with the current display of selects.
- The same behaviour should be seen: change one item and page should notice.
- Changing a producer for a product should work as expected.
- From 10 items or more, a search input must be visible, but not under 10 or 10

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [X] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
