### PR TITLE
Fix Redundant presence validation on belongs part VI

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -642,11 +642,10 @@ Rails/RedundantActiveRecordAllMethod:
     - 'app/models/spree/variant.rb'
     - 'spec/system/admin/product_import_spec.rb'
 
-# Offense count: 4
+# Offense count: 3
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/RedundantPresenceValidationOnBelongsTo:
   Exclude:
-    - 'app/models/spree/line_item.rb'
     - 'app/models/spree/order.rb'
 
 # Offense count: 1

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -7,8 +7,6 @@ module Spree
     include VariantUnits::VariantAndLineItemNaming
     include LineItemStockChanges
 
-    self.belongs_to_required_by_default = false
-
     searchable_attributes :price, :quantity, :order_id, :variant_id, :tax_category_id
     searchable_associations :order, :order_cycle, :variant, :product, :supplier, :tax_category
     searchable_scopes :with_tax, :without_tax
@@ -19,7 +17,7 @@ module Spree
     belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant"
     has_one :product, through: :variant
     has_one :supplier, through: :product
-    belongs_to :tax_category, class_name: "Spree::TaxCategory"
+    belongs_to :tax_category, class_name: "Spree::TaxCategory", optional: true
 
     has_many :adjustments, as: :adjustable, dependent: :destroy
 
@@ -28,7 +26,6 @@ module Spree
     before_validation :copy_tax_category
     before_validation :copy_dimensions
 
-    validates :variant, presence: true
     validates :quantity, numericality: {
       only_integer: true,
       greater_than: -1,

--- a/db/migrate/20240529081209_require_order_and_variant_on_line_item.rb
+++ b/db/migrate/20240529081209_require_order_and_variant_on_line_item.rb
@@ -1,0 +1,6 @@
+class RequireOrderAndVariantOnLineItem < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :spree_line_items, :order_id, false
+    change_column_null :spree_line_items, :variant_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_17_121235) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_29_081209) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -541,8 +541,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_17_121235) do
   end
 
   create_table "spree_line_items", id: :serial, force: :cascade do |t|
-    t.integer "order_id"
-    t.integer "variant_id"
+    t.integer "order_id", null: false
+    t.integer "variant_id", null: false
     t.integer "quantity", null: false
     t.decimal "price", precision: 10, scale: 2, null: false
     t.datetime "created_at", precision: nil, null: false

--- a/lib/tasks/data/check_missing_required_ids_in_spree_line_items.rake
+++ b/lib/tasks/data/check_missing_required_ids_in_spree_line_items.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :ofn do
+  namespace :data do
+    desc 'Checking missing required ids in Spree::LineItem'
+    task check_missing_required_missing_ids_in_spree_line_items: :environment do
+      puts 'Checking for null order_id'
+      ids = Spree::LineItem.where(order_id: nil).pluck(:id)
+
+      if ids.empty?
+        puts 'No NULL order_id found in spree_line_items'
+      else
+        puts 'NULL order_ids s have been found in spree_line_items:'
+        print ids
+      end
+
+      puts 'Checking for null variant_id'
+      ids = Spree::LineItem.where(variant_id: nil).pluck(:id)
+
+      if ids.empty?
+        puts 'No NULL variant_id found in spree_line_items'
+      else
+        puts 'NULL variant_id s have been found in spree_line_items:'
+        print ids
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?
- Contributes to #11482
- First attempt was made by #12380 , but some choices will have to be made file by file. Cf. conversation
-  Continuation of #12514
- See also #11297 that started the work

#### What should we test?
First commit is a rake test to check if any order_id or variant_id is missing.

I made order_id compulsory even though there is no validation in the model but it seemed to me logical.
Furthermore, in the factory, both variant and order are needed to create a lineItem object.
For the same reason, I did not make task_category_id compulsory.

If everything goes fines, then after migration, all tests should pass and no rubocop offense should be raised.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
