### PR TITLE
Fix manager cannot edit enterprise 12533

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,9 +27,6 @@ Openfoodnetwork::Application.configure do
   # Raise exceptions instead of rendering exception templates
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment
-  config.action_controller.allow_forgery_protection    = false
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -425,10 +425,6 @@ RSpec.describe '
       within("tbody#e_#{distributor1.id}") { click_link 'Settings' }
 
       fill_in 'enterprise_name', with: 'Eaterprises'
-
-      # Because poltergist does not support form onchange event
-      # We need trigger the change manually
-      page.evaluate_script("angular.element(enterprise_form).scope().setFormDirty()")
       click_button 'Update'
 
       expect(flash_message).to eq('Enterprise "Eaterprises" has been successfully updated!')
@@ -441,10 +437,6 @@ RSpec.describe '
         within("tbody#e_#{distributor3.id}") { click_link 'Settings' }
 
         fill_in 'enterprise_name', with: 'Eaterprises'
-
-        # Because poltergist does not support form onchange event
-        # We need trigger the change manually
-        page.evaluate_script("angular.element(enterprise_form).scope().setFormDirty()")
         click_button 'Update'
 
         expect(flash_message).to eq('Enterprise "Eaterprises" has been successfully updated!')


### PR DESCRIPTION
#### What? Why?

- Closes #12533

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This config dates all the way back to commit number one:
https://github.com/openfoodfoundation/openfoodnetwork/blame/master/config/environments/test.rb#L31

So I had a look at the other settings. They still seem appropriate.
Also I had a look at the default `test.rb` for the latest version of Rails. Interestingly that still disables forgery protection.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
