### PR TITLE
Allow negative stock levels for on-demand products

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -112,8 +112,7 @@ module VariantStock
   #
   # This enables us to override this behaviour for variant overrides
   def move(quantity, originator = nil)
-    # Don't change variant stock if variant is on_demand or has been deleted
-    return if on_demand || deleted_at
+    return if deleted_at
 
     raise_error_if_no_stock_item_available
 

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -15,7 +15,9 @@ class VariantOverride < ApplicationRecord
   # Need to ensure this can be set by the user.
   validates :default_stock, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :price, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
-  validates :count_on_hand, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :count_on_hand, numericality: {
+    greater_than_or_equal_to: 0, unless: :on_demand?
+  }, allow_nil: true
 
   default_scope { where(permission_revoked_at: nil) }
 

--- a/lib/open_food_network/scope_variant_to_hub.rb
+++ b/lib/open_food_network/scope_variant_to_hub.rb
@@ -43,11 +43,7 @@ module OpenFoodNetwork
       #   - updates variant_override.count_on_hand
       #   - does not create stock_movement
       #   - does not update stock_item.count_on_hand
-      # If it is a variant override with on_demand:
-      #   - don't change stock or call super (super would change the variant's stock)
       def move(quantity, originator = nil)
-        return if @variant_override&.on_demand
-
         if @variant_override&.stock_overridden?
           @variant_override.move_stock! quantity
         else

--- a/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
+++ b/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
@@ -181,9 +181,9 @@ module OpenFoodNetwork
             scoper.scope v2
           end
 
-          it "doesn't reduce variant's stock" do
+          it "does reduce variant's stock" do
             v2.move(-2)
-            expect(Spree::Variant.find(v2.id).on_hand).to eq 5
+            expect(Spree::Variant.find(v2.id).on_hand).to eq 3
           end
         end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -303,8 +303,8 @@ module Spree
           expect(order.shipment.manifest.first.variant).to eq line_item.variant
         end
 
-        it "does not reduce the variant's stock level" do
-          expect(variant_on_demand.reload.on_hand).to eq 1
+        it "reduces the variant's stock level" do
+          expect(variant_on_demand.reload.on_hand).to eq(-9)
         end
 
         it "does not mark inventory units as backorderd" do

--- a/spec/system/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/system/consumer/shopping/variant_overrides_spec.rb
@@ -210,12 +210,12 @@ RSpec.describe "shopping with variant overrides defined" do
       expect(product1_variant1_override.reload.count_on_hand).to be_nil
     end
 
-    it "does not subtract stock from variants where the override has on_demand: true" do
+    it "does subtract stock from variants where the override has on_demand: true" do
       click_add_to_cart product4_variant1, 2
       click_checkout
       expect do
         complete_checkout
-      end.to change { product4_variant1.reload.on_hand }.by(0)
+      end.to change { product4_variant1.reload.on_hand }.by(-2)
       expect(product4_variant1_override.reload.count_on_hand).to be_nil
     end
 


### PR DESCRIPTION
:information_source: **Funded Feature. Please track ALL ASSOCIATED WORK under the associated tracking code https://github.com/openfoodfoundation/openfoodnetwork/issues/11678 DFC Orders**

#### What? Why?

- Part of #11678

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We want to place backorders on a wholesaler's platform when we run out of stock in our local OFN store. This complicates the stock logic though. To allow customers to order more than we have in stock, we set the products to on demand. And we change the logic to still count stock, allowing it to go negative, so that we know how much stock we need to order from the wholesaler.

This PR just prepares the change in OFN stock logic without adding the backordering logic. While it seems to be a fairly easy change, there's potential for subtle bugs around products going out of stock. We may have assumptions in our code that I'm not aware of.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Test the checkout of stock controlled items and on-demand items.
- Test the order creation as admin of those items.
- Test with producer products and with inventory products (using variant overrides).
- When a stock controlled product goes out of stock during checkout, we still need to raise an error.
- When an on-demand product goes out of stock, we should still be able to check out and it should not be marked as out of stock.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
