### PR TITLE
Update and Recalculate Fees after Order Adjusted in Backoffice

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -155,6 +155,7 @@ module Spree
       if adjustment
         adjustment.originator = payment_method
         adjustment.label = adjustment_label
+        adjustment.amount = payment_method.compute_amount(self)
         adjustment.save
       elsif !processing_refund? && payment_method.present?
         payment_method.create_adjustment(adjustment_label, self, true)

--- a/app/views/spree/admin/orders/_form/_adjustments.html.haml
+++ b/app/views/spree/admin/orders/_form/_adjustments.html.haml
@@ -6,7 +6,7 @@
         %tr
           %th= Spree.t('name')
           %th= Spree.t('amount')
-      %tbody.with-border
+      %tbody.with-border#order_adjustments
         - adjustments.each do |adjustment|
           %tr.total
             %td.strong= adjustment.label + ":"

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -172,6 +172,27 @@ RSpec.describe '
     expect(order.line_items.reload.map(&:product)).to include product
   end
 
+  context "When adding a product on an order with transaction fee" do
+    let(:order_with_fees) { create(:completed_order_with_fees, user:, distributor:, order_cycle: ) }
+
+    it 'recalculates transaction fee' do
+      login_as_admin
+      visit spree.edit_admin_order_path(order_with_fees)
+
+      transaction_fee = order_with_fees.all_adjustments.payment_fee.eligible.first.amount
+      expect(page.find("#order_adjustments").text).to have_content(transaction_fee)
+
+      select2_select product.name, from: 'add_variant_id', search: true
+      find('button.add_variant').click
+      sleep(1)
+
+      new_transaction_fee = order_with_fees.all_adjustments.payment_fee.eligible.first.amount
+
+      expect(new_transaction_fee).to be > transaction_fee
+      expect(page.find("#order_adjustments").text).to have_content(new_transaction_fee)
+    end
+  end
+
   shared_examples_for "Cancelling the order" do
     it "shows a modal about order cancellation" do
       expect(page).to have_content "This will cancel the current order."

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -179,17 +179,15 @@ RSpec.describe '
       login_as_admin
       visit spree.edit_admin_order_path(order_with_fees)
 
-      transaction_fee = order_with_fees.all_adjustments.payment_fee.eligible.first.amount
+      adjustment_for_transaction_fee = order_with_fees.all_adjustments.payment_fee.eligible.first
+      transaction_fee = adjustment_for_transaction_fee.amount
+
       expect(page.find("#order_adjustments").text).to have_content(transaction_fee)
 
       select2_select product.name, from: 'add_variant_id', search: true
       find('button.add_variant').click
-      sleep(1)
-
-      new_transaction_fee = order_with_fees.all_adjustments.payment_fee.eligible.first.amount
-
-      expect(new_transaction_fee).to be > transaction_fee
-      expect(page.find("#order_adjustments").text).to have_content(new_transaction_fee)
+      expect(page).to have_css("#order_adjustments",
+                               text: adjustment_for_transaction_fee.reload.amount)
     end
   end
 


### PR DESCRIPTION
#### What? Why?

- Closes #12512 

#### What should we test?
- log as an admin or hub's owner (classical/legacy mode)
- visit `admin/orders`
- pick an order from the list, one that is complete, but with a transaction fee associated to a payment method
    like a card payment
- one should see a non zero transaction fee under `ORDER ADJUSTMENTS`
- add a product from the `Select a variant` select box
- chose a quantity from the newly showed line
- click on the `+` sign to add the product/variant to the order
- the transaction fee should be updated

#### Extras
The `UPDATE AND RECALCULATE FEES` is for shipment fees only.
A click on it executes this line:
`@order.shipments.map(&:refresh_rates)` from the `edit` method in the `orders` controller.

But the recalculation is in the `ensure_correct_adjustment` method in the `payment` model.
That is triggered by an `after_save` hook.
That is triggered when (amongst others I guess) a new product is added in the dashboard.
Problem was, no recalculation of the amount was made in the update mode, only in the create mode.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
