### PR TITLE
Fix RedundantPresenceValidationOnBelongs on Spree::Order model

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -642,12 +642,6 @@ Rails/RedundantActiveRecordAllMethod:
     - 'app/models/spree/variant.rb'
     - 'spec/system/admin/product_import_spec.rb'
 
-# Offense count: 3
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/RedundantPresenceValidationOnBelongsTo:
-  Exclude:
-    - 'app/models/spree/order.rb'
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/RelativeDateConstant:

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -8,8 +8,6 @@ module Spree
     include Balance
     include SetUnusedAddressFields
 
-    self.belongs_to_required_by_default = false
-
     searchable_attributes :number, :state, :shipment_state, :payment_state, :distributor_id,
                           :order_cycle_id, :email, :total, :customer_id
     searchable_associations :shipping_method, :bill_address, :distributor
@@ -33,13 +31,13 @@ module Spree
 
     token_resource
 
-    belongs_to :user, class_name: "Spree::User"
-    belongs_to :created_by, class_name: "Spree::User"
+    belongs_to :user, class_name: "Spree::User", optional: true
+    belongs_to :created_by, class_name: "Spree::User", optional: true
 
-    belongs_to :bill_address, class_name: 'Spree::Address'
+    belongs_to :bill_address, class_name: 'Spree::Address', optional: true
     alias_attribute :billing_address, :bill_address
 
-    belongs_to :ship_address, class_name: 'Spree::Address'
+    belongs_to :ship_address, class_name: 'Spree::Address', optional: true
     alias_attribute :shipping_address, :ship_address
 
     has_many :state_changes, as: :stateful, dependent: :destroy
@@ -70,9 +68,9 @@ module Spree
              dependent: :destroy
     has_many :invoices, dependent: :restrict_with_exception
 
-    belongs_to :order_cycle
-    belongs_to :distributor, class_name: 'Enterprise'
-    belongs_to :customer
+    belongs_to :order_cycle, optional: true
+    belongs_to :distributor, class_name: 'Enterprise', optional: true
+    belongs_to :customer, optional: true
     has_one :proxy_order, dependent: :destroy
     has_one :subscription, through: :proxy_order
 


### PR DESCRIPTION
#### What? Why?
- Contributes to #11482
- First attempt was made by #12380 , 
-  Continuation of #12259 
- See also #11297 that started the work

This is the last file to be checked.


#### What should we test?
Run the tests. They should all passes

#### What did I do what I have done ?
No migration, no checks here, contrary to the last PRs.
My goal was to ensure some of the presence of foreign ids was done, even though they appeared optional.
But, by doing tests, it appears they should be called optional.
This is what I found:
- by making `order_cycle_id`, `distributor_id` & `customer_id mandatory`, I can not even pass the first page,  because:
```
ActiveRecord::RecordInvalid in HomeController#index
Validation failed: Order cycle must exist, Distributor must exist, Customer must exist
```
File: `File: lib/spree/core/controller_helpers/order.rb`
Line:
```ruby
@current_order = Spree::Order.new(currency: current_currency) <- New order almost naked
@current_order.user ||= spree_current_user
# See https://github.com/spree/spree/issues/3346 for reasons why this line is here
@current_order.created_by ||= spree_current_user
@current_order.save! <- Crashes here

```

Regarding `created_by` & `user_id`:
- In spec: (File `spec/models/spree/order_spec.rb`)
```ruby
context "#associate_user!" do
  it "should associate a user with a persisted order" do
    order = create(:order_with_line_items, created_by: nil) <- Here
    # Why test with a nil ? Must have been some reason there
```
- Also in code (File: `app/controllers/spree/admin/orders/customer_details_controller.rb`)
```ruby
def update
  if @order.update(order_params)
    if params[:guest_checkout] == "false"
      @order.associate_user!(Spree::User.find_by(email: @order.email)) <- Here
```
- Another one (File `app/services/orders/cart_reset_service.rb`
```ruby
order.associate_user!(current_user) if order.user.blank? || order.email.blank?
```
The associate_user tells me that creating an order before assigning it to a user is commonplace. Same with created_by.
There are other occurrences of this in the code.

To me, the app needs these fields to be not null.
It might be a bit unusual, these fields that should be required as they are foreign keys, but that describes how the app works.
But,  we can also leave the file as it is and add a line in the .rubocop_to_do not to touche it :)


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
