### PR TITLE
Add enterprise logo and contact name to DFC API with standard attributes

### DIFF
--- a/engines/dfc_provider/app/controllers/dfc_provider/enterprises_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/enterprises_controller.rb
@@ -15,6 +15,7 @@ module DfcProvider
 
       render json: DfcIo.export(
         enterprise,
+        enterprise.mainContact,
         *enterprise.localizations,
         *enterprise.suppliedProducts,
         *enterprise.catalogItems,

--- a/engines/dfc_provider/app/services/enterprise_builder.rb
+++ b/engines/dfc_provider/app/services/enterprise_builder.rb
@@ -21,6 +21,7 @@ class EnterpriseBuilder < DfcBuilder
       localizations: [address],
       phoneNumbers: [enterprise.phone].compact,
       socialMedias: SocialMediaBuilder.social_medias(enterprise),
+      logo: enterprise.logo_url(:small),
 
       # The model strips the protocol and we need to add it:
       websites: [enterprise.website].compact_blank.map { |url| "https://#{url}" },
@@ -31,7 +32,9 @@ class EnterpriseBuilder < DfcBuilder
       # But that would require a new endpoint for a single string.
       add_ofn_property(e, "ofn:contact_name", enterprise.contact_name)
 
+      # DEPRECATED: please use the standard `logo` attribute above.
       add_ofn_property(e, "ofn:logo_url", enterprise.logo_url(:small))
+
       add_ofn_property(e, "ofn:promo_image_url", enterprise.promo_image_url(:large))
     end
   end

--- a/engines/dfc_provider/app/services/enterprise_builder.rb
+++ b/engines/dfc_provider/app/services/enterprise_builder.rb
@@ -22,6 +22,7 @@ class EnterpriseBuilder < DfcBuilder
       phoneNumbers: [enterprise.phone].compact,
       socialMedias: SocialMediaBuilder.social_medias(enterprise),
       logo: enterprise.logo_url(:small),
+      mainContact: contact(enterprise),
 
       # The model strips the protocol and we need to add it:
       websites: [enterprise.website].compact_blank.map { |url| "https://#{url}" },
@@ -59,5 +60,15 @@ class EnterpriseBuilder < DfcBuilder
         members
       end
     end
+  end
+
+  def self.contact(enterprise)
+    firstName, lastName = enterprise.contact_name&.split(/ ([^ ]+)$/) # rubocop:disable Naming/VariableName
+
+    DataFoodConsortium::Connector::Person.new(
+      urls.enterprise_url(enterprise.id, anchor: "mainContact"),
+      firstName:, # rubocop:disable Naming/VariableName
+      lastName:, # rubocop:disable Naming/VariableName
+    )
   end
 end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -103,6 +103,7 @@ paths:
                       dfc-b:hasDescription: Beautiful
                       dfc-b:manages: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:supplies: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                      dfc-b:hasMainContact: http://test.host/api/dfc/enterprises/10000#mainContact
                       ofn:long_description: "<p>Hello, world!</p><p>This is a paragraph.</p>"
                     - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       "@type": dfc-b:CatalogItem
@@ -383,11 +384,17 @@ paths:
                       dfc-b:VATnumber: 123 456
                       dfc-b:manages: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:supplies: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                      dfc-b:hasMainContact: http://test.host/api/dfc/enterprises/10000#mainContact
                       ofn:long_description: "<p>Hello, world!</p><p>This is a paragraph.</p>"
                       ofn:contact_name: Fred Farmer
                       ofn:logo_url: http://test.host/rails/active_storage/url/logo.png
                       ofn:promo_image_url: http://test.host/rails/active_storage/url/promo.png
                       dfc-b:affiliates: http://test.host/api/dfc/enterprise_groups/60000
+                    - "@id": http://test.host/api/dfc/enterprises/10000#mainContact
+                      "@type": dfc-b:Person
+                      dfc-b:logo: ''
+                      dfc-b:firstName: Fred
+                      dfc-b:familyName: Farmer
                     - "@id": http://test.host/api/dfc/addresses/40000
                       "@type": dfc-b:Address
                       dfc-b:hasStreet: 42 Doveton Street

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -99,7 +99,6 @@ paths:
                     - "@id": http://test.host/api/dfc/enterprises/10000
                       "@type": dfc-b:Enterprise
                       dfc-b:hasAddress: http://test.host/api/dfc/addresses/40000
-                      dfc-b:logo: ''
                       dfc-b:name: Fred's Farm
                       dfc-b:hasDescription: Beautiful
                       dfc-b:manages: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
@@ -378,7 +377,7 @@ paths:
                       dfc-b:email: hello@example.org
                       dfc-b:websitePage: https://openfoodnetwork.org
                       dfc-b:hasSocialMedia: http://test.host/api/dfc/enterprises/10000/social_medias/facebook
-                      dfc-b:logo: ''
+                      dfc-b:logo: http://test.host/rails/active_storage/url/logo.png
                       dfc-b:name: Fred's Farm
                       dfc-b:hasDescription: This is an awesome enterprise
                       dfc-b:VATnumber: 123 456


### PR DESCRIPTION
#### What? Why?

Some enterprise data was added as custom attributes because the DFC didn't support them yet. But now we have a standard and should use it. I'm keeping the old fields for backwards-compatibility. We may remove them in the future.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test needed.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
