### PR TITLE
Updating specs for BUU (feature parity)

### DIFF
--- a/spec/system/admin/authentication_spec.rb
+++ b/spec/system/admin/authentication_spec.rb
@@ -10,21 +10,27 @@ RSpec.describe "Authentication" do
   let(:user) { create(:user, password: "password", password_confirmation: "password") }
   let!(:enterprise) { create(:enterprise, owner: user) } # Required for access to admin
 
-  it "logging into admin redirects home, then back to admin" do
-    visit spree.admin_dashboard_path
+  context "as anonymous user" do
+    it "logging into admin redirects home, then back to admin" do
+      visit spree.admin_dashboard_path
 
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_login_button
-    expect(page).to have_content "DASHBOARD"
-    expect(page).to have_current_path spree.admin_dashboard_path
-    expect(page).not_to have_content "CONFIGURATION"
-  end
+      fill_in "Email", with: user.email
+      fill_in "Password", with: user.password
+      click_login_button
+      expect(page).to have_content "DASHBOARD"
+      expect(page).to have_current_path spree.admin_dashboard_path
+      expect(page).not_to have_content "CONFIGURATION"
+    end
 
-  it "viewing my account" do
-    login_to_admin_section
-    click_link "Account"
-    expect(page).to have_current_path spree.account_path
+    it "viewing my account" do
+      login_to_admin_section
+      click_link "Account"
+      expect(page).to have_current_path spree.account_path
+    end
+
+    it "is redirected to login page when attempting to access product listing" do
+      expect { visit spree.admin_products_path }.not_to raise_error
+    end
   end
 
   context "logged in" do

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -283,35 +283,6 @@ RSpec.describe '
         expect(page).to have_selector "#p_#{product1.id}"
       end
     end
-
-    context 'a shipped product' do
-      let!(:order) { create(:shipped_order, line_items_count: 1) }
-      let!(:line_item) { order.reload.line_items.first }
-
-      context "a deleted line item from a shipped order" do
-        before do
-          login_as_admin
-          visit spree.admin_products_path
-
-          within "#p_#{order.variants.first.product_id}" do
-            accept_alert { page.find("[data-powertip=Remove]").click }
-          end
-        end
-
-        it 'removes it from the product list' do
-          visit spree.admin_products_path
-
-          expect(page).to have_selector "#p_#{product1.id}"
-          expect(page).not_to have_selector "#p_#{order.variants.first.product_id}"
-        end
-
-        it 'keeps the line item on the order (admin)' do
-          visit spree.edit_admin_order_path(order)
-
-          expect(page).to have_content(line_item.product.name.to_s)
-        end
-      end
-    end
   end
 
   describe 'cloning' do

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -20,12 +20,6 @@ RSpec.describe '
     @enterprise_fees = (0..2).map { |i| create(:enterprise_fee, enterprise: @distributors[i]) }
   end
 
-  context "as anonymous user" do
-    it "is redirected to login page when attempting to access product listing" do
-      expect { visit spree.admin_products_path }.not_to raise_error
-    end
-  end
-
   describe "creating a product" do
     let!(:tax_category) { create(:tax_category, name: 'Test Tax Category') }
 

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -256,6 +256,81 @@ RSpec.describe '
     end
   end
 
+  describe "deleting" do
+    let!(:product1) { create(:simple_product, name: 'a product to keep', supplier: @supplier) }
+
+    context 'a simple product' do
+      let!(:product2) { create(:simple_product, name: 'a product to delete', supplier: @supplier) }
+
+      before do
+        login_as_admin
+        visit spree.admin_products_path
+
+        within "#p_#{product2.id}" do
+          accept_alert { page.find("[data-powertip=Remove]").click }
+        end
+        visit current_path
+      end
+
+      it 'removes it from the product list' do
+        expect(page).not_to have_selector "#p_#{product2.id}"
+        expect(page).to have_selector "#p_#{product1.id}"
+      end
+    end
+
+    context 'a shipped product' do
+      let!(:order) { create(:shipped_order, line_items_count: 1) }
+      let!(:line_item) { order.reload.line_items.first }
+
+      context "a deleted line item from a shipped order" do
+        before do
+          login_as_admin
+          visit spree.admin_products_path
+
+          within "#p_#{order.variants.first.product_id}" do
+            accept_alert { page.find("[data-powertip=Remove]").click }
+          end
+        end
+
+        it 'removes it from the product list' do
+          visit spree.admin_products_path
+
+          expect(page).to have_selector "#p_#{product1.id}"
+          expect(page).not_to have_selector "#p_#{order.variants.first.product_id}"
+        end
+
+        it 'keeps the line item on the order (admin)' do
+          visit spree.edit_admin_order_path(order)
+
+          expect(page).to have_content(line_item.product.name.to_s)
+        end
+      end
+    end
+  end
+
+  describe 'cloning' do
+    let!(:product1) {
+      create(:simple_product, name: 'a weight product', supplier: @supplier, variant_unit: "weight")
+    }
+
+    context 'products' do
+      before do
+        login_as_admin
+        visit spree.admin_products_path
+      end
+
+      it 'creates a copy of the product' do
+        within "#p_#{product1.id}" do
+          page.find("[data-powertip=Clone]").click
+        end
+        visit current_path
+        within "#p_#{product1.id + 1}" do
+          expect(page).to have_input "product_name", with: 'COPY OF a weight product'
+        end
+      end
+    end
+  end
+
   context "as an enterprise user" do
     let!(:tax_category) { create(:tax_category) }
     let(:filter) { { producerFilter: 2 } }

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -662,9 +662,6 @@ RSpec.describe '
     context "editing a product's variant unit scale" do
       let(:product) { create(:simple_product, name: 'a product', supplier: @supplier2) }
 
-      # TODO below -> assertions commented out refer to bug:
-      # https://github.com/openfoodfoundation/openfoodnetwork/issues/7180
-
       before do
         allow(Spree::Config).to receive(:available_units).and_return("g,lb,oz,kg,T,mL,L,kL")
         visit spree.edit_admin_product_path product

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -256,52 +256,6 @@ RSpec.describe '
     end
   end
 
-  describe "deleting" do
-    let!(:product1) { create(:simple_product, name: 'a product to keep', supplier: @supplier) }
-
-    context 'a simple product' do
-      let!(:product2) { create(:simple_product, name: 'a product to delete', supplier: @supplier) }
-
-      before do
-        login_as_admin
-        visit spree.admin_products_path
-
-        within "#p_#{product2.id}" do
-          accept_alert { page.find("[data-powertip=Remove]").click }
-        end
-        visit current_path
-      end
-
-      it 'removes it from the product list' do
-        expect(page).not_to have_selector "#p_#{product2.id}"
-        expect(page).to have_selector "#p_#{product1.id}"
-      end
-    end
-  end
-
-  describe 'cloning' do
-    let!(:product1) {
-      create(:simple_product, name: 'a weight product', supplier: @supplier, variant_unit: "weight")
-    }
-
-    context 'products' do
-      before do
-        login_as_admin
-        visit spree.admin_products_path
-      end
-
-      it 'creates a copy of the product' do
-        within "#p_#{product1.id}" do
-          page.find("[data-powertip=Clone]").click
-        end
-        visit current_path
-        within "#p_#{product1.id + 1}" do
-          expect(page).to have_input "product_name", with: 'COPY OF a weight product'
-        end
-      end
-    end
-  end
-
   context "as an enterprise user" do
     let!(:tax_category) { create(:tax_category) }
     let(:filter) { { producerFilter: 2 } }

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1438,6 +1438,14 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
         )
       end
     end
+
+    it "shows inactive products that I supply" do
+      product_supplied_inactive
+
+      visit spree.admin_products_path
+
+      expect(page).to have_selector row_containing_name(product_supplied_inactive.name)
+    end
   end
 
   def create_products(amount)

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1365,9 +1365,6 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
               within modal_selector do
                 page.find(delete_button_selector).click
               end
-
-              expect(page).not_to have_selector(modal_selector)
-              expect(page).not_to have_selector(variant_selector)
             end
 
             it 'keeps the line item on the order (admin)' do
@@ -1403,12 +1400,12 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
     end
 
     before do
-      @enterprise_user = create(:user)
-      @enterprise_user.enterprise_roles.build(enterprise: supplier_managed1).save
-      @enterprise_user.enterprise_roles.build(enterprise: supplier_managed2).save
-      @enterprise_user.enterprise_roles.build(enterprise: distributor_managed).save
+      enterprise_user = create(:user)
+      enterprise_user.enterprise_roles.build(enterprise: supplier_managed1).save
+      enterprise_user.enterprise_roles.build(enterprise: supplier_managed2).save
+      enterprise_user.enterprise_roles.build(enterprise: distributor_managed).save
 
-      login_as @enterprise_user
+      login_as enterprise_user
     end
 
     it "shows only products that I supply" do

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1336,6 +1336,38 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
             end
           end
         end
+
+        context 'a shipped product' do
+          let!(:order) { create(:shipped_order, line_items_count: 1) }
+          let!(:line_item) { order.reload.line_items.first }
+
+          context "a deleted line item from a shipped order" do
+            before do
+              login_as_admin
+              visit admin_products_url
+
+              # Delete Variant
+              within variant_selector do
+                page.find(".vertical-ellipsis-menu").click
+                page.find(delete_option_selector).click
+              end
+
+              delete_button_selector = "input[type=button][value='Delete variant']"
+              within modal_selector do
+                page.find(delete_button_selector).click
+              end
+
+              expect(page).not_to have_selector(modal_selector)
+              expect(page).not_to have_selector(variant_selector)
+            end
+
+            it 'keeps the line item on the order (admin)' do
+              visit spree.edit_admin_order_path(order)
+
+              expect(page).to have_content(line_item.product.name.to_s)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1474,6 +1474,18 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       expect(flash_message).to eq 'Product "Big Bag Of Apples" has been successfully created!'
       expect(page).to have_selector row_containing_name('Big Bag Of Apples')
     end
+
+    it "allows me to update a product" do
+      visit spree.admin_products_path
+
+      within row_containing_name(product_supplied.name) do
+        fill_in "Name", with: "Pommes"
+      end
+      click_button "Save changes"
+
+      expect(page).to have_content "Changes saved"
+      expect(page).to have_selector row_containing_name("Pommes")
+    end
   end
 
   def create_products(amount)

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1416,6 +1416,28 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       expect(page).to have_selector row_containing_name(product_supplied_permitted.name)
       expect(page).not_to have_selector row_containing_name(product_not_supplied.name)
     end
+
+    it "shows only suppliers that I manage or have permission to" do
+      visit spree.admin_products_path
+
+      within row_containing_name(product_supplied.name) do
+        page.has_select?(
+          '_products_0_supplier_id',
+          options: [
+            supplier_managed1.name, supplier_managed2.name, supplier_permitted.name
+          ], selected: supplier_managed1.name
+        )
+      end
+
+      within row_containing_name(product_supplied_permitted.name) do
+        page.has_select?(
+          '_products_0_supplier_id',
+          options: [
+            supplier_managed1.name, supplier_managed2.name, supplier_permitted.name
+          ], selected: supplier_managed1.name
+        )
+      end
+    end
   end
 
   def create_products(amount)

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1446,6 +1446,34 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
 
       expect(page).to have_selector row_containing_name(product_supplied_inactive.name)
     end
+
+    it "allows me to create a product" do
+      taxon = create(:taxon, name: 'Fruit')
+      shipping_category = create(:shipping_category)
+
+      visit spree.admin_products_path
+
+      click_link "New Product"
+      expect(page).to have_content "New Product"
+      expect(page).to have_select 'product_supplier_id',
+                                  with_options: [supplier_managed1.name, supplier_managed2.name,
+                                                 supplier_permitted.name]
+
+      within 'fieldset#new_product' do
+        fill_in 'product_name', with: 'Big Bag Of Apples'
+        select supplier_permitted.name, from: 'product_supplier_id'
+        select 'Weight (g)', from: 'product_variant_unit_with_scale'
+        fill_in 'product_unit_value', with: '100'
+        fill_in 'product_price', with: '10.00'
+        select taxon.name, from: 'product_primary_taxon_id'
+        select shipping_category.name, from: 'product_shipping_category_id'
+      end
+      click_button 'Create'
+
+      expect(URI.parse(current_url).path).to eq spree.admin_products_path
+      expect(flash_message).to eq 'Product "Big Bag Of Apples" has been successfully created!'
+      expect(page).to have_selector row_containing_name('Big Bag Of Apples')
+    end
   end
 
   def create_products(amount)

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -623,6 +623,15 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       end
     end
 
+    describe "creating a new product" do
+      it "redirects to the New Product page" do
+        visit admin_products_url
+        expect {
+          click_link("New Product")
+        }.to change { current_path }.to(spree.new_admin_product_path)
+      end
+    end
+
     describe "adding variants" do
       it "creates a new variant" do
         click_on "New variant"

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1419,9 +1419,8 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
 
     it "shows only suppliers that I manage or have permission to" do
       visit spree.admin_products_path
-
       within row_containing_name(product_supplied.name) do
-        page.has_select?(
+        expect(page).to have_select(
           '_products_0_supplier_id',
           options: [
             supplier_managed1.name, supplier_managed2.name, supplier_permitted.name
@@ -1430,11 +1429,11 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       end
 
       within row_containing_name(product_supplied_permitted.name) do
-        page.has_select?(
-          '_products_0_supplier_id',
+        expect(page).to have_select(
+          '_products_1_supplier_id',
           options: [
             supplier_managed1.name, supplier_managed2.name, supplier_permitted.name
-          ], selected: supplier_managed1.name
+          ], selected: supplier_permitted.name
         )
       end
     end

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1446,34 +1446,6 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       expect(page).to have_selector row_containing_name(product_supplied_inactive.name)
     end
 
-    it "allows me to create a product" do
-      taxon = create(:taxon, name: 'Fruit')
-      shipping_category = create(:shipping_category)
-
-      visit spree.admin_products_path
-
-      click_link "New Product"
-      expect(page).to have_content "New Product"
-      expect(page).to have_select 'product_supplier_id',
-                                  with_options: [supplier_managed1.name, supplier_managed2.name,
-                                                 supplier_permitted.name]
-
-      within 'fieldset#new_product' do
-        fill_in 'product_name', with: 'Big Bag Of Apples'
-        select supplier_permitted.name, from: 'product_supplier_id'
-        select 'Weight (g)', from: 'product_variant_unit_with_scale'
-        fill_in 'product_unit_value', with: '100'
-        fill_in 'product_price', with: '10.00'
-        select taxon.name, from: 'product_primary_taxon_id'
-        select shipping_category.name, from: 'product_shipping_category_id'
-      end
-      click_button 'Create'
-
-      expect(URI.parse(current_url).path).to eq spree.admin_products_path
-      expect(flash_message).to eq 'Product "Big Bag Of Apples" has been successfully created!'
-      expect(page).to have_selector row_containing_name('Big Bag Of Apples')
-    end
-
     it "allows me to update a product" do
       visit spree.admin_products_path
 


### PR DESCRIPTION
#### What? Why?

- Closes #12519 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Verifies the tests regarding the scenarios below (-> pointing to the relevant test cases in `./spec/system/admin/products_v3/products_spec.rb`):

```
As an Administrator
  I want to be able to manage products in bulk
  listing products:
```

- [x] displays a list of products -> `it "displays a list of products" do`
- [x] displays a message when number of products is zero -> `describe "with no products" do`
- [x] displays a select box for suppliers, with the appropriate supplier selected -> `it "can search for and update a product" do`
- [x] displays an on hand count in a span for each product -> `it "displays an on hand count in a span for each product" do`
- [x] displays 'on demand' for any variant that is available on demand -> `it "displays an on hand count in a span for each product" do`
- [x] displays a select box for the unit of measure for the product's variants -> `describe "Changing unit scale" do`
- [x] displays a text field for the item name when unit is set to 'Items' -> `it "saves a custom item unit name" do`

Also verified that:

- [x] creating a new product -> is covered in `./spec/system/admin/products_spec.rb`, and in the test it `"redirects to the New Product page" do`
- [x] creating new variants -> `describe "adding variants" do`
- [x] updating product attributes -> `describe "updating" do` (covers both changes on products and variants)
- [x] using edit buttons -> `describe "edit" do`
- [x] "using clone buttons" -> `describe "clone" do`
- [x] "using filtering controls" -> `describe "search" do`
- [x] as an enterprise manager -> `context "as an enterprise manager" do`
- [x] Updating product image -> `describe "edit image" do`
- [ ]  "using column display dropdown" -> `describe "using column display dropdown" do` -> "Pending implementation, issue #11055"

In this PR, test cases are moved (copied and then deleted) from:  
- `./spec/system/admin/products_spec.rb`

And copied updated from:
- `./spec/system/admin/bulk_product_update_spec.rb`

to:
- `./spec/system/admin/products_v3/products_spec.rb`

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
