### PR TITLE
Display only per_item fees for oc incoming exchange #11326

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -4,8 +4,9 @@ angular.module('admin.orderCycles')
 
     order_cycle_id = $location.absUrl().match(/\/admin\/order_cycles\/(\d+)/)[1]
     $scope.order_cycle = OrderCycle.load(order_cycle_id)
+    $scope.order_cycle_id = order_cycle_id
     $scope.enterprises = Enterprise.index(order_cycle_id: order_cycle_id)
-    $scope.enterprise_fees = EnterpriseFee.index(order_cycle_id: order_cycle_id, per_item: true)
+    $scope.enterprise_fees = EnterpriseFee.index(order_cycle_id: order_cycle_id)
 
     $scope.removeCoordinatorFee = ($event, index) ->
       $event.preventDefault()

--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -3,6 +3,7 @@ angular.module('admin.orderCycles')
     $controller('AdminOrderCycleBasicCtrl', {$scope: $scope, ocInstance: ocInstance})
 
     order_cycle_id = $location.absUrl().match(/\/admin\/order_cycles\/(\d+)/)[1]
+    $scope.order_cycle_id = order_cycle_id
     $scope.order_cycle = OrderCycle.load(order_cycle_id)
     $scope.enterprises = Enterprise.index(order_cycle_id: order_cycle_id)
     $scope.enterprise_fees = EnterpriseFee.index(order_cycle_id: order_cycle_id)

--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -4,7 +4,6 @@ angular.module('admin.orderCycles')
 
     order_cycle_id = $location.absUrl().match(/\/admin\/order_cycles\/(\d+)/)[1]
     $scope.order_cycle = OrderCycle.load(order_cycle_id)
-    $scope.order_cycle_id = order_cycle_id
     $scope.enterprises = Enterprise.index(order_cycle_id: order_cycle_id)
     $scope.enterprise_fees = EnterpriseFee.index(order_cycle_id: order_cycle_id)
 

--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -5,7 +5,7 @@ angular.module('admin.orderCycles')
     order_cycle_id = $location.absUrl().match(/\/admin\/order_cycles\/(\d+)/)[1]
     $scope.order_cycle = OrderCycle.load(order_cycle_id)
     $scope.enterprises = Enterprise.index(order_cycle_id: order_cycle_id)
-    $scope.enterprise_fees = EnterpriseFee.index(order_cycle_id: order_cycle_id)
+    $scope.enterprise_fees = EnterpriseFee.index(order_cycle_id: order_cycle_id, per_item: true)
 
     $scope.removeCoordinatorFee = ($event, index) ->
       $event.preventDefault()

--- a/app/assets/javascripts/admin/order_cycles/controllers/incoming_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/incoming_controller.js.coffee
@@ -2,7 +2,7 @@ angular.module('admin.orderCycles').controller 'AdminOrderCycleIncomingCtrl', ($
   $controller('AdminOrderCycleExchangesCtrl', {$scope: $scope, ocInstance: ocInstance, $location: $location})
 
   $scope.view = 'incoming'
-
+  # NB: weirdly at this next line $scope.order_cycle.id comes out undefined so we use $scope.order_cycle_id instead
   $scope.enterprise_fees = EnterpriseFee.index(order_cycle_id: $scope.order_cycle_id, per_item: true)
   $scope.exchangeTotalVariants = (exchange) ->
     return unless $scope.enterprises? && $scope.enterprises[exchange.enterprise_id]?

--- a/app/assets/javascripts/admin/order_cycles/controllers/incoming_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/incoming_controller.js.coffee
@@ -1,8 +1,9 @@
-angular.module('admin.orderCycles').controller 'AdminOrderCycleIncomingCtrl', ($scope, $rootScope, $controller, $location, Enterprise, OrderCycle, ExchangeProduct, ocInstance) ->
+angular.module('admin.orderCycles').controller 'AdminOrderCycleIncomingCtrl', ($scope, $rootScope, $controller, $location, Enterprise, EnterpriseFee, OrderCycle, ExchangeProduct, ocInstance) ->
   $controller('AdminOrderCycleExchangesCtrl', {$scope: $scope, ocInstance: ocInstance, $location: $location})
 
   $scope.view = 'incoming'
 
+  $scope.enterprise_fees = EnterpriseFee.index(order_cycle_id: $scope.order_cycle_id, per_item: true)
   $scope.exchangeTotalVariants = (exchange) ->
     return unless $scope.enterprises? && $scope.enterprises[exchange.enterprise_id]?
 

--- a/app/assets/javascripts/admin/order_cycles/services/enterprise_fee.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/services/enterprise_fee.js.coffee
@@ -6,6 +6,8 @@ angular.module('admin.orderCycles').factory('EnterpriseFee', ($resource) ->
       params:
         order_cycle_id: '@order_cycle_id'
         coordinator_id: '@coordinator_id'
+        per_item: '@per_item'
+        per_order: '@per_order'
   })
 
   {

--- a/app/controllers/admin/enterprise_fees_controller.rb
+++ b/app/controllers/admin/enterprise_fees_controller.rb
@@ -65,7 +65,11 @@ module Admin
         order_cycle ||= OrderCycle.new(coordinator:) if coordinator.present?
         enterprises = OpenFoodNetwork::OrderCyclePermissions.new(spree_current_user,
                                                                  order_cycle).visible_enterprises
-        EnterpriseFee.for_enterprises(enterprises).order('enterprise_id', 'fee_type', 'name')
+
+        EnterpriseFee.for_enterprises(enterprises)
+                     .order('enterprise_id', 'fee_type', 'name')
+                     .yield_self { |fees| params[:per_item] ? fees.per_item : fees }
+                     .yield_self { |fees| params[:per_order] ? fees.per_order : fees }
       else
         collection = EnterpriseFee.managed_by(spree_current_user).order('enterprise_id',
                                                                         'fee_type', 'name')

--- a/app/controllers/admin/enterprise_fees_controller.rb
+++ b/app/controllers/admin/enterprise_fees_controller.rb
@@ -66,16 +66,20 @@ module Admin
         enterprises = OpenFoodNetwork::OrderCyclePermissions.new(spree_current_user,
                                                                  order_cycle).visible_enterprises
 
-        EnterpriseFee.for_enterprises(enterprises)
-          .order('enterprise_id', 'fee_type', 'name')
-          .then { |fees| params[:per_item] ? fees.per_item : fees }
-          .then { |fees| params[:per_order] ? fees.per_order : fees }
+        fees = EnterpriseFee.for_enterprises(enterprises).order('enterprise_id', 'fee_type', 'name')
+        filter_fees(fees)
       else
         collection = EnterpriseFee.managed_by(spree_current_user).order('enterprise_id',
                                                                         'fee_type', 'name')
         collection = collection.for_enterprise(current_enterprise) if current_enterprise
         collection
       end
+    end
+
+    def filter_fees(fees)
+      fees = fees.per_item if params[:per_item]
+      fees = fees.per_order if params[:per_order]
+      fees
     end
 
     def collection_actions

--- a/app/controllers/admin/enterprise_fees_controller.rb
+++ b/app/controllers/admin/enterprise_fees_controller.rb
@@ -67,9 +67,9 @@ module Admin
                                                                  order_cycle).visible_enterprises
 
         EnterpriseFee.for_enterprises(enterprises)
-                     .order('enterprise_id', 'fee_type', 'name')
-                     .yield_self { |fees| params[:per_item] ? fees.per_item : fees }
-                     .yield_self { |fees| params[:per_order] ? fees.per_order : fees }
+          .order('enterprise_id', 'fee_type', 'name')
+          .then { |fees| params[:per_item] ? fees.per_item : fees }
+          .then { |fees| params[:per_order] ? fees.per_order : fees }
       else
         collection = EnterpriseFee.managed_by(spree_current_user).order('enterprise_id',
                                                                         'fee_type', 'name')

--- a/spec/controllers/admin/enterprise_fees_controller_spec.rb
+++ b/spec/controllers/admin/enterprise_fees_controller_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe Admin::EnterpriseFeesController do
                                         per_order: true }
         expect(assigns(:collection)).to include fee1, fee3
       end
+      it 'returns all enterprise fees of enterprise' do
+        get :for_order_cycle, format: :json,
+                              params: { for_order_cycle: true, order_cycle_id: order_cycle.id }
+        expect(assigns(:collection)).to include fee1, fee2, fee3, fee4
+      end
     end
   end
 end

--- a/spec/controllers/admin/enterprise_fees_controller_spec.rb
+++ b/spec/controllers/admin/enterprise_fees_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: false
+
+require 'spec_helper'
+require 'open_food_network/order_cycle_permissions'
+
+RSpec.describe Admin::EnterpriseFeesController do
+  before { @request.env['HTTP_REFERER'] = 'http://test.com/' }
+
+  before do
+    allow(controller).to receive_messages spree_current_user: super_admin
+  end
+
+  describe "for_order_cycle" do
+    context "as super admin" do
+      let(:super_admin) { create(:admin_user) }
+      let!(:enterprise){ create(:distributor_enterprise_with_tax, name: 'Enterprise') }
+      let!(:fee1) { create(:enterprise_fee, :flat_rate, enterprise:) }
+      let!(:fee2) { create(:enterprise_fee, :per_item, enterprise:) }
+      let!(:fee3) { create(:enterprise_fee, :flat_rate, enterprise:) }
+      let!(:fee4) { create(:enterprise_fee, :per_item, enterprise:) }
+      let!(:order_cycle){
+        create(:simple_order_cycle, name: "oc1", suppliers: [enterprise],
+                                    distributors: [enterprise])
+      }
+
+      it 'returns only per item enterprise fees of enterprise' do
+        get :for_order_cycle, format: :json,
+                              params: { for_order_cycle: true, order_cycle_id: order_cycle.id,
+                                        per_item: true }
+        expect(assigns(:collection)).to include fee2, fee4
+      end
+      it 'returns only per order enterprise fees of enterprise' do
+        get :for_order_cycle, format: :json,
+                              params: { for_order_cycle: true, order_cycle_id: order_cycle.id,
+                                        per_order: true }
+        expect(assigns(:collection)).to include fee1, fee3
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/enterprise_fees_controller_spec.rb
+++ b/spec/controllers/admin/enterprise_fees_controller_spec.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: false
 
 require 'spec_helper'
-require 'open_food_network/order_cycle_permissions'
 
 RSpec.describe Admin::EnterpriseFeesController do
-  before { @request.env['HTTP_REFERER'] = 'http://test.com/' }
-
   before do
     allow(controller).to receive_messages spree_current_user: super_admin
   end

--- a/spec/javascripts/unit/admin/order_cycles/controllers/incoming_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/order_cycles/controllers/incoming_controller_spec.js.coffee
@@ -17,6 +17,8 @@ describe 'AdminOrderCycleIncomingCtrl', ->
       preventDefault: jasmine.createSpy('preventDefault')
     OrderCycle =
       addSupplier: jasmine.createSpy('addSupplier')
+    EnterpriseFee =
+      index: jasmine.createSpy('index').and.returnValue('enterprise fees list')
     ocInstance = {}
 
     module('admin.orderCycles')

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -154,6 +154,22 @@ describe '
       create(:enterprise_fee, :flat_rate, enterprise: supplier_permitted,
                                           name: 'Supplier distributor fee4')
     }
+    let!(:distributor_permitted_fee1) {
+      create(:enterprise_fee, :per_item, enterprise: distributor_permitted,
+                                         name: 'Distributor distributor fee1')
+    }
+    let!(:distributor_permitted_fee2) {
+      create(:enterprise_fee, :flat_rate, enterprise: distributor_permitted,
+                                          name: 'Distributor distributor fee2')
+    }
+    let!(:distributor_permitted_fee3) {
+      create(:enterprise_fee, :per_item, enterprise: distributor_permitted,
+                                         name: 'Distributor distributor fee3')
+    }
+    let!(:distributor_permitted_fee4) {
+      create(:enterprise_fee, :flat_rate, enterprise: distributor_permitted,
+                                          name: 'Distributor distributor fee4')
+    }
     let!(:shipping_method) {
       create(:shipping_method,
              distributors: [distributor_managed, distributor_unmanaged, distributor_permitted])
@@ -300,6 +316,18 @@ describe '
         select 'Permitted distributor', from: 'new_distributor_id'
         click_button 'Add distributor'
         expect(page).to have_content "Permitted distributor"
+
+        within("tr.distributor-#{distributor_permitted.id}") { click_button 'Add fee' }
+        expect(page).to have_select(
+          "order_cycle_outgoing_exchange_1_enterprise_fees_0_enterprise_id", minimum: 1
+        )
+        select "Permitted distributor",
+               from: "order_cycle_outgoing_exchange_1_enterprise_fees_0_enterprise_id"
+        expect(page).to have_select(
+          "order_cycle_outgoing_exchange_1_enterprise_fees_0_enterprise_fee_id",
+          options: ["", distributor_permitted_fee1.name, distributor_permitted_fee2.name,
+                    distributor_permitted_fee3.name, distributor_permitted_fee4.name]
+        )
 
         expect(page).to have_input 'order_cycle_outgoing_exchange_0_pickup_time'
         fill_in 'order_cycle_outgoing_exchange_0_pickup_time', with: 'pickup time'

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -139,16 +139,20 @@ describe '
       create(:enterprise_fee, enterprise: distributor_managed, name: 'Managed distributor fee')
     }
     let!(:supplier_permitted_fee1) {
-      create(:enterprise_fee, :per_item, enterprise: supplier_permitted, name: 'Supplier distributor fee1')
+      create(:enterprise_fee, :per_item, enterprise: supplier_permitted,
+                                         name: 'Supplier distributor fee1')
     }
     let!(:supplier_permitted_fee2) {
-      create(:enterprise_fee, :flat_rate, enterprise: supplier_permitted, name: 'Supplier distributor fee2')
+      create(:enterprise_fee, :flat_rate, enterprise: supplier_permitted,
+                                          name: 'Supplier distributor fee2')
     }
     let!(:supplier_permitted_fee3) {
-      create(:enterprise_fee, :per_item, enterprise: supplier_permitted, name: 'Supplier distributor fee3')
+      create(:enterprise_fee, :per_item, enterprise: supplier_permitted,
+                                         name: 'Supplier distributor fee3')
     }
     let!(:supplier_permitted_fee4) {
-      create(:enterprise_fee, :flat_rate, enterprise: supplier_permitted, name: 'Supplier distributor fee4')
+      create(:enterprise_fee, :flat_rate, enterprise: supplier_permitted,
+                                          name: 'Supplier distributor fee4')
     }
     let!(:shipping_method) {
       create(:shipping_method,
@@ -271,10 +275,16 @@ describe '
         expect(page).to have_content "Permitted supplier"
 
         within("tr.supplier-#{supplier_permitted.id}") { click_button 'Add fee' }
-        expect(page).to have_select("order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id", minimum: 1)
-        page.find("select#order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id").all('option[label]').first.select_option
+        expect(page).to have_select(
+          "order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id", minimum: 1
+        )
+        page.find("select#order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id")
+          .all('option[label]').first.select_option
         sleep 1
-        expect(page).to have_select("order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_fee_id", options: ["", supplier_permitted_fee1.name, supplier_permitted_fee3.name])
+        expect(page).to have_select(
+          "order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_fee_id",
+          options: ["", supplier_permitted_fee1.name, supplier_permitted_fee3.name]
+        )
 
         select_incoming_variant supplier_managed, 0, variant_managed
         select_incoming_variant supplier_permitted, 1, variant_permitted

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -278,7 +278,8 @@ describe '
         expect(page).to have_select(
           "order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id", minimum: 1
         )
-        select "Permitted supplier", from: "order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id"
+        select "Permitted supplier",
+               from: "order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id"
         expect(page).to have_select(
           "order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_fee_id",
           options: ["", supplier_permitted_fee1.name, supplier_permitted_fee3.name]

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -138,6 +138,18 @@ describe '
     let!(:distributor_managed_fee) {
       create(:enterprise_fee, enterprise: distributor_managed, name: 'Managed distributor fee')
     }
+    let!(:supplier_permitted_fee1) {
+      create(:enterprise_fee, :per_item, enterprise: supplier_permitted, name: 'Supplier distributor fee1')
+    }
+    let!(:supplier_permitted_fee2) {
+      create(:enterprise_fee, :flat_rate, enterprise: supplier_permitted, name: 'Supplier distributor fee2')
+    }
+    let!(:supplier_permitted_fee3) {
+      create(:enterprise_fee, :per_item, enterprise: supplier_permitted, name: 'Supplier distributor fee3')
+    }
+    let!(:supplier_permitted_fee4) {
+      create(:enterprise_fee, :flat_rate, enterprise: supplier_permitted, name: 'Supplier distributor fee4')
+    }
     let!(:shipping_method) {
       create(:shipping_method,
              distributors: [distributor_managed, distributor_unmanaged, distributor_permitted])
@@ -257,6 +269,12 @@ describe '
         select 'Permitted supplier', from: 'new_supplier_id'
         click_button 'Add supplier'
         expect(page).to have_content "Permitted supplier"
+
+        within("tr.supplier-#{supplier_permitted.id}") { click_button 'Add fee' }
+        expect(page).to have_select("order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id", minimum: 1)
+        page.find("select#order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id").all('option[label]').first.select_option
+        sleep 1
+        expect(page).to have_select("order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_fee_id", options: ["", supplier_permitted_fee1.name, supplier_permitted_fee3.name])
 
         select_incoming_variant supplier_managed, 0, variant_managed
         select_incoming_variant supplier_permitted, 1, variant_permitted

--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -278,9 +278,7 @@ describe '
         expect(page).to have_select(
           "order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id", minimum: 1
         )
-        page.find("select#order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id")
-          .all('option[label]').first.select_option
-        sleep 1
+        select "Permitted supplier", from: "order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id"
         expect(page).to have_select(
           "order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_fee_id",
           options: ["", supplier_permitted_fee1.name, supplier_permitted_fee3.name]


### PR DESCRIPTION
Add per_item param to EnterpriseFee angular service and rails controller

#### What? Why?

- Closes #11326

![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/23547158/9c1b8010-2431-4426-ad59-51f8c4f97d4b)


The order cycle incoming exchange should only show per_item fees. 
Solution was to pass additional parameter to the EnterpriseFee service/controller and get the appropriate fee scope

#### Uncertain
- Add new scopes in EnterpriseFee?
- Make scopes additive?
- Dont modify EnterpriseFee service call in EditController ? Call directly in IncomingController
- Should Weight calculators be explicitly filtered?
#### What should we test?
- Add a new per item EnterpriseFee for Fred's Farm
- Add a new per order EnterpriseFee2 for Fred's Farm
- Go to the Order Cycles Incoming Products page. Select Fred's Farm and click 'Add Fee' . Select Fred's Farm in the first dropdown
- Click on fee dropdown underneath, only the per item EnterpriseFee should display. Previously it would display both per item and per order EnterpriseFee 


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->


#### Tests
- [] Unit tests - EnterpriseFee service
- [X] Unit tests - EnterpriseFee controller
- [X] Unit tests - Order cycle Incoming view