### PR TITLE
Error messages don't block bottom of page clicks

### DIFF
--- a/app/webpacker/css/admin_v3/components/messages.scss
+++ b/app/webpacker/css/admin_v3/components/messages.scss
@@ -27,9 +27,9 @@
 
 .flash-container {
   position: fixed;
-  left: 0;
-  bottom: 0;
-  width: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 3.5rem;
   z-index: $flash-message-z-index;
   display: flex;
   justify-content: center;
@@ -38,7 +38,6 @@
     position: relative;
     display: flex;
     align-items: center;
-    bottom: 3.5rem;
     padding: 0.25rem;
     min-width: 24rem;
     max-width: 48.25em;


### PR DESCRIPTION

#### What? Why?

- Closes #12362

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The flash container was set to 100% width to center the messages on the screen. The messages were covering only part of the screen though. So the container beyond the actual message box was covering part of the page, blocking clicks on elements.

A new way of centering the container with CSS translate means that the width of the container can be the same as the content, not covering anyting accidentally.

And moving the whole container up instead of only moving the contained message allows us to interact with elements below the flash message as well.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Activate products_v3 feature.
- Delete your payments methods and shipping methods.
- Go to the products edit screen.
- Observe the warning message at the bottom.
- Make sure that you can interact with all visible elements around the error message.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
