### PR TITLE
Cache public assets in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,15 @@ jobs:
         run: |
           bin/rake db:create db:schema:load
 
+      - name: Restore cached public assets
+        id: cache-public-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
+
       - name: Run tests
         env:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: 864ef557d85ea8e603e086c0387d5154
@@ -84,6 +93,15 @@ jobs:
         run: |
           git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
           bin/rake knapsack_pro:rspec
+
+      - name: Save cached public assets
+        id: cache-public-save
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
 
   models:
     runs-on: ubuntu-22.04
@@ -127,6 +145,15 @@ jobs:
         run: |
           bin/rake db:create db:schema:load
 
+      - name: Restore cached public assets
+        id: cache-public-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
+
       - name: Run tests
         env:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: 09476e2ce491c12083df62768667c674
@@ -143,6 +170,15 @@ jobs:
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/models/**/*_spec.rb}" 
         run: |
           bin/rake knapsack_pro:rspec
+
+      - name: Save cached public assets
+        id: cache-public-save
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
 
   system_admin:
     runs-on: ubuntu-22.04
@@ -193,8 +229,16 @@ jobs:
         run: |
           bin/rake db:create db:schema:load
 
-      - name: Run tests
+      - name: Restore cached public assets
+        id: cache-public-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
 
+      - name: Run tests
         env:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ff2456e64c9f2aa5157eb0daf711d3c3
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
@@ -211,6 +255,15 @@ jobs:
 
         run: |
           bin/rake knapsack_pro:queue:rspec
+
+      - name: Save cached public assets
+        id: cache-public-save
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
 
       - name: Archive failed tests screenshots
         if: failure()
@@ -269,6 +322,15 @@ jobs:
       - name: Set up database
         run: |
           bin/rake db:create db:schema:load
+
+      - name: Restore cached public assets
+        id: cache-public-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
 
       - name: Run tests
 
@@ -348,8 +410,16 @@ jobs:
         run: |
           bin/rake db:create db:schema:load
 
-      - name: Run tests
+      - name: Restore cached public assets
+        id: cache-public-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
 
+      - name: Run tests
         env:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: d6ea7ceb766404ccd016c19aa2c81b1c
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
@@ -366,6 +436,15 @@ jobs:
 
         run: |
           bin/rake knapsack_pro:rspec
+
+      - name: Save cached public assets
+        id: cache-public-save
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
 
       - name: Archive failed tests screenshots
         if: failure()
@@ -426,6 +505,15 @@ jobs:
         run: |
           bin/rake db:create db:schema:load
 
+      - name: Restore cached public assets
+        id: cache-public-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
+
       - name: Run tests
         env:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: e3b8800198d2d89b70c7edbdd85f8fd8
@@ -442,6 +530,15 @@ jobs:
           KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN: "{engines/**/*_spec.rb,spec/models/**/*_spec.rb,spec/controllers/**/*_spec.rb,spec/serializers/**/*_spec.rb,spec/lib/**/*_spec.rb,spec/migrations/**/*_spec.rb,spec/system/**/*_spec.rb}"
         run: |
           bin/rake knapsack_pro:rspec
+
+      - name: Save cached public assets
+        id: cache-public-save
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+          key: public
 
   non_knapsack_jest_karma:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
If cached assets exist, they will be downloaded which should be quicker than building them again. Then assets:precompile will build any missing assets, skipping over cached ones. Then finally, all assets are saved to a newer version of the cache.

It sounds like GitHub automatically manages cache versions based on branch and time, so new branches will inherit the master cache, rather than cache from another branch.

If this works, this generic code should live in a shared module or something.

#### What? Why?

- Closes # <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
