### PR TITLE
Cache yarn global package data in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
+          cache: yarn
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -185,6 +186,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
+          cache: yarn
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -262,6 +264,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
+          cache: yarn
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -340,6 +343,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
+          cache: yarn
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -418,6 +422,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
+          cache: yarn
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
@@ -470,6 +475,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
+          cache: yarn
 
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
I set out to cache the node_modules folder, but came across this easy fix first: https://github.com/actions/setup-node?tab=readme-ov-file#caching-global-packages-data
I don't know what this actually does, because it doesn't install the dependencies, that still needs to happen next.
But it saves about 6 seconds (see results below), so I think it's worth adding.

### What should we test?
- green specs
- spec time slightly reduced

### Next up
We could probably save a further 6 seconds by caching node_modules. This guide looks straightforward. But why is this not built-in to an official action??
https://github.com/actions/cache/blob/main/examples.md#node---yarn