### PR TITLE
Fixes offenses raised by Rails/UnusedRenderContent

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -746,17 +746,6 @@ Rails/UnknownEnv:
   Exclude:
     - 'app/models/spree/app_configuration.rb'
 
-# Offense count: 7
-# Configuration parameters: Severity.
-Rails/UnusedRenderContent:
-  Exclude:
-    - 'app/controllers/admin/bulk_line_items_controller.rb'
-    - 'app/controllers/admin/tag_rules_controller.rb'
-    - 'app/controllers/api/v0/enterprise_fees_controller.rb'
-    - 'app/controllers/api/v0/products_controller.rb'
-    - 'app/controllers/api/v0/taxons_controller.rb'
-    - 'app/controllers/api/v0/variants_controller.rb'
-
 # Offense count: 1
 Security/Open:
   Exclude:

--- a/app/controllers/admin/bulk_line_items_controller.rb
+++ b/app/controllers/admin/bulk_line_items_controller.rb
@@ -35,7 +35,7 @@ module Admin
       order.with_lock do
         if order.contents.update_item(@line_item, line_item_params)
           # No Content, does not trigger ng resource auto-update
-          render body: nil, status: :no_content
+          head :no_content
         else
           render json: { errors: @line_item.errors }, status: :precondition_failed
         end
@@ -49,7 +49,7 @@ module Admin
       authorize! :update, order
 
       order.contents.remove(@line_item.variant)
-      render body: nil, status: :no_content # No Content, does not trigger ng resource auto-update
+      head :no_content # No Content, does not trigger ng resource auto-update
     end
 
     private

--- a/app/controllers/admin/tag_rules_controller.rb
+++ b/app/controllers/admin/tag_rules_controller.rb
@@ -5,7 +5,7 @@ module Admin
     respond_to :json
 
     respond_override destroy: { json: {
-      success: lambda { render body: nil, status: :no_content }
+      success: lambda { head :no_content }
     } }
 
     def map_by_tag

--- a/app/controllers/api/v0/enterprise_fees_controller.rb
+++ b/app/controllers/api/v0/enterprise_fees_controller.rb
@@ -9,7 +9,7 @@ module Api
         authorize! :destroy, enterprise_fee
 
         if enterprise_fee.destroy
-          render plain: I18n.t(:successfully_removed), status: :no_content
+          head :no_content
         else
           render plain: enterprise_fee.errors.full_messages.first, status: :forbidden
         end

--- a/app/controllers/api/v0/products_controller.rb
+++ b/app/controllers/api/v0/products_controller.rb
@@ -44,7 +44,7 @@ module Api
         authorize! :delete, @product
         @product.destroyed_by = current_api_user
         @product.destroy
-        render json: @product, serializer: Api::Admin::ProductSerializer, status: :no_content
+        head :no_content
       end
 
       def bulk_products

--- a/app/controllers/api/v0/taxons_controller.rb
+++ b/app/controllers/api/v0/taxons_controller.rb
@@ -55,7 +55,7 @@ module Api
       def destroy
         authorize! :delete, Spree::Taxon
         taxon.destroy
-        render json: taxon, serializer: Api::TaxonSerializer, status: :no_content
+        head :no_content
       end
 
       private

--- a/app/controllers/api/v0/variants_controller.rb
+++ b/app/controllers/api/v0/variants_controller.rb
@@ -44,7 +44,7 @@ module Api
         authorize! :delete, @variant
 
         VariantDeleter.new.delete(@variant)
-        render json: @variant, serializer: Api::VariantSerializer, status: :no_content
+        head :no_content
       end
 
       private


### PR DESCRIPTION
#### What? Why?

Contributes to #11482 

The: [Rails/UnusedRenderContent Cop](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsunusedrendercontent) checks offenses when both sending some content AND a non-content status code.

In any cases, adding `status: :no_content` (with content) drops content from response
So, I replaced with `head :no_content` ( that is: HTTP code  204)

#### What should we test?
Nothing.
Automatic specs should all pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
