### PR TITLE
Add translation key for Spree::Image#attachment

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,8 @@ en:
       spree/product: Product
       spree/shipping_method: Shipping Method
     attributes:
+      spree/image:
+        attachment: Attachment
       spree/order/ship_address:
         address1: "Shipping address (Street + House number)"
         address2: "Shipping address line 2"


### PR DESCRIPTION
#### What? Why?
This came up from https://github.com/openfoodfoundation/openfoodnetwork/pull/12558#issuecomment-2175725329

It will allow other languages to translate this field name in Transifex. Hmm are the a lot of other field names that need translating too?

#### What should we test?
- green specs ✅ (Spec failure is flaky shops_caching_spec)
