### PR TITLE
Revert "Allow negative stock levels for on-demand products"

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -112,7 +112,8 @@ module VariantStock
   #
   # This enables us to override this behaviour for variant overrides
   def move(quantity, originator = nil)
-    return if deleted_at
+    # Don't change variant stock if variant is on_demand or has been deleted
+    return if on_demand || deleted_at
 
     raise_error_if_no_stock_item_available
 

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -15,9 +15,7 @@ class VariantOverride < ApplicationRecord
   # Need to ensure this can be set by the user.
   validates :default_stock, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :price, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
-  validates :count_on_hand, numericality: {
-    greater_than_or_equal_to: 0, unless: :on_demand?
-  }, allow_nil: true
+  validates :count_on_hand, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
   default_scope { where(permission_revoked_at: nil) }
 

--- a/lib/open_food_network/scope_variant_to_hub.rb
+++ b/lib/open_food_network/scope_variant_to_hub.rb
@@ -43,7 +43,11 @@ module OpenFoodNetwork
       #   - updates variant_override.count_on_hand
       #   - does not create stock_movement
       #   - does not update stock_item.count_on_hand
+      # If it is a variant override with on_demand:
+      #   - don't change stock or call super (super would change the variant's stock)
       def move(quantity, originator = nil)
+        return if @variant_override&.on_demand
+
         if @variant_override&.stock_overridden?
           @variant_override.move_stock! quantity
         else

--- a/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
+++ b/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
@@ -181,9 +181,9 @@ module OpenFoodNetwork
             scoper.scope v2
           end
 
-          it "does reduce variant's stock" do
+          it "doesn't reduce variant's stock" do
             v2.move(-2)
-            expect(Spree::Variant.find(v2.id).on_hand).to eq 3
+            expect(Spree::Variant.find(v2.id).on_hand).to eq 5
           end
         end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -303,8 +303,8 @@ module Spree
           expect(order.shipment.manifest.first.variant).to eq line_item.variant
         end
 
-        it "reduces the variant's stock level" do
-          expect(variant_on_demand.reload.on_hand).to eq(-9)
+        it "does not reduce the variant's stock level" do
+          expect(variant_on_demand.reload.on_hand).to eq 1
         end
 
         it "does not mark inventory units as backorderd" do

--- a/spec/system/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/system/consumer/shopping/variant_overrides_spec.rb
@@ -210,12 +210,12 @@ RSpec.describe "shopping with variant overrides defined" do
       expect(product1_variant1_override.reload.count_on_hand).to be_nil
     end
 
-    it "does subtract stock from variants where the override has on_demand: true" do
+    it "does not subtract stock from variants where the override has on_demand: true" do
       click_add_to_cart product4_variant1, 2
       click_checkout
       expect do
         complete_checkout
-      end.to change { product4_variant1.reload.on_hand }.by(-2)
+      end.to change { product4_variant1.reload.on_hand }.by(0)
       expect(product4_variant1_override.reload.count_on_hand).to be_nil
     end
 


### PR DESCRIPTION
Reverts openfoodfoundation/openfoodnetwork#12536

I have a suspicion that this causes a new error:

* #12586

The PR was just preparing further work. So we can revert it now and test more thoroughly later.