### PR TITLE
Fixes Rails/RedundantActiveRecordAllMethod issues

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -115,6 +115,11 @@ Rails/OutputSafety:
   Exclude:
     - spec/**/*
 
+Rails/RedundantActiveRecordAllMethod:
+  AllowedReceivers:
+    - ActionMailer::Preview
+    - ActiveSupport::TimeZone
+
 Rails/SkipsModelValidations:
   AllowedMethods:
     - touch

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -654,17 +654,6 @@ Rails/PluckInWhere:
   Exclude:
     - 'app/models/spree/variant.rb'
 
-# Offense count: 4
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowedReceivers.
-# AllowedReceivers: ActionMailer::Preview, ActiveSupport::TimeZone
-Rails/RedundantActiveRecordAllMethod:
-  Exclude:
-    - 'app/models/spree/tax_rate.rb'
-    - 'app/models/spree/user.rb'
-    - 'app/models/spree/variant.rb'
-    - 'spec/system/admin/product_import_spec.rb'
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/RelativeDateConstant:

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -31,7 +31,7 @@ module Spree
       return [] if order.distributor && !order.distributor.charges_sales_tax
       return [] unless order.tax_zone
 
-      all.includes(zone: { zone_members: :zoneable }).load.select do |rate|
+      includes(zone: { zone_members: :zoneable }).load.select do |rate|
         rate.potentially_applicable?(order.tax_zone)
       end
     end

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -96,7 +96,7 @@ module Spree
     end
 
     def build_enterprise_roles
-      Enterprise.all.find_each do |enterprise|
+      Enterprise.find_each do |enterprise|
         unless enterprise_roles.find_by enterprise_id: enterprise.id
           enterprise_roles.build(enterprise:)
         end

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -238,7 +238,7 @@ module Spree
     end
 
     def create_stock_items
-      StockLocation.all.find_each do |stock_location|
+      StockLocation.find_each do |stock_location|
         stock_location.propagate_variant(self)
       end
     end

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Product Import" do
                               count_on_hand: 96)
   }
 
-  let(:shipping_category_id_str) { Spree::ShippingCategory.all.first.id.to_s }
+  let(:shipping_category_id_str) { Spree::ShippingCategory.first.id.to_s }
 
   describe "when importing products from uploaded file" do
     before do


### PR DESCRIPTION
#### What? Why?

- Contributes to #11482

- Cop: [Rails/RedundantActiveRecordAllMethod](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsredundantactiverecordallmethod)

  - if receiver is an Active Record object, `.all` can be safely removed
  - There are 2 allowed receivers that are listed in the styleguide file (those are defaults cf. cop documentation).


#### What should we test?
Nothing. Linters should raise no rubocop offenses.
All specs should pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
