### PR TITLE
Load large on-screen reports on demand

### DIFF
--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -53,7 +53,14 @@ class ReportJob < ApplicationJob
   end
 
   def actioncable_content(format, blob)
-    return blob.result if format.to_sym == :html
+    if format.to_sym == :html
+      return blob.result if blob.byte_size < 10**6 # 1 MB
+
+      return render(
+        partial: "admin/reports/display",
+        locals: { file_url: blob.expiring_service_url }
+      )
+    end
 
     render(partial: "admin/reports/download", locals: { file_url: blob.expiring_service_url })
   end

--- a/app/views/admin/reports/_display.html.haml
+++ b/app/views/admin/reports/_display.html.haml
@@ -2,4 +2,4 @@
   %p.notice= t ".report_is_big"
   %p= link_to t(".display_anyway"), file_url, target: "_blank",
     class: "button icon icon-file",
-    onclick: "(async function (element) { element.outerHTML = await (await (await fetch(element.href))).text() })(this); return false;"
+    onclick: "(async function (element) { element.outerHTML = await (await fetch(element.href)).text() })(this); return false;"

--- a/app/views/admin/reports/_display.html.haml
+++ b/app/views/admin/reports/_display.html.haml
@@ -1,0 +1,5 @@
+.download
+  %p.notice= t ".report_is_big"
+  %p= link_to t(".display_anyway"), file_url, target: "_blank",
+    class: "button icon icon-file",
+    onclick: "(async function (element) { element.outerHTML = await (await (await fetch(element.href))).text() })(this); return false;"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1670,6 +1670,9 @@ en:
       pack_by_customer: Pack By Customer
       pack_by_supplier: Pack By Supplier
       pack_by_product: Pack By Product
+      display:
+        report_is_big: "This report is big and may slow down your device."
+        display_anyway: "Display anyway"
       download:
         button: "Download Report"
       show:


### PR DESCRIPTION
#### What? Why?

- Part of #11752 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Sending large reports via Cable Ready is unreliable. The events are dropped at an unknown point and the report is never displayed to the user. Instead we just send a link to the report via Cable Ready and offer a button to load the report on screen.

This has the UX benefit of warning the user about the size as well. Weaker devices can struggle rendering big HTML documents.

![Screenshot from 2024-06-20 11-08-11](https://github.com/openfoodfoundation/openfoodnetwork/assets/3524483/0bd07e14-f336-4573-b9fb-136161ef8ab9)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Log in as enterprise user.
- Load a few different reports on screen.
- Load a few big reports on screen.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
