### PR TITLE
Hide customer data on orders_and_distributors report

### DIFF
--- a/lib/reporting/reports/orders_and_distributors/base.rb
+++ b/lib/reporting/reports/orders_and_distributors/base.rb
@@ -32,7 +32,7 @@ module Reporting
         # rubocop:enable Metrics/AbcSize
 
         def search
-          report_line_items.list
+          report_line_items.list(line_item_includes)
         end
 
         def query_result
@@ -40,6 +40,11 @@ module Reporting
         end
 
         private
+
+        def line_item_includes
+          [{ variant: { product: :supplier },
+             order: [:bill_address, :payments, { distributor: :address}] }]
+        end
 
         def permissions
           @permissions ||= ::Permissions::Order.new(user, ransack_params)

--- a/lib/reporting/reports/orders_and_distributors/base.rb
+++ b/lib/reporting/reports/orders_and_distributors/base.rb
@@ -32,18 +32,18 @@ module Reporting
         # rubocop:enable Metrics/AbcSize
 
         def search
-          report_line_items.list(line_item_includes)
+          report_line_items.orders
         end
 
         def query_result
-          search
+          report_line_items.list(line_item_includes)
         end
 
         private
 
         def line_item_includes
           [{ variant: { product: :supplier },
-             order: [:bill_address, :payments, { distributor: :address}] }]
+             order: [:bill_address, :payments, { distributor: :address }] }]
         end
 
         def permissions

--- a/lib/reporting/reports/orders_and_distributors/base.rb
+++ b/lib/reporting/reports/orders_and_distributors/base.rb
@@ -32,26 +32,21 @@ module Reporting
         # rubocop:enable Metrics/AbcSize
 
         def search
-          permissions.visible_orders.select("DISTINCT spree_orders.*").
-            complete.not_state(:canceled).
-            ransack(ransack_params)
+          report_line_items.list
         end
 
         def query_result
-          orders = search.result
-          # Mask non editable order details
-          editable_orders_ids = permissions.editable_orders.select(&:id).map(&:id)
-          orders
-            .filter { |order| order.in?(editable_orders_ids) }
-            .each { |order| Orders::MaskDataService.new(order).call }
-          # Get Line Items
-          orders.map(&:line_items).flatten
+          search
         end
 
         private
 
         def permissions
           @permissions ||= ::Permissions::Order.new(user, ransack_params)
+        end
+
+        def report_line_items
+          @report_line_items ||= Reporting::LineItems.new(permissions, params)
         end
       end
     end

--- a/spec/lib/reports/orders_and_distributors_report_spec.rb
+++ b/spec/lib/reports/orders_and_distributors_report_spec.rb
@@ -2,108 +2,100 @@
 
 require 'spec_helper'
 
-module Reporting
-  module Reports
-    module OrdersAndDistributors
-      RSpec.describe Base do
-        describe 'orders and distributors report' do
-          it 'should return a header row describing the report' do
-            subject = Base.new nil
+RSpec.describe Reporting::Reports::OrdersAndDistributors::Base do
+  describe 'orders and distributors report' do
+    subject { described_class.new nil }
 
-            expect(subject.table_headers).to eq(
-              [
-                'Order date', 'Order Id',
-                'Customer Name', 'Customer Email', 'Customer Phone', 'Customer City',
-                'SKU', 'Item name', 'Variant', 'Quantity', 'Max Quantity', 'Cost', 'Shipping Cost',
-                'Payment Method',
-                'Distributor', 'Distributor address', 'Distributor city', 'Distributor postcode',
-                'Shipping Method', 'Shipping instructions'
-              ]
-            )
-          end
+    it 'should return a header row describing the report' do
+      expect(subject.table_headers).to eq(
+        [
+          'Order date', 'Order Id',
+          'Customer Name', 'Customer Email', 'Customer Phone', 'Customer City',
+          'SKU', 'Item name', 'Variant', 'Quantity', 'Max Quantity', 'Cost', 'Shipping Cost',
+          'Payment Method',
+          'Distributor', 'Distributor address', 'Distributor city', 'Distributor postcode',
+          'Shipping Method', 'Shipping instructions'
+        ]
+      )
+    end
 
-          context 'with completed order' do
-            let(:bill_address) { create(:address) }
-            let(:distributor) { create(:distributor_enterprise) }
-            let(:distributor1) { create(:distributor_enterprise) }
-            let(:product) { create(:product) }
-            let(:shipping_method) { create(:shipping_method) }
-            let(:shipping_instructions) { 'pick up on thursday please!' }
-            let(:order) {
-              create(:order,
-                     state: 'complete', completed_at: Time.zone.now,
-                     distributor:, bill_address:,
-                     special_instructions: shipping_instructions)
-            }
-            let(:payment_method) { create(:payment_method, distributors: [distributor]) }
-            let(:payment) { create(:payment, payment_method:, order:) }
-            let(:line_item) { create(:line_item_with_shipment, product:, order:) }
+    context 'with completed order' do
+      let(:bill_address) { create(:address) }
+      let(:distributor) { create(:distributor_enterprise) }
+      let(:distributor1) { create(:distributor_enterprise) }
+      let(:product) { create(:product) }
+      let(:shipping_method) { create(:shipping_method) }
+      let(:shipping_instructions) { 'pick up on thursday please!' }
+      let(:order) {
+        create(:order,
+               state: 'complete', completed_at: Time.zone.now,
+               distributor:, bill_address:,
+               special_instructions: shipping_instructions)
+      }
+      let(:payment_method) { create(:payment_method, distributors: [distributor]) }
+      let(:payment) { create(:payment, payment_method:, order:) }
+      let(:line_item) { create(:line_item_with_shipment, product:, order:) }
+      subject { described_class.new create(:admin_user) }
 
-            before do
-              order.select_shipping_method(shipping_method.id)
-              order.payments << payment
-              order.line_items << line_item
-            end
+      before do
+        order.select_shipping_method(shipping_method.id)
+        order.payments << payment
+        order.line_items << line_item
+      end
 
-            it 'should denormalise order and distributor details for display as csv' do
-              subject = Base.new create(:admin_user), {}
-              allow(subject).to receive(:unformatted_render?).and_return(true)
-              table = subject.table_rows
+      it 'should denormalise order and distributor details for display as csv' do
+        allow(subject).to receive(:unformatted_render?).and_return(true)
+        table = subject.table_rows
 
-              expect(table.size).to eq 1
-              expect(table[0]).to eq([
-                                       order.reload.completed_at.strftime("%F %T"),
-                                       order.id,
-                                       bill_address.full_name,
-                                       order.email,
-                                       bill_address.phone,
-                                       bill_address.city,
-                                       line_item.product.sku,
-                                       line_item.product.name,
-                                       line_item.options_text,
-                                       line_item.quantity,
-                                       line_item.max_quantity,
-                                       line_item.price * line_item.quantity,
-                                       line_item.distribution_fee,
-                                       payment_method.name,
-                                       distributor.name,
-                                       distributor.address.address1,
-                                       distributor.address.city,
-                                       distributor.address.zipcode,
-                                       shipping_method.name,
-                                       shipping_instructions
-                                     ])
-            end
+        expect(table.size).to eq 1
+        expect(table[0]).to eq([
+                                 order.reload.completed_at.strftime("%F %T"),
+                                 order.id,
+                                 bill_address.full_name,
+                                 order.email,
+                                 bill_address.phone,
+                                 bill_address.city,
+                                 line_item.product.sku,
+                                 line_item.product.name,
+                                 line_item.options_text,
+                                 line_item.quantity,
+                                 line_item.max_quantity,
+                                 line_item.price * line_item.quantity,
+                                 line_item.distribution_fee,
+                                 payment_method.name,
+                                 distributor.name,
+                                 distributor.address.address1,
+                                 distributor.address.city,
+                                 distributor.address.zipcode,
+                                 shipping_method.name,
+                                 shipping_instructions
+                               ])
+      end
 
-            it "prints one row per line item" do
-              create(:line_item_with_shipment, order:)
+      it "prints one row per line item" do
+        create(:line_item_with_shipment, order:)
 
-              subject = Base.new(create(:admin_user))
+        table = subject.table_rows
+        expect(table.size).to eq 2
+      end
 
-              table = subject.table_rows
-              expect(table.size).to eq 2
-            end
+      context "filtering by distributor" do
+        it do
+          create(:line_item_with_shipment, order:)
 
-            context "filtering by distributor" do
-              it do
-                create(:line_item_with_shipment, order:)
+          report1 = described_class.new(create(:admin_user), {})
+          table = report1.table_rows
+          expect(table.size).to eq 2
 
-                report1 = Base.new(create(:admin_user), {})
-                table = report1.table_rows
-                expect(table.size).to eq 2
+          report2 = described_class.new(create(:admin_user),
+                                        { q: { distributor_id_in: [distributor.id] } })
+          table2 = report2.table_rows
+          expect(table2.size).to eq 2
 
-                report2 = Base.new(create(:admin_user),
-                                   { q: { distributor_id_in: [distributor.id] } })
-                table2 = report2.table_rows
-                expect(table2.size).to eq 2
-
-                report3 = Base.new(create(:admin_user),
-                                   { q: { distributor_id_in: [distributor1.id] } })
-                table3 = report3.table_rows
-                expect(table3.size).to eq 0
-              end
-            end
-          end
+          report3 = described_class.new(create(:admin_user),
+                                        { q: { distributor_id_in: [distributor1.id] } })
+          table3 = report3.table_rows
+          expect(table3.size).to eq 0
         end
       end
     end

--- a/spec/lib/reports/orders_and_distributors_report_spec.rb
+++ b/spec/lib/reports/orders_and_distributors_report_spec.rb
@@ -115,7 +115,6 @@ RSpec.describe Reporting::Reports::OrdersAndDistributors::Base do
         end
 
         it "shows line items supplied by my producers, with contact details hidden" do
-          pending '#12559'
           expect(row).not_to include("FirstName LastName")
           expect(row).not_to include("123-456", "City", order.email)
           expect(row[2..5]).to eq ["HIDDEN", "HIDDEN", "", ""]
@@ -128,7 +127,6 @@ RSpec.describe Reporting::Reports::OrdersAndDistributors::Base do
 
           it "shows line items supplied by my producers, with only contact names shown" do
             expect(row).to include("FirstName LastName")
-            pending '#12559'
             expect(row).not_to include("123-456", "City", order.email)
             expect(row[2..5]).to eq [bill_address.full_name, "HIDDEN", "", ""]
           end

--- a/spec/lib/reports/orders_and_distributors_report_spec.rb
+++ b/spec/lib/reports/orders_and_distributors_report_spec.rb
@@ -136,19 +136,13 @@ RSpec.describe Reporting::Reports::OrdersAndDistributors::Base do
       it "minimises database queries" do
         subject # build context first
 
-        # surely we can do better than that for each row
         expect { subject.table_rows }.to query_database [
           "Spree::Role Exists?",
           "Spree::Role Exists?",
           "SQL",
           "Spree::LineItem Load",
-          "Spree::Order Load",
-          "Spree::Address Load",
-          "Spree::Payment Load",
           "Spree::PaymentMethod Load",
           "Spree::Calculator Load",
-          "Enterprise Load",
-          "Spree::Address Load",
           "Spree::Shipment Load",
           "Spree::ShippingRate Load",
           "Spree::ShippingMethod Load",

--- a/spec/lib/reports/orders_and_distributors_report_spec.rb
+++ b/spec/lib/reports/orders_and_distributors_report_spec.rb
@@ -132,6 +132,28 @@ RSpec.describe Reporting::Reports::OrdersAndDistributors::Base do
           end
         end
       end
+
+      it "minimises database queries" do
+        subject # build context first
+
+        # surely we can do better than that for each row
+        expect { subject.table_rows }.to query_database [
+          "Spree::Role Exists?",
+          "Spree::Role Exists?",
+          "SQL",
+          "Spree::LineItem Load",
+          "Spree::Order Load",
+          "Spree::Address Load",
+          "Spree::Payment Load",
+          "Spree::PaymentMethod Load",
+          "Spree::Calculator Load",
+          "Enterprise Load",
+          "Spree::Address Load",
+          "Spree::Shipment Load",
+          "Spree::ShippingRate Load",
+          "Spree::ShippingMethod Load",
+        ]
+      end
     end
   end
 end


### PR DESCRIPTION
### What? Why?

- Part two of #12559
- Closes https://github.com/openfoodfoundation/openfoodnetwork/pull/12588 as an alternative

This report had some custom code, which was using the `MaskDataService`, but it wasn't working for some reason. 

Digging around to figure out how it was meant to work, I discovered that the report framework handles this for us. So I deleted some code 💥😁


### What should we test?
For the "Orders and Distributors"  report (` /admin/reports/orders_and_distributors`). My understanding (please correct if wrong):

#### As a supplier with product orders:
* Customer details should be masked by default (name, email, phone, city)
* Distributor address always shows

#### With "Customer Names in Reports"
Enable "show_customer_names_to_suppliers"  for the distributor: Enterprises > Edit > Shop Preferences > **Customer Names in Reports**
* Customer name should appear in report
* Other customer details remain masked (email, phone, city)
* Distributor address always shows

When distributor has 
#### As an admin or distributor
I guess the customer details always show
