### PR TITLE
12346 - Fix Rubocop Rails/Pluck and Rails/PluckInWhere

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -625,27 +625,6 @@ Rails/LexicallyScopedActionFilter:
     - 'app/controllers/spree/admin/zones_controller.rb'
     - 'app/controllers/spree/users_controller.rb'
 
-# Offense count: 32
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/Pluck:
-  Exclude:
-    - 'app/controllers/admin/variant_overrides_controller.rb'
-    - 'app/services/cart_service.rb'
-    - 'lib/reporting/report_headers_builder.rb'
-    - 'spec/controllers/admin/bulk_line_items_controller_spec.rb'
-    - 'spec/controllers/admin/subscriptions_controller_spec.rb'
-    - 'spec/controllers/api/v0/order_cycles_controller_spec.rb'
-    - 'spec/controllers/api/v0/orders_controller_spec.rb'
-    - 'spec/controllers/api/v0/products_controller_spec.rb'
-    - 'spec/controllers/api/v0/shops_controller_spec.rb'
-    - 'spec/controllers/api/v0/states_controller_spec.rb'
-    - 'spec/controllers/api/v0/taxons_controller_spec.rb'
-    - 'spec/helpers/spree/admin/orders_helper_spec.rb'
-    - 'spec/lib/reports/lettuce_share_report_spec.rb'
-    - 'spec/lib/reports/users_and_enterprises_report_spec.rb'
-    - 'spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb'
-    - 'spec/support/api_helper.rb'
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -627,14 +627,6 @@ Rails/LexicallyScopedActionFilter:
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: conservative, aggressive
-Rails/PluckInWhere:
-  Exclude:
-    - 'app/models/spree/variant.rb'
-
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/RelativeDateConstant:
   Exclude:
     - 'lib/tasks/data/remove_transient_data.rb'

--- a/app/controllers/admin/variant_overrides_controller.rb
+++ b/app/controllers/admin/variant_overrides_controller.rb
@@ -88,7 +88,7 @@ module Admin
     end
 
     def modified_variant_overrides_ids
-      variant_overrides_params.map { |vo| vo[:id] }
+      variant_overrides_params.pluck(:id)
     end
 
     def collection_actions

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -143,7 +143,7 @@ module Spree
       return where("1=0") if enterprise.blank?
 
       joins(:product).
-        where(spree_products: { id: Spree::Product.stockable_by(enterprise).pluck(:id) })
+        where(spree_products: { id: Spree::Product.stockable_by(enterprise).select(:id) })
     }
 
     # Define sope as class method to allow chaining with other scopes filtering id.

--- a/app/services/cart_service.rb
+++ b/app/services/cart_service.rb
@@ -50,7 +50,7 @@ class CartService
 
   def indexed_variants(variants_data)
     @indexed_variants ||= begin
-      variant_ids_in_data = variants_data.map{ |v| v[:variant_id] }
+      variant_ids_in_data = variants_data.pluck(:variant_id)
 
       Spree::Variant.with_deleted.where(id: variant_ids_in_data).
         includes(:default_price, :stock_items, :product).

--- a/lib/reporting/report_headers_builder.rb
+++ b/lib/reporting/report_headers_builder.rb
@@ -22,7 +22,7 @@ module Reporting
 
     def fields_to_hide
       if report.display_header_row?
-        report.formatted_rules.map { |rule| rule[:fields_used_in_header] }.flatten.compact_blank
+        report.formatted_rules.pluck(:fields_used_in_header).flatten.compact_blank
       else
         []
       end.concat(params_fields_to_hide)
@@ -30,9 +30,10 @@ module Reporting
 
     def fields_to_show
       fields_in_headers = if report.display_header_row?
-                            report.formatted_rules.map { |rule|
-                              rule[:fields_used_in_header]
-                            }.flatten.compact_blank
+                            report.formatted_rules
+                              .pluck(:fields_used_in_header)
+                              .flatten
+                              .compact_blank
                           else
                             []
                           end

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -59,13 +59,11 @@ RSpec.describe Admin::BulkLineItemsController, type: :controller do
         end
 
         it "formats final_weight_volume as a float" do
-          expect(json_response['line_items'].pluck(:final_weight_volume).all?{ |fwv|
-                   fwv.is_a?(Float)
-                 }).to eq(true)
+          expect(json_response[:line_items]).to all(include(final_weight_volume: a_kind_of(Float)))
         end
 
         it "returns distributor object with id key" do
-          expect(json_response['line_items'].pluck(:supplier).all?{ |d| d.key?('id') }).to eq(true)
+          expect(json_response[:line_items].pluck(:supplier)).to all(include(:id))
         end
       end
 

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -59,15 +59,13 @@ RSpec.describe Admin::BulkLineItemsController, type: :controller do
         end
 
         it "formats final_weight_volume as a float" do
-          expect(json_response['line_items'].map{ |line_item|
-                   line_item['final_weight_volume']
-                 }.all?{ |fwv| fwv.is_a?(Float) }).to eq(true)
+          expect(json_response['line_items'].pluck(:final_weight_volume).all?{ |fwv|
+                   fwv.is_a?(Float)
+                 }).to eq(true)
         end
 
         it "returns distributor object with id key" do
-          expect(json_response['line_items'].map{ |line_item|
-                   line_item['supplier']
-                 }.all?{ |d| d.key?('id') }).to eq(true)
+          expect(json_response['line_items'].pluck(:supplier).all?{ |d| d.key?('id') }).to eq(true)
         end
       end
 
@@ -460,6 +458,6 @@ RSpec.describe Admin::BulkLineItemsController, type: :controller do
   private
 
   def line_item_ids
-    json_response['line_items'].map{ |line_item| line_item['id'] }
+    json_response['line_items'].pluck(:id)
   end
 end

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Admin::SubscriptionsController, type: :controller do
           get(:index, params:)
           json_response = JSON.parse(response.body)
           expect(json_response.count).to be 2
-          expect(json_response.map{ |so| so['id'] }).to include subscription.id, subscription2.id
+          expect(json_response.pluck(:id)).to include subscription.id, subscription2.id
         end
 
         context "when ransack predicates are submitted" do
@@ -79,7 +79,7 @@ RSpec.describe Admin::SubscriptionsController, type: :controller do
             get(:index, params:)
             json_response = JSON.parse(response.body)
             expect(json_response.count).to be 1
-            ids = json_response.map{ |so| so['id'] }
+            ids = json_response.pluck(:id)
             expect(ids).to include subscription2.id
             expect(ids).not_to include subscription.id
           end

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Admin::SubscriptionsController, type: :controller do
           get(:index, params:)
           json_response = JSON.parse(response.body)
           expect(json_response.count).to be 2
-          expect(json_response.pluck(:id)).to include subscription.id, subscription2.id
+          expect(json_response.pluck('id')).to include subscription.id, subscription2.id
         end
 
         context "when ransack predicates are submitted" do
@@ -79,7 +79,7 @@ RSpec.describe Admin::SubscriptionsController, type: :controller do
             get(:index, params:)
             json_response = JSON.parse(response.body)
             expect(json_response.count).to be 1
-            ids = json_response.pluck(:id)
+            ids = json_response.pluck('id')
             expect(ids).to include subscription2.id
             expect(ids).not_to include subscription.id
           end

--- a/spec/controllers/api/v0/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/v0/order_cycles_controller_spec.rb
@@ -222,7 +222,7 @@ module Api
       it "loads taxons for distributed products in the order cycle" do
         api_get :taxons, id: order_cycle.id, distributor: distributor.id
 
-        taxons = json_response.map{ |taxon| taxon['name'] }
+        taxons = json_response.pluck(:name)
 
         expect(json_response.length).to be 2
         expect(taxons).to include taxon1.name, taxon2.name
@@ -233,7 +233,7 @@ module Api
       it "loads properties for distributed products in the order cycle" do
         api_get :properties, id: order_cycle.id, distributor: distributor.id
 
-        properties = json_response.map{ |property| property['name'] }
+        properties = json_response.pluck(:name)
 
         expect(json_response.length).to be 2
         expect(properties).to include property1.presentation, property2.presentation
@@ -248,7 +248,7 @@ module Api
         it "loads producer properties for distributed products in the order cycle" do
           api_get :properties, id: order_cycle.id, distributor: distributor.id
 
-          properties = json_response.map{ |property| property['name'] }
+          properties = json_response.pluck(:name)
 
           expect(json_response.length).to be 3
           expect(properties).to include property1.presentation, property2.presentation,
@@ -301,7 +301,7 @@ module Api
     private
 
     def product_ids
-      json_response.map{ |product| product['id'] }
+      json_response.pluck(:id)
     end
   end
 end

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -146,8 +146,8 @@ module Api
                       as: :json
 
           expect(json_response['orders']
-            .pluck(:id)).to eq serialized_orders([order2, order3, order1, order4])
-              .pluck(:id)
+            .pluck('id')).to eq serialized_orders([order2, order3, order1, order4])
+              .pluck('id')
         end
 
         context "with an order without billing address" do
@@ -161,17 +161,17 @@ module Api
                         as: :json
 
             expect(json_response['orders']
-              .pluck(:id)).to match_array serialized_orders([order2, order3, order1, order4,
-                                                             order7])
-                .pluck(:id)
+              .pluck('id')).to match_array serialized_orders([order2, order3, order1, order4,
+                                                              order7])
+                .pluck('id')
           end
 
           it 'can sort orders by bill_address.lastname' do
             get :index, params: { q: { s: 'bill_address_lastname ASC' } },
                         as: :json
             expect(json_response['orders']
-              .pluck(:id)).to eq serialized_orders([order2, order3, order1, order4, order7])
-                .pluck(:id)
+              .pluck('id')).to eq serialized_orders([order2, order3, order1, order4, order7])
+                .pluck('id')
           end
         end
       end

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -146,8 +146,8 @@ module Api
                       as: :json
 
           expect(json_response['orders']
-            .map{ |o| o[:id] }).to eq serialized_orders([order2, order3, order1, order4])
-              .map{ |o| o["id"] }
+            .pluck(:id)).to eq serialized_orders([order2, order3, order1, order4])
+              .pluck(:id)
         end
 
         context "with an order without billing address" do
@@ -161,19 +161,17 @@ module Api
                         as: :json
 
             expect(json_response['orders']
-              .map{ |o| o[:id] }).to match_array serialized_orders([order2, order3, order1, order4,
-                                                                    order7])
-                .map{ |o|
-                                                   o["id"]
-                                                 }
+              .pluck(:id)).to match_array serialized_orders([order2, order3, order1, order4,
+                                                             order7])
+                .pluck(:id)
           end
 
           it 'can sort orders by bill_address.lastname' do
             get :index, params: { q: { s: 'bill_address_lastname ASC' } },
                         as: :json
             expect(json_response['orders']
-              .map{ |o| o[:id] }).to eq serialized_orders([order2, order3, order1, order4, order7])
-                .map{ |o| o["id"] }
+              .pluck(:id)).to eq serialized_orders([order2, order3, order1, order4, order7])
+                .pluck(:id)
           end
         end
       end

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -155,23 +155,22 @@ module Api
             create(:order_with_line_items, billing_address: nil, order_cycle:,
                                            distributor:)
           }
+          let(:expected_order_ids) {
+            serialized_orders([order2, order3, order1, order4, order7]).pluck('id')
+          }
 
           it 'can show orders without bill address' do
             get :index, params: { q: {} },
                         as: :json
 
-            expect(json_response['orders']
-              .pluck('id')).to match_array serialized_orders([order2, order3, order1, order4,
-                                                              order7])
-                .pluck('id')
+            expect(json_response[:orders].pluck(:id)).to match_array(expected_order_ids)
           end
 
           it 'can sort orders by bill_address.lastname' do
             get :index, params: { q: { s: 'bill_address_lastname ASC' } },
                         as: :json
-            expect(json_response['orders']
-              .pluck('id')).to eq serialized_orders([order2, order3, order1, order4, order7])
-                .pluck('id')
+
+            expect(json_response[:orders].pluck(:id)).to eq expected_order_ids
           end
         end
       end

--- a/spec/controllers/api/v0/products_controller_spec.rb
+++ b/spec/controllers/api/v0/products_controller_spec.rb
@@ -295,6 +295,6 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
   end
 
   def returned_product_ids
-    json_response['products'].map{ |obj| obj['id'] }
+    json_response['products'].pluck(:id)
   end
 end

--- a/spec/controllers/api/v0/shops_controller_spec.rb
+++ b/spec/controllers/api/v0/shops_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Api::V0::ShopsController, type: :controller do
 
         expect(json_response).not_to match hub.name
 
-        response_ids = json_response.map { |shop| shop['id'] }
+        response_ids = json_response.pluck(:id)
         expect(response_ids).to contain_exactly(closed_hub1.id, closed_hub2.id)
       end
     end

--- a/spec/controllers/api/v0/states_controller_spec.rb
+++ b/spec/controllers/api/v0/states_controller_spec.rb
@@ -17,7 +17,7 @@ module Api
     it "gets all states" do
       api_get :index
       expect(json_response.first.symbolize_keys.keys).to include(*attributes)
-      expect(json_response.map { |state| state[:name] }).to include(state.name)
+      expect(json_response.pluck(:name)).to include(state.name)
     end
 
     context "pagination" do

--- a/spec/controllers/api/v0/taxons_controller_spec.rb
+++ b/spec/controllers/api/v0/taxons_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::V0::TaxonsController do
     it "gets all taxons" do
       api_get :index
 
-      json_names = json_response.map { |taxon_data| taxon_data["name"] }
+      json_names = json_response.pluck(:name)
       expect(json_names).to include(taxon.name, taxon2.name)
     end
 

--- a/spec/helpers/spree/admin/orders_helper_spec.rb
+++ b/spec/helpers/spree/admin/orders_helper_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Spree::Admin::OrdersHelper, type: :helper do
       before { allow(order).to receive(:resumed?) { true } }
 
       it "includes a resend confirmation link" do
-        links = helper.order_links(order).map { |link| link[:name] }
+        links = helper.order_links(order).pluck(:name)
 
         expect(links).to match_array(["Edit Order", "Resend Confirmation"])
       end
@@ -94,7 +94,7 @@ RSpec.describe Spree::Admin::OrdersHelper, type: :helper do
         before { enable_invoices }
 
         it "includes send invoice and print invoice links" do
-          links = helper.order_links(order).map { |link| link[:name] }
+          links = helper.order_links(order).pluck(:name)
 
           expect(links).to match_array(
             ["Edit Order", "Print Invoice", "Resend Confirmation", "Send Invoice"]

--- a/spec/lib/reports/lettuce_share_report_spec.rb
+++ b/spec/lib/reports/lettuce_share_report_spec.rb
@@ -79,9 +79,7 @@ module Reporting
               }
               rows = report.table_rows
               expect(rows.count).to eq 2
-              expect(rows.map{ |row|
-                       row[0]
-                     } ).to include variant.product.name, variant2.product.name
+              expect(rows.pluck(0) ).to include variant.product.name, variant2.product.name
             end
           end
         end

--- a/spec/lib/reports/users_and_enterprises_report_spec.rb
+++ b/spec/lib/reports/users_and_enterprises_report_spec.rb
@@ -82,7 +82,7 @@ module Reporting
               let!(:subject) { Base.new nil, params }
 
               it "excludes enterprises that are not explicitly requested" do
-                results = subject.owners_and_enterprises.to_a.map{ |oae| oae["name"] }
+                results = subject.owners_and_enterprises.to_a.pluck(:name)
                 expect(results).to include enterprise1.name
                 expect(results).not_to include enterprise2.name
               end
@@ -93,7 +93,7 @@ module Reporting
               let!(:subject) { Base.new nil, params }
 
               it "excludes enterprises that are not explicitly requested" do
-                results = subject.owners_and_enterprises.to_a.map{ |oae| oae["name"] }
+                results = subject.owners_and_enterprises.to_a.pluck(:name)
                 expect(results).to include enterprise1.name
                 expect(results).not_to include enterprise2.name
               end
@@ -106,7 +106,7 @@ module Reporting
               let!(:subject) { Base.new nil, params }
 
               it "excludes enterprises that are not explicitly requested" do
-                results = subject.managers_and_enterprises.to_a.map{ |mae| mae["name"] }
+                results = subject.managers_and_enterprises.to_a.pluck(:name)
                 expect(results).to include enterprise1.name
                 expect(results).not_to include enterprise2.name
               end
@@ -124,7 +124,7 @@ module Reporting
               end
 
               it "excludes enterprises whose managers are not explicitly requested" do
-                results = subject.managers_and_enterprises.to_a.map{ |mae| mae["name"] }
+                results = subject.managers_and_enterprises.to_a.pluck(:name)
                 expect(results).to include enterprise1.name
                 expect(results).not_to include enterprise2.name
               end

--- a/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
+++ b/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
     describe "supplied products" do
       it "renders variants regardless of whether they are in the coordinators inventory" do
         expect(serialized_product).to have_json_size(2).at_path 'variants'
-        variant_ids = parse_json(serialized_product)['variants'].pluck(:id)
+        variant_ids = parse_json(serialized_product)['variants'].pluck('id')
         expect(variant_ids).to include non_inventory_variant.id, inventory_variant.id
       end
     end

--- a/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
+++ b/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
     describe "supplied products" do
       it "renders variants regardless of whether they are in the coordinators inventory" do
         expect(serialized_product).to have_json_size(2).at_path 'variants'
-        variant_ids = parse_json(serialized_product)['variants'].map{ |v| v['id'] }
+        variant_ids = parse_json(serialized_product)['variants'].pluck(:id)
         expect(variant_ids).to include non_inventory_variant.id, inventory_variant.id
       end
     end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -15,7 +15,7 @@ module OpenFoodNetwork
     end
 
     def json_response_ids
-      json_response[:data]&.map{ |item| item["id"] }
+      json_response[:data]&.pluck(:id)
     end
 
     def json_error_detail


### PR DESCRIPTION
#### What? Why?

- Closes #12346 
-  This PR fixes the `Rails/Pluck` and `Rails/PluckInWhere` Rubocop errors

#### What should we test?

- Build should be green

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->