### PR TITLE
Fixes Rails/RelativeDateConstant offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -654,12 +654,6 @@ Rails/PluckInWhere:
   Exclude:
     - 'app/models/spree/variant.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/RelativeDateConstant:
-  Exclude:
-    - 'lib/tasks/data/remove_transient_data.rb'
-
 # Offense count: 56
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Include.

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -18,9 +18,9 @@ class RemoveTransientData
   def call
     Rails.logger.info("#{self.class.name}: processing")
 
-    Spree::StateChange.where("created_at < ?", @expiration_date).delete_all
-    Spree::LogEntry.where("created_at < ?", @expiration_date).delete_all
-    Session.where("updated_at < ?", @expiration_date).delete_all
+    Spree::StateChange.where("created_at < ?", expiration_date).delete_all
+    Spree::LogEntry.where("created_at < ?", expiration_date).delete_all
+    Session.where("updated_at < ?", expiration_date).delete_all
 
     clear_old_cart_data!
   end
@@ -29,7 +29,7 @@ class RemoveTransientData
 
   def clear_old_cart_data!
     old_carts = Spree::Order.
-      where("spree_orders.state = 'cart' AND spree_orders.updated_at < ?", @expiration_date).
+      where("spree_orders.state = 'cart' AND spree_orders.updated_at < ?", expiration_date).
       merge(orders_without_payments)
 
     old_cart_line_items = Spree::LineItem.where(order_id: old_carts)

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RemoveTransientData
-  RETENTION_PERIOD = 3.months.ago.to_date
+  RETENTION_PERIOD = 3.months
 
   # This model lets us operate on the sessions DB table using ActiveRecord's
   # methods within the scope of this service. This relies on the AR's
@@ -9,12 +9,18 @@ class RemoveTransientData
   class Session < ApplicationRecord
   end
 
+  attr_reader :expiration_date
+
+  def initialize
+    @expiration_date = RETENTION_PERIOD.ago.to_date
+  end
+
   def call
     Rails.logger.info("#{self.class.name}: processing")
 
-    Spree::StateChange.where("created_at < ?", RETENTION_PERIOD).delete_all
-    Spree::LogEntry.where("created_at < ?", RETENTION_PERIOD).delete_all
-    Session.where("updated_at < ?", RETENTION_PERIOD).delete_all
+    Spree::StateChange.where("created_at < ?", @expiration_date).delete_all
+    Spree::LogEntry.where("created_at < ?", @expiration_date).delete_all
+    Session.where("updated_at < ?", @expiration_date).delete_all
 
     clear_old_cart_data!
   end
@@ -23,7 +29,7 @@ class RemoveTransientData
 
   def clear_old_cart_data!
     old_carts = Spree::Order.
-      where("spree_orders.state = 'cart' AND spree_orders.updated_at < ?", RETENTION_PERIOD).
+      where("spree_orders.state = 'cart' AND spree_orders.updated_at < ?", @expiration_date).
       merge(orders_without_payments)
 
     old_cart_line_items = Spree::LineItem.where(order_id: old_carts)


### PR DESCRIPTION
#### What? Why?

Contributes to #11482 

The: [Rails/RelativeDateConstant Cop](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsrelativedateconstant) checks whether constant value isn’t relative date. Because the relative date will be evaluated only once.

Constant is relative date : Constant.since or Constant.ago.

However here, expiration date should stay the same for the same instance hence, in init.
Spec has been modified accordingly

#### What should we test?
Nothing.
Automatic specs should all pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
