### PR TITLE
[Invoices] Notify if any order cannot be invoiced on bulk invoice printing (update the behavior only when invoice flag enabled )

### DIFF
--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -33,19 +33,9 @@ module Admin
     end
 
     def bulk_invoice(params)
-      visible_orders = editable_orders.invoiceable.where(id: params[:bulk_ids])
+      visible_orders = bulk_load_orders(params)
 
-      if Spree::Config.enterprise_number_required_on_invoices?
-        distributors_without_abn = Enterprise.where(
-          id: visible_orders.select(:distributor_id),
-          abn: nil,
-        )
-
-        if distributors_without_abn.exists?
-          render_business_number_required_error(distributors_without_abn)
-          return
-        end
-      end
+      return if notify_if_abn_related_issue(visible_orders)
 
       cable_ready.append(
         selector: "#orders-index",
@@ -133,6 +123,36 @@ module Admin
       flash[:error] = I18n.t(:must_have_valid_business_number,
                              enterprise_name: distributor_names.join(", "))
       morph_admin_flashes
+    end
+
+    def bulk_load_orders(params)
+      editable_orders.invoiceable.where(id: params[:bulk_ids])
+    end
+
+    def notify_if_abn_related_issue(orders)
+      return false unless abn_required?
+
+      distributors = distributors_without_abn(orders)
+      return false if distributors.empty?
+
+      render_business_number_required_error(distributors)
+      true
+    end
+
+    def abn_required?
+      Spree::Config.enterprise_number_required_on_invoices?
+    end
+
+    def distributors_without_abn(orders)
+      abn = if OpenFoodNetwork::FeatureToggle.enabled?(:invoices)
+              [nil, ""]
+            else
+              [nil]
+            end
+      Enterprise.where(
+        id: orders.select(:distributor_id),
+        abn:,
+      )
     end
   end
 end

--- a/spec/system/admin/orders/bulk_actions_spec.rb
+++ b/spec/system/admin/orders/bulk_actions_spec.rb
@@ -420,7 +420,6 @@ RSpec.describe '
               end
 
               context "with legal invoices feature", feature: :invoices do
-                before { pending("#12373") }
                 it_behaves_like "should not print the invoice"
               end
             end


### PR DESCRIPTION
#### What? Why?

- Closes #12373

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
