### PR TITLE
[BUU] Enable admin_style_v3 for new users from 3/07/2024

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -18,7 +18,14 @@ Flipper.configure do |flipper|
   end
 end
 
-Flipper.register(:admins) { |actor| actor.respond_to?(:admin?) && actor.admin? }
+# Groups
+Flipper.register(:admins) do |actor|
+  actor.respond_to?(:admin?) && actor.admin?
+end
+Flipper.register(:new_2024_07_03) do |actor|
+  actor.respond_to?(:created_at?) && actor.created_at >= "2024-07-03".to_time
+end
+
 Flipper::UI.configure do |config|
   config.descriptions_source = ->(_keys) do
     # return has to be hash of {String key => String description}

--- a/db/migrate/20240625024328_activate_admin_style_v3_for_new_users.rb
+++ b/db/migrate/20240625024328_activate_admin_style_v3_for_new_users.rb
@@ -1,0 +1,5 @@
+class ActivateAdminStyleV3ForNewUsers < ActiveRecord::Migration[7.0]
+  def up
+    Flipper.enable_group(:admin_style_v3, :new_2024_07_03)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_29_081209) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_25_024328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"

--- a/spec/migrations/20240625024328_activate_admin_style_v3_for_new_users_spec.rb
+++ b/spec/migrations/20240625024328_activate_admin_style_v3_for_new_users_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../db/migrate/20240625024328_activate_admin_style_v3_for_new_users'
+
+RSpec.describe ActivateAdminStyleV3ForNewUsers do
+  it "activates new product screen for new users" do
+    Timecop.freeze Time.zone.parse("2024-07-03") do
+      user_new = create(:user)
+
+      expect {
+        subject.up
+      }.to change {
+        OpenFoodNetwork::FeatureToggle.enabled?(:admin_style_v3, user_new)
+      }.to(true)
+    end
+  end
+
+  it "doesn't activate new product screen for old users" do
+    Timecop.freeze Time.zone.parse("2024-07-02") do
+      user_old = create(:user)
+
+      expect {
+        subject.up
+      }.not_to change {
+        OpenFoodNetwork::FeatureToggle.enabled?(:admin_style_v3, user_old)
+      }
+    end
+  end
+end


### PR DESCRIPTION
### What? Why?

- Closes #12282


### What should we test?
This is hard to test on staging, so I have done a dev test.

#### 1. Migration
```
rake db:migrate
```
![Screenshot 2024-06-25 at 1 13 51 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/76194d06-4b5f-4d13-b6fb-89ec84e6b23e)


#### 2. User created before 3rd July:
![Screenshot 2024-06-25 at 1 15 04 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/74fc6719-bb52-48f9-ac73-25d97d030720)

#### 3. User created on 3rd July:
```
u = Spree::User.find 4
u.created_at = Time.zone.parse("2024-07-03")
u.save!
```
![Screenshot 2024-06-25 at 1 15 00 pm](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/846015b4-5436-40d5-ab35-165585780259)

### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


### Dependencies
It's not strictly a dependency, but now that we are phasing the new design in, the test suite should be using the new design asap:

- https://github.com/openfoodfoundation/openfoodnetwork/pull/11645


### Documentation updates
Uh.. yeah everything? 😕 
I think the old screenshots will be ok, but will look dated and it would be good to refresh them sometime.

More importantly, the Bulk Products screen will be different. I could only find one page in the guide for this:
* https://guide.openfoodnetwork.org/basic-features/products-1/product-variants#how-do-i-create-a-product-variant
