### PR TITLE
Fixes Rails/UnknownEnv offense

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -129,6 +129,13 @@ Rails/SkipsModelValidations:
     - update_column
     - update_columns
 
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - production
+    - staging
+    - test
+
 Rails/WhereExists:
   EnforcedStyle: where # Cf. conversion https://github.com/openfoodfoundation/openfoodnetwork/pull/12363
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -694,13 +694,6 @@ Rails/UniqueValidationWithoutIndex:
     - 'app/models/spree/zone.rb'
 
 # Offense count: 1
-# Configuration parameters: Severity, Environments.
-# Environments: development, test, production
-Rails/UnknownEnv:
-  Exclude:
-    - 'app/models/spree/app_configuration.rb'
-
-# Offense count: 1
 Security/Open:
   Exclude:
     - 'app/services/image_importer.rb'


### PR DESCRIPTION
#### What? Why?

- Contributes to #11482 

The [Rails/UnknownEnv Cop](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsunknownenv) checks that environments called with Rails.env predicates exist.
`development`, `test`, and `production` do not raise any issue.
Any other env must be add in the `Environments` config parameter.
In that case, one must add the 3 default.

To put it in another way:
- Rails.env.typo? will always return false and will not return an error.
- The way to check this is to add environments in the `Environments` config parameter (rubocop yml file)
- So the parameter in the rubocop file acts like a check of a possible typo.


#### What should we test?
Nothing.
Automatic specs should all pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
