### PR TITLE
[BUU] Add translation for "Products V3" page title

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4170,6 +4170,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         bulk_order_management: "Bulk Order Management"
         subscriptions: "Subscriptions"
         products: "Products"
+        products_v3: "Products"
         option_types: "Option Types"
         properties: "Properties"
         variant_overrides: "Inventory"


### PR DESCRIPTION
#### What? Why?

- https://openfoodnetwork.slack.com/archives/C01CXQNJ1J6/p1719301514839289


#### What should we test?
In English, the page title shows as "Products" instead of "Products V3"


Or, should it be "Bulk Edit Products"? Hmm, I'll leave that up to locale translators.

![Screenshot 2024-06-26 at 10 00 50 am](https://github.com/openfoodfoundation/openfoodnetwork/assets/4188088/7b5e2625-42ee-43f1-9ac5-f383c78ab2f2)

