### PR TITLE
Keep stock selection when error on saving

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,6 +160,7 @@ Metrics/ClassLength:
     - 'app/services/cart_service.rb'
     - 'app/services/order_cycles/form_service.rb'
     - 'app/services/orders/sync_service.rb'
+    - 'app/services/sets/product_set.rb'
     - 'engines/order_management/app/services/order_management/order/updater.rb'
     - 'lib/open_food_network/enterprise_fee_calculator.rb'
     - 'lib/open_food_network/order_cycle_form_applicator.rb'

--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -67,6 +67,18 @@ module VariantStock
     end
   end
 
+  def on_demand_desired_or_current
+    return on_demand_desired if new_record?
+
+    on_demand
+  end
+
+  def on_hand_desired_or_current
+    return on_hand_desired if new_record?
+
+    on_hand
+  end
+
   # Moving Spree::Stock::Quantifier.can_supply? to the variant enables us
   #   to override this behaviour for variant overrides
   # We can have this responsibility here in the variant because there is

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -11,6 +11,11 @@ module Spree
 
     self.belongs_to_required_by_default = false
 
+    # 2 not to be persisted attributes to store preferences.
+    # Values to be set via the UI that can be passed by back to UI
+    # in a not yet persisted variant. Setters are below.
+    attr_reader :on_hand_desired, :on_demand_desired
+
     acts_as_paranoid
 
     searchable_attributes :sku, :display_as, :display_name, :primary_taxon_id, :supplier_id
@@ -242,6 +247,15 @@ module Spree
         variant_unit: values[0],
         variant_unit_scale: values[1] || nil
       )
+    end
+
+    # aiming to deal with UI that deals with 0/"0"/1/"1"
+    def on_demand_desired=(val)
+      @on_demand_desired = ActiveModel::Type::Boolean.new.cast(val)
+    end
+
+    def on_hand_desired=(val)
+      @on_hand_desired = ActiveModel::Type::Integer.new.cast(val)
     end
 
     private

--- a/app/services/permitted_attributes/variant.rb
+++ b/app/services/permitted_attributes/variant.rb
@@ -4,7 +4,8 @@ module PermittedAttributes
   class Variant
     def self.attributes
       [
-        :id, :sku, :on_hand, :on_demand, :shipping_category_id, :price, :unit_value,
+        :id, :sku, :on_hand, :on_hand_desired, :on_demand, :on_demand_desired,
+        :shipping_category_id, :price, :unit_value,
         :unit_description, :variant_unit, :variant_unit_name, :variant_unit_scale, :display_name,
         :display_as, :tax_category_id, :weight, :height, :width, :depth, :taxon_ids,
         :primary_taxon_id, :supplier_id

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -127,11 +127,11 @@ module Sets
       on_demand = variant_attributes.delete(:on_demand)
 
       variant = product.variants.create(variant_attributes)
+
       return variant if variant.errors.present?
 
       begin
-        variant.on_demand = on_demand if on_demand.present?
-        variant.on_hand = on_hand.to_i if on_hand.present?
+        create_stock_for_variant(variant, on_demand, on_hand)
       rescue StandardError => e
         notify_bugsnag(e, product, variant, variant_attributes)
         raise e
@@ -152,6 +152,13 @@ module Sets
         report.add_metadata(:product_set, :product_error, product.errors.first) if !product.valid?
         report.add_metadata(:product_set, :variant_error, variant.errors.first) if !variant.valid?
       end
+    end
+
+    def create_stock_for_variant(variant, on_demand, on_hand)
+      variant.on_demand = on_demand if on_demand.present?
+      variant.on_demand = variant.on_demand_desired if variant.on_demand_desired.present?
+      variant.on_hand = on_hand.to_i if on_hand.present?
+      variant.on_hand = variant.on_hand_desired.to_i if variant.on_hand_desired.present?
     end
   end
 end

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -131,7 +131,11 @@ module Sets
       return variant if variant.errors.present?
 
       begin
-        create_stock_for_variant(variant, on_demand, on_hand)
+        if on_hand || on_demand
+          create_stock_for_variant(variant, on_demand, on_hand)
+        else
+          create_stock_for_variant_from_desired(variant)
+        end
       rescue StandardError => e
         notify_bugsnag(e, product, variant, variant_attributes)
         raise e
@@ -156,8 +160,11 @@ module Sets
 
     def create_stock_for_variant(variant, on_demand, on_hand)
       variant.on_demand = on_demand if on_demand.present?
-      variant.on_demand = variant.on_demand_desired if variant.on_demand_desired.present?
       variant.on_hand = on_hand.to_i if on_hand.present?
+    end
+
+    def create_stock_for_variant_from_desired(variant)
+      variant.on_demand = variant.on_demand_desired if variant.on_demand_desired.present?
       variant.on_hand = variant.on_hand_desired.to_i if variant.on_hand_desired.present?
     end
   end

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -1,3 +1,4 @@
+- method_on_demand, method_on_hand = variant.new_record? ? [:on_demand_desired, :on_hand_desired ]: [:on_demand, :on_hand]
 %td.col-image
   -# empty
 %td.col-name.field.naked_inputs
@@ -37,14 +38,14 @@
   = error_message_on variant, :price
 %td.col-on_hand.field.popout{'data-controller': "popout"}
   %button.popout__button{'data-popout-target': "button", 'aria-label': t('admin.products_page.columns.on_hand')}
-    = variant.on_demand ? t(:on_demand) : variant.on_hand
+    = variant.send(method_on_demand) ? t(:on_demand) : variant.send(method_on_hand)
   %div.popout__container{ style: 'display: none;', 'data-controller': 'toggle-control', 'data-popout-target': "dialog" }
     .field
-      = f.number_field :on_hand, min: 0, 'aria-label': t('admin.products_page.columns.on_hand'), 'data-toggle-control-target': 'control', disabled: f.object.on_demand
-      = error_message_on variant, :on_hand
+      = f.number_field method_on_hand, min: 0, 'aria-label': t('admin.products_page.columns.on_hand'), 'data-toggle-control-target': 'control', disabled: f.object.send(method_on_demand)
+      = error_message_on variant, method_on_hand
     .field.checkbox
-      = f.label :on_demand do
-        = f.check_box :on_demand, 'data-action': 'change->toggle-control#disableIfPresent change->popout#closeIfChecked'
+      = f.label method_on_demand do
+        = f.check_box method_on_demand, 'data-action': 'change->toggle-control#disableIfPresent change->popout#closeIfChecked'
         = t(:on_demand)
 %td.col-producer.field.naked_inputs
   = render(SearchableDropdownComponent.new(form: f,

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -38,10 +38,10 @@
   = error_message_on variant, :price
 %td.col-on_hand.field.popout{'data-controller': "popout"}
   %button.popout__button{'data-popout-target': "button", 'aria-label': t('admin.products_page.columns.on_hand')}
-    = variant.send(method_on_demand) ? t(:on_demand) : variant.send(method_on_hand)
+    = variant.on_demand_desired_or_current ? t(:on_demand) : variant.on_hand_desired_or_current
   %div.popout__container{ style: 'display: none;', 'data-controller': 'toggle-control', 'data-popout-target': "dialog" }
     .field
-      = f.number_field method_on_hand, min: 0, 'aria-label': t('admin.products_page.columns.on_hand'), 'data-toggle-control-target': 'control', disabled: f.object.send(method_on_demand)
+      = f.number_field method_on_hand, min: 0, 'aria-label': t('admin.products_page.columns.on_hand'), 'data-toggle-control-target': 'control', disabled: f.object.on_demand_desired_or_current
       = error_message_on variant, method_on_hand
     .field.checkbox
       = f.label method_on_demand do

--- a/spec/system/admin/products_v3/create_spec.rb
+++ b/spec/system/admin/products_v3/create_spec.rb
@@ -90,9 +90,9 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
           select taxon.name, from: 'Category'
 
           if stock == "on_hand"
-            find('input[id$="_on_hand"]').fill_in with: "66"
+            find('input[id$="_on_hand_desired"]').fill_in with: "66"
           elsif stock == "on_demand"
-            find('input[id$="_on_demand"]').check
+            find('input[id$="_on_demand_desired"]').check
           end
         end
 

--- a/spec/system/admin/products_v3/update_spec.rb
+++ b/spec/system/admin/products_v3/update_spec.rb
@@ -654,6 +654,45 @@ RSpec.describe 'As an enterprise user, I can update my products' do
       end
     end
 
+    context 'When trying to save an invalid variant with Stock value ' do
+      let(:new_variant_row) { find_field("Name", placeholder: "Apples", with: "").ancestor("tr") }
+
+      before do
+        visit admin_products_url
+        click_on "New variant"
+      end
+
+      it 'displays the correct value afterwards for On Hand' do
+        within new_variant_row do
+          fill_in "Name", with: "Large box"
+          click_on "On Hand"
+          fill_in "On Hand", with: "19"
+        end
+
+        click_button "Save changes"
+
+        expect(page).to have_content "Please review the errors and try again"
+        within row_containing_name("Large box") do
+          expect(page).to have_content "19"
+        end
+      end
+
+      it 'displays the correct value afterwards for On demand' do
+        within new_variant_row do
+          fill_in "Name", with: "Large box"
+          click_on "On Hand"
+          check "On demand"
+        end
+
+        click_button "Save changes"
+
+        expect(page).to have_content "Please review the errors and try again"
+        within row_containing_name("Large box") do
+          expect(page).to have_content "On demand"
+        end
+      end
+    end
+
     context "pagination" do
       let!(:product_a) { create(:simple_product, name: "zucchini") } # appears on p2
 

--- a/spec/system/admin/products_v3/update_spec.rb
+++ b/spec/system/admin/products_v3/update_spec.rb
@@ -667,6 +667,9 @@ RSpec.describe 'As an enterprise user, I can update my products' do
           fill_in "Name", with: "Large box"
           click_on "On Hand"
           fill_in "On Hand", with: "19"
+          tomselect_select("Weight (kg)", from: "Unit scale")
+          click_on "Unit"
+          fill_in "Unit value", with: "1"
         end
 
         click_button "Save changes"
@@ -682,6 +685,9 @@ RSpec.describe 'As an enterprise user, I can update my products' do
           fill_in "Name", with: "Large box"
           click_on "On Hand"
           check "On demand"
+          tomselect_select("Weight (kg)", from: "Unit scale")
+          click_on "Unit"
+          fill_in "Unit value", with: "1"
         end
 
         click_button "Save changes"


### PR DESCRIPTION
#### What? Why?

- Closes #12569 

#### What should we test?
- Feature Admin V3 toggled on
- Visit `/admin/products`
- Add a variant ( + sign) to a product
- Do not fill anything, except the On Hand part
  -  click on checkbox `On demand`
  - or choose a number
- Click `Save changes`
- Page should return in error mode with a `cannot be blank` in the `Unit` column
- But  the status for the `On Hand` part should keep what was entered at first.

#### How I did it
I added 2 not to be persisted attributes aimed at dealing with the UI. Their purpose is to be passed and passed by in case of validation errors from and to the UI.
Therefore, there is no interference with the current fields and logic.

In the view: I added some kind of "mode": when variant exists on DB or not.
So instead of on_hand/on_demand methods passed in form helpers, it will be now either:
- `on_hand` when variant exists (current only case)
- `on_hand_desired` for a new variant

So that, in `variant`, one can get values from the ui whether or not the variant exists or not.
In case validation fails, the value for on_hand/on_demand are stored and are passed by to the ui in the variant object.
If everything fine, then variant is persisted in DB.



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
