### PR TITLE
[Reports] Fix data-disable on Go button

### DIFF
--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -17,7 +17,7 @@
     = render partial: "rendering_options"
 
     #report-go.actions.filter-actions{ data: { controller: "scoped-channel", "scoped-channel-id-value": request.uuid } }
-      = button t(:go), "report__submit-btn", "submit", "data-disable-with": true 
+      = button t(:go), "report__submit-btn", "submit", "data-disable": true 
 
 .report__header.print-hidden
   - if @report.message.present?


### PR DESCRIPTION
#### What? Why?

- It was picked up in testing, see comment : https://github.com/openfoodfoundation/openfoodnetwork/pull/12619#pullrequestreview-2150220285

I use the wrong attributes to disable the button, which explains Konrad seeing true appear on the button, this PR fixes it.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

As an enterprise user
- visit reports tab
- Choose any report, preferably one that you know has the potential to be slow
- Generate a report by clicking "Go"
  -> Notice the button being disabled **\***,  and clicking doesn't do anything 
  -> Notice the button being enabled **\*\*** again

**\***
  - With admin v3 enabled : button becomes grey, and pointer doesn't change
  - With legacy style : the button doesn't change but clicking doesn't do anything

**\*\***
  - With admin v3 enabled : button becomes blue again, and pointer change to a hand
  - With legacy style : the button doesn't change but clicking should load the report again


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

