### PR TITLE
Fix Voucher Code Field Focus Issue

### DIFF
--- a/app/webpacker/controllers/toggle_control_controller.js
+++ b/app/webpacker/controllers/toggle_control_controller.js
@@ -1,5 +1,7 @@
 import { Controller } from "stimulus";
 
+const BUTTON_TYPES = ['submit', 'button'];
+
 // Toggle state of a control based on a condition.
 //
 // 1. When an action occurs on an element,
@@ -57,10 +59,8 @@ export default class extends Controller {
       target.disabled = disable;
     });
 
-    // Focus first when enabled
-    if (!disable) {
-      this.controlTargets[0].focus();
-    }
+    // Focus first when enabled and it's not a button
+    if (!disable) this.#focusFieldControl();
   }
 
   #toggleDisplay(show) {
@@ -69,9 +69,7 @@ export default class extends Controller {
     });
 
     // Focus first when displayed
-    if (show) {
-      this.controlTargets[0].focus();
-    }
+    if (show) this.#focusFieldControl();
   }
 
   // Return input's value, but only if it would be submitted by a form
@@ -80,5 +78,11 @@ export default class extends Controller {
     if (input.type != "checkbox" || input.checked) {
       return input.value;
     }
+  }
+
+  #focusFieldControl() {
+    const control = this.controlTargets[0];
+    const isButton = BUTTON_TYPES.includes(control.type);
+    if(!isButton) control.focus();
   }
 }

--- a/spec/javascripts/stimulus/toggle_control_controller_test.js
+++ b/spec/javascripts/stimulus/toggle_control_controller_test.js
@@ -71,11 +71,12 @@ describe("ToggleControlController", () => {
         </div>`;
       });
 
-      it("Enables when input is filled", () => {
+      it("Enables when input is filled and focuses the control", () => {
         input.value = "a"
         input.dispatchEvent(new Event("input"));
 
         expect(control.disabled).toBe(false);
+        expect(document.activeElement).toBe(control);
       });
 
       it("Disables when input is emptied", () => {
@@ -88,6 +89,37 @@ describe("ToggleControlController", () => {
         expect(control.disabled).toBe(true);
       });
     });
+    describe("with button as control target", () => {
+      beforeEach(() => {
+        document.body.innerHTML = `<div data-controller="toggle-control">
+          <input id="input" value="" data-action="input->toggle-control#enableIfPresent" />
+          <button id="control" data-toggle-control-target="control">
+        </div>`;
+      });
+
+      it("Enables the button control when input is filled, focus remains on input", () => {
+        // Simulating click on input to focus it
+        input.focus();
+        input.value = "test"
+        input.dispatchEvent(new Event("input"));
+
+        expect(control.disabled).toBe(false);
+        expect(document.activeElement).toBe(input);
+      });
+
+      it("Disables the button control when input is emptied, focus remains on input", () => {
+        // Simulating click on input to focus it
+        input.focus();
+        input.value = "test"
+        input.dispatchEvent(new Event("input"));
+
+        input.value = ""
+        input.dispatchEvent(new Event("input"));
+
+        expect(control.disabled).toBe(true);
+        expect(document.activeElement).toBe(input);
+      });
+    })
   });
 
   describe("#displayIfMatch", () => {


### PR DESCRIPTION
#### What? Why?

- Closes #12632
- Currently, we are using the generic `toggle_control_controller` to enable the **Apply** button if the voucher code is present.
- This controller focuses the `control` after performing some toggle action on it i.e. after enabling etc.
- In this case, the control is a `submit` button (**Apply**), and when user enters the voucher code, and after that the controller **_enables_** the **Apply** button and **_focuses_** it. Hence, the focus is lost from the Voucher Code input field.
- I assume the _focus_ functionality was intended for text-related fields, so this PR adds the check such that if the `control` is a button, then it won't be focused. Hence, the currently focused field will remain focused.


#### What should we test?
- On the checkout page, when entering the voucher code, the field should remain focused and let you fill in the entire code without re-clicking it to focus after each character.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
