### PR TITLE
(Fix) Product description not correctly truncated

### DIFF
--- a/app/webpacker/css/darkswarm/_shop-product-rows.scss
+++ b/app/webpacker/css/darkswarm/_shop-product-rows.scss
@@ -144,7 +144,7 @@
           }
 
           .product-description {
-            white-space: nowrap;
+            white-space: normal;
             overflow: hidden;
             text-overflow: ellipsis;
             margin-bottom: 0.75rem;
@@ -156,8 +156,7 @@
             -webkit-box-orient: vertical;
             overflow: hidden; 
             // line-clamp is not supported in Safari
-            line-height: 1rem;
-            height: 1.75rem;
+            line-height: 1.75rem;
 
             > div {
               margin-bottom: 1.5rem; // Equivalent to p (trix doesn't use p as separator by default, so emulate div as p to be backward compatible)


### PR DESCRIPTION
#### What? Why?

- Closes #10685

Set CSS white-space property to normal and unify height and line-height CSS values
#### What should we test?
Test possible combinations of very long product descriptions with and without line breaks to confirm text is properly truncated.
![Screenshot from 2024-07-01 19-16-14](https://github.com/openfoodfoundation/openfoodnetwork/assets/65476715/cc6811e9-4e7c-4ea4-b1f7-c24d2f903527)
![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/65476715/c470860a-e5be-4596-b3c4-2e68b3862957)

#### Expected result
![image](https://github.com/openfoodfoundation/openfoodnetwork/assets/65476715/ee55e220-5a58-44ce-8624-653e63635bb1)

#### Release notes

N/A

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] Technical changes only

#### Dependencies
N/A

#### Documentation updates
N/A