### PR TITLE
Redirect successful user signup request to main home page [OFN-11597]

### DIFF
--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -47,14 +47,8 @@ module Spree
       @user = Spree::User.new(user_params)
 
       if @user.save
-        render cable_ready: cable_car.inner_html(
-          "#signup-feedback",
-          partial("layouts/alert",
-                  locals: {
-                    type: "success",
-                    message: t('devise.user_registrations.spree_user.signed_up_but_unconfirmed')
-                  })
-        )
+        flash[:success] = t('devise.user_registrations.spree_user.signed_up_but_unconfirmed')
+        render cable_ready: cable_car.redirect_to(url: main_app.root_path)
       else
         render status: :unprocessable_entity, cable_ready: cable_car.morph(
           "#signup-tab",


### PR DESCRIPTION
#### What? Why?

- Closes #11597

Redirect successful user signup requests to the main home page



#### What should we test?
1. Register on the website
2. Check the modal closes when clicking on "sign up now" and the user is redirected to the home page
3. The message explaining the confirmation email appears on a home page flash banner
4. Errors messages like non matching passwords, wrong email... should be kept within the modal

- Visit ... page.
path:  /login

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] Technical changes only


#### Dependencies
N/A



#### Documentation updates
N/A
