### PR TITLE
Fixes Rails/SelectMap offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -644,12 +644,6 @@ Rails/RootPathnameMethods:
   Exclude:
     - 'spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/SelectMap:
-  Exclude:
-    - 'app/models/enterprise.rb'
-
 # Offense count: 4
 # Configuration parameters: ForbiddenMethods, AllowedMethods.
 # ForbiddenMethods: decrement!, decrement_counter, increment!, increment_counter, insert, insert!, insert_all, insert_all!, toggle!, touch, touch_all, update_all, update_attribute, update_column, update_columns, update_counters, upsert, upsert_all

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -427,10 +427,9 @@ class Enterprise < ApplicationRecord
     test_permalink = UrlGenerator.to_url(test_permalink)
     test_permalink = "my-enterprise" if test_permalink.blank?
     existing = Enterprise.
-      select(:permalink).
       order(:permalink).
       where("permalink LIKE ?", "#{test_permalink}%").
-      map(&:permalink)
+      pluck(:permalink)
 
     if existing.include?(test_permalink)
       used_indices = existing.map do |p|


### PR DESCRIPTION
#### What? Why?

Contributes to #11482 

The [Rails/SelectMap]( https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsselectmap) hecks for uses of `select(:column_name)` with `map(&:column_name)`. 
These can be replaced with `pluck(:column_name)`.

This is a very small one.

#### What should we test?
Nothing.
Automatic specs should all pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
