### PR TITLE
Use public contact email at the bottom of order confirmation email [OFN-12509]

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -10,4 +10,8 @@ module MailerHelper
       link_to ofn, "https://www.openfoodnetwork.org"
     end
   end
+
+  def order_reply_email(order)
+    order.distributor.email_address.presence || order.distributor.contact.email
+  end
 end

--- a/app/views/spree/order_mailer/_signoff.html.haml
+++ b/app/views/spree/order_mailer/_signoff.html.haml
@@ -10,7 +10,7 @@
   = @order.distributor.phone || ""
   %br
   %a{:href => "mailto:#{@order.distributor.contact.email}", :target => "_blank"}
-    = @order.distributor.contact.email
+    = @order.distributor.email_address.presence ||  @order.distributor.contact.email
   %br
   = @order.distributor.website || ""
   %br

--- a/app/views/spree/order_mailer/_signoff.html.haml
+++ b/app/views/spree/order_mailer/_signoff.html.haml
@@ -9,8 +9,8 @@
   %br
   = @order.distributor.phone || ""
   %br
-  %a{:href => "mailto:#{@order.distributor.contact.email}", :target => "_blank"}
-    = @order.distributor.email_address.presence ||  @order.distributor.contact.email
+  %a{:href => "mailto:#{order_reply_email(@order)}", :target => "_blank"}
+    = order_reply_email(@order)
   %br
   = @order.distributor.website || ""
   %br


### PR DESCRIPTION
#### What? Why?

- Closes #12509

Replace enterprise owner email with enterprise email (when set), in customer order confirmation email sign off.



#### What should we test?

- Visit ... page.
http://localhost:3000/fredo-s-farm-hub/shop#/shop_panel

**1. With public email set in enterprise contact settings**
Add items to the cart and create an order.
Now check that the conformation email is the public email


**2. _Without_ public email set in enterprise contact settings**
Add items to the cart and create an order.
Now check that the conformation email is the enterprise owner email

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes

Use enterprise public contact email at the bottom of order confirmation email 

The title of the pull request will be included in the release notes.


#### Dependencies
N/A



#### Documentation updates
N/A
