### PR TITLE
[BUU] Activate admin_style_v3 for all super admins

### DIFF
--- a/db/migrate/20240710013128_enable_feature_admin_style_v3_for_admins.rb
+++ b/db/migrate/20240710013128_enable_feature_admin_style_v3_for_admins.rb
@@ -1,0 +1,5 @@
+class EnableFeatureAdminStyleV3ForAdmins < ActiveRecord::Migration[7.0]
+  def up
+    Flipper.enable_group(:admin_style_v3, :admins)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_25_024328) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_10_013128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"


### PR DESCRIPTION
⚠ _Please use clockify code **#7198 Back Office Uplift (Product)** while reviewing or working on this task._

#### What? Why?

- Closes #12651 

#### What should we test?
As on issue:
> 1. Before staging he PR check super admins dont' see the new admin by default
> 2. After staging the PR, check all super admins see it, they can remove the "admin" group but then no super admin can see the new UI unless there are in another group who has access
> 3. Check this does not affect other users


