### PR TITLE
[BUU] Re-Organize products_v3 Feature specs

### DIFF
--- a/spec/system/admin/products_v3/actions_spec.rb
+++ b/spec/system/admin/products_v3/actions_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
     end
   end
 
-  describe "actions" do
+  describe "actions menu" do
     describe "edit" do
       let!(:variant_a1) {
         create(:variant,
@@ -561,121 +561,5 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
       expect(page).to have_content "Changes saved"
       expect(page).to have_selector row_containing_name("Pommes")
     end
-  end
-
-  describe "creating a new product" do
-    let!(:stock_location) { create(:stock_location, backorderable_default: false) }
-    let!(:supplier) { create(:supplier_enterprise) }
-    let!(:distributor) { create(:distributor_enterprise) }
-    let!(:shipping_category) { create(:shipping_category) }
-    let!(:taxon) { create(:taxon) }
-
-    before do
-      login_as_admin
-      visit spree.admin_products_path
-    end
-
-    it "creating a new product" do
-      find("a", text: "New Product").click
-      expect(page).to have_content "New Product"
-      fill_in 'product_name', with: 'Big Bag Of Apples'
-      tomselect_select supplier.name, from: 'product[supplier_id]'
-      select_tom_select 'Weight (g)', from: 'product_variant_unit_field'
-      fill_in 'product_unit_value', with: '100'
-      fill_in 'product_price', with: '10.00'
-      # TODO dropdowns below are still using select2:
-      select taxon.name, from: 'product_primary_taxon_id' # ...instead of tom-select
-      select shipping_category.name, from: 'product_shipping_category_id' # ...instead of tom-select
-      click_button 'Create'
-      expect(URI.parse(current_url).path).to eq spree.admin_products_path
-      expect(flash_message).to eq 'Product "Big Bag Of Apples" has been successfully created!'
-      expect(page).to have_field "_products_0_name", with: 'Big Bag Of Apples'
-    end
-  end
-
-  context "creating new variants" do
-    let!(:product) { create(:product, variant_unit: 'weight', variant_unit_scale: 1000) }
-
-    before do
-      login_as_admin
-      visit spree.admin_products_path
-    end
-
-    it "hovering over the New variant button displays the text" do
-      page.find('button[aria-label="New variant"]', text: "New variant", visible: false)
-      find("button.secondary.condensed.naked.icon-plus").hover
-      page.find('button[aria-label="New variant"]', text: "New variant", visible: true)
-      expect(page).to have_content "New variant"
-    end
-
-    shared_examples "creating a new variant (bulk)" do |stock|
-      it "handles the #{stock} behaviour" do
-        # the product and the default variant is displayed
-        expect(page).to have_selector("input[aria-label=Name][value='#{product.name}']",
-                                      visible: true, count: 1)
-        expect(page).to have_selector("input[aria-label=Name][placeholder='#{product.name}']",
-                                      visible: false, count: 1)
-
-        # when a second variant is added, the number of lines increases
-        expect {
-          find("button.secondary.condensed.naked.icon-plus").click
-        }.to change{
-          page.all("input[aria-label=Name][placeholder='#{product.name}']", visible: false).count
-        }.from(1).to(2)
-
-        # When I fill out variant details and hit update
-        within page.all("tr.condensed")[1] do # selects second variant row
-          find('input[id$="_sku"]').fill_in with: "345"
-          find('input[id$="_display_name"]').fill_in with: "Small bag"
-          find('button[id$="unit_to_display"]').click # opens the unit value pop out
-          find('input[id$="_unit_value_with_description"]').fill_in with: "0.002"
-          find('input[id$="_display_as"]').fill_in with: "2 grams"
-          find('button[aria-label="On Hand"]').click
-          find('input[id$="_price"]').fill_in with: "11.1"
-          if stock == "on_hand"
-            find('input[id$="_on_hand"]').fill_in with: "66"
-          elsif stock == "on_demand"
-            find('input[id$="_on_demand"]').check
-          end
-        end
-
-        expect(page).to have_content "1 product modified."
-
-        expect {
-          click_on "Save changes"
-          expect(page).to have_content "Changes saved"
-        }.to change {
-               Spree::Variant.count
-             }.from(1).to(2)
-
-        click_on "Dismiss"
-        expect(page).not_to have_content "Changes saved"
-
-        new_variant = Spree::Variant.where(deleted_at: nil).last
-        expect(new_variant.sku).to eq "345"
-        expect(new_variant.display_name).to eq "Small bag"
-        expect(new_variant.unit_value).to eq 2.0
-        expect(new_variant.display_as).to eq "2 grams"
-        expect(new_variant.unit_presentation).to eq "2 grams"
-        expect(new_variant.price).to eq 11.1
-        if stock == "on_hand"
-          expect(new_variant.on_hand).to eq 66
-        elsif stock == "on_demand"
-          expect(new_variant.on_demand).to eq true
-        end
-
-        within page.all("tr.condensed")[1] do # selects second variant row
-          page.find('input[id$="_sku"]').fill_in with: "789"
-        end
-
-        accept_confirm do
-          click_on "Discard changes" # does not save chages
-        end
-        expect(page).not_to have_content "Changes saved"
-      end
-    end
-
-    it_behaves_like "creating a new variant (bulk)", "on_hand"
-    it_behaves_like "creating a new variant (bulk)", "on_demand"
   end
 end

--- a/spec/system/admin/products_v3/create_spec.rb
+++ b/spec/system/admin/products_v3/create_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+RSpec.describe 'As an enterprise user, I can manage my products', feature: :admin_style_v3 do
+  include AuthenticationHelper
+  include WebHelper
+
+  describe "creating a new product" do
+    let!(:stock_location) { create(:stock_location, backorderable_default: false) }
+    let!(:supplier) { create(:supplier_enterprise) }
+    let!(:distributor) { create(:distributor_enterprise) }
+    let!(:shipping_category) { create(:shipping_category) }
+    let!(:taxon) { create(:taxon) }
+
+    before { visit_products_page_as_admin }
+
+    it "creating a new product" do
+      find("a", text: "New Product").click
+      expect(page).to have_content "New Product"
+      fill_in 'product_name', with: 'Big Bag Of Apples'
+      tomselect_select supplier.name, from: 'product[supplier_id]'
+      select_tom_select 'Weight (g)', from: 'product_variant_unit_field'
+      fill_in 'product_unit_value', with: '100'
+      fill_in 'product_price', with: '10.00'
+      # TODO dropdowns below are still using select2:
+      select taxon.name, from: 'product_primary_taxon_id' # ...instead of tom-select
+      select shipping_category.name, from: 'product_shipping_category_id' # ...instead of tom-select
+      click_button 'Create'
+      expect(URI.parse(current_url).path).to eq spree.admin_products_path
+      expect(flash_message).to eq 'Product "Big Bag Of Apples" has been successfully created!'
+      expect(page).to have_field "_products_0_name", with: 'Big Bag Of Apples'
+    end
+  end
+
+  describe "creating new variants" do
+    let!(:product) { create(:product, variant_unit: 'weight', variant_unit_scale: 1000) }
+
+    before { visit_products_page_as_admin }
+
+    it "hovering over the New variant button displays the text" do
+      page.find('button[aria-label="New variant"]', text: "New variant", visible: false)
+      find("button.secondary.condensed.naked.icon-plus").hover
+      page.find('button[aria-label="New variant"]', text: "New variant", visible: true)
+      expect(page).to have_content "New variant"
+    end
+
+    shared_examples "creating a new variant (bulk)" do |stock|
+      it "handles the #{stock} behaviour" do
+        # the product and the default variant is displayed
+        expect(page).to have_selector("input[aria-label=Name][value='#{product.name}']",
+                                      visible: true, count: 1)
+        expect(page).to have_selector("input[aria-label=Name][placeholder='#{product.name}']",
+                                      visible: false, count: 1)
+
+        # when a second variant is added, the number of lines increases
+        expect {
+          find("button.secondary.condensed.naked.icon-plus").click
+        }.to change{
+          page.all("input[aria-label=Name][placeholder='#{product.name}']", visible: false).count
+        }.from(1).to(2)
+
+        # When I fill out variant details and hit update
+        within page.all("tr.condensed")[1] do # selects second variant row
+          find('input[id$="_sku"]').fill_in with: "345"
+          find('input[id$="_display_name"]').fill_in with: "Small bag"
+          find('button[id$="unit_to_display"]').click # opens the unit value pop out
+          find('input[id$="_unit_value_with_description"]').fill_in with: "0.002"
+          find('input[id$="_display_as"]').fill_in with: "2 grams"
+          find('button[aria-label="On Hand"]').click
+          find('input[id$="_price"]').fill_in with: "11.1"
+          if stock == "on_hand"
+            find('input[id$="_on_hand"]').fill_in with: "66"
+          elsif stock == "on_demand"
+            find('input[id$="_on_demand"]').check
+          end
+        end
+
+        expect(page).to have_content "1 product modified."
+
+        expect {
+          click_on "Save changes"
+          expect(page).to have_content "Changes saved"
+        }.to change {
+               Spree::Variant.count
+             }.from(1).to(2)
+
+        click_on "Dismiss"
+        expect(page).not_to have_content "Changes saved"
+
+        new_variant = Spree::Variant.where(deleted_at: nil).last
+        expect(new_variant.sku).to eq "345"
+        expect(new_variant.display_name).to eq "Small bag"
+        expect(new_variant.unit_value).to eq 2.0
+        expect(new_variant.display_as).to eq "2 grams"
+        expect(new_variant.unit_presentation).to eq "2 grams"
+        expect(new_variant.price).to eq 11.1
+        if stock == "on_hand"
+          expect(new_variant.on_hand).to eq 66
+        elsif stock == "on_demand"
+          expect(new_variant.on_demand).to eq true
+        end
+
+        within page.all("tr.condensed")[1] do # selects second variant row
+          page.find('input[id$="_sku"]').fill_in with: "789"
+        end
+
+        accept_confirm do
+          click_on "Discard changes" # does not save chages
+        end
+        expect(page).not_to have_content "Changes saved"
+      end
+    end
+
+    it_behaves_like "creating a new variant (bulk)", "on_hand"
+    it_behaves_like "creating a new variant (bulk)", "on_demand"
+  end
+
+  def visit_products_page_as_admin
+    login_as_admin
+    visit spree.admin_products_path
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Closes #12497
- As the products_v3 specs are getting bigger, so this PR modularizes the existing file a bit more as per the suggestion in the issue.
- Thanks to @filipefurtad0, most of the work was already done in https://github.com/openfoodfoundation/openfoodnetwork/pull/12595. I think we just needed to separate the `create_spec` from the `products_spec` and rename it to `actions_spec`
- Please let me know if I'm missing something. Thanks

#### What should we test?
- Build should be green

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled
