### PR TITLE
Replace product by variant to see producer name on views

### DIFF
--- a/app/views/admin/variant_overrides/_hidden_products.html.haml
+++ b/app/views/admin/variant_overrides/_hidden_products.html.haml
@@ -12,7 +12,7 @@
         %th.add=t('admin.variant_overrides.index.add')
     %tbody{ "ng-repeat": 'product in filteredProducts | limitTo:productLimit' }
       %tr{ id: "v_{{variant.id}}", "ng-repeat": 'variant in product.variants | inventoryVariants:hub_id:views' }
-        %td.producer{ "ng-bind": '::producersByID[product.producer_id].name' }
+        %td.producer{ "ng-bind": '::producersByID[variant.producer_id].name' }
         %td.product{ "ng-bind": '::product.name' }
         %td.variant
           %span{ "ng-bind": '::variant.display_name || ""' }

--- a/app/views/admin/variant_overrides/_new_products.html.haml
+++ b/app/views/admin/variant_overrides/_new_products.html.haml
@@ -13,7 +13,7 @@
       %th.hide=t('admin.variant_overrides.index.hide')
   %tbody{ "ng-repeat": 'product in filteredProducts | limitTo:productLimit' }
     %tr{ id: "v_{{variant.id}}", "ng-repeat": 'variant in product.variants | inventoryVariants:hub_id:views' }
-      %td.producer{ "ng-bind-html": '::producersByID[product.producer_id].name' }
+      %td.producer{ "ng-bind-html": '::producersByID[variant.producer_id].name' }
       %td.product{ "ng-bind": '::product.name' }
       %td.variant
         %span{ "ng-bind": '::variant.display_name || ""' }

--- a/spec/system/admin/variant_overrides_spec.rb
+++ b/spec/system/admin/variant_overrides_spec.rb
@@ -547,6 +547,7 @@ RSpec.describe "
       visit admin_inventory_path
 
       expect(page).to have_text first_variant.name
+      expect(page).to have_text first_variant.supplier.name
       expect(page).to have_selector "tr.product", count: 10
       expect(page).to have_button "Show more"
       expect(page).to have_button "Show all (91  More)"


### PR DESCRIPTION
#### What? Why?

- Closes #12642 

Bug related to the various changes made in the product/variant models & their relationships.


#### What should we test?
Cf. #12642  for use case

- log in as admin/ shop user
- navigate to `/admin/inventory`
- select a shop and make sure not all of the shop products are already in inventory
- click `review now` button
- one should see the `producer` column filled with enterprise names
  - new/hidden /inventory products 



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
