### PR TITLE
Fixes Rails/RootPathnameMethods offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -638,12 +638,6 @@ Rails/ResponseParsedBody:
     - 'spec/controllers/spree/credit_cards_controller_spec.rb'
     - 'spec/controllers/user_registrations_controller_spec.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/RootPathnameMethods:
-  Exclude:
-    - 'spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb'
-
 # Offense count: 7
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Reporting::Reports::OrdersAndFulfillment::OrderCycleCustomerTotal
       end
     end
     let(:comparison_report) do
-      File.read(Rails.root.join(report_file_name))
+      Rails.root.join(report_file_name).read
     end
     let(:report_file_name) do
       "spec/fixtures/reports/orders_and_fulfillment/order_cycle_customer_totals_report.csv"


### PR DESCRIPTION
#### What? Why?

Contributes to #11482 

The [Rails/RootPathnameMethods]( https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsrootpathnamemethods) 
states:
`Use Rails.root IO methods instead of passing it to File.`

This is a tiny one.


#### What should we test?
Nothing.
Automatic specs should all pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
