### PR TITLE
Simply change COPY OF to [CLONE] in Bulk Product Cloning [admin_style_v3]

### DIFF
--- a/lib/spree/core/product_duplicator.rb
+++ b/lib/spree/core/product_duplicator.rb
@@ -19,7 +19,7 @@ module Spree
 
       def duplicate_product
         product.dup.tap do |new_product|
-          new_product.name = "COPY OF #{product.name}"
+          new_product.name = "#{product.name} [CLONE]"
           new_product.sku = ""
           new_product.created_at = nil
           new_product.deleted_at = nil

--- a/spec/controllers/api/v0/products_controller_spec.rb
+++ b/spec/controllers/api/v0/products_controller_spec.rb
@@ -173,14 +173,14 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
       it 'clones the product' do
         spree_post :clone, product_id: product.id, format: :json
 
-        expect(json_response['name']).to eq("COPY OF #{product.name}")
+        expect(json_response['name']).to eq("#{product.name} [CLONE]")
       end
 
       it 'clones a product with image' do
         spree_post :clone, product_id: product_with_image.id, format: :json
 
         expect(response.status).to eq(201)
-        expect(json_response['name']).to eq("COPY OF #{product_with_image.name}")
+        expect(json_response['name']).to eq("#{product_with_image.name} [CLONE]")
       end
 
       # test cases related to bug #660: product duplication clones master variant
@@ -213,14 +213,14 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
       it 'clones the product' do
         spree_post :clone, product_id: product.id, format: :json
 
-        expect(json_response['name']).to eq("COPY OF #{product.name}")
+        expect(json_response['name']).to eq("#{product.name} [CLONE]")
       end
 
       it 'clones a product with image' do
         spree_post :clone, product_id: product_with_image.id, format: :json
 
         expect(response.status).to eq(201)
-        expect(json_response['name']).to eq("COPY OF #{product_with_image.name}")
+        expect(json_response['name']).to eq("#{product_with_image.name} [CLONE]")
       end
     end
   end

--- a/spec/lib/spree/core/product_duplicator_spec.rb
+++ b/spec/lib/spree/core/product_duplicator_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Spree::Core::ProductDuplicator do
 
   it "can duplicate a product" do
     duplicator = Spree::Core::ProductDuplicator.new(product)
-    expect(new_product).to receive(:name=).with("COPY OF foo")
+    expect(new_product).to receive(:name=).with("foo [CLONE]")
     expect(new_product).to receive(:sku=).with("")
     expect(new_product).to receive(:product_properties=).with([new_property])
     expect(new_product).to receive(:created_at=).with(nil)

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -11,7 +11,7 @@ module Spree
       context '#duplicate' do
         it 'duplicates product' do
           clone = product.duplicate
-          expect(clone.name).to eq 'COPY OF ' + product.name
+          expect(clone.name).to eq product.name + ' [CLONE]'
           expect(clone.sku).to eq ""
           expect(clone.image).to eq product.image
         end

--- a/spec/services/order_cycles/clone_service_spec.rb
+++ b/spec/services/order_cycles/clone_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OrderCycles::CloneService do
       ex2 = create(:exchange, order_cycle: oc)
 
       occ = OrderCycles::CloneService.new(oc).create
-      expect(occ.name).to eq("COPY OF #{oc.name}")
+      expect(occ.name).to eq("#{oc.name} [CLONE]")
       expect(occ.orders_open_at).to be_nil
       expect(occ.orders_close_at).to be_nil
       expect(occ.coordinator).not_to be_nil

--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe '
 
     expect(page).to have_selector "a.clone-product", count: 1
     find("a.clone-product").click
-    expect(page).to have_field "product_name", with: "COPY OF #{p.name}"
+    expect(page).to have_field "product_name", with: "#{p.name} [CLONE]"
 
     within "#p_#{p.id}" do
       fill_in "product_name", with: "new product name"
@@ -679,13 +679,13 @@ RSpec.describe '
           find("a.clone-product").click
         end
         expect(page).to have_selector "a.clone-product", count: 4
-        expect(page).to have_field "product_name", with: "COPY OF #{p1.name}"
+        expect(page).to have_field "product_name", with: "#{p1.name} [CLONE]"
         expect(page).to have_select "producer_id", selected: p1.supplier.name.to_s
 
         visit spree.admin_products_path
 
         expect(page).to have_selector "a.clone-product", count: 4
-        expect(page).to have_field "product_name", with: "COPY OF #{p1.name}"
+        expect(page).to have_field "product_name", with: "#{p1.name} [CLONE]"
         expect(page).to have_select "producer_id", selected: p1.supplier.name.to_s
       end
     end

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -325,13 +325,13 @@ RSpec.describe '
         visit spree.admin_products_path
       end
 
-      it 'creates a copy of the product' do
+      it 'creates a clone of the product' do
         within "#p_#{product1.id}" do
           page.find("[data-powertip=Clone]").click
         end
         visit current_path
         within "#p_#{product1.id + 1}" do
-          expect(page).to have_input "product_name", with: 'COPY OF a weight product'
+          expect(page).to have_input "product_name", with: 'a weight product [CLONE]'
         end
       end
     end

--- a/spec/system/admin/products_v3/products_spec.rb
+++ b/spec/system/admin/products_v3/products_spec.rb
@@ -1031,7 +1031,7 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
             input_content = page.find_all('input[type=text]').map(&:value).join
 
             # Products does not include the cloned product.
-            expect(input_content).not_to match /COPY OF Apples/
+            expect(input_content).not_to match /Apples [CLONE]/
           end
 
           within row_containing_name("Apples") do
@@ -1046,7 +1046,7 @@ RSpec.describe 'As an enterprise user, I can manage my products', feature: :admi
             input_content = page.find_all('input[type=text]').map(&:value).join
 
             # Products include the cloned product.
-            expect(input_content).to match /COPY OF Apples/
+            expect(input_content).to match /Apples [CLONE]/
           end
         end
       end


### PR DESCRIPTION
#### What? Why?

- Closes ##12623

I propose a simple solution for this issue: change new_product.name = "COPY OF #{product.name}" to new_product.name = "#{product.name} [CLONE]" and update all corresponding references in tests and comments. This new naming convention better aligns with the action name (Clone). 

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
