### PR TITLE
Do not check missing ship/pay methods on turbo request

### DIFF
--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -82,6 +82,9 @@ module Spree
       private
 
       def html_request?
+        return false if request.format.symbol == :turbo_stream ||
+                        request.format.to_s.include?("turbo")
+
         request.format.html?
       end
 


### PR DESCRIPTION
#### What? Why?

- Contributes to #12596


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Not finalized yet, but this first version should stop displaying twice a dismiss box checking the absence of shipment/payment methods when reproducing the steps to reproduce from issue #12596.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [X] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
