### PR TITLE
Fix URL State management on the Products page

### DIFF
--- a/app/views/admin/products_v3/_filters.html.haml
+++ b/app/views/admin/products_v3/_filters.html.haml
@@ -1,6 +1,6 @@
 = form_with url: admin_products_path, id: "filters", method: :get, data: { "search-target": "form", 'turbo-frame': "_self", 'turbo-action': "advance" } do
   = hidden_field_tag :page, nil, class: "page"
-  = hidden_field_tag :per_page, nil, class: "per-page"
+  = hidden_field_tag :per_page, params[:per_page], class: "per-page"
   = hidden_field_tag '[q][s]', params.dig(:q, :s) || 'name asc', class: 'sort', 'data-default': 'name asc'
 
   .query

--- a/app/views/admin/products_v3/_filters.html.haml
+++ b/app/views/admin/products_v3/_filters.html.haml
@@ -1,4 +1,4 @@
-= form_with url: admin_products_path, id: "filters", method: :get, data: { "search-target": "form", 'turbo-frame': "_self" } do
+= form_with url: admin_products_path, id: "filters", method: :get, data: { "search-target": "form", 'turbo-frame': "_self", 'turbo-action': "advance" } do
   = hidden_field_tag :page, nil, class: "page"
   = hidden_field_tag :per_page, nil, class: "per-page"
   = hidden_field_tag '[q][s]', params.dig(:q, :s) || 'name asc', class: 'sort', 'data-default': 'name asc'

--- a/app/views/admin/products_v3/_sort.html.haml
+++ b/app/views/admin/products_v3/_sort.html.haml
@@ -4,7 +4,7 @@
       = t(".pagination.total_html", total: pagy.count, from: pagy.from, to: pagy.to)
 
     - if search_term.present? || producer_id.present? || category_id.present?
-      %a{ href: url_for(page: 1), class: "button disruptive", 'data-turbo-frame': "_self" }
+      %a{ href: url_for(page: 1), class: "button disruptive", data: { 'turbo-frame': "_self", 'turbo-action': "advance" } }
         = t(".pagination.clear_search")
 
   %form.with-dropdown

--- a/app/views/spree/admin/shared/_head.html.haml
+++ b/app/views/spree/admin/shared/_head.html.haml
@@ -1,4 +1,5 @@
 %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}
+%meta{ name: "turbo-cache-control", content: "no-cache" }
 
 = csrf_meta_tags
 = action_cable_meta_tag


### PR DESCRIPTION
#### What? Why?

- Closes #11640
- Turbo was enabled for the affected form submissions, which by default does not update the URL upon submission.
- This PR adds the `data-turbo-action = advance` to the affected form submissions such that the default form submission behavior is not affected as well as turbo remains intact.
- Moreover, it fixes the scenario as explained in [this comment ](https://github.com/openfoodfoundation/openfoodnetwork/issues/11640#issuecomment-2227527531)as well.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Please validate the expected behavior as given in the issue.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled