### PR TITLE
[inventory] Fix product sorting

### DIFF
--- a/app/queries/product_scope_query.rb
+++ b/app/queries/product_scope_query.rb
@@ -41,6 +41,7 @@ class ProductScopeQuery
       merge(product_scope).
       includes(variants: [:product, :default_price, :stock_items, :supplier]).
       where(variants: { supplier_id: producer_ids }).
+      order("enterprises.name, spree_products.name").
       ransack(@params[:q]).result(distinct: true)
   end
 


### PR DESCRIPTION
#### What? Why?

- Closes #12670 

The product sorting in the inventory got broken after the product refactor, where the supplier got moved to the variant, this PR re add the sorting. Product are now sorted by producer alphabetically and product alphabetically.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

* Go to Inventory
* Observe that products are displayed in alphabetical order by producer
* Observe that products are displayed in alphabetical order by product within the same producer

This may help with https://github.com/openfoodfoundation/openfoodnetwork/issues/12679, but it might be easiest to wait and test the replication case given in production.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
