### PR TITLE
Output debugging info to log

### DIFF
--- a/app/constraints/feature_toggle_constraint.rb
+++ b/app/constraints/feature_toggle_constraint.rb
@@ -13,7 +13,10 @@ class FeatureToggleConstraint
   end
 
   def enabled?(request)
-    OpenFoodNetwork::FeatureToggle.enabled?(@feature, current_user(request))
+    user = current_user(request)
+    enabled = OpenFoodNetwork::FeatureToggle.enabled?(@feature, user)
+    Rails.logger.info "FeatureToggleConstraint #{@feature} enabled: #{enabled.to_s}; for user: #{user&.id.to_s}; path: #{request.path}"
+    enabled
   end
 
   def current_user(request)


### PR DESCRIPTION
> I’ve noticed that sometimes (on au_staging) when I view the bulk products screen at `/admin/products`, I get the old screen. When I reloaded the page, I got the new one. Weird, something caching somewhere.  

- https://openfoodnetwork.slack.com/archives/C01CXQNJ1J6/p1721175709114389

Trying to debug why it's happening...


#### What? Why?

- Closes # <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
