### PR TITLE
Activates admin_style_v3 for 25 per cent users

### DIFF
--- a/db/migrate/20240718150852_activate_admin_style_v3_for_25_p_cent_users.rb
+++ b/db/migrate/20240718150852_activate_admin_style_v3_for_25_p_cent_users.rb
@@ -1,0 +1,5 @@
+class ActivateAdminStyleV3For25PCentUsers < ActiveRecord::Migration[7.0]
+  def up
+    Flipper.enable_percentage_of_actors(:admin_style_v3, 25)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_15_103415) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_18_150852) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"


### PR DESCRIPTION
#### What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/12658

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Under `/admin/feature-toggle/features/admin_style_v3`:

First, enable the feature for:
- a specific user
- a specific group (like `admins`)

Before the PR, the percentage should in principle be 0%; if not, note which percentage is enabled for the staging server:
![image](https://github.com/user-attachments/assets/53bfa663-a8a5-445a-971a-b6e89e77d8bf)

After the PR, the percentage should go up to 25% - it should overwrite any previously set percentage:
![image](https://github.com/user-attachments/assets/c625199e-c919-44a8-9339-749261057f9f)

It should not change the enabled user and group.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
