### PR TITLE
Enables Simple Coverage reports (considering Knapsack splitting)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,6 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-
   models:
     runs-on: ubuntu-22.04
     services:
@@ -154,6 +153,14 @@ jobs:
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/models/**/*_spec.rb}" 
         run: |
           bin/rake knapsack_pro:rspec
+
+      - name: Save SimpleCov file
+        uses: actions/upload-artifact@v3
+        with:
+          name: simple-cov-output-files
+          path: coverage/*.*
+          retention-days: 7
+          if-no-files-found: ignore
 
   system_admin:
     runs-on: ubuntu-22.04
@@ -233,6 +240,14 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      - name: Save SimpleCov file
+        uses: actions/upload-artifact@v3
+        with:
+          name: simple-cov-output-files
+          path: coverage/*.*
+          retention-days: 7
+          if-no-files-found: ignore
+
   system_consumer:
     runs-on: ubuntu-22.04
     services:
@@ -308,6 +323,14 @@ jobs:
         with:
           name: failed-tests-screenshots
           path: tmp/capybara/screenshots/*.png
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Save SimpleCov file
+        uses: actions/upload-artifact@v3
+        with:
+          name: simple-cov-output-files
+          path: coverage/*.*
           retention-days: 7
           if-no-files-found: ignore
 
@@ -390,6 +413,14 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      - name: Save SimpleCov file
+        uses: actions/upload-artifact@v3
+        with:
+          name: simple-cov-output-files
+          path: coverage/*.*
+          retention-days: 7
+          if-no-files-found: ignore
+
   test_the_rest:
     runs-on: ubuntu-22.04
     services:
@@ -458,6 +489,14 @@ jobs:
         run: |
           bin/rake knapsack_pro:rspec
 
+      - name: Save SimpleCov file
+        uses: actions/upload-artifact@v3
+        with:
+          name: simple-cov-output-files
+          path: coverage/*.*
+          retention-days: 7
+          if-no-files-found: ignore
+
   non_knapsack_jest_karma:
     runs-on: ubuntu-22.04
     services:
@@ -495,3 +534,11 @@ jobs:
 
       - name: Run jest tests
         run: yarn jest
+
+      - name: Save SimpleCov file
+        uses: actions/upload-artifact@v3
+        with:
+          name: simple-cov-output-files
+          path: coverage/*.*
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
+
     strategy:
       fail-fast: false
       matrix:
@@ -85,6 +86,15 @@ jobs:
         run: |
           git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
           bin/rake knapsack_pro:rspec
+
+      - name: Save SimpleCov file
+        uses: actions/upload-artifact@v3
+        with:
+          name: simple-cov-output-files
+          path: coverage/*.*
+          retention-days: 7
+          if-no-files-found: ignore
+
 
   models:
     runs-on: ubuntu-22.04

--- a/.simplecov
+++ b/.simplecov
@@ -1,17 +1,5 @@
 #!/bin/env ruby
 
 SimpleCov.start 'rails' do
-  add_filter '/bin/'
-  add_filter '/config/'
-  add_filter '/jobs/application_job.rb'
-  add_filter '/schemas/'
-  add_filter '/lib/generators'
-  add_filter '/spec/'
-  add_filter '/vendor/'
-  add_filter '/public'
-  add_filter '/swagger'
-  add_filter '/script'
-  add_filter '/log'
   add_filter '/db'
-  add_filter '/lib/tasks/sample_data/'
 end

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -2,9 +2,11 @@
 
 # This file defines configurations that are universal to all spec types (feature, system, etc)
 
+require 'simplecov' # if ENV["COVERAGE"]
+SimpleCov.start
+
 ENV["RAILS_ENV"] ||= 'test'
 
-require 'simplecov' if ENV["COVERAGE"]
 require 'rubygems'
 require 'pry' unless ENV['CI']
 require 'view_component/test_helpers'
@@ -26,6 +28,10 @@ end
 
 require 'knapsack_pro'
 KnapsackPro::Adapters::RSpecAdapter.bind
+
+KnapsackPro::Hooks::Queue.before_queue do
+  SimpleCov.command_name("rspec_ci_node_#{KnapsackPro::Config::Env.ci_node_index}")
+end
 
 # Allow connections to selenium whilst raising errors when connecting to external sites
 require 'webmock/rspec'


### PR DESCRIPTION
...generated by parallel CI nodes, according to documentation here: https://docs.knapsackpro.com/ruby/simplecov/

#### What? Why?

- Closes Closes [#11948](https://github.com/openfoodfoundation/openfoodnetwork/issues/11948).

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
