### PR TITLE
Revert product description truncation fix  

### DIFF
--- a/app/webpacker/css/darkswarm/_shop-product-rows.scss
+++ b/app/webpacker/css/darkswarm/_shop-product-rows.scss
@@ -144,7 +144,7 @@
           }
 
           .product-description {
-            white-space: normal;
+            white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
             margin-bottom: 0.75rem;
@@ -156,7 +156,9 @@
             -webkit-box-orient: vertical;
             overflow: hidden; 
             // line-clamp is not supported in Safari
-            line-height: 1.75rem;
+            // Trick to get overflow: hidden to work in old Safari
+            line-height: 1rem;
+            height: 1.75rem;
 
             > div {
               margin-bottom: 1.5rem; // Equivalent to p (trix doesn't use p as separator by default, so emulate div as p to be backward compatible)


### PR DESCRIPTION
#### What? Why?

- Closes #12692
- Re-opens https://github.com/openfoodfoundation/openfoodnetwork/issues/10685

Product description is displaying wrong on safari Iphone, reverting https://github.com/openfoodfoundation/openfoodnetwork/pull/12635 as a quick fix
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
* Check product description displays properly on safari. (See examples from iPhone 12-14 on above issue)
* See https://github.com/openfoodfoundation/openfoodnetwork/issues/10685 for example of problematic description that we expect to not be quite right.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
