### PR TITLE
[BUU] fix error 500 on hungary instance

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -264,6 +264,7 @@ module Spree
     def variant_unit_with_scale
       scale_clean = ActiveSupport::NumberHelper.number_to_rounded(variant_unit_scale,
                                                                   precision: nil,
+                                                                  significant: false,
                                                                   strip_insignificant_zeros: true)
       [variant_unit, scale_clean].compact_blank.join("_")
     end


### PR DESCRIPTION

#### What? Why?

- Closes #12682 <!-- Insert issue number here. -->

This PR #12683 fixes the first occurrence of the bug but uncovered another one.

When running with `:hu` locale, call to `number_to_rounded` with parameter `precision: nil` breaks, adding `significant: false` fixes the issue.


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
You'll need to set the server local to `hu` :
- open `apps/openfoodnetwork/current/.env.staging` and change set locale to `hu` 
```
LOCALE="hu"
```
- restart puma
- As an admin, load products page -> it doesn't break

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
