### PR TITLE
Bump upload artifact v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Archive failed tests screenshots
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: failed-tests-screenshots
           path: tmp/capybara/screenshots/*.png
@@ -294,7 +294,7 @@ jobs:
 
       - name: Archive failed tests screenshots
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: failed-tests-screenshots
           path: tmp/capybara/screenshots/*.png
@@ -373,7 +373,7 @@ jobs:
 
       - name: Archive failed tests screenshots
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: failed-tests-screenshots
           path: tmp/capybara/screenshots/*.png

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,15 +371,6 @@ jobs:
         run: |
           bin/rake knapsack_pro:rspec
 
-      - name: Archive failed tests screenshots
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: failed-tests-screenshots
-          path: tmp/capybara/screenshots/*.png
-          retention-days: 7
-          if-no-files-found: ignore
-
   test_the_rest:
     runs-on: ubuntu-22.04
     services:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -476,3 +476,13 @@ jobs:
 
       - name: Run jest tests
         run: yarn jest
+
+merge:
+ runs-on: ubuntu-latest
+ needs: upload
+ steps:
+   - name: Merge Artifacts
+     uses: actions/upload-artifact/merge@v4
+     with:
+       name: all-my-files
+       pattern: my-artifact-*


### PR DESCRIPTION
#### What? Why?

- Closes #12701

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We use [actions/upload-artifact](https://github.com/actions/upload-artifact) to create artifacts i.e., files like screenshots, when a spec fails. We've been getting a deprecation error. This PR fixes it.

Also, it removes the screenshot code from the engines node - I this is only needed on system specs, right?

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build
- when a system spec fails, we get a screenshot of the screen, with the failure.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
