### PR TITLE
Fixes 422 error due to bad sql building

### DIFF
--- a/spec/services/products_renderer_spec.rb
+++ b/spec/services/products_renderer_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe ProductsRenderer do
           search_param = { q: { "with_variants_supplier_properties" => [property_organic.id] } }
           products_renderer = ProductsRenderer.new(distributor, order_cycle, customer, search_param)
 
-          products = products_renderer.send(:products)
+          products = products_renderer.__send__(:products)
           expect(products).to eq([product_apples, product_cherries])
         end
       end

--- a/spec/services/products_renderer_spec.rb
+++ b/spec/services/products_renderer_spec.rb
@@ -155,6 +155,19 @@ RSpec.describe ProductsRenderer do
           products = products_renderer.send(:products)
           expect(products).to eq([product_cherries, product_banana_bread, product_doughnuts])
         end
+
+        it "filters products with producer properties when sorting is enabled" do
+          allow(distributor).to receive(:preferred_shopfront_taxon_order) {
+            "#{fruits.id},#{cakes.id}"
+          }
+          fruits_supplier.producer_properties.create!({ property_id: property_organic.id,
+                                                        value: '1', position: 1 })
+          search_param = { q: { "with_variants_supplier_properties" => [property_organic.id] } }
+          products_renderer = ProductsRenderer.new(distributor, order_cycle, customer, search_param)
+
+          products = products_renderer.send(:products)
+          expect(products).to eq([product_apples, product_cherries])
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

- Closes #12656

When some properties are defined at the enterprise level, there is a 422 return code as well as a "Products loading ..." displayed when customer filters products.

Reason is a bug in SQL Query building.
First part of query use `supplier_properties` parameter, but not second part, that can leads to mismatch between the 2 parts:
https://github.com/openfoodfoundation/openfoodnetwork/blob/dfea0cd805c555b84dce163f9ed83842a5b5b992/app/services/order_cycles/distributed_products_service.rb#L37-L40

The 2nd bit:
https://github.com/openfoodfoundation/openfoodnetwork/blob/dfea0cd805c555b84dce163f9ed83842a5b5b992/app/services/order_cycles/distributed_products_service.rb#L81-L83


#### What should we test?
See § "Steps to Reproduce" from #12656

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
