### PR TITLE
[BUU] Style fixes

### DIFF
--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -257,31 +257,20 @@
       min-width: 15em;
 
       .search-input {
-        width: 100%;
         position: relative;
-        background-color: $lighter-grey;
-        border: 1px solid $lighter-grey;
-        border-radius: 4px;
-        height: $btn-relaxed-height;
-        line-height: $btn-relaxed-height;
-
-        &:has(input:focus),
-        &:has(input:active) {
-          border: 1px solid $dark-blue;
-        }
 
         > input {
-          // Totally hide the input from its container
-          background-color: transparent;
-          border: none;
-          width: calc(100% - 30px); // 30px is the width of the search icon + padding
+          padding-left: 33px;
+          width: 100%;
         }
 
         &:before {
+          position: absolute;
           font-family: FontAwesome;
           content: "\f002";
           color: $near-black;
           font-size: 16px;
+          margin-top: 0.7rem;
           margin-left: 10px;
         }
       }

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -220,9 +220,6 @@
     justify-content: space-between;
     align-items: center;
 
-    line-height: $btn-relaxed-height;
-    height: $btn-relaxed-height;
-
     &.disabled-section {
       display: none;
     }

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -226,6 +226,7 @@
 
     .pagination-description {
       flex-grow: 1; // Grow to fill space
+      margin-right: 1em; // TODO: cleanup and use flex gap
     }
 
     .with-dropdown {


### PR DESCRIPTION
### What? Why?

This should prevent a [style problem](https://openfoodnetworkaus.slack.com/archives/CGCD7SZSP/p1721887558686379) that was raised from Mac Firefox (I couldn't replicate it)
![image (4)](https://github.com/user-attachments/assets/bd5f81d9-63fe-44d2-a57a-40c9888831b9)

It also fixes the weird blue box issue after using Chrome autocomplete, and some other formatting for small screens:
![Screenshot 2024-07-29 at 3 24 32 pm](https://github.com/user-attachments/assets/92d57b8f-43b1-4381-8a04-039d49bf9fef)

#### Screenshot
Now autocomplete and small screen sizes look better (sorry I didn't fix the search button, that will take a bit more work..)
![Screenshot 2024-07-29 at 3 24 52 pm](https://github.com/user-attachments/assets/7c97d6d4-bb2b-45a4-96aa-4ecb7b704bb8)

### What should we test?

- Visit new bulk products page
- Select an item from browser's autocomplete 
- View on various screen sizes

I considered disabling autocomplete for this field, because it seems to get in the way sometimes. But I think you would often be searching for the same thing, so perhaps it's worth keeping. Curious if there are other opinions.
