### PR TITLE
Add request_id to logs for production and staging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,6 +40,7 @@ Openfoodnetwork::Application.configure do
 
   # Configure logging:
   config.log_formatter = Logger::Formatter.new.tap { |f| f.datetime_format = "%Y-%m-%d %H:%M:%S" }
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production
   config.cache_store = :redis_cache_store, {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -40,6 +40,7 @@ Openfoodnetwork::Application.configure do
 
   # Configure logging:
   config.log_formatter = Logger::Formatter.new.tap { |f| f.datetime_format = "%Y-%m-%d %H:%M:%S" }
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production
   config.cache_store = :redis_cache_store, {


### PR DESCRIPTION
It will prepend a request unique id to each log lines, it makes it easier to debug individual request.

#### What? Why?
Logs in rails are spread over multiple lines and all request log are mixed up. To allow easier debugging, we prepend log lines with a`request_id`. That way we can filter log by request_id which make it much easier to debug individual request.
This PR adds `request_id` for staging and production environment.

Logs will look like this : 
```
[455d70a6-b320-4a7e-95f6-861b43d3ba7b]   Rendered layouts/_matomo_tag.html.haml (Duration: 4.1ms | Allocations: 3751)
[455d70a6-b320-4a7e-95f6-861b43d3ba7b]   Rendered spree/layouts/_admin_body.html.haml (Duration: 50.4ms | Allocations: 75534)
[455d70a6-b320-4a7e-95f6-861b43d3ba7b]   Rendered layout spree/layouts/admin.html.haml (Duration: 2189.4ms | Allocations: 3265841)
[455d70a6-b320-4a7e-95f6-861b43d3ba7b] Completed 200 OK in 2788ms (Views: 2167.1ms | ActiveRecord: 136.2ms | SQL Queries: 35 (11 cached) | Allocations: 3621190)
```

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- release the PR to staging, and load a page 
- login to the staging server via a ssh
- open a log file, and you should see something like the example above.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
