### PR TITLE
Adds undercover gem to the stack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,11 @@ jobs:
           git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
           bin/rake knapsack_pro:rspec
 
+      - name: Check code coverage changes
+
+        run: |
+          bundle exec undercover --compare origin/master
+
   models:
     runs-on: ubuntu-22.04
     services:
@@ -144,6 +149,11 @@ jobs:
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/models/**/*_spec.rb}" 
         run: |
           bin/rake knapsack_pro:rspec
+
+      - name: Check code coverage changes
+
+        run: |
+          bundle exec undercover --compare origin/master
 
   system_admin:
     runs-on: ubuntu-22.04
@@ -222,6 +232,11 @@ jobs:
           path: tmp/capybara/screenshots/*.png
           retention-days: 7
           if-no-files-found: ignore
+          
+      - name: Check code coverage changes
+
+        run: |
+          bundle exec undercover --compare origin/master
 
   system_consumer:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Check code coverage changes
 
         run: |
-          bundle exec undercover --compare origin/master
+          bin/rake undercover:run_diff_master
 
   models:
     runs-on: ubuntu-22.04
@@ -153,7 +153,7 @@ jobs:
       - name: Check code coverage changes
 
         run: |
-          bundle exec undercover --compare origin/master
+          bin/rake undercover:run_diff_master
 
   system_admin:
     runs-on: ubuntu-22.04
@@ -236,7 +236,7 @@ jobs:
       - name: Check code coverage changes
 
         run: |
-          bundle exec undercover --compare origin/master
+          bin/rake undercover:run_diff_master
 
   system_consumer:
     runs-on: ubuntu-22.04
@@ -315,6 +315,11 @@ jobs:
           path: tmp/capybara/screenshots/*.png
           retention-days: 7
           if-no-files-found: ignore
+
+      - name: Check code coverage changes
+
+        run: |
+          bin/rake undercover:run_diff_master
 
   engines:
     runs-on: ubuntu-22.04
@@ -395,6 +400,11 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      - name: Check code coverage changes
+
+        run: |
+          bin/rake undercover:run_diff_master
+
   test_the_rest:
     runs-on: ubuntu-22.04
     services:
@@ -463,6 +473,11 @@ jobs:
         run: |
           bin/rake knapsack_pro:rspec
 
+      - name: Check code coverage changes
+
+        run: |
+          bin/rake undercover:run_diff_master
+
   non_knapsack_jest_karma:
     runs-on: ubuntu-22.04
     services:
@@ -500,3 +515,8 @@ jobs:
 
       - name: Run jest tests
         run: yarn jest
+                  
+      - name: Check code coverage changes
+
+        run: |
+          bin/rake undercover:run_diff_master

--- a/Gemfile
+++ b/Gemfile
@@ -173,6 +173,7 @@ group :test do
   gem 'pdf-reader'
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
+  gem 'simplecov-lcov', require: false
   gem 'undercover', require: false
   gem 'vcr', require: false
   gem 'webmock', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -173,6 +173,7 @@ group :test do
   gem 'pdf-reader'
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
+  gem 'undercover', require: false
   gem 'vcr', require: false
   gem 'webmock', require: false
   # See spec/spec_helper.rb for instructions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -974,7 +974,6 @@ DEPENDENCIES
   sidekiq
   sidekiq-scheduler
   simplecov
-  simplecov-html
   simplecov-lcov
   spreadsheet_architect
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -736,6 +736,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     spreadsheet_architect (5.0.0)
       caxlsx (>= 3.3.0, < 4)
@@ -973,6 +974,8 @@ DEPENDENCIES
   sidekiq
   sidekiq-scheduler
   simplecov
+  simplecov-html
+  simplecov-lcov
   spreadsheet_architect
   spring
   spring-commands-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,8 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    imagen (0.1.8)
+      parser (>= 2.5, != 2.5.1.1)
     immigrant (0.3.6)
       activerecord (>= 3.0)
     invisible_captcha (2.2.0)
@@ -705,6 +707,7 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.8.2)
       fugit (~> 1.1, >= 1.1.6)
+    rugged (1.7.2)
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -789,6 +792,11 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    undercover (0.5.0)
+      bigdecimal
+      imagen (>= 0.1.8)
+      rainbow (>= 2.1, < 4.0)
+      rugged (>= 0.27, < 1.8)
     unicode-display_width (2.5.0)
     uniform_notifier (1.16.0)
     uri (0.13.0)
@@ -976,6 +984,7 @@ DEPENDENCIES
   stripe
   timecop
   turbo-rails
+  undercover
   valid_email2
   validates_lengths_from_database
   vcr

--- a/lib/tasks/undercover.rake
+++ b/lib/tasks/undercover.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+require 'simplecov-lcov'
+require 'undercover'
+
+namespace :undercover do
+  desc "Runs undercover comparison against master"
+  task run_diff_master: :environment do
+    "bundle exec undercover --compare origin/master"
+  end
+end

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -5,6 +5,13 @@
 ENV["RAILS_ENV"] ||= 'test'
 
 require 'simplecov' if ENV["COVERAGE"]
+require 'simplecov-lcov'
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::LcovFormatter,
+])
+require 'undercover'
+
 require 'rubygems'
 require 'pry' unless ENV['CI']
 require 'view_component/test_helpers'

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -4,14 +4,14 @@
 
 ENV["RAILS_ENV"] ||= 'test'
 
-require 'simplecov' if ENV["COVERAGE"]
-require 'simplecov-lcov'
+require 'simplecov' if ENV["COVERAGE"] || ENV["RAILS_ENV"]
+require 'simplecov-lcov' if ENV["COVERAGE"] || ENV["RAILS_ENV"]
 SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.
   new([
         SimpleCov::Formatter::LcovFormatter,
       ])
-require 'undercover'
+require 'undercover' if ENV["COVERAGE"] || ENV["RAILS_ENV"]
 
 require 'rubygems'
 require 'pry' unless ENV['CI']

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -33,6 +33,10 @@ Shoulda::Matchers.configure do |config|
 end
 
 require 'knapsack_pro'
+KnapsackPro::Hooks::Queue.before_queue do
+  SimpleCov.command_name("rspec_ci_node_#{KnapsackPro::Config::Env.ci_node_index}")
+end
+
 KnapsackPro::Adapters::RSpecAdapter.bind
 
 # Allow connections to selenium whilst raising errors when connecting to external sites

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -7,9 +7,10 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'simplecov' if ENV["COVERAGE"]
 require 'simplecov-lcov'
 SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::LcovFormatter,
-])
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.
+  new([
+        SimpleCov::Formatter::LcovFormatter,
+      ])
 require 'undercover'
 
 require 'rubygems'


### PR DESCRIPTION
#### What? Why?

(Please note: do not try to install this gem with a [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) environment running :exclamation: )

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds undercover gem to the stack and runs it within every CI node - by adding a `Check code coverage changes` task:

![image](https://github.com/user-attachments/assets/011826ee-6000-42aa-9cb6-0dfc1594aa8a)

If there are no changes, we should see:

![image](https://github.com/user-attachments/assets/5f9daeae-a06d-448d-a2b5-7561167fd2af)

This, however, is not seen on the first pic. I think the rake task is not doing what it should - it should yield the same output as when ran locallt. Any ideas here? :question: 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

There are two main use cases for this gem:

- to find untested code changes locally (with the [CLI](https://github.com/grodowski/undercover#usage))

To do this locally, run:
`bundle exec undercover --compare origin/master`

- to have review checks on GitHub

To achieve this, a a rake task was created and called within each type on specs, within `build.yml`. I'm not sure this is the best approach, happy for comments/suggestions/improvements!

Ideally, we'd test both scenarios, locally and remotely (CI):

**Locally**
- Commiting a code change without adding tests, on a given branch
- Run `bundle exec undercover --compare origin/master`
- One should see an output from indicating changes on code coverage 

**Remotely/CI**
- Push the previous commits 
- On each node, we should be able to see an output, indicating code changes

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
