### PR TITLE
Preload enterprise logos and promo images for /shops page

### DIFF
--- a/app/services/shops_list_service.rb
+++ b/app/services/shops_list_service.rb
@@ -19,5 +19,7 @@ class ShopsListService
       .includes(address: [:state, :country])
       .includes(:properties)
       .includes(supplied_products: :properties)
+      .with_attached_promo_image
+      .with_attached_logo
   end
 end

--- a/spec/services/shops_list_service_spec.rb
+++ b/spec/services/shops_list_service_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ShopsListService do
+  subject { described_class.new }
+  before do
+    create_list :enterprise, 3, :with_logo_image, :with_promo_image
+    create_list :distributor_enterprise, 3,
+                :with_logo_image,
+                :with_promo_image,
+                with_payment_and_shipping: true
+  end
+
+  let(:shop) { subject.open_shops.first }
+
+  describe "#open_shops" do
+    it "preloads promo images" do
+      expect(shop.association(:promo_image_attachment).loaded?).to be true
+      expect(shop.promo_image.association(:blob).loaded?).to be true
+    end
+
+    it "preloads logos" do
+      expect(shop.association(:logo_attachment).loaded?).to be true
+      expect(shop.logo.association(:blob).loaded?).to be true
+    end
+  end
+
+  describe "#closed_shops" do
+    let(:shop) { subject.closed_shops.first }
+
+    it "preloads promo images" do
+      expect(shop.association(:promo_image_attachment).loaded?).to be true
+      expect(shop.promo_image.association(:blob).loaded?).to be true
+    end
+
+    it "preloads logos" do
+      expect(shop.association(:logo_attachment).loaded?).to be true
+      expect(shop.logo.association(:blob).loaded?).to be true
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

When visiting https://openfoodnetwork.org.uk/shops, the page load is very slow. Given that this page is linked to from the 
CTA above the fold on https://openfoodnetwork.org.uk, it seems ideal that should load quickly.

One of the low-hanging fruits here is to make sure that each of the enterprise's `logo` and `promo_image` is preloaded, to avoid `n+2` queries:
<img width="1676" alt="Screenshot 2024-08-01 at 14 26 05" src="https://github.com/user-attachments/assets/8379ae10-2afc-4d3d-af53-bb92c2ce05a5">

It's not _the most_ significant performance increase (though I have a few other ones too) - especially when there is caching - but it feels like a sensible thing to do

#### What should we test?
- Visit /shops page

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

#### Dependencies
I have some other low-hanging fruit optimisations that I might propose here too (which might also be more significant) but they should be distinct enough to be separate follow-ons

#### Documentation updates
N/A
