### PR TITLE
Preload enterprise distributed_properties for /shops page

### DIFF
--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -81,41 +81,7 @@ module Api
     def distributed_properties
       return [] unless active
 
-      (distributed_product_properties + distributed_producer_properties).uniq do |property_object|
-        property_object.property.presentation
-      end
-    end
-
-    def distributed_product_properties
-      return [] unless active
-
-      properties = Spree::Property
-        .joins(products: { variants: { exchanges: :order_cycle } })
-        .merge(Exchange.outgoing)
-        .merge(Exchange.to_enterprise(enterprise))
-        .select('DISTINCT spree_properties.*')
-
-      return properties.merge(OrderCycle.active) if active
-
-      properties
-    end
-
-    def distributed_producer_properties
-      return [] unless active
-
-      properties = Spree::Property
-        .joins(
-          producer_properties: {
-            producer: { supplied_products: { variants: { exchanges: :order_cycle } } }
-          }
-        )
-        .merge(Exchange.outgoing)
-        .merge(Exchange.to_enterprise(enterprise))
-        .select('DISTINCT spree_properties.*')
-
-      return properties.merge(OrderCycle.active) if active
-
-      properties
+      enterprise.distributed_properties
     end
 
     def active

--- a/app/services/shops_list_service.rb
+++ b/app/services/shops_list_service.rb
@@ -19,5 +19,6 @@ class ShopsListService
       .includes(address: [:state, :country])
       .includes(:properties)
       .includes(supplied_products: :properties)
+      .includes(:distributed_product_properties, :distributed_producer_properties)
   end
 end

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -87,14 +87,6 @@ RSpec.describe Api::CachedEnterpriseSerializer do
         properties = cached_enterprise_serializer.distributed_properties
         expect(properties.map(&:presentation)).to eq([property.presentation])
       end
-
-      it 'fetches producer properties' do
-        distributed_producer_properties = cached_enterprise_serializer
-          .distributed_producer_properties
-
-        expect(distributed_producer_properties.map(&:presentation))
-          .to eq(producer.producer_properties.map(&:property).map(&:presentation))
-      end
     end
   end
 

--- a/spec/services/shops_list_service_spec.rb
+++ b/spec/services/shops_list_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ShopsListService do
+  subject { described_class.new }
+  before do
+    create_list :enterprise, 3, :with_logo_image, :with_promo_image
+    create_list :distributor_enterprise, 3,
+                :with_logo_image,
+                :with_promo_image,
+                with_payment_and_shipping: true
+  end
+
+  let(:shop) { subject.open_shops.first }
+
+  describe "#open_shops" do
+    it "preloads distributed_product_properties" do
+      expect(shop.distributed_product_properties.loaded?).to be true
+    end
+
+    it "preloads distributed_producer_properties" do
+      expect(shop.distributed_producer_properties.loaded?).to be true
+    end
+  end
+
+  describe "#closed_shops" do
+    let(:shop) { subject.closed_shops.first }
+
+    it "preloads distributed_product_properties" do
+      expect(shop.distributed_product_properties.loaded?).to be true
+    end
+
+    it "preloads distributed_producer_properties" do
+      expect(shop.distributed_producer_properties.loaded?).to be true
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

When visiting https://openfoodnetwork.org.uk/shops, the page load is very slow. Given that this page is linked to from the
CTA above the fold on https://openfoodnetwork.org.uk/, it seems ideal that should load quickly.

Here, I have moved `distributed_producer_properties` and `distributed_product_properties` out of the enterprise serialiser and into the model (IMO a serialiser shouldn't be making new queries to the DB anyway), and defined them as associations so that they can be preloaded. This should improve on the n+2 situation as visible here (in green):

<img width="1676" alt="Screenshot 2024-08-01 at 14 26 05" src="https://github.com/user-attachments/assets/99259142-1b8f-4af3-a438-1d0b0c95bb02">

There is potentially further that one could go (defining just a single `distributed_properties` has_many relationship), but I'm not sure if it's worth it, or about any other intricacies about how it is used.

#### What should we test?
- Visit /shops page
- Check page performance

I haven't been able to test this on a representative data set locally, so I'm unable to confirm how much of an impact this has!

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

#### Dependencies
It's similar to https://github.com/openfoodfoundation/openfoodnetwork/pull/12723, but doesn't depend on it directly

#### Documentation updates
