### PR TITLE
Fix flaky spec with fixed order of products

### DIFF
--- a/spec/system/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
+++ b/spec/system/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
@@ -13,7 +13,13 @@ RSpec.describe '
   describe "editing an order cycle with multiple pages of products" do
     let(:order_cycle) { create(:order_cycle) }
     let(:supplier_enterprise) { order_cycle.exchanges.incoming.first.sender }
-    let!(:new_product) { create(:product, supplier_id: supplier_enterprise.id) }
+    let!(:new_product) {
+      create(
+        :product,
+        supplier_id: supplier_enterprise.id,
+        name: "Z Last Product", # ordered by name
+      )
+    }
 
     before do
       stub_const("#{Api::V0::ExchangeProductsController}::DEFAULT_PER_PAGE", 1)
@@ -26,7 +32,7 @@ RSpec.describe '
       expect(page).to have_selector ".exchange-product-details"
 
       expect(page).to have_content "1 of 2 Variants Loaded"
-      expect(page).not_to have_content new_product.name
+      expect(page).not_to have_content "Z Last Product"
     end
 
     it "load all products" do


### PR DESCRIPTION
#### What? Why?

- Closes #12727 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

On certain branches the changed spec would always fail due to the order of generated product names. Defining the tested product name made the order deterministic and the spec pass.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
