### PR TITLE
Update product variant unit display name, price, and total price width on different screen sizes [OFN-6567]

### DIFF
--- a/app/views/shop/products/_shop_variant.html.haml
+++ b/app/views/shop/products/_shop_variant.html.haml
@@ -1,8 +1,8 @@
 = cache_with_locale do
-  .small-4.medium-4.large-5.columns.variant-name
+  .small-3.columns.variant-name
     .inline{"ng-if" => "::variant.display_name"} {{ ::variant.display_name }}
     .variant-unit {{ ::variant.unit_to_display }}
-  .small-3.medium-3.large-2.columns.variant-price
+  .small-4.medium-3.columns.variant-price
     %price-breakdown{"price-breakdown" => "_", variant: "variant",
       "price-breakdown-append-to-body" => "true",
       "price-breakdown-placement" => "bottom",
@@ -16,7 +16,7 @@
       key: "'js.shopfront.unit_price_tooltip'"}
       {{ variant.unit_price_price | localizeCurrency }}&nbsp;/&nbsp;{{ variant.unit_price_unit }}
 
-  .medium-2.large-2.columns.total-price
+  .medium-3.columns.total-price
     %span{"ng-class" => "{filled: variant.line_item.total_price}"}
       {{ variant.line_item.total_price | localizeCurrency }}
   = render partial: "shop/products/shop_variant_no_group_buy"


### PR DESCRIPTION
#### What? Why?
Update product variant unit labels and price widths on medium and large screens to fit long values (unit label and total price)

- Closes #6567

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
If we have a product variant with a price above 1000, then adding items to the cart will lresult in overlapping content (unit price and total price) around certain screen sizes (641px - 735px and 1025px - 1145px) depending on the total price.
### Before

##### About 645px
![image](https://github.com/user-attachments/assets/e61c2b9d-dd84-41c3-b7b5-364635eca9cf)

##### About 1030px
![image](https://github.com/user-attachments/assets/a5d3ad09-b27b-4524-97b4-e908157ef385)

#### What should we test?
Check that the product price, total price, and add-to-cart button content do not overlap across different screen sizes

- Visit ... page.
http://localhost:3000/SHOP_NAME/shop

#### Release notes

Fix product price and total_price overlapping content when product unit price is high (eg above 1000)

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes

Update product variant unit labels and price widths on medium and large screens to fit long values (unit label and total price)


#### Dependencies
N/A



#### Documentation updates
N/A
