### PR TITLE
Fix 'Back to products list' stateful navigation

### DIFF
--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -11,6 +11,8 @@ module Admin
     def index
       fetch_products
       render "index", locals: { producers:, categories:, tax_category_options:, flash: }
+
+      session[:products_return_to_url] = request.url
     end
 
     def bulk_update

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -10,6 +10,7 @@ module Spree
       include OpenFoodNetwork::SpreeApiKeyLoader
       include OrderCyclesHelper
       include EnterprisesHelper
+      helper ::Admin::ProductsHelper
 
       before_action :load_data
       before_action :load_producers, only: [:index, :new]

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -27,5 +27,9 @@ module Admin
 
       [precised_unit_value, variant.unit_description].compact_blank.join(" ")
     end
+
+    def products_return_to_url
+      session[:products_return_to_url] || admin_products_url
+    end
   end
 end

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -28,8 +28,12 @@ module Admin
       [precised_unit_value, variant.unit_description].compact_blank.join(" ")
     end
 
-    def products_return_to_url
-      session[:products_return_to_url] || admin_products_url
+    def products_return_to_url(url_filters)
+      if feature?(:admin_style_v3, spree_current_user)
+        return session[:products_return_to_url] || admin_products_url
+      end
+
+      "#{admin_products_path}#{url_filters.empty? ? '' : "#?#{url_filters.to_query}"}"
     end
   end
 end

--- a/app/views/spree/admin/products/edit.html.haml
+++ b/app/views/spree/admin/products/edit.html.haml
@@ -1,7 +1,7 @@
 = admin_inject_available_units
 
 - content_for :page_actions do
-  %li= button_link_to t('admin.products.back_to_products_list'), "#{admin_products_path}#{(@url_filters.empty? ? "" : "#?#{@url_filters.to_query}")}", :icon => 'icon-arrow-left'
+  %li= button_link_to t('admin.products.back_to_products_list'), products_return_to_url, :icon => 'icon-arrow-left'
   %li#new_product_link
     = button_link_to t(:new_product), new_object_url, { :icon => 'icon-plus', :id => 'admin_new_product' }
 
@@ -16,4 +16,4 @@
     .form-buttons.filter-actions.actions
       = button t(:update), 'icon-refresh'
 
-      = button_link_to t(:cancel), "#{collection_url}#{(@url_filters.empty? ? "" : "#?#{@url_filters.to_query}")}", icon: 'icon-remove'
+      = button_link_to t(:cancel), products_return_to_url, icon: 'icon-remove'

--- a/app/views/spree/admin/products/edit.html.haml
+++ b/app/views/spree/admin/products/edit.html.haml
@@ -1,7 +1,7 @@
 = admin_inject_available_units
 
 - content_for :page_actions do
-  %li= button_link_to t('admin.products.back_to_products_list'), products_return_to_url, :icon => 'icon-arrow-left'
+  %li= button_link_to t('admin.products.back_to_products_list'), products_return_to_url(@url_filters), :icon => 'icon-arrow-left'
   %li#new_product_link
     = button_link_to t(:new_product), new_object_url, { :icon => 'icon-plus', :id => 'admin_new_product' }
 
@@ -16,4 +16,4 @@
     .form-buttons.filter-actions.actions
       = button t(:update), 'icon-refresh'
 
-      = button_link_to t(:cancel), products_return_to_url, icon: 'icon-remove'
+      = button_link_to t(:cancel), products_return_to_url(@url_filters), icon: 'icon-remove'


### PR DESCRIPTION
#### What? Why?

- Closes #12698 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
- After successfully editing the product, the user clicks on the 'Back to products list' button, then the previously selected filters are removed and all the products are displayed.
- This PR fixes this by using the server session storage to store the URL with the applied filters and upon navigation back, we use that stored URL so that the applied filters are persisted.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Follow the steps to reproduce as per the issue
- Issue's excepted behavior should meet.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
