### PR TITLE
Stabilise spec by not relying on record ids

### DIFF
--- a/spec/system/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
+++ b/spec/system/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
@@ -46,10 +46,9 @@ RSpec.describe '
 
       expect_all_products_loaded
 
-      expect(page).to have_checked_field(
-        "order_cycle_incoming_exchange_0_variants_#{new_product.variants.first.id}",
-        disabled: false
-      )
+      within("div.exchange-product", text: "Z Last Product") do
+        expect(page).to have_checked_field "1g", disabled: false
+      end
     end
 
     def expect_all_products_loaded


### PR DESCRIPTION


#### What? Why?

Fixing tests on:
- #12722  <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

A spec was referring to and input id:

```
"order_cycle_incoming_exchange_0_variants_#{new_product.variants.first.id}"
```

But sometimes the exchange would have the id 1 instead of 0 and the test would fail. Instead I opted to select the field by text visible to the user.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
