### PR TITLE
Pluralize admin products search result [OFN-12532-v1]

### DIFF
--- a/app/views/admin/products_v3/_sort.html.haml
+++ b/app/views/admin/products_v3/_sort.html.haml
@@ -1,7 +1,7 @@
 #sort
   %div.pagination-description
     - if pagy.present?
-      = t(".pagination.total_html", total: pagy.count, from: pagy.from, to: pagy.to)
+      = t(".pagination.products_total_html", count: pagy.count, from: pagy.from, to: pagy.to)
 
     - if search_term.present? || producer_id.present? || category_id.present?
       %a{ href: url_for(page: 1), class: "button disruptive", data: { 'turbo-frame': "_self", 'turbo-action': "advance" } }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -880,7 +880,9 @@ en:
         search: Search
       sort:
         pagination:
-          total_html: "<strong>%{total} products</strong> found for your search criteria. Showing %{from} to %{to}."
+          products_total_html:
+            one: "<strong>%{count} product</strong> found for your search criteria. Showing %{from} to %{to}."
+            other: "<strong>%{count} products</strong> found for your search criteria. Showing %{from} to %{to}."
           per_page:
             show: Show
             per_page: "%{num} per page"

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
         search_for "searchable product"
 
         expect(page).to have_field "search_term", with: "searchable product"
-        expect(page).to have_content "1 products found for your search criteria. Showing 1 to 1."
+        expect(page).to have_content "1 product found for your search criteria. Showing 1 to 1."
         expect_products_count_to_be 1
       end
 
@@ -216,7 +216,7 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
         search_for "searchable product"
 
         expect(page).to have_field "search_term", with: "searchable product"
-        expect(page).to have_content "1 products found for your search criteria. Showing 1 to 1."
+        expect(page).to have_content "1 product found for your search criteria. Showing 1 to 1."
         expect_products_count_to_be 1
       end
 
@@ -229,7 +229,7 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
         search_for "Big box"
 
         expect(page).to have_field "search_term", with: "Big box"
-        expect(page).to have_content "1 products found for your search criteria. Showing 1 to 1."
+        expect(page).to have_content "1 product found for your search criteria. Showing 1 to 1."
         expect_products_count_to_be 1
       end
 
@@ -246,7 +246,7 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
         expect_per_page_to_be 15
         expect_products_count_to_be 1
         search_for "searchable product"
-        expect(page).to have_content "1 products found for your search criteria. Showing 1 to 1."
+        expect(page).to have_content "1 product found for your search criteria. Showing 1 to 1."
         expect_products_count_to_be 1
       end
 
@@ -256,7 +256,7 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
 
         search_for "searchable product"
         expect(page).to have_field "search_term", with: "searchable product"
-        expect(page).to have_content "1 products found for your search criteria. Showing 1 to 1."
+        expect(page).to have_content "1 product found for your search criteria. Showing 1 to 1."
         expect_products_count_to_be 1
         expect(page).to have_field "Name", with: product_by_name.name
 
@@ -348,7 +348,7 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
 
         search_by_category "Category 1"
 
-        expect(page).to have_content "1 products found for your search criteria. Showing 1 to 1."
+        expect(page).to have_content "1 product found for your search criteria. Showing 1 to 1."
         expect(page).to have_select "category_id", selected: "Category 1"
         expect_products_count_to_be 1
         expect(page).to have_field "Name", with: product_by_category.name


### PR DESCRIPTION
#### What? Why?

- Closes #12532

  Pluralize admin products search result



#### What should we test?

Searches yielding one result should have a translation for the singular case:

"1 product found for your search criteria."

- Visit ... page.
http://localhost:3000/admin/products

#### Release notes

Pluralize admin products search result

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
 Pluralize admin products search result

#### Dependencies
<!-- Does this PR depend on another one? -->
N/A



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR? -->
N/A
