### PR TITLE
Improve effiency of OrderCycle.earliest_closing_times

### DIFF
--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -154,9 +154,8 @@ class OrderCycle < ApplicationRecord
         joins(:order_cycle).
         merge(OrderCycle.active).
         group('exchanges.receiver_id').
-        select("exchanges.receiver_id AS receiver_id,
-                MIN(order_cycles.orders_close_at) AS earliest_close_at").
-        map { |ex| [ex.receiver_id, ex.earliest_close_at.to_time] }
+        pluck(Arel.sql("exchanges.receiver_id AS receiver_id"),
+              Arel.sql("MIN(order_cycles.orders_close_at) AS earliest_close_at"))
     ]
   end
 

--- a/app/serializers/api/uncached_enterprise_serializer.rb
+++ b/app/serializers/api/uncached_enterprise_serializer.rb
@@ -7,7 +7,7 @@ module Api
     attributes :orders_close_at, :active
 
     def orders_close_at
-      options[:data].earliest_closing_times[object.id]
+      options[:data].earliest_closing_times[object.id]&.to_time
     end
 
     def active

--- a/spec/serializers/api/uncached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/uncached_enterprise_serializer_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Api::UncachedEnterpriseSerializer do
+  let(:serializer) {
+    described_class.new enterprise, { data: OpenFoodNetwork::EnterpriseInjectionData.new }
+  }
+  let(:enterprise) { create :enterprise }
+
+  before do
+    allow_any_instance_of(OpenFoodNetwork::EnterpriseInjectionData).to(
+      receive(:earliest_closing_times).
+        and_return(data)
+    )
+  end
+
+  describe '#orders_close_at' do
+    context "for an enterprise with an active order cycle" do
+      let(:order_cycle) { create :open_order_cycle, coordinator: enterprise }
+      let(:data) { { enterprise.id => order_cycle.orders_close_at } }
+
+      it "returns a closing time for an enterprise" do
+        expect(serializer.orders_close_at).to eq order_cycle.orders_close_at
+      end
+    end
+
+    context "for an enterprise without an active order cycle" do
+      let(:data) { {} }
+
+      it "returns nil for an enterprise without a closing time" do
+        expect(serializer.orders_close_at).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

When visiting https://openfoodnetwork.org.uk/shops, the page load is very slow. Given that this page is linked to from the
CTA above the fold on https://openfoodnetwork.org.uk/, it seems ideal that should load quickly.

From my testing so far, it is significantly quicker to calculate the open shops by using `pluck` instead of a `select` and `map` - pluck uses less computation and memory, because it pulls the raw values rather than active record objects.

#### What should we test?
I did a bit of benchmarking myself, but feel free to run these as well to compare:
```
$ rails runner benchmark.rb
Running via Spring preloader in process 93743
              user     system      total        real
select map 18.210275   0.490729  18.701004 ( 21.091514)
pluck     5.991475   0.128221   6.119696 (  8.205571)
Number of OrderCycles: 80010
```
where benchmark.rb is:
```ruby
require "benchmark"

OrderCycle.instance_eval do
  def self.earliest_closing_times_select_map
    Hash[
      Exchange.
        outgoing.
        joins(:order_cycle).
        merge(OrderCycle.active).
        group("exchanges.receiver_id").
        select("exchanges.receiver_id AS receiver_id,
                MIN(order_cycles.orders_close_at) AS earliest_close_at").
        map { |ex| [ex.receiver_id, ex.earliest_close_at.to_time] }
    ]
  end

  def self.earliest_closing_times_pluck
    Hash[
      Exchange.
        outgoing.
        joins(:order_cycle).
        merge(OrderCycle.active).
        group("exchanges.receiver_id").
        pluck(Arel.sql("exchanges.receiver_id AS receiver_id"),
              Arel.sql("MIN(order_cycles.orders_close_at) AS earliest_close_at"))
    ]
  end
end

N = 20

Benchmark.benchmark(Benchmark::CAPTION, 7, Benchmark::FORMAT) do |x|
  ActiveRecord::Base.uncached do
    x.report("select map") do
      N.times { OrderCycle.earliest_closing_times_select_map }
    end

    x.report("pluck") do
      N.times { OrderCycle.earliest_closing_times_pluck }
    end
  end
end

puts "Number of OrderCycles: #{OrderCycle.count}"
```

I'm not sure if ~80K order cycles would be a representative number for a production instance, but it seems like there is enough of a difference here for this to be useful?

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

The title of the pull request will be included in the release notes.

#### Dependencies

#### Documentation updates
