### PR TITLE
Load MiniMagick before use

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: false
 
+require "mini_magick"
+
 class Enterprise < ApplicationRecord
   SELLS = %w(unspecified none own any).freeze
   ENTERPRISE_SEARCH_RADIUS = 100

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "mini_magick"
+
 module Spree
   class Image < Asset
     has_one_attached :attachment, service: image_service do |attachment|


### PR DESCRIPTION

#### What? Why?

- Closes #12751<!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We only reference MiniMagick when rescuing errors but when it's not loaded, that code fails to find the error class itself to apply the rescue block.

The rescue block is covered by a spec but the code passes there as MiniMagick is loaded.

We can see this error only in development, staging and production with a freshly restarted server before any image has been uploaded. An upload triggers the loading of MiniMagick and the error disappears.

So there are two conditions to trigger this bug:

* MiniMagick is not loaded.
* An image to display is not processed and the processing raises an error other than `ActiveStorage::Error`.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- This will be a production test on the Hungarian instance.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
