### PR TITLE
Optimise shops page: Enable injected enterprise data to be scoped to specific enterprise ids

### DIFF
--- a/app/helpers/injection_helper.rb
+++ b/app/helpers/injection_helper.rb
@@ -94,11 +94,11 @@ module InjectionHelper
   end
 
   def inject_taxons
-    inject_json_array "taxons", Spree::Taxon.all, Api::TaxonSerializer
+    inject_json_array "taxons", Spree::Taxon.all.to_a, Api::TaxonSerializer
   end
 
   def inject_properties
-    inject_json_array "properties", Spree::Property.all, Api::PropertySerializer
+    inject_json_array "properties", Spree::Property.all.to_a, Api::PropertySerializer
   end
 
   def inject_currency_config

--- a/app/helpers/injection_helper.rb
+++ b/app/helpers/injection_helper.rb
@@ -10,8 +10,6 @@ module InjectionHelper
   def inject_enterprises(enterprises = nil)
     enterprises ||= default_enterprise_query
 
-    # make sure the query is performed now so it is only performed once
-    enterprises = enterprises.to_a
     inject_json_array(
       "enterprises",
       enterprises,
@@ -56,8 +54,7 @@ module InjectionHelper
       relatives_including_self.
       activated.
       includes(:properties, address: [:state, :country], supplied_products: :properties).
-      all.
-      to_a
+      all
 
     inject_json_array "enterprises",
                       enterprises_and_relatives,
@@ -66,7 +63,7 @@ module InjectionHelper
   end
 
   def inject_group_enterprises(group)
-    enterprises = group.enterprises.activated.visible.all.to_a
+    enterprises = group.enterprises.activated.visible.all
     inject_json_array(
       "enterprises",
       enterprises,
@@ -97,11 +94,11 @@ module InjectionHelper
   end
 
   def inject_taxons
-    inject_json_array "taxons", Spree::Taxon.all.to_a, Api::TaxonSerializer
+    inject_json_array "taxons", Spree::Taxon.all, Api::TaxonSerializer
   end
 
   def inject_properties
-    inject_json_array "properties", Spree::Property.all.to_a, Api::PropertySerializer
+    inject_json_array "properties", Spree::Property.all, Api::PropertySerializer
   end
 
   def inject_currency_config

--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -87,16 +87,20 @@ module Spree
 
     # Return the services (pickup, delivery) that different distributors provide, in the format:
     # {distributor_id => {pickup: true, delivery: false}, ...}
-    def self.services
-      Hash[
-        Spree::ShippingMethod.
-          joins(:distributor_shipping_methods).
-          group('distributor_id').
-          select("distributor_id").
-          select("BOOL_OR(spree_shipping_methods.require_ship_address = 'f') AS pickup").
-          select("BOOL_OR(spree_shipping_methods.require_ship_address = 't') AS delivery").
-          map { |sm| [sm.distributor_id.to_i, { pickup: sm.pickup, delivery: sm.delivery }] }
-      ]
+    #
+    # Optionally, specify some distributor_ids as a parameter to scope the results
+    def self.services(distributor_ids = nil)
+      methods = Spree::ShippingMethod.joins(:distributor_shipping_methods).group('distributor_id')
+
+      if distributor_ids.present?
+        methods = methods.where(distributor_shipping_methods: { distributor_id: distributor_ids })
+      end
+
+      methods.
+        pluck(Arel.sql("distributor_id"),
+              Arel.sql("BOOL_OR(spree_shipping_methods.require_ship_address = 'f') AS pickup"),
+              Arel.sql("BOOL_OR(spree_shipping_methods.require_ship_address = 't') AS delivery")).
+        to_h { |(distributor_id, pickup, delivery)| [distributor_id.to_i, { pickup:, delivery: }] }
     end
 
     def self.backend

--- a/app/models/spree/taxon.rb
+++ b/app/models/spree/taxon.rb
@@ -28,15 +28,15 @@ module Spree
     #
     # Optionally, specify some enterprise_ids to scope the results
     def self.supplied_taxons(enterprise_ids = nil)
-      taxons = Spree::Taxon.
-        joins(variants: :supplier).
-        select('spree_taxons.*, enterprises.id AS enterprise_id')
+      taxons = Spree::Taxon.joins(variants: :supplier)
 
       taxons = taxons.where(enterprises: { id: enterprise_ids }) if enterprise_ids.present?
 
-      taxons.each_with_object({}) do |t, collection|
-        collection[t.enterprise_id.to_i] ||= Set.new
-        collection[t.enterprise_id.to_i] << t.id
+      taxons
+        .pluck('spree_taxons.id, enterprises.id AS enterprise_id')
+        .each_with_object({}) do |(taxon_id, enterprise_id), collection|
+        collection[enterprise_id.to_i] ||= Set.new
+        collection[enterprise_id.to_i] << taxon_id
       end
     end
 

--- a/lib/open_food_network/enterprise_injection_data.rb
+++ b/lib/open_food_network/enterprise_injection_data.rb
@@ -22,8 +22,10 @@ module OpenFoodNetwork
     end
 
     def shipping_method_services
-      @shipping_method_services ||= CacheService.cached_data_by_class("shipping_method_services",
-                                                                      Spree::ShippingMethod) do
+      @shipping_method_services ||= CacheService.cached_data_by_class(
+        "shipping_method_services_#{@enterprise_ids.hash}",
+        Spree::ShippingMethod
+      ) do
         # This result relies on a simple join with DistributorShippingMethod.
         # Updated DistributorShippingMethod records touch their associated Spree::ShippingMethod.
         Spree::ShippingMethod.services(@enterprise_ids)
@@ -31,7 +33,10 @@ module OpenFoodNetwork
     end
 
     def supplied_taxons
-      @supplied_taxons ||= CacheService.cached_data_by_class("supplied_taxons", Spree::Taxon) do
+      @supplied_taxons ||= CacheService.cached_data_by_class(
+        "supplied_taxons_#{@enterprise_ids.hash}",
+        Spree::Taxon
+      ) do
         # This result relies on a join with associated supplied products, through the
         # class Classification which maps the relationship. Classification records touch
         # their associated Spree::Taxon when updated. A Spree::Product's primary_taxon

--- a/lib/open_food_network/enterprise_injection_data.rb
+++ b/lib/open_food_network/enterprise_injection_data.rb
@@ -2,13 +2,23 @@
 
 module OpenFoodNetwork
   class EnterpriseInjectionData
+    # By default, data is fetched for *every* enterprise in the DB, but we specify some ids of
+    # enterprises that we are interested in, there is a lot less data to fetch
+    def initialize(enterprise_ids = nil)
+      @enterprise_ids = enterprise_ids
+    end
+
     def active_distributor_ids
       @active_distributor_ids ||=
-        Enterprise.distributors_with_active_order_cycles.ready_for_checkout.pluck(:id)
+        begin
+          enterprises = Enterprise.distributors_with_active_order_cycles.ready_for_checkout
+          enterprises = enterprises.where(id: @enterprise_ids) if @enterprise_ids.present?
+          enterprises.pluck(:id)
+        end
     end
 
     def earliest_closing_times
-      @earliest_closing_times ||= OrderCycle.earliest_closing_times
+      @earliest_closing_times ||= OrderCycle.earliest_closing_times(@enterprise_ids)
     end
 
     def shipping_method_services
@@ -16,7 +26,7 @@ module OpenFoodNetwork
                                                                       Spree::ShippingMethod) do
         # This result relies on a simple join with DistributorShippingMethod.
         # Updated DistributorShippingMethod records touch their associated Spree::ShippingMethod.
-        Spree::ShippingMethod.services
+        Spree::ShippingMethod.services(@enterprise_ids)
       end
     end
 
@@ -26,16 +36,16 @@ module OpenFoodNetwork
         # class Classification which maps the relationship. Classification records touch
         # their associated Spree::Taxon when updated. A Spree::Product's primary_taxon
         # is also touched when changed.
-        Spree::Taxon.supplied_taxons
+        Spree::Taxon.supplied_taxons(@enterprise_ids)
       end
     end
 
     def all_distributed_taxons
-      @all_distributed_taxons ||= Spree::Taxon.distributed_taxons(:all)
+      @all_distributed_taxons ||= Spree::Taxon.distributed_taxons(:all, @enterprise_ids)
     end
 
     def current_distributed_taxons
-      @current_distributed_taxons ||= Spree::Taxon.distributed_taxons(:current)
+      @current_distributed_taxons ||= Spree::Taxon.distributed_taxons(:current, @enterprise_ids)
     end
   end
 end

--- a/spec/lib/open_food_network/enterprise_injection_data_spec.rb
+++ b/spec/lib/open_food_network/enterprise_injection_data_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OpenFoodNetwork::EnterpriseInjectionData do
   let!(:closed_oc) { create :closed_order_cycle, coordinator: enterprise4 }
 
   context "when scoped to specific enterprises" do
-    let(:subject) {
+    subject {
       described_class.new([enterprise1.id, enterprise2.id])
     }
 

--- a/spec/lib/open_food_network/enterprise_injection_data_spec.rb
+++ b/spec/lib/open_food_network/enterprise_injection_data_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'open_food_network/enterprise_injection_data'
+
+RSpec.describe OpenFoodNetwork::EnterpriseInjectionData do
+  let(:enterprise1) { create :distributor_enterprise, with_payment_and_shipping: true }
+  let(:enterprise2) { create :distributor_enterprise, with_payment_and_shipping: true }
+  let(:enterprise3) { create :distributor_enterprise, with_payment_and_shipping: true }
+  let(:enterprise4) { create :distributor_enterprise, with_payment_and_shipping: true }
+
+  before do
+    [enterprise1, enterprise2, enterprise3].each do |ent|
+      create :open_order_cycle, distributors: [ent]
+    end
+  end
+
+  let!(:closed_oc) { create :closed_order_cycle, coordinator: enterprise4 }
+
+  context "when scoped to specific enterprises" do
+    let(:subject) {
+      described_class.new([enterprise1.id, enterprise2.id])
+    }
+
+    describe "#active_distributor_ids" do
+      it "should include enterprise1.id and enterprise2.id" do
+        ids = subject.active_distributor_ids
+        expect(ids).to include enterprise1.id
+        expect(ids).to include enterprise2.id
+        expect(ids).not_to include enterprise3.id
+      end
+    end
+  end
+
+  context "when unscoped to specific enterprises" do
+    let(:subject) { described_class.new }
+
+    describe "#active_distributor_ids" do
+      it "should include all enterprise ids" do
+        ids = subject.active_distributor_ids
+        expect(ids).to include enterprise1.id
+        expect(ids).to include enterprise2.id
+        expect(ids).to include enterprise3.id
+      end
+    end
+  end
+end

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -423,6 +423,25 @@ RSpec.describe OrderCycle do
     it "returns the earliest closing time" do
       expect(OrderCycle.earliest_closing_times[e2.id].round).to eq(time2.round)
     end
+
+    context "when scoped by distributors" do
+      it "returns times for the given distributors" do
+        expect(OrderCycle.earliest_closing_times([e1.id])).to have_key e1.id
+        expect(OrderCycle.earliest_closing_times([e2.id])).to have_key e2.id
+      end
+
+      it "doesn't return times for other distributors" do
+        expect(OrderCycle.earliest_closing_times([e1.id])).not_to have_key e2.id
+        expect(OrderCycle.earliest_closing_times([e2.id])).not_to have_key e1.id
+      end
+    end
+
+    context "when not scoped by distributors" do
+      it "returns times for all distributors" do
+        expect(OrderCycle.earliest_closing_times).to have_key e1.id
+        expect(OrderCycle.earliest_closing_times).to have_key e2.id
+      end
+    end
   end
 
   describe "finding all line items sold by to a user by a given shop" do

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -434,6 +434,11 @@ RSpec.describe OrderCycle do
         expect(OrderCycle.earliest_closing_times([e1.id])).not_to have_key e2.id
         expect(OrderCycle.earliest_closing_times([e2.id])).not_to have_key e1.id
       end
+
+      it "returns the correct values" do
+        expect(OrderCycle.earliest_closing_times([e1.id])[e1.id].round).to eq time1.round
+        expect(OrderCycle.earliest_closing_times([e2.id])[e2.id].round).to eq time2.round
+      end
     end
 
     context "when not scoped by distributors" do

--- a/spec/models/spree/taxon_spec.rb
+++ b/spec/models/spree/taxon_spec.rb
@@ -2,54 +2,108 @@
 
 require 'spec_helper'
 
-module Spree
-  RSpec.describe Taxon do
-    let(:taxon) { Spree::Taxon.new(name: "Ruby on Rails") }
+RSpec.describe Spree::Taxon do
+  let(:taxon) { described_class.new(name: "Ruby on Rails") }
 
-    let(:e) { create(:supplier_enterprise) }
-    let(:t1) { create(:taxon) }
-    let(:t2) { create(:taxon) }
+  let(:e) { create(:supplier_enterprise) }
+  let(:e2) { create(:supplier_enterprise) }
+  let(:t1) { create(:taxon) }
+  let(:t2) { create(:taxon) }
 
-    describe "finding all supplied taxons" do
-      let!(:p1) {
-        create(:simple_product, primary_taxon_id: t1.id, supplier_id: e.id)
-      }
+  describe ".supplied_taxons" do
+    let!(:p1) {
+      create(:simple_product, primary_taxon_id: t1.id, supplier_id: e.id)
+    }
+    let!(:p2) {
+      create(:simple_product, primary_taxon_id: t2.id, supplier_id: e2.id)
+    }
 
+    context "when scoped to specific enterprises" do
       it "finds taxons" do
-        expect(Taxon.supplied_taxons).to eq(e.id => Set.new([t1.id]))
+        expect(described_class.supplied_taxons([e.id])).to eq(e.id => Set.new([t1.id]))
+        expect(described_class.supplied_taxons([e2.id])).to eq(e2.id => Set.new([t2.id]))
+        expect(described_class.supplied_taxons([e.id, e2.id])).to eq(
+          e.id => Set.new([t1.id]),
+          e2.id => Set.new([t2.id])
+        )
       end
     end
 
-    describe "finding distributed taxons" do
-      let!(:oc_open) {
-        create(:open_order_cycle, distributors: [e], variants: [p_open.variants.first])
-      }
-      let!(:oc_closed) {
-        create(:closed_order_cycle, distributors: [e], variants: [p_closed.variants.first])
-      }
-      let!(:p_open) { create(:simple_product, primary_taxon: t1) }
-      let!(:p_closed) { create(:simple_product, primary_taxon: t2) }
+    context "when not scoped to specific enterprises" do
+      it "finds taxons" do
+        expect(described_class.supplied_taxons).to eq(
+          e.id => Set.new([t1.id]),
+          e2.id => Set.new([t2.id])
+        )
+      end
+    end
+  end
 
+  describe ".distributed_taxons" do
+    before do
+      [e, e2].each do |ent|
+        p_open = create(:simple_product, primary_taxon: t1)
+        p_closed = create(:simple_product, primary_taxon: t2)
+        create(:open_order_cycle, distributors: [ent], variants: [p_open.variants.first])
+        create(:closed_order_cycle, distributors: [ent], variants: [p_closed.variants.first])
+      end
+    end
+
+    context "when scoped to specific enterprises" do
       it "finds all distributed taxons" do
-        expect(Taxon.distributed_taxons(:all)).to eq(e.id => Set.new([t1.id, t2.id]))
+        expect(described_class.distributed_taxons(:all, [e.id])).to eq(
+          e.id => Set.new([t1.id, t2.id])
+        )
+        expect(described_class.distributed_taxons(:all, [e2.id])).to eq(
+          e2.id => Set.new([t1.id, t2.id])
+        )
+        expect(described_class.distributed_taxons(:all, [e.id, e2.id])).to eq(
+          e.id => Set.new([t1.id, t2.id]),
+          e2.id => Set.new([t1.id, t2.id]),
+        )
       end
 
       it "finds currently distributed taxons" do
-        expect(Taxon.distributed_taxons(:current)).to eq(e.id => Set.new([t1.id]))
+        expect(described_class.distributed_taxons(:current, [e.id])).to eq(
+          e.id => Set.new([t1.id])
+        )
+        expect(described_class.distributed_taxons(:current, [e2.id])).to eq(
+          e2.id => Set.new([t1.id])
+        )
+        expect(described_class.distributed_taxons(:current, [e.id, e2.id])).to eq(
+          e.id => Set.new([t1.id]),
+          e2.id => Set.new([t1.id]),
+        )
       end
     end
 
-    describe "touches" do
-      let!(:taxon1) { create(:taxon) }
-      let!(:taxon2) { create(:taxon) }
-      let!(:product) { create(:simple_product, primary_taxon_id: taxon1.id) }
-      let(:variant) { product.variants.first }
-
-      it "is touched when assignment of primary_taxon on a variant changes" do
-        expect do
-          variant.update(primary_taxon: taxon2)
-        end.to change { taxon2.reload.updated_at }
+    context "when not scoped to specific enterprises" do
+      it "finds all distributed taxons" do
+        expect(described_class.distributed_taxons(:all)).to eq(
+          e.id => Set.new([t1.id, t2.id]),
+          e2.id => Set.new([t1.id, t2.id]),
+        )
       end
+
+      it "finds currently distributed taxons" do
+        expect(described_class.distributed_taxons(:current)).to eq(
+          e.id => Set.new([t1.id]),
+          e2.id => Set.new([t1.id]),
+        )
+      end
+    end
+  end
+
+  describe "touches" do
+    let!(:taxon1) { create(:taxon) }
+    let!(:taxon2) { create(:taxon) }
+    let!(:product) { create(:simple_product, primary_taxon_id: taxon1.id) }
+    let(:variant) { product.variants.first }
+
+    it "is touched when assignment of primary_taxon on a variant changes" do
+      expect do
+        variant.update(primary_taxon: taxon2)
+      end.to change { taxon2.reload.updated_at }
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

When visiting https://openfoodnetwork.org.uk/shops, the page load is very slow. Given that this page is linked to from the
CTA above the fold on https://openfoodnetwork.org.uk/, it seems ideal that should load quickly.

It appears that part of the problem is that the `InjectionHelper` (via `OpenFoodNetwork::EnterpriseInjectionData`) fetches  information about _all_ enterprises (even ones which don't need to be serialised).

In some cases there could be a lot of rows pulled from the DB into memory, especially in the cases where there are joins (eg. `Spree::Taxon.supplied_taxons` pulls in all taxons of all products for all enterprises) - and then sometimes there are application-side operations happening on them too (eg. looping or creating hashes).

I opted to make this scoping optional where possible to try to ensure that they are non-breaking for other areas

I did a bit of benchmarking locally using
```
ab -n 20 -c 1 -H 'Accept: text/html'  -H 'Cookie: ...' 'http://localhost:3000/shops#/'
```
for this branch against master, and these were the results:

<details>
<summary>master (1940ms page load average):</summary>

```
This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient).....done


Server Software:        
Server Hostname:        localhost
Server Port:            3000

Document Path:          /shops#/
Document Length:        44150 bytes

Concurrency Level:      1
Time taken for tests:   38.817 seconds
Complete requests:      20
Failed requests:        19
   (Connect: 0, Receive: 0, Length: 19, Exceptions: 0)
Total transferred:      922991 bytes
HTML transferred:       884035 bytes
Requests per second:    0.52 [#/sec] (mean)
Time per request:       1940.863 [ms] (mean)
Time per request:       1940.863 [ms] (mean, across all concurrent requests)
Transfer rate:          23.22 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:  1697 1941 218.5   1815    2531
Waiting:     1696 1941 218.5   1815    2531
Total:       1697 1941 218.5   1815    2532

Percentage of the requests served within a certain time (ms)
  50%   1815
  66%   2015
  75%   2095
  80%   2132
  90%   2259
  95%   2532
  98%   2532
  99%   2532
 100%   2532 (longest request)
```
</details>

<details>
<summary>this branch (686ms page load average):</summary>

```
This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient).....done


Server Software:        
Server Hostname:        localhost
Server Port:            3000

Document Path:          /shops#/
Document Length:        43823 bytes

Concurrency Level:      1
Time taken for tests:   13.730 seconds
Complete requests:      20
Failed requests:        19
   (Connect: 0, Receive: 0, Length: 19, Exceptions: 0)
Total transferred:      914886 bytes
HTML transferred:       879896 bytes
Requests per second:    1.46 [#/sec] (mean)
Time per request:       686.478 [ms] (mean)
Time per request:       686.478 [ms] (mean, across all concurrent requests)
Transfer rate:          65.07 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.2      0       1
Processing:   543  686  91.4    671     955
Waiting:      543  686  91.4    670     955
Total:        543  686  91.4    671     956

Percentage of the requests served within a certain time (ms)
  50%    671
  66%    684
  75%    745
  80%    757
  90%    814
  95%    956
  98%    956
  99%    956
 100%    956 (longest request)
```
</details>

#### What should we test?
- The /shops page is the main one
- The groups page (eg /groups/1#/map) - from `inject_group_enterprises`
- The order show or edit page (eg /orders/R888114387) - from `inject_enterprise_and_relatives`

The other 2 pages incidentally also seem to be quicker for me, by a similar amount

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

#### Dependencies


#### Documentation updates
