### PR TITLE
Remove direct dependency on MiniMagick

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: false
 
-require "mini_magick"
-
 class Enterprise < ApplicationRecord
   SELLS = %w(unspecified none own any).freeze
   ENTERPRISE_SEARCH_RADIUS = 100
@@ -479,7 +477,7 @@ class Enterprise < ApplicationRecord
     return unless image.variable?
 
     image_variant_url_for(image.variant(name))
-  rescue ActiveStorage::Error, MiniMagick::Error, ActionView::Template::Error => e
+  rescue StandardError => e
     Bugsnag.notify "Enterprise ##{id} #{image.try(:name)} error: #{e.message}"
     Rails.logger.error(e.message)
 

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "mini_magick"
-
 module Spree
   class Image < Asset
     has_one_attached :attachment, service: image_service do |attachment|
@@ -35,7 +33,7 @@ module Spree
       return self.class.default_image_url(size) unless attachment.attached?
 
       image_variant_url_for(variant(size))
-    rescue ActiveStorage::Error, MiniMagick::Error, ActionView::Template::Error => e
+    rescue StandardError => e
       Bugsnag.notify "Product ##{viewable_id} Image ##{id} error: #{e.message}"
       Rails.logger.error(e.message)
 


### PR DESCRIPTION
#### What? Why?

- Closes #12769 
- Alternative fix for https://github.com/openfoodfoundation/openfoodnetwork/issues/12751
- Follow up from #12754

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We still depend on it as long as we set it as image processor but now we can switch to another image processor without changing the code around error handling.

We now rescue from unknown errors during image processing which should make the app more robust.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit a shopfront with images.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
