### PR TITLE
[BUU] Fix Messy flash notifications on new products page

### DIFF
--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -24,7 +24,7 @@ module Spree
       # Warn the user when they have an active order cycle with hubs that are not ready
       # for checkout (ie. does not have valid shipping and payment methods).
       def warn_invalid_order_cycles
-        return if session[:displayed_order_cycle_warning]
+        return if flash[:notice].present? || session[:displayed_order_cycle_warning]
 
         warning = OrderCycles::WarningService.new(spree_current_user).call
         return if warning.blank?

--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -19,15 +19,18 @@ module Spree
 
       before_action :authorize_admin
       before_action :set_locale
-      before_action :warn_invalid_order_cycles, if: :html_request?
+      before_action :warn_invalid_order_cycles, if: :page_load_request?
 
       # Warn the user when they have an active order cycle with hubs that are not ready
       # for checkout (ie. does not have valid shipping and payment methods).
       def warn_invalid_order_cycles
-        return if flash[:notice].present?
+        return if session[:displayed_order_cycle_warning]
 
         warning = OrderCycles::WarningService.new(spree_current_user).call
-        flash[:notice] = warning if warning.present?
+        return if warning.blank?
+
+        flash.now[:notice] = warning
+        session[:displayed_order_cycle_warning] = true
       end
 
       protected
@@ -80,6 +83,12 @@ module Spree
       end
 
       private
+
+      def page_load_request?
+        return false if request.format.include?('turbo')
+
+        html_request?
+      end
 
       def html_request?
         request.format.html?

--- a/spec/system/admin/order_cycles/complex_editing_multiple_updation_spec.rb
+++ b/spec/system/admin/order_cycles/complex_editing_multiple_updation_spec.rb
@@ -111,9 +111,6 @@ RSpec.describe '
       click_link 'Orders'
     end
 
-    # Click dismiss on distributor warning
-    click_button 'Dismiss'
-
     # Click cancel with unsaved changes
     dismiss_confirm "" do
       click_button 'Cancel'
@@ -168,9 +165,6 @@ RSpec.describe '
     # Go to incoming step
     click_button 'Next'
 
-    # Click dismiss on distributor warning
-    click_button 'Dismiss'
-
     # Go to outgoing step
     click_button 'Next'
 
@@ -191,9 +185,6 @@ RSpec.describe '
     dismiss_confirm "" do
       click_link 'Orders'
     end
-
-    # Click dismiss on distributor warning
-    click_button 'Dismiss'
 
     # Click cancel with unsaved changes
     dismiss_confirm "" do

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -778,7 +778,6 @@ RSpec.describe '
           visit spree.edit_admin_order_path(order)
 
           expect(page).not_to have_content different_shipping_method_for_distributor1.name
-          click_button 'Dismiss'
 
           find('.edit-method').click
 
@@ -1099,8 +1098,6 @@ RSpec.describe '
       expect(page).to have_selector 'h1', text: 'Customer Details'
       click_link "Order Details"
 
-      click_button 'Dismiss'
-
       expect(page).to have_content 'Add Product'
       select2_select product.name, from: 'add_variant_id', search: true
 
@@ -1110,8 +1107,6 @@ RSpec.describe '
 
       expect(page).to have_select2 'order_distributor_id', with_options: [distributor1.name]
       expect(page).not_to have_select2 'order_distributor_id', with_options: [distributor2.name]
-
-      click_button 'Dismiss'
 
       expect(page).to have_select2 'order_order_cycle_id',
                                    with_options: ["#{order_cycle1.name} (open)"]

--- a/spec/system/admin/overview_spec.rb
+++ b/spec/system/admin/overview_spec.rb
@@ -117,6 +117,24 @@ RSpec.describe '
                                         text: "MANAGE ORDER CYCLES"
         end
       end
+
+      context "with open order cycles of distributors not ready for checkout" do
+        let!(:order_cycle) { create(:simple_order_cycle, distributors: [d1]) }
+
+        it 'should only display the order cycle warning once after login' do
+          # First visit the page after login
+          visit spree.admin_dashboard_path
+          expected_oc_warning = I18n.t(
+            :active_distributors_not_ready_for_checkout_message_singular,
+            distributor_names: d1.name
+          )
+          expect(page).to have_content(expected_oc_warning)
+
+          # Reload the page
+          visit spree.admin_dashboard_path
+          expect(page).not_to have_content(expected_oc_warning)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #12596
- If the distributors have active order cycles but haven't set up shipping or payment methods, then a warning is displayed on the new screen.
- This warning is displayed each time the user visits any screen or switches tabs/pages.
- This PR fixes this such that the warning is displayed only once per user session.

#### What should we test?

- Have distributors that don't have payment or shipping methods setup
- Have order cycles opened for them
- Once you login, on the new admin screen, you should be able to see the order cycle warning
- Refresh the page, switch the tab, or navigate to another page, the order cycle warning should not be displayed anymore

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->