### PR TITLE
Clearer error message and clean up for Product Categories

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3947,7 +3947,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     more: "More"
     new_adjustment: "New adjustment"
     new_tax_category: "New Tax Category"
-    new_taxon: "New taxon"
     new_user: "New user"
     no_pending_payments: "No pending payments"
     remove: "Remove"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3045,7 +3045,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   spree_admin_single_enterprise_hint: "Hint: To allow people to find you, turn on your visibility under"
   spree_admin_eg_pickup_from_school: "eg. 'Pick-up from Primary School'"
   spree_admin_eg_collect_your_order: "eg. 'Please collect your order from 123 Imaginary St, Northcote, 3070'"
-  spree_classification_primary_taxon_error: "Taxon %{taxon} is the primary taxon of %{product} and cannot be deleted"
   spree_order_availability_error: "Distributor or order cycle cannot supply the products in your cart"
   spree_order_populator_error: "That distributor or order cycle can't supply all the products in your cart. Please choose another."
   spree_order_cycle_error: "Please choose an order cycle for this order."
@@ -4594,7 +4593,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         destroy:
           delete_taxon:
             success: "Successfully deleted the product category" 
-            error: "Unable to delete the product category"
+            error: "Unable to delete the product category due to assigned products."
         form:
           name: Name
           meta_title: Meta Title
@@ -4838,7 +4837,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       key_cleared: "Key cleared"
       shipment:
         cannot_ready: "Cannot ready shipment."
-      invalid_taxonomy_id: "Invalid taxonomy id."
       toggle_api_key_view: "Show API key view for user"
     activerecord:
       models:


### PR DESCRIPTION
#### What? Why?

- Closes #12773

I found that the code had no place to use spree_classification_primary_taxon_error and invalid_taxonomy_id, so I deleted them


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

As described in the issue:

* Admin setting page should work properly with new taxons options
* All crud actions should be available in admin settings for taxons

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
