### PR TITLE
Add warning popup to order cycle list [OFN-12775]

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycles_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycles_controller.js.coffee
@@ -1,7 +1,11 @@
 angular.module("admin.orderCycles").controller "OrderCyclesCtrl", ($scope, $q, Columns, StatusMessage, RequestMonitor, OrderCycles, Enterprises, Schedules, Dereferencer) ->
   $scope.RequestMonitor = RequestMonitor
   $scope.columns = Columns.columns
-  $scope.saveAll = -> OrderCycles.saveChanges($scope.order_cycles_form)
+  $scope.saveAll = ($event) ->
+    trigger_action = $($event.target).data('trigger-action')
+    confirm = $($event.target).data('confirm')
+    OrderCycles.saveChanges($scope.order_cycles_form, { trigger_action, confirm })
+
   $scope.ordersCloseAtLimit = -31 # days
 
   $scope.resetSelectFilters = ->

--- a/app/assets/javascripts/admin/resources/services/order_cycles.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/order_cycles.js.coffee
@@ -29,13 +29,13 @@ angular.module("admin.resources").factory 'OrderCycles', ($q, $injector, OrderCy
         deferred.reject(response)
       deferred.promise
 
-    saveChanges: (form) ->
+    saveChanges: (form, params = {}) ->
       changed = {}
       for id, orderCycle of @byID when not @saved(orderCycle)
         changed[Object.keys(changed).length] = @changesFor(orderCycle)
       if Object.keys(changed).length > 0
         StatusMessage.display('progress', "Saving...")
-        OrderCycleResource.bulkUpdate { order_cycle_set: { collection_attributes: changed } }, (data) =>
+        OrderCycleResource.bulkUpdate { order_cycle_set: { collection_attributes: changed }, confirm: params['confirm'], trigger_action: params['trigger_action'] }, (data) =>
           for orderCycle in data
             delete orderCycle.coordinator
             delete orderCycle.producers
@@ -47,8 +47,10 @@ angular.module("admin.resources").factory 'OrderCycles', ($q, $injector, OrderCy
         , (response) =>
           if response.data.errors?
             StatusMessage.display('failure', response.data.errors[0])
+          else if (response.data.trigger_action)
+            StatusMessage.display('notice', t('js.order_cycles.unsaved_changes'), response.data.trigger_action)
           else
-            StatusMessage.display('failure', "Oh no! I was unable to save your changes.")
+            StatusMessage.display('failure', t('js.order_cycles.bulk_save_error'))
 
     saved: (order_cycle) ->
       @diff(order_cycle).length == 0

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -315,7 +315,7 @@ class OrderCycle < ApplicationRecord
 
   def same_datetime_value(attribute, string)
     return true if self[attribute].blank? && string.blank?
-    return false if [[attribute].present?, string.present?].include?(false)
+    return false if self[attribute].blank? || string.blank?
 
     DateTime.parse(string).to_fs(:short) == self[attribute]&.to_fs(:short)
   end

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -313,6 +313,13 @@ class OrderCycle < ApplicationRecord
     coordinator.sells == 'own'
   end
 
+  def same_datetime_value(attribute, string)
+    return true if self[attribute].blank? && string.blank?
+    return false if [[attribute].present?, string.present?].include?(false)
+
+    DateTime.parse(string).to_fs(:short) == self[attribute]&.to_fs(:short)
+  end
+
   private
 
   def opening?

--- a/app/services/sets/order_cycle_set.rb
+++ b/app/services/sets/order_cycle_set.rb
@@ -9,16 +9,25 @@ module Sets
       super(OrderCycle, collection, attributes)
     end
 
-    def process(found_element, attributes)
-      if @confirm_datetime_change && found_element.orders.exists? &&
-         ((attributes.key?(:orders_open_at) &&
-           !found_element.same_datetime_value(:orders_open_at, attributes[:orders_open_at])) ||
-          (attributes.key?(:orders_close_at) &&
-            !found_element.same_datetime_value(:orders_close_at, attributes[:orders_close_at])))
+    def process(order_cycle, attributes)
+      if @confirm_datetime_change &&
+         order_cycle.orders.exists? &&
+         datetime_value_changed(order_cycle, attributes)
         raise @error_class
       end
 
       super
+    end
+
+    private
+
+    def datetime_value_changed(order_cycle, attributes)
+      # return true if either key is present in params and change in values detected
+      return true if attributes.key?(:orders_open_at) &&
+                     !order_cycle.same_datetime_value(:orders_open_at, attributes[:orders_open_at])
+
+      attributes.key?(:orders_close_at) &&
+        !order_cycle.same_datetime_value(:orders_close_at, attributes[:orders_close_at])
     end
   end
 end

--- a/app/services/sets/order_cycle_set.rb
+++ b/app/services/sets/order_cycle_set.rb
@@ -3,7 +3,22 @@
 module Sets
   class OrderCycleSet < ModelSet
     def initialize(collection, attributes = {})
+      @confirm_datetime_change = attributes.delete :confirm_datetime_change
+      @error_class = attributes.delete :error_class
+
       super(OrderCycle, collection, attributes)
+    end
+
+    def process(found_element, attributes)
+      if @confirm_datetime_change && found_element.orders.exists? &&
+         ((attributes.key?(:orders_open_at) &&
+           !found_element.same_datetime_value(:orders_open_at, attributes[:orders_open_at])) ||
+          (attributes.key?(:orders_close_at) &&
+            !found_element.same_datetime_value(:orders_close_at, attributes[:orders_close_at])))
+        raise @error_class
+      end
+
+      super
     end
   end
 end

--- a/app/views/admin/order_cycles/_date_time_warning_modal_content.html.haml
+++ b/app/views/admin/order_cycles/_date_time_warning_modal_content.html.haml
@@ -4,11 +4,18 @@
   %div{ style: 'font-size: 1rem;' }
     = t('.content')
 %p.modal-actions.justify-end.gap-1
-  %button.button.secondary{ "ng-click": "submit($event, null)", type: "button", style: "display: none;", data: { action: 'click->modal#close', 'trigger-action': 'save' } }
-    = t('.proceed')
-  %button.button.secondary{ "ng-click": "submit($event, '#{main_app.admin_order_cycle_incoming_path(@order_cycle)}')", type: "button", style: "display: none;", data: {  action: 'click->modal#close', 'trigger-action': 'saveAndNext' } }
-    = t('.proceed')
-  %button.button.secondary{ "ng-click": "submit($event, '#{main_app.admin_order_cycles_path}')", type: "button", style: "display: none;", data: { action: 'click->modal#close', 'trigger-action': 'saveAndBack' } }
-    = t('.proceed')
-  %button.button.primary{ type: "button", 'data-action': 'click->modal#close' }
-    = t('.cancel')
+  - if action == 'simple_update'
+    %button.button.secondary{ "ng-click": "submit($event, null)", type: "button", style: "display: none;", data: { action: 'click->modal#close', 'trigger-action': 'save' } }
+      = t('.proceed')
+    %button.button.secondary{ "ng-click": "submit($event, '#{main_app.admin_order_cycle_incoming_path(@order_cycle)}')", type: "button", style: "display: none;", data: {  action: 'click->modal#close', 'trigger-action': 'saveAndNext' } }
+      = t('.proceed')
+    %button.button.secondary{ "ng-click": "submit($event, '#{main_app.admin_order_cycles_path}')", type: "button", style: "display: none;", data: { action: 'click->modal#close', 'trigger-action': 'saveAndBack' } }
+      = t('.proceed')
+    %button.button.primary{ type: "button", 'data-action': 'click->modal#close' }
+      = t('.cancel')
+
+  - if action == 'bulk_update'
+    %button.button.secondary{ "ng-click": "saveAll($event)", type: "button", style: "display: none;", data: { action: 'click->modal#close', trigger_action: 'bulk_save' } }
+      = t('.proceed')
+    %button.button.primary{ type: "button", 'data-action': 'click->modal#close' }
+      = t('.cancel')

--- a/app/views/admin/order_cycles/edit.html.haml
+++ b/app/views/admin/order_cycles/edit.html.haml
@@ -37,4 +37,4 @@
       %button.modal-target-trigger{ type: 'button', data: { 'action': 'modal-link#open' }, style: 'display: none;' } 
       = render ModalComponent.new(id: "linked-order-warning-modal", close_button: false) do
         .content.flex-column.gap-2
-          = render 'date_time_warning_modal_content'
+          = render 'date_time_warning_modal_content', action: 'simple_update'

--- a/app/views/admin/order_cycles/index.html.haml
+++ b/app/views/admin/order_cycles/index.html.haml
@@ -23,12 +23,20 @@
     .thirteen.columns.alpha &nbsp;
     %columns-dropdown{ action: "#{controller_name}_#{action_name}" }
 
-  %form{ name: 'order_cycles_form' }
-    %save-bar{ dirty: "order_cycles_form.$dirty", persist: "false" }
-      %input.red{ type: "button", value: t(:save_changes), "ng-click": "saveAll()", "ng-disabled": "!order_cycles_form.$dirty" }
-    %table.index#listing_order_cycles{ "ng-show": 'orderCycles.length > 0' }
-      = render 'admin/order_cycles/header' #, simple_index: simple_index
-      %tbody
-        = render 'admin/order_cycles/row' #, simple_index: simple_index
-    = render 'admin/order_cycles/loading_flash'
-    = render 'admin/order_cycles/show_more'
+    %div{ data: { controller: 'order-cycle-form' } }
+      %form{ name: 'order_cycles_form' }
+        %save-bar{ dirty: "order_cycles_form.$dirty", persist: "false" }
+          %input.red{ type: "button", value: t(:save_changes), "ng-click": "saveAll($event)", "ng-disabled": "!order_cycles_form.$dirty",
+                      data: { confirm: "true", 'trigger-action': 'bulk_save' } }
+        %table.index#listing_order_cycles{ "ng-show": 'orderCycles.length > 0' }
+          = render 'admin/order_cycles/header' #, simple_index: simple_index
+          %tbody
+            = render 'admin/order_cycles/row' #, simple_index: simple_index
+        = render 'admin/order_cycles/loading_flash'
+        = render 'admin/order_cycles/show_more'
+
+        %div.warning-modal{ data: { controller: 'modal modal-link', 'modal-link-target-value': "linked-order-warning-modal" } }
+          %button.modal-target-trigger{ type: 'button', data: { 'action': 'modal-link#open' }, style: 'display: none;' } 
+          = render ModalComponent.new(id: "linked-order-warning-modal", close_button: false) do
+            .content.flex-column.gap-2
+              = render 'date_time_warning_modal_content', action: 'bulk_update'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3704,6 +3704,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         enterprise that are not present in the uploaded file.
     order_cycles:
       unsaved_changes: "You have unsaved changes"
+      bulk_save_error: "Oh no! I was unable to save your changes."
       create_failure: "Failed to create order cycle"
       update_success: 'Your order cycle has been updated.'
       update_failure: "Failed to update order cycle"

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -336,7 +336,6 @@ module Admin
 
       context "as a manager of the coordinator" do
         let(:user) { coordinator.owner }
-        let(:error_class) { Admin::OrderCyclesController::DateTimeChangeError }
         let(:expected) {
           [order_cycle, allowed.merge(restricted).merge(datetime_confirmation_attrs), user]
         }

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -803,4 +803,31 @@ RSpec.describe OrderCycle do
       expect(order_cycle).not_to be_simple
     end
   end
+
+  describe "same_datetime_value" do
+    it 'returns true when old and new values are nil' do
+      order_cycle = create(:order_cycle, orders_open_at: nil, orders_close_at: nil)
+      expect(order_cycle.same_datetime_value(:orders_open_at, nil)).to be_truthy
+    end
+
+    it 'returns false if one value is nil and other not nil' do
+      order_cycle = create(:order_cycle, orders_open_at: "2024-09-30 06:09", orders_close_at: nil)
+      expect(order_cycle.same_datetime_value(:orders_open_at, nil)).to be_falsey
+      expect(order_cycle.same_datetime_value(:orders_close_at, "2024-09-30 06:09")).to be_falsey
+    end
+
+    it 'returns true if either values are same' do
+      order_cycle = create(:order_cycle, orders_open_at: Time.zone.parse("2024-09-30 06:09"),
+                                         orders_close_at: Time.zone.parse("2024-11-30 06:09"))
+      expect(order_cycle.same_datetime_value(:orders_open_at, "2024-09-30 06:09")).to be_truthy
+      expect(order_cycle.same_datetime_value(:orders_close_at, "2024-11-30 06:09")).to be_truthy
+    end
+
+    it 'returns false if either values are not same' do
+      order_cycle = create(:order_cycle, orders_open_at: Time.zone.parse("2024-09-30 06:09"),
+                                         orders_close_at: Time.zone.parse("2024-11-30 06:09"))
+      expect(order_cycle.same_datetime_value(:orders_open_at, "2024-10-30 06:09")).to be_falsey
+      expect(order_cycle.same_datetime_value(:orders_close_at, "2024-12-30 06:09")).to be_falsey
+    end
+  end
 end

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -200,6 +200,56 @@ RSpec.describe '
       end
     end
   end
+  describe 'updating order cycles' do
+    let!(:order_cycle) { create(:simple_order_cycle) }
+    before(:each) do
+      login_as_admin
+      visit admin_order_cycles_path
+    end
+
+    context 'with attached order cycles' do
+      let!(:order) { create(:order, order_cycle: ) }
+      it('renders warning modal with datetime value changed') do
+        within("tr.order-cycle-#{order_cycle.id}") do
+          find('input.datetimepicker', match: :first).click
+        end
+        within(".flatpickr-calendar.open") do
+          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
+          select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
+          find("button", text: "Close").click
+        end
+        expect(page).to have_content('You have unsaved changes')
+
+        # click save to open warning modal
+        click_button('Save')
+        expect(page).to have_content('You have unsaved changes')
+        expect(page).to have_content "Orders are linked to this order cycle."
+
+        # confirm to close modal and update order cycle changed fields
+        click_button('Proceed anyway')
+        expect(page).not_to have_content "Orders are linked to this cycle"
+        expect(page).to have_content('Order cycles have been updated.')
+      end
+    end
+
+    context 'with no attached order cycles' do
+      it('renders warnig modal with datetime value changed') do
+        within("tr.order-cycle-#{order_cycle.id}") do
+          find('input.datetimepicker', match: :first).click
+        end
+        within(".flatpickr-calendar.open") do
+          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
+          select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
+          find("button", text: "Close").click
+        end
+        expect(page).to have_content('You have unsaved changes')
+
+        click_button('Save')
+        expect(page).not_to have_content "Orders are linked to this order cycle."
+        expect(page).to have_content('Order cycles have been updated.')
+      end
+    end
+  end
 
   private
 


### PR DESCRIPTION
#### What? Why?

- Closes #12775

Include OC warning modal to OC list page



#### What should we test?
- Changing a datetime value from OC list should trigger the confirmation modal

- Visit ... page.
localhost:3000/admin/order_cycles

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] Technical changes only


Include OC warning modal to OC list page


#### Dependencies
N/A



#### Documentation updates
N/A
