### PR TITLE
Add fallback report loading in case websockets fail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ gem 'sidekiq-scheduler'
 gem "cable_ready"
 gem "stimulus_reflex"
 
+gem "turbo_power"
 gem "turbo-rails"
 
 gem 'combine_pdf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -785,6 +785,8 @@ GEM
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
+    turbo_power (0.6.2)
+      turbo-rails (>= 1.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -973,6 +975,7 @@ DEPENDENCIES
   stripe
   timecop
   turbo-rails
+  turbo_power
   valid_email2
   validates_lengths_from_database
   vcr

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -58,18 +58,6 @@ module Admin
     end
 
     def render_in_background
-      cable_ready[ScopedChannel.for_id(params[:uuid])]
-        .inner_html(
-          selector: "#report-go",
-          html: helpers.button(t(:go), "report__submit-btn", "submit", disabled: true)
-        ).inner_html(
-          selector: "#report-table",
-          html: render_to_string(partial: "admin/reports/loading")
-        ).scroll_into_view(
-          selector: "#report-table",
-          block: "start"
-        ).broadcast
-
       blob = ReportBlob.create_for_upload_later!(report_filename)
 
       ReportJob.perform_later(
@@ -78,8 +66,6 @@ module Admin
         blob:,
         channel: ScopedChannel.for_id(params[:uuid]),
       )
-
-      head :no_content
     end
   end
 end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -6,7 +6,7 @@ module Admin
     include ReportsActions
     helper ReportsHelper
 
-    before_action :authorize_report, only: [:show]
+    before_action :authorize_report, only: [:show, :create]
 
     # Define model class for Can? permissions
     def model_class
@@ -20,14 +20,17 @@ module Admin
     end
 
     def show
-      @report = report_class.new(spree_current_user, params, render: render_data?)
+      @report = report_class.new(spree_current_user, params, render: false)
       @rendering_options = rendering_options # also stores user preferences
 
-      if render_data?
-        render_in_background
-      else
-        show_report
-      end
+      show_report
+    end
+
+    def create
+      @report = report_class.new(spree_current_user, params, render: true)
+      @rendering_options = rendering_options # also stores user preferences
+
+      render_in_background
     end
 
     private
@@ -52,10 +55,6 @@ module Admin
     def load_selected_variant
       variant = Spree::Variant.find(params[:variant_id_in][0])
       @variant_serialized = Api::Admin::VariantSerializer.new(variant)
-    end
-
-    def render_data?
-      request.post?
     end
 
     def render_in_background

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -21,14 +21,15 @@ module Admin
 
     def show
       @report = report_class.new(spree_current_user, params, render: false)
-      @rendering_options = rendering_options # also stores user preferences
+      @rendering_options = rendering_options
 
       show_report
     end
 
     def create
       @report = report_class.new(spree_current_user, params, render: true)
-      @rendering_options = rendering_options # also stores user preferences
+      @rendering_options = rendering_options
+      update_rendering_options
 
       render_in_background
     end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -58,12 +58,12 @@ module Admin
     end
 
     def render_in_background
-      blob = ReportBlob.create_for_upload_later!(report_filename)
+      @blob = ReportBlob.create_for_upload_later!(report_filename)
 
       ReportJob.perform_later(
         report_class:, user: spree_current_user, params:,
         format: report_format,
-        blob:,
+        blob: @blob,
         channel: ScopedChannel.for_id(params[:uuid]),
       )
     end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -28,7 +28,6 @@ module Admin
 
     def create
       @report = report_class.new(spree_current_user, params, render: true)
-      @rendering_options = rendering_options
       update_rendering_options
 
       render_in_background

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -70,10 +70,12 @@ module Admin
           block: "start"
         ).broadcast
 
+      blob = ReportBlob.create_for_upload_later!(report_filename)
+
       ReportJob.perform_later(
         report_class:, user: spree_current_user, params:,
         format: report_format,
-        filename: report_filename,
+        blob:,
         channel: ScopedChannel.for_id(params[:uuid]),
       )
 

--- a/app/controllers/concerns/reports_actions.rb
+++ b/app/controllers/concerns/reports_actions.rb
@@ -91,7 +91,7 @@ module ReportsActions
   end
 
   def update_rendering_options
-    @rendering_options.update(
+    rendering_options.update(
       options: {
         fields_to_show: params[:fields_to_show],
         display_summary_row: params[:display_summary_row].present?,

--- a/app/controllers/concerns/reports_actions.rb
+++ b/app/controllers/concerns/reports_actions.rb
@@ -88,13 +88,9 @@ module ReportsActions
         display_header_row: false
       }
     end
-    update_rendering_options
-    @rendering_options
   end
 
   def update_rendering_options
-    return unless request.post?
-
     @rendering_options.update(
       options: {
         fields_to_show: params[:fields_to_show],

--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -9,12 +9,12 @@ class ReportJob < ApplicationJob
 
   NOTIFICATION_TIME = 5.seconds
 
-  def perform(report_class:, user:, params:, format:, filename:, channel: nil)
+  def perform(report_class:, user:, params:, format:, blob:, channel: nil)
     start_time = Time.zone.now
 
     report = report_class.new(user, params, render: true)
     result = report.render_as(format)
-    blob = ReportBlob.create!(filename, result)
+    blob.store(result)
 
     execution_time = Time.zone.now - start_time
 

--- a/app/models/report_blob.rb
+++ b/app/models/report_blob.rb
@@ -5,7 +5,7 @@ class ReportBlob < ActiveStorage::Blob
   # AWS S3 limits URL expiry to one week.
   LIFETIME = 1.week
 
-  def self.create!(filename, content)
+  def self.create_locally!(filename, content)
     create_and_upload!(
       io: StringIO.new(content),
       filename:,
@@ -15,11 +15,34 @@ class ReportBlob < ActiveStorage::Blob
     )
   end
 
+  def self.create_for_upload_later!(filename)
+    # ActiveStorage discourages modifying a blob later but we need a blob
+    # before we know anything about the report file. It enables us to use the
+    # same blob in the controller to read the result.
+    create_before_direct_upload!(
+      filename:,
+      byte_size: 0,
+      checksum: "0",
+      content_type: content_type(filename),
+      service_name: :local,
+    ).tap do |blob|
+      ActiveStorage::PurgeJob.set(wait: LIFETIME).perform_later(blob)
+    end
+  end
+
   def self.content_type(filename)
     MIME::Types.of(filename).first&.to_s || "application/octet-stream"
   end
 
+  def store(content)
+    io = StringIO.new(content)
+    upload(io, identify: false)
+    save!
+  end
+
   def result
+    return if checksum == "0"
+
     @result ||= download.force_encoding(Encoding::UTF_8)
   end
 

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -244,7 +244,7 @@ module Spree
 
       # Reports page
       can [:admin, :index, :show], ::Admin::ReportsController
-      can [:admin, :show, :customers, :orders_and_distributors, :group_buys, :payments,
+      can [:admin, :show, :create, :customers, :orders_and_distributors, :group_buys, :payments,
            :orders_and_fulfillment, :products_and_inventory, :order_cycle_management,
            :packing, :enterprise_fee_summary, :bulk_coop], :report
     end
@@ -324,7 +324,7 @@ module Spree
       end
 
       # Reports page
-      can [:admin, :index, :show], ::Admin::ReportsController
+      can [:admin, :index, :show, :create], ::Admin::ReportsController
       can [:admin, :customers, :group_buys, :sales_tax, :payments,
            :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory,
            :order_cycle_management, :xero_invoices, :enterprise_fee_summary, :bulk_coop], :report

--- a/app/views/admin/reports/_fallback_display.html.haml
+++ b/app/views/admin/reports/_fallback_display.html.haml
@@ -1,0 +1,44 @@
+.download.hidden
+  = link_to t("admin.reports.download.button"), file_url, target: "_blank", class: "button icon icon-file"
+
+:javascript
+  (function () {
+    const tryDownload = function() {
+      const link = document.querySelector(".download a");
+
+      // If the report was already rendered via web sockets:
+      if (link == null) return;
+
+      fetch(link.href).then((response) => {
+        if (response.ok) {
+          response.blob().then((blob) => blob.text()).then((text) => {
+            const loading = document.querySelector(".loading");
+
+            if (loading == null) return;
+
+            loading.remove();
+            document.querySelector("#report-go button").disabled = false;
+
+            if (link.href.endsWith(".html")) {
+              // This replaces the hidden download button with the report:
+              link.parentElement.outerHTML = text;
+            } else {
+              // Or just show the download button when it's ready:
+              document.querySelector(".download").classList.remove("hidden")
+            }
+          });
+        } else {
+          setTimeout(tryDownload, 1000);
+        }
+      });
+    }
+
+    /*
+      A lot of reports are rendered within 250ms. Others take at least
+      2.5 seconds. There's a big gap in between. Observed on:
+      https://openfoodnetwork.org.au/admin/sidekiq/metrics/ReportJob?period=8h
+      https://openfoodnetwork.org.uk/admin/sidekiq/metrics/ReportJob?period=8h
+      https://coopcircuits.fr/admin/sidekiq/metrics/ReportJob?period=8h
+    */
+    setTimeout(tryDownload, 250);
+  })();

--- a/app/views/admin/reports/_fallback_display.html.haml
+++ b/app/views/admin/reports/_fallback_display.html.haml
@@ -28,7 +28,7 @@
             }
           });
         } else {
-          setTimeout(tryDownload, 1000);
+          setTimeout(tryDownload, 2000);
         }
       });
     }
@@ -39,6 +39,9 @@
       https://openfoodnetwork.org.au/admin/sidekiq/metrics/ReportJob?period=8h
       https://openfoodnetwork.org.uk/admin/sidekiq/metrics/ReportJob?period=8h
       https://coopcircuits.fr/admin/sidekiq/metrics/ReportJob?period=8h
+
+      But let's leave the timed response to websockets for now and just poll
+      as a backup mechanism.
     */
-    setTimeout(tryDownload, 250);
+    setTimeout(tryDownload, 3000);
   })();

--- a/app/views/admin/reports/create.turbo_stream.haml
+++ b/app/views/admin/reports/create.turbo_stream.haml
@@ -2,4 +2,5 @@
   = button t(:go), "report__submit-btn", "submit", disabled: true
 = turbo_stream.update "report-table" do
   = render "admin/reports/loading"
+  = render "admin/reports/fallback_display", file_url: @blob.expiring_service_url
 = turbo_stream.scroll_into_view("#report-table", behavior: "smooth")

--- a/app/views/admin/reports/create.turbo_stream.haml
+++ b/app/views/admin/reports/create.turbo_stream.haml
@@ -2,4 +2,4 @@
   = button t(:go), "report__submit-btn", "submit", disabled: true
 = turbo_stream.update "report-table" do
   = render "admin/reports/loading"
-= turbo_stream.action(:scroll_into_view, "report-table")
+= turbo_stream.scroll_into_view("#report-table", behavior: "smooth")

--- a/app/views/admin/reports/create.turbo_stream.haml
+++ b/app/views/admin/reports/create.turbo_stream.haml
@@ -1,0 +1,5 @@
+= turbo_stream.update "report-go" do
+  = button t(:go), "report__submit-btn", "submit", disabled: true
+= turbo_stream.update "report-table" do
+  = render "admin/reports/loading"
+= turbo_stream.action(:scroll_into_view, "report-table")

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -3,7 +3,7 @@
 
 - content_for :minimal_js, true
 
-= form_for @report.search, { url: url_for, data: { remote: "true" } } do |f|
+= form_for @report.search, { url: url_for, data: { turbo: "true" } } do |f|
   = hidden_field_tag "uuid", request.uuid
 
   %fieldset.no-border-bottom.print-hidden

--- a/app/webpacker/js/turbo.js
+++ b/app/webpacker/js/turbo.js
@@ -1,5 +1,8 @@
 import "@hotwired/turbo";
 
+import TurboPower from "turbo_power";
+TurboPower.initialize(Turbo.StreamActions);
+
 document.addEventListener("turbo:frame-missing", (event) => {
   // don't replace frame contents
   event.preventDefault();

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -135,6 +135,7 @@ Openfoodnetwork::Application.routes.draw do
     end
 
     get '/reports', to: 'reports#index', as: :reports
-    match '/reports/:report_type(/:report_subtype)', to: 'reports#show', via: [:get, :post], as: :report
+    match '/reports/:report_type(/:report_subtype)', to: 'reports#show', via: :get, as: :report
+    match '/reports/:report_type(/:report_subtype)', to: 'reports#create', via: :post
   end
 end

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "stimulus_reflex": "3.5.1",
     "tom-select": "^2.3.1",
     "trix": "^2.1.5",
+    "turbo_power": "^0.6.2",
     "webpack": "~4"
   },
   "devDependencies": {

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe Admin::ReportsController, type: :controller do
     end
 
     it "triggers the delivery report" do
-      spree_post :show, {
+      spree_post :create, {
         q: { completed_at_lt: 1.day.ago },
         shipping_method_in: ["123"], # We just need to search for shipping methods
         report_type: :order_cycle_management,

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -311,13 +311,14 @@ RSpec.describe Admin::ReportsController, type: :controller do
 
     it "triggers the delivery report" do
       spree_post :create, {
+        format: :turbo,
         q: { completed_at_lt: 1.day.ago },
         shipping_method_in: ["123"], # We just need to search for shipping methods
         report_type: :order_cycle_management,
         report_subtype: "delivery",
       }
 
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ReportMailer do
         blob:,
       ).report_ready
     }
-    let(:blob) { ReportBlob.create!("customers.csv", "report content") }
+    let(:blob) { ReportBlob.create_locally!("customers.csv", "report content") }
 
     it "notifies about a report" do
       expect(email.subject).to eq "Report ready"

--- a/spec/models/report_blob_spec.rb
+++ b/spec/models/report_blob_spec.rb
@@ -7,8 +7,16 @@ RSpec.describe ReportBlob, type: :model do
     content = "This works. ✓"
 
     expect do
-      blob = ReportBlob.create!("customers.html", content)
+      blob = ReportBlob.create_locally!("customers.html", content)
       content = blob.result
     end.not_to change { content.encoding }.from(Encoding::UTF_8)
+  end
+
+  it "can be created first and filled later" do
+    blob = ReportBlob.create_for_upload_later!("customers.html")
+
+    expect { blob.store("Hello") }
+      .to change { blob.checksum }.from("0")
+      .and change { blob.result }.from(nil).to("Hello")
   end
 end

--- a/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
@@ -93,8 +93,7 @@ RSpec.describe "enterprise fee summaries" do
 
         it "generates file with data for all enterprises" do
           select "CSV"
-          click_on "Go"
-          perform_enqueued_jobs(only: ReportJob)
+          run_report
           click_on "Download Report"
           expect(downloaded_filename).to include ".csv"
           expect(downloaded_content).to have_content(distributor.name)
@@ -118,8 +117,7 @@ RSpec.describe "enterprise fee summaries" do
 
         it "generates file with data for the enterprise" do
           select "CSV"
-          click_on "Go"
-          perform_enqueued_jobs(only: ReportJob)
+          run_report
           click_on "Download Report"
 
           expect(downloaded_filename).to include ".csv"
@@ -154,8 +152,7 @@ RSpec.describe "enterprise fee summaries" do
 
         find("#report_format").click
         select "CSV"
-        click_on "Go"
-        perform_enqueued_jobs(only: ReportJob)
+        run_report
         click_on "Download Report"
 
         expect(downloaded_filename).to include ".csv"

--- a/spec/system/admin/reports/orders_and_fulfillment_spec.rb
+++ b/spec/system/admin/reports/orders_and_fulfillment_spec.rb
@@ -256,12 +256,12 @@ RSpec.describe "Orders And Fulfillment" do
         describe "Totals" do
           before do
             click_link "Order Cycle Supplier Totals"
-            run_report
           end
 
           context "with the header row option not selected" do
             before do
               find("#display_header_row").set(false) # hides the header row
+              run_report
             end
 
             it "displays the report" do

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -139,14 +139,15 @@ RSpec.describe '
       # Unlocking the breakpoint will continue execution of the controller.
       breakpoint.unlock
 
-      # We have to wait to be sure that the "loading" spinner won't appear
-      # within the next half second. The default wait time would wait for
-      # 10 seconds which slows down the spec.
-      using_wait_time 0.5 do
-        page.has_selector? ".loading"
-      end
+      # Now the controller response will show the loading spinner again and
+      # the fallback mechanism will render the report later.
+      expect(page).to have_selector ".loading"
+
+      # Wait for the fallback mechanism:
+      sleep 3
 
       expect(page).not_to have_selector ".loading"
+      expect(page).to have_content "First Name Last Name Billing Address Email"
     end
   end
 

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -115,8 +115,6 @@ RSpec.describe '
     end
 
     it "allows the report to finish before the loading screen is rendered" do
-      pending "Race condition between loading message and report rendering"
-
       login_as_admin
       visit admin_report_path(report_type: :customers)
 

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -115,6 +115,8 @@ RSpec.describe '
     end
 
     it "allows the report to finish before the loading screen is rendered" do
+      pending "Race condition between loading message and report rendering"
+
       login_as_admin
       visit admin_report_path(report_type: :customers)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8825,6 +8825,11 @@ tty-browserify@0.0.0:
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
 
+turbo_power@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/turbo_power/-/turbo_power-0.6.2.tgz#d2320ffd18d7dba641bfbddaba388ffef5d90cb6"
+  integrity sha512-GCrwi6+rSLVORqb1LwP9pf/jP1Zo5lJgzGbLVu8g79T6LvB/9GGg7VWdLlWB0RvvDE1/+3hm32MPtEL5g89fsg==
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"


### PR DESCRIPTION
#### What? Why?

- Closes #11752 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Our busy servers are often not responsive enough for the real-time interaction of websockets. Sometimes the event of a finished report gets lost and the user sees an endless spinner.

I replaced some of the websockets interactions with HTTP responses using Turbo Streams. And I added a fallback script that checks once a second if the report is ready and we missed it. Then it's displayed.

I still kept the websockets communication for ready reports because that's our only mechanism to let the browser know that the report is ready right now instead of polling in intervals. We don't want to poll too often and we want to see the report as soon as possible. Replacing that use of websockets would need an SSE implementation to publish the event.

Having both, websockets and a polling Javascript, trying to achieve the same thing at the same time, created a new race condition though. I hope that the effects are rare and minimal to the user though.

I also observed some flaky specs that seem to be unrelated to this change. The build seems to be in a bad shape at the moment.

Let me know if you think that this is not good enough or if you have an idea for an easy improvement. My first goal is to unblock the users who, currently, have to click 40 times before they get a report.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Report display on screen.
- Report for download.
- Small reports and large reports.
- Server calm and server busy (render reports in multiple tabs).

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
