### PR TITLE
Make OC edit warning modal cancel button redirect user to OC list [OFN-12774]

### DIFF
--- a/app/assets/javascripts/admin/utils/services/navigation_check.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/navigation_check.js.coffee
@@ -9,6 +9,7 @@ angular.module("admin.utils")
           $window.onbeforeunload = @onBeforeUnloadHandler
 
         $rootScope.$on "$locationChangeStart", @locationChangeStartHandler
+        $window.onBeforeUnloadHandler = @onBeforeUnloadHandler
 
       # Action for regular browser navigation.
       onBeforeUnloadHandler: ($event) =>

--- a/app/views/admin/order_cycles/_date_time_warning_modal_content.html.haml
+++ b/app/views/admin/order_cycles/_date_time_warning_modal_content.html.haml
@@ -11,8 +11,7 @@
       = t('.proceed')
     %button.button.secondary{ "ng-click": "submit($event, '#{main_app.admin_order_cycles_path}')", type: "button", style: "display: none;", data: { action: 'click->modal#close', 'trigger-action': 'saveAndBack' } }
       = t('.proceed')
-    = link_to t('.cancel'), admin_order_cycles_path, id: 'cancel', class: 'button primary'
-
+    = link_to t('.cancel'), admin_order_cycles_path, id: 'cancel', class: 'button primary', data: { 'order-cycle-form-target': 'cancel' }
   - if action == 'bulk_update'
     %button.button.secondary{ "ng-click": "saveAll($event)", type: "button", style: "display: none;", data: { action: 'click->modal#close', trigger_action: 'bulk_save' } }
       = t('.proceed')

--- a/app/views/admin/order_cycles/_date_time_warning_modal_content.html.haml
+++ b/app/views/admin/order_cycles/_date_time_warning_modal_content.html.haml
@@ -11,8 +11,7 @@
       = t('.proceed')
     %button.button.secondary{ "ng-click": "submit($event, '#{main_app.admin_order_cycles_path}')", type: "button", style: "display: none;", data: { action: 'click->modal#close', 'trigger-action': 'saveAndBack' } }
       = t('.proceed')
-    %button.button.primary{ type: "button", 'data-action': 'click->modal#close' }
-      = t('.cancel')
+    = link_to t('.cancel'), admin_order_cycles_path, id: 'cancel', class: 'button primary'
 
   - if action == 'bulk_update'
     %button.button.secondary{ "ng-click": "saveAll($event)", type: "button", style: "display: none;", data: { action: 'click->modal#close', trigger_action: 'bulk_save' } }

--- a/app/webpacker/controllers/order_cycle_form_controller.js
+++ b/app/webpacker/controllers/order_cycle_form_controller.js
@@ -1,13 +1,17 @@
 import { Controller } from "stimulus";
 
 export default class extends Controller {
-  static targets = ['statusMessage']
+  static targets = ['statusMessage', 'cancel']
   connect() {
     this.observer = new MutationObserver(this.updateCallback);
     this.observer.observe(
       this.statusMessageTarget,
       { attributes: true, attributeOldValue: true, attributeFilter: ['data-type'] }
     );
+
+    if (this.hasCancelTarget) {
+      this.cancelTarget.addEventListener('click', this.removeUnloadEvent)
+    }
   }
 
   // Callback to trigger warning modal
@@ -38,7 +42,14 @@ export default class extends Controller {
     }
   }
 
+  removeUnloadEvent() {
+    window.removeEventListener('beforeunload', window.onBeforeUnloadHandler)
+  }
+
   disconnect() {
     this.observer.disconnect();
+    if (this.hasCancelTarget) {
+      this.cancelTarget.removeEventListener('click', this.removeUnloadEvent)
+    }
   }
 }

--- a/spec/system/admin/order_cycles/edit_spec.rb
+++ b/spec/system/admin/order_cycles/edit_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe '
         expect(page).to have_field 'order_cycle_orders_close_at', with: '2024-03-30 00:00'
         expect(page).to have_content('Your order cycle has been updated.')
       end
+
+      it "it redirects user to oc list when modal cancel is clicked" do
+        login_as_admin
+        visit edit_admin_order_cycle_path(order_cycle)
+
+        # change date range field value
+        find('#order_cycle_orders_close_at').click
+        within(".flatpickr-calendar.open") do
+          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
+          select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
+          find("button", text: "Close").click
+        end
+
+        # click save to open warning modal
+        click_button('Save')
+        expect(page).to have_content('You have unsaved changes')
+        expect(page).to have_content "Orders are linked to this order cycle."
+
+        # Now cancel modal
+        within('.modal-actions') do
+          click_link('Cancel')
+        end
+        expect(page).not_to have_content('You have unsaved changes')
+        expect(page).to have_current_path admin_order_cycles_path
+      end
     end
 
     context 'with no attached order' do


### PR DESCRIPTION
#### What? Why?

- Closes #12774

Make OC edit warning modal cancel button redirect the user to OC list



#### What should we test?
Verify that the cancel button in the edit OC warning modal links to the OC list.

- Visit ... page.
 /admin/order_cycles/2/edit

#### Release notes

Order cycle warning modal cancel link redirects the user to Order cycle list

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

Order cycle warning modal cancel link redirects the user to Order cycle list


#### Dependencies
N/A



#### Documentation updates
N/A
