### PR TITLE
Reproduces S2 bug #12768

### DIFF
--- a/spec/system/admin/order_cycles/edit_spec.rb
+++ b/spec/system/admin/order_cycles/edit_spec.rb
@@ -144,8 +144,8 @@ RSpec.describe '
 
         # click save
         click_button('Save')
-        expect(page.find('#order_cycle_name').value).to eq 'OC1 name updated'
         expect(page).to have_content('Your order cycle has been updated.')
+        expect(page.find('#order_cycle_name').value).to eq 'OC1 name updated'
 
         # Now change date range field value
         find('#order_cycle_orders_close_at').click
@@ -157,9 +157,9 @@ RSpec.describe '
         expect(page).to have_content('You have unsaved changes')
 
         click_button('Save')
+        expect(page).to have_content('Your order cycle has been updated.')
         expect(page).not_to have_content "Orders are linked to this cycle"
         expect(page).to have_field 'order_cycle_orders_close_at', with: '2024-03-30 00:00'
-        expect(page).to have_content('Your order cycle has been updated.')
       end
     end
   end

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -499,12 +499,16 @@ RSpec.describe '
   end
 
   describe 'bulk coop report' do
+    let!(:order) { create(:completed_order_with_totals) }
+
     before do
       login_as_admin
       visit admin_reports_path
     end
 
     it "generating Bulk Co-op Supplier Report" do
+      pending("S2 bug #12768")
+
       click_link "Bulk Co-op Supplier Report"
       run_report
 


### PR DESCRIPTION
#### What? Why?

1) Contributes to #12768.
2) Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/12786.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

1)

The bug is only observable if running the report returns any results; otherwise, only an empty table header is displayed and the bug does not occur.

The only currently existing spec for the Bulk Coop Supplier Report was only asserting on the table header, and no complete order was setup for the test. This meant that the test always passed, as it never was returning any results.

The PR adds a complete order to the test setup, and reproduces the bug, setting the test as pending.

2)

The PR surfaced a flaky spec, which - for some mysterious reason :eyes: - never passed with this PR. I've opened a flaky spec issue for this and made the required change to close it.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
