### PR TITLE
Fix supplier loading on Product & inventory report

### DIFF
--- a/lib/reporting/frontend_data.rb
+++ b/lib/reporting/frontend_data.rb
@@ -21,8 +21,9 @@ module Reporting
     end
 
     def suppliers_of_products_distributed_by(distributors)
-      supplier_ids = Spree::Product.in_distributors(distributors.select('enterprises.id')).
-        select('spree_products.supplier_id')
+      supplier_ids = Spree::Variant.joins(exchange_variants: { exchange: :order_cycle }).
+        where(exchanges: { incoming: false, receiver: distributors } )
+        .select("spree_variants.supplier_id")
 
       Enterprise.where(id: supplier_ids)
     end

--- a/lib/reporting/reports/xero_invoices/base.rb
+++ b/lib/reporting/reports/xero_invoices/base.rb
@@ -60,11 +60,6 @@ module Reporting
 
         private
 
-        def line_item_includes
-          [:bill_address, :adjustments,
-           { line_items: { variant: { product: :supplier } } }]
-        end
-
         def detail_rows_for_order(order, invoice_number, opts)
           rows = []
 

--- a/spec/lib/reports/frontend_data_spec.rb
+++ b/spec/lib/reports/frontend_data_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Reporting::FrontendData do
+  subject { described_class.new(user) }
+
+  let(:user) { create(:user, enterprises: [distributor1, distributor2]) }
+  let(:distributor1) { create(:distributor_enterprise) }
+  let(:distributor2) { create(:distributor_enterprise) }
+
+  let(:supplier1) { create(:supplier_enterprise) }
+  let(:supplier2) { create(:supplier_enterprise) }
+  let(:supplier3) { create(:supplier_enterprise) }
+
+  let(:product1) { create(:simple_product, name: "Product Supplier 1", supplier_id: supplier1.id) }
+  let(:product2) { create(:simple_product, name: "Product Supplier 2", supplier_id: supplier2.id) }
+  let(:product3) { create(:simple_product, name: "Product Supplier 3", supplier_id: supplier3.id) }
+
+  let(:order_cycle1) {
+    create(:simple_order_cycle, coordinator: distributor1,
+                                distributors: [distributor1],
+                                variants: [product1.variants.first, product2.variants.first])
+  }
+
+  let(:order_cycle2) {
+    create(:simple_order_cycle, coordinator: distributor2,
+                                distributors: [distributor2],
+                                variants: [product3.variants.first])
+  }
+
+  let!(:order1) {
+    create(:order, order_cycle: order_cycle1, distributor: distributor1)
+  }
+  let!(:order2) {
+    create(:order, order_cycle: order_cycle2, distributor: distributor2)
+  }
+
+  describe "#suppliers_of_products_distributed_by" do
+    it "returns supplier of products for the given distributors" do
+      distributors = Enterprise.where(id: [distributor1, distributor2])
+
+      expect(subject.suppliers_of_products_distributed_by(distributors)).to match_array(
+        [supplier1, supplier2, supplier3]
+      )
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

I came across this when fixing #12768 
Not all supplier are loaded in the "Product & inventory" report  it's missing the suppliers of products distributed by the distributors the current user manages. As far as I could tell it wasn't covered by spec. 


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
Set up an enterprise user that can manage another enterprise, and create an order cycle including the managed enterprise products. Place an order including at least one of the managed enterprise products.

As an admin
- Visit Report page and choose Product & Inventory -> "All product"
- Check the managed enterprise is included in the supplier dorpdown

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
