### PR TITLE
Update deprecated WickedPdf config syntax

### DIFF
--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,20 +1,13 @@
-if Rails.env.test?
-  Rails.application.reloader.to_prepare do
-    WickedPdf.config = {
-      #:wkhtmltopdf => '/usr/local/bin/wkhtmltopdf',
-      #:layout => "pdf.html",
-      :page_size => 'A3',
-      :exe_path => `bundle exec which wkhtmltopdf`.chomp
-    }
-  end
-else
-  Rails.application.reloader.to_prepare do
-    WickedPdf.config = {
-      #:wkhtmltopdf => '/usr/local/bin/wkhtmltopdf',
-      #:layout => "pdf.html",
-      :page_size => 'A4', # default
-      :exe_path => `bundle exec which wkhtmltopdf`.chomp
-    }
+WickedPdf.configure do |c|
+  c.exe_path = `bundle exec which wkhtmltopdf`.chomp
+
+  if Rails.env.test?
+    # Conversion from PDF to text struggles with multi-line text.
+    # We avoid that by printing on bigger pages.
+    # https://github.com/openfoodfoundation/openfoodnetwork/pull/9674
+    c.page_size = "A3"
+  else
+    c.page_size = "A4"
   end
 end
 


### PR DESCRIPTION
#### What? Why?

While developing, I noticed a deprecation warning.

> WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.

So I followed the instructions and simplified it a bit.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Print an invoice.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
