### PR TITLE
Fix typos in "category" and unify capitals on "Back To Xyz List" buttons

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,7 +103,7 @@ en:
     errors:
       models:
         enterprise_fee:
-          inherit_tax_requires_per_item_calculator: "Inheriting the tax categeory requires a per-item calculator."
+          inherit_tax_requires_per_item_calculator: "Inheriting the tax category requires a per-item calculator."
         spree/image:
           attributes:
             attachment:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -531,7 +531,7 @@ en:
   password_confirmation: Password Confirmation
   reset_password_token: Reset password token
   expired: has expired, please request a new one
-  back_to_payments_list: "Back to Payments List"
+  back_to_payments_list: "Back To Payments List"
   maestro_or_solo_cards: "Maestro/Solo cards"
   backordered: "Backordered"
   on_hand: "On Hand"
@@ -854,7 +854,7 @@ en:
       variants:
         infinity: "Infinity"
         to_order_tip: "Items made to order do not have a set stock level, such as loaves of bread made fresh to order."
-      back_to_products_list: "Back to products list"
+      back_to_products_list: "Back To Products List"
       editing_product: "Editing Product"
       tabs:
         product_details: "Product Details"
@@ -1467,10 +1467,10 @@ en:
         contact_name: Contact Name
       edit:
         editing: 'Settings:'
-        back_link: Back to enterprises list
+        back_link: Back To Enterprises List
       new:
         title: New Enterprise
-        back_link: Back to enterprises list
+        back_link: Back To Enterprises List
       welcome:
         welcome_title: Welcome to the Open Food Network!
         welcome_text: You have successfully created a
@@ -3365,7 +3365,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   order_cycles_no_permission_to_coordinate_error: "None of your enterprises have permission to coordinate an order cycle"
   order_cycles_no_permission_to_create_error: "You don't have permission to create an order cycle coordinated by that enterprise"
   order_cycle_closed: "The order cycle you've selected has just closed. Please try again!"
-  back_to_orders_list: "Back to order list"
+  back_to_orders_list: "Back To Orders List"
   no_orders_found: "No Orders Found"
   order_information: "Order Information"
   new_payment: "New Payment"
@@ -4066,7 +4066,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     tax_rate_amount_explanation: "Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)"
     included_in_price: "Included in Price"
     show_rate_in_label: "Show rate in label"
-    back_to_tax_rates_list: "Back to Tax Rates List"
+    back_to_tax_rates_list: "Back To Tax Rates List"
 
     tax_settings: "Tax Settings"
     zones: "Zones"
@@ -4081,7 +4081,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     iso_name: "ISO Name"
     states_required: "States Required"
     editing_country: "Editing Country"
-    back_to_countries_list: "Back to Countries List"
+    back_to_countries_list: "Back To Countries List"
 
     states: "States"
     abbreviation: "Abbreviation"
@@ -4257,7 +4257,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           continue: "Continue"
         new:
           new_return_authorization: "New Return Authorization"
-          back_to_return_authorizations_list: "Back To Return Authorization List"
+          back_to_return_authorizations_list: "Back To Return Authorizations List"
           continue: "Continue"
         edit:
           receive: "receive"
@@ -4581,7 +4581,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           total: "Total"
           billing_address_name: "Name"
       taxons:
-        back_to_list: "Back to Product Categeory List"
+        back_to_list: "Back To Product Categories List"
         index:
           title: "Product Categories"
           new_taxon: 'New product category'

--- a/spec/models/enterprise_fee_spec.rb
+++ b/spec/models/enterprise_fee_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe EnterpriseFee do
           )
           expect(subject.save).to eq false
           expect(subject.errors.full_messages.first).to eq(
-            "Inheriting the tax categeory requires a per-item calculator."
+            "Inheriting the tax category requires a per-item calculator."
           )
         end
       end

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe '
       # editing to an invalid combination
       select 'Flat Rate (per order)', from: "#{prefix}_calculator_type"
       expect{ click_button 'Update' }.not_to change { fee.reload.calculator_type }
-      expect(page).to have_content "Inheriting the tax categeory requires a per-item calculator."
+      expect(page).to have_content "Inheriting the tax category requires a per-item calculator."
     end
   end
 
@@ -299,7 +299,7 @@ RSpec.describe '
       end
 
       context "an error message is displayed" do
-        message = 'Inheriting the tax categeory requires a per-item calculator.'
+        message = 'Inheriting the tax category requires a per-item calculator.'
         it_behaves_like "setting it up", 'Inherit From Product',
                         'Flat Rate (per order)', message, 0
       end

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe '
     describe "editing page" do
       let!(:product) { create(:simple_product, name: 'a product', supplier_id: supplier2.id) }
 
-      describe "'Back to products list' and 'Cancel' buttons" do
+      describe "'Back To Products List' and 'Cancel' buttons" do
         context "navigates to edit from the bulk product update page with searched results" do
           it "should navigate back to the same searched results page" do
             # Navigating to a searched URL
@@ -326,7 +326,7 @@ RSpec.describe '
               click_link('Edit', href: spree.edit_admin_product_path(product))
             end
 
-            expect(page).to have_link('Back to products list',
+            expect(page).to have_link('Back To Products List',
                                       href: products_page_url)
             expect(page).to have_link('Cancel',
                                       href: products_page_url)
@@ -338,7 +338,7 @@ RSpec.describe '
             # Navigating to a searched URL
             visit spree.edit_admin_product_path(product)
 
-            expect(page).to have_link('Back to products list',
+            expect(page).to have_link('Back To Products List',
                                       href: admin_products_url)
             expect(page).to have_link('Cancel',
                                       href: admin_products_url)


### PR DESCRIPTION
#### What? Why?
Fixes two occurrences of the typo categeory (additional e).
Makes the labels on the "Back To Xyz List" buttons in the admin area use a capital letter uniformly. 

![image](https://github.com/user-attachments/assets/6e1ae263-f8b2-41c6-b0fe-143f96d03c21)

![image](https://github.com/user-attachments/assets/d54e73a2-fa87-4326-9e45-ff5b9293743d)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit admin pages with a button "Back To Xyz List", e.g. edit product details, edit order, edit shipping methods, edit product category,  edit countries, etc.
- Check the label of the 'Back To Xyz List' button.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
