### PR TITLE
[BUU] Fix Table width not responsive to the amount of selected columns

### DIFF
--- a/app/views/admin/products_v3/_product_row.html.haml
+++ b/app/views/admin/products_v3/_product_row.html.haml
@@ -25,7 +25,7 @@
   -# empty
 %td.col-on_hand.align-right
   -# empty
-%td.col-on_hand.align-right
+%td.col-producer.align-right
   -# empty
 %td.col-category.align-left
   -# empty


### PR DESCRIPTION
#### What? Why?

- Closes #12809
- It looks like there was a typo in the class name for the producer in the product row column. As a result, when the producer column is selected as hidden, the variant's producer column hides correctly, but the product's producer column remains visible due to the incorrect class name.
- This PR fixes this typo
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit the products page
- Hide any of the Producer and On Hand columns
- Columns width should remain responsive.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled