### PR TITLE
[BUU] Fix the too Narrow Price field

### DIFF
--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -21,8 +21,8 @@
       %col.col-sku{ width:"8%", style:"min-width: 6em" }
       %col.col-unit_scale{ width:"8%" }
       %col.col-unit{ width:"8%" }
-      %col.col-price{ width:"5%", style:"min-width: 5em" }
-      %col.col-on_hand{ width:"10%"}
+      %col.col-price{ width:"10%", style:"min-width: 5em" }
+      %col.col-on_hand{ width:"8%" }
       %col.col-producer{ style:"min-width: 6em" }= # (grow to fill)
       %col.col-category{ width:"8%" }
       %col.col-tax_category{ width:"8%" }


### PR DESCRIPTION
#### What? Why?

- Closes #12810
- The price column space is adjusted such that it's able to fully display the maximum number (_99,999,999.99_) our system allows for it, hence this PR makes it to 10%.
- However, its consequence is that the width of the name column is reduced a bit in the case when all the columns are being displayed.
- To fix this, the user may hide some unnecessary columns to make space for the name column, or for now, this PR takes some space from the On Hand column by reducing it to 8%.
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit the products page
- Update product price to any number between 1 to 99,999,999.99
- It should fully display the price without cutting it off

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
