### PR TITLE
Increase column space in bulk products table

### DIFF
--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -16,7 +16,7 @@
   %table.products{ 'data-column-preferences-target': "table" }
     %colgroup
       -# The `min-width` property works in Chrome but not Firefox so is considered progressive enhancement.
-      %col.col-image{ width:"56px" }= # (image size + padding)
+      %col.col-image{ width:"44px" }= # (image size + padding)
       %col.col-name{ style:"min-width: 6em" }= # (grow to fill)
       %col.col-sku{ width:"8%", style:"min-width: 6em" }
       %col.col-unit_scale{ width:"8%" }

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -148,7 +148,7 @@
         border-bottom: 2px solid $color-tbl-bg;
 
         &.with-image {
-          padding: 8px;
+          padding: 4px 2px;
         }
       }
 

--- a/app/webpacker/css/admin_v3/globals/variables.scss
+++ b/app/webpacker/css/admin_v3/globals/variables.scss
@@ -40,8 +40,8 @@ $color-tbl-thead-txt:            $color-headers !default;
 $color-tbl-thead-bg:             $light-grey !default;
 $color-tbl-border:               $pale-blue !default;
 $padding-tbl-cell:               12px;
-$padding-tbl-cell-condensed:     4px 12px;
-$padding-tbl-cell-relaxed:       12px 12px;
+$padding-tbl-cell-condensed:     4px 3px;
+$padding-tbl-cell-relaxed:       8px 3px;
 
 // Button colors
 $color-btn-bg:                   $teal !default;


### PR DESCRIPTION
I had a look at one of the [original designs](https://www.figma.com/proto/v1zbrWDZSRd3Nqoe0SJ2Sm/Engineering-Delivery---Back-Office?page-id=363%3A2039&type=design&node-id=392-4793&viewport=376%2C497%2C0.08&t=dSLOjkxd3SHsINta-1&scaling=min-zoom) and found that we had way more padding than was originally intended. I think we intended to review and correct the padding after implementing all the components... well it's better late than never!
This should give us some more breathing room.

## Before
![Screenshot 2024-08-26 at 4 34 16 pm](https://github.com/user-attachments/assets/e4dc555a-e945-4628-a242-de44e872f92f)

## After
![Screenshot 2024-08-26 at 4 54 42 pm](https://github.com/user-attachments/assets/c295bccc-22d2-4ad1-98ff-400c2c5294e9)

(I just noticed that the first product in the screenshot has a space at the start of the name, which is a bit confusing sorry)


This is closer to the original design (at least the one i referred to):
* 6px between inputs
* 6px vertical padding on condensed rows (depending how you count it)
* 12px vertical padding on relaxed rows

Note that 'relaxed' rows are now smaller than the regular rows, which was not the original intention. But we haven't got spare time to do a broader review of table styles right now.

## What should we test?
Admin products screen,
* with different samples of data (eg different staging environments or different pages)
* with some columns hidden
* with a screen as narrow as 768px (a tablet in portrait mode)

## follow-up
I think it would be helpful to also reduce the padding on the dropdown arrows:
![Screenshot 2024-08-26 at 4 44 56 pm](https://github.com/user-attachments/assets/66bbbb67-d702-4f2b-b27d-b6dce29b9557)

Popouts already have very little padding (due to space constraints):
![Screenshot 2024-08-26 at 4 44 37 pm](https://github.com/user-attachments/assets/4499f451-8b05-48d5-bcd1-c5b1536b6df3)

We could use this padding for other dropdowns in the bulk products table too.

(I'm not proposing we change the dropdown arrow padding on elements _outside_ the table, they can stay the same.
