### PR TITLE
[BUU] Fix Error 500 on accessing /products page

### DIFF
--- a/config/locales/en_FR.yml
+++ b/config/locales/en_FR.yml
@@ -824,7 +824,7 @@ en_FR:
       sort:
         pagination:
           products_total_html:
-            one: "<strong>%{total} products</strong> found for your search criteria. Showing %{from} to %{to}."
+            one: "<strong>%{count} product</strong> found for your search criteria. Showing %{from} to %{to}."
             other: "<strong>%{count} products</strong> found for your search criteria. Showing %{from} to %{to}."
           per_page:
             show: Show

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -824,8 +824,8 @@ en_GB:
       sort:
         pagination:
           products_total_html:
-            one: "<strong>%{total} product</strong> found for your search criteria. Showing %{from} to %{to}."
-            other: "<strong>%{total} products</strong> found for your search criteria. Showing %{from} to %{to}. "
+            one: "<strong>%{count} product</strong> found for your search criteria. Showing %{from} to %{to}."
+            other: "<strong>%{count} products</strong> found for your search criteria. Showing %{from} to %{to}. "
           per_page:
             show: Show
             per_page: "%{num} per page"


### PR DESCRIPTION
**Context:** https://openfoodnetwork.slack.com/archives/CG7NJ966B/p1724767186657359
#### What? Why?

- Closes #12819
- There's a wrong variable name (`total`) being used in `en_FR` and `en_GB` locales.
- This PR fixes this by replacing all instances with the correct variable name (`count`)
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Should be tested on UK and FR servers
- Choose English as the language
- Visit the products page
- It should be displayed without error
- Try to filter the products such that only one product is displayed in the table and the page should not break as well.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
