### PR TITLE
Fix artifact path for simplecov report upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -556,6 +556,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: combined-simplecov-report
-          path: coverage/*.*
+          path: coverage/**/*.*
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
#### What? Why?

Resolves issue in comment here: https://github.com/openfoodfoundation/openfoodnetwork/pull/12798#pullrequestreview-2259533755; only files in the root of the coverage directory were being uploaded, not nested files

#### What should we test?
- Go to the assets after the CI run
- Download the report
  - The directory should now contain the `assets` folder
- Open index.html
  - the page should now be properly styled

#### Release notes

- [x] Technical changes only

The title of the pull request will be included in the release notes.

#### Dependencies

#### Documentation updates
