### PR TITLE
Optimise shops page: Only inject distributors with active order cycles

### DIFF
--- a/app/services/shops_list_service.rb
+++ b/app/services/shops_list_service.rb
@@ -2,7 +2,10 @@
 
 class ShopsListService
   def open_shops
-    shops_list.ready_for_checkout.all
+    shops_list.
+      ready_for_checkout.
+      distributors_with_active_order_cycles.
+      all
   end
 
   def closed_shops

--- a/app/services/shops_list_service.rb
+++ b/app/services/shops_list_service.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 class ShopsListService
+  # shops that are ready for checkout, and have an order cycle that is currently open
   def open_shops
     shops_list.
       ready_for_checkout.
-      distributors_with_active_order_cycles.
-      all
+      distributors_with_active_order_cycles
   end
 
+  # shops that are either not ready for checkout, or don't have an open order cycle; the inverse of
+  # #open_shops
   def closed_shops
-    shops_list.not_ready_for_checkout.all
+    shops_list.where.not(id: open_shops.reselect("enterprises.id"))
   end
 
   private

--- a/spec/controllers/api/v0/shops_controller_spec.rb
+++ b/spec/controllers/api/v0/shops_controller_spec.rb
@@ -32,10 +32,19 @@ RSpec.describe Api::V0::ShopsController, type: :controller do
     end
 
     describe "#closed_shops" do
+      let!(:hub_open_order_cycle) {
+        create(:simple_order_cycle, orders_open_at: 10.days.ago,
+                                    orders_close_at: 17.days.from_now,
+                                    suppliers: [create(:supplier_enterprise)],
+                                    distributors: [hub], variants: [product.variants.first])
+      }
+
       it "returns data for all closed shops" do
         get :closed_shops, params: {}
 
-        expect(json_response).not_to match hub.name
+        # `hub` has an open order cycle (hub_open_order_cycle), so it should be excluded from
+        # results
+        expect(json_response.inspect).not_to match hub.name
 
         response_ids = json_response.pluck(:id)
         expect(response_ids).to contain_exactly(closed_hub1.id, closed_hub2.id)

--- a/spec/services/shops_list_service_spec.rb
+++ b/spec/services/shops_list_service_spec.rb
@@ -5,16 +5,19 @@ require "spec_helper"
 RSpec.describe ShopsListService do
   subject { described_class.new }
   before do
-    create_list :enterprise, 3, :with_logo_image, :with_promo_image
-    create_list :distributor_enterprise, 3,
-                :with_logo_image,
-                :with_promo_image,
-                with_payment_and_shipping: true
+    enterprises = create_list :enterprise, 3, :with_logo_image, :with_promo_image
+    distributors = create_list :distributor_enterprise, 3,
+                               :with_logo_image,
+                               :with_promo_image,
+                               with_payment_and_shipping: true
+    create :distributor_order_cycle, distributors: [distributors[0]], suppliers: [enterprises[0]]
   end
 
-  let(:shop) { subject.open_shops.first }
+  let(:shop) { shops.first }
 
   describe "#open_shops" do
+    let(:shops) { subject.open_shops }
+
     it "preloads promo images" do
       expect(shop.association(:promo_image_attachment).loaded?).to be true
       expect(shop.promo_image.association(:blob).loaded?).to be true
@@ -23,11 +26,17 @@ RSpec.describe ShopsListService do
     it "preloads logos" do
       expect(shop.association(:logo_attachment).loaded?).to be true
       expect(shop.logo.association(:blob).loaded?).to be true
+    end
+
+    it "only fetches enterprises with an active order cycle" do
+      open_enterprise_ids = Enterprise.distributors_with_active_order_cycles.pluck(:id).to_set
+      expect(open_enterprise_ids).not_to be_empty
+      expect(shops.pluck(:id)).to all be_in open_enterprise_ids
     end
   end
 
   describe "#closed_shops" do
-    let(:shop) { subject.closed_shops.first }
+    let(:shops) { subject.closed_shops }
 
     it "preloads promo images" do
       expect(shop.association(:promo_image_attachment).loaded?).to be true
@@ -37,6 +46,15 @@ RSpec.describe ShopsListService do
     it "preloads logos" do
       expect(shop.association(:logo_attachment).loaded?).to be true
       expect(shop.logo.association(:blob).loaded?).to be true
+    end
+
+    it "fetches enterprises without active order cycles" do
+      open_enterprise_ids = Enterprise.distributors_with_active_order_cycles.pluck(:id).to_set
+      expect(open_enterprise_ids).not_to be_empty
+
+      shops.pluck(:id).each do |shop_id|
+        expect(shop_id).not_to be_in open_enterprise_ids
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

This follows on from some of my previous changes, to optimise the load time for the `/shops` page (esp. the UK instance).

When looking at the html on the https://openfoodnetwork.org.uk/shops page, I could see that >4000 shops are being injected - but only a few dozen (tops) are displayed as open and active; there are client-side filters which filter all of them to pick out the active ones (`active.js.coffee`/`closed_shops.js.coffee`). From what I can work out, the rest of the shops are superfluous because the closed shops are fetched via API (https://github.com/openfoodfoundation/openfoodnetwork/pull/5156).

The `active` attribute (as read by the filters on the front end) is determined by:

```ruby
    def active
      options[:data].active_distributor_ids&.include? object.id
    end
```

where `active_distributor_ids` is determined by:

```ruby
    def active_distributor_ids
      @active_distributor_ids ||=
        begin
          enterprises = Enterprise.distributors_with_active_order_cycles.ready_for_checkout
          enterprises = enterprises.where(id: @enterprise_ids) if @enterprise_ids.present?
          enterprises.pluck(:id)
        end
    end
```

so it seems logical to me to move `distributors_with_active_order_cycles` into the `open_shops` method, because it's the same logic that will be used to filter the open shops, but just doing it sooner on the back end rather than client-side.

#### What should we test?
- Visit `/shops`
- Check that the expected open shops are listed
- Check that the filters are displayed and working as before
- Click on "Show closed shops"
- Check that the expected closed shops load ok

`ShopsListService#open_shops` is only used on this page, so it shouldn't have any other knock-on effects

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

#### Dependencies


#### Documentation updates