### PR TITLE
[admin] Update page titles

### DIFF
--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -1,6 +1,9 @@
 - content_for :main_ng_app_name do
   = "admin.lineItems"
 
+- content_for :html_title do
+  = t("admin.orders.bulk_management.page_title")
+
 - content_for :page_title do
   %h1.page-title
     = t("admin.orders.bulk_management.page_title")

--- a/app/views/spree/admin/payments/paypal_refund.html.haml
+++ b/app/views/spree/admin/payments/paypal_refund.html.haml
@@ -1,5 +1,8 @@
 = render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Payments' }
 
+- content_for :html_title do
+  = Spree.t('refund', scope: :paypal)
+
 - content_for :page_title do
   %i.icon-arrow-right
   = link_to Spree.t(:payments), admin_order_payments_path(@order)

--- a/app/views/spree/admin/shared/_head.html.haml
+++ b/app/views/spree/admin/shared/_head.html.haml
@@ -7,6 +7,8 @@
 %title
   - if content_for? :html_title
     = yield :html_title
+  - elsif content_for? :page_title
+    = strip_tags(yield(:page_title))
   - else
     = t("spree.admin.tab.#{controller.controller_name}", :default => controller.controller_name.titleize)
   = " - OFN #{t(:administration)}"


### PR DESCRIPTION
## What? Why?
It struck me today that the browser tab title/history doesn't include the full name of the page you're on. For example, if I had edited multiple products and wanted to go back to a particular one, I can't choose it. They are all simply labelled "Products".
![Screenshot 2024-09-02 at 10 54 17 am](https://github.com/user-attachments/assets/7bad973f-d6e6-484e-9d6a-9201e0b77342)

So I wondered if we can easily use the titles that appear on the page. At first glance it looks much more helpful to me:


![Screenshot 2024-09-02 at 10 57 40 am](https://github.com/user-attachments/assets/d9da704a-75fd-4fa2-8b8a-0cd1b0a6670b)

Although note that there are some differences. Sometimes the page title doesn't match the  navigation menu. For example:
![Screenshot 2024-09-02 at 10 58 55 am](https://github.com/user-attachments/assets/7cb3ed9b-00f6-45e5-9e0c-97ba5b1d9d61)

Some deeper pages have arrows, so these are stripped:
![Screenshot 2024-09-02 at 11 07 32 am](https://github.com/user-attachments/assets/dcfe399b-04b8-4792-834d-b1ea328687c1)

## What should we test?
Click around and check the page titles in the browser tab, and in browser history. 
Try another language too.
One page was changed that I didn't know how to test:
* Paypal refund
