### PR TITLE
Fix karma test

### DIFF
--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -121,18 +121,24 @@ describe "LineItemsCtrl", ->
         scope.line_items = [ line_item1, line_item2 ]
 
       it "show popup about order cancellation only on last item deletion", ->
+        spyOn(window, "confirm").and.callFake(-> return true)
         spyOn(window, "ofnCancelOrderAlert")
+
         scope.deleteLineItem(line_item2)
+        expect(confirm).toHaveBeenCalled()
         expect(ofnCancelOrderAlert).not.toHaveBeenCalled()
+
         scope.deleteLineItem(line_item1)
         expect(ofnCancelOrderAlert).toHaveBeenCalled()
 
       it "deletes the line item", ->
         spyOn(window, "confirm").and.callFake(-> return true)
         spyOn(LineItems, "delete")
+
         scope.deleteLineItem(line_item2)
+        expect(confirm).toHaveBeenCalled()
         expect(LineItems.delete).toHaveBeenCalledWith(line_item2, jasmine.anything())
-    
+
     describe "deleting 'checked' line items", ->
       line_item1 = line_item2 = line_item3 = line_item4 = null
       order1 = order2 = order3 = null

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -171,10 +171,14 @@ describe "LineItemsCtrl", ->
 
       it "asks for confirmation only if orders will be canceled", ->
         spyOn(window, "ofnCancelOrderAlert")
+
         line_item3.checked = true
         scope.deleteLineItems(scope.line_items)
+
         line_item1.checked = true
         scope.deleteLineItems(scope.line_items)
+        expect(ofnCancelOrderAlert).toHaveBeenCalled()
+
 
     describe "check boxes for line items", ->
       line_item1 = line_item2 = null


### PR DESCRIPTION
#### What? Why?

- Closes #12832

For some reason karma hangs and fails with a timeout error if a `confirm` javascript pop up isn't mocked. I am not sure why it stopped working suddenly, `karma` is deprecated and has not been updated in the last week. I suspect it might be a chrome issue.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build :green_circle: 
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
