### PR TITLE
Enable include-hidden-files for uploading code coverage chunks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
           path: coverage/*.*
           retention-days: 2 # doesn't need to be long, because it's the combined results that matter
           if-no-files-found: ignore
+          include-hidden-files: true
 
   models:
     runs-on: ubuntu-22.04
@@ -160,6 +161,7 @@ jobs:
           path: coverage/*.*
           retention-days: 2 # doesn't need to be long, because it's the combined results that matter
           if-no-files-found: ignore
+          include-hidden-files: true
 
   system_admin:
     runs-on: ubuntu-22.04
@@ -237,6 +239,7 @@ jobs:
           path: coverage/*.*
           retention-days: 2 # doesn't need to be long, because it's the combined results that matter
           if-no-files-found: ignore
+          include-hidden-files: true
 
       - name: Archive failed tests screenshots
         if: failure()
@@ -323,6 +326,7 @@ jobs:
           path: coverage/*.*
           retention-days: 2 # doesn't need to be long, because it's the combined results that matter
           if-no-files-found: ignore
+          include-hidden-files: true
 
       - name: Archive failed tests screenshots
         if: failure()
@@ -410,6 +414,7 @@ jobs:
           path: coverage/*.*
           retention-days: 2 # doesn't need to be long, because it's the combined results that matter
           if-no-files-found: ignore
+          include-hidden-files: true
 
   test_the_rest:
     runs-on: ubuntu-22.04
@@ -486,6 +491,7 @@ jobs:
           path: coverage/*.*
           retention-days: 2 # doesn't need to be long, because it's the combined results that matter
           if-no-files-found: ignore
+          include-hidden-files: true
 
   non_knapsack_jest_karma:
     runs-on: ubuntu-22.04
@@ -559,3 +565,4 @@ jobs:
           path: coverage/**/*.*
           retention-days: 7
           if-no-files-found: ignore
+          include-hidden-files: true


### PR DESCRIPTION
#### What? Why?

- Fixes CI builds - currently affecting master https://github.com/openfoodfoundation/openfoodnetwork/pull/12827#issuecomment-2327063352

It looks like it could be https://github.com/actions/upload-artifact/issues/602 - this project certainly isn't the only one affected! 😅

The partial simplecov reports are all called `.resultset.json` (or something like that), so they are likely classed as "hidden"

#### What should we test?
Confirm that all of CI passes and a combined simplecov report is downloadable again

#### Release notes

- [x] Technical changes only

The title of the pull request will be included in the release notes.


#### Dependencies


#### Documentation updates
