### PR TITLE
[BUU2] Hide producer column when there's only one producer in the admin account

### DIFF
--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -37,5 +37,9 @@ module Admin
 
       "#{admin_products_path}#{url_filters.empty? ? '' : "#?#{url_filters.to_query}"}"
     end
+
+    def hide_producer_column?(producer_options)
+      spree_current_user.column_preferences.products.empty? && producer_options.one?
+    end
   end
 end

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -41,6 +41,8 @@ module Admin
       "#{admin_products_path}#{url_filters.empty? ? '' : "#?#{url_filters.to_query}"}"
     end
 
+    # if user hasn't saved any preferences on products page and there's only one producer;
+    # we need to hide producer column
     def hide_producer_column?(producer_options)
       spree_current_user.column_preferences.products.empty? && producer_options.one?
     end

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -10,8 +10,11 @@ module Admin
       end
     end
 
-    def prepare_new_variant(product)
-      product.variants.build
+    def prepare_new_variant(product, producer_options)
+      # e.g producer_options = [['producer name', id]]
+      product.variants.build do |new_variant|
+        new_variant.supplier_id = producer_options.first.second if producer_options.one?
+      end
     end
 
     def unit_value_with_description(variant)

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -44,7 +44,7 @@ module Admin
     # if user hasn't saved any preferences on products page and there's only one producer;
     # we need to hide producer column
     def hide_producer_column?(producer_options)
-      spree_current_user.column_preferences.products.empty? && producer_options.one?
+      spree_current_user.column_preferences.bulk_edit_product.empty? && producer_options.one?
     end
   end
 end

--- a/app/models/column_preference.rb
+++ b/app/models/column_preference.rb
@@ -37,7 +37,7 @@ class ColumnPreference < ApplicationRecord
   end
 
   def self.valid_columns_for(action_name)
-    __send__("#{action_name}_columns").keys.map(&:to_s)
+    get_default_preferences(action_name, Spree::User.new).keys.map(&:to_s)
   end
 
   def self.known_actions

--- a/app/models/column_preference.rb
+++ b/app/models/column_preference.rb
@@ -15,7 +15,7 @@ class ColumnPreference < ApplicationRecord
   validates :column_name, presence: true, inclusion: { in: proc { |p|
                                                              valid_columns_for(p.action_name)
                                                            } }
-  scope :products, -> { where(action_name: 'products_v3_index') }
+  scope :bulk_edit_product, -> { where(action_name: 'products_v3_index') }
 
   def self.for(user, action_name)
     stored_preferences = where(user_id: user.id, action_name:)

--- a/app/models/column_preference.rb
+++ b/app/models/column_preference.rb
@@ -15,10 +15,11 @@ class ColumnPreference < ApplicationRecord
   validates :column_name, presence: true, inclusion: { in: proc { |p|
                                                              valid_columns_for(p.action_name)
                                                            } }
+  scope :products, -> { where(action_name: 'products_v3_index') }
 
   def self.for(user, action_name)
     stored_preferences = where(user_id: user.id, action_name:)
-    default_preferences = __send__("#{action_name}_columns")
+    default_preferences = get_default_preferences(action_name, user)
     filter(default_preferences, user, action_name)
     default_preferences.each_with_object([]) do |(column_name, default_attributes), preferences|
       stored_preference = stored_preferences.find_by(column_name:)
@@ -51,5 +52,14 @@ class ColumnPreference < ApplicationRecord
     return if user.admin? || user.enterprises.where(enable_subscriptions: true).any?
 
     default_preferences.delete(:schedules)
+  end
+
+  def self.get_default_preferences(action_name, user)
+    case action_name
+    when 'products_v3_index'
+      products_v3_index_columns(user)
+    else
+      __send__("#{action_name}_columns")
+    end
   end
 end

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -42,6 +42,7 @@ module Spree
     has_many :credit_cards, dependent: :destroy
     has_many :report_rendering_options, class_name: "::ReportRenderingOptions", dependent: :destroy
     has_many :webhook_endpoints, dependent: :destroy
+    has_many :column_preferences, dependent: :destroy
     has_one :oidc_account, dependent: :destroy
 
     accepts_nested_attributes_for :enterprise_roles, allow_destroy: true

--- a/app/views/admin/products_v3/_product_variant_row.html.haml
+++ b/app/views/admin/products_v3/_product_variant_row.html.haml
@@ -11,7 +11,7 @@
         %tr.condensed{ id: dom_id(variant), 'data-controller': "variant", 'class': "nested-form-wrapper", 'data-new-record': variant.new_record? ? "true" : false }
           = render partial: 'variant_row', locals: { variant:, f: variant_form, category_options:, tax_category_options:, producer_options: }
 
-    = form.fields_for("products][#{product_index}][variants_attributes][NEW_RECORD", prepare_new_variant(product)) do |new_variant_form|
+    = form.fields_for("products][#{product_index}][variants_attributes][NEW_RECORD", prepare_new_variant(product, producer_options)) do |new_variant_form|
       %template{ 'data-nested-form-target': "template" }
         %tr.condensed{ 'data-controller': "variant", 'class': "nested-form-wrapper", 'data-new-record': "true" }
           = render partial: 'variant_row', locals: { variant: new_variant_form.object, f: new_variant_form, category_options:, tax_category_options:, producer_options: }

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -13,7 +13,7 @@
   = hidden_field_tag :producer_id, @producer_id
   = hidden_field_tag :category_id, @category_id
 
-  %table.products{ 'data-column-preferences-target': "table" }
+  %table.products{ 'data-column-preferences-target': "table", class: (hide_producer_column?(producer_options) ? 'hide-producer' : '') }
     %colgroup
       -# The `min-width` property works in Chrome but not Firefox so is considered progressive enhancement.
       %col.col-image{ width:"44px" }= # (image size + padding)

--- a/lib/open_food_network/column_preference_defaults.rb
+++ b/lib/open_food_network/column_preference_defaults.rb
@@ -77,7 +77,9 @@ module OpenFoodNetwork
       }
     end
 
-    def products_v3_index_columns
+    def products_v3_index_columns(user)
+      producer_visibility = display_producer_column?(user)
+
       I18n.with_options scope: 'admin.products_page.columns' do
         {
           image: { name: t(:image), visible: true },
@@ -87,7 +89,7 @@ module OpenFoodNetwork
           unit_scale: { name: t(:unit_scale), visible: true },
           price: { name: t(:price), visible: true },
           on_hand: { name: t(:on_hand), visible: true },
-          producer: { name: t(:producer), visible: true },
+          producer: { name: t(:producer), visible: producer_visibility },
           category: { name: t(:category), visible: true },
           tax_category: { name: t(:tax_category), visible: true },
           inherits_properties: { name: t(:inherits_properties), visible: true },
@@ -133,6 +135,13 @@ module OpenFoodNetwork
         payment_method: { name: I18n.t("admin.payment_method"), visible: false },
         shipping_method: { name: I18n.t("admin.shipping_method"), visible: false }
       }
+    end
+
+    def display_producer_column?(user)
+      producers = OpenFoodNetwork::Permissions.new(user)
+        .managed_product_enterprises.is_primary_producer
+
+      producers.many?
     end
   end
 end

--- a/spec/system/admin/products_v3/actions_spec.rb
+++ b/spec/system/admin/products_v3/actions_spec.rb
@@ -34,42 +34,59 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
   describe "column selector" do
     let!(:product) { create(:simple_product) }
 
-    before do
-      visit admin_products_url
+    context "with one producer only" do
+      before do
+        visit admin_products_url
+      end
+
+      it "hides column and remembers saved preference" do
+        # Name shows by default
+        expect(page).to have_checked_field "Name"
+        expect(page).to have_selector "th", text: "Name"
+        expect_other_columns_visible
+
+        # Producer is hidden by if only one producer is present
+        expect(page).not_to have_checked_field "Producer"
+        expect(page).not_to have_selector "th", text: "Producer"
+
+        # Name is hidden
+        ofn_drop_down("Columns").click
+        within ofn_drop_down("Columns") do
+          uncheck "Name"
+        end
+        expect(page).not_to have_selector "th", text: "Name"
+        expect_other_columns_visible
+
+        # Preference saved
+        click_on "Save as default"
+        expect(page).to have_content "Column preferences saved"
+        refresh
+
+        # Preference remembered
+        ofn_drop_down("Columns").click
+        within ofn_drop_down("Columns") do
+          expect(page).to have_unchecked_field "Name"
+        end
+        expect(page).not_to have_selector "th", text: "Name"
+        expect_other_columns_visible
+      end
+
+      def expect_other_columns_visible
+        expect(page).to have_selector "th", text: "Price"
+        expect(page).to have_selector "th", text: "On Hand"
+      end
     end
 
-    it "hides column and remembers saved preference" do
-      # Name shows by default
-      expect(page).to have_checked_field "Name"
-      expect(page).to have_selector "th", text: "Name"
-      expect_other_columns_visible
+    context "with multiple producers" do
+      let!(:producer2) { create(:supplier_enterprise, owner: user) }
 
-      # Name is hidden
-      ofn_drop_down("Columns").click
-      within ofn_drop_down("Columns") do
-        uncheck "Name"
+      before { visit admin_products_url }
+
+      it "has selected producer column by default" do
+        # Producer shows by default
+        expect(page).to have_checked_field "Producer"
+        expect(page).to have_selector "th", text: "Producer"
       end
-      expect(page).not_to have_selector "th", text: "Name"
-      expect_other_columns_visible
-
-      # Preference saved
-      click_on "Save as default"
-      expect(page).to have_content "Column preferences saved"
-      refresh
-
-      # Preference remembered
-      ofn_drop_down("Columns").click
-      within ofn_drop_down("Columns") do
-        expect(page).to have_unchecked_field "Name"
-      end
-      expect(page).not_to have_selector "th", text: "Name"
-      expect_other_columns_visible
-    end
-
-    def expect_other_columns_visible
-      expect(page).to have_selector "th", text: "Producer"
-      expect(page).to have_selector "th", text: "Price"
-      expect(page).to have_selector "th", text: "On Hand"
     end
   end
 

--- a/spec/system/admin/products_v3/actions_spec.rb
+++ b/spec/system/admin/products_v3/actions_spec.rb
@@ -46,8 +46,18 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
         expect_other_columns_visible
 
         # Producer is hidden by if only one producer is present
-        expect(page).not_to have_checked_field "Producer"
+        expect(page).to have_unchecked_field "Producer"
         expect(page).not_to have_selector "th", text: "Producer"
+
+        # Show Producer column
+        ofn_drop_down("Columns").click
+        within ofn_drop_down("Columns") do
+          check "Producer"
+        end
+
+        # Preference saved
+        save_preferences
+        expect(page).to have_selector "th", text: "Producer"
 
         # Name is hidden
         ofn_drop_down("Columns").click
@@ -58,9 +68,7 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
         expect_other_columns_visible
 
         # Preference saved
-        click_on "Save as default"
-        expect(page).to have_content "Column preferences saved"
-        refresh
+        save_preferences
 
         # Preference remembered
         ofn_drop_down("Columns").click
@@ -74,6 +82,13 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
       def expect_other_columns_visible
         expect(page).to have_selector "th", text: "Price"
         expect(page).to have_selector "th", text: "On Hand"
+      end
+
+      def save_preferences
+        # Preference saved
+        click_on "Save as default"
+        expect(page).to have_content "Column preferences saved"
+        refresh
       end
     end
 

--- a/spec/system/admin/products_v3/create_spec.rb
+++ b/spec/system/admin/products_v3/create_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
   include WebHelper
 
   let!(:supplier) { create(:supplier_enterprise) }
+  # Creating another producer such that producer column is visible
+  # otherwise on one producer, it's hidden by default
   let!(:supplier2) { create(:supplier_enterprise) }
   let!(:taxon) { create(:taxon) }
 

--- a/spec/system/admin/products_v3/create_spec.rb
+++ b/spec/system/admin/products_v3/create_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
   include WebHelper
 
   let!(:supplier) { create(:supplier_enterprise) }
+  let!(:supplier2) { create(:supplier_enterprise) }
   let!(:taxon) { create(:taxon) }
 
   describe "creating a new product" do

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
         expect(page).to have_selector "th", text: "Unit"
         expect(page).to have_selector "th", text: "Price"
         expect(page).to have_selector "th", text: "On Hand"
-        expect(page).to have_selector "th", text: "Producer"
         expect(page).to have_selector "th", text: "Category"
         expect(page).to have_selector "th", text: "Tax Category"
         expect(page).to have_selector "th", text: "Inherits Properties?"

--- a/spec/system/admin/products_v3/update_spec.rb
+++ b/spec/system/admin/products_v3/update_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'As an enterprise user, I can update my products' do
   include FileHelper
 
   let(:producer) { create(:supplier_enterprise) }
-  let(:user) { create(:user, enterprises: [producer]) }
+  let(:producer2) { create(:supplier_enterprise) }
+  let(:user) { create(:user, enterprises: [producer, producer2]) }
 
   before do
     login_as user


### PR DESCRIPTION
#### What? Why?

- Closes #11200
- This PR adds the ability to hide the producer column if the there's only one producer available.
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
