### PR TITLE
[BUU] Fix Display ordering in shopfront field to allow re-ordering of the sequence

### DIFF
--- a/app/webpacker/css/admin_v3/components/select2.scss
+++ b/app/webpacker/css/admin_v3/components/select2.scss
@@ -233,6 +233,7 @@ label .select2-container {
         font-size: 85%;
         @extend .icon-remove;
         @extend [class^="icon-"], :before;
+        width: 0;
         margin-left: 2px;
         color: $color-1;
       }

--- a/app/webpacker/css/admin_v3/components/select2.scss
+++ b/app/webpacker/css/admin_v3/components/select2.scss
@@ -230,8 +230,7 @@ label .select2-container {
       justify-content: center;
 
       .select2-search-choice-close {
-        background-image: none !important;
-        font-size: 85% !important;
+        font-size: 85%;
         @extend .icon-remove;
         @extend [class^="icon-"], :before;
         margin-left: 2px;

--- a/app/webpacker/css/admin_v3/components/select2.scss
+++ b/app/webpacker/css/admin_v3/components/select2.scss
@@ -182,7 +182,6 @@ label .select2-container {
 .select2-container {
   .select2-choice,
   .select2-choices {
-    height: $btn-relaxed-height !important; // !important is needed because of vendor/assets/stylesheets/select2.css.scss
     padding: 10px;
   }
 }

--- a/app/webpacker/css/admin_v3/components/select2.scss
+++ b/app/webpacker/css/admin_v3/components/select2.scss
@@ -228,16 +228,14 @@ label .select2-container {
       display: flex;
       align-items: center;
       justify-content: center;
-      padding-left: 7px;
 
       .select2-search-choice-close {
-        position: relative;
-        order: -1;
-        width: auto;
-        left: 0;
-        top: 0;
-        margin: 0;
-        padding: 0;
+        background-image: none !important;
+        font-size: 85% !important;
+        @extend .icon-remove;
+        @extend [class^="icon-"], :before;
+        margin-left: 2px;
+        color: $color-1;
       }
     }
   }


### PR DESCRIPTION
#### What? Why?

- Closes #12852
- This PR tweaks some styling to fix the height issues of the select2 which was causing the display issue.
- Moreover, it's also observed that the functionality to remove the selected option was not implemented. 
- This has also been implemented as part of this PR.

**Before:**
![image](https://github.com/user-attachments/assets/374c2e8d-1684-42c6-aee1-59ea612bcbd3)
**After:**
![image](https://github.com/user-attachments/assets/624957c8-c233-4c61-8a9a-9441cefd6a23)
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Validate the issue's expected behavior
   - Check if the vertical alignment for other dropdown fields on the admin Enterprise screens still looks ok.
- Along with the above, please also validate the removal of the selected option

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
