### PR TITLE
Anonymise customer first and last names

### DIFF
--- a/lib/tasks/data/anonymize_data.rake
+++ b/lib/tasks/data/anonymize_data.rake
@@ -46,10 +46,14 @@ namespace :ofn do
                               unconfirmed_email = concat(id, '_ofn_user@example.com')")
       Customer.where(user_id: nil)
         .update_all("email = concat(id, '_ofn_customer@example.com'),
-                     name = concat('Customer Number ', id, ' (without connected User)')")
+                     name = concat('Customer Number ', id, ' (without connected User)'),
+                     first_name = concat('Customer Number ', id),
+                     last_name = '(without connected User)'")
       Customer.where.not(user_id: nil)
         .update_all("email = concat(user_id, '_ofn_user@example.com'),
-                     name = concat('Customer Number ', id, ' - User ', user_id)")
+                     name = concat('Customer Number ', id, ' - User ', user_id),
+                     first_name = concat('Customer Number ', id),
+                     last_name = concat('User ', user_id)")
 
       Spree::Order.update_all("email = concat(id, '_ofn_order@example.com')")
     end


### PR DESCRIPTION
These were added a couple of years ago in https://github.com/openfoodfoundation/openfoodnetwork/pull/8763 But I guess we never noticed the names weren't getting anonymised.

Now they will be anonymised whenever we run the rake task `ofn:data:anonymize`. This task is used when refreshing staging servers.

The old 'name' field is still in the DB. It was kept for compatibility during migraiton but never cleaned up. I've added the tech debt task to the welcome new devs board now: https://github.com/openfoodfoundation/openfoodnetwork/issues/8835


### What should we test?
Run the script and check that customer names can not be viewed in the system.

This must be executed on **uk_staging** because it was recently refreshed from prod and the customer names will still be present. IE:

1. First, add the `pr-staged-uk` label and wait for the PR to be deployed.
2. While waiting, check that customer names are still visible in the admin interface
3. Once staged, execute the rake task:
   ```
   ssh openfoodnetwork@staging.openfoodnetwork.org.uk
   cd apps/openfoodnetwork/current
   RAILS_ENV=staging bundle exec rake ofn:data:anonymize
   ```
4. Then the customer names should be masked.


### Dependencies
- Requires deploying a PR to uk_staging, which is not yet set up: openfoodfoundation/ofn-install#937