### PR TITLE
Alert user when error requesting a report

### DIFF
--- a/app/webpacker/js/turbo.js
+++ b/app/webpacker/js/turbo.js
@@ -8,10 +8,23 @@ document.addEventListener("turbo:frame-missing", (event) => {
   event.preventDefault();
 
   // show error message instead
-  status = event.detail.response.status;
+  showError(event.detail.response?.status);
+});
+
+document.addEventListener("turbo:submit-end", (event) => {
+  if (!event.detail.success){
+    // show error message on failure
+    showError(event.detail.fetchResponse?.statusCode);
+    event.preventDefault();
+  }
+});
+
+function showError(status) {
   if(status == 401) {
     alert(I18n.t("errors.unauthorized.message"));
+  } else if(status === undefined) {
+    alert(I18n.t("errors.network_error.message"));
   } else {
     alert(I18n.t("errors.general_error.message"));
   }
-});
+}

--- a/app/webpacker/js/turbo.js
+++ b/app/webpacker/js/turbo.js
@@ -20,11 +20,12 @@ document.addEventListener("turbo:submit-end", (event) => {
 });
 
 function showError(status) {
+  // Note that other 4xx errors will be handled differently.
   if(status == 401) {
     alert(I18n.t("errors.unauthorized.message"));
   } else if(status === undefined) {
     alert(I18n.t("errors.network_error.message"));
-  } else {
+  } else if (status >= 500) {
     alert(I18n.t("errors.general_error.message"));
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,6 +188,10 @@ en:
         We record all errors and may be working on a fix.
 
         If the problem persists or is urgent, please contact us."
+    unauthorized:
+      message: "You are not authorised to perform that action."
+    network_error:
+      message: "Network error: please try again later."
   stripe:
     error_code:
       incorrect_number: "The card number is incorrect."


### PR DESCRIPTION
I'm not sure why, but Turbo was swallowing the `unauthorized` error, so I thought we should alert the user to help with debugging. Same with network error, it gave no feedback before.

I think this can be tested with Capybara in theory, but I haven't invested the time on it.

### What should we test?
This occurs whenever submitting a form with Turbo. The best example is running any report.

There are three types of errors:
1. Network error: turn off wifi/disable network
2. Authorisation error: ~~This can be tested with bug #12835. Otherwise~~ I think you could test this by log out in another tab then log in as a shopper
3. Other errors (eg 500). You could temporarily stop puma on the staging server: `sudo systemctl stop puma` (then start it again).

There are other types of errors that aren't handled by this and should be handled differently, for example:
1. On the bulk product page, if you try to update a product that will fails we get a 422 that we handle nicely on the UI
