### PR TITLE
[BUU] Add missing permission check on product actions

### DIFF
--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -40,6 +40,8 @@ module Admin
         { id: params[:id] }
       ).find_product
 
+      authorize! :delete, @record
+
       @record.destroyed_by = spree_current_user
       status = :ok
 
@@ -74,6 +76,8 @@ module Admin
 
     def clone
       @product = Spree::Product.find(params[:id])
+      authorize! :clone, @product
+
       status = :ok
 
       begin

--- a/spec/requests/admin/products_v3_spec.rb
+++ b/spec/requests/admin/products_v3_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe "Admin::ProductsV3" do
+  include AuthenticationHelper
+
+  let(:user) { create(:user) }
+  let(:headers) { { Accept: "text/vnd.turbo-stream.html" } }
+  let(:product) { create(:simple_product, supplier_id: create(:supplier_enterprise).id) }
+
+  before do
+    login_as user
+  end
+
+  describe "DELETE /admin/product_v3/:id" do
+    it "checks for permission" do
+      delete(admin_product_destroy_path(product), headers: )
+
+      expect(response).to redirect_to('/unauthorized')
+    end
+  end
+
+  describe "POST /admin/clone/:id" do
+    it "checks for permission" do
+      post(admin_clone_product_path(product), headers: )
+
+      expect(response).to redirect_to('/unauthorized')
+    end
+  end
+
+  describe "DELETE /admin/product_v3/destroy_variant/:id" do
+    it "checks for permission" do
+      delete(admin_destroy_variant_path(product.variants.first), headers: )
+
+      expect(response).to redirect_to('/unauthorized')
+    end
+  end
+
+  describe "POST /admin/products/bulk_update" do
+    it "checks for permission" do
+      variant = product.variants.first
+
+      params = {
+        products: {
+          '0': {
+            id: product.id,
+            name: "Updated product name",
+            variants_attributes: {
+              '0': {
+                id: variant.id,
+                display_name: "Updated variant display name",
+              }
+            }
+          }
+        }
+      }
+
+      post(admin_products_bulk_update_path, params:, headers: )
+
+      expect(response).to redirect_to('/unauthorized')
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Some of the Bulk product edit page actions where missing permission check, so someone could potentially delete product they are not managing. This PR add the missing permission checks

NOTE, this PR #12867 will make unauthorised error more obvious to the user
#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
This should probably be tested by a dev, as it requires use of the developer tools

As an enterprise user :
- Navigate to Bulk Product Edit page
- Open the developer tools, update a clone link href , and add a product id the current user isn't managing
- With the developer tool console open, Click on the updated clone link 
- in the developer tools console, you should see an unauthorised error, and the page will reload

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
