### PR TITLE
Use Dockerv2

### DIFF
--- a/.github/workflows/mapi.yml
+++ b/.github/workflows/mapi.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: docker/build
-    - run: docker-compose up --detach
+    - run: docker compose up --detach
     - run: until curl -f -s http://localhost:3000; do echo "waiting for api server"; sleep 1; done
-    - run: docker-compose exec -T db psql postgresql://ofn:f00d@localhost:5432/open_food_network_dev --command="update spree_users set spree_api_key='testing' where login='ofn@example.com'"
+    - run: docker compose exec -T db psql postgresql://ofn:f00d@localhost:5432/open_food_network_dev --command="update spree_users set spree_api_key='testing' where login='ofn@example.com'"
     # equivalent to Flipper.enable(:api_v1)
-    - run: docker-compose exec -T db psql postgresql://ofn:f00d@localhost:5432/open_food_network_dev --command="insert into flipper_features (key, created_at, updated_at) values ('api_v1', localtimestamp, localtimestamp)"
-    - run: docker-compose exec -T db psql postgresql://ofn:f00d@localhost:5432/open_food_network_dev --command="insert into flipper_gates (feature_key, key, value, created_at, updated_at) values ('api_v1', 'boolean', 'true', localtimestamp, localtimestamp)"
+    - run: docker compose exec -T db psql postgresql://ofn:f00d@localhost:5432/open_food_network_dev --command="insert into flipper_features (key, created_at, updated_at) values ('api_v1', localtimestamp, localtimestamp)"
+    - run: docker compose exec -T db psql postgresql://ofn:f00d@localhost:5432/open_food_network_dev --command="insert into flipper_gates (feature_key, key, value, created_at, updated_at) values ('api_v1', 'boolean', 'true', localtimestamp, localtimestamp)"
 
     # Run Mayhem for API
     - name: Run Mayhem for API

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 ## What's the point?
 * Setting up the Open Food Network app on your local machine is quick and easy with the aid of Docker.
 * Docker provides a common virtual environment available to all developers and resolves the infamous "but it works on my machine" problem.
-* Use the scripts in this directory to execute tasks in Docker. Please note that these scripts are intended to be executed from this app's root directory (/openfoodnetwork). These scripts allow you to bypass the need to keep typing "docker-compose run web".
+* Use the scripts in this directory to execute tasks in Docker. Please note that these scripts are intended to be executed from this app's root directory (/openfoodnetwork). These scripts allow you to bypass the need to keep typing "docker compose run web".
 
 ## Limitations
 1. The docker environment can't directly control your host system browser, which means that browser specs (under `/spec/system/`) and email previews will not work. You may be able to find a solution with [this article](https://evilmartians.com/chronicles/system-of-a-test-setting-up-end-to-end-rails-testing). If so, please contribute!
@@ -17,10 +17,6 @@
 * Visit https://docs.docker.com/engine/install/#server and select your Linux distribution to install Docker Engine.
 Note: There is no need to install Docker Desktop on Linux.
 * Follow the installation instructions provided. Installing from Docker repositories is recommended.
-* Install Docker Compose V1. Docker Engine comes with Docker Compose V2 which is not yet supported by our Docker scripts.
-```sh
-$ sudo apt install docker-compose
-```
 * To run Docker commands as a regular user instead of as root (with sudo), follow the instructions at https://docs.docker.com/engine/install/linux-postinstall/.
 
 #### Windows
@@ -93,7 +89,7 @@ You may need to wait several minutes before getting the server up and running pr
 * If you’re getting the following error:
 ```sh
 dockerpycreds.errors.InitializationError: docker-credential-desktop not installed or not available in PATH
-[8929] Failed to execute script docker-compose
+[8929] Failed to execute script docker compose
 ```
 Just change the entry in ~/.docker/config.json like this (credStore instead of credsStore), and you’re good to go:
 ```sh
@@ -125,7 +121,7 @@ See [#8421](https://github.com/openfoodfoundation/openfoodnetwork/issues/8421) f
 
 ## Script Summary
 * docker/build(.ps1): This script builds the Docker containers specified for this app, seeds the database, and logs the screen output for these operations. After you use "git clone" to download this repository, run the docker/build script to start the setup process.
-* docker/server(.ps1): Use this script to run this app in the Rails server. This script executes the "docker-compose up" command and logs the results. If all goes well, you will be able to view this app on your local browser at http://localhost:3000/.
+* docker/server(.ps1): Use this script to run this app in the Rails server. This script executes the "docker compose up" command and logs the results. If all goes well, you will be able to view this app on your local browser at http://localhost:3000/.
 * docker/test(.ps1): Use this script to run the entire test suite. **Note limitation with system specs mentioned above**.
 * docker/qtest: Use this script to run the entire test suite in quiet mode. The deprecation warnings are removed to make the test results easier to read.
 * docker/run: Use this script to run commands within the Docker container. If you want shell access, enter "docker/run bash". To execute "ls -l" within the Docker container, enter "docker/run ls -l".

--- a/docker/build-log
+++ b/docker/build-log
@@ -1,12 +1,12 @@
 #!/bin/bash
 set +e
 
-docker-compose down -v --remove-orphans
+docker compose down -v --remove-orphans
 wait
 echo '###########################'
-echo 'BEGIN: docker-compose build'
+echo 'BEGIN: docker compose build'
 echo '###########################'
-docker-compose build # Set up the Docker containers
+docker compose build # Set up the Docker containers
 echo '##############################'
-echo 'FINISHED: docker-compose build'
+echo 'FINISHED: docker compose build'
 echo '##############################'

--- a/docker/build-log.ps1
+++ b/docker/build-log.ps1
@@ -1,5 +1,5 @@
 Write-Host "Docker cleaning: remove old containers" -ForegroundColor Blue
-docker-compose.exe down -v --remove-orphans
+docker compose down -v --remove-orphans
 Write-Host "Docker build: set up the docker containers" -ForegroundColor Blue
-docker-compose.exe build
+docker compose build
 Write-Host "Docker build finished"

--- a/docker/cop
+++ b/docker/cop
@@ -3,9 +3,9 @@
 # This script runs RuboCop.
 
 echo '-------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rubocop'
+echo 'BEGIN: docker compose run web bundle exec rubocop'
 echo '-------------------------------------------------'
-docker-compose run web bundle exec rubocop
+docker compose run web bundle exec rubocop
 echo '-----------------------------------------------'
-echo 'END: docker-compose run web bundle exec rubocop'
+echo 'END: docker compose run web bundle exec rubocop'
 echo '-----------------------------------------------'

--- a/docker/cop.ps1
+++ b/docker/cop.ps1
@@ -1,4 +1,4 @@
 # This script runs RuboCop
 
 Write-Host "bundle exec rubocop : runs rubocop" -ForegroundColor Blue
-docker-compose.exe run web bundle exec rubocop
+docker compose run web bundle exec rubocop

--- a/docker/qtest-log
+++ b/docker/qtest-log
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 echo '--------------------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo 'BEGIN: docker compose run web bundle exec rake db:test:prepare'
 echo '--------------------------------------------------------------'
-docker-compose run web bundle exec rake db:test:prepare
+docker compose run web bundle exec rake db:test:prepare
 echo '------------------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo 'END: docker compose run web bundle exec rake db:test:prepare'
 echo '------------------------------------------------------------'
 
 echo '--------------------------------------'
 echo 'BEGIN: running test suite (quiet mode)'
 echo '--------------------------------------'
-docker-compose run web bundle exec rspec spec | grep -v 'DEPRECATION WARNING' | grep -v 'Post.includes(:comments)' | grep -v 'Currently, Active Record recognizes the table in the string' | grep -v "If you don't rely on implicit join references"
+docker compose run web bundle exec rspec spec | grep -v 'DEPRECATION WARNING' | grep -v 'Post.includes(:comments)' | grep -v 'Currently, Active Record recognizes the table in the string' | grep -v "If you don't rely on implicit join references"
 echo '------------------------------------'
 echo 'END: running test suite (quiet mode)'
 echo '------------------------------------'

--- a/docker/run
+++ b/docker/run
@@ -2,7 +2,7 @@
 
 set -e
 
-# Use this script to execute commaands in the Docker container.
+# Use this script to execute commands in the Docker container.
 # Example: To run the "ls -l" command in the Docker container, enter the command "docker/run ls -l".
 
 function cleanup {
@@ -12,11 +12,11 @@ function cleanup {
 
   # ignore errors
   set +e
-  docker-compose down
+  docker compose down
 
   exit $code
 }
 
 trap cleanup EXIT
 
-docker-compose run web $@
+docker compose run web $@

--- a/docker/seed
+++ b/docker/seed
@@ -3,25 +3,25 @@
 # This is the data seeding script.
 
 echo '-------------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rake db:reset'
+echo 'BEGIN: docker compose run web bundle exec rake db:reset'
 echo '-------------------------------------------------------'
-docker-compose run web bundle exec rake db:reset
+docker compose run web bundle exec rake db:reset
 echo '-----------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rake db:reset'
+echo 'END: docker compose run web bundle exec rake db:reset'
 echo '-----------------------------------------------------'
 
 echo '--------------------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo 'BEGIN: docker compose run web bundle exec rake db:test:prepare'
 echo '--------------------------------------------------------------'
-docker-compose run web bundle exec rake db:test:prepare
+docker compose run web bundle exec rake db:test:prepare
 echo '------------------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo 'END: docker compose run web bundle exec rake db:test:prepare'
 echo '------------------------------------------------------------'
 
 echo '--------------------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rake ofn:sample_data'
+echo 'BEGIN: docker compose run web bundle exec rake ofn:sample_data'
 echo '--------------------------------------------------------------'
-docker-compose run web bundle exec rake ofn:sample_data
+docker compose run web bundle exec rake ofn:sample_data
 echo '------------------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rake ofn:sample_data'
+echo 'END: docker compose run web bundle exec rake ofn:sample_data'
 echo '------------------------------------------------------------'

--- a/docker/seed.ps1
+++ b/docker/seed.ps1
@@ -4,10 +4,10 @@
 # - seed the database with sample data
 
 Write-Host "bundle exec rake db:reset : reset the dev and test databases" -ForegroundColor Blue
-docker-compose.exe run web bundle exec rake db:reset
+docker compose run web bundle exec rake db:reset
 
 Write-Host "bundle exec rake db:test:prepare : prepare the database" -ForegroundColor Blue
-docker-compose.exe run web bundle exec rake db:test:prepare
+docker compose run web bundle exec rake db:test:prepare
 
 Write-Host "bundle exec rake ofn:sample_data : seed the database with sample data" -ForegroundColor Blue
-docker-compose.exe run web bundle exec rake ofn:sample_data
+docker compose run web bundle exec rake ofn:sample_data

--- a/docker/server-log
+++ b/docker/server-log
@@ -2,8 +2,8 @@
 set +e
 
 echo '########################'
-echo 'BEGIN: docker-compose up'
+echo 'BEGIN: docker compose up'
 echo '########################'
 echo 'View this app in your web browser at'
 echo 'http://localhost:3000/'
-docker-compose up
+docker compose up

--- a/docker/server.ps1
+++ b/docker/server.ps1
@@ -1,6 +1,6 @@
 # This script launches the whole stack of containers (web server, database, webpack, redis, etc.)
 $DateTime=Get-Date -Format "yyyyMMdd-HHmmss"
 
-Write-Host "Docker-compose up: launches the whole stack of containers" -ForegroundColor Blue
-docker-compose.exe up -d > log/server-$DateTime.log 2>&1
-Write-Host "Docker-compose up finished : View this app in your web browser at http://localhost:3000/" -ForegroundColor Blue
+Write-Host "Docker compose up: launches the whole stack of containers" -ForegroundColor Blue
+docker compose up -d > log/server-$DateTime.log 2>&1
+Write-Host "Docker compose up finished : View this app in your web browser at http://localhost:3000/" -ForegroundColor Blue

--- a/docker/test
+++ b/docker/test
@@ -7,17 +7,17 @@ set -e
 DATE=`date +%Y%m%d-%H%M%S-%3N`
 
 echo '--------------------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo 'BEGIN: docker compose run web bundle exec rake db:test:prepare'
 echo '--------------------------------------------------------------'
-docker-compose run web bundle exec rake db:test:prepare 2>&1 | tee log/test-prepare-$DATE.log
+docker compose run web bundle exec rake db:test:prepare 2>&1 | tee log/test-prepare-$DATE.log
 echo '------------------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo 'END: docker compose run web bundle exec rake db:test:prepare'
 echo '------------------------------------------------------------'
 
 echo '----------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rspec spec'
+echo 'BEGIN: docker compose run web bundle exec rspec spec'
 echo '----------------------------------------------------'
-docker-compose run web bundle exec rspec --no-color spec 2>&1 | tee log/test-rspec-$DATE.log
+docker compose run web bundle exec rspec --no-color spec 2>&1 | tee log/test-rspec-$DATE.log
 echo '--------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rspec spec'
+echo 'END: docker compose run web bundle exec rspec spec'
 echo '--------------------------------------------------'

--- a/docker/test.ps1
+++ b/docker/test.ps1
@@ -4,6 +4,6 @@
 $DateTime=Get-Date -Format "yyyyMMdd-HHmmss"
 
 Write-Host "bundle exec rake db:test:prepare : prepare the database for rspec tests" -ForegroundColor Blue
-docker-compose.exe run web bundle exec rake db:test:prepare > log/test-prepare-$DateTime.log 2>&1
+docker compose run web bundle exec rake db:test:prepare > log/test-prepare-$DateTime.log 2>&1
 Write-Host "bundle exec rspec spec : launch the rspec tests" -ForegroundColor Blue
-docker-compose.exe run web bundle exec rspec spec > log/test-rspec-$DateTime.log 2>&1
+docker compose run web bundle exec rspec spec > log/test-rspec-$DateTime.log 2>&1


### PR DESCRIPTION
#### What? Why?

Dockerv1 used `docker-compose` executable (with a dash). Dockerv2 uses `docker compose` (with a space). The `docker-compose` executable [is no longer receiving updates](https://docs.docker.com/compose/releases/migrate/). With some recent versions of Docker, this may cause a `ContainerError` when trying to run it. 

- Helps #8823 

#### What should we test?

Spin up the docker  container:
```sh
docker/server
```
Verify that there are no fatal errors.
Visit HTTP://localhost:3000/

This has been tested under  Ubuntu, but not on Windows/Mac

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates

Getting Started Guide was updated to include the `docker compose` command and remove the requirement of installing Dockerv1.
