### PR TITLE
Fix date dependent spec

### DIFF
--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -33,16 +33,13 @@ RSpec.describe Spree::CreditCardsController, type: :controller do
           }
         end
 
-        before do
-          # there should be no cards stored locally
-          expect(Spree::CreditCard.count).to eq(0)
-        end
-
         it "saves the card locally" do
-          spree_post :new_from_token, params
+          expect {
+            spree_post :new_from_token, params
+          }.to change {
+            Spree::CreditCard.count
+          }.from(0).to(1)
 
-          # checks whether a card was created
-          expect(Spree::CreditCard.count).to eq(1)
           card = Spree::CreditCard.last
 
           # retrieves the created card from Stripe

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Spree::CreditCardsController, type: :controller do
           {
             format: :json,
             exp_month: 9,
-            exp_year: 2024,
+            exp_year: 1.year.from_now.year,
             last4: 4242,
             token: token['id'],
             cc_type: "visa"


### PR DESCRIPTION
#### What? Why?

This spec broke after I merge my pull request. I couldn't see any connection and found that it broke on old commits as well even though it had passed CI. So I looked at the spec and found a hard-coded expiry date for a credit card. Now it's always pointing to next year.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
