### PR TITLE
[Product Preview] Fix price currency display

### DIFF
--- a/app/views/admin/products_v3/product_preview.turbo_stream.haml
+++ b/app/views/admin/products_v3/product_preview.turbo_stream.haml
@@ -59,18 +59,18 @@
                     .variant-unit
                       = variant.unit_to_display
                   .small-4.medium-3.columns.variant-price
-                    = number_to_currency(variant.price)
+                    = Spree::Money.new(variant.price)
                     .unit-price.variant-unit-price
                       = render AdminTooltipComponent.new(text: t("js.shopfront.unit_price_tooltip"), link_text: "", placement: "top", link_class: "question-mark-icon")
                       - # TODO use an helper
                       - unit_price = UnitPrice.new(variant)
                       - price_per_unit = variant.price / (unit_price.denominator || 1)
-                      = "#{number_to_currency(price_per_unit)}&nbsp;/&nbsp;#{unit_price.unit}".html_safe
+                      = "#{Spree::Money.new(price_per_unit)}&nbsp;/&nbsp;#{unit_price.unit}".html_safe
 
 
                   .medium-3.columns.total-price
                     %span
-                      = number_to_currency(0.00) 
+                      = Spree::Money.new(0.00) 
                   .small-5.medium-3.large-3.columns.variant-quantity-column.text-right
                     .variant-quantity-inputs
                       %button.add-variant


### PR DESCRIPTION
**:warning: Please use clockify code #12476 Flower Farms :warning:** 

#### What? Why?

- Closes #12891  <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
The product preview was displaying $ regardless of the configured currency. It now used `Spree::Money` to display prices, which will use the configured currency, and currency settings.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Use staging server configured with a currency other than $, ie `uk-staging` or `fr-staging`
- visit the Bulk Edit Product page 
- open a product preview using the "three dot" action  menu
  --> check the prices are displayed using the correct currency sign 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
