### PR TITLE
Fail gracefully on DFC product import errors

### DIFF
--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -38,6 +38,11 @@ module Admin
       end
 
       @count = imported.compact.count
+    rescue Faraday::Error,
+           Addressable::URI::InvalidURIError,
+           ActionController::ParameterMissing => e
+      flash[:error] = e.message
+      redirect_to admin_product_import_path
     end
 
     private

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -111,6 +111,31 @@ RSpec.describe SuppliedProductBuilder do
     end
   end
 
+  describe ".update_product" do
+    let(:subject) { builder.update_product(product, variant) }
+    let(:product) {
+      DfcIo.import(product_json).find do |subject|
+        subject.is_a? DataFoodConsortium::Connector::SuppliedProduct
+      end
+    }
+    let(:product_json) { ExampleJson.read("product.GET") }
+
+    it "updates a variant" do
+      variant # Create test data first
+
+      expect { subject }.not_to change {
+        Spree::Variant.count
+      }
+
+      expect(subject).to eq variant
+      expect(subject.display_name).to eq "Fillet Steak - 201g x 1 Steak"
+      expect(subject.variant_unit).to eq "items"
+      expect(subject.unit_value).to eq 1
+      expect(subject.on_demand).to eq false
+      expect(subject.on_hand).to eq 11
+    end
+  end
+
   describe ".import_product" do
     let(:supplied_product) do
       DfcProvider::SuppliedProduct.new(

--- a/spec/system/admin/dfc_product_import_spec.rb
+++ b/spec/system/admin/dfc_product_import_spec.rb
@@ -66,7 +66,9 @@ RSpec.describe "DFC Product Import" do
     }.to change { enterprise.supplied_products.count }
       .and change { linked_variant.display_name }
       .and change { linked_variant.unit_value }
-      .and change { linked_variant.price }
+      .and change { linked_variant.price }.to(2.09)
+      .and change { linked_variant.on_demand }.to(true)
+      .and change { linked_variant.on_hand }.by(0)
 
     expect(page).to have_content "Importing a DFC product catalog"
 


### PR DESCRIPTION
#### What? Why?

- Specs #12902
- Closes #12903 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit Admin Product Import.
- Enter a bogus URL or somewhere you don't have access to as catalog URL.
- Try to import catalog.
- You should see an error message.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
