### PR TITLE
Import product's invalid weight as 1 item

### DIFF
--- a/engines/dfc_provider/app/services/quantitative_value_builder.rb
+++ b/engines/dfc_provider/app/services/quantitative_value_builder.rb
@@ -31,11 +31,15 @@ class QuantitativeValueBuilder < DfcBuilder
     measure, unit_name, unit_scale = map_unit(quantity.unit)
     value = quantity.value.to_f * unit_scale
 
+    # Import invalid value as one item.
     if measure.in?(%w(weight volume)) && value <= 0
       measure = "items"
       unit_name = "items"
       value = 1
     end
+
+    # Items don't have a scale, only a value on the variant.
+    unit_scale = nil if measure == "items"
 
     variant.variant_unit = measure
     variant.variant_unit_name = unit_name if measure == "items"

--- a/engines/dfc_provider/spec/services/quantitative_value_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/quantitative_value_builder_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe QuantitativeValueBuilder do
 
       expect(variant.variant_unit).to eq "items"
       expect(variant.variant_unit_name).to eq "Jar"
-      expect(variant.variant_unit_scale).to eq 1
+      expect(variant.variant_unit_scale).to eq nil
       expect(variant.unit_value).to eq 3
     end
 
@@ -141,7 +141,7 @@ RSpec.describe QuantitativeValueBuilder do
 
       expect(variant.variant_unit).to eq "items"
       expect(variant.variant_unit_name).to eq "dozen"
-      expect(variant.variant_unit_scale).to eq 12
+      expect(variant.variant_unit_scale).to eq nil
       expect(variant.unit_value).to eq 24
     end
   end

--- a/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/supplied_product_builder_spec.rb
@@ -107,6 +107,8 @@ RSpec.describe SuppliedProductBuilder do
       expect(subject).to be_persisted
       expect(subject.name).to eq("Fillet Steak - 201g x 1 Steak")
       expect(subject.variant_unit).to eq("items")
+      expect(subject.variant_unit_scale).to eq(nil)
+      expect(subject.variant_unit_with_scale).to eq("items")
       expect(subject.unit_value).to eq(1)
     end
   end


### PR DESCRIPTION
#### What? Why?

- Closes #12909 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We previously stored a scale which made the product screen believe that we are dealing with weight.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit Admin Product Import.
- Import DFC catalog with zero weight products.
- Visit Admin Product Edit.
- No products should appears as unsaved.
- Imported zero weight products should appear as _1 item_ products.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
