### PR TITLE
Add Bugsnag notification if we reach tax rate refund code

### DIFF
--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -110,7 +110,7 @@ module Spree
             "Notice: Tax refund should not be possible, please check the default zone and " \
             "the tax rate zone configuration"
           ) do |payload|
-            payload.add_metadata :order_tax_zone, order.tax_zone
+            payload.add_metadata :order_tax_zone, item.order.tax_zone
             payload.add_metadata :tax_rate_zone, zone
             payload.add_metadata :default_zone, Zone.default_tax
           end

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -105,6 +105,15 @@ module Spree
         if default_zone_or_zone_match?(item.order)
           calculator.compute(item)
         else
+          # Tax refund should not be possible with the way our production server are configured
+          Bugsnag.notify(
+            "Notice: Tax refund should not be possible, please check the default zone and " \
+            "the tax rate zone configuration"
+          ) do |payload|
+            payload.add_metadata :order_tax_zone, order.tax_zone
+            payload.add_metadata :tax_rate_zone, zone
+            payload.add_metadata :default_zone, Zone.default_tax
+          end
           # In this case, it's a refund.
           calculator.compute(item) * - 1
         end

--- a/spec/models/spree/tax_rate_spec.rb
+++ b/spec/models/spree/tax_rate_spec.rb
@@ -386,6 +386,16 @@ module Spree
                 Spree::TaxRate.adjust(order, order.line_items)
                 expect(line_item.adjustments.credit.count).to eq 2
               end
+
+              it "notifies bugsnag" do
+                # there are two tax rate
+                expect(Bugsnag).to receive(:notify).with(
+                  "Notice: Tax refund should not be possible, please check the default zone and " \
+                  "the tax rate zone configuration"
+                ).twice
+
+                Spree::TaxRate.adjust(order, order.line_items)
+              end
             end
           end
 

--- a/spec/models/spree/tax_rate_spec.rb
+++ b/spec/models/spree/tax_rate_spec.rb
@@ -392,7 +392,7 @@ module Spree
                 expect(Bugsnag).to receive(:notify).with(
                   "Notice: Tax refund should not be possible, please check the default zone and " \
                   "the tax rate zone configuration"
-                ).twice
+                ).twice.and_call_original
 
                 Spree::TaxRate.adjust(order, order.line_items)
               end


### PR DESCRIPTION
#### What? Why?

This was discovered when investigating #12908  

The original Spree code allow for a tax adjustment to be considered a refund in a specific scenario:
- instance is using inclusive tax
- instance that applies different tax rate in different tax zones

This scenario should not happen with how our instances are configured More info: https://github.com/openfoodfoundation/openfoodnetwork/pull/6565#discussion_r566535431


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green specs

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
