### PR TITLE
Filter reports by last 3 months by default

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -58,4 +58,9 @@ module ReportsHelper
       .where(order_id: orders.map(&:id))
       .pluck(:originator_id)
   end
+
+  def datepicker_time(datetime)
+    datetime = Time.zone.parse(datetime) if datetime.is_a? String
+    datetime.strftime('%Y-%m-%d %H:%M')
+  end
 end

--- a/app/views/admin/reports/_date_range_form.html.haml
+++ b/app/views/admin/reports/_date_range_form.html.haml
@@ -4,8 +4,8 @@
 - start_field = "#{field}_gt"
 - end_field = "#{field}_lt"
 - query = params[:q].to_h
-- start_date ||= query[start_field].presence || 3.months.ago.beginning_of_day.strftime('%Y-%m-%d %H:%M')
-- end_date ||= query[end_field].presence || Time.zone.tomorrow.beginning_of_day.strftime('%Y-%m-%d %H:%M')
+- start_date = datepicker_time(query[start_field].presence || 3.months.ago.beginning_of_day)
+- end_date = datepicker_time(query[end_field].presence || Time.zone.tomorrow.beginning_of_day)
 
 .row.date-range-filter
   .alpha.two.columns= label_tag nil, t(:date_range)

--- a/app/views/admin/reports/_date_range_form.html.haml
+++ b/app/views/admin/reports/_date_range_form.html.haml
@@ -1,8 +1,8 @@
 -# Field used for ransack search. This date range is mostly used for Spree::Order
 -# so default field is 'completed_at'
 - field ||= 'completed_at'
-- start_date ||= params[:q].try(:[], :completed_at_gt)
-- end_date ||= params[:q].try(:[], :completed_at_lt)
+- start_date ||= params[:q].try(:[], :completed_at_gt) || 3.months.ago.beginning_of_day
+- end_date ||= params[:q].try(:[], :completed_at_lt) || Time.zone.tomorrow.beginning_of_day
 
 .row.date-range-filter
   .alpha.two.columns= label_tag nil, t(:date_range)

--- a/app/views/admin/reports/_date_range_form.html.haml
+++ b/app/views/admin/reports/_date_range_form.html.haml
@@ -1,8 +1,11 @@
 -# Field used for ransack search. This date range is mostly used for Spree::Order
 -# so default field is 'completed_at'
 - field ||= 'completed_at'
-- start_date ||= params[:q].try(:[], :completed_at_gt) || 3.months.ago.beginning_of_day
-- end_date ||= params[:q].try(:[], :completed_at_lt) || Time.zone.tomorrow.beginning_of_day
+- start_field = "#{field}_gt"
+- end_field = "#{field}_lt"
+- query = params[:q].to_h
+- start_date ||= query[start_field].presence || 3.months.ago.beginning_of_day
+- end_date ||= query[end_field].presence || Time.zone.tomorrow.beginning_of_day
 
 .row.date-range-filter
   .alpha.two.columns= label_tag nil, t(:date_range)
@@ -10,5 +13,5 @@
     .field-block.omega.four.columns
       .date-range-fields{ data: { controller: "flatpickr", "flatpickr-mode-value": "range", "flatpickr-enable-time-value": true , "flatpickr-default-hour": 0 } }
         = text_field_tag nil, nil, class: "datepicker fullwidth", data: { "flatpickr-target": "instance", action: "flatpickr_clear@window->flatpickr#clear" }
-        = text_field_tag "q[#{field}_gt]", nil, data: { "flatpickr-target": "start" }, style: "display: none", value: start_date
-        = text_field_tag "q[#{field}_lt]", nil, data: { "flatpickr-target": "end" }, style: "display: none", value: end_date
+        = text_field_tag "q[#{start_field}]", nil, data: { "flatpickr-target": "start" }, style: "display: none", value: start_date
+        = text_field_tag "q[#{end_field}]", nil, data: { "flatpickr-target": "end" }, style: "display: none", value: end_date

--- a/app/views/admin/reports/_date_range_form.html.haml
+++ b/app/views/admin/reports/_date_range_form.html.haml
@@ -4,14 +4,14 @@
 - start_field = "#{field}_gt"
 - end_field = "#{field}_lt"
 - query = params[:q].to_h
-- start_date ||= query[start_field].presence || 3.months.ago.beginning_of_day
-- end_date ||= query[end_field].presence || Time.zone.tomorrow.beginning_of_day
+- start_date ||= query[start_field].presence || 3.months.ago.beginning_of_day.strftime('%Y-%m-%d %H:%M')
+- end_date ||= query[end_field].presence || Time.zone.tomorrow.beginning_of_day.strftime('%Y-%m-%d %H:%M')
 
 .row.date-range-filter
   .alpha.two.columns= label_tag nil, t(:date_range)
   .omega.fourteen.columns
     .field-block.omega.four.columns
-      .date-range-fields{ data: { controller: "flatpickr", "flatpickr-mode-value": "range", "flatpickr-enable-time-value": true , "flatpickr-default-hour": 0 } }
+      .date-range-fields{ data: { controller: "flatpickr", "flatpickr-mode-value": "range", "flatpickr-enable-time-value": true , "flatpickr-default-hour": 0, "flatpickr-default-date": [start_date, end_date] } }
         = text_field_tag nil, nil, class: "datepicker fullwidth", data: { "flatpickr-target": "instance", action: "flatpickr_clear@window->flatpickr#clear" }
         = text_field_tag "q[#{start_field}]", nil, data: { "flatpickr-target": "start" }, style: "display: none", value: start_date
         = text_field_tag "q[#{end_field}]", nil, data: { "flatpickr-target": "end" }, style: "display: none", value: end_date

--- a/app/views/admin/reports/filters/_packing.html.haml
+++ b/app/views/admin/reports/filters/_packing.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'admin/reports/date_range_form', 
-         locals: { f: f, field: 'order_completed_at', start_date: params[:q].try(:[], :order_completed_at_gt), end_date: params[:q].try(:[], :order_completed_at_lt) }
+         locals: { f: f, field: 'order_completed_at' }
 
 .row
   .alpha.two.columns= label_tag nil, t(:report_hubs)

--- a/spec/support/features/datepicker_helper.rb
+++ b/spec/support/features/datepicker_helper.rb
@@ -43,5 +43,11 @@ module Features
       select_datetime_from_datepicker datetime_selector
       find("body").send_keys(:escape)
     end
+
+    def close_datepicker
+      within(".flatpickr-calendar.open") do
+        click_button "Close"
+      end
+    end
   end
 end

--- a/spec/support/features/datepicker_helper.rb
+++ b/spec/support/features/datepicker_helper.rb
@@ -12,13 +12,22 @@ module Features
       # Once the datepicker is open,
       # it simply consist to select the 'from' date and then the 'to' date
       select_date_from_datepicker(from)
-      select_date_from_datepicker(to, from)
+      select_date_from_datepicker(to)
     end
 
-    def select_date_from_datepicker(date, reference_date = Time.zone.today)
-      navigate_datepicker_to_month(date, reference_date)
-      find('.flatpickr-calendar.open .flatpickr-days .flatpickr-day:not(.prevMonthDay)',
-           text: date.strftime("%e").to_s.strip, exact_text: true, match: :first).click
+    def select_date_from_datepicker(date)
+      within ".flatpickr-calendar.open" do
+        # Unfortunately, flatpickr doesn't notice a change of year when we do
+        #
+        #     fill_in "Year", with: date.year
+        #
+        # A working alternative is:
+        find(".cur-year").send_keys(date.year.to_s)
+        select date.strftime("%B"), from: "Month"
+
+        aria_date = date.strftime("%B %-d, %Y")
+        find("[aria-label='#{aria_date}']").click
+      end
     end
 
     def select_datetime_from_datepicker(datetime)
@@ -27,34 +36,6 @@ module Features
       # Then select time
       find(".flatpickr-calendar.open .flatpickr-hour").set datetime.strftime("%H").to_s.strip
       find(".flatpickr-calendar.open .flatpickr-minute").set datetime.strftime("%M").to_s.strip
-    end
-
-    def navigate_datepicker_to_month(date, reference_date)
-      month_and_year = date.strftime("%-m %Y")
-
-      until datepicker_month_and_year == month_and_year.upcase
-        if date < reference_date
-          navigate_datepicker_to_previous_month
-        elsif date > reference_date
-          navigate_datepicker_to_next_month
-        end
-      end
-    end
-
-    def navigate_datepicker_to_previous_month
-      find('.flatpickr-calendar.open .flatpickr-months .flatpickr-prev-month').click
-    end
-
-    def navigate_datepicker_to_next_month
-      find('.flatpickr-calendar.open .flatpickr-months .flatpickr-next-month').click
-    end
-
-    def datepicker_month_and_year
-      month = find(".flatpickr-calendar.open .flatpickr-current-month " \
-                   "select.flatpickr-monthDropdown-months").value.to_i + 1
-      year = find(".flatpickr-calendar.open .flatpickr-current-month " \
-                  ".numInputWrapper .cur-year").value
-      "#{month} #{year}"
     end
 
     def pick_datetime(calendar_selector, datetime_selector)

--- a/spec/system/admin/order_cycles/edit_spec.rb
+++ b/spec/system/admin/order_cycles/edit_spec.rb
@@ -41,11 +41,8 @@ RSpec.describe '
 
         # change date range field value
         find('#order_cycle_orders_close_at').click
-        within(".flatpickr-calendar.open") do
-          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
-          select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
-          find("button", text: "Close").click
-        end
+        select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
+        close_datepicker
         expect(page).to have_content('You have unsaved changes')
 
         # click save to open warning modal
@@ -66,11 +63,8 @@ RSpec.describe '
 
         # change date range field value
         find('#order_cycle_orders_close_at').click
-        within(".flatpickr-calendar.open") do
-          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
-          select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
-          find("button", text: "Close").click
-        end
+        select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
+        close_datepicker
 
         # click save to open warning modal
         click_button('Save')
@@ -102,11 +96,8 @@ RSpec.describe '
 
         # Now change date range field value
         find('#order_cycle_orders_close_at').click
-        within(".flatpickr-calendar.open") do
-          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
-          select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
-          find("button", text: "Close").click
-        end
+        select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
+        close_datepicker
         expect(page).to have_content('You have unsaved changes')
 
         click_button('Save')
@@ -137,11 +128,8 @@ RSpec.describe '
 
         # change date range field value
         find('#order_cycle_orders_close_at').click
-        within(".flatpickr-calendar.open") do
-          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
-          select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
-          find("button", text: "Close").click
-        end
+        select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
+        close_datepicker
 
         expect(page).to have_content('You have unsaved changes')
 
@@ -175,11 +163,8 @@ RSpec.describe '
 
         # Now change date range field value
         find('#order_cycle_orders_close_at').click
-        within(".flatpickr-calendar.open") do
-          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
-          select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
-          find("button", text: "Close").click
-        end
+        select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
+        close_datepicker
         expect(page).to have_content('You have unsaved changes')
         sleep(2)
 

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -182,12 +182,8 @@ RSpec.describe '
           find('input.datetimepicker', match: :first).click
         end
 
-        # Sets the value to test_value then looks for the close button and click it
-        within(".flatpickr-calendar.open") do
-          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
-          select_datetime_from_datepicker test_value
-          find("button", text: "Close").click
-        end
+        select_datetime_from_datepicker test_value
+        close_datepicker
 
         # Should no more have opened flatpickr
         expect(page).not_to have_selector '.flatpickr-calendar.open'
@@ -213,11 +209,8 @@ RSpec.describe '
         within("tr.order-cycle-#{order_cycle.id}") do
           find('input.datetimepicker', match: :first).click
         end
-        within(".flatpickr-calendar.open") do
-          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
-          select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
-          find("button", text: "Close").click
-        end
+        select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
+        close_datepicker
         expect(page).to have_content('You have unsaved changes')
 
         # click save to open warning modal
@@ -237,11 +230,8 @@ RSpec.describe '
         within("tr.order-cycle-#{order_cycle.id}") do
           find('input.datetimepicker', match: :first).click
         end
-        within(".flatpickr-calendar.open") do
-          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
-          select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
-          find("button", text: "Close").click
-        end
+        select_datetime_from_datepicker Time.zone.parse("2024-03-30 00:00")
+        close_datepicker
         expect(page).to have_content('You have unsaved changes')
 
         click_button('Save')

--- a/spec/system/admin/reports/customers_report_spec.rb
+++ b/spec/system/admin/reports/customers_report_spec.rb
@@ -5,8 +5,11 @@ require "system_helper"
 RSpec.describe "Customers report" do
   include AuthenticationHelper
 
+  let(:enterprise_user) { create(:enterprise_user) }
+  let(:distributor) { enterprise_user.enterprises[0] }
+
   it "can be rendered" do
-    login_as_admin
+    login_as enterprise_user
     visit admin_reports_path
 
     within "table.index" do
@@ -23,5 +26,25 @@ RSpec.describe "Customers report" do
         ]
       ]
     )
+  end
+
+  it "displays filtered data by default" do
+    old_order = create(
+      :completed_order_with_totals, distributor:, completed_at: 4.months.ago
+    )
+    new_order = create(:completed_order_with_totals, distributor:)
+    future_order = create(
+      :completed_order_with_totals, distributor:, completed_at: 1.day.from_now
+    )
+
+    login_as enterprise_user
+    visit admin_report_path(report_type: :customers)
+    run_report
+
+    rows = find("table.report__table").all("tbody tr")
+    expect(rows.count).to eq 1
+    expect(rows[0].all("td")[3].text).to eq new_order.email
+    expect(page).not_to have_content old_order.email
+    expect(page).not_to have_content future_order.email
   end
 end

--- a/spec/system/admin/reports/customers_report_spec.rb
+++ b/spec/system/admin/reports/customers_report_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+RSpec.describe "Customers report" do
+  include AuthenticationHelper
+
+  it "can be rendered" do
+    login_as_admin
+    visit admin_reports_path
+
+    within "table.index" do
+      click_link "Customers"
+    end
+    run_report
+
+    rows = find("table.report__table").all("thead tr")
+    table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
+    expect(table.sort).to eq([
+      ["First Name", "Last Name", "Billing Address", "Email", "Phone", "Hub", "Hub Address",
+       "Shipping Method", "Total Number of Orders", "Total incl. tax ($)",
+       "Last completed order date"]
+    ].sort)
+  end
+end

--- a/spec/system/admin/reports/customers_report_spec.rb
+++ b/spec/system/admin/reports/customers_report_spec.rb
@@ -14,12 +14,14 @@ RSpec.describe "Customers report" do
     end
     run_report
 
-    rows = find("table.report__table").all("thead tr")
-    table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
-    expect(table.sort).to eq([
-      ["First Name", "Last Name", "Billing Address", "Email", "Phone", "Hub", "Hub Address",
-       "Shipping Method", "Total Number of Orders", "Total incl. tax ($)",
-       "Last completed order date"]
-    ].sort)
+    expect(table_headers).to eq(
+      [
+        [
+          "First Name", "Last Name", "Billing Address", "Email", "Phone",
+          "Hub", "Hub Address", "Shipping Method", "Total Number of Orders",
+          "Total incl. tax ($)", "Last completed order date",
+        ]
+      ]
+    )
   end
 end

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -151,28 +151,6 @@ RSpec.describe '
     end
   end
 
-  describe "Can access Customers reports and generate customers report" do
-    before do
-      login_as_admin
-      visit admin_reports_path
-    end
-
-    it "customers report" do
-      within "table.index" do
-        click_link "Customers"
-      end
-      run_report
-
-      rows = find("table.report__table").all("thead tr")
-      table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
-      expect(table.sort).to eq([
-        ["First Name", "Last Name", "Billing Address", "Email", "Phone", "Hub", "Hub Address",
-         "Shipping Method", "Total Number of Orders", "Total incl. tax ($)",
-         "Last completed order date"]
-      ].sort)
-    end
-  end
-
   describe "Order cycle management report" do
     before do
       login_as_admin


### PR DESCRIPTION
#### What? Why?

- Closes #12894 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

When introducing the flatpickr date selector to reports, we lost the default date range. I'm bringing it back now with a default of the last three months.

![Screen Shot 2024-10-17 at 09 07 41](https://github.com/user-attachments/assets/ebd7ce76-2ffd-46c1-9d4c-60e0a2bf3ae5)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit Admin Reports and select a report.
- Reports with a date range should have the date range pre-filled.
- Running the report should filter by that default date range.
- You should be able to change the dates and the filter should work as before.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
