### PR TITLE
Request offline access when connecting OIDC account

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -155,7 +155,7 @@ if ENV["OPENID_APP_ID"].present? && ENV["OPENID_APP_SECRET"].present?
     config.omniauth :openid_connect, {
       name: :openid_connect,
       issuer: "https://login.lescommuns.org/auth/realms/data-food-consortium",
-      scope: [:openid, :profile, :email],
+      scope: [:openid, :profile, :email, :offline_access],
       response_type: :code,
       uid_field: "email",
       discovery: true,

--- a/spec/fixtures/vcr_cassettes/DfcRequest/refreshes_the_access_token_on_fail.yml
+++ b/spec/fixtures/vcr_cassettes/DfcRequest/refreshes_the_access_token_on_fail.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 Mar 2024 05:44:06 GMT
+      - Thu, 17 Oct 2024 22:34:30 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -29,14 +29,14 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Set-Cookie:
-      - AUTH_SESSION_ID=1710481447.162.5206.870756|6055218c9898cae39f8ffd531999e49a;
+      - AUTH_SESSION_ID=1729204471.193.75356.242686|78230f584c0d7db97d376e98de5321dc;
         Path=/; Secure; HttpOnly
       Cache-Control:
       - no-cache, must-revalidate, no-transform, no-store
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -47,7 +47,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"issuer":"https://login.lescommuns.org/auth/realms/data-food-consortium","authorization_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/auth","token_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/token","introspection_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/token/introspect","userinfo_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/userinfo","end_session_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/logout","frontchannel_logout_session_supported":true,"frontchannel_logout_supported":true,"jwks_uri":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/certs","check_session_iframe":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/login-status-iframe.html","grant_types_supported":["authorization_code","implicit","refresh_token","password","client_credentials","urn:openid:params:grant-type:ciba","urn:ietf:params:oauth:grant-type:device_code"],"acr_values_supported":["0","1"],"response_types_supported":["code","none","id_token","token","id_token
         token","code id_token","code token","code id_token token"],"subject_types_supported":["public","pairwise"],"id_token_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"id_token_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"id_token_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"userinfo_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"userinfo_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"userinfo_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"request_object_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"request_object_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"response_modes_supported":["query","fragment","form_post","query.jwt","fragment.jwt","form_post.jwt","jwt"],"registration_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/clients-registrations/openid-connect","token_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"token_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"introspection_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"introspection_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"authorization_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"claims_supported":["aud","sub","iss","auth_time","name","given_name","family_name","preferred_username","email","acr"],"claim_types_supported":["normal"],"claims_parameter_supported":true,"scopes_supported":["openid","microprofile-jwt","phone","roles","profile","email","address","web-origins","acr","offline_access"],"request_parameter_supported":true,"request_uri_parameter_supported":true,"require_request_uri_registration":true,"code_challenge_methods_supported":["plain","S256"],"tls_client_certificate_bound_access_tokens":true,"revocation_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/revoke","revocation_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"revocation_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"backchannel_logout_supported":true,"backchannel_logout_session_supported":true,"device_authorization_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/auth/device","backchannel_token_delivery_modes_supported":["poll","ping"],"backchannel_authentication_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/ext/ciba/auth","backchannel_authentication_request_signing_alg_values_supported":["PS384","ES384","RS384","ES256","RS256","ES512","PS256","PS512","RS512"],"require_pushed_authorization_requests":false,"pushed_authorization_request_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/ext/par/request","mtls_endpoint_aliases":{"token_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/token","revocation_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/revoke","introspection_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/token/introspect","device_authorization_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/auth/device","registration_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/clients-registrations/openid-connect","userinfo_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/userinfo","pushed_authorization_request_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/ext/par/request","backchannel_authentication_endpoint":"https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/ext/ciba/auth"},"authorization_response_iss_parameter_supported":true}'
-  recorded_at: Fri, 15 Mar 2024 05:44:05 GMT
+  recorded_at: Thu, 17 Oct 2024 22:34:30 GMT
 - request:
     method: post
     uri: https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/token
@@ -71,7 +71,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 Mar 2024 05:44:07 GMT
+      - Thu, 17 Oct 2024 22:34:31 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -81,7 +81,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Set-Cookie:
-      - AUTH_SESSION_ID=1710481448.492.2309.531618|6055218c9898cae39f8ffd531999e49a;
+      - AUTH_SESSION_ID=1729204472.43.75092.609685|78230f584c0d7db97d376e98de5321dc;
         Path=/; Secure; HttpOnly
       Cache-Control:
       - no-store
@@ -90,7 +90,7 @@ http_interactions:
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -99,7 +99,7 @@ http_interactions:
       - 1; mode=block
     body:
       encoding: ASCII-8BIT
-      string: '{"access_token":"<HIDDEN-OPENID-TOKEN>","expires_in":1800,"refresh_expires_in":28510621,"refresh_token":"<HIDDEN-OPENID-TOKEN>","token_type":"Bearer","id_token":"<HIDDEN-OPENID-TOKEN>","not-before-policy":0,"session_state":"989db9a7-584c-4eeb-bff5-db77b53e8def","scope":"openid
-        profile email"}'
-  recorded_at: Fri, 15 Mar 2024 05:44:07 GMT
+      string: '{"access_token":"<HIDDEN-OPENID-TOKEN>","expires_in":1800,"refresh_expires_in":0,"refresh_token":"<HIDDEN-OPENID-TOKEN>","token_type":"Bearer","id_token":"<HIDDEN-OPENID-TOKEN>","not-before-policy":0,"session_state":"c2483b2c-607e-4996-9f5e-9ef85176ff75","scope":"openid
+        profile email offline_access"}'
+  recorded_at: Thu, 17 Oct 2024 22:34:31 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
#### What? Why?

- Closes #12931

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We were getting refresh tokens that were tied to the current login session. While a session is valid for a year, it also ends when the user logs out or when the Keycloak server restarts. The latter seemed to happen quite often and integrations failed every few days.

Requesting `offline_access` gives us a refresh token that is valid even after the user logged out of their account.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test needed.
- But you could link your OIDC account, then go to Keycloak, log out there and then try to import a DFC catalog in OFN. It should still work.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
