### PR TITLE
Spec restock after order cancellation

### DIFF
--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Spree::Order do
     end
   end
 
-  describe "#cancel" do
+  describe "#cancel!" do
     let(:order) { create(:order_with_totals_and_distribution, :completed) }
 
     before { order.cancel! }

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -378,21 +378,25 @@ RSpec.describe Spree::Order do
   describe "#cancel!" do
     let(:order) { create(:order_with_totals_and_distribution, :completed) }
 
-    before { order.cancel! }
-
     it "should cancel the order" do
-      expect(order.state).to eq 'canceled'
+      expect { order.cancel! }.to change { order.state }.to("canceled")
     end
 
     it "should cancel the shipments" do
-      expect(order.shipments.pluck(:state)).to eq ['canceled']
+      expect { order.cancel! }.to change {
+        order.shipments.pluck(:state)
+      }.to(["canceled"])
     end
 
     context "when payment has not been taken" do
       context "and payment is in checkout state" do
         it "should change the state of the payment to void" do
-          order.payments.reload
-          expect(order.payments.pluck(:state)).to eq ['void']
+          expect {
+            order.cancel!
+            order.payments.reload
+          }.to change {
+            order.payments.pluck(:state)
+          }.to(["void"])
         end
       end
     end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -400,6 +400,27 @@ RSpec.describe Spree::Order do
         end
       end
     end
+
+    it "restocks items without reload" do
+      pending "Cancelling a newly created order updates shipments without callbacks"
+      # But in production, orders are always created in one request and
+      # cancelled in another request. This is only an issue in specs.
+
+      expect { order.cancel }.to change {
+        order.variants.first.on_hand
+      }.by(1)
+    end
+
+    it "restocks items" do
+      # If we don't reload the order, it keeps thinking that its shipping
+      # address changed and triggers a shipment update without shipment
+      # callbacks. This can be removed if the above spec passes.
+      order.reload
+
+      expect { order.cancel }.to change {
+        order.variants.first.on_hand
+      }.by(1)
+    end
   end
 
   describe "#resume" do


### PR DESCRIPTION
#### What? Why?

- Helps with speccing #12876 <!-- Insert issue number here. -->


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

My big afternoon detour resulted in a simple spec. Now I know how to spec order cancellations for DFC Orders.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
