### PR TITLE
Bug 12939

### DIFF
--- a/app/services/variant_units/option_value_namer.rb
+++ b/app/services/variant_units/option_value_namer.rb
@@ -41,7 +41,9 @@ module VariantUnits
           value, unit_name = option_value_value_unit_scaled
         else
           value = @nameable.unit_value
-          unit_name = pluralize(@nameable.variant_unit_name, value)
+
+          unit_name = @nameable.variant_unit_name
+          unit_name = pluralize(unit_name, value) if unit_name.present?
         end
 
         value = value.to_i if value == value.to_i

--- a/spec/services/variant_units/option_value_namer_spec.rb
+++ b/spec/services/variant_units/option_value_namer_spec.rb
@@ -131,6 +131,15 @@ module VariantUnits
         end
       end
 
+      it "don't crash when variant_unit_name is nil" do
+        pending "#12939"
+        v = instance_double(Spree::Variant, variant_unit: 'items', variant_unit_scale: nil,
+                                            variant_unit_name: nil, unit_value: 100)
+
+        option_value_namer = OptionValueNamer.new v
+        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [100, ""]
+      end
+
       it "generates singular values for item units when value is 1" do
         v = instance_double(Spree::Variant, variant_unit: 'items', variant_unit_scale: nil,
                                             variant_unit_name: 'packet', unit_value: 1)

--- a/spec/services/variant_units/option_value_namer_spec.rb
+++ b/spec/services/variant_units/option_value_namer_spec.rb
@@ -132,12 +132,11 @@ module VariantUnits
       end
 
       it "don't crash when variant_unit_name is nil" do
-        pending "#12939"
         v = instance_double(Spree::Variant, variant_unit: 'items', variant_unit_scale: nil,
                                             variant_unit_name: nil, unit_value: 100)
 
         option_value_namer = OptionValueNamer.new v
-        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [100, ""]
+        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [100, nil]
       end
 
       it "generates singular values for item units when value is 1" do


### PR DESCRIPTION
#### What? Why?

- Fix #12939
- alternative to, and closes #12941 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
There are two scenarios: 
`git diff db/schema.rb | grep unit_value`
1. DB has a default value for spree_variants.unit_value,
   `+    t.float "unit_value", default: 1.0, null: false`
2. or not.

Scenario 1 is already tested in prod! US, DE and HU. Check the above `git diff` and test on a staging server.

- Visit /admin/products 
- create a new product 
- view /admin/products again

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
