### PR TITLE
Fix OptionValueNamer to handle weird scenario

### DIFF
--- a/app/services/variant_units/option_value_namer.rb
+++ b/app/services/variant_units/option_value_namer.rb
@@ -39,9 +39,13 @@ module VariantUnits
       if @nameable.unit_value.present?
         if %w(weight volume).include? @nameable.variant_unit
           value, unit_name = option_value_value_unit_scaled
-        else
+        # on some production server Spree::Variant.new gives a variant with unit_value = 1.0 and
+        # nothing else set, which breaks the OptionValueNamer
+        elsif @nameable.variant_unit_name.present?
           value = @nameable.unit_value
           unit_name = pluralize(@nameable.variant_unit_name, value)
+        else
+          value = unit_name = nil
         end
 
         value = value.to_i if value == value.to_i

--- a/spec/services/variant_units/option_value_namer_spec.rb
+++ b/spec/services/variant_units/option_value_namer_spec.rb
@@ -35,6 +35,14 @@ module VariantUnits
         allow(subject).to receive(:value_scaled?) { false }
         expect(subject.name).to eq("value unit")
       end
+
+      context "when only unit_value is set" do
+        it "returns an empty string" do
+          v.unit_value = 1.0
+
+          expect(subject.name).to eq("")
+        end
+      end
     end
 
     describe "determining if a variant's value is scaled" do


### PR DESCRIPTION
#### What? Why?
- Closes #12939 
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

On some production server, Spree::Variant.new return a variant with only unit_vallue set to 1.0. This fix the unexpected scenario.

Affected servers so far :
* de_prod
* us_prod
* hu_prod

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
