### PR TITLE
Fix rounding issues by upgrading decimal maths library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ gem "active_model_serializers", "0.8.4"
 gem 'activerecord-session_store'
 gem 'acts-as-taggable-on'
 gem 'angularjs-file-upload-rails', '~> 2.4.1'
-gem 'bigdecimal', '3.0.2'
+gem 'bigdecimal'
 gem 'bootsnap', require: false
 gem 'geocoder'
 gem 'gmaps4rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     base64 (0.2.0)
     bcp47_spec (0.2.1)
     bcrypt (3.1.20)
-    bigdecimal (3.0.2)
+    bigdecimal (3.1.8)
     bindata (2.5.0)
     bindex (0.8.1)
     bootsnap (1.18.3)
@@ -865,7 +865,7 @@ DEPENDENCIES
   angularjs-rails (= 1.8.0)
   arel-helpers (~> 2.12)
   aws-sdk-s3
-  bigdecimal (= 3.0.2)
+  bigdecimal
   bootsnap
   bugsnag
   bullet

--- a/app/services/variant_units/option_value_namer.rb
+++ b/app/services/variant_units/option_value_namer.rb
@@ -58,7 +58,7 @@ module VariantUnits
     def option_value_value_unit_scaled
       unit_scale, unit_name = scale_for_unit_value
 
-      value = (@nameable.unit_value / unit_scale).to_d.truncate(2)
+      value = (@nameable.unit_value / unit_scale).to_d.round(2)
 
       [value, unit_name]
     end

--- a/app/services/variant_units/option_value_namer.rb
+++ b/app/services/variant_units/option_value_namer.rb
@@ -58,7 +58,7 @@ module VariantUnits
     def option_value_value_unit_scaled
       unit_scale, unit_name = scale_for_unit_value
 
-      value = (@nameable.unit_value / unit_scale).to_d.round(2)
+      value = (@nameable.unit_value.to_d / unit_scale).round(2)
 
       [value, unit_name]
     end

--- a/spec/lib/reports/sales_tax_totals_by_order_spec.rb
+++ b/spec/lib/reports/sales_tax_totals_by_order_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "Reporting::Reports::SalesTax::SalesTaxTotalsByOrder" do
         total = report.total_excl_tax(query_row)
 
         # discounted order total - discounted order tax
-        expect(total).to eq((113.3 - 10) - (3.3 - 0.29))
+        expect(total).to eq((BigDecimal('113.3') - 10) - (BigDecimal('3.3') - BigDecimal('0.29')))
       end
     end
   end

--- a/spec/lib/reports/sales_tax_totals_by_order_spec.rb
+++ b/spec/lib/reports/sales_tax_totals_by_order_spec.rb
@@ -145,7 +145,8 @@ RSpec.describe "Reporting::Reports::SalesTax::SalesTaxTotalsByOrder" do
         total = report.total_excl_tax(query_row)
 
         # discounted order total - discounted order tax
-        expect(total).to eq((BigDecimal('113.3') - 10) - (BigDecimal('3.3') - BigDecimal('0.29')))
+        # (113.3 - 10) - (3.3 - 0.29)
+        expect(total).to eq 100.29
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

BigDecimal was version locked, but with some small modifications to a test and another small modification to display logic, it doesn't need to be. This allows us to use default gems on Alpine Docker images much easier. It also allows dependabot to automatically upgrade the gem when necessary.

#### What should we test?
- Visit http://localhost:3000/admin/products
- Edit any product's unit to be 500.1, which causes a rounding error.
- Save and verify that the display unit is 500.1 and not 500.09, which happened when we used `trunc` to create the value instead of `round`.

#### Release notes
BigDecimal will now be updated to the latest version more easily.

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

The title of the pull request will be included in the release notes.
