### PR TITLE
Ensure shipment gets updated when an order is updated

### DIFF
--- a/app/models/spree/order_contents.rb
+++ b/app/models/spree/order_contents.rb
@@ -38,6 +38,7 @@ module Spree
         line_item.price = variant.price
         order.line_items << line_item
       end
+      update_shipment
 
       order.reload
       line_item

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -166,12 +166,6 @@ RSpec.describe Spree::OrderContents do
   end
 
   describe "#update_or_create" do
-    it "ensures shipments are updated" do
-      expect(order).to receive(:ensure_updated_shipments)
-
-      subject.update_or_create(variant, { quantity: 2, max_quantity: 3 })
-    end
-
     describe "creating" do
       it "creates a new line item with given attributes" do
         subject.update_or_create(variant, { quantity: 2, max_quantity: 3 })
@@ -180,6 +174,12 @@ RSpec.describe Spree::OrderContents do
         expect(line_item.quantity).to eq 2
         expect(line_item.max_quantity).to eq 3
         expect(line_item.price).to eq variant.price
+      end
+
+      it "ensures shipments are updated" do
+        expect(order).to receive(:ensure_updated_shipments)
+
+        subject.update_or_create(variant, { quantity: 2, max_quantity: 3 })
       end
     end
 
@@ -191,6 +191,12 @@ RSpec.describe Spree::OrderContents do
 
         expect(line_item.reload.quantity).to eq 3
         expect(line_item.max_quantity).to eq 4
+      end
+
+      it "ensures shipments are updated" do
+        expect(order).to receive(:ensure_updated_shipments)
+
+        subject.update_or_create(variant, { quantity: 3, max_quantity: 4 })
       end
     end
   end

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -166,6 +166,12 @@ RSpec.describe Spree::OrderContents do
   end
 
   describe "#update_or_create" do
+    it "ensures shipments are updated" do
+      expect(order).to receive(:ensure_updated_shipments)
+
+      subject.update_or_create(variant, { quantity: 2, max_quantity: 3 })
+    end
+
     describe "creating" do
       it "creates a new line item with given attributes" do
         subject.update_or_create(variant, { quantity: 2, max_quantity: 3 })


### PR DESCRIPTION
#### What? Why?


I came across this while looking at #12907 
Given an order up to "Order Summary" step, if a customer then update the cart by going back to the shop page via the link next to the cart, the order shipment won't be updated.
It results in :
- the data on the order detail page in the back office being wrong
- the stock level not being updated properly 

To fix this, we make sure we delete existing shipment and restart the checkout flow.
 
![Screenshot Capture - 2024-10-30 - 21-22-06](https://github.com/user-attachments/assets/8c54de65-e1dd-4600-afe5-32c32f636ba7)
Order confirmation started with 2 potatoes test , was updated to 4 potatoes test and 3 potatoes

![Screenshot Capture - 2024-10-30 - 21-22-41](https://github.com/user-attachments/assets/3b7b7941-1641-4ec5-9609-e67c2bdef3ff)
Admin screen showing only the original items/quantity , 2 potatoes test

![Screenshot Capture - 2024-10-30 - 21-22-57](https://github.com/user-attachments/assets/e666df7f-f6c3-4caa-9363-6ba99ea4f6f8)
Potatoes test stock reduced from 50 to 48, and Potatoes stock stayed at 20


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
As an enterprise manager:
- set up a product with some stock, ie not "on demand"

As a customer
1. update quantity
- Start an order (use a product with stock) , proceed to checkout and progress to "Order confirmation" step
- Click on the shop link next to the cart
- update an item quantity of a product with stock 
- Proceed to checkout again 
 --> the order should have the correct items and quantity
- Complete the order

2. add a new item
- Start an order , proceed to checkout and progress to "Order confirmation" step
- Click on the shop link next to the cart
- add a new item in the cart, with a product with a stock 
- Proceed to checkout again 
 --> the order should have the correct items and quantity
- Complete the order

For both scenario, As an enterprise manager
- open the order just created
  --> The items should all be there and have the correct quantity
- Go to the Bulk Edit product page
  --> verify that the stock of the products in the order have been decreased by the correct number

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
