### PR TITLE
Show alert if map cannot load

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
@@ -20,10 +20,13 @@ angular.module('Darkswarm').directive 'mapSearch', ($timeout, Search) ->
     $timeout =>
       map = ctrl.getMap()
 
-      searchBox = scope.createSearchBox map
-      scope.bindSearchResponse map, searchBox
-      scope.biasResults map, searchBox
-      scope.performUrlSearch map
+      if !map
+        alert(t('gmap_load_failure'))
+      else
+        searchBox = scope.createSearchBox map
+        scope.bindSearchResponse map, searchBox
+        scope.biasResults map, searchBox
+        scope.performUrlSearch map
 
     scope.createSearchBox = (map) ->
       map.controls[google.maps.ControlPosition.TOP_LEFT].push scope.input

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2784,6 +2784,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   confirm_hub_change: "Are you sure? This will change your selected hub and remove any items in your shopping cart."
   confirm_oc_change: "Are you sure? This will change your selected order cycle and remove any items in your shopping cart."
   location_placeholder: "Type in a location..."
+  gmap_load_failure: "Unable to load map. Please check your browser settings and allow 3rd party cookies for this website."
   error_required: "can't be blank"
   error_number: "must be number"
   error_email: "must be email address"

--- a/spec/system/consumer/map_spec.rb
+++ b/spec/system/consumer/map_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+RSpec.describe 'Map' do
+  context 'map can load' do
+    it 'does not show alert' do
+      url_whitelist = page.driver.browser.url_whitelist
+      page.driver.browser.url_whitelist = nil
+
+      assert_raises(Capybara::ModalNotFound) do
+        accept_alert { visit '/map' }
+      end
+
+      page.driver.browser.url_whitelist = url_whitelist
+    end
+  end
+
+  context 'map cannot load' do
+    it 'shows alert' do
+      message = accept_alert { visit '/map' }
+      expect(message).to eq("Unable to load map.
+      Please check your browser settings
+      and allow 3rd party cookies for this website.".squish)
+    end
+  end
+end

--- a/spec/system/consumer/map_spec.rb
+++ b/spec/system/consumer/map_spec.rb
@@ -19,9 +19,10 @@ RSpec.describe 'Map' do
   context 'map cannot load' do
     it 'shows alert' do
       message = accept_alert { visit '/map' }
-      expect(message).to eq("Unable to load map.
-      Please check your browser settings
-      and allow 3rd party cookies for this website.".squish)
+      expect(message).to eq(
+        "Unable to load map. Please check your browser " \
+        "settings and allow 3rd party cookies for this website."
+      )
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #8230

Some browsers may fail to load Google Maps if 3rd party cookies are disabled. This causes downstream errors where the search bar attempts to render. More importantly, the user doesn't know why the map might have failed to load. This solution shows an alert instructing the user to check their network and 3rd party cookie settings.

#### What should we test?
Visit `/map`. Ensure the map still loads correctly.

The 3rd party cookie issue cannot be directly reproduced. Instead, the page has to be loaded while offline. This can only be done in local development where the page is locally hosted and Google Maps is loaded from the network.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
