### PR TITLE
Add cities and countries to DFC affiliate sales data endpoint

### DIFF
--- a/engines/dfc_provider/app/services/affiliate_sales_data_row_builder.rb
+++ b/engines/dfc_provider/app/services/affiliate_sales_data_row_builder.rb
@@ -12,7 +12,11 @@ class AffiliateSalesDataRowBuilder < DfcBuilder
   def build_supplier
     DataFoodConsortium::Connector::Enterprise.new(
       nil,
-      localizations: [build_address(item[:supplier_postcode])],
+      localizations: [build_address(
+        item[:supplier_postcode],
+        item[:supplier_city],
+        item[:supplier_country]
+      )],
       suppliedProducts: [build_product],
     )
   end
@@ -20,7 +24,11 @@ class AffiliateSalesDataRowBuilder < DfcBuilder
   def build_distributor
     DataFoodConsortium::Connector::Enterprise.new(
       nil,
-      localizations: [build_address(item[:distributor_postcode])],
+      localizations: [build_address(
+        item[:distributor_postcode],
+        item[:distributor_city],
+        item[:distributor_country]
+      )],
     )
   end
 
@@ -89,9 +97,11 @@ class AffiliateSalesDataRowBuilder < DfcBuilder
     )
   end
 
-  def build_address(postcode)
+  def build_address(postcode, city, country)
     DataFoodConsortium::Connector::Address.new(
       nil,
+      city:,
+      country:,
       postalCode: postcode,
     )
   end

--- a/engines/dfc_provider/app/services/affiliate_sales_data_row_builder.rb
+++ b/engines/dfc_provider/app/services/affiliate_sales_data_row_builder.rb
@@ -14,7 +14,6 @@ class AffiliateSalesDataRowBuilder < DfcBuilder
       nil,
       localizations: [build_address(
         item[:supplier_postcode],
-        item[:supplier_city],
         item[:supplier_country]
       )],
       suppliedProducts: [build_product],
@@ -26,7 +25,6 @@ class AffiliateSalesDataRowBuilder < DfcBuilder
       nil,
       localizations: [build_address(
         item[:distributor_postcode],
-        item[:distributor_city],
         item[:distributor_country]
       )],
     )
@@ -97,10 +95,9 @@ class AffiliateSalesDataRowBuilder < DfcBuilder
     )
   end
 
-  def build_address(postcode, city, country)
+  def build_address(postcode, country)
     DataFoodConsortium::Connector::Address.new(
       nil,
-      city:,
       country:,
       postalCode: postcode,
     )

--- a/engines/dfc_provider/app/services/affiliate_sales_query.rb
+++ b/engines/dfc_provider/app/services/affiliate_sales_query.rb
@@ -55,10 +55,8 @@ class AffiliateSalesQuery
         spree_variants.unit_presentation,
         spree_line_items.price,
         distributor_addresses.zipcode AS distributor_postcode,
-        distributor_addresses.city AS distributor_city,
         distributor_countries.name AS distributor_country,
         supplier_addresses.zipcode AS supplier_postcode,
-        supplier_addresses.city AS supplier_city,
         supplier_countries.name AS supplier_country,
 
         SUM(spree_line_items.quantity) AS quantity_sold
@@ -75,8 +73,6 @@ class AffiliateSalesQuery
         spree_line_items.price,
         distributor_postcode,
         supplier_postcode,
-        distributor_city,
-        supplier_city,
         distributor_country,
         supplier_country
       SQL
@@ -92,10 +88,8 @@ class AffiliateSalesQuery
         unit_presentation
         price
         distributor_postcode
-        distributor_city
         distributor_country
         supplier_postcode
-        supplier_city
         supplier_country
         quantity_sold
       ]

--- a/engines/dfc_provider/app/services/affiliate_sales_query.rb
+++ b/engines/dfc_provider/app/services/affiliate_sales_query.rb
@@ -38,9 +38,11 @@ class AffiliateSalesQuery
         JOIN spree_products ON spree_products.id = spree_variants.product_id
         JOIN enterprises AS suppliers ON suppliers.id = spree_variants.supplier_id
         JOIN spree_addresses AS supplier_addresses ON supplier_addresses.id = suppliers.address_id
+        JOIN spree_countries AS supplier_countries ON supplier_countries.id = supplier_addresses.country_id
         JOIN spree_orders ON spree_orders.id = spree_line_items.order_id
         JOIN enterprises AS distributors ON distributors.id = spree_orders.distributor_id
         JOIN spree_addresses AS distributor_addresses ON distributor_addresses.id = distributors.address_id
+        JOIN spree_countries AS distributor_countries ON distributor_countries.id = distributor_addresses.country_id
       SQL
     end
 
@@ -53,7 +55,11 @@ class AffiliateSalesQuery
         spree_variants.unit_presentation,
         spree_line_items.price,
         distributor_addresses.zipcode AS distributor_postcode,
+        distributor_addresses.city AS distributor_city,
+        distributor_countries.name AS distributor_country,
         supplier_addresses.zipcode AS supplier_postcode,
+        supplier_addresses.city AS supplier_city,
+        supplier_countries.name AS supplier_country,
 
         SUM(spree_line_items.quantity) AS quantity_sold
       SQL
@@ -68,7 +74,11 @@ class AffiliateSalesQuery
         spree_variants.unit_presentation,
         spree_line_items.price,
         distributor_postcode,
-        supplier_postcode
+        supplier_postcode,
+        distributor_city,
+        supplier_city,
+        distributor_country,
+        supplier_country
       SQL
     end
 
@@ -82,7 +92,11 @@ class AffiliateSalesQuery
         unit_presentation
         price
         distributor_postcode
+        distributor_city
+        distributor_country
         supplier_postcode
+        supplier_city
+        supplier_country
         quantity_sold
       ]
     end

--- a/engines/dfc_provider/spec/services/affiliate_sales_query_spec.rb
+++ b/engines/dfc_provider/spec/services/affiliate_sales_query_spec.rb
@@ -53,9 +53,17 @@ RSpec.describe AffiliateSalesQuery do
     it "converts an array to a hash" do
       row = [
         "Apples",
-        "item", "item", nil, nil,
+        "item",
+        "item",
+        nil,
+        nil,
         15.50,
-        "3210", "3211",
+        "3210",
+        "city1",
+        "country1",
+        "3211",
+        "city2",
+        "country2",
         3,
       ]
       expect(query.label_row(row)).to eq(
@@ -67,7 +75,11 @@ RSpec.describe AffiliateSalesQuery do
           unit_presentation: nil,
           price: 15.50,
           distributor_postcode: "3210",
+          distributor_city: "city1",
+          distributor_country: "country1",
           supplier_postcode: "3211",
+          supplier_city: "city2",
+          supplier_country: "country2",
           quantity_sold: 3,
         }
       )

--- a/engines/dfc_provider/spec/services/affiliate_sales_query_spec.rb
+++ b/engines/dfc_provider/spec/services/affiliate_sales_query_spec.rb
@@ -59,10 +59,8 @@ RSpec.describe AffiliateSalesQuery do
         nil,
         15.50,
         "3210",
-        "city1",
         "country1",
         "3211",
-        "city2",
         "country2",
         3,
       ]
@@ -75,10 +73,8 @@ RSpec.describe AffiliateSalesQuery do
           unit_presentation: nil,
           price: 15.50,
           distributor_postcode: "3210",
-          distributor_city: "city1",
           distributor_country: "country1",
           supplier_postcode: "3211",
-          supplier_city: "city2",
           supplier_country: "country2",
           quantity_sold: 3,
         }

--- a/spec/system/admin/reports/pay_your_suppliers_spec.rb
+++ b/spec/system/admin/reports/pay_your_suppliers_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe "Pay Your Suppliers Report" do
   before do
     login_as owner
     visit admin_reports_path
+
+    update_line_items_product_names
   end
 
   context "on Reports page" do
@@ -137,5 +139,19 @@ RSpec.describe "Pay Your Suppliers Report" do
       # summary row
       expect(lines.last).to have_content("TOTAL 50.0 50.0 0.0 0.0 0.0 50.0")
     end
+  end
+
+  def update_line_items_product_names
+    n = 1
+    update_product_name_proc = proc do |order|
+      order.line_items.each do |line_item|
+        product = line_item.variant.product
+        product.update!(name: "Product##{n}")
+        n += 1
+      end
+    end
+
+    update_product_name_proc.call(order1)
+    update_product_name_proc.call(order2)
   end
 end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -97,12 +97,14 @@ paths:
                       dfc-b:hasAddress:
                         "@type": dfc-b:Address
                         dfc-b:hasPostalCode: '20170'
+                        dfc-b:hasCity: Herndon
+                        dfc-b:hasCountry: Australia
                       dfc-b:supplies:
                         "@type": dfc-b:SuppliedProduct
                         dfc-b:name: Tomato
                         dfc-b:hasQuantity:
                           "@type": dfc-b:QuantitativeValue
-                          dfc-b:hasUnit: dfc-m:Gram
+                          dfc-b:hasUnit: dfc-m:Piece
                           dfc-b:value: 1.0
                         dfc-b:concernedBy:
                           "@type": dfc-b:OrderLine
@@ -124,6 +126,8 @@ paths:
                                   dfc-b:hasAddress:
                                     "@type": dfc-b:Address
                                     dfc-b:hasPostalCode: '20170'
+                                    dfc-b:hasCity: Herndon
+                                    dfc-b:hasCountry: Australia
         '400':
           description: bad request
   "/api/dfc/enterprises/{enterprise_id}/catalog_items":

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -97,7 +97,6 @@ paths:
                       dfc-b:hasAddress:
                         "@type": dfc-b:Address
                         dfc-b:hasPostalCode: '20170'
-                        dfc-b:hasCity: Herndon
                         dfc-b:hasCountry: Australia
                       dfc-b:supplies:
                         "@type": dfc-b:SuppliedProduct
@@ -126,7 +125,6 @@ paths:
                                   dfc-b:hasAddress:
                                     "@type": dfc-b:Address
                                     dfc-b:hasPostalCode: '20170'
-                                    dfc-b:hasCity: Herndon
                                     dfc-b:hasCountry: Australia
         '400':
           description: bad request


### PR DESCRIPTION
#### What? Why?

- Closes #12890
- This PR adds country and city data in the affiliate sales data endpoint for supplier and distributor

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->