### PR TITLE
Fix Bugsnag call to notify

### DIFF
--- a/app/controllers/concerns/order_completion.rb
+++ b/app/controllers/concerns/order_completion.rb
@@ -51,7 +51,7 @@ module OrderCompletion
 
   def order_invalid!
     Bugsnag.notify("Notice: invalid order loaded during checkout") do |payload|
-      payload.add_metadata :order, @order
+      payload.add_metadata :order, :order, @order
     end
 
     flash[:error] = t('checkout.order_not_loaded')

--- a/app/controllers/concerns/order_stock_check.rb
+++ b/app/controllers/concerns/order_stock_check.rb
@@ -21,7 +21,7 @@ module OrderStockCheck
     return unless current_order_cycle&.closed?
 
     Bugsnag.notify("Notice: order cycle closed during checkout completion") do |payload|
-      payload.add_metadata :order, current_order
+      payload.add_metadata :order, :order, current_order
     end
     current_order.empty!
     current_order.set_order_cycle! nil

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -7,7 +7,7 @@ class ErrorsController < ApplicationController
     Bugsnag.notify("404") do |event|
       event.severity = "info"
 
-      event.add_metadata(:request, request.env)
+      event.add_metadata(:request, :request, request.env)
     end
     render status: :not_found, formats: :html
   end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -7,7 +7,7 @@ class ErrorsController < ApplicationController
     Bugsnag.notify("404") do |event|
       event.severity = "info"
 
-      event.add_metadata(:request, :request, request.env)
+      event.add_metadata(:request, :env, request.env)
     end
     render status: :not_found, formats: :html
   end

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -214,10 +214,10 @@ module Spree
 
       def notify_bugsnag(error, product, variant)
         Bugsnag.notify(error) do |report|
-          report.add_metadata(:product, product.attributes)
-          report.add_metadata(:product_error, product.errors.first) unless product.valid?
-          report.add_metadata(:variant, variant.attributes)
-          report.add_metadata(:variant_error, variant.errors.first) unless variant.valid?
+          report.add_metadata(:product,
+                              { product: product.attributes, variant: variant.attributes })
+          report.add_metadata(:product, :product_error, product.errors.first) unless product.valid?
+          report.add_metadata(:product, :variant_error, variant.errors.first) unless variant.valid?
         end
       end
 

--- a/app/jobs/backorder_job.rb
+++ b/app/jobs/backorder_job.rb
@@ -20,7 +20,7 @@ class BackorderJob < ApplicationJob
     # Errors here shouldn't affect the checkout. So let's report them
     # separately:
     Bugsnag.notify(e) do |payload|
-      payload.add_metadata(:order, order)
+      payload.add_metadata(:order, :order, order)
     end
   end
 

--- a/app/jobs/stock_sync_job.rb
+++ b/app/jobs/stock_sync_job.rb
@@ -17,7 +17,7 @@ class StockSyncJob < ApplicationJob
     # Errors here shouldn't affect the shopping. So let's report them
     # separately:
     Bugsnag.notify(e) do |payload|
-      payload.add_metadata(:order, order)
+      payload.add_metadata(:order, :order, order)
     end
   end
 
@@ -30,7 +30,7 @@ class StockSyncJob < ApplicationJob
     # Errors here shouldn't affect the shopping. So let's report them
     # separately:
     Bugsnag.notify(e) do |payload|
-      payload.add_metadata(:order, order)
+      payload.add_metadata(:order, :order, order)
     end
   end
 

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -56,7 +56,7 @@ class SubscriptionConfirmJob < ApplicationJob
       send_failed_payment_email(order)
     else
       Bugsnag.notify(e) do |payload|
-        payload.add_metadata :order, order
+        payload.add_metadata :order, :order, order
       end
       send_failed_payment_email(order, e.message)
     end
@@ -109,8 +109,7 @@ class SubscriptionConfirmJob < ApplicationJob
     SubscriptionMailer.failed_payment_email(order).deliver_now
   rescue StandardError => e
     Bugsnag.notify(e) do |payload|
-      payload.add_metadata :order, order
-      payload.add_metadata :error_message, error_message
+      payload.add_metadata :subscription_data, { order:, error_message: }
     end
   end
 end

--- a/app/services/place_proxy_order.rb
+++ b/app/services/place_proxy_order.rb
@@ -25,7 +25,7 @@ class PlaceProxyOrder
   rescue StandardError => e
     summarizer.record_and_log_error(:processing, order, e.message)
     Bugsnag.notify(e) do |payload|
-      payload.add_metadata :order, order
+      payload.add_metadata :order, :order, order
     end
   end
 
@@ -57,8 +57,7 @@ class PlaceProxyOrder
     true
   rescue StandardError => e
     Bugsnag.notify(e) do |payload|
-      payload.add_metadata :subscription, subscription
-      payload.add_metadata :proxy_order, proxy_order
+      payload.add_metadata(:proxy_order, { subscription:, proxy_order: })
     end
     false
   end

--- a/app/services/sets/product_set.rb
+++ b/app/services/sets/product_set.rb
@@ -146,11 +146,11 @@ module Sets
 
     def notify_bugsnag(error, product, variant, variant_attributes)
       Bugsnag.notify(error) do |report|
-        report.add_metadata(:product, product.attributes)
-        report.add_metadata(:product_error, product.errors.first) unless product.valid?
-        report.add_metadata(:variant_attributes, variant_attributes)
-        report.add_metadata(:variant, variant.attributes)
-        report.add_metadata(:variant_error, variant.errors.first) unless variant.valid?
+        report.add_metadata( :product_set,
+                             { product: product.attributes, variant_attributes:,
+                               variant: variant.attributes } )
+        report.add_metadata(:product_set, :product_error, product.errors.first) if !product.valid?
+        report.add_metadata(:product_set, :variant_error, variant.errors.first) if !variant.valid?
       end
     end
   end


### PR DESCRIPTION

#### What? Why?
Looking at some Bugsnag report, I noticed the metadata wasn't showing up. It turned out we are using `add_metadata` as expected. Doc: https://docs.bugsnag.com/platforms/ruby/rails/reporting-handled-errors/#add_metadata

#### What should we test?
Green specs :green_circle: 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.