### PR TITLE
[Products] Empty option on unit scale dropdown

### DIFF
--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -12,7 +12,7 @@
   = f.hidden_field :variant_unit_scale
   = f.select :variant_unit_with_scale,
       options_for_select(WeightsAndMeasures.variant_unit_options, variant.variant_unit_with_scale),
-      { include_blank: true },
+      { include_blank: t('.select_unit_scale') },
       { class: "fullwidth no-input", 'aria-label': t('admin.products_page.columns.unit_scale'), data: { "controller": "tom-select", "tom-select-options-value": '{ "plugins": [] }', action: "change->toggle-control#displayIfMatch" }, required: true }
   = error_message_on variant, :variant_unit, 'data-toggle-control-target': 'control'
   .field

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -973,6 +973,7 @@ en:
         category_field_name: "Category"
         tax_category_field_name: "Tax Category"
         producer_field_name: "Producer"
+        select_unit_scale: Select unit scale
       clone:
         success: Successfully cloned the product
         error: Unable to clone the product


### PR DESCRIPTION
#### What? Why?

- Closes #12919
- This PR replaces the empty option with the prompt to select the unit scale.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Add a new variant for the product on the products page
- Please make sure that you can view "Select unit scale" as first option for the unit scale field.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->