### PR TITLE
Back Office Product List - Hide search field and filters when there are no products in list

### DIFF
--- a/app/views/admin/products_v3/_content.html.haml
+++ b/app/views/admin/products_v3/_content.html.haml
@@ -6,11 +6,11 @@
   .container
     .sixteen.columns
       = render partial: 'admin/shared/flashes', locals: { flashes: } if defined? flashes
-      = render partial: 'filters', locals: { search_term: search_term,
-                                              producer_id: producer_id,
-                                              producer_options: producer_options,
-                                              category_options: category_options,
-                                              category_id: category_id }
+      = render partial: 'filters', locals: { search_term:,
+                                              producer_id:,
+                                              producer_options:,
+                                              category_options:,
+                                              category_id: } if display_search_filter
   - if products.any?
     .container.results
       .sixteen.columns

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -15,7 +15,8 @@
   = render partial: "content", locals: { products: @products, pagy: @pagy, search_term: @search_term,
                                producer_options: producers, producer_id: @producer_id,
                                category_options: categories, category_id: @category_id,
-                               tax_category_options:, flashes: flash }
+                               tax_category_options:, flashes: flash,
+                               display_search_filter: (@products.any? || @search_term.present? || @category_id.present?) }
   - %w[product variant].each do |object_type|
     = render partial: 'delete_modal', locals: { object_type: }
   #modal-component


### PR DESCRIPTION
#### What? Why?

- Closes #12957

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
- When a new person signs up and goes to the admin for the first time, they likely won't have any product, verify that in this scenario, search filter should not be present

- When products are present and user searches with a product name which is not present in the list, search filter should still be visible

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

