### PR TITLE
Bugfix/12968 product import update

### DIFF
--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -297,7 +297,7 @@ module ProductImport
         unscaled_units = entry.unscaled_units.to_f || 0
         entry.unit_value = unscaled_units * unit_scale unless unit_scale.nil?
 
-        if entry.match_inventory_variant?(existing_variant)
+        if entry.match_variant?(existing_variant)
           variant_override = create_inventory_item(entry, existing_variant)
           return validate_inventory_item(entry, variant_override)
         end

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -161,7 +161,7 @@ module ProductImport
     end
 
     def unit_fields_validation(entry)
-      unit_types = ['g', 'oz', 'lb', 'kg', 't', 'ml', 'l', 'kl', '']
+      unit_types = ['mg', 'g', 'kg', 'oz', 'lb', 't', 'ml', 'cl', 'dl', 'l', 'kl', 'gal', '']
 
       if entry.units.blank?
         mark_as_invalid(entry, attribute: 'units',

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -85,10 +85,6 @@ module ProductImport
     end
 
     def match_variant?(variant)
-      match_display_name?(variant) && variant.unit_value.to_d == unscaled_units.to_d
-    end
-
-    def match_inventory_variant?(variant)
       match_display_name?(variant) && variant.unit_value.to_d == unit_value.to_d
     end
 

--- a/app/models/product_import/unit_converter.rb
+++ b/app/models/product_import/unit_converter.rb
@@ -32,14 +32,18 @@ module ProductImport
 
     def unit_scales
       {
+        'mg' => { scale: 0.001, unit: 'weight' },
         'g' => { scale: 1, unit: 'weight' },
         'kg' => { scale: 1000, unit: 'weight' },
         'oz' => { scale: 28.35, unit: 'weight' },
         'lb' => { scale: 453.6, unit: 'weight' },
         't' => { scale: 1_000_000, unit: 'weight' },
         'ml' => { scale: 0.001, unit: 'volume' },
+        'cl' => { scale: 0.01, unit: 'volume' },
+        'dl' => { scale: 0.1, unit: 'volume' },
         'l' => { scale: 1, unit: 'volume' },
-        'kl' => { scale: 1000, unit: 'volume' }
+        'kl' => { scale: 1000, unit: 'volume' },
+        'gal' => { scale: 4.54609, unit: 'volume' },
       }
     end
 

--- a/spec/models/product_import/spreadsheet_entry_spec.rb
+++ b/spec/models/product_import/spreadsheet_entry_spec.rb
@@ -20,16 +20,15 @@ RSpec.describe ProductImport::SpreadsheetEntry do
   }
   let(:display_name) { "" }
 
-  # TODO test match on display_name
   describe "#match_variant?" do
     it "returns true if matching" do
-      variant = create(:variant, unit_value: 500)
+      variant = create(:variant, unit_value: 500_000)
 
       expect(entry.match_variant?(variant)).to be(true)
     end
 
     it "returns false if not machting" do
-      variant = create(:variant, unit_value: 250)
+      variant = create(:variant, unit_value: 500)
 
       expect(entry.match_variant?(variant)).to be(false)
     end
@@ -38,7 +37,7 @@ RSpec.describe ProductImport::SpreadsheetEntry do
       let(:display_name) { "Good" }
 
       it "returns true" do
-        variant = create(:variant, unit_value: 500, display_name: "Good")
+        variant = create(:variant, unit_value: 500_000, display_name: "Good")
 
         expect(entry.match_variant?(variant)).to be(true)
       end
@@ -48,43 +47,9 @@ RSpec.describe ProductImport::SpreadsheetEntry do
       let(:display_name) { "Bad" }
 
       it "returns false" do
-        variant = create(:variant, unit_value: 500, display_name: "Good")
+        variant = create(:variant, unit_value: 500_000, display_name: "Good")
 
         expect(entry.match_variant?(variant)).to be(false)
-      end
-    end
-  end
-
-  describe "#match_inventory_variant?" do
-    it "returns true if matching" do
-      variant = create(:variant, unit_value: 500_000)
-
-      expect(entry.match_inventory_variant?(variant)).to be(true)
-    end
-
-    it "returns false if not machting" do
-      variant = create(:variant, unit_value: 500)
-
-      expect(entry.match_inventory_variant?(variant)).to be(false)
-    end
-
-    context "with same display_name" do
-      let(:display_name) { "Good" }
-
-      it "returns true" do
-        variant = create(:variant, unit_value: 500_000, display_name: "Good")
-
-        expect(entry.match_inventory_variant?(variant)).to be(true)
-      end
-    end
-
-    context "with different display_name" do
-      let(:display_name) { "Bad" }
-
-      it "returns false" do
-        variant = create(:variant, unit_value: 500_000, display_name: "Good")
-
-        expect(entry.match_inventory_variant?(variant)).to be(false)
       end
     end
   end

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -578,11 +578,11 @@ RSpec.describe ProductImport::ProductImporter do
   describe "updating non-updatable fields on existing variants" do
     let(:csv_data) {
       CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type",
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "variant_unit_name",
                 "shipping_category"]
-        csv << ["Beetroot", enterprise3.name, "Vegetables", "5", "3.50", "500", "Kg",
+        csv << ["Beetroot", enterprise3.name, "Vegetables", "5", "3.50", "500", "Half",
                 shipping_category.name]
-        csv << ["Tomato", enterprise3.name, "Vegetables", "6", "5.50", "500", "Kg",
+        csv << ["Tomato", enterprise3.name, "Vegetables", "6", "5.50", "500", "Half",
                 shipping_category.name]
       end
     }


### PR DESCRIPTION
#### What? Why?

- Closes #12968
- Previously, we could not use the same file with `unit_type` equals other than `g`, to update.
- For example: I've used the file with product name = 'Potato' and units = 1 and unit_type = 'kg' and price = 100 to create the mentioned product.
- If I use the above file and try to update just the price = 50, the system does not recognize this product and tries creating a new one.
- This PR has fixed it such that the above scenario works
- Moreover, the following unit_types were not recognized by the system to import the product, however, these are supported by the products screen:
  - mg
  - cL
  - dL
  - gal
- This has been fixed in this PR

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Validate the scenarios mentioned in the above section
- Plus as mentioned in the issue as well

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->