### PR TITLE
Order cycle mail reports to producers display different data in html and txt versions

### DIFF
--- a/app/views/producer_mailer/order_cycle_report.text.haml
+++ b/app/views/producer_mailer/order_cycle_report.text.haml
@@ -15,7 +15,7 @@ Orders summary
 = t :producer_mail_order_text
 \
 - @grouped_line_items.each_pair do |product_and_full_name, line_items|
-  #{line_items.first.variant.sku} - #{raw(line_items.first.variant.supplier.name)} - #{raw(product_and_full_name)} (QTY: #{line_items.sum(&:quantity)}) @ #{line_items.first.single_money} = #{Spree::Money.new(line_items.sum(&:total), currency: line_items.first.currency)}
+  #{line_items.first.variant.sku} - #{raw(line_items.first.variant.supplier.name)} - #{raw(product_and_full_name)} (QTY: #{line_items.sum(&:quantity)}) @ #{line_items.first.single_money} = #{Spree::Money.new(line_items.sum(&:total), currency: line_items.first.currency)} (#{Spree::Money.new(line_items.sum(&:included_tax), currency: line_items.first.currency)} tax incl.)
 \
 \
 #{t :total}: #{@total}

--- a/app/views/producer_mailer/order_cycle_report.text.haml
+++ b/app/views/producer_mailer/order_cycle_report.text.haml
@@ -1,13 +1,13 @@
-#{t :producer_mail_greeting} #{@producer.name},
+#{t :producer_mail_greeting} #{raw(@producer.name)},
 \
 = t :producer_mail_text_before
 \
 - @distributors_pickup_times.each do |distributor_name, pickup_time|
-  \- #{distributor_name} (#{pickup_time})
+  \- #{raw(distributor_name)} (#{pickup_time})
 \
 - if @receival_instructions
   = t :producer_mail_delivery_instructions
-  = @receival_instructions
+  = raw(@receival_instructions)
 \
 Orders summary
 ================
@@ -30,7 +30,7 @@ Orders summary
 = t :producer_mail_text_after
 
 #{t :producer_mail_signoff},
-#{@coordinator.name}
-#{@coordinator.address.address1}, #{@coordinator.address.city}, #{@coordinator.address.zipcode}
+#{raw(@coordinator.name)}
+#{raw(@coordinator.address.address1)}, #{@coordinator.address.city}, #{@coordinator.address.zipcode}
 #{@coordinator.phone}
 #{@coordinator.contact.email}

--- a/app/views/producer_mailer/order_cycle_report.text.haml
+++ b/app/views/producer_mailer/order_cycle_report.text.haml
@@ -18,7 +18,7 @@ Orders summary
   #{line_items.first.variant.sku} - #{raw(line_items.first.variant.supplier.name)} - #{raw(product_and_full_name)} (#{t(:producer_mail_qty)}: #{line_items.sum(&:quantity)}) @ #{line_items.first.single_money} = #{Spree::Money.new(line_items.sum(&:total), currency: line_items.first.currency)} (#{t(:with_tax_incl, amount: Spree::Money.new(line_items.sum(&:included_tax), currency: line_items.first.currency))})
 \
 \
-#{t :total}: #{@total}
+#{t :total}: #{@total} (#{t(:with_tax_incl, amount: @tax_total)})
 \
 - if @customer_line_items
   = t :producer_mail_order_customer_text

--- a/app/views/producer_mailer/order_cycle_report.text.haml
+++ b/app/views/producer_mailer/order_cycle_report.text.haml
@@ -20,7 +20,7 @@ Orders summary
 \
 #{t :total}: #{@total}
 \
-- if @customer_grouped_line_items
+- if @customer_line_items
   = t :producer_mail_order_customer_text
   \
   - @customer_line_items.each do |line_item|

--- a/app/views/producer_mailer/order_cycle_report.text.haml
+++ b/app/views/producer_mailer/order_cycle_report.text.haml
@@ -15,7 +15,7 @@ Orders summary
 = t :producer_mail_order_text
 \
 - @grouped_line_items.each_pair do |product_and_full_name, line_items|
-  #{line_items.first.variant.sku} - #{raw(line_items.first.variant.supplier.name)} - #{raw(product_and_full_name)} (QTY: #{line_items.sum(&:quantity)}) @ #{line_items.first.single_money} = #{Spree::Money.new(line_items.sum(&:total), currency: line_items.first.currency)} (#{Spree::Money.new(line_items.sum(&:included_tax), currency: line_items.first.currency)} tax incl.)
+  #{line_items.first.variant.sku} - #{raw(line_items.first.variant.supplier.name)} - #{raw(product_and_full_name)} (#{t(:producer_mail_qty)}: #{line_items.sum(&:quantity)}) @ #{line_items.first.single_money} = #{Spree::Money.new(line_items.sum(&:total), currency: line_items.first.currency)} (#{t(:with_tax_incl, amount: Spree::Money.new(line_items.sum(&:included_tax), currency: line_items.first.currency))})
 \
 \
 #{t :total}: #{@total}
@@ -24,7 +24,7 @@ Orders summary
   = t :producer_mail_order_customer_text
   \
   - @customer_line_items.each do |line_item|
-    #{line_item[:sku]} - #{raw(line_item[:supplier_name])} - #{raw(line_item[:product_and_full_name])} (QTY: #{line_item[:quantity]})  - #{raw(line_item[:first_name])} #{raw(line_item[:last_name])}
+    #{line_item[:sku]} - #{raw(line_item[:supplier_name])} - #{raw(line_item[:product_and_full_name])} (#{t(:producer_mail_qty)}: #{line_item[:quantity]})  - #{raw(line_item[:first_name])} #{raw(line_item[:last_name])}
 \
 \
 = t :producer_mail_text_after

--- a/app/views/producer_mailer/order_cycle_report.text.haml
+++ b/app/views/producer_mailer/order_cycle_report.text.haml
@@ -31,6 +31,6 @@ Orders summary
 
 #{t :producer_mail_signoff},
 #{raw(@coordinator.name)}
-#{raw(@coordinator.address.address1)}, #{@coordinator.address.city}, #{@coordinator.address.zipcode}
+#{raw(@coordinator.address.address1)}, #{raw(@coordinator.address.city)}, #{raw(@coordinator.address.zipcode)}
 #{@coordinator.phone}
 #{@coordinator.contact.email}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,6 +351,8 @@ en:
   sku: "SKU"
   subtotal: "Subtotal"
   tax_rate: "Tax rate"
+  with_tax_incl: "%{amount} tax incl."
+  producer_mail_qty: QTY
   validators:
     date_time_string_validator:
       not_string_error: "must be a string"

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe ProducerMailer, type: :mailer do
     summary = customer_details_summary_text(mail)
     product_line_by_summary(summary, product_name)
   end
-  
+
   def product_line_from_order_summary_text(mail, product_name)
     summary = body_as_text(mail)
       .split(I18n.t(:producer_mail_order_customer_text))


### PR DESCRIPTION
#### What? Why?

- Closes #12993
- This PR fixes the condition to display the customer details
- Along with this, included tax is also added to the text version
- This PR also added the specs for the text version of the report
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

##### Before
[Screencast from 12-02-2024 06:48:08 PM.webm](https://github.com/user-attachments/assets/60b03a72-0064-40aa-b6d5-cff6c5e88473)

##### After
[Screencast from 12-02-2024 06:50:09 PM.webm](https://github.com/user-attachments/assets/1d8a23d1-9063-4aea-8fad-d2fb5bd7395e)


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
