### PR TITLE
Amend DFC backorder completely

### DIFF
--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -24,6 +24,7 @@ module Api
         Orders::WorkflowService.new(@order).advance_to_payment if @order.line_items.any?
 
         @order.recreate_all_fees!
+        AmendBackorderJob.perform_later(@order) if @order.completed?
 
         render json: @shipment, serializer: Api::ShipmentSerializer, status: :ok
       end
@@ -73,6 +74,7 @@ module Api
 
         @order.contents.add(variant, quantity, @shipment)
         @order.recreate_all_fees!
+        AmendBackorderJob.perform_later(@order) if @order.completed?
 
         render json: @shipment, serializer: Api::ShipmentSerializer, status: :ok
       end
@@ -86,6 +88,7 @@ module Api
         @shipment.reload if @shipment.persisted?
 
         @order.recreate_all_fees!
+        AmendBackorderJob.perform_later(@order) if @order.completed?
 
         render json: @shipment, serializer: Api::ShipmentSerializer, status: :ok
       end

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -70,6 +70,7 @@ module Spree
         @order.restock_items = params.fetch(:restock_items, "true") == "true"
 
         if @order.public_send(event.to_s)
+          AmendBackorderJob.perform_later(@order) if event == "cancel"
           flash[:success] = Spree.t(:order_updated)
         else
           flash[:error] = Spree.t(:cannot_perform_operation)

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -70,7 +70,7 @@ module Spree
         @order.restock_items = params.fetch(:restock_items, "true") == "true"
 
         if @order.public_send(event.to_s)
-          AmendBackorderJob.perform_later(@order) if event == "cancel"
+          AmendBackorderJob.perform_later(@order) if @order.completed?
           flash[:success] = Spree.t(:order_updated)
         else
           flash[:error] = Spree.t(:cannot_perform_operation)

--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -77,6 +77,8 @@ module Spree
           @order.create_tax_charge!
         end
 
+        AmendBackorderJob.perform_later(@order) if @order.completed?
+
         respond_with(@order) do |format|
           format.html do
             if params.key?(:checkout)

--- a/app/jobs/amend_backorder_job.rb
+++ b/app/jobs/amend_backorder_job.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'open_food_network/order_cycle_permissions'
-
 # When orders are created, adjusted or cancelled, we need to amend
 # an existing backorder as well.
 class AmendBackorderJob < ApplicationJob
@@ -13,125 +11,11 @@ class AmendBackorderJob < ApplicationJob
     end
   end
 
-  # The following is a mix of the BackorderJob and the CompleteBackorderJob.
-  # TODO: Move the common code into a re-usable service class.
   def amend_backorder(order)
-    variants = distributed_linked_variants(order)
-    return unless variants.any?
+    backorder = BackorderUpdater.new.amend_backorder(order)
 
     user = order.distributor.owner
-    order_cycle = order.order_cycle
-
-    # We are assuming that all variants are linked to the same wholesale
-    # shop and its catalog:
-    reference_link = variants[0].semantic_links[0].semantic_id
-    urls = FdcUrlBuilder.new(reference_link)
-    orderer = FdcBackorderer.new(user, urls)
-    broker = FdcOfferBroker.new(user, urls)
-
-    backorder = orderer.find_open_order(order)
-
-    updated_lines = update_order_lines(backorder, order_cycle, variants, broker, orderer)
-    unprocessed_lines = backorder.lines.to_set - updated_lines
-    cancel_stale_lines(unprocessed_lines, order, broker)
-
-    # Clean up empty lines:
-    backorder.lines.reject! { |line| line.quantity.zero? }
-
-    FdcBackorderer.new(user, urls).send_order(backorder)
-  end
-
-  def update_order_lines(backorder, order_cycle, variants, broker, orderer)
-    variants.map do |variant|
-      link = variant.semantic_links[0].semantic_id
-      solution = broker.best_offer(link)
-      line = orderer.find_or_build_order_line(backorder, solution.offer)
-      if variant.on_demand
-        adjust_stock(variant, solution, line)
-      else
-        aggregate_final_quantities(order_cycle, line, variant, solution)
-      end
-
-      line
-    end
-  end
-
-  def cancel_stale_lines(unprocessed_lines, order, broker)
-    managed_variants = managed_linked_variants(order)
-    unprocessed_lines.each do |line|
-      wholesale_quantity = line.quantity.to_i
-      wholesale_product_id = line.offer.offeredItem.semanticId
-      transformation = broker.wholesale_to_retail(wholesale_product_id)
-      linked_variant = managed_variants.linked_to(transformation.retail_product_id)
-
-      if linked_variant.nil?
-        transformation.factor = 1
-        linked_variant = managed_variants.linked_to(wholesale_product_id)
-      end
-
-      # Adjust stock level back, we're not going to order this one.
-      if linked_variant&.on_demand
-        retail_quantity = wholesale_quantity * transformation.factor
-        linked_variant.on_hand -= retail_quantity
-      end
-
-      # We don't have any active orders for this
-      line.quantity = 0
-    end
-  end
-
-  def adjust_stock(variant, solution, line)
-    if variant.on_hand.negative?
-      needed_quantity = -1 * variant.on_hand # We need to replenish it.
-
-      # The number of wholesale packs we need to order to fulfill the
-      # needed quantity.
-      # For example, we order 2 packs of 12 cans if we need 15 cans.
-      wholesale_quantity = (needed_quantity.to_f / solution.factor).ceil
-
-      # The number of individual retail items we get with the wholesale order.
-      # For example, if we order 2 packs of 12 cans, we will get 24 cans
-      # and we'll account for that in our stock levels.
-      retail_quantity = wholesale_quantity * solution.factor
-
-      line.quantity = line.quantity.to_i + wholesale_quantity
-      variant.on_hand += retail_quantity
-    else
-      # Note that a division of integers dismisses the remainder, like `floor`:
-      wholesale_items_contained_in_stock = variant.on_hand / solution.factor
-
-      # But maybe we didn't actually order that much:
-      deductable_quantity = [line.quantity, wholesale_items_contained_in_stock].min
-
-      if deductable_quantity.positive?
-        line.quantity -= deductable_quantity
-
-        retail_stock_change = deductable_quantity * solution.factor
-        variant.on_hand -= retail_stock_change
-      end
-    end
-  end
-
-  def managed_linked_variants(order)
-    user = order.distributor.owner
-    order_cycle = order.order_cycle
-
-    # These permissions may be too complex. Here may be scope to optimise.
-    permissions = OpenFoodNetwork::OrderCyclePermissions.new(user, order_cycle)
-    permissions.visible_variants_for_outgoing_exchanges_to(order.distributor)
-      .where.associated(:semantic_links)
-  end
-
-  def distributed_linked_variants(order)
-    order.order_cycle.variants_distributed_by(order.distributor)
-      .where.associated(:semantic_links)
-  end
-
-  def aggregate_final_quantities(order_cycle, line, variant, transformation)
-    # We may want to query all these quantities in one go instead of this n+1.
-    orders = order_cycle.orders.invoiceable
-    quantity = Spree::LineItem.where(order: orders, variant:).sum(:quantity)
-    wholesale_quantity = (quantity.to_f / transformation.factor).ceil
-    line.quantity = wholesale_quantity
+    urls = nil # Not needed to send order. The backorder id is the URL.
+    FdcBackorderer.new(user, urls).send_order(backorder) if backorder
   end
 end

--- a/app/jobs/amend_backorder_job.rb
+++ b/app/jobs/amend_backorder_job.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-# When orders are cancelled, we need to amend
+require 'open_food_network/order_cycle_permissions'
+
+# When orders are created, adjusted or cancelled, we need to amend
 # an existing backorder as well.
-# We're not dealing with line item changes just yet.
 class AmendBackorderJob < ApplicationJob
   sidekiq_options retry: 0
 
@@ -15,81 +16,119 @@ class AmendBackorderJob < ApplicationJob
   # The following is a mix of the BackorderJob and the CompleteBackorderJob.
   # TODO: Move the common code into a re-usable service class.
   def amend_backorder(order)
-    order_cycle = order.order_cycle
-    distributor = order.distributor
-    user = distributor.owner
-    items = backorderable_items(order)
+    variants = distributed_linked_variants(order)
+    return unless variants.any?
 
-    return if items.empty?
+    user = order.distributor.owner
+    order_cycle = order.order_cycle
 
     # We are assuming that all variants are linked to the same wholesale
     # shop and its catalog:
-    reference_link = items[0].variant.semantic_links[0].semantic_id
+    reference_link = variants[0].semantic_links[0].semantic_id
     urls = FdcUrlBuilder.new(reference_link)
     orderer = FdcBackorderer.new(user, urls)
+    broker = FdcOfferBroker.new(user, urls)
 
     backorder = orderer.find_open_order(order)
 
-    variants = order_cycle.variants_distributed_by(distributor)
-    adjust_quantities(order_cycle, user, backorder, urls, variants)
+    updated_lines = update_order_lines(backorder, order_cycle, variants, broker, orderer)
+    unprocessed_lines = backorder.lines.to_set - updated_lines
+    cancel_stale_lines(unprocessed_lines, order, broker)
+
+    # Clean up empty lines:
+    backorder.lines.reject! { |line| line.quantity.zero? }
 
     FdcBackorderer.new(user, urls).send_order(backorder)
   end
 
-  # Check if we have enough stock to reduce the backorder.
-  #
-  # Our local stock can increase when users cancel their orders.
-  # But stock levels could also have been adjusted manually. So we review all
-  # quantities before finalising the order.
-  def adjust_quantities(order_cycle, user, order, urls, variants)
-    broker = FdcOfferBroker.new(user, urls)
+  def update_order_lines(backorder, order_cycle, variants, broker, orderer)
+    variants.map do |variant|
+      link = variant.semantic_links[0].semantic_id
+      solution = broker.best_offer(link)
+      line = orderer.find_or_build_order_line(backorder, solution.offer)
+      if variant.on_demand
+        adjust_stock(variant, solution, line)
+      else
+        aggregate_final_quantities(order_cycle, line, variant, solution)
+      end
 
-    order.lines.each do |line|
-      line.quantity = line.quantity.to_i
+      line
+    end
+  end
+
+  def cancel_stale_lines(unprocessed_lines, order, broker)
+    managed_variants = managed_linked_variants(order)
+    unprocessed_lines.each do |line|
+      wholesale_quantity = line.quantity.to_i
       wholesale_product_id = line.offer.offeredItem.semanticId
       transformation = broker.wholesale_to_retail(wholesale_product_id)
-      linked_variant = variants.linked_to(transformation.retail_product_id)
+      linked_variant = managed_variants.linked_to(transformation.retail_product_id)
 
-      # Assumption: If a transformation is present then we only sell the retail
-      # variant. If that can't be found, it was deleted and we'll ignore that
-      # for now.
-      next if linked_variant.nil?
+      if linked_variant.nil?
+        transformation.factor = 1
+        linked_variant = managed_variants.linked_to(wholesale_product_id)
+      end
 
-      # Find all line items for this order cycle
-      # Update quantity accordingly
-      if linked_variant.on_demand
-        release_superfluous_stock(line, linked_variant, transformation)
-      else
-        aggregate_final_quantities(order_cycle, line, linked_variant, transformation)
+      # Adjust stock level back, we're not going to order this one.
+      if linked_variant&.on_demand
+        retail_quantity = wholesale_quantity * transformation.factor
+        linked_variant.on_hand -= retail_quantity
+      end
+
+      # We don't have any active orders for this
+      line.quantity = 0
+    end
+  end
+
+  def adjust_stock(variant, solution, line)
+    if variant.on_hand.negative?
+      needed_quantity = -1 * variant.on_hand # We need to replenish it.
+
+      # The number of wholesale packs we need to order to fulfill the
+      # needed quantity.
+      # For example, we order 2 packs of 12 cans if we need 15 cans.
+      wholesale_quantity = (needed_quantity.to_f / solution.factor).ceil
+
+      # The number of individual retail items we get with the wholesale order.
+      # For example, if we order 2 packs of 12 cans, we will get 24 cans
+      # and we'll account for that in our stock levels.
+      retail_quantity = wholesale_quantity * solution.factor
+
+      line.quantity = line.quantity.to_i + wholesale_quantity
+      variant.on_hand += retail_quantity
+    else
+      # Note that a division of integers dismisses the remainder, like `floor`:
+      wholesale_items_contained_in_stock = variant.on_hand / solution.factor
+
+      # But maybe we didn't actually order that much:
+      deductable_quantity = [line.quantity, wholesale_items_contained_in_stock].min
+
+      if deductable_quantity.positive?
+        line.quantity -= deductable_quantity
+
+        retail_stock_change = deductable_quantity * solution.factor
+        variant.on_hand -= retail_stock_change
       end
     end
-
-    # Clean up empty lines:
-    order.lines.reject! { |line| line.quantity.zero? }
   end
 
-  # We look at all linked variants.
-  def backorderable_items(order)
-    order.line_items.select do |item|
-      # TODO: scope variants to hub.
-      # We are only supporting producer stock at the moment.
-      item.variant.semantic_links.present?
-    end
+  def managed_linked_variants(order)
+    user = order.distributor.owner
+    order_cycle = order.order_cycle
+
+    # These permissions may be too complex. Here may be scope to optimise.
+    permissions = OpenFoodNetwork::OrderCyclePermissions.new(user, order_cycle)
+    permissions.visible_variants_for_outgoing_exchanges_to(order.distributor)
+      .where.associated(:semantic_links)
   end
 
-  def release_superfluous_stock(line, linked_variant, transformation)
-    # Note that a division of integers dismisses the remainder, like `floor`:
-    wholesale_items_contained_in_stock = linked_variant.on_hand / transformation.factor
-
-    # But maybe we didn't actually order that much:
-    deductable_quantity = [line.quantity, wholesale_items_contained_in_stock].min
-    line.quantity -= deductable_quantity
-
-    retail_stock_changes = deductable_quantity * transformation.factor
-    linked_variant.on_hand -= retail_stock_changes
+  def distributed_linked_variants(order)
+    order.order_cycle.variants_distributed_by(order.distributor)
+      .where.associated(:semantic_links)
   end
 
   def aggregate_final_quantities(order_cycle, line, variant, transformation)
+    # We may want to query all these quantities in one go instead of this n+1.
     orders = order_cycle.orders.invoiceable
     quantity = Spree::LineItem.where(order: orders, variant:).sum(:quantity)
     wholesale_quantity = (quantity.to_f / transformation.factor).ceil

--- a/app/jobs/complete_backorder_job.rb
+++ b/app/jobs/complete_backorder_job.rb
@@ -24,8 +24,7 @@ class CompleteBackorderJob < ApplicationJob
 
     urls = FdcUrlBuilder.new(order.lines[0].offer.offeredItem.semanticId)
 
-    variants = order_cycle.variants_distributed_by(distributor)
-    adjust_quantities(order_cycle, user, order, urls, variants)
+    BackorderUpdater.new.update(order, user, distributor, order_cycle)
 
     FdcBackorderer.new(user, urls).complete_order(order)
 
@@ -35,56 +34,5 @@ class CompleteBackorderJob < ApplicationJob
     BackorderMailer.backorder_incomplete(user, distributor, order_cycle, order_id).deliver_later
 
     raise
-  end
-
-  # Check if we have enough stock to reduce the backorder.
-  #
-  # Our local stock can increase when users cancel their orders.
-  # But stock levels could also have been adjusted manually. So we review all
-  # quantities before finalising the order.
-  def adjust_quantities(order_cycle, user, order, urls, variants)
-    broker = FdcOfferBroker.new(user, urls)
-
-    order.lines.each do |line|
-      line.quantity = line.quantity.to_i
-      wholesale_product_id = line.offer.offeredItem.semanticId
-      transformation = broker.wholesale_to_retail(wholesale_product_id)
-      linked_variant = variants.linked_to(transformation.retail_product_id)
-
-      # Assumption: If a transformation is present then we only sell the retail
-      # variant. If that can't be found, it was deleted and we'll ignore that
-      # for now.
-      next if linked_variant.nil?
-
-      # Find all line items for this order cycle
-      # Update quantity accordingly
-      if linked_variant.on_demand
-        release_superfluous_stock(line, linked_variant, transformation)
-      else
-        aggregate_final_quantities(order_cycle, line, linked_variant, transformation)
-      end
-    end
-
-    # Clean up empty lines:
-    order.lines.reject! { |line| line.quantity.zero? }
-  end
-
-  def release_superfluous_stock(line, linked_variant, transformation)
-    # Note that a division of integers dismisses the remainder, like `floor`:
-    wholesale_items_contained_in_stock = linked_variant.on_hand / transformation.factor
-
-    # But maybe we didn't actually order that much:
-    deductable_quantity = [line.quantity, wholesale_items_contained_in_stock].min
-    line.quantity -= deductable_quantity
-
-    retail_stock_changes = deductable_quantity * transformation.factor
-    linked_variant.on_hand -= retail_stock_changes
-  end
-
-  def aggregate_final_quantities(order_cycle, line, variant, transformation)
-    orders = order_cycle.orders.invoiceable
-    quantity = Spree::LineItem.where(order: orders, variant:).sum(:quantity)
-    wholesale_quantity = (quantity.to_f / transformation.factor).ceil
-    line.quantity = wholesale_quantity
   end
 end

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -142,8 +142,6 @@ module Spree
 
             OrderMailer.cancel_email(id).deliver_later if send_cancellation_email
             update(payment_state: updater.update_payment_state)
-
-            AmendBackorderJob.perform_later(self)
           end
 
           def after_resume

--- a/app/services/backorder_updater.rb
+++ b/app/services/backorder_updater.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'open_food_network/order_cycle_permissions'
+
+# Update a backorder to reflect all local orders and stock levels
+# connected to the associated order cycle.
+class BackorderUpdater
+  # Given an OFN order was created, changed or cancelled,
+  # we re-calculate how much to order in for every variant.
+  def amend_backorder(order)
+    variants = distributed_linked_variants(order)
+
+    # Temporary code: once we don't need a variant link to look up the
+    # backorder, we don't need this check anymore.
+    # Then we can adjust the backorder even though there are no linked variants
+    # in the order cycle right now. Some variants may have been in the order
+    # cycle before and got ordered before being removed from the order cycle.
+    return unless variants.any?
+
+    user = order.distributor.owner
+    order_cycle = order.order_cycle
+
+    # We are assuming that all variants are linked to the same wholesale
+    # shop and its catalog:
+    reference_link = variants[0].semantic_links[0].semantic_id
+    urls = FdcUrlBuilder.new(reference_link)
+    orderer = FdcBackorderer.new(user, urls)
+    broker = FdcOfferBroker.new(user, urls)
+
+    backorder = orderer.find_open_order(order)
+
+    updated_lines = update_order_lines(backorder, order_cycle, variants, broker, orderer)
+    unprocessed_lines = backorder.lines.to_set - updated_lines
+    cancel_stale_lines(unprocessed_lines, order, broker)
+
+    # Clean up empty lines:
+    backorder.lines.reject! { |line| line.quantity.zero? }
+
+    backorder
+  end
+
+  def update_order_lines(backorder, order_cycle, variants, broker, orderer)
+    variants.map do |variant|
+      link = variant.semantic_links[0].semantic_id
+      solution = broker.best_offer(link)
+      line = orderer.find_or_build_order_line(backorder, solution.offer)
+      if variant.on_demand
+        adjust_stock(variant, solution, line)
+      else
+        aggregate_final_quantities(order_cycle, line, variant, solution)
+      end
+
+      line
+    end
+  end
+
+  def cancel_stale_lines(unprocessed_lines, order, broker)
+    managed_variants = managed_linked_variants(order)
+    unprocessed_lines.each do |line|
+      wholesale_quantity = line.quantity.to_i
+      wholesale_product_id = line.offer.offeredItem.semanticId
+      transformation = broker.wholesale_to_retail(wholesale_product_id)
+      linked_variant = managed_variants.linked_to(transformation.retail_product_id)
+
+      if linked_variant.nil?
+        transformation.factor = 1
+        linked_variant = managed_variants.linked_to(wholesale_product_id)
+      end
+
+      # Adjust stock level back, we're not going to order this one.
+      if linked_variant&.on_demand
+        retail_quantity = wholesale_quantity * transformation.factor
+        linked_variant.on_hand -= retail_quantity
+      end
+
+      # We don't have any active orders for this
+      line.quantity = 0
+    end
+  end
+
+  def adjust_stock(variant, solution, line)
+    if variant.on_hand.negative?
+      needed_quantity = -1 * variant.on_hand # We need to replenish it.
+
+      # The number of wholesale packs we need to order to fulfill the
+      # needed quantity.
+      # For example, we order 2 packs of 12 cans if we need 15 cans.
+      wholesale_quantity = (needed_quantity.to_f / solution.factor).ceil
+
+      # The number of individual retail items we get with the wholesale order.
+      # For example, if we order 2 packs of 12 cans, we will get 24 cans
+      # and we'll account for that in our stock levels.
+      retail_quantity = wholesale_quantity * solution.factor
+
+      line.quantity = line.quantity.to_i + wholesale_quantity
+      variant.on_hand += retail_quantity
+    else
+      # Note that a division of integers dismisses the remainder, like `floor`:
+      wholesale_items_contained_in_stock = variant.on_hand / solution.factor
+
+      # But maybe we didn't actually order that much:
+      deductable_quantity = [line.quantity, wholesale_items_contained_in_stock].min
+
+      if deductable_quantity.positive?
+        line.quantity -= deductable_quantity
+
+        retail_stock_change = deductable_quantity * solution.factor
+        variant.on_hand -= retail_stock_change
+      end
+    end
+  end
+
+  def managed_linked_variants(order)
+    user = order.distributor.owner
+    order_cycle = order.order_cycle
+
+    # These permissions may be too complex. Here may be scope to optimise.
+    permissions = OpenFoodNetwork::OrderCyclePermissions.new(user, order_cycle)
+    permissions.visible_variants_for_outgoing_exchanges_to(order.distributor)
+      .where.associated(:semantic_links)
+  end
+
+  def distributed_linked_variants(order)
+    order.order_cycle.variants_distributed_by(order.distributor)
+      .where.associated(:semantic_links)
+  end
+
+  def aggregate_final_quantities(order_cycle, line, variant, transformation)
+    # We may want to query all these quantities in one go instead of this n+1.
+    orders = order_cycle.orders.invoiceable
+    quantity = Spree::LineItem.where(order: orders, variant:).sum(:quantity)
+    wholesale_quantity = (quantity.to_f / transformation.factor).ceil
+    line.quantity = wholesale_quantity
+  end
+end

--- a/app/services/fdc_backorderer.rb
+++ b/app/services/fdc_backorderer.rb
@@ -152,7 +152,7 @@ class FdcBackorderer
   end
 
   def new?(order)
-    order.semanticId == urls.orders_url
+    order.semanticId == urls&.orders_url
   end
 
   def build_sale_session(order)

--- a/app/services/orders/bulk_cancel_service.rb
+++ b/app/services/orders/bulk_cancel_service.rb
@@ -15,8 +15,7 @@ module Orders
         order.send_cancellation_email = @send_cancellation_email
         order.restock_items = @restock_items
         order.cancel
-        AmendBackorderJob.perform_later(order)
-      end
+      end.tap { |orders| AmendBackorderJob.schedule_bulk_update_for(orders) }
       # rubocop:enable Rails/FindEach
     end
 

--- a/app/services/orders/bulk_cancel_service.rb
+++ b/app/services/orders/bulk_cancel_service.rb
@@ -15,6 +15,7 @@ module Orders
         order.send_cancellation_email = @send_cancellation_email
         order.restock_items = @restock_items
         order.cancel
+        AmendBackorderJob.perform_later(order)
       end
       # rubocop:enable Rails/FindEach
     end

--- a/app/services/orders/customer_cancellation_service.rb
+++ b/app/services/orders/customer_cancellation_service.rb
@@ -10,6 +10,7 @@ module Orders
       return unless order.cancel
 
       Spree::OrderMailer.cancel_email_for_shop(order).deliver_later
+      AmendBackorderJob.perform_later(order)
     end
 
     private

--- a/spec/services/backorder_updater_spec.rb
+++ b/spec/services/backorder_updater_spec.rb
@@ -110,8 +110,10 @@ RSpec.describe BackorderUpdater do
   end
 
   describe "#distributed_linked_variants" do
+    let(:order_cycle) { order.order_cycle }
+
     it "selects available variants with semantic links" do
-      variants = subject.distributed_linked_variants(order)
+      variants = subject.distributed_linked_variants(order_cycle, distributor)
       expect(variants).to match_array [beans, chia_seed]
     end
   end

--- a/spec/services/backorder_updater_spec.rb
+++ b/spec/services/backorder_updater_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe AmendBackorderJob do
+RSpec.describe BackorderUpdater do
   let(:order) { create(:completed_order_with_totals) }
   let(:distributor) { order.distributor }
   let(:beans) { beans_item.variant }
@@ -106,6 +106,13 @@ RSpec.describe AmendBackorderJob do
       expect { subject.amend_backorder(order) }
         .to change { backorder.lines.count }.from(2).to(1)
         .and change { beans.reload.on_hand }.by(-12)
+    end
+  end
+
+  describe "#distributed_linked_variants" do
+    it "selects available variants with semantic links" do
+      variants = subject.distributed_linked_variants(order)
+      expect(variants).to match_array [beans, chia_seed]
     end
   end
 end

--- a/spec/services/fdc_backorderer_spec.rb
+++ b/spec/services/fdc_backorderer_spec.rb
@@ -106,4 +106,20 @@ RSpec.describe FdcBackorderer do
       expect(found_line).to eq existing_line
     end
   end
+
+  describe "#new?" do
+    describe "without knowing URLs" do
+      let(:subject) { FdcBackorderer.new(nil, nil) }
+
+      it "recognises new orders" do
+        order = DataFoodConsortium::Connector::Order.new(nil)
+        expect(subject.new?(order)).to eq true
+      end
+
+      it "recognises existing orders" do
+        order = DataFoodConsortium::Connector::Order.new("https://order")
+        expect(subject.new?(order)).to eq false
+      end
+    end
+  end
 end

--- a/spec/system/admin/orders/bulk_actions_spec.rb
+++ b/spec/system/admin/orders/bulk_actions_spec.rb
@@ -447,6 +447,7 @@ RSpec.describe '
           end
         end
       end
+
       it "can bulk cancel 2 orders" do
         page.find("#listing_orders tbody tr:nth-child(1) input[name='bulk_ids[]']").click
         page.find("#listing_orders tbody tr:nth-child(2) input[name='bulk_ids[]']").click
@@ -463,7 +464,7 @@ RSpec.describe '
           uncheck "Send a cancellation email to the customer"
           expect {
             find_button("Cancel").click # Cancels the cancel action
-          }.not_to enqueue_job(ActionMailer::MailDeliveryJob).exactly(:twice)
+          }.not_to enqueue_mail
         end
 
         page.find("span.icon-reorder", text: "Actions").click
@@ -474,7 +475,7 @@ RSpec.describe '
         within ".reveal-modal" do
           expect {
             find_button("Confirm").click # Confirms the cancel action
-          }.not_to enqueue_job(ActionMailer::MailDeliveryJob).exactly(:twice)
+          }.not_to enqueue_mail
         end
 
         expect(page).to have_content("CANCELLED", count: 2)

--- a/spec/system/admin/orders/bulk_actions_spec.rb
+++ b/spec/system/admin/orders/bulk_actions_spec.rb
@@ -467,18 +467,21 @@ RSpec.describe '
           }.not_to enqueue_mail
         end
 
+        expect(page).not_to have_content "This will cancel the current order."
+
         page.find("span.icon-reorder", text: "Actions").click
         within ".ofn-drop-down .menu" do
           page.find("span", text: "Cancel Orders").click
         end
 
-        within ".reveal-modal" do
-          expect {
+        expect {
+          within ".reveal-modal" do
             click_on "Confirm" # Confirms the cancel action
-          }.not_to enqueue_mail
-        end
-
-        expect(page).to have_content("CANCELLED", count: 2)
+          end
+          expect(page).to have_content("CANCELLED", count: 2)
+        }.to enqueue_job(AmendBackorderJob).exactly(:twice)
+          # You can't combine negative matchers.
+          .and enqueue_mail.exactly(0).times
       end
     end
 

--- a/spec/system/admin/orders/bulk_actions_spec.rb
+++ b/spec/system/admin/orders/bulk_actions_spec.rb
@@ -463,7 +463,7 @@ RSpec.describe '
         within ".reveal-modal" do
           uncheck "Send a cancellation email to the customer"
           expect {
-            find_button("Cancel").click # Cancels the cancel action
+            click_on "Cancel" # Cancels the cancel action
           }.not_to enqueue_mail
         end
 
@@ -474,7 +474,7 @@ RSpec.describe '
 
         within ".reveal-modal" do
           expect {
-            find_button("Confirm").click # Confirms the cancel action
+            click_on "Confirm" # Confirms the cancel action
           }.not_to enqueue_mail
         end
 


### PR DESCRIPTION
#### :information_source: Funded Feature. Please track ALL ASSOCIATED WORK under the associated tracking code `#11678 DFC Orders`

#### What? Why?

- Closes #12915 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Before, we accounted for cancelled orders but not for changed or removed line items. Now we completely re-calculate the backorder and can re-use this logic whenever something changes.

But so far, we still only trigger this when an order is cancelled or when the backorder is completed.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- _In all these cases a backorder should get updated:_
- Place an order that triggers a backorder.
- Create an order as admin that triggers a backorder.
- Cancel an order as customer or admin.
- Bulk cancel orders as admin.
- Adjust quantities on order as customer or admin.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
