### PR TITLE
Bulk product import stalling at 66% when missing info

### DIFF
--- a/app/controllers/admin/product_import_controller.rb
+++ b/app/controllers/admin/product_import_controller.rb
@@ -30,13 +30,13 @@ module Admin
     def validate_data
       return unless process_data('validate')
 
-      render json: @importer.import_results, response: 200
+      render json: @importer.import_results
     end
 
     def save_data
       return unless process_data('save')
 
-      render json: @importer.save_results, response: 200
+      render json: @importer.save_results
     end
 
     def reset_absent_products
@@ -76,7 +76,7 @@ module Admin
       begin
         @importer.public_send("#{method}_entries")
       rescue StandardError => e
-        render json: e.message, response: 500
+        render plain: e.message, status: :internal_server_error
         return false
       end
 

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -79,9 +79,8 @@ module ProductImport
         if entry.attributes['on_hand'].present?
           new_variant.on_hand = entry.attributes['on_hand']
         end
+        check_on_hand_nil(entry, new_variant)
       end
-
-      check_on_hand_nil(entry, new_variant)
 
       if new_variant.valid?
         entry.product_object = new_variant


### PR DESCRIPTION
#### What? Why?

- Closes #12973

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
- **Root cause and Fix:** https://github.com/openfoodfoundation/openfoodnetwork/pull/13001#discussion_r1862705554
- Along with the above, this PR also fixes error response rendering from the products import controller.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue
- Please make sure that the sheet doesn't have the `units` and `on_hand` value present

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled