### PR TITLE
[Orders Page] - Fix Pagination not working

### DIFF
--- a/app/webpacker/controllers/search_controller.js
+++ b/app/webpacker/controllers/search_controller.js
@@ -10,7 +10,8 @@ export default class extends Controller {
 
   changePage(event) {
     const productsForm = document.querySelector("#products-form");
-    productsForm.scrollIntoView({ behavior: "smooth" });
+    if (productsForm) productsForm.scrollIntoView({ behavior: "smooth" });
+
     this.page.value = event.target.dataset.page;
     this.submitSearch();
     this.page.value = 1;


### PR DESCRIPTION

#### What? Why?

- Closes #13002
- `searchController`  is also being used on the Orders Page along with Products
- `productForm` is not accessible on the orders page
- Hence the code breaks on the Orders page when controller action tries to do the `scrollIntoView` on the `productForm`
- This PR puts the check in the controller to do the `scrollIntoView` only if the `productForm` is available

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue
- Also, Re-validate https://github.com/openfoodfoundation/openfoodnetwork/pull/12962
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
