### PR TITLE
[Orders Page] Fix Confirmation modals do not auto-close

### DIFF
--- a/app/webpacker/controllers/flatpickr_controller.js
+++ b/app/webpacker/controllers/flatpickr_controller.js
@@ -13,6 +13,7 @@ import { ru } from "flatpickr/dist/l10n/ru";
 import { sv } from "flatpickr/dist/l10n/sv";
 import { tr } from "flatpickr/dist/l10n/tr";
 import { en } from "flatpickr/dist/l10n/default.js";
+import { hu } from "flatpickr/dist/l10n/hu";
 import ShortcutButtonsPlugin from "shortcut-buttons-flatpickr";
 import labelPlugin from "flatpickr/dist/plugins/labelPlugin/labelPlugin";
 
@@ -36,6 +37,7 @@ export default class extends Flatpickr {
     sv: sv,
     tr: tr,
     en: en,
+    hu: hu,
   };
 
   initialize() {

--- a/app/webpacker/controllers/mixins/useOpenAndCloseAsAModal.js
+++ b/app/webpacker/controllers/mixins/useOpenAndCloseAsAModal.js
@@ -12,8 +12,8 @@ export const useOpenAndCloseAsAModal = (controller) => {
     }.bind(controller),
 
     close: function (_event, remove = false) {
-      // Only execute close if there is an open modal
-      if (!document.querySelector("body").classList.contains('modal-open')) return;
+      // Only execute close if the current modal is open
+      if (!this.modalTarget.classList.contains('in')) return;
 
       this.modalTarget.classList.remove("in");
       this.backgroundTarget.classList.remove("in");


### PR DESCRIPTION
#### What? Why?

- Closes #12982 ,  #12803

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
- **Context:** https://github.com/openfoodfoundation/openfoodnetwork/issues/12982#issuecomment-2499096920
- This PR fixes auto-close functionality for all the Orders Page confirmation modals after the confirmation.
- Moreover, it also fixes the `flatpickr invalid locale hu error` as mentioned in the issue

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Validate that you can cancel the order
- And after cancelation, the modal is closed automatically
- Along with the above, please validate the following modals such that when you click confirm, they get closed automatically after the intended operation (_operation's validity is out of the scope of this issue, we just need to validate whether the modal automatically closes or not_).
  - Resend Confirmation
  - Send Invoice Confirmation
- Lastly, please validate that in the Hungarian locale, when you use any date picker (e.g. on the Order Cycles Page), you can view the calender in the Hungarian locale, and no error should be displayed on the console related to flatpickr.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled