### PR TITLE
Added the :selected option with the default tax category #12989

### DIFF
--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -11,6 +11,7 @@ module Spree
       include OrderCyclesHelper
       include EnterprisesHelper
       helper ::Admin::ProductsHelper
+      helper Spree::Admin::TaxCategoriesHelper
 
       before_action :load_data
       before_action :load_producers, only: [:index, :new]

--- a/app/helpers/spree/admin/tax_categories_helper.rb
+++ b/app/helpers/spree/admin/tax_categories_helper.rb
@@ -12,7 +12,6 @@ module Spree
         else
           {
             include_blank: t(:none),
-            selected: nil
           }
         end
       end

--- a/app/helpers/spree/admin/tax_categories_helper.rb
+++ b/app/helpers/spree/admin/tax_categories_helper.rb
@@ -1,8 +1,21 @@
-module Spree::Admin::TaxCategoriesHelper
-  def tax_category_dropdown_options(require_tax_category)
-    {
-      :include_blank => Spree::Config.products_require_tax_category ? false : t(:none), 
-      selected: Spree::Config.products_require_tax_category ? Spree::TaxCategory.find_by(is_default: true)&.id : nil
-    }
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    module TaxCategoriesHelper
+      def tax_category_dropdown_options(require_tax_category)
+        if require_tax_category
+          {
+            include_blank: false,
+            selected: Spree::TaxCategory.find_by(is_default: true)&.id
+          }
+        else
+          {
+            include_blank: t(:none),
+            selected: nil
+          }
+        end
+      end
+    end
   end
 end

--- a/app/helpers/spree/admin/tax_categories_helper.rb
+++ b/app/helpers/spree/admin/tax_categories_helper.rb
@@ -1,0 +1,8 @@
+module Spree::Admin::TaxCategoriesHelper
+  def tax_category_dropdown_options(require_tax_category)
+    {
+      :include_blank => Spree::Config.products_require_tax_category ? false : t(:none), 
+      selected: Spree::Config.products_require_tax_category ? Spree::TaxCategory.find_by(is_default: true)&.id : nil
+    }
+  end
+end

--- a/app/views/spree/admin/products/_tax_category_form.html.haml
+++ b/app/views/spree/admin/products/_tax_category_form.html.haml
@@ -1,5 +1,5 @@
 = f.field_container :tax_category_id do
   = f.label :tax_category_id, t(:tax_category)
   %br
-  = f.collection_select(:tax_category_id, Spree::TaxCategory.all, :id, :name, {:include_blank => Spree::Config.products_require_tax_category ? false : t(:none), selected: Spree::TaxCategory.find_by(is_default: true)&.id}, {:class => "select2 fullwidth"})
+  = f.collection_select(:tax_category_id, Spree::TaxCategory.all, :id, :name, tax_category_dropdown_options(Spree::Config.products_require_tax_category), {:class => "select2 fullwidth"})
   = f.error_message_on :tax_category_id

--- a/app/views/spree/admin/products/_tax_category_form.html.haml
+++ b/app/views/spree/admin/products/_tax_category_form.html.haml
@@ -1,5 +1,5 @@
 = f.field_container :tax_category_id do
   = f.label :tax_category_id, t(:tax_category)
   %br
-  = f.collection_select(:tax_category_id, Spree::TaxCategory.all, :id, :name, {:include_blank => Spree::Config.products_require_tax_category ? false : t(:none)}, {:class => "select2 fullwidth"})
+  = f.collection_select(:tax_category_id, Spree::TaxCategory.all, :id, :name, {:include_blank => Spree::Config.products_require_tax_category ? false : t(:none), selected: Spree::TaxCategory.find_by(is_default: true)&.id}, {:class => "select2 fullwidth"})
   = f.error_message_on :tax_category_id

--- a/spec/helpers/spree/admin/tax_categories_helper_spec.rb
+++ b/spec/helpers/spree/admin/tax_categories_helper_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Spree::Admin::TaxCategoriesHelper do
     context 'when products do not require a tax category' do
       it 'returns include_blank as the translated "none" string' do
         options = helper.tax_category_dropdown_options(false)
-        expect(options[:include_blank]).to eq(I18n.t(:none))
+        expect(options[:include_blank]).to eq("None")
       end
 
       it 'does not include a selected tax category' do

--- a/spec/helpers/spree/admin/tax_categories_helper_spec.rb
+++ b/spec/helpers/spree/admin/tax_categories_helper_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Spree::Admin::TaxCategoriesHelper do
+  describe '#tax_category_dropdown_options' do
+    let!(:default_tax_category) { create(:tax_category, is_default: true) }
+    let!(:other_tax_category) { create(:tax_category, is_default: false) }
+
+    context 'when products require a tax category' do
+      it 'returns include_blank as false' do
+        options = helper.tax_category_dropdown_options(true)
+        expect(options[:include_blank]).to eq(false)
+      end
+
+      it 'returns the default tax category as selected' do
+        options = helper.tax_category_dropdown_options(true)
+        expect(options[:selected]).to eq(default_tax_category.id)
+      end
+
+      context 'when no default tax category exists' do
+        before { default_tax_category.update(is_default: false) }
+
+        it 'returns nil for the selected value' do
+          options = helper.tax_category_dropdown_options(true)
+          expect(options[:selected]).to be_nil
+        end
+      end
+    end
+
+    context 'when products do not require a tax category' do
+      it 'returns include_blank as the translated "none" string' do
+        options = helper.tax_category_dropdown_options(false)
+        expect(options[:include_blank]).to eq(I18n.t(:none))
+      end
+
+      it 'does not include a selected tax category' do
+        options = helper.tax_category_dropdown_options(false)
+        expect(options[:selected]).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request solves the default tax category not showing problem when you create a new product in the admin panel

- Closes #12989

Added the following code:

selected: Spree::TaxCategory.find_by(is_default: true)&.id

in the _tax_category_form.html.haml file.



#### What should we test?
1. Open product creation screen.
2. See the tax category is the one that is set to default.


<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
