### PR TITLE
Fix gaps in cart & checkout tables on Firefox

### DIFF
--- a/app/webpacker/css/darkswarm/cart-page.scss
+++ b/app/webpacker/css/darkswarm/cart-page.scss
@@ -11,8 +11,6 @@
 
 #cart-detail {
   width: 100%;
-  display: block;
-  overflow-x: auto;
 
   .cart-item-delete,
   .bought-item-delete {

--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -394,9 +394,6 @@
 }
 
 #line-items {
-  display: block;
-  overflow-x: auto;
-
   h5 {
     background-color: transparent;
   }


### PR DESCRIPTION
#### What? Why?

- Closes #10261

Tables from the cart and checkout pages would show some gaps where the table content doesn't extend to take all the available space. Not forcing the `display` CSS property of `table` elements to `block` appears to fix the issue without adverse side effects.

| before | after |
|-----------|---------|
| ![order_edit_table_before](https://github.com/user-attachments/assets/9b98f69e-36c4-46f1-9d60-f3930d6e62f3) | ![order_edit_table_after](https://github.com/user-attachments/assets/7aa29daf-e93f-4bdb-824b-4eb19d434e31) |


The `display: block` properties were originally added in PR #10103 to address issue #9976 on mobile, but it does not seem to be working anymore, with or without this patch. For example, in the screenshot below, the white gap at the right of the footer hints at how much extra width is added on the page:
![mobile_viewport_content_too_wide](https://github.com/user-attachments/assets/db39699e-8e71-4d72-925a-7b080b917733)

PR #10103 was aiming to make the table itself scroll horizontally while keeping the overall body width matching the viewport. It doesn't work today, and upon testing, seems unfeasible on Firefox (see the issue mentioned on https://stackoverflow.com/a/48736763, compare behaviour on Chrome & Firefox). If it was working, it would be sometimes confusing as there would be no or very little indication that the table has the ability to scroll. I would suggest to entirely change the table's layout on Mobile instead. For example, put price, quantity and the remove button below the item title and description, so that everything can fit without needing to scroll.



#### What should we test?
Repro steps:

1. A mobile device or some way to simulate it will be needed. I used the mobile/responsive mode from dev tools. E.g. on Firefox , the Galaxy Note 20 at 412px width.
2. As an admin: In one of the hubs, edit some of the items to make sure a few have some reasonably long name without spaces, so that it is not auto-wrapped. Example: on my simulated phone above, I observed "Mushrooms" to be long enough to cause the issue.
3. As a customer, on a mobile device: Edit an already placed order:
    - Place an order on that hub
    - Visit /account#/orders and click "Edit" for that order -> Notice that the whole page scrolls horizontally

There is also an affected table on the cart page, but I couldn't repro the issue there.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

The title of the pull request will be included in the release notes.
