### PR TITLE
Add customer code to notify producer emails when enabled

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -86,7 +86,8 @@ class ProducerMailer < ApplicationMailer
         product_and_full_name: line_item.product_and_full_name,
         quantity: line_item.quantity,
         first_name: line_item.order.billing_address.first_name,
-        last_name: line_item.order.billing_address.last_name
+        last_name: line_item.order.billing_address.last_name,
+        business_name: line_item.order.customer.code,
       }
     end.sort_by { |line_item| [line_item[:last_name].downcase, line_item[:first_name].downcase] }
   end

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -79,7 +79,11 @@ class ProducerMailer < ApplicationMailer
   def set_customer_data(line_items)
     return unless @coordinator.show_customer_names_to_suppliers?
 
+    @display_business_name = false
     line_items.map do |line_item|
+      customer_code = line_item.order.customer.code
+      @display_business_name = true if customer_code.present?
+
       {
         sku: line_item.variant.sku,
         supplier_name: line_item.variant.supplier.name,
@@ -87,7 +91,7 @@ class ProducerMailer < ApplicationMailer
         quantity: line_item.quantity,
         first_name: line_item.order.billing_address.first_name,
         last_name: line_item.order.billing_address.last_name,
-        business_name: line_item.order.customer.code,
+        business_name: customer_code,
       }
     end.sort_by { |line_item| [line_item[:last_name].downcase, line_item[:first_name].downcase] }
   end

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -81,7 +81,7 @@ class ProducerMailer < ApplicationMailer
 
     @display_business_name = false
     line_items.map do |line_item|
-      customer_code = line_item.order.customer.code
+      customer_code = line_item.order.customer&.code
       @display_business_name = true if customer_code.present?
 
       {

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -81,8 +81,9 @@
           = t :first_name
         %th.text-right
           = t :last_name
-        %th.text-right
-          = t :business_name
+        - if @display_business_name
+          %th.text-right
+            = t :business_name
     %tbody
       - @customer_line_items.each do |line_item|
         %tr
@@ -99,8 +100,9 @@
             = line_item[:first_name]
           %td
             = line_item[:last_name]
-          %td
-            = line_item[:business_name]
+          - if @display_business_name
+            %td
+              = line_item[:business_name]
 %p
   = t :producer_mail_text_after
 %p

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -81,6 +81,8 @@
           = t :first_name
         %th.text-right
           = t :last_name
+        %th.text-right
+          = t :business_name
     %tbody
       - @customer_line_items.each do |line_item|
         %tr
@@ -97,6 +99,8 @@
             = line_item[:first_name]
           %td
             = line_item[:last_name]
+          %td
+            = line_item[:business_name]
 %p
   = t :producer_mail_text_after
 %p

--- a/app/views/producer_mailer/order_cycle_report.text.haml
+++ b/app/views/producer_mailer/order_cycle_report.text.haml
@@ -24,7 +24,7 @@ Orders summary
   = t :producer_mail_order_customer_text
   \
   - @customer_line_items.each do |line_item|
-    #{line_item[:sku]} - #{raw(line_item[:supplier_name])} - #{raw(line_item[:product_and_full_name])} (#{t(:producer_mail_qty)}: #{line_item[:quantity]})  - #{raw(line_item[:first_name])} #{raw(line_item[:last_name])}
+    #{line_item[:sku]} - #{raw(line_item[:supplier_name])} - #{raw(line_item[:product_and_full_name])} (#{t(:producer_mail_qty)}: #{line_item[:quantity]})  - #{raw(line_item[:first_name])} #{raw(line_item[:last_name])} #{raw(line_item[:business_name])}
 \
 \
 = t :producer_mail_text_after

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3461,6 +3461,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     ready: Ready
     pending: Pending
     shipped: Shipped
+  business_name: Business Name
   js:
     saving: 'Saving...'
     changes_saved: 'Changes saved.'

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -183,6 +183,29 @@ RSpec.describe ProducerMailer, type: :mailer do
       expect(mail.body.encoded).to match(/.*Abby.*Doe.*smith/m)
       expect(customer_details_summary_text(mail)).to include('Abby', 'Doe', 'smith')
     end
+
+    context "validate business name" do
+      let(:table_header) do
+        body_as_html(mail).find("table.order-summary.customer-order thead")
+      end
+
+      context "when no customer has customer code" do
+        it 'should not displays business name column' do
+          expect(table_header).not_to have_selector("th", text: 'Business Name')
+        end
+      end
+
+      context "when customer have code" do
+        before { order.customer.update(code: 'Test Business Name') }
+
+        it 'displays business name for the customer' do
+          expect(table_header).to have_selector("th", text: 'Business Name')
+          expect(
+            body_as_html(mail).find("table.order-summary.customer-order tbody tr")
+          ).to have_selector("td", text: 'Test Business Name')
+        end
+      end
+    end
   end
 
   context 'when flag show_customer_names_to_suppliers is false' do

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe ProducerMailer, type: :mailer do
       context "when no customer has customer code" do
         it 'should not displays business name column' do
           expect(table_header).not_to have_selector("th", text: 'Business Name')
+          expect(customer_details_summary_text(mail)).not_to include('Test Business Name')
         end
       end
 
@@ -203,6 +204,7 @@ RSpec.describe ProducerMailer, type: :mailer do
           expect(
             body_as_html(mail).find("table.order-summary.customer-order tbody tr")
           ).to have_selector("td", text: 'Test Business Name')
+          expect(customer_details_summary_text(mail)).to include('Test Business Name')
         end
       end
     end


### PR DESCRIPTION
⚠️ Please use clockify code #12476 Flower Farms

#### What? Why?

- Closes #13007
- This PR adds customer code as "Business Name" in the Order Cycle Report for producers
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->
To test the text version of the report, this PR needs to be merged first:
- https://github.com/openfoodfoundation/openfoodnetwork/pull/12996
- Feedback is needed on the attached issue (https://github.com/openfoodfoundation/openfoodnetwork/issues/12993)

However, the respective changes are also incorporated in the text version as well.