### PR TITLE
Add 'tax category' to the All Products report

### DIFF
--- a/lib/reporting/reports/products_and_inventory/all_products.rb
+++ b/lib/reporting/reports/products_and_inventory/all_products.rb
@@ -4,6 +4,12 @@ module Reporting
   module Reports
     module ProductsAndInventory
       class AllProducts < Base
+        def default_params
+          {
+            fields_to_hide: [:tax_category]
+          }
+        end
+
         def message
           I18n.t("spree.admin.reports.products_and_inventory.all_products.message")
         end
@@ -19,7 +25,8 @@ module Reporting
           super.merge(
             {
               on_demand: proc{ |variant| variant.on_demand },
-              on_hand: proc{ |variant| variant.on_demand ? I18n.t(:on_demand) : variant.on_hand }
+              on_hand: proc{ |variant| variant.on_demand ? I18n.t(:on_demand) : variant.on_hand },
+              tax_category: proc { |variant| variant.tax_category_id && variant.tax_category.name }
             }
           )
         end

--- a/spec/lib/reports/products_and_inventory_report_spec.rb
+++ b/spec/lib/reports/products_and_inventory_report_spec.rb
@@ -283,7 +283,8 @@ module Reporting
                                                "Amount",
                                                "SKU",
                                                "On Demand?",
-                                               "On Hand"
+                                               "On Hand",
+                                               "Tax Category"
                                              ])
         end
 
@@ -293,8 +294,8 @@ module Reporting
           variant.save!
 
           last_row = report.table_rows.last
-          on_demand_column = last_row[-2]
-          on_hand_column = last_row[-1]
+          on_demand_column = last_row[-3]
+          on_hand_column = last_row[-2]
 
           expect(on_demand_column).to eq("Yes")
           expect(on_hand_column).to eq("On demand")
@@ -306,11 +307,22 @@ module Reporting
           variant.save!
 
           last_row = report.table_rows.last
-          on_demand_column = last_row[-2]
-          on_hand_column = last_row[-1]
+          on_demand_column = last_row[-3]
+          on_hand_column = last_row[-2]
 
           expect(on_demand_column).to eq("No")
           expect(on_hand_column).to eq(22)
+        end
+
+        it "renders tax category if present, otherwise none" do
+          variant.update!(tax_category: create(:tax_category, name: 'Test Category'))
+
+          table_rows = report.table_rows
+          first_row = table_rows.first # row for default variant, as result of product creation
+          last_row = table_rows.last # row for the variant created/updated above
+
+          expect(first_row.last).to eq('none')
+          expect(last_row.last).to eq('Test Category')
         end
       end
     end


### PR DESCRIPTION
**⚠️ Please use clockify code #12476 Flower Farms**

#### What? Why?

- Closes #13008
- This PR adds the tax category field in the All Products report

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
