### PR TITLE
Changing a variant unit scale from items to weight/volume does not remove variant unit name

### DIFF
--- a/app/services/variant_units/variant_and_line_item_naming.rb
+++ b/app/services/variant_units/variant_and_line_item_naming.rb
@@ -65,6 +65,7 @@ module VariantUnits
     def unit_value_attributes
       units = { unit_presentation: option_value_name }
       units.merge!(variant_unit:) if has_attribute?(:variant_unit)
+      units.merge!(variant_unit_name: '') if reset_variant_unit_name?
       units
     end
 
@@ -78,6 +79,10 @@ module VariantUnits
       return display_as if has_attribute?(:display_as) && display_as.present?
 
       VariantUnits::OptionValueNamer.new(self).name
+    end
+
+    def reset_variant_unit_name?
+      has_attribute?(:variant_unit_name) && has_attribute?(:variant_unit) && variant_unit != 'items'
     end
   end
 end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -987,11 +987,11 @@ RSpec.describe Spree::Variant do
 
       variant.variant_unit = 'weight'
       variant.variant_unit_scale = 1
-      variant.variant_unit_name = 'g'
       variant.save!
 
       expect(variant.variant_unit).to eq 'weight'
       expect(variant.unit_presentation).to eq "1g"
+      expect(variant.variant_unit_name).to eq('')
 
       variant.update(variant_unit: 'volume')
 


### PR DESCRIPTION
#### What? Why?

- Closes #13026
- This PR resets the variant unit name if the variant unit is changed to any unit other than `items`

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
