### PR TITLE
Install rbenv automatically if missing

### DIFF
--- a/script/rbenv-install.sh
+++ b/script/rbenv-install.sh
@@ -2,12 +2,23 @@
 #
 # Install our selected Ruby version defined in the .ruby-version file.
 #
-# Requires:
+# Requires and tries to install if missing:
 # - [rbenv](https://github.com/rbenv/rbenv#readme)
 # - [ruby-build](https://github.com/rbenv/ruby-build#readme)
 #
 # If our ruby-build version is outdated and it can't build the version we want
 # then we try upgrading ruby-build and installing again.
+
+if ! command -v rbenv > /dev/null; then
+  # Install rbenv:
+  git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+  ~/.rbenv/bin/rbenv init
+  eval "$(rbenv init -)"
+
+  # Install ruby-build:
+  mkdir -p "$(rbenv root)"/plugins
+  git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+fi
 
 if rbenv install --skip-existing; then
   echo "Ruby is installed."

--- a/script/rbenv-install.sh
+++ b/script/rbenv-install.sh
@@ -13,7 +13,7 @@ if ! command -v rbenv > /dev/null; then
   # Install rbenv:
   git clone https://github.com/rbenv/rbenv.git ~/.rbenv
   ~/.rbenv/bin/rbenv init
-  eval "$(rbenv init -)"
+  eval "$(~/.rbenv/bin/rbenv init -)"
 
   # Install ruby-build:
   mkdir -p "$(rbenv root)"/plugins


### PR DESCRIPTION


#### What? Why?

This small script addition will allow us to remove the rbenv installation from our Ansible provisioning scripts.

Ansible has become hard to maintain and the rbenv installation caused an issue today. Somehow it didn't install Ruby with the specified jemalloc flag.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- We need to test that this works on different machines.
- Run `./script/rbenv-install.sh` to make sure it doesn't run anything unnecessarily.
- Temporarily move your rbenv installation and verify that the script installs it for you.
- Restore your old installation, if you wish.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
