### PR TITLE
Fix DFC catalog syncs for blank cart

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -11,7 +11,7 @@ class CartController < BaseController
       order.cap_quantity_at_stock!
       order.recreate_all_fees!
 
-      StockSyncJob.sync_linked_catalogs(order)
+      StockSyncJob.sync_linked_catalogs_later(order)
 
       render json: { error: false, stock_levels: stock_levels(order) }, status: :ok
     else

--- a/app/jobs/stock_sync_job.rb
+++ b/app/jobs/stock_sync_job.rb
@@ -9,11 +9,11 @@ class StockSyncJob < ApplicationJob
   # enqueue a new job. That should save some time loading the order with
   # all the stock data to make this decision.
   def self.sync_linked_catalogs_later(order)
-    sync_categories_by_perform_method(order, :perform_later)
+    sync_catalogs_by_perform_method(order, :perform_later)
   end
 
   def self.sync_linked_catalogs_now(order)
-    sync_categories_by_perform_method(order, :perform_now)
+    sync_catalogs_by_perform_method(order, :perform_now)
   end
 
   def self.catalog_ids(order)
@@ -59,7 +59,7 @@ class StockSyncJob < ApplicationJob
       .where(semantic_links: { semantic_id: product_ids })
   end
 
-  def self.sync_categories_by_perform_method(order, perform_method)
+  def self.sync_catalogs_by_perform_method(order, perform_method)
     distributor = order.distributor
     return unless distributor
 

--- a/spec/jobs/stock_sync_job_spec.rb
+++ b/spec/jobs/stock_sync_job_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe StockSyncJob do
     "https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/SuppliedProducts"
   }
 
-  describe ".sync_linked_catalogs" do
-    subject { StockSyncJob.sync_linked_catalogs(order) }
+  describe ".sync_linked_catalogs_later" do
+    subject { StockSyncJob.sync_linked_catalogs_later(order) }
     it "ignores products without semantic link" do
       expect { subject }.not_to enqueue_job(StockSyncJob)
     end
@@ -34,6 +34,15 @@ RSpec.describe StockSyncJob do
       expect(Bugsnag).to receive(:notify).and_call_original
 
       expect { subject }.not_to raise_error
+    end
+
+    context "when order has no distributor" do
+      let!(:order) { create(:order) }
+
+      it 'should not raise error' do
+        expect(Bugsnag).not_to receive(:notify).and_call_original
+        expect { subject }.not_to raise_error
+      end
     end
   end
 
@@ -58,6 +67,15 @@ RSpec.describe StockSyncJob do
       expect(Bugsnag).to receive(:notify).and_call_original
 
       expect { subject }.not_to raise_error
+    end
+
+    context "when order has no distributor" do
+      let!(:order) { create(:order) }
+
+      it 'should not raise error' do
+        expect(Bugsnag).not_to receive(:notify).and_call_original
+        expect { subject }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
ℹ️ Funded Feature. Please track ALL ASSOCIATED WORK under the associated tracking code #11678 DFC Orders


#### What? Why?

- Closes #13024

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- In an order cycle with DFC products:
- Check that stock adjusts after changes in Shopify after the user added a product to the cart.
- If an item goes out of stock during checkout, the checkout should fail.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->