### PR TITLE
Add plural form for flower farming variant unit names

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3917,7 +3917,39 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     sack:
       one: "sack"
       other: "sacks"
-
+    bucket:
+      one: "bucket"
+      other: "buckets"
+    pail:
+      one: "pail"
+      other: pails
+    stem:
+      one: "stem"
+      other: "stems"
+    plug:
+      one: "plug"
+      other: "plugs"
+    plant:
+      one: "plant"
+      other: "plants"
+    bundle:
+      one: "bundle"
+      other: "bundles"
+    bulb:
+      one: "bulb"
+      other: "bulbs"
+    root:
+      one: "root"
+      other: "roots"
+    tuber:
+      one: "tuber"
+      other: "tubers"
+    corm:
+      one: "corm"
+      other: "corms"
+    crate:
+      one: "crate"
+      other: "crates"
   producers:
     signup:
       start_free_profile: "Start with a free profile, and expand when you're ready!"


### PR DESCRIPTION
⚠️ Please use clockify code #12476 Flower Farms

#### What? Why?

- Closes #13032
- This PR adds some more plural forms for the flower farming variant unit names
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
