### PR TITLE
Add 'Voucher:' before voucher code on edit cart page

### DIFF
--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -35,7 +35,8 @@
           %tr.order-adjustment
             %td.text-right{:colspan => "3"}
               - if adjustment.originator_type == "Voucher"
-                = t(:order_voucher_label, code: adjustment.label)
+                = "#{t(:voucher)}:"
+                = adjustment.label
               - else
                 = adjustment.label
             %td.text-right.total

--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -34,7 +34,10 @@
         - checkout_adjustments_for(@order, exclude: [:line_item]).reverse_each do |adjustment|
           %tr.order-adjustment
             %td.text-right{:colspan => "3"}
-              = adjustment.label
+              - if adjustment.originator_type == "Voucher"
+                = t(:order_voucher_label, code: adjustment.label)
+              - else
+                = adjustment.label
             %td.text-right.total
               %span= adjustment.display_amount.to_html
             %td

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2455,6 +2455,7 @@ en:
   order_back_to_store: Back To Store
   order_back_to_cart: Back To Cart
   order_back_to_website: Back To Website
+  order_voucher_label: "Voucher: %{code}"
   checkout_details_title: Checkout Details
   checkout_payment_title: Checkout Payment
   checkout_summary_title: Checkout Summary

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2455,7 +2455,6 @@ en:
   order_back_to_store: Back To Store
   order_back_to_cart: Back To Cart
   order_back_to_website: Back To Website
-  order_voucher_label: "Voucher: %{code}"
   checkout_details_title: Checkout Details
   checkout_payment_title: Checkout Payment
   checkout_summary_title: Checkout Summary

--- a/spec/views/spree/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/orders/edit.html.haml_spec.rb
@@ -42,17 +42,19 @@ RSpec.describe "spree/orders/edit.html.haml" do
     end
 
     it "includes Voucher text with label" do
-      expect(rendered).to include("Voucher: #{voucher.code}")
+      expect(rendered).to have_content("Voucher:\n#{voucher.code}")
     end
 
-    # shipping fee is derived from 'completed_order_with_fees' factory, it applies when using shipping method such as Home Delivery.
+    # Shipping fee is derived from 'completed_order_with_fees' factory.
+    # It applies when using shipping method such as Home Delivery.
     it "includes Shipping label" do
-      expect(rendered).to include("Shipping")
+      expect(rendered).to have_content("Shipping")
     end
 
-    # transaction fee is derived from 'completed_order_with_fees' factory, it applies when using payment methods such as Check & Stripe.
+    # Transaction fee is derived from 'completed_order_with_fees' factory.
+    # It applies when using payment methods such as Check & Stripe.
     it "includes Transaction fee label" do
-      expect(rendered).to include("Transaction fee")
+      expect(rendered).to have_content("Transaction fee")
     end
   end
 end

--- a/spec/views/spree/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/orders/edit.html.haml_spec.rb
@@ -31,4 +31,28 @@ RSpec.describe "spree/orders/edit.html.haml" do
       expect(rendered).to have_selector(".unit-price")
     end
   end
+
+  describe "display adjustments" do
+    let(:voucher) { create(:voucher, enterprise: order.distributor) }
+
+    before do
+      voucher.create_adjustment(voucher.code, order)
+      OrderManagement::Order::Updater.new(order).update_voucher
+      render
+    end
+
+    it "includes Voucher text with label" do
+      expect(rendered).to include("Voucher: #{voucher.code}")
+    end
+
+    # shipping fee is derived from 'completed_order_with_fees' factory, it applies when using shipping method such as Home Delivery.
+    it "includes Shipping label" do
+      expect(rendered).to include("Shipping")
+    end
+
+    # transaction fee is derived from 'completed_order_with_fees' factory, it applies when using payment methods such as Check & Stripe.
+    it "includes Transaction fee label" do
+      expect(rendered).to include("Transaction fee")
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #13059

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- When voucher is used in an order as a shopper, edit cart page will contain "Voucher:" text before voucher code.
- Check also for translated "Voucher" text.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

Before:
![Screenshot 2025-01-04 at 2 19 39 PM](https://github.com/user-attachments/assets/4cae36fc-15a5-41c2-b1dc-9e5352841b3f)


After:

![Screenshot 2025-01-04 at 2 20 04 PM](https://github.com/user-attachments/assets/35e8c5c7-8935-438b-b3e9-93bc790fb1af)
