### PR TITLE
Admin updates can trigger new backorders until the order cycle is closed

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -92,6 +92,7 @@ class CheckoutController < BaseController
     end
     @order.process_payments!
     @order.confirm!
+    BackorderJob.check_stock(@order)
     order_completion_reset @order
   end
 

--- a/app/jobs/amend_backorder_job.rb
+++ b/app/jobs/amend_backorder_job.rb
@@ -27,9 +27,9 @@ class AmendBackorderJob < ApplicationJob
       user = order.distributor.owner
       urls = nil # Not needed to send order. The backorder id is the URL.
       FdcBackorderer.new(user, urls).send_order(backorder)
-    elsif order.order_cycle.open?
+    elsif !order.order_cycle.closed?
 
-      # We don't have an order to amend but the order cycle is open.
+      # We don't have an order to amend but the order cycle is or will open.
       # We can assume that this job was triggered by an admin creating a new
       # order or adding backorderable items to an order.
       BackorderJob.new.place_backorder(order)

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -392,8 +392,6 @@ module Spree
 
       deliver_order_confirmation_email
 
-      BackorderJob.check_stock(self)
-
       state_changes.create(
         previous_state: 'cart',
         next_state: 'complete',

--- a/app/services/backorder_updater.rb
+++ b/app/services/backorder_updater.rb
@@ -28,7 +28,7 @@ class BackorderUpdater
 
     backorder = orderer.find_open_order(order)
 
-    update(backorder, user, distributor, order_cycle)
+    update(backorder, user, distributor, order_cycle) if backorder
   end
 
   # Update a given backorder according to a distributor's order cycle.

--- a/app/services/backorder_updater.rb
+++ b/app/services/backorder_updater.rb
@@ -58,6 +58,9 @@ class BackorderUpdater
     variants.map do |variant|
       link = variant.semantic_links[0].semantic_id
       solution = broker.best_offer(link)
+
+      next unless solution.offer
+
       line = orderer.find_or_build_order_line(backorder, solution.offer)
       if variant.on_demand
         adjust_stock(variant, solution, line)
@@ -66,7 +69,7 @@ class BackorderUpdater
       end
 
       line
-    end
+    end.compact
   end
 
   def cancel_stale_lines(unprocessed_lines, managed_variants, broker)

--- a/spec/services/backorder_updater_spec.rb
+++ b/spec/services/backorder_updater_spec.rb
@@ -107,6 +107,13 @@ RSpec.describe BackorderUpdater do
         .to change { backorder.lines.count }.from(2).to(1)
         .and change { beans.reload.on_hand }.by(-12)
     end
+
+    it "skips updating if there's is no backorder" do
+      allow_any_instance_of(FdcBackorderer).to receive(:find_open_order)
+        .and_return(nil)
+
+      expect { subject.amend_backorder(order) }.not_to raise_error
+    end
   end
 
   describe "#distributed_linked_variants" do

--- a/spec/system/consumer/checkout/backorder_spec.rb
+++ b/spec/system/consumer/checkout/backorder_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+RSpec.describe "Checkout" do
+  include ShopWorkflow
+  include CheckoutHelper
+
+  let(:variant) { order.variants.first }
+  let(:order) { create(:order_ready_for_confirmation) }
+
+  before do
+    variant.semantic_links << SemanticLink.new(semantic_id: "https://product")
+    set_order order
+    login_as create(:user)
+  end
+
+  it "triggers a backorder" do
+    visit checkout_step_path(:summary)
+
+    expect { place_order }.to enqueue_job BackorderJob
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Closes #13056 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We had a case when an order was updated after the order cycle closed. The backorder amendment failed because the backorder was completed already. We now handle this gracefully by skipping the amendment. But if the order cycle is still open or will open then we can actually create a new backorder. We can assume that the order cycle hasn't had a backorder yet.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Have an upcoming or open order cycle with FDC products.
- Place an order as admin for that order cycle with FDC products.
- A backorder in Shopify should be created.
- After the order cycle closed, update one of the orders in OFN.
- No new backorder should be created.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
