### PR TITLE
Fix flaky admin order spec

### DIFF
--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -189,12 +189,13 @@ RSpec.describe '
 
       expect {
         select2_select product.name, from: 'add_variant_id', search: true
+
         find('button.add_variant').click
+
+        expect(page).to have_css("#order_adjustments", text: 15.00)
+        expect(page).to have_css(".order-total", text: 63.99)
       }.to change { order_with_fees.payments.first.adjustment.amount }.from(10.00).to(15.00)
         .and change { order_with_fees.reload.total }.from(36.00).to(63.99)
-
-      expect(page).to have_css("#order_adjustments", text: 15.00)
-      expect(page).to have_css(".order-total", text: 63.99)
     end
   end
 


### PR DESCRIPTION

#### What? Why?

- Closes #11462 <!-- Insert issue number here. -->

The issue is referring to a different case in the same spec file. But I think that the described case was fixed by another commit:

* a74cf970839ba4fa0c38f53435aef9beb6c5291c

Here I'm fixing another case that I stumbled across:

* https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/12699353717/job/35399821033?pr=12491

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We were trying to assert values in the database without waiting for he update to finish. First expecting the changed values on the screen ensures that Capybara waits for the action to finish. Then we can check the database.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
