### PR TITLE
New variants should inherit tax category in UI

### DIFF
--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -14,6 +14,7 @@ module Admin
       # e.g producer_options = [['producer name', id]]
       product.variants.build do |new_variant|
         new_variant.supplier_id = producer_options.first.second if producer_options.one?
+        new_variant.tax_category_id = product.variants.first.tax_category_id
       end
     end
 

--- a/spec/helpers/admin/products_helper_spec.rb
+++ b/spec/helpers/admin/products_helper_spec.rb
@@ -46,4 +46,19 @@ RSpec.describe Admin::ProductsHelper do
       end
     end
   end
+
+  describe '#prepare_new_variant' do
+    let(:zone) { create(:zone_with_member) }
+    let(:product) {
+      create(:taxed_product, zone:, price: 12.54, tax_rate_amount: 0,
+                             included_in_price: true)
+    }
+
+    context 'when tax category is present for first varient' do
+      it 'sets tax category for new variant' do
+        first_variant_tax_id = product.variants.first.tax_category_id
+        expect(helper.prepare_new_variant(product, []).tax_category_id).to eq(first_variant_tax_id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/12120

Creation of a new variant was setting tax category as none. This is problematic for any hub selling taxable products. The fix is on creating a new variant in the UI it should set tax category from the first variant.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit page. - /admin/products
- Create a new variant for any product that already has tax category set for its first variant.

After changes it should behave similar to below

https://github.com/user-attachments/assets/4f5693e2-fe0e-4bec-b55d-4dc9714d92c6



#### Release notes


Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
