### PR TITLE
Update ActionCable config

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -16,6 +16,7 @@ SECRET_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 OFN_REDIS_URL="redis://localhost:6379/1"
 OFN_REDIS_JOBS_URL="redis://localhost:6379/2"
+OFN_REDIS_CABLE_URL="redis://localhost:6379/0"
 
 SITE_URL="0.0.0.0:3000"
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,12 +5,12 @@ development:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("OFN_REDIS_URL", "redis://localhost:6380/0") %>
+  url: <%= ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/0") %>
   channel_prefix: your_application_production
 
 staging:
   adapter: redis
-  url: <%= ENV.fetch("OFN_REDIS_URL", "redis://localhost:6380/0") %>
+  url: <%= ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/0") %>
   channel_prefix: your_application_staging
 
 test:

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,19 +1,19 @@
 development:
   adapter: redis
-  url: <%= ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/1") %>
+  url: <%= ENV.fetch("OFN_REDIS_CABLE_URL", "redis://localhost:6379/1") %>
   channel_prefix: your_application_development
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/0") %>
+  url: <%= ENV.fetch("OFN_REDIS_CABLE_URL", "redis://localhost:6379/0") %>
   channel_prefix: your_application_production
 
 staging:
   adapter: redis
-  url: <%= ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/0") %>
+  url: <%= ENV.fetch("OFN_REDIS_CABLE_URL", "redis://localhost:6379/0") %>
   channel_prefix: your_application_staging
 
 test:
   adapter: redis
-  url: <%= ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/1") %>
+  url: <%= ENV.fetch("OFN_REDIS_CABLE_URL", "redis://localhost:6379/1") %>
   channel_prefix: your_application_test


### PR DESCRIPTION
#### What? Why?

- Closes # <!-- Insert issue number here. -->

Update ActionCable configuration to use the first redis instance, running on port 6379, it's currently unused in production. The second instance is configured specifically for cache use and the third one to be used a job queue for Sidekiq. 
Although it would make more sense to have the cache on the first redis instance, as it's the "most default" part of rails, it would involve changing the redis configuration. This is the quicker change. 

It also allow the ActionCable redis url to be configured by using the env variable  `OFN_REDIS_CABLE_URL`, it's useful to set up a dev environment.  

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Test any pages using Reflexes
For instance:

As an enterprise manager

- Visit enterprise configuration page
- Click on "Users" in the left hand side menu
- Click on "Add an unregistered user"
- Enter an email and click on "Invite"
  -> The invite proceed with no error message

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Dependency
We need to fix the production server before we can merge this PR, see: https://github.com/openfoodfoundation/ofn-install/pull/988 :heavy_check_mark: 