### PR TITLE
Publish price as in new DFC standard

### DIFF
--- a/engines/dfc_provider/app/services/offer_builder.rb
+++ b/engines/dfc_provider/app/services/offer_builder.rb
@@ -7,10 +7,17 @@ class OfferBuilder < DfcBuilder
       id: variant.id,
     )
 
+    price = DataFoodConsortium::Connector::Price.new(
+      value: variant.price.to_f,
+
+      # The DFC measures define only five currencies at the moment.
+      # And they are not standardised enough to align with our ISO 4217
+      # currency codes. So I propose to just use those currency codes instead.
+      # https://github.com/datafoodconsortium/taxonomies/issues/48
+      unit: "dfc-m:#{variant.currency}",
+    )
     DataFoodConsortium::Connector::Offer.new(
-      id,
-      price: variant.price.to_f,
-      stockLimitation: stock_limitation(variant),
+      id, price:, stockLimitation: stock_limitation(variant),
     )
   end
 

--- a/engines/dfc_provider/spec/services/offer_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/offer_builder_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../spec_helper"
 
 RSpec.describe OfferBuilder do
-  let(:variant) { build(:variant) }
+  let(:variant) { build(:variant, id: 5) }
 
   describe ".offer" do
     it "assigns a stock level" do
@@ -25,6 +25,15 @@ RSpec.describe OfferBuilder do
       offer = OfferBuilder.build(variant)
 
       expect(offer.stockLimitation).to eq nil
+    end
+
+    it "assigns a price with currency" do
+      variant.id = 5
+
+      offer = OfferBuilder.build(variant)
+
+      expect(offer.price.value).to eq 19.99
+      expect(offer.price.unit).to eq "dfc-m:AUD"
     end
   end
 end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -181,7 +181,10 @@ paths:
                       ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
                     - "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
                       "@type": dfc-b:Offer
-                      dfc-b:hasPrice: 19.99
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AUD
                       dfc-b:stockLimitation: 0
         '401':
           description: unauthorized
@@ -219,7 +222,10 @@ paths:
                       dfc-b:offeredThrough: http://test.host/api/dfc/enterprises/10000/offers/10001
                     - "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
                       "@type": dfc-b:Offer
-                      dfc-b:hasPrice: 19.99
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AUD
                       dfc-b:stockLimitation: 0
         '404':
           description: not found
@@ -499,7 +505,10 @@ paths:
                     "@context": https://www.datafoodconsortium.org
                     "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
                     "@type": dfc-b:Offer
-                    dfc-b:hasPrice: 19.99
+                    dfc-b:hasPrice:
+                      "@type": dfc-b:Price
+                      dfc-b:value: 19.99
+                      dfc-b:hasUnit: dfc-m:AUD
                     dfc-b:stockLimitation: 5
     put:
       summary: Update Offer


### PR DESCRIPTION
#### What? Why?

I noticed that our API documentation was out of date and we didn't publish prices correctly.

The change may affect API integrations that read prices from the OFN catalog. An offer's price attribute is now an object with currency instead of just a number value:

```diff
-                      dfc-b:hasPrice: 19.99
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AUD
```

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
