### PR TITLE
Do not allow spaces in external billing

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -133,6 +133,9 @@ class Enterprise < ApplicationRecord
               message: Spree.t('errors.messages.invalid_instagram_url')
             }, allow_blank: true
   validate :validate_white_label_logo_link
+  validates :external_billing_id,
+            format: { with: /\A\S+\Z/ },
+            allow_blank: true
 
   before_validation :initialize_permalink, if: lambda { permalink.nil? }
   before_validation :set_unused_address_fields

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -134,7 +134,7 @@ class Enterprise < ApplicationRecord
             }, allow_blank: true
   validate :validate_white_label_logo_link
   validates :external_billing_id,
-            format: { with: /\A\S+\Z/ },
+            format: { with: /^\S+$/ },
             allow_blank: true
 
   before_validation :initialize_permalink, if: lambda { permalink.nil? }

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -134,7 +134,7 @@ class Enterprise < ApplicationRecord
             }, allow_blank: true
   validate :validate_white_label_logo_link
   validates :external_billing_id,
-            format: { with: /\A\S+\Z/ },
+            format: { with: /\A\S+\z/ },
             allow_blank: true
 
   before_validation :initialize_permalink, if: lambda { permalink.nil? }

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -134,7 +134,7 @@ class Enterprise < ApplicationRecord
             }, allow_blank: true
   validate :validate_white_label_logo_link
   validates :external_billing_id,
-            format: { with: /^\S+$/ },
+            format: { with: /\A\S+\Z/ },
             allow_blank: true
 
   before_validation :initialize_permalink, if: lambda { permalink.nil? }

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -415,6 +415,18 @@ RSpec.describe Enterprise do
         expect(e).not_to be_valid
       end
     end
+
+    describe "external_billing_id" do
+      it "validates the external_billing_id attribute" do
+        e = build(:enterprise, external_billing_id: '123456')
+        expect(e).to be_valid
+      end
+
+      it "does not validate the external_billing_id attribute with spaces" do
+        e = build(:enterprise, external_billing_id: '123 456')
+        expect(e).not_to be_valid
+      end
+    end
   end
 
   describe "serialisation" do


### PR DESCRIPTION
**⚠️ when working on this use [#12942 Invoicing ID](https://app.clockify.me/projects/6718e92c391d371937e54688/edit) clockify code**
#### What? Why?

- Closes #13073 

I forgot to add a basic validation on the external_billing_id field on my last PR.


#### What should we test?
- Visit an enterprise page as superadmin
- Try to change the External Billing Id field on Primary Details tab
- Verify that adding a space on the value is failing the form submission

#### Release notes
- Do not allow spaces in external billing id on enterprises

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
