### PR TITLE
Fetch variant enterprise fees from order lineitems adjustments #11529

### DIFF
--- a/lib/reporting/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_producer.rb
+++ b/lib/reporting/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_producer.rb
@@ -161,11 +161,9 @@ module Reporting
         # { variant: [enterprise_fee_ids] }
         def enterprise_fees_per_variant(order)
           hash = {}
-          order.order_cycle.exchanges.each do |exchange|
-            exchange.variants.each do |variant|
-              hash[variant] ||= order.order_cycle.coordinator_fee_ids
-              hash[variant] += exchange.enterprise_fee_ids
-            end
+          order.line_items.each do |li|
+            hash[li.variant] ||= order.order_cycle.coordinator_fee_ids
+            hash[li.variant] += li.adjustments.enterprise_fee.map(&:originator_id)
           end
           hash
         end

--- a/spec/lib/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_producer_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/enterprise_fees_with_tax_report_by_producer_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe Reporting::Reports::EnterpriseFeeSummary::EnterpriseFeesWithTaxRe
 
     report = described_class.new(current_user)
 
-    pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/11529"
     expect(report.query_result.values).to eq [[order]]
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #11529

When the order exchange is removed, the variant enterprise fees cannot be summarized. The change uses the order line item adjustment information to get the variant enterprise fee ids instead.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Create an order with per item enterprise fee. Run the tax report by producer enterprise fees and note the resulting enterprise fees. 
- Remove the exchange of the order cycle of that order. Rerun the tax report by producer enterprise fees and note that the resulting enterprise fees are still the same/have not disappeared. 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


