### PR TITLE
Remove tax rate refund code path

### DIFF
--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -101,25 +101,9 @@ module Spree
 
     # This method is used by Adjustment#update to recalculate the cost.
     def compute_amount(item)
-      if included_in_price
-        if default_zone_or_zone_match?(item.order)
-          calculator.compute(item)
-        else
-          # Tax refund should not be possible with the way our production server are configured
-          Alert.raise(
-            "Notice: Tax refund should not be possible, please check the default zone and " \
-            "the tax rate zone configuration"
-          ) do |payload|
-            payload.add_metadata :order_tax_zone, item.order.tax_zone
-            payload.add_metadata :tax_rate_zone, zone
-            payload.add_metadata :default_zone, Zone.default_tax
-          end
-          # In this case, it's a refund.
-          calculator.compute(item) * - 1
-        end
-      else
-        calculator.compute(item)
-      end
+      return 0 if included_in_price && !default_zone_or_zone_match?(item.order)
+
+      calculator.compute(item)
     end
 
     def default_zone_or_zone_match?(order)

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -105,7 +105,7 @@ module Spree
         if default_zone_or_zone_match?(item.order)
           calculator.compute(item)
         else
-          # In this case, it's a refund.
+          # In this case, it's a refund (for instance offering a manual discount via an adjustment)
           calculator.compute(item) * - 1
         end
       else

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -101,9 +101,16 @@ module Spree
 
     # This method is used by Adjustment#update to recalculate the cost.
     def compute_amount(item)
-      return 0 if included_in_price && !default_zone_or_zone_match?(item.order)
-
-      calculator.compute(item)
+      if included_in_price
+        if default_zone_or_zone_match?(item.order)
+          calculator.compute(item)
+        else
+          # In this case, it's a refund.
+          calculator.compute(item) * - 1
+        end
+      else
+        calculator.compute(item)
+      end
     end
 
     def default_zone_or_zone_match?(order)

--- a/app/models/spree/zone.rb
+++ b/app/models/spree/zone.rb
@@ -7,6 +7,8 @@ module Spree
     has_and_belongs_to_many :shipping_methods, join_table: 'spree_shipping_methods_zones'
 
     validates :name, presence: true, uniqueness: true
+    validates :zone_members, presence: true
+
     after_save :remove_defunct_members
     after_save :remove_previous_default
 

--- a/app/views/spree/admin/zones/index.html.haml
+++ b/app/views/spree/admin/zones/index.html.haml
@@ -22,7 +22,7 @@
       %tr
         %th= sort_link [:spree, @search], :name, t("spree.name"), title: 'zones_order_by_name_title'
         %th
-          = sort_link [:spree, @search], :description, t("spree.description"), {}, {title: 'zones_order_by_description_title'}
+          = sort_link [:spree, @search], :description, t("spree.description"), {title: 'zones_order_by_description_title'}
         %th= t("spree.default_tax")
         %th.actions
     %tbody

--- a/app/views/spree/admin/zones/new.html.haml
+++ b/app/views/spree/admin/zones/new.html.haml
@@ -11,5 +11,7 @@
 
 = form_for [:admin, @zone] do |zone_form|
   = render partial: 'form', locals: { zone_form: zone_form }
+  = render partial: 'member_type', locals: { type: 'country', zone_form: zone_form }
+  = render partial: 'member_type', locals: { type: 'state', zone_form: zone_form }
   .clear
   = render partial: 'spree/admin/shared/new_resource_links'

--- a/db/default/zones.rb
+++ b/db/default/zones.rb
@@ -1,24 +1,25 @@
 # frozen_string_literal: true
 
 unless Spree::Zone.find_by(name: "EU_VAT")
-  eu_vat = Spree::Zone.create(name: "EU_VAT",
-                              description: "Countries that make up the EU VAT zone.")
+  eu_vat = Spree::Zone.new(
+    name: "EU_VAT", description: "Countries that make up the EU VAT zone."
+  )
 
   ["Poland", "Finland", "Portugal", "Romania", "Germany", "France",
    "Slovakia", "Hungary", "Slovenia", "Ireland", "Austria", "Spain",
    "Italy", "Belgium", "Sweden", "Latvia", "Bulgaria", "United Kingdom",
    "Lithuania", "Cyprus", "Luxembourg", "Malta", "Denmark", "Netherlands",
    "Estonia"].each do |name|
-    eu_vat.zone_members << Spree::ZoneMember.create(zoneable: Spree::Country.find_by!(name:))
+    eu_vat.zone_members.new(zoneable: Spree::Country.find_by!(name:))
   end
   eu_vat.save!
 end
 
 unless Spree::Zone.find_by(name: "North America")
-  north_america = Spree::Zone.create(name: "North America", description: "USA + Canada")
+  north_america = Spree::Zone.new(name: "North America", description: "USA + Canada")
 
   ["United States", "Canada"].each do |name|
-    north_america.zone_members << Spree::ZoneMember.create(zoneable: Spree::Country.find_by!(name:))
+    north_america.zone_members.new(zoneable: Spree::Country.find_by!(name:))
   end
   north_america.save!
 end

--- a/db/default/zones.rb
+++ b/db/default/zones.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 unless Spree::Zone.find_by(name: "EU_VAT")
-  eu_vat = Spree::Zone.create(name: "EU_VAT", description: "Countries that make up the EU VAT zone.")
+  eu_vat = Spree::Zone.create(name: "EU_VAT",
+                              description: "Countries that make up the EU VAT zone.")
 
   ["Poland", "Finland", "Portugal", "Romania", "Germany", "France",
    "Slovakia", "Hungary", "Slovenia", "Ireland", "Austria", "Spain",

--- a/db/default/zones.rb
+++ b/db/default/zones.rb
@@ -1,22 +1,21 @@
-# frozen_string_literal: true
-
 unless Spree::Zone.find_by(name: "EU_VAT")
-  eu_vat = Spree::Zone.create!(name: "EU_VAT",
-                               description: "Countries that make up the EU VAT zone.")
+  eu_vat = Spree::Zone.create(name: "EU_VAT", description: "Countries that make up the EU VAT zone.")
 
   ["Poland", "Finland", "Portugal", "Romania", "Germany", "France",
    "Slovakia", "Hungary", "Slovenia", "Ireland", "Austria", "Spain",
    "Italy", "Belgium", "Sweden", "Latvia", "Bulgaria", "United Kingdom",
    "Lithuania", "Cyprus", "Luxembourg", "Malta", "Denmark", "Netherlands",
    "Estonia"].each do |name|
-    eu_vat.zone_members.create!(zoneable: Spree::Country.find_by!(name:))
+    eu_vat.zone_members << Spree::ZoneMember.create(zoneable: Spree::Country.find_by!(name:))
   end
+  eu_vat.save!
 end
 
 unless Spree::Zone.find_by(name: "North America")
-  north_america = Spree::Zone.create!(name: "North America", description: "USA + Canada")
+  north_america = Spree::Zone.create(name: "North America", description: "USA + Canada")
 
   ["United States", "Canada"].each do |name|
-    north_america.zone_members.create!(zoneable: Spree::Country.find_by!(name:))
+    north_america.zone_members << Spree::ZoneMember.create(zoneable: Spree::Country.find_by!(name:))
   end
+  north_america.save!
 end

--- a/lib/tasks/sample_data/addressing.rb
+++ b/lib/tasks/sample_data/addressing.rb
@@ -16,8 +16,10 @@ module Addressing
   end
 
   def zone
-    zone = Spree::Zone.find_or_create_by!(name: ENV.fetch('CHECKOUT_ZONE'))
-    zone.members.create!(zoneable: country) unless zone.zoneables.include?(country)
+    zone = Spree::Zone.find_or_create_by(name: ENV.fetch('CHECKOUT_ZONE'))
+    zone.members << Spree::ZoneMember.create(zoneable: country) unless
+      zone.zoneables.include?(country)
+    zone.save!
     zone
   end
 

--- a/spec/factories/zone_factory.rb
+++ b/spec/factories/zone_factory.rb
@@ -1,21 +1,18 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :zone, class: Spree::Zone do
+  factory :zone, aliases: [:zone_with_member], class: Spree::Zone do
     sequence(:name) { |n| "#{generate(:random_string)}#{n}" }
     description { generate(:random_string) }
-  end
+    default_tax { true }
+    zone_members { [Spree::ZoneMember.new(zoneable: member)] }
 
-  factory :zone_with_member, parent: :zone do
     transient do
       member { Spree::Country.find_by(name: "Australia") }
     end
-
-    default_tax { true }
-    zone_members { [Spree::ZoneMember.new(zoneable: member)] }
   end
 
-  factory :zone_with_state_member, parent: :zone_with_member do
+  factory :zone_with_state_member, parent: :zone do
     member { Spree::State.find_by(name: "Victoria") }
   end
 end

--- a/spec/helpers/spree/base_helper_spec.rb
+++ b/spec/helpers/spree/base_helper_spec.rb
@@ -26,9 +26,8 @@ RSpec.describe Spree::BaseHelper do
     context "with a checkout zone defined" do
       context "checkout zone is of type country" do
         before do
-          @country_zone = create(:zone, name: "CountryZone")
-          @country_zone.members.create(zoneable: country)
-          allow(ENV).to receive(:fetch).and_return(@country_zone.name)
+          country_zone = create(:zone, name: "CountryZone", member: country)
+          allow(ENV).to receive(:fetch).and_return(country_zone.name)          
         end
 
         it "return only the countries defined by the checkout zone" do

--- a/spec/models/invoice/data_presenter_spec.rb
+++ b/spec/models/invoice/data_presenter_spec.rb
@@ -61,9 +61,10 @@ RSpec.describe Invoice::DataPresenter do
         expect(presenter.display_line_item_tax_rate(taxable_line_item)).to eq "15.0%, 20.0%"
       end
 
-      context "one of the tax rate is appliable to a different tax zone" do
+      context "one of the tax rate is applicable to a different tax zone" do
         before do
-          order.line_items.last.tax_category.tax_rates.last.update!(zone: create(:zone))
+          new_zone = create(:zone, default_tax: false, member: Spree::Country.last)
+          order.line_items.last.tax_category.tax_rates.last.update!(zone: new_zone)
           order.create_tax_charge!
           Orders::GenerateInvoiceService.new(order).generate_or_update_latest_invoice
         end

--- a/spec/models/spree/tax_rate_spec.rb
+++ b/spec/models/spree/tax_rate_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Spree
   RSpec.describe TaxRate do
-    describe "#match" do
+    describe ".match" do
       let!(:zone) { create(:zone_with_member) }
       let!(:order) { create(:order, distributor: hub, bill_address: create(:address)) }
       let!(:tax_rate) {
@@ -44,7 +44,7 @@ module Spree
         let(:tax_category) { create(:tax_category) }
         let(:calculator) { ::Calculator::FlatRate.new }
 
-        it "should return an empty array when tax_zone is nil" do
+        it "returns an empty array when tax_zone is nil" do
           allow(order).to receive(:tax_zone) { nil }
           expect(Spree::TaxRate.match(order)).to eq []
         end
@@ -57,12 +57,12 @@ module Spree
           context "when there is no default tax zone" do
             let(:zone) { create( :zone, name: "Country Zone", default_tax: false, member: country) }
 
-            it "should return an empty array" do
+            it "returns an empty array" do
               allow(order).to receive(:tax_zone).and_return(zone)
               expect(Spree::TaxRate.match(order)).to eq []
             end
 
-            it "should return the rate that matches the rate zone" do
+            it "returns the rate that matches the rate zone" do
               rate = Spree::TaxRate.create(
                 amount: 1,
                 zone:,
@@ -75,7 +75,7 @@ module Spree
               expect(Spree::TaxRate.match(order)).to eq [rate]
             end
 
-            it "should return all rates that match the rate zone" do
+            it "returns all rates that match the rate zone" do
               rate1 = Spree::TaxRate.create(
                 amount: 1,
                 zone:,
@@ -98,7 +98,7 @@ module Spree
             context "when the tax_zone is contained within a rate zone" do
               let(:sub_zone) { create(:zone, name: "State Zone", member: create(:state, country:)) }
 
-              it "should return the rate zone" do
+              it "returns the rate zone" do
                 allow(order).to receive(:tax_zone).and_return(sub_zone)
 
                 rate = Spree::TaxRate.create(
@@ -192,7 +192,7 @@ module Spree
         end
       end
 
-      context "default" do
+      describe ".default" do
         let(:tax_category) { create(:tax_category) }
         let(:country) { create(:country) }
         let(:calculator) { ::Calculator::FlatRate.new }
@@ -200,7 +200,7 @@ module Spree
         context "when there is no default tax_category" do
           before { tax_category.is_default = false }
 
-          it "should return 0" do
+          it "returns 0" do
             expect(Spree::TaxRate.default).to eq 0
           end
         end
@@ -211,23 +211,22 @@ module Spree
           context "when the default category has tax rates in the default tax zone" do
             before(:each) do
               allow(DefaultCountry).to receive(:id) { country.id }
-              @zone = create(:zone, name: "Country Zone", default_tax: true)
-              @zone.zone_members.create(zoneable: country)
+              zone = create(:zone, name: "Country Zone", default_tax: true, member: country)
               rate = Spree::TaxRate.create(
                 amount: 1,
-                zone: @zone,
+                zone:,
                 tax_category:,
                 calculator:
               )
             end
 
-            it "should return the correct tax_rate" do
+            it "returns the correct tax_rate" do
               expect(Spree::TaxRate.default.to_f).to eq 1.0
             end
           end
 
           context "when the default category has no tax rates in the default tax zone" do
-            it "should return 0" do
+            it "returns 0" do
               expect(Spree::TaxRate.default).to eq 0
             end
           end
@@ -264,7 +263,7 @@ module Spree
         context "not taxable line item " do
           let!(:line_item) { order.contents.add(nontaxable, 1) }
 
-          it "should not create a tax adjustment" do
+          it "does not create a tax adjustment" do
             Spree::TaxRate.adjust(order, order.line_items)
             expect(line_item.adjustments.tax.charge.count).to eq 0
           end

--- a/spec/models/spree/zone_spec.rb
+++ b/spec/models/spree/zone_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Zone do
-  context "#match" do
+  describe "#match" do
     let(:country_zone) { create(:zone, name: 'CountryZone') }
     let(:country) do
       country = create(:country)
@@ -63,7 +63,7 @@ RSpec.describe Spree::Zone do
     end
   end
 
-  context "#countries" do
+  describe "#countries" do
     let(:state) { create(:state) }
     let(:country) { state.country }
 
@@ -88,7 +88,7 @@ RSpec.describe Spree::Zone do
     end
   end
 
-  context "#contains_address?" do
+  describe "#contains_address?" do
     let(:state) { create(:state) }
     let(:country) { state.country }
     let(:address) { create(:address, country:, state:) }
@@ -112,7 +112,7 @@ RSpec.describe Spree::Zone do
     end
   end
 
-  context ".default_tax" do
+  describe ".default_tax" do
     context "when there is a default tax zone specified" do
       before { @foo_zone = create(:zone, name: 'whatever', default_tax: true) }
 
@@ -129,7 +129,7 @@ RSpec.describe Spree::Zone do
     end
   end
 
-  context "#contains?" do
+  describe "#contains?" do
     let(:country1) { create(:country) }
     let(:country2) { create(:country) }
     let(:country3) { create(:country) }
@@ -257,7 +257,7 @@ RSpec.describe Spree::Zone do
     end
   end
 
-  context "#save" do
+  describe "#save" do
     context "when default_tax is true" do
       it "should clear previous default tax zone" do
         zone1 = create(:zone, name: 'foo', default_tax: true)
@@ -279,7 +279,7 @@ RSpec.describe Spree::Zone do
     end
   end
 
-  context "#kind" do
+  describe "#kind" do
     context "when the zone consists of country zone members" do
       before do
         @zone = create(:zone, name: 'country', zone_members: [])

--- a/spec/models/spree/zone_spec.rb
+++ b/spec/models/spree/zone_spec.rb
@@ -3,6 +3,12 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Zone do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name) }
+    it { is_expected.to validate_presence_of(:zone_members) }
+  end
+
   describe "#match" do
     let(:country_zone) { create(:zone, name: 'CountryZone') }
     let(:country) do

--- a/spec/system/admin/adjustments_spec.rb
+++ b/spec/system/admin/adjustments_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe '
   }
 
   let!(:tax_category_included) { create(:tax_category, name: 'TVA 20%', is_default: true) }
-  let!(:default_tax_zone) { create(:zone, default_tax: true) }
+  let!(:default_tax_zone) { create(:zone, default_tax: true, member: Spree::Country.last) }
   let!(:tax_rate2) {
     create(:tax_rate, name: "TVA 20%", amount: 0.2, zone: default_tax_zone, included_in_price: true,
                       tax_category: tax_category_included, calculator: Calculator::DefaultTax.new )

--- a/spec/system/admin/configuration/tax_rates_spec.rb
+++ b/spec/system/admin/configuration/tax_rates_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe "Tax Rates" do
   include AuthenticationHelper
 
   let!(:calculator) { create(:calculator_per_item, calculable: create(:order)) }
-  let!(:tax_rate) { create(:tax_rate, name: "IVA", calculator:) }
-  let!(:zone) { create(:zone, name: "Ilhas") }
+  let!(:tax_rate) {
+    create(:tax_rate, name: "IVA", calculator:, zone: create(:zone, default_tax: false))
+  }
+  let!(:zone) { create(:zone, name: "Ilhas", default_tax: false) }
   let!(:tax_category) { create(:tax_category, name: "Full") }
 
   before do

--- a/spec/system/admin/configuration/zones_spec.rb
+++ b/spec/system/admin/configuration/zones_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe "Zones" do
   include AuthenticationHelper
   include WebHelper
 
+  before do
+    Spree::Zone.delete_all
+  end
+
   it "list existing zones" do
     login_as_admin
     visit spree.edit_admin_general_settings_path
@@ -34,6 +38,11 @@ RSpec.describe "Zones" do
 
     fill_in "zone_name", with: "japan"
     fill_in "zone_description", with: "japanese time zone"
+    choose "Country Based"
+
+    click_link "Add country"
+    find('.select2').find(:xpath, 'option[2]').select_option
+
     click_button "Create"
 
     expect(page).to have_content("successfully created!")


### PR DESCRIPTION
#### What? Why?
Follow up from #12921
Since Bugsnag was added, it has been triggered once on in `hu_prod`, which was due to a misconfiguration of the zone, no country was assigned to zone used for tax. Same problem that lead to the discovery of the issue in the first place. 
This PR address the issue by fixing the zone screen, it now requires at least on state or country.

I originally thought we could remove the "refund code" but there are some legitimate use, for instance offering a manual discount via an adjustment see : https://github.com/openfoodfoundation/openfoodnetwork/blob/master/spec/system/admin/adjustments_spec.rb

Reviewer: the git history isn't great as I kept my attempt at deleting the "refund code" 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


As a super admin : 

- Visit Configuration -> Zone
- Try creating a new zone without adding any member 
  --> you should get an error: "Zone members can't be blank"
- Try updating a existing zone with no member
  --> you should get an error: "Zone members can't be blank"

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.