### PR TITLE
Handle wrong OIDC tokens gracefully

### DIFF
--- a/engines/dfc_provider/app/services/authorization_control.rb
+++ b/engines/dfc_provider/app/services/authorization_control.rb
@@ -20,7 +20,7 @@ class AuthorizationControl
 
   def user
     oidc_user || ofn_api_user || ofn_user
-  rescue JWT::ExpiredSignature
+  rescue JWT::DecodeError
     nil
   end
 

--- a/engines/dfc_provider/spec/services/authorization_control_spec.rb
+++ b/engines/dfc_provider/spec/services/authorization_control_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe AuthorizationControl do
 
       expect(auth(oidc_token: token).user).to eq nil
     end
+
+    it "ignores malformed tokens" do
+      token = "eyJhbGciOiJSUzI1NiIsInR5c"
+
+      expect(auth(oidc_token: token).user).to eq nil
+    end
   end
 
   describe "with OFN API token" do


### PR DESCRIPTION

#### What? Why?

- Closes https://app.bugsnag.com/yaycode/openfoodnetwork-uk/errors/6792b3804714603e79cb8efc

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

If you copy and paste only part of a token then a general DecodeError is raised. It's the parent class for all other related errors like for expired signatures.

Now we just fail authentication instead of raising a server error.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only. Not worth testing.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
