### PR TITLE
Creates GH Actions section for sample data

### DIFF
--- a/.github/workflows/sample_data.yaml
+++ b/.github/workflows/sample_data.yaml
@@ -13,7 +13,7 @@ on:
           - staging.openfoodnetwork.org.uk
           - staging.openfoodnetwork.org.au
           - staging.coopcircuits.fr
-      sample_data:
+      sample_data_name:
         description: "Sample Data Name"
         type: string
         required: true
@@ -35,5 +35,5 @@ jobs:
           sudo systemctl stop puma sidekiq
           mkdir -p ~/backup/
           pg_dump -h localhost -U ofn_user openfoodnetwork | gzip > ~/backup/staging-`date +%Y%m%d%H%M%S`-before-reset.sql.gz
-          bundle exec rake db:reset ofn:sample_data
+          bundle exec rake db:reset ofn:${{ secrets.sample_data_name }}
           sudo systemctl stop puma sidekiq

--- a/.github/workflows/sample_data.yaml
+++ b/.github/workflows/sample_data.yaml
@@ -33,7 +33,6 @@ jobs:
         if: success()
         run: |
           sudo systemctl stop puma sidekiq
-          mkdir -p ~/backup/
-          pg_dump -h localhost -U ofn_user openfoodnetwork | gzip > ~/backup/staging-`date +%Y%m%d%H%M%S`-before-reset.sql.gz
+          ~/apps/openfoodnetwork/current/script/ci/save-staging-baseline.sh
           bundle exec rake db:reset ofn:${{ secrets.sample_data_name }}
           sudo systemctl stop puma sidekiq

--- a/.github/workflows/sample_data.yaml
+++ b/.github/workflows/sample_data.yaml
@@ -1,0 +1,39 @@
+name: "Deploy Sample Data"
+
+on:
+  pull_request_target:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      server:
+        description: "Staging Server"
+        type: choice
+        required: true
+        options:
+          - staging.openfoodnetwork.org.uk
+          - staging.openfoodnetwork.org.au
+          - staging.coopcircuits.fr
+      sample_data:
+        description: "Sample Data Name"
+        type: string
+        required: true
+
+jobs:
+  deploy_sample_data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check user has write access"
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        with:
+          permission: "write"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run sample data script
+        if: success()
+        run: |
+          sudo systemctl stop puma sidekiq
+          mkdir -p ~/backup/
+          pg_dump -h localhost -U ofn_user openfoodnetwork | gzip > ~/backup/staging-`date +%Y%m%d%H%M%S`-before-reset.sql.gz
+          bundle exec rake db:reset ofn:sample_data
+          sudo systemctl stop puma sidekiq


### PR DESCRIPTION
#### What? Why?

- Closes #13094

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Introduces a section on GH-Actions to provide the possibility to manage creation of sample data.

Mockup:

![image](https://github.com/user-attachments/assets/47047276-39be-41d5-af88-c320f015bf87)

Marked in yellow: section on branch/tag to be removed. Not sure how to do this.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit GH-Actions section.
- Notice there is a new section called "Deploy Sample Data"
- Select it; Click Run Workflow (right side of the screen)
- It should open a menu, similar to the "Deploy to Staging"
- One should be able to select a staging server (dropdown)
- One should be able to and type in sample data file name
- Clicking Run Workflow should run the script, and:
  - make a backup/baseline of the DB
  - create sample data according to the given input

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

We'll need to add this to the testers handbook.