### PR TITLE
Specify OpenStreetMap marker size and tip position so they are positioned correctly at all zoom levels

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/open_street_map.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/open_street_map.js.coffee
@@ -13,6 +13,8 @@ angular.module('Darkswarm').directive 'ofnOpenStreetMap', ($window, MapCentreCal
 
     buildMarker = (enterprise, latlng, title) ->
       icon = L.icon
+        iconAnchor: [14, 33]
+        iconSize: [28, 33]
         iconUrl: enterprise.icon
       marker = L.marker latlng,
         draggable:   true,


### PR DESCRIPTION
#### What? Why?

- Closes #13070

**Before**

Before the size of Open Street Map markers and the position of the marker pin wasn't not set as suggested in the [Leaflet documentation](https://leafletjs.com/reference.html#icon). This was causing the markers to appear in the wrong position when the map was zoomed out.

https://github.com/user-attachments/assets/45ec2643-ae76-43ec-92de-244c04dda867

**After**

https://github.com/user-attachments/assets/f569b457-f9eb-4a2d-8602-e209f61b41c7

#### What should we test?

- Visit /map on an instance where Open Street Maps is in use.
- Check enterprise icons are positioned correctly when the map is zoomed out.

#### Release notes
Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes