### PR TITLE
Simplify default country code lookup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Set up database
         run: |
           bin/rails db:create db:schema:load
-          bin/rails runner spec/support/seeds.rb # Asset compile needs a country.
 
       - name: Run tests
         env:
@@ -213,7 +212,6 @@ jobs:
       - name: Set up database
         run: |
           bin/rails db:create db:schema:load
-          bin/rails runner spec/support/seeds.rb # Asset compile needs a country.
 
       - name: Run tests
 
@@ -301,7 +299,6 @@ jobs:
       - name: Set up database
         run: |
           bin/rails db:create db:schema:load
-          bin/rails runner spec/support/seeds.rb # Asset compile needs a country.
 
       - name: Run tests
 
@@ -390,7 +387,6 @@ jobs:
       - name: Set up database
         run: |
           bin/rails db:create db:schema:load
-          bin/rails runner spec/support/seeds.rb # Asset compile needs a country.
 
       - name: Run tests
 
@@ -470,7 +466,6 @@ jobs:
       - name: Set up database
         run: |
           bin/rails db:create db:schema:load
-          bin/rails runner spec/support/seeds.rb # Asset compile needs a country.
 
       - name: Run tests
         env:

--- a/app/services/default_country.rb
+++ b/app/services/default_country.rb
@@ -5,15 +5,14 @@ class DefaultCountry
     country.id
   end
 
+  # Two letter code defined in ISO-3166-1.
   def self.code
-    country.iso
+    # Changing ENV requires restarting the process.
+    ENV.fetch("DEFAULT_COUNTRY_CODE", nil)
   end
 
   def self.country
-    # Changing ENV requires restarting the process.
-    iso = ENV.fetch("DEFAULT_COUNTRY_CODE", nil)
-
     # When ENV changes on restart, this cache will be reset as well.
-    @country ||= Spree::Country.find_by(iso:) || Spree::Country.first
+    @country ||= Spree::Country.find_by(iso: code) || Spree::Country.first
   end
 end


### PR DESCRIPTION
#### What? Why?

Triggering asset precompilation on CI revealed that it was depending on a country entry in the database. But it was just accessing a country code which is available as environment variable. I removed that indirection which makes assets now independent of the database.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
