### PR TITLE
Remove unused preference default_country_id

### DIFF
--- a/app/models/spree/app_configuration.rb
+++ b/app/models/spree/app_configuration.rb
@@ -37,7 +37,6 @@ module Spree
     preference :currency_symbol_position, :string, default: "before"
     preference :currency_thousands_separator, :string, default: ","
     preference :display_currency, :boolean, default: false
-    preference :default_country_id, :integer
     preference :default_meta_description, :string, default: 'OFN demo site'
     preference :default_meta_keywords, :string, default: 'ofn, demo'
     preference :default_seo_title, :string, default: ''

--- a/db/migrate/20250128031518_delete_default_country_id_preference.rb
+++ b/db/migrate/20250128031518_delete_default_country_id_preference.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class DeleteDefaultCountryIdPreference < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL.squish
+      DELETE FROM spree_preferences
+      WHERE key = '/spree/app_configuration/default_country_id '
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_13_055412) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_28_031518) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -234,12 +234,10 @@ RSpec.configure do |config|
     end
   end
 
-  default_country_id = DefaultCountry.id
   # Ensure we start with consistent config settings
   config.before(:each) do
     reset_spree_preferences do |spree_config|
       # These are all settings that differ from Spree's defaults
-      spree_config.default_country_id = default_country_id
       spree_config.shipping_instructions = true
     end
     CurrentConfig.clear_all

--- a/spec/support/seeds.rb
+++ b/spec/support/seeds.rb
@@ -22,8 +22,3 @@ if Spree::Country.where(name: "France").empty?
   Spree::State.create!({ "name" => "Alsace", "abbr" => "Als", :country => country })
   Spree::State.create!({ "name" => "Aquitaine", "abbr" => "Aq", :country => country })
 end
-
-# Since the country seeding differs from other environments, the default
-# country id has to be updated here. This line can be removed as soon as the
-# default country id is replaced by something database independent.
-Spree::Config.default_country_id = Spree::Country.find_by(name: 'Australia').id


### PR DESCRIPTION
#### What? Why?

The default country is set by ofn-install as environment variable for the app. The old Spree preference to set the default country has been unused for nearly four years now. It's time to remove it.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Checkout as guest.
- The billing and shipping address should have the default country pre-selected.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
