### PR TITLE
Log rack-timeout ready and completed messages in DEBUG mode

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,7 @@
+# https://github.com/zombocom/rack-timeout/blob/main/doc/logging.md
+# state changes into timed_out and expired are logged at the ERROR level
+
+# Log ready and completed messages in DEBUG mode only (instead of default INFO)
+Rack::Timeout::StateChangeLoggingObserver::STATE_LOG_LEVEL[:ready] = :debug
+Rack::Timeout::StateChangeLoggingObserver::STATE_LOG_LEVEL[:completed] = :debug
+


### PR DESCRIPTION
#### What? Why?

I noticed heaps of unnecessary rack-timeout lines in server logs. There's one at the start and end of each request, but it doesn't provide any helpful info:
```
I, [2025-01-29 23:10:48 #2546762]  INFO -- : source=rack-timeout id=615f34b0-f409-4109-ab1a-534251436f77 wait=2ms timeout=29998ms state=ready
I, [2025-01-29 23:10:48 #2546762]  INFO -- : [615f34b0-f409-4109-ab1a-534251436f77] Started GET "/" for 172.105.161.249 at 2025-01-29 23:10:48 +0000
I, [2025-01-29 23:10:48 #2546762]  INFO -- : [615f34b0-f409-4109-ab1a-534251436f77] Processing by HomeController#index as */*
I, [2025-01-29 23:10:48 #2546762]  INFO -- : [615f34b0-f409-4109-ab1a-534251436f77]   Rendered home/index.html.haml within layouts/darkswarm (Duration: 17.5ms | Allocations: 5719)
I, [2025-01-29 23:10:48 #2546762]  INFO -- : [615f34b0-f409-4109-ab1a-534251436f77]   Rendered layout layouts/darkswarm.html.haml (Duration: 37.3ms | Allocations: 13696)
I, [2025-01-29 23:10:48 #2546762]  INFO -- : [615f34b0-f409-4109-ab1a-534251436f77] Completed 200 OK in 41ms (Views: 34.4ms | ActiveRecord: 3.4ms | Allocations: 14897)
I, [2025-01-29 23:10:48 #2546762]  INFO -- : source=rack-timeout id=615f34b0-f409-4109-ab1a-534251436f77 wait=2ms timeout=29998ms service=49ms state=completed
```

So we don't need these lines, but we still want to know when timeouts occur.

#### What should we test?

Note that rack-timeout is disabled on dev by default. 
I tested this in dev by adding a `sleep` to `HomeController` and enabling rack timeout in  `.env.development.local`:

```
RACK_TIMEOUT_SERVICE_TIMEOUT="10"
RACK_TIMEOUT_WAIT_TIMEOUT="10"
RACK_TIMEOUT_WAIT_OVERTIME="10"

DEV_LOG_LEVEL = info
```

Looks good: no unnecessary "ready" or "completed" messages, and it correctly shows "timed_out"

```
Started GET "/" for ::1 at 2025-01-30 10:24:55 +1100
Processing by HomeController#index as HTML
source=rack-timeout id=1088070d-ac06-4899-a096-01e4c60ec81d timeout=10000ms service=10001ms state=timed_out
  Rendered public/500.html (Duration: 0.4ms | Allocations: 99)
Completed 504 Gateway Timeout in 9899ms (Views: 8.0ms | ActiveRecord: 33.4ms | SQL Queries: 7 (0 cached) | Allocations: 192342)
```
