### PR TITLE
Allow producer to edit their products on hubs' orders

### DIFF
--- a/app/controllers/api/v0/orders_controller.rb
+++ b/app/controllers/api/v0/orders_controller.rb
@@ -67,7 +67,8 @@ module Api
       def serialized_orders(orders)
         ActiveModel::ArraySerializer.new(
           orders,
-          each_serializer: Api::Admin::OrderSerializer
+          each_serializer: Api::Admin::OrderSerializer,
+          current_user: current_api_user
         )
       end
 

--- a/app/controllers/spree/admin/variants_controller.rb
+++ b/app/controllers/spree/admin/variants_controller.rb
@@ -64,7 +64,10 @@ module Spree
       end
 
       def search
-        scoper = OpenFoodNetwork::ScopeVariantsForSearch.new(variant_search_params)
+        scoper = OpenFoodNetwork::ScopeVariantsForSearch.new(
+          variant_search_params,
+          spree_current_user
+        )
         @variants = scoper.search
         render json: @variants, each_serializer: ::Api::Admin::VariantSerializer
       end

--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -162,7 +162,7 @@ module Spree
       def display_value_for_producer(order, value)
         return value unless filter_by_supplier?(order)
 
-        order.distributor&.show_customer_names_to_suppliers ? value : t("admin.reports.hidden")
+        order.distributor&.show_customer_names_to_suppliers ? value : t("admin.reports.hidden_field")
       end
     end
   end

--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -162,7 +162,11 @@ module Spree
       def display_value_for_producer(order, value)
         return value unless filter_by_supplier?(order)
 
-        order.distributor&.show_customer_names_to_suppliers ? value : t("admin.reports.hidden_field")
+        if order.distributor&.show_customer_names_to_suppliers
+          value
+        else
+          t("admin.reports.hidden_field")
+        end
       end
     end
   end

--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -159,6 +159,11 @@ module Spree
           spree_current_user.can_manage_line_items_in_orders_only?
       end
 
+      def display_value_for_producer(order, value)
+        return value unless distributor_allows_order_editing?(order)
+
+        order.distributor&.show_customer_names_to_suppliers ? value : t("admin.reports.hidden")
+      end
     end
   end
 end

--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -142,6 +142,23 @@ module Spree
         end
         number_field_tag :quantity, manifest_item.quantity, html_options
       end
+
+      def prepare_shipment_manifest(shipment)
+        manifest = shipment.manifest
+
+        if distributor_allows_order_editing?(shipment.order)
+          supplier_ids = spree_current_user.enterprises.ids
+          manifest.select! { |mi| supplier_ids.include?(mi.variant.supplier_id) }
+        end
+
+        manifest
+      end
+
+      def distributor_allows_order_editing?(order)
+        order.distributor&.enable_producers_to_edit_orders &&
+          spree_current_user.can_manage_line_items_in_orders_only?
+      end
+
     end
   end
 end

--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -146,7 +146,7 @@ module Spree
       def prepare_shipment_manifest(shipment)
         manifest = shipment.manifest
 
-        if distributor_allows_order_editing?(shipment.order)
+        if filter_by_supplier?(shipment.order)
           supplier_ids = spree_current_user.enterprises.ids
           manifest.select! { |mi| supplier_ids.include?(mi.variant.supplier_id) }
         end
@@ -154,13 +154,13 @@ module Spree
         manifest
       end
 
-      def distributor_allows_order_editing?(order)
+      def filter_by_supplier?(order)
         order.distributor&.enable_producers_to_edit_orders &&
           spree_current_user.can_manage_line_items_in_orders_only?
       end
 
       def display_value_for_producer(order, value)
-        return value unless distributor_allows_order_editing?(order)
+        return value unless filter_by_supplier?(order)
 
         order.distributor&.show_customer_names_to_suppliers ? value : t("admin.reports.hidden")
       end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -381,7 +381,7 @@ class Enterprise < ApplicationRecord
     sells == 'any'
   end
 
-  def is_producer
+  def is_producer_only
     is_primary_producer && sells == 'none'
   end
 

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -381,6 +381,10 @@ class Enterprise < ApplicationRecord
     sells == 'any'
   end
 
+  def is_producer
+    is_primary_producer && sells == 'none'
+  end
+
   # Simplify enterprise categories for frontend logic and icons, and maybe other things.
   def category
     # Make this crazy logic human readable so we can argue about it sanely.

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -360,7 +360,7 @@ module Spree
         order.variants.any? { |variant| user.enterprises.ids.include?(variant.supplier_id) }
       end
 
-      can [:admin, :read, :index, :edit, :update], Spree::Order do |order|
+      can [:admin, :read, :index, :edit, :update, :bulk_management], Spree::Order do |order|
         can_edit_order_lambda.call(order)
       end
       can [:admin, :index, :create, :destroy, :update], Spree::LineItem do |item|
@@ -370,6 +370,7 @@ module Spree
         can_edit_order_lambda.call(shipment.order)
       end
 
+      can [:visible], Enterprise
     end
 
     def add_relationship_management_abilities(user)

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -353,23 +353,22 @@ module Spree
       end
     end
 
+    def can_edit_order(order, user)
+      return unless order.distributor&.enable_producers_to_edit_orders
+
+      order.variants.any? { |variant| user.enterprises.ids.include?(variant.supplier_id) }
+    end
+
     def add_manage_line_items_abilities(user)
-      can_edit_order_lambda = lambda do |order|
-        return unless order.distributor&.enable_producers_to_edit_orders
-
-        order.variants.any? { |variant| user.enterprises.ids.include?(variant.supplier_id) }
-      end
-
       can [:admin, :read, :index, :edit, :update, :bulk_management], Spree::Order do |order|
-        can_edit_order_lambda.call(order)
+        can_edit_order(order, user)
       end
       can [:admin, :index, :create, :destroy, :update], Spree::LineItem do |item|
-        can_edit_order_lambda.call(item.order)
+        can_edit_order(item.order, user)
       end
       can [:index, :create, :add, :read, :edit, :update], Spree::Shipment do |shipment|
-        can_edit_order_lambda.call(shipment.order)
+        can_edit_order(shipment.order, user)
       end
-
       can [:visible], Enterprise
     end
 

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -369,6 +369,9 @@ module Spree
       can [:index, :create, :add, :read, :edit, :update], Spree::Shipment do |shipment|
         can_edit_order(shipment.order, user)
       end
+      can [:admin, :index], OrderCycle do |order_cycle|
+        can_edit_order(order_cycle.order, user)
+      end
       can [:visible], Enterprise
     end
 

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -108,6 +108,13 @@ module Spree
         where(spree_adjustments: { id: nil })
     }
 
+    scope :editable_by_producers, ->(enterprises_ids) {
+      joins(:variant, order: :distributor).where(
+        distributor: { enable_producers_to_edit_orders: true },
+        spree_variants: { supplier_id: enterprises_ids }
+      )
+    }
+
     def copy_price
       return unless variant
 

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -140,6 +140,15 @@ module Spree
       end
     }
 
+    scope :editable_by_producers, ->(enterprises) {
+      joins(
+        :distributor, line_items: :supplier
+      ).where(
+        supplier: enterprises,
+        distributor: { enable_producers_to_edit_orders: true }
+      )
+    }
+
     scope :distributed_by_user, lambda { |user|
       if user.admin?
         where(nil)
@@ -171,14 +180,6 @@ module Spree
     scope :invoiceable, -> { where(state: [:complete, :resumed]) }
     scope :by_state, lambda { |state| where(state:) }
     scope :not_state, lambda { |state| where.not(state:) }
-    scope :editable_by_producers, ->(enterprises) {
-      joins(
-        :distributor, line_items: :supplier
-      ).where(
-        supplier: { id: enterprises.ids },
-        distributor: { enable_producers_to_edit_orders: true }
-      )
-    }
 
     def initialize(*_args)
       @checkout_processing = nil

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -144,7 +144,7 @@ module Spree
       joins(
         :distributor, line_items: :supplier
       ).where(
-        supplier: enterprises,
+        supplier: { id: enterprises },
         distributor: { enable_producers_to_edit_orders: true }
       )
     }

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -171,6 +171,14 @@ module Spree
     scope :invoiceable, -> { where(state: [:complete, :resumed]) }
     scope :by_state, lambda { |state| where(state:) }
     scope :not_state, lambda { |state| where.not(state:) }
+    scope :editable_by_producers, ->(enterprises) {
+      joins(
+        :distributor, line_items: :supplier
+      ).where(
+        supplier: { id: enterprises.ids },
+        distributor: { enable_producers_to_edit_orders: true }
+      )
+    }
 
     def initialize(*_args)
       @checkout_processing = nil

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -156,9 +156,9 @@ module Spree
     # any of order distributors allow them to edit their orders.
     def can_manage_line_items_in_orders?
       @can_manage_line_items_in_orders ||= begin
-        has_any_producer = enterprises.any?(&:is_producer)
-        has_producer_editable_orders = Spree::Order.editable_by_producers(enterprises).exists?
-        has_any_producer && has_producer_editable_orders
+        return unless enterprises.any?(&:is_producer_only)
+
+        Spree::Order.editable_by_producers(enterprises).exists?
       end
     end
 

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -155,11 +155,11 @@ module Spree
     # Users can manage line items in orders if they have producer enterprise and
     # any of order distributors allow them to edit their orders.
     def can_manage_line_items_in_orders?
-      @can_manage_line_items_in_orders ||= begin
-        return unless enterprises.any?(&:is_producer_only)
+      return @can_manage_line_items_in_orders if defined? @can_manage_line_items_in_orders
 
+      @can_manage_line_items_in_orders =
+        enterprises.any?(&:is_producer_only) &&
         Spree::Order.editable_by_producers(enterprises).exists?
-      end
     end
 
     def can_manage_line_items_in_orders_only?

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -162,6 +162,9 @@ module Spree
       end
     end
 
+    def can_manage_line_items_in_orders_only?
+      !can_manage_orders? && can_manage_line_items_in_orders?
+    end
 
     protected
 

--- a/app/serializers/api/admin/order_serializer.rb
+++ b/app/serializers/api/admin/order_serializer.rb
@@ -102,13 +102,16 @@ module Api
       end
 
       def display_value_for_producer(order, value)
-        filter_by_supplier = (
+        filter_by_supplier =
           order.distributor&.enable_producers_to_edit_orders &&
           options[:current_user]&.can_manage_line_items_in_orders_only?
-        )
         return value unless filter_by_supplier
 
-        order.distributor&.show_customer_names_to_suppliers ? value : I18n.t("admin.reports.hidden_field")
+        if order.distributor&.show_customer_names_to_suppliers
+          value
+        else
+          I18n.t("admin.reports.hidden_field")
+        end
       end
     end
   end

--- a/app/serializers/api/admin/order_serializer.rb
+++ b/app/serializers/api/admin/order_serializer.rb
@@ -15,8 +15,14 @@ module Api
       has_one :distributor, serializer: Api::Admin::IdSerializer
       has_one :order_cycle, serializer: Api::Admin::IdSerializer
 
+      def full_name_for_sorting
+        value = [last_name, first_name].compact_blank.join(", ")
+        display_value_for_producer(object, value)
+      end
+
       def full_name
-        object.billing_address.nil? ? "" : ( object.billing_address.full_name || "" )
+        value = object.billing_address.nil? ? "" : ( object.billing_address.full_name || "" )
+        display_value_for_producer(object, value)
       end
 
       def first_name
@@ -65,11 +71,12 @@ module Api
       end
 
       def email
-        object.email || ""
+        display_value_for_producer(object, object.email || "")
       end
 
       def phone
-        object.billing_address.nil? ? "a" : ( object.billing_address.phone || "" )
+        value = object.billing_address.nil? ? "a" : ( object.billing_address.phone || "" )
+        display_value_for_producer(object, value)
       end
 
       def created_at
@@ -92,6 +99,16 @@ module Api
 
       def spree_routes_helper
         Spree::Core::Engine.routes.url_helpers
+      end
+
+      def display_value_for_producer(order, value)
+        filter_by_supplier = (
+          order.distributor&.enable_producers_to_edit_orders &&
+          options[:current_user]&.can_manage_line_items_in_orders_only?
+        )
+        return value unless filter_by_supplier
+
+        order.distributor&.show_customer_names_to_suppliers ? value : I18n.t("admin.reports.hidden_field")
       end
     end
   end

--- a/app/services/permissions/order.rb
+++ b/app/services/permissions/order.rb
@@ -24,7 +24,8 @@ module Permissions
     # Any orders that the user can edit
     def editable_orders
       orders = if @user.can_manage_line_items_in_orders_only?
-                 produced_orders.joins(:distributor).where(
+                 Spree::Order.joins(:distributor).where(
+                   id: produced_orders.select(:id),
                    distributor: { enable_producers_to_edit_orders: true }
                  )
                else

--- a/app/services/permissions/order.rb
+++ b/app/services/permissions/order.rb
@@ -43,7 +43,13 @@ module Permissions
 
     # Any line items that I can edit
     def editable_line_items
-      Spree::LineItem.where(order_id: editable_orders.select(:id))
+      if @user.can_manage_line_items_in_orders_only?
+        Spree::LineItem.editable_by_producers(
+          @permissions.managed_enterprises.select("enterprises.id")
+        )
+      else
+        Spree::LineItem.where(order_id: editable_orders.select(:id))
+      end
     end
 
     private

--- a/app/services/permissions/order.rb
+++ b/app/services/permissions/order.rb
@@ -24,8 +24,7 @@ module Permissions
     # Any orders that the user can edit
     def editable_orders
       orders = if @user.can_manage_line_items_in_orders_only?
-                 Spree::Order.joins(:distributor).where(
-                   id: produced_orders.select(:id),
+                 produced_orders.joins(:distributor).where(
                    distributor: { enable_producers_to_edit_orders: true }
                  )
                else

--- a/app/services/permitted_attributes/enterprise.rb
+++ b/app/services/permitted_attributes/enterprise.rb
@@ -39,6 +39,7 @@ module PermittedAttributes
         :preferred_product_low_stock_display,
         :hide_ofn_navigation, :white_label_logo, :white_label_logo_link,
         :hide_groups_tab, :external_billing_id,
+        :enable_producers_to_edit_orders
       ]
     end
   end

--- a/app/services/search_orders.rb
+++ b/app/services/search_orders.rb
@@ -28,7 +28,8 @@ class SearchOrders
   end
 
   def search_query
-    base_query = ::Permissions::Order.new(current_user).editable_orders.not_empty.or(::Permissions::Order.new(current_user).editable_orders.finalized)
+    base_query = ::Permissions::Order.new(current_user).editable_orders.not_empty
+      .or(::Permissions::Order.new(current_user).editable_orders.finalized)
 
     return base_query if params[:shipping_method_id].blank?
 

--- a/app/services/search_orders.rb
+++ b/app/services/search_orders.rb
@@ -28,8 +28,7 @@ class SearchOrders
   end
 
   def search_query
-    base_query = ::Permissions::Order.new(current_user).editable_orders.not_empty
-      .or(::Permissions::Order.new(current_user).editable_orders.finalized)
+    base_query = ::Permissions::Order.new(current_user).editable_orders.not_empty.or(::Permissions::Order.new(current_user).editable_orders.finalized)
 
     return base_query if params[:shipping_method_id].blank?
 

--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -123,8 +123,6 @@
   .five.columns.omega
     = f.radio_button :show_customer_contacts_to_suppliers, false
     = f.label :show_customer_contacts_to_suppliers, t('.customer_contacts_false'), value: :false
-    = radio_button :enterprise, :show_customer_names_to_suppliers, false
-    = label :enterprise_show_customer_names_to_suppliers, t('.customer_names_false'), value: :false
 
 .row
   .three.columns.alpha

--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -123,3 +123,17 @@
   .five.columns.omega
     = f.radio_button :show_customer_contacts_to_suppliers, false
     = f.label :show_customer_contacts_to_suppliers, t('.customer_contacts_false'), value: :false
+    = radio_button :enterprise, :show_customer_names_to_suppliers, false
+    = label :enterprise_show_customer_names_to_suppliers, t('.customer_names_false'), value: :false
+
+.row
+  .three.columns.alpha
+    %label= t('.producers_to_edit_orders')
+    %div{'ofn-with-tip' => t('.producers_to_edit_orders_tip')}
+      %a= t 'admin.whats_this'
+  .three.columns
+    = radio_button :enterprise, :enable_producers_to_edit_orders, true
+    = label :enterprise_enable_producers_to_edit_orders, t('.producers_edit_orders_true'), value: :true
+  .five.columns.omega
+    = radio_button :enterprise, :enable_producers_to_edit_orders, false
+    = label :enterprise_enable_producers_to_edit_orders, t('.producers_edit_orders_false'), value: :false

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -8,23 +8,24 @@
   - if @order.shipments.any?
     = render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => @order }
 
-  - if @order.line_items.exists?
-    = render partial: "spree/admin/orders/note", locals: { order: @order }
+  - if spree_current_user.can_manage_orders?
+    - if @order.line_items.exists?
+      = render partial: "spree/admin/orders/note", locals: { order: @order }
 
-  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.line_item_adjustments, :title => t(".line_item_adjustments")}
-  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => order_adjustments_for_display(@order), :title => t(".order_adjustments")}
+    = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.line_item_adjustments, :title => t(".line_item_adjustments")}
+    = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => order_adjustments_for_display(@order), :title => t(".order_adjustments")}
 
-  - if @order.line_items.exists?
-    %fieldset#order-total.no-border-bottom.order-details-total
-      %legend{ align: 'center' }= t(".order_total")
-      %span.order-total= @order.display_total
+    - if @order.line_items.exists?
+      %fieldset#order-total.no-border-bottom.order-details-total
+        %legend{ align: 'center' }= t(".order_total")
+        %span.order-total= @order.display_total
 
-    = form_for @order, url: spree.admin_order_url(@order), method: :put do |f|
-      = render partial: 'spree/admin/orders/_form/distribution_fields'
+      = form_for @order, url: spree.admin_order_url(@order), method: :put do |f|
+        = render partial: 'spree/admin/orders/_form/distribution_fields'
 
-      .filter-actions.actions{"ng-show" => "distributionChosen()"}
-        = button t(:update_and_recalculate_fees), 'icon-refresh'
-        = link_to_with_icon 'button icon-arrow-left', t(:back), spree.admin_orders_url
+        .filter-actions.actions{"ng-show" => "distributionChosen()"}
+          = button t(:update_and_recalculate_fees), 'icon-refresh'
+          = link_to_with_icon 'button icon-arrow-left', t(:back), spree.admin_orders_url
 
   = javascript_tag do
     var order_number = '#{@order.number}';

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -62,7 +62,7 @@
 
         - if shipment.fee_adjustment.present? && shipment.can_modify?
           %td.actions
-            - if can? :update, shipment
+            - if can? :update, shipment.shipping_method
               = link_to '', '', :class => 'edit-method icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')
 
       %tr.edit-tracking.hidden.total
@@ -86,7 +86,7 @@
             = Spree.t(:no_tracking_present)
 
         %td.actions
-          - if can?(:update, shipment) && shipment.can_modify?
+          - if spree_current_user.can_manage_orders? && can?(:update, shipment) && shipment.can_modify?
             = link_to '', '', :class => 'edit-tracking icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')
             - if shipment.tracking.present?
               = link_to '', '', :class => 'delete-tracking icon_link icon-trash no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'remove' }, :title => Spree.t('delete')

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -1,4 +1,4 @@
-- shipment.manifest.each do |item|
+- prepare_shipment_manifest(shipment).each do |item|
   - line_item = order.find_line_item_by_variant(item.variant)
 
   - if line_item.present?

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -34,10 +34,11 @@
       %span.state{ class: order.shipment_state.to_s}
         = t('js.admin.orders.shipment_states.' + order.shipment_state.to_s)
   %td
-    %a{ href: "mailto:#{order.email}", target: "_blank" }
-      = order.email
+    - email_value = display_value_for_producer(order, order.email)
+    %a{ href: "mailto:#{email_value}", target: "_blank" }
+      = email_value
   %td
-    = order&.bill_address&.full_name_for_sorting
+    = display_value_for_producer(order, order.bill_address&.full_name_for_sorting)
   %td.align-left
     %span
       = order.display_total

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -47,7 +47,7 @@
       - if local_assigns[:success]
         %i.success.icon-ok-sign{"data-controller": "ephemeral"}
     = render AdminTooltipComponent.new(text: t('spree.admin.orders.index.edit'), link_text: "", link: edit_admin_order_path(order), link_class: "icon_link with-tip icon-edit no-text")
-    - if order.ready_to_ship?
+    - if spree_current_user.can_manage_orders? && order.ready_to_ship?
       %form
         = render ShipOrderComponent.new(order: order)
       = render partial: 'admin/shared/tooltip_button', locals: {button_class: "icon-road icon_link with-tip no-text", reflex_data_id: order.id.to_s, tooltip_text: t('spree.admin.orders.index.ship'), shipment: true}

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -51,5 +51,5 @@
         = render ShipOrderComponent.new(order: order)
       = render partial: 'admin/shared/tooltip_button', locals: {button_class: "icon-road icon_link with-tip no-text", reflex_data_id: order.id.to_s, tooltip_text: t('spree.admin.orders.index.ship'), shipment: true}
 
-    - if order.payment_required? && order.pending_payments.reject(&:requires_authorization?).any?
+    - if can?(:update, Spree::Payment) && order.payment_required? && order.pending_payments.reject(&:requires_authorization?).any?
       = render partial: 'admin/shared/tooltip_button', locals: {button_class: "icon-capture icon_link no-text", button_reflex: "click->Admin::OrdersReflex#capture", reflex_data_id: order.id.to_s,  tooltip_text: t('spree.admin.orders.index.capture')}

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -6,14 +6,16 @@
 - content_for :page_actions do
   - if can?(:fire, @order)
     %li= event_links(@order)
-  = render partial: 'spree/admin/shared/order_links'
+  - if spree_current_user.can_manage_orders?
+    = render partial: 'spree/admin/shared/order_links'
   - if can?(:admin, Spree::Order)
     %li
       %a.button.icon-arrow-left{icon: 'icon-arrow-left', href: admin_orders_path }
         = t(:back_to_orders_list)
 
 = render partial: "spree/admin/shared/order_page_title"
-= render partial: "spree/admin/shared/order_tabs", locals: { current: 'Order Details' }
+- if spree_current_user.can_manage_orders?
+  = render partial: "spree/admin/shared/order_tabs", locals: { current: 'Order Details' }
 
 %div
   = render partial: "spree/shared/error_messages", locals: { target: @order }

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -3,9 +3,10 @@
 
 - content_for :minimal_js, true
 
-- content_for :page_actions do
-  %li
-    = button_link_to t('.new_order'), spree.new_admin_order_url, icon: 'icon-plus', id: 'admin_new_order'
+- if can?(:create, Spree::Order)
+  - content_for :page_actions do
+    %li
+      = button_link_to t('.new_order'), spree.new_admin_order_url, icon: 'icon-plus', id: 'admin_new_order'
 
 = render partial: 'spree/admin/shared/order_sub_menu'
 

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -3,7 +3,7 @@
 
 - content_for :minimal_js, true
 
-- if can?(:create, Spree::Order)
+- if can?(:create, Spree::Order) && spree_current_user.can_manage_orders?
   - content_for :page_actions do
     %li
       = button_link_to t('.new_order'), spree.new_admin_order_url, icon: 'icon-plus', id: 'admin_new_order'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1348,12 +1348,16 @@ en:
           enable_subscriptions_true: "Enabled"
           customer_names_in_reports: "Customer Names in Reports"
           customer_names_tip: "Enable your suppliers to see your customers names in reports"
+          producers_to_edit_orders: "Ability for producers to edit orders"
+          producers_to_edit_orders_tip: "Enable your suppliers to see orders containing their products, and edit quantity and weight for their own products only."
           customer_names_false: "Disabled"
           customer_names_true: "Enabled"
           customer_contacts_in_reports: "Customer contact details in reports"
           customer_contacts_tip: "Enable your suppliers to see your customer email and phone numbers in reports"
           customer_contacts_false: "Disabled"
           customer_contacts_true: "Enabled"
+          producers_edit_orders_false: "Disabled"
+          producers_edit_orders_true: "Enabled"
           shopfront_message: "Shopfront Message"
           shopfront_message_placeholder: >
             An optional message to welcome customers and explain how to shop with you. If text is entered here it will be displayed in a home tab when customers first arrive at your shopfront.

--- a/db/migrate/20250202121858_add_enable_producers_to_edit_orders_to_enterprises.rb
+++ b/db/migrate/20250202121858_add_enable_producers_to_edit_orders_to_enterprises.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEnableProducersToEditOrdersToEnterprises < ActiveRecord::Migration[7.0]
+  def change
+    add_column :enterprises, :enable_producers_to_edit_orders, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -230,7 +230,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_04_234657) do
     t.text "white_label_logo_link"
     t.boolean "hide_groups_tab", default: false
     t.string "external_billing_id", limit: 128
-    t.boolean "show_customer_contacts_to_suppliers", default: false, null: false
     t.index ["address_id"], name: "index_enterprises_on_address_id"
     t.index ["is_primary_producer", "sells"], name: "index_enterprises_on_is_primary_producer_and_sells"
     t.index ["name"], name: "index_enterprises_on_name", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -230,6 +230,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_04_234657) do
     t.text "white_label_logo_link"
     t.boolean "hide_groups_tab", default: false
     t.string "external_billing_id", limit: 128
+    t.boolean "enable_producers_to_edit_orders", default: false, null: false
+    t.boolean "show_customer_contacts_to_suppliers", default: false, null: false
     t.index ["address_id"], name: "index_enterprises_on_address_id"
     t.index ["is_primary_producer", "sells"], name: "index_enterprises_on_is_primary_producer_and_sells"
     t.index ["name"], name: "index_enterprises_on_name", unique: true

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -123,8 +123,24 @@ RSpec.describe Admin::BulkLineItemsController, type: :controller do
           get :index, as: :json
         end
 
-        it "does not display line items for which my enterprise is a supplier" do
-          expect(response).to redirect_to unauthorized_path
+        context "with no distributor allows to edit orders" do
+          before { get :index, as: :json }
+
+          it "does not display line items for which my enterprise is a supplier" do
+            expect(response).to redirect_to unauthorized_path
+          end
+        end
+
+        context "with distributor allows to edit orders" do
+          before do
+            distributor1.update_columns(enable_producers_to_edit_orders: true)
+            get :index, as: :json
+          end
+
+          it "retrieves a list of line_items from the supplier" do
+            keys = json_response['line_items'].first.keys.map(&:to_sym)
+            expect(line_item_attributes.all?{ |attr| keys.include? attr }).to eq(true)
+          end
         end
       end
 

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -120,7 +120,6 @@ RSpec.describe Admin::BulkLineItemsController, type: :controller do
       context "producer enterprise" do
         before do
           allow(controller).to receive_messages spree_current_user: supplier.owner
-          get :index, as: :json
         end
 
         context "with no distributor allows to edit orders" do

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -84,11 +84,25 @@ module Api
         context 'producer enterprise' do
           before do
             allow(controller).to receive(:spree_current_user) { supplier.owner }
-            get :index
           end
 
-          it "does not display line items for which my enterprise is a supplier" do
-            assert_unauthorized!
+          context "with no distributor allows to edit orders" do
+            before { get :index }
+
+            it "does not display line items for which my enterprise is a supplier" do
+              assert_unauthorized!
+            end
+          end
+
+          context "with distributor allows to edit orders" do
+            before do
+              distributor.update_columns(enable_producers_to_edit_orders: true)
+              get :index
+            end
+
+            it "retrieves a list of orders which have my supplied products" do
+              returns_orders(json_response)
+            end
           end
         end
 

--- a/spec/controllers/spree/admin/mail_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/mail_methods_controller_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Spree::Admin::MailMethodsController do
                           owned_groups: nil)
     allow(user).to receive_messages(enterprises: [create(:enterprise)],
                                     admin?: true,
-                                    locale: nil)
+                                    locale: nil,
+                                    can_manage_orders?: true)
     allow(controller).to receive_messages(spree_current_user: user)
 
     expect {

--- a/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -5,151 +5,192 @@ require 'spec_helper'
 module Spree
   module Admin
     RSpec.describe VariantsController, type: :controller do
-      before { controller_login_as_admin }
+      context "log in as admin user" do
+        before { controller_login_as_admin }
 
-      describe "#index" do
-        describe "deleted variants" do
-          let(:product) { create(:product, name: 'Product A') }
-          let(:deleted_variant) do
-            deleted_variant = product.variants.create(
-              unit_value: "2", variant_unit: "weight", variant_unit_scale: 1, price: 1,
-              primary_taxon: create(:taxon), supplier: create(:supplier_enterprise)
-            )
-            deleted_variant.delete
-            deleted_variant
-          end
+        describe "#index" do
+          describe "deleted variants" do
+            let(:product) { create(:product, name: 'Product A') }
+            let(:deleted_variant) do
+              deleted_variant = product.variants.create(
+                unit_value: "2", variant_unit: "weight", variant_unit_scale: 1, price: 1,
+                primary_taxon: create(:taxon), supplier: create(:supplier_enterprise)
+              )
+              deleted_variant.delete
+              deleted_variant
+            end
 
-          it "lists only non-deleted variants with params[:deleted] == off" do
-            spree_get :index, product_id: product.id, deleted: "off"
-            expect(assigns(:variants)).to eq(product.variants)
-          end
+            it "lists only non-deleted variants with params[:deleted] == off" do
+              spree_get :index, product_id: product.id, deleted: "off"
+              expect(assigns(:variants)).to eq(product.variants)
+            end
 
-          it "lists only deleted variants with params[:deleted] == on" do
-            spree_get :index, product_id: product.id, deleted: "on"
-            expect(assigns(:variants)).to eq([deleted_variant])
+            it "lists only deleted variants with params[:deleted] == on" do
+              spree_get :index, product_id: product.id, deleted: "on"
+              expect(assigns(:variants)).to eq([deleted_variant])
+            end
           end
         end
-      end
 
-      describe "#update" do
-        let!(:variant) { create(:variant, display_name: "Tomatoes", sku: 123, supplier: producer) }
-        let(:producer) { create(:enterprise) }
+        describe "#update" do
+          let!(:variant) { create(:variant, display_name: "Tomatoes", sku: 123, supplier: producer) }
+          let(:producer) { create(:enterprise) }
 
-        it "updates the variant" do
-          expect {
-            spree_put(
-              :update,
-              id: variant.id,
-              product_id: variant.product.id,
-              variant: { display_name: "Better tomatoes", sku: 456 }
-            )
-            variant.reload
-          }.to change { variant.display_name }.to("Better tomatoes")
-            .and change { variant.sku }.to(456.to_s)
-        end
-
-        context "when updating supplier" do
-          let(:new_producer) { create(:enterprise) }
-
-          it "updates the supplier" do
+          it "updates the variant" do
             expect {
+              spree_put(
+                :update,
+                id: variant.id,
+                product_id: variant.product.id,
+                variant: { display_name: "Better tomatoes", sku: 456 }
+              )
+              variant.reload
+            }.to change { variant.display_name }.to("Better tomatoes")
+              .and change { variant.sku }.to(456.to_s)
+          end
+
+          context "when updating supplier" do
+            let(:new_producer) { create(:enterprise) }
+
+            it "updates the supplier" do
+              expect {
+                spree_put(
+                  :update,
+                  id: variant.id,
+                  product_id: variant.product.id,
+                  variant: { supplier_id: new_producer.id }
+                )
+                variant.reload
+              }.to change { variant.supplier_id }.to(new_producer.id)
+            end
+
+            it "removes associated product from existing Order Cycles" do
+              distributor = create(:distributor_enterprise)
+              order_cycle = create(
+                :simple_order_cycle,
+                variants: [variant],
+                coordinator: distributor,
+                distributors: [distributor]
+              )
+
               spree_put(
                 :update,
                 id: variant.id,
                 product_id: variant.product.id,
                 variant: { supplier_id: new_producer.id }
               )
-              variant.reload
-            }.to change { variant.supplier_id }.to(new_producer.id)
+
+              expect(order_cycle.reload.distributed_variants).not_to include variant
+            end
+          end
+        end
+
+        describe "#search" do
+          let(:supplier) { create(:supplier_enterprise) }
+          let!(:p1) { create(:simple_product, name: 'Product 1', supplier_id: supplier.id) }
+          let!(:p2) { create(:simple_product, name: 'Product 2', supplier_id: supplier.id) }
+          let!(:v1) { p1.variants.first }
+          let!(:v2) { p2.variants.first }
+          let!(:vo) { create(:variant_override, variant: v1, hub: d, count_on_hand: 44) }
+          let!(:d)  { create(:distributor_enterprise) }
+          let!(:oc) { create(:simple_order_cycle, distributors: [d], variants: [v1]) }
+
+          it "filters by distributor" do
+            spree_get :search, q: 'Prod', distributor_id: d.id.to_s
+            expect(assigns(:variants)).to eq([v1])
           end
 
-          it "removes associated product from existing Order Cycles" do
-            distributor = create(:distributor_enterprise)
-            order_cycle = create(
-              :simple_order_cycle,
-              variants: [variant],
-              coordinator: distributor,
-              distributors: [distributor]
-            )
+          it "applies variant overrides" do
+            spree_get :search, q: 'Prod', distributor_id: d.id.to_s
+            expect(assigns(:variants)).to eq([v1])
+            expect(assigns(:variants).first.on_hand).to eq(44)
+          end
 
-            spree_put(
-              :update,
-              id: variant.id,
-              product_id: variant.product.id,
-              variant: { supplier_id: new_producer.id }
-            )
+          it "filters by order cycle" do
+            spree_get :search, q: 'Prod', order_cycle_id: oc.id.to_s
+            expect(assigns(:variants)).to eq([v1])
+          end
 
-            expect(order_cycle.reload.distributed_variants).not_to include variant
+          it "does not filter when no distributor or order cycle is specified" do
+            spree_get :search, q: 'Prod'
+            expect(assigns(:variants)).to match_array [v1, v2]
+          end
+        end
+
+        describe '#destroy' do
+          let(:variant) { create(:variant) }
+
+          context 'when requesting with html' do
+            before do
+              allow(Spree::Variant).to receive(:find).with(variant.id.to_s) { variant }
+              allow(variant).to receive(:destroy).and_call_original
+            end
+
+            it 'deletes the variant' do
+              spree_delete :destroy, id: variant.id, product_id: variant.product.id,
+                                     format: 'html'
+              expect(variant).to have_received(:destroy)
+            end
+
+            it 'shows a success flash message' do
+              spree_delete :destroy, id: variant.id, product_id: variant.product.id,
+                                     format: 'html'
+              expect(flash[:success]).to be
+            end
+
+            it 'redirects to admin_product_variants_url' do
+              spree_delete :destroy, id: variant.id, product_id: variant.product.id,
+                                     format: 'html'
+              expect(response).to redirect_to spree.admin_product_variants_url(variant.product.id)
+            end
+
+            it 'destroys all its exchanges' do
+              exchange = create(:exchange)
+              variant.exchanges << exchange
+
+              spree_delete :destroy, id: variant.id, product_id: variant.product.id,
+                                     format: 'html'
+              expect(variant.exchanges.reload).to be_empty
+            end
           end
         end
       end
 
-      describe "#search" do
-        let(:supplier) { create(:supplier_enterprise) }
-        let!(:p1) { create(:simple_product, name: 'Product 1', supplier_id: supplier.id) }
-        let!(:p2) { create(:simple_product, name: 'Product 2', supplier_id: supplier.id) }
+      context "log in as supplier and distributor enable_producers_to_edit_orders" do
+        let(:supplier1) { create(:supplier_enterprise) }
+        let(:supplier2) { create(:supplier_enterprise) }
+        let!(:p1) { create(:simple_product, name: 'Product 1', supplier_id: supplier1.id) }
+        let!(:p2) { create(:simple_product, name: 'Product 2', supplier_id: supplier2.id) }
         let!(:v1) { p1.variants.first }
         let!(:v2) { p2.variants.first }
-        let!(:vo) { create(:variant_override, variant: v1, hub: d, count_on_hand: 44) }
-        let!(:d)  { create(:distributor_enterprise) }
-        let!(:oc) { create(:simple_order_cycle, distributors: [d], variants: [v1]) }
+        let!(:d)  { create(:distributor_enterprise, enable_producers_to_edit_orders: true) }
+        let!(:oc) { create(:simple_order_cycle, distributors: [d], variants: [v1, v2]) }
 
-        it "filters by distributor" do
-          spree_get :search, q: 'Prod', distributor_id: d.id.to_s
-          expect(assigns(:variants)).to eq([v1])
+        before do
+          order = create(:order_with_line_items, distributor: d, line_items_count: 1)
+          order.line_items.take.variant.update_attribute(:supplier_id, supplier1.id)
+          controller_login_as_enterprise_user([supplier1])
         end
 
-        it "applies variant overrides" do
-          spree_get :search, q: 'Prod', distributor_id: d.id.to_s
-          expect(assigns(:variants)).to eq([v1])
-          expect(assigns(:variants).first.on_hand).to eq(44)
+        describe "#search" do
+          it "filters by distributor and supplier1 products" do
+            spree_get :search, q: 'Prod', distributor_id: d.id.to_s
+            expect(assigns(:variants)).to eq([v1])
+          end
         end
 
-        it "filters by order cycle" do
-          spree_get :search, q: 'Prod', order_cycle_id: oc.id.to_s
-          expect(assigns(:variants)).to eq([v1])
-        end
-
-        it "does not filter when no distributor or order cycle is specified" do
-          spree_get :search, q: 'Prod'
-          expect(assigns(:variants)).to match_array [v1, v2]
-        end
-      end
-
-      describe '#destroy' do
-        let(:variant) { create(:variant) }
-
-        context 'when requesting with html' do
-          before do
-            allow(Spree::Variant).to receive(:find).with(variant.id.to_s) { variant }
-            allow(variant).to receive(:destroy).and_call_original
-          end
-
-          it 'deletes the variant' do
-            spree_delete :destroy, id: variant.id, product_id: variant.product.id,
-                                   format: 'html'
-            expect(variant).to have_received(:destroy)
-          end
-
-          it 'shows a success flash message' do
-            spree_delete :destroy, id: variant.id, product_id: variant.product.id,
-                                   format: 'html'
-            expect(flash[:success]).to be
-          end
-
-          it 'redirects to admin_product_variants_url' do
-            spree_delete :destroy, id: variant.id, product_id: variant.product.id,
-                                   format: 'html'
-            expect(response).to redirect_to spree.admin_product_variants_url(variant.product.id)
-          end
-
-          it 'destroys all its exchanges' do
-            exchange = create(:exchange)
-            variant.exchanges << exchange
-
-            spree_delete :destroy, id: variant.id, product_id: variant.product.id,
-                                   format: 'html'
-            expect(variant.exchanges.reload).to be_empty
+        describe "#update" do
+          it "updates the variant" do
+            expect {
+              spree_put(
+                :update,
+                id: v1.id,
+                product_id: v1.product.id,
+                variant: { display_name: "Better tomatoes", sku: 456 }
+              )
+              v1.reload
+            }.to change { v1.display_name }.to("Better tomatoes")
+              .and change { v1.sku }.to(456.to_s)
           end
         end
       end

--- a/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -33,7 +33,14 @@ module Spree
         end
 
         describe "#update" do
-          let!(:variant) { create(:variant, display_name: "Tomatoes", sku: 123, supplier: producer) }
+          let!(:variant) {
+            create(
+              :variant,
+              display_name: "Tomatoes",
+              sku: 123,
+              supplier: producer
+            )
+          }
           let(:producer) { create(:enterprise) }
 
           it "updates the variant" do

--- a/spec/lib/open_food_network/scope_variants_for_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_for_search_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
   let!(:oc3) { create(:simple_order_cycle, distributors: [d2], variants: [v4]) }
   let!(:s1) { create(:schedule, order_cycles: [oc1]) }
   let!(:s2) { create(:schedule, order_cycles: [oc2]) }
-  let(:spree_current_user) { create(:user) }
+  let!(:spree_current_user) { create(:user) }
 
   let(:scoper) { OpenFoodNetwork::ScopeVariantsForSearch.new(params, spree_current_user) }
 
@@ -67,13 +67,6 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
 
       it "returns all products distributed through that distributor" do
         expect{ result }.to query_database [
-          "TRANSACTION",
-          "Spree::User Exists?",
-          "Spree::User Create",
-          "Customer Load",
-          "Customer Load",
-          "Spree::Order Load",
-          "TRANSACTION",
           "Enterprise Load",
           "VariantOverride Load",
           "SQL",
@@ -194,7 +187,7 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
     context "when search is done by the producer allowing to edit orders" do
       let(:params) { { q: "product" } }
       let(:producer) { create(:supplier_enterprise) }
-      let(:spree_current_user) {
+      let!(:spree_current_user) {
         instance_double('Spree::User', enterprises: Enterprise.where(id: producer.id),
                                        can_manage_line_items_in_orders_only?: true)
       }

--- a/spec/lib/open_food_network/scope_variants_for_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_for_search_spec.rb
@@ -194,9 +194,12 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
     context "when search is done by the producer allowing to edit orders" do
       let(:params) { { q: "product" } }
       let(:producer) { create(:supplier_enterprise) }
-      let(:spree_current_user) { instance_double('Spree::User', enterprises: Enterprise.where(id: producer.id), can_manage_line_items_in_orders_only?: true) }
+      let(:spree_current_user) {
+        instance_double('Spree::User', enterprises: Enterprise.where(id: producer.id),
+                                       can_manage_line_items_in_orders_only?: true)
+      }
 
-      it "returns all products distributed through distributors allowing producers to edit orders" do
+      it "returns products distributed by distributors allowing producers to edit orders" do
         v1.supplier_id = producer.id
         v2.supplier_id = producer.id
         v1.save!

--- a/spec/lib/open_food_network/scope_variants_for_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_for_search_spec.rb
@@ -190,6 +190,22 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
           to eq(["Product 1", "Product a", "Product b", "Product c"])
       end
     end
+
+    context "when search is done by the producer allowing to edit orders" do
+      let(:params) { { q: "product" } }
+      let(:producer) { create(:supplier_enterprise) }
+      let(:spree_current_user) { instance_double('Spree::User', enterprises: Enterprise.where(id: producer.id), can_manage_line_items_in_orders_only?: true) }
+
+      it "returns all products distributed through distributors allowing producers to edit orders" do
+        v1.supplier_id = producer.id
+        v2.supplier_id = producer.id
+        v1.save!
+        v2.save!
+
+        expect(result).to include v1, v2
+        expect(result).not_to include v3, v4
+      end
+    end
   end
 
   private

--- a/spec/lib/reports/orders_and_distributors_report_spec.rb
+++ b/spec/lib/reports/orders_and_distributors_report_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe Reporting::Reports::OrdersAndDistributors::Base do
         subject # build context first
 
         expect { subject.table_rows }.to query_database [
+          "Enterprise Pluck",
           "SQL",
           "Spree::LineItem Load",
           "Spree::PaymentMethod Load",

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -1013,25 +1013,25 @@ RSpec.describe Enterprise do
     end
   end
 
-  describe "#is_producer" do
+  describe "#is_producer_only" do
     context "when enterprise is_primary_producer and sells none" do
       it "returns true" do
         enterprise = build(:supplier_enterprise)
-        expect(enterprise.is_producer).to be true
+        expect(enterprise.is_producer_only).to be true
       end
     end
 
     context "when enterprise is_primary_producer and sells any" do
       it "returns false" do
         enterprise = build(:enterprise, is_primary_producer: true, sells: "any")
-        expect(enterprise.is_producer).to be false
+        expect(enterprise.is_producer_only).to be false
       end
     end
 
     context "when enterprise is_primary_producer and sells own" do
       it "returns false" do
         enterprise = build(:enterprise, is_primary_producer: true, sells: "own")
-        expect(enterprise.is_producer).to be false
+        expect(enterprise.is_producer_only).to be false
       end
     end
   end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -1012,6 +1012,29 @@ RSpec.describe Enterprise do
       expect(expected).to include(sender)
     end
   end
+
+  describe "#is_producer" do
+    context "when enterprise is_primary_producer and sells none" do
+      it "returns true" do
+        enterprise = build(:supplier_enterprise)
+        expect(enterprise.is_producer).to be true
+      end
+    end
+
+    context "when enterprise is_primary_producer and sells any" do
+      it "returns false" do
+        enterprise = build(:enterprise, is_primary_producer: true, sells: "any")
+        expect(enterprise.is_producer).to be false
+      end
+    end
+
+    context "when enterprise is_primary_producer and sells own" do
+      it "returns false" do
+        enterprise = build(:enterprise, is_primary_producer: true, sells: "own")
+        expect(enterprise.is_producer).to be false
+      end
+    end
+  end
 end
 
 def enterprise_name_error(owner_email)

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -240,6 +240,24 @@ RSpec.describe Spree::Ability do
         it { expect(subject.can_manage_enterprises?(user)).to be true }
         it { expect(subject.can_manage_orders?(user)).to be false }
         it { expect(subject.can_manage_order_cycles?(user)).to be false }
+
+        context "with no distributor allows me to edit orders" do
+          it { expect(subject.can_manage_orders?(user)).to be false }
+          it { expect(subject.can_manage_line_items_in_orders?(user)).to be false }
+        end
+
+        context "with any distributor allows me to edit orders containing my product" do
+          before do
+            order = create(
+              :order_with_line_items,
+              line_items_count: 1,
+              distributor: create(:distributor_enterprise, enable_producers_to_edit_orders: true)
+            )
+            order.line_items.first.variant.update!(supplier_id: enterprise_none_producer.id)
+          end
+
+          it { expect(subject.can_manage_line_items_in_orders?(user)).to be true }
+        end
       end
 
       context "as a profile" do
@@ -260,6 +278,7 @@ RSpec.describe Spree::Ability do
       it { expect(subject.can_manage_products?(user)).to be false }
       it { expect(subject.can_manage_enterprises?(user)).to be false }
       it { expect(subject.can_manage_orders?(user)).to be false }
+      it { expect(subject.can_manage_line_items_in_orders?(user)).to be false }
       it { expect(subject.can_manage_order_cycles?(user)).to be false }
 
       it "can create enterprises straight off the bat" do

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe Spree::User do
 
   describe "#can_manage_line_items_in_orders_only?" do
     let(:producer) { create(:supplier_enterprise) }
-    let(:order) { create(:order, distributor: distributor) }
+    let(:order) { create(:order, distributor:) }
 
     subject { user.can_manage_line_items_in_orders_only? }
 
@@ -310,7 +310,8 @@ RSpec.describe Spree::User do
 
       context "order containing their product" do
         before do
-          order.line_items << create(:line_item, product: create(:product, supplier_id: producer.id))
+          order.line_items << create(:line_item,
+                                     product: create(:product, supplier_id: producer.id))
         end
         context "order distributor allow producer to edit orders" do
           let(:distributor) do

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -298,4 +298,39 @@ RSpec.describe Spree::User do
       end
     end
   end
+
+  describe "#can_manage_line_items_in_orders_only?" do
+    let(:producer) { create(:supplier_enterprise) }
+    let(:order) { create(:order, distributor: distributor) }
+
+    subject { user.can_manage_line_items_in_orders_only? }
+
+    context "when user has producer" do
+      let(:user) { create(:user, enterprises: [producer]) }
+
+      context "order containing their product" do
+        before do
+          order.line_items << create(:line_item, product: create(:product, supplier_id: producer.id))
+        end
+        context "order distributor allow producer to edit orders" do
+          let(:distributor) do
+            create(:distributor_enterprise, enable_producers_to_edit_orders: true)
+          end
+
+          it { is_expected.to be_truthy }
+        end
+
+        context "order distributor doesn't allow producer to edit orders" do
+          let(:distributor) { create(:distributor_enterprise) }
+          it { is_expected.to be_falsey }
+        end
+      end
+    end
+
+    context "no order containing their product" do
+      let(:user) { create(:user, enterprises: [create(:distributor_enterprise)]) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end

--- a/spec/services/permissions/order_spec.rb
+++ b/spec/services/permissions/order_spec.rb
@@ -67,7 +67,9 @@ module Permissions
           end
 
           context "with search params" do
-            let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
+            let(:search_params) {
+              { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') }
+            }
             let(:permissions) { Permissions::Order.new(user, search_params) }
 
             it "only returns completed, non-cancelled orders within search filter range" do

--- a/spec/services/permissions/order_spec.rb
+++ b/spec/services/permissions/order_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Permissions
   RSpec.describe Order do
-    let(:user) { double(:user) }
+    let(:user) { double(:user, can_manage_line_items_in_orders_only?: false) }
     let(:permissions) { Permissions::Order.new(user) }
     let!(:basic_permissions) { OpenFoodNetwork::Permissions.new(user) }
     let(:distributor) { create(:distributor_enterprise) }

--- a/spec/services/permissions/order_spec.rb
+++ b/spec/services/permissions/order_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Permissions
   RSpec.describe Order do
-    let(:user) { double(:user, can_manage_line_items_in_orders_only?: false) }
     let(:permissions) { Permissions::Order.new(user) }
     let!(:basic_permissions) { OpenFoodNetwork::Permissions.new(user) }
     let(:distributor) { create(:distributor_enterprise) }
@@ -28,68 +27,24 @@ module Permissions
 
     before { allow(OpenFoodNetwork::Permissions).to receive(:new) { basic_permissions } }
 
-    describe "finding orders that are visible in reports" do
-      let(:random_enterprise) { create(:distributor_enterprise) }
-      let(:order) { create(:order, order_cycle:, distributor: ) }
-      let!(:line_item) { create(:line_item, order:) }
-      let!(:producer) { create(:supplier_enterprise) }
+    context "with user cannot only manage line_items in orders" do
+      let(:user) { instance_double('Spree::User', can_manage_line_items_in_orders_only?: false) }
 
-      before do
-        allow(basic_permissions).to receive(:coordinated_order_cycles) { Enterprise.where("1=0") }
-      end
+      describe "finding orders that are visible in reports" do
+        let(:random_enterprise) { create(:distributor_enterprise) }
+        let(:order) { create(:order, order_cycle:, distributor: ) }
+        let!(:line_item) { create(:line_item, order:) }
+        let!(:producer) { create(:supplier_enterprise) }
 
-      context "as the hub through which the order was placed" do
         before do
-          allow(basic_permissions).to receive(:managed_enterprises) {
-                                        Enterprise.where(id: distributor)
-                                      }
+          allow(basic_permissions).to receive(:coordinated_order_cycles) { Enterprise.where("1=0") }
         end
 
-        it "should let me see the order" do
-          expect(permissions.visible_orders).to include order
-        end
-      end
-
-      context "as the coordinator of the order cycle through which the order was placed" do
-        before do
-          allow(basic_permissions).to receive(:managed_enterprises) {
-                                        Enterprise.where(id: coordinator)
-                                      }
-          allow(basic_permissions).to receive(:coordinated_order_cycles) {
-                                        OrderCycle.where(id: order_cycle)
-                                      }
-        end
-
-        it "should let me see the order" do
-          expect(permissions.visible_orders).to include order
-        end
-
-        context "with search params" do
-          let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
-          let(:permissions) { Permissions::Order.new(user, search_params) }
-
-          it "only returns completed, non-cancelled orders within search filter range" do
-            expect(permissions.visible_orders).to include order_completed
-            expect(permissions.visible_orders).not_to include order_cancelled
-            expect(permissions.visible_orders).not_to include order_cart
-            expect(permissions.visible_orders).not_to include order_from_last_year
-          end
-        end
-      end
-
-      context "as a producer which has granted P-OC to the distributor of an order" do
-        before do
-          allow(basic_permissions).to receive(:managed_enterprises) {
-                                        Enterprise.where(id: producer)
-                                      }
-          create(:enterprise_relationship, parent: producer, child: distributor,
-                                           permissions_list: [:add_to_order_cycle])
-        end
-
-        context "which contains my products" do
+        context "as the hub through which the order was placed" do
           before do
-            line_item.variant.supplier = producer
-            line_item.variant.save
+            allow(basic_permissions).to receive(:managed_enterprises) {
+                                          Enterprise.where(id: distributor)
+                                        }
           end
 
           it "should let me see the order" do
@@ -97,118 +52,206 @@ module Permissions
           end
         end
 
-        context "which does not contain my products" do
+        context "as the coordinator of the order cycle through which the order was placed" do
+          before do
+            allow(basic_permissions).to receive(:managed_enterprises) {
+                                          Enterprise.where(id: coordinator)
+                                        }
+            allow(basic_permissions).to receive(:coordinated_order_cycles) {
+                                          OrderCycle.where(id: order_cycle)
+                                        }
+          end
+
+          it "should let me see the order" do
+            expect(permissions.visible_orders).to include order
+          end
+
+          context "with search params" do
+            let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
+            let(:permissions) { Permissions::Order.new(user, search_params) }
+
+            it "only returns completed, non-cancelled orders within search filter range" do
+              expect(permissions.visible_orders).to include order_completed
+              expect(permissions.visible_orders).not_to include order_cancelled
+              expect(permissions.visible_orders).not_to include order_cart
+              expect(permissions.visible_orders).not_to include order_from_last_year
+            end
+          end
+        end
+
+        context "as a producer which has granted P-OC to the distributor of an order" do
+          before do
+            allow(basic_permissions).to receive(:managed_enterprises) {
+                                          Enterprise.where(id: producer)
+                                        }
+            create(:enterprise_relationship, parent: producer, child: distributor,
+                                             permissions_list: [:add_to_order_cycle])
+          end
+
+          context "which contains my products" do
+            before do
+              line_item.variant.supplier = producer
+              line_item.variant.save
+            end
+
+            it "should let me see the order" do
+              expect(permissions.visible_orders).to include order
+            end
+          end
+
+          context "which does not contain my products" do
+            it "should not let me see the order" do
+              expect(permissions.visible_orders).not_to include order
+            end
+          end
+        end
+
+        context "as an enterprise that is a distributor in the order cycle, " \
+                "but not the distributor of the order" do
+          before do
+            allow(basic_permissions).to receive(:managed_enterprises) {
+                                          Enterprise.where(id: random_enterprise)
+                                        }
+          end
+
           it "should not let me see the order" do
             expect(permissions.visible_orders).not_to include order
           end
         end
       end
 
-      context "as an enterprise that is a distributor in the order cycle, " \
-              "but not the distributor of the order" do
+      describe "finding line items that are visible in reports" do
+        let(:random_enterprise) { create(:distributor_enterprise) }
+        let(:order) { create(:order, order_cycle:, distributor: ) }
+        let!(:line_item1) { create(:line_item, order:) }
+        let!(:line_item2) { create(:line_item, order:) }
+        let!(:producer) { create(:supplier_enterprise) }
+
         before do
-          allow(basic_permissions).to receive(:managed_enterprises) {
-                                        Enterprise.where(id: random_enterprise)
-                                      }
+          allow(basic_permissions).to receive(:coordinated_order_cycles) { Enterprise.where("1=0") }
         end
 
-        it "should not let me see the order" do
-          expect(permissions.visible_orders).not_to include order
+        context "as the hub through which the parent order was placed" do
+          before do
+            allow(basic_permissions).to receive(:managed_enterprises) {
+                                          Enterprise.where(id: distributor)
+                                        }
+          end
+
+          it "should let me see the line_items" do
+            expect(permissions.visible_line_items).to include line_item1, line_item2
+          end
+        end
+
+        context "as the coordinator of the order cycle through which the parent order was placed" do
+          before do
+            allow(basic_permissions).to receive(:managed_enterprises) {
+                                          Enterprise.where(id: coordinator)
+                                        }
+            allow(basic_permissions).to receive(:coordinated_order_cycles) {
+                                          OrderCycle.where(id: order_cycle)
+                                        }
+          end
+
+          it "should let me see the line_items" do
+            expect(permissions.visible_line_items).to include line_item1, line_item2
+          end
+        end
+
+        context "as the manager producer which has granted P-OC to the distributor " \
+                "of the parent order" do
+          before do
+            allow(basic_permissions).to receive(:managed_enterprises) {
+                                          Enterprise.where(id: producer)
+                                        }
+            create(:enterprise_relationship, parent: producer, child: distributor,
+                                             permissions_list: [:add_to_order_cycle])
+
+            line_item1.variant.supplier = producer
+            line_item1.variant.save
+          end
+
+          it "should let me see the line_items pertaining to variants I produce" do
+            ps = permissions.visible_line_items
+            expect(ps).to include line_item1
+            expect(ps).not_to include line_item2
+          end
+        end
+
+        context "as an enterprise that is a distributor in the order cycle, " \
+                "but not the distributor of the parent order" do
+          before do
+            allow(basic_permissions).to receive(:managed_enterprises) {
+                                          Enterprise.where(id: random_enterprise)
+                                        }
+          end
+
+          it "should not let me see the line_items" do
+            expect(permissions.visible_line_items).not_to include line_item1, line_item2
+          end
+        end
+
+        context "with search params" do
+          let!(:line_item3) { create(:line_item, order: order_completed) }
+          let!(:line_item4) { create(:line_item, order: order_cancelled) }
+          let!(:line_item5) { create(:line_item, order: order_cart) }
+          let!(:line_item6) { create(:line_item, order: order_from_last_year) }
+
+          let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
+          let(:permissions) { Permissions::Order.new(user, search_params) }
+
+          before do
+            allow(user).to receive(:admin?) { "admin" }
+          end
+
+          it "only returns line items from completed, " \
+             "non-cancelled orders within search filter range" do
+            expect(permissions.visible_line_items).to include order_completed.line_items.first
+            expect(permissions.visible_line_items).not_to include order_cancelled.line_items.first
+            expect(permissions.visible_line_items).not_to include order_cart.line_items.first
+            expect(permissions.visible_line_items)
+              .not_to include order_from_last_year.line_items.first
+          end
         end
       end
     end
 
-    describe "finding line items that are visible in reports" do
-      let(:random_enterprise) { create(:distributor_enterprise) }
-      let(:order) { create(:order, order_cycle:, distributor: ) }
-      let!(:line_item1) { create(:line_item, order:) }
-      let!(:line_item2) { create(:line_item, order:) }
-      let!(:producer) { create(:supplier_enterprise) }
-
-      before do
-        allow(basic_permissions).to receive(:coordinated_order_cycles) { Enterprise.where("1=0") }
+    context "with user can only manage line_items in orders" do
+      let(:producer) { create(:supplier_enterprise) }
+      let(:user) do
+        create(:user, enterprises: [producer])
       end
+      let!(:order_by_distributor_allow_edits) do
+        order = create(
+          :order_with_line_items,
+          distributor: create(
+            :distributor_enterprise,
+            enable_producers_to_edit_orders: true
+          ),
+          line_items_count: 1
+        )
+        order.line_items.first.variant.update_attribute(:supplier_id, producer.id)
 
-      context "as the hub through which the parent order was placed" do
-        before do
-          allow(basic_permissions).to receive(:managed_enterprises) {
-                                        Enterprise.where(id: distributor)
-                                      }
-        end
-
-        it "should let me see the line_items" do
-          expect(permissions.visible_line_items).to include line_item1, line_item2
-        end
+        order
       end
-
-      context "as the coordinator of the order cycle through which the parent order was placed" do
-        before do
-          allow(basic_permissions).to receive(:managed_enterprises) {
-                                        Enterprise.where(id: coordinator)
-                                      }
-          allow(basic_permissions).to receive(:coordinated_order_cycles) {
-                                        OrderCycle.where(id: order_cycle)
-                                      }
-        end
-
-        it "should let me see the line_items" do
-          expect(permissions.visible_line_items).to include line_item1, line_item2
+      let!(:order_by_distributor_disallow_edits) do
+        create(
+          :order_with_line_items,
+          distributor: create(:distributor_enterprise),
+          line_items_count: 1
+        )
+      end
+      describe "#editable_orders" do
+        it "returns orders where the distributor allows producers to edit" do
+          expect(permissions.editable_orders.count).to eq 1
+          expect(permissions.editable_orders).to include order_by_distributor_allow_edits
         end
       end
 
-      context "as the manager producer which has granted P-OC to the distributor " \
-              "of the parent order" do
-        before do
-          allow(basic_permissions).to receive(:managed_enterprises) {
-                                        Enterprise.where(id: producer)
-                                      }
-          create(:enterprise_relationship, parent: producer, child: distributor,
-                                           permissions_list: [:add_to_order_cycle])
-
-          line_item1.variant.supplier = producer
-          line_item1.variant.save
-        end
-
-        it "should let me see the line_items pertaining to variants I produce" do
-          ps = permissions.visible_line_items
-          expect(ps).to include line_item1
-          expect(ps).not_to include line_item2
-        end
-      end
-
-      context "as an enterprise that is a distributor in the order cycle, " \
-              "but not the distributor of the parent order" do
-        before do
-          allow(basic_permissions).to receive(:managed_enterprises) {
-                                        Enterprise.where(id: random_enterprise)
-                                      }
-        end
-
-        it "should not let me see the line_items" do
-          expect(permissions.visible_line_items).not_to include line_item1, line_item2
-        end
-      end
-
-      context "with search params" do
-        let!(:line_item3) { create(:line_item, order: order_completed) }
-        let!(:line_item4) { create(:line_item, order: order_cancelled) }
-        let!(:line_item5) { create(:line_item, order: order_cart) }
-        let!(:line_item6) { create(:line_item, order: order_from_last_year) }
-
-        let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
-        let(:permissions) { Permissions::Order.new(user, search_params) }
-
-        before do
-          allow(user).to receive(:admin?) { "admin" }
-        end
-
-        it "only returns line items from completed, " \
-           "non-cancelled orders within search filter range" do
-          expect(permissions.visible_line_items).to include order_completed.line_items.first
-          expect(permissions.visible_line_items).not_to include order_cancelled.line_items.first
-          expect(permissions.visible_line_items).not_to include order_cart.line_items.first
-          expect(permissions.visible_line_items)
-            .not_to include order_from_last_year.line_items.first
+      describe "#editable_line_items" do
+        it "returns line items from orders where the distributor allows producers to edit" do
+          expect(permissions.editable_line_items.count).to eq 1
+          expect(permissions.editable_line_items.first.order).to eq order_by_distributor_allow_edits
         end
       end
     end

--- a/spec/system/admin/orders/producer_actions_spec.rb
+++ b/spec/system/admin/orders/producer_actions_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+RSpec.describe 'As a producer who have the ability to update orders' do
+  include AdminHelper
+  include AuthenticationHelper
+  include WebHelper
+
+  let!(:supplier1) { create(:supplier_enterprise, name: 'My supplier1') }
+  let!(:supplier2) { create(:supplier_enterprise, name: 'My supplier2') }
+  let!(:supplier1_v1) { create(:variant, supplier_id: supplier1.id) }
+  let!(:supplier1_v2) { create(:variant, supplier_id: supplier1.id) }
+  let!(:supplier2_v1) { create(:variant, supplier_id: supplier2.id) }
+  let(:order_cycle) do
+    create(:simple_order_cycle, distributors: [distributor], variants: [supplier1_v1, supplier1_v2])
+  end
+  let!(:order_containing_supplier1_products) do
+    o = create(
+      :completed_order_with_totals,
+      distributor:, order_cycle:,
+      user: supplier1_ent_user, line_items_count: 1
+    )
+    o.line_items.first.update_columns(variant_id: supplier1_v1.id)
+    o
+  end
+  let!(:order_containing_supplier2_v1_products) do
+    o = create(
+      :completed_order_with_totals,
+      distributor:, order_cycle:,
+      user: supplier2_ent_user, line_items_count: 1
+    )
+    o.line_items.first.update_columns(variant_id: supplier2_v1.id)
+    o
+  end
+  let(:supplier1_ent_user) { create(:user, enterprises: [supplier1]) }
+  let(:supplier2_ent_user) { create(:user, enterprises: [supplier2]) }
+
+  context "As supplier1 enterprise user" do
+    before { login_as(supplier1_ent_user) }
+    let(:order) { order_containing_supplier1_products }
+    let(:user) { supplier1_ent_user }
+
+    describe 'orders index page' do
+      before { visit spree.admin_orders_path }
+
+      context "when no distributor allow the producer to edit orders" do
+        let(:distributor) { create(:distributor_enterprise) }
+
+        it "should not allow producer to view orders page" do
+          expect(page).to have_content 'Unauthorized'
+        end
+      end
+
+      context "when distributor allows the producer to edit orders" do
+        let(:distributor) { create(:distributor_enterprise, enable_producers_to_edit_orders: true) }
+        it "should not allow to add new orders" do
+          expect(page).not_to have_link('New Order')
+        end
+
+        context "when distributor doesn't allow to view customer details" do
+          it "should allow producer to view orders page with HIDDEN customer details" do
+            within('#listing_orders tbody') do
+              expect(page).to have_selector('tr', count: 1) # Only one order
+              # One for Email, one for Name
+              expect(page).to have_selector('td', text: 'HIDDEN', count: 2)
+            end
+          end
+        end
+
+        context "when distributor allows to view customer details" do
+          let(:distributor) do
+            create(
+              :distributor_enterprise,
+              enable_producers_to_edit_orders: true,
+              show_customer_names_to_suppliers: true
+            )
+          end
+          it "should allow producer to view orders page with customer details" do
+            within('#listing_orders tbody') do
+              name = order.bill_address&.full_name_for_sorting
+              email = order.email
+              expect(page).to have_selector('tr', count: 1) # Only one order
+              expect(page).to have_selector('td', text: name, count: 1)
+              expect(page).to have_selector('td', text: email, count: 1)
+            end
+          end
+        end
+      end
+    end
+
+    describe 'orders edit page' do
+      before { visit spree.edit_admin_order_path(order) }
+
+      context "when no distributor allow the producer to edit orders" do
+        let(:distributor) { create(:distributor_enterprise) }
+
+        it "should not allow producer to view orders page" do
+          expect(page).to have_content 'Unauthorized'
+        end
+      end
+
+      context "when distributor allows to edit orders" do
+        let(:distributor) { create(:distributor_enterprise, enable_producers_to_edit_orders: true) }
+        let(:product) { supplier1_v2.product }
+
+        it "should allow me to manage my products in the order" do
+          expect(page).to have_content 'Add Product'
+
+          # Add my product
+          add_product(product)
+          expect_product_change(product, :add)
+
+          # Edit my product
+          edit_product(product)
+          expect_product_change(product, :update, 2)
+
+          # Delete my product
+          delete_product(product)
+          expect_product_change(product, :remove)
+        end
+      end
+
+
+      def expect_product_change(product, action, expected_qty = 0)
+        within('table.index') do
+          # JS for this page sometimes take more than 2 seconds (default timeout for cappybara)
+          timeout = 5
+          item_name_selector = 'tbody tr td.item-name'
+          quantity_selector = 'tbody tr td.item-qty-show'
+
+          case action
+          when :add
+            expect(page).to have_selector item_name_selector, text: product.name, wait: timeout
+          when :update
+            expect(page).to have_selector quantity_selector, text: expected_qty, wait: timeout
+          when :remove
+            expect(page).not_to have_selector item_name_selector, text: product.name, wait: timeout
+          else
+            raise 'Invalid action'
+          end
+        end
+      end
+
+      def add_product(product)
+        select2_select product.name, from: 'add_variant_id', search: true
+        find('button.add_variant').click
+      end
+
+      def edit_product(product)
+        find('a.edit-item.icon_link.icon-edit.no-text.with-tip').click
+        fill_in 'quantity', with: 2
+        find("a[data-variant-id='#{product.variants.last.id}'][data-action='save']").click
+      end
+
+      def delete_product(product)
+        find("a[data-variant-id='#{product.variants.last.id}'][data-action='remove']").click
+        click_button 'OK'
+      end
+
+    end
+  end
+
+end

--- a/spec/system/admin/orders/producer_actions_spec.rb
+++ b/spec/system/admin/orders/producer_actions_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'As a producer who have the ability to update orders' do
             within('#listing_orders tbody') do
               expect(page).to have_selector('tr', count: 1) # Only one order
               # One for Email, one for Name
-              expect(page).to have_selector('td', text: 'HIDDEN', count: 2)
+              expect(page).to have_selector('td', text: '< Hidden >', count: 2)
             end
           end
         end

--- a/spec/system/admin/orders/producer_actions_spec.rb
+++ b/spec/system/admin/orders/producer_actions_spec.rb
@@ -83,6 +83,12 @@ RSpec.describe 'As a producer who have the ability to update orders' do
               expect(page).to have_selector('tr', count: 1) # Only one order
               expect(page).to have_selector('td', text: name, count: 1)
               expect(page).to have_selector('td', text: email, count: 1)
+              within 'td.actions' do
+                # to have edit button
+                expect(page).to have_selector("a.icon-edit")
+                # not to have ship button
+                expect(page).not_to have_selector('button.icon-road')
+              end
             end
           end
         end

--- a/spec/system/admin/orders/producer_actions_spec.rb
+++ b/spec/system/admin/orders/producer_actions_spec.rb
@@ -122,19 +122,17 @@ RSpec.describe 'As a producer who have the ability to update orders' do
       end
 
       def expect_product_change(product, action, expected_qty = 0)
-        within('table.index') do
-          # JS for this page sometimes take more than 2 seconds (default timeout for cappybara)
-          timeout = 5
-          item_name_selector = 'tbody tr td.item-name'
-          quantity_selector = 'tbody tr td.item-qty-show'
+        # JS for this page sometimes take more than 2 seconds (default timeout for cappybara)
+        timeout = 5
 
+        within('table.index tbody tr', wait: timeout) do
           case action
           when :add
-            expect(page).to have_selector item_name_selector, text: product.name, wait: timeout
+            expect(page).to have_text(product.name, wait: timeout)
           when :update
-            expect(page).to have_selector quantity_selector, text: expected_qty, wait: timeout
+            expect(page).to have_text(expected_qty.to_s, wait: timeout)
           when :remove
-            expect(page).not_to have_selector item_name_selector, text: product.name, wait: timeout
+            expect(page).not_to have_text(product.name, wait: timeout)
           else
             raise 'Invalid action'
           end

--- a/spec/system/admin/orders/producer_actions_spec.rb
+++ b/spec/system/admin/orders/producer_actions_spec.rb
@@ -121,7 +121,6 @@ RSpec.describe 'As a producer who have the ability to update orders' do
         end
       end
 
-
       def expect_product_change(product, action, expected_qty = 0)
         within('table.index') do
           # JS for this page sometimes take more than 2 seconds (default timeout for cappybara)
@@ -157,8 +156,6 @@ RSpec.describe 'As a producer who have the ability to update orders' do
         find("a[data-variant-id='#{product.variants.last.id}'][data-action='remove']").click
         click_button 'OK'
       end
-
     end
   end
-
 end

--- a/spec/system/admin/producer_bulk_order_management.rb
+++ b/spec/system/admin/producer_bulk_order_management.rb
@@ -66,7 +66,8 @@ RSpec.describe 'As a producer who have the ability to update orders' do
           it "should allow producer to view bulk orders page with customer details" do
             within('tbody') do
               expect(page).to have_selector('tr', count: 1)
-              expect(page).to have_selector('td', text: order.bill_address.full_name_for_sorting, count: 1)
+              expect(page).to have_selector('td', text: order.bill_address.full_name_for_sorting,
+                                                  count: 1)
             end
           end
         end

--- a/spec/system/admin/producer_bulk_order_management.rb
+++ b/spec/system/admin/producer_bulk_order_management.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+RSpec.describe 'As a producer who have the ability to update orders' do
+  include AdminHelper
+  include AuthenticationHelper
+  include WebHelper
+
+  let!(:supplier1) { create(:supplier_enterprise, name: 'My supplier1') }
+  let!(:supplier2) { create(:supplier_enterprise, name: 'My supplier2') }
+  let!(:supplier1_v1) { create(:variant, supplier_id: supplier1.id) }
+  let!(:supplier1_v2) { create(:variant, supplier_id: supplier1.id) }
+  let!(:supplier2_v1) { create(:variant, supplier_id: supplier2.id) }
+  let(:order_cycle) do
+    create(:simple_order_cycle, distributors: [distributor], variants: [supplier1_v1, supplier1_v2])
+  end
+  let!(:order_containing_supplier1_products) do
+    o = create(
+      :completed_order_with_totals,
+      distributor:, order_cycle:,
+      user: supplier1_ent_user, line_items_count: 1
+    )
+    o.line_items.first.update_columns(variant_id: supplier1_v1.id)
+    o
+  end
+
+  let(:supplier1_ent_user) { create(:user, enterprises: [supplier1]) }
+
+  context "As supplier1 enterprise user" do
+    before { login_as(supplier1_ent_user) }
+    let(:order) { order_containing_supplier1_products }
+    let(:user) { supplier1_ent_user }
+
+    describe 'bulk orders index page' do
+      before { visit spree.admin_bulk_order_management_path }
+
+      context "when no distributor allow the producer to edit orders" do
+        let(:distributor) { create(:distributor_enterprise) }
+
+        it "should not allow producer to view orders page" do
+          expect(page).to have_content 'Unauthorized'
+        end
+      end
+
+      context "when distributor allows the producer to edit orders" do
+        let(:distributor) { create(:distributor_enterprise, enable_producers_to_edit_orders: true) }
+
+        context "when distributor doesn't allow to view customer details" do
+          it "should allow producer to view bulk orders page with HIDDEN customer details" do
+            within('tbody') do
+              expect(page).to have_selector('tr', count: 1)
+              expect(page).to have_selector('td', text: '< Hidden >', count: 1)
+            end
+          end
+        end
+
+        context "when distributor allows to view customer details" do
+          let(:distributor) do
+            create(
+              :distributor_enterprise,
+              enable_producers_to_edit_orders: true,
+              show_customer_names_to_suppliers: true
+            )
+          end
+          it "should allow producer to view bulk orders page with customer details" do
+            within('tbody') do
+              expect(page).to have_selector('tr', count: 1)
+              expect(page).to have_selector('td', text: order.bill_address.full_name_for_sorting, count: 1)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "spree/admin/orders/edit.html.haml" do
       end
     end
 
-    allow(view).to receive_messages spree_current_user: create(:user)
+    allow(view).to receive_messages spree_current_user: create(:admin_user)
   end
 
   context "when order is complete" do


### PR DESCRIPTION
⚠️ Please use clockify code #12476 Flower Farms

#### What? Why?

- Closes #13031
- This PR incorporates the ability for producers to edit their products on hubs' orders as per the features mentioned in the issue

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mention in the issue
- Along with this, please test the whole existing order module

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
