### PR TITLE
Add option to define your own rubocop command

### DIFF
--- a/script/rubocop-diff.sh
+++ b/script/rubocop-diff.sh
@@ -7,7 +7,25 @@
 #   ./script/rubocop-diff.sh --cached || exit 1
 #
 
-rubocop="`dirname $0`/../bin/rubocop"
+# If you prefer to use faster boot times of the Rubocop Server then you can
+# define your way of calling rubocop:
+#
+#   export RUBOCOP_BIN="rubocop --server"
+#
+# Or locked to the bundled version (needs update after `bundle update`):
+#
+#   export RUBOCOP_BIN="`bundle show rubocop`/exe/rubocop --server"
+#
+# I don't know how to set that automatically though.
+#
+# But I observed some performance improvement:
+#
+# * Using default binstup with spring: boot: 6.2s, repeat: 0.4s, 0.4s, ...
+# * Using rubocop server binstub without bundler: boot: 2s, repeat: 1s, 0.3s, ...
+# * Using rubocop executable directly: boot: 2.1s, repeat: 1s, 0.16s, ...
+#
+# The default binstub is still the safest, always using the bundled version.
+: ${RUBOCOP_BIN="`dirname $0`/../bin/rubocop"}
 cached="$1" # may be empty
 
 if git diff $cached --diff-filter=ACMR HEAD --quiet; then
@@ -17,7 +35,8 @@ fi
 
 exec git diff $cached --name-only --relative --diff-filter=ACMR HEAD |\
 	xargs \
-	$rubocop --force-exclusion \
-                 --fail-level A \
-                 --format simple \
-                 --parallel --cache true
+	$RUBOCOP_BIN \
+          --force-exclusion \
+          --fail-level A \
+          --format simple \
+          --parallel --cache true

--- a/script/rubocop-diff.sh
+++ b/script/rubocop-diff.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 #
 # While you are developing, you can call this script to check all
-# changed files. And then you can also tell Git to check before every
+# changed files. You can auto-correct them if you wish:
+#
+#   ./script/rubocop-diff.sh -a
+#
+# And then you can also tell Git to check before every
 # commit by adding this line to your `.git/hooks/pre-commit` file:
 #
 #   ./script/rubocop-diff.sh --cached || exit 1
@@ -26,7 +30,12 @@
 #
 # The default binstub is still the safest, always using the bundled version.
 : ${RUBOCOP_BIN="`dirname $0`/../bin/rubocop"}
-cached="$1" # may be empty
+
+if [ "$1" = "--cached" ]; then
+  cached="$1"
+else
+  rubocop_opt="$1"
+fi
 
 if git diff $cached --diff-filter=ACMR HEAD --quiet; then
 	# nothing changed
@@ -39,4 +48,5 @@ exec git diff $cached --name-only --relative --diff-filter=ACMR HEAD |\
           --force-exclusion \
           --fail-level A \
           --format simple \
-          --parallel --cache true
+          --parallel --cache true \
+	  "$rubocop_opt"


### PR DESCRIPTION
#### What? Why?

When Rubocop isn't preloaded with spring, it takes a long time to check my first commit. It also needs the whole Rails environment to work. So I prefer to load it without the bundle and in server mode instead of spring. It's faster.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No testing needed.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
