### PR TITLE
Updating form field borders for better contrast

### DIFF
--- a/app/webpacker/css/admin/globals/variables.scss
+++ b/app/webpacker/css/admin/globals/variables.scss
@@ -146,6 +146,7 @@ $h2-size:                        $h3-size + 2 !default;
 $h1-size:                        $h2-size + 2 !default;
 
 $border-radius:                  3px !default;
+$border-input:                   1px solid #2e3132; // Copied over from admin_v3 variables as a temporary solution
 
 $font-weight-bold:               600 !default;
 $font-weight-normal:             400 !default;

--- a/app/webpacker/css/admin/tag_rules.scss
+++ b/app/webpacker/css/admin/tag_rules.scss
@@ -1,4 +1,10 @@
 tags-input {
+  .tags {
+    border: $border-input;
+    border-radius: $border-radius;
+    box-shadow: none;
+    padding: 4px; // hack to make the height match other inputs
+  }
   &.limit-reached {
     input,
     span.input {

--- a/app/webpacker/css/admin_v3/components/select2.scss
+++ b/app/webpacker/css/admin_v3/components/select2.scss
@@ -1,4 +1,10 @@
 .select2-container {
+  border: $border-input;
+  border-radius: $border-radius;
+  padding-bottom: 7px;  // hack to make the height match other inputs
+}
+
+.select2-container {
   &:hover .select2-choice,
   &.select2-container-active .select2-choice {
     background-color: $color-sel-hover-bg !important;
@@ -6,7 +12,6 @@
   }
   .select2-choice {
     background-image: none !important;
-    background-color: $color-sel-bg;
     border: none !important;
     box-shadow: none !important;
     @include border-radius($border-radius);
@@ -40,7 +45,7 @@
 }
 
 .select2-drop {
-  border-color: $color-sel-hover-bg;
+  border-color: $color-txt-brd;
   box-shadow: none !important;
   z-index: 1000000;
 
@@ -141,6 +146,7 @@
   }
   .select2-choices {
     @extend input, [type="text"];
+    border: none;
     padding: 6px 3px 3px 3px;
     box-shadow: none;
     background-image: none !important;

--- a/app/webpacker/css/admin_v3/components/tom_select.scss
+++ b/app/webpacker/css/admin_v3/components/tom_select.scss
@@ -17,10 +17,9 @@
 
   .ts-control {
     box-shadow: none;
-    border-color: $lighter-grey;
-    background-color: $lighter-grey;
+    border: $border-input;
+    border-radius: $border-radius;
     background-image: none;
-    @include border-radius($border-radius);
 
     input {
       font-size: $body-font-size;

--- a/app/webpacker/css/admin_v3/globals/variables.scss
+++ b/app/webpacker/css/admin_v3/globals/variables.scss
@@ -83,7 +83,7 @@ $color-sel-hover-bg:             $lighter-grey !default;
 
 // Text inputs styles
 $color-txt-bg:                   $lighter-grey !default;
-$color-txt-brd:                  $lighter-grey !default;
+$color-txt-brd:                  $dark-grey !default;
 $color-txt-text:                 $near-black !default;
 $color-txt-hover-brd:            $teal !default;
 $color-txt-disabled-text:        $medium-grey !default;
@@ -171,6 +171,7 @@ $h3-size:                        $h4-size + 2 !default;
 $h2-size:                        $h3-size + 2 !default;
 $h1-size:                        $h2-size + 2 !default;
 
+$border-input:                   1px solid $color-txt-brd;
 $border-radius:                  4px !default;
 $box-shadow:                     0px 1px 0px rgba(0, 0, 0, 0.05), 0px 2px 2px rgba(0, 0, 0, 0.07) !default;
 

--- a/app/webpacker/css/admin_v3/shared/forms.scss
+++ b/app/webpacker/css/admin_v3/shared/forms.scss
@@ -14,11 +14,10 @@ input[type="datetime"],
 input[type="time"],
 input[type="number"],
 textarea {
-  @include border-radius($border-radius);
   padding: ($vpadding-txt - 1px) ($hpadding-txt - 1px); // Minus 1px for border
-  border: 1px solid $color-txt-brd;
+  border: $border-input;
+  border-radius: $border-radius;
   color: $color-txt-text;
-  background-color: $color-txt-bg;
   font-size: 14px;
   line-height: 22px;
 


### PR DESCRIPTION
#### What? Why?

Closes: #12846 

Border colours on forms did not have sufficient contrast. [New contrast ratio using `$dark-grey #2E3132` passes WCAG AA for user interface components](https://webaim.org/resources/contrastchecker/?fcolor=2E3132&bcolor=FFFFFF).

Note: on top of the border change I've refactored (adjusted) a few of the inputs as with the new border it was obvious there were some size and border radius differences.

##### Screenshots of the new UI on this branch

**Inputs and tomselects**
![Inputs and Tomselects](https://github.com/user-attachments/assets/6beec85a-c9d3-4981-b569-fafecee2dca1)

**Select2**
![ofn_select2](https://github.com/user-attachments/assets/c7e59ec4-ffc2-401a-ac71-cac3b48e5c94)

**Tags**
![ofn_tags](https://github.com/user-attachments/assets/b5f2f449-b345-460a-98b6-906e5184ec42)

#### What should we test?

1. All versions of input fields i.e. text, number, time etc. - any form should do, found a `textarea` under /admin/general_settings/edit
2. Tomselect fields - Go to /admin/orders, both **Status** and **Shipping method** are tomselects
4. Select2 fields - Go to /admin/order_cycles, both **Involving** and **Schedule** are select2
5. Tag fields - Go to /admin/order_cycles and edit an order, the **Tag** field is at the bottom
6. Find any custom form inputs that I may have missed.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

#### Documentation updates
Form related content does not seem to exist on the Wiki. Suggest adding a wiki entry under Design for Design styleguide: forms