### PR TITLE
Open admin dashboard in same tab by default

### DIFF
--- a/app/views/shared/menu/_signed_in.html.haml
+++ b/app/views/shared/menu/_signed_in.html.haml
@@ -9,7 +9,7 @@
 
     - if admin_user? or enterprise_user?
       %li
-        %a{href: spree.admin_dashboard_path, target:'_blank'}
+        %a{href: spree.admin_dashboard_path}
           %i.ofn-i_021-tools
           = t 'label_administration'
 

--- a/app/views/shared/menu/_signed_in_offcanvas.html.haml
+++ b/app/views/shared/menu/_signed_in_offcanvas.html.haml
@@ -1,6 +1,6 @@
 - if admin_user? or enterprise_user?
   %li
-    %a{href: spree.admin_dashboard_path, target:'_blank'}
+    %a{href: spree.admin_dashboard_path}
       %i.ofn-i_021-tools
       = t 'label_admin'
 


### PR DESCRIPTION
#### What? Why?

Relating to recent discussions around avoiding opening links in new tabs. We want to decide this on a case by case basis. So I'm putting this forward to discuss this particular case.

We have two links from the shop menu to the admin dashboard. One is visible for desktop views in the top right corner in a menu and the other one is visible on small screens in the sidebar menu.

I find the new tab annoying. Rachel made the point that sometimes you want to have the shop and the admin panel open at the same time to see the effects of your admin actions.

People can still open tabs themselves. Do they use it? Shall we create a feature toggle for this to test? We could remove the new tab on small screens and keep it on big screens...

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Open the admin dashboard from the menu on small and big screens.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
