### PR TITLE
Speed up super admin dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -182,6 +182,7 @@ end
 group :development do
   gem 'debugger-linecache'
   gem 'foreman'
+  gem 'i18n-tasks'
   gem 'listen'
   gem 'pry', '~> 0.13.0'
   gem 'query_count'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,6 +351,16 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n-js (3.9.2)
       i18n (>= 0.6.6)
+    i18n-tasks (1.0.14)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -777,6 +787,8 @@ GEM
       faraday (~> 2.0)
       faraday-follow_redirects
     temple (0.8.2)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     thor (1.3.1)
     thread-local (1.1.0)
     tilt (2.3.0)
@@ -905,6 +917,7 @@ DEPENDENCIES
   highline (= 2.0.3)
   i18n
   i18n-js (~> 3.9.0)
+  i18n-tasks
   image_processing
   immigrant
   invisible_captcha

--- a/app/assets/javascripts/templates/admin/columns_dropdown.html.haml
+++ b/app/assets/javascripts/templates/admin/columns_dropdown.html.haml
@@ -2,13 +2,13 @@
   .ofn-drop-down-label
     = "&nbsp; #{t('admin.columns')}".html_safe
     %span{ 'ng-class' => "expanded && 'icon-caret-up' || !expanded && 'icon-caret-down'" }
-  %div.menu{ 'ng-show' => "expanded" }
+  .menu{ 'ng-show' => "expanded" }
     .menu_items
       .menu_item{ "ng-repeat": "column in columns", "ng-click": "toggle(column);" }
         %input{ type: "checkbox", "ng-checked": "column.visible" }
         %span
           {{ column.name }}
       %hr
-      %div.menu_item.text-center
+      .menu_item.text-center
         %input.fullwidth.orange{ type: "button", "ng-value": "saved() ? 'Saved': 'Saving'", "ng-show": "saved() || saving", "ng-disabled": "saved()" }
         %input.fullwidth.red{ type: "button", value: t('admin.column_save_as_default').html_safe, "ng-show": "!saved() && !saving", "ng-click": "saveColumnPreferences(action)" }

--- a/app/assets/javascripts/templates/admin/modals/image_upload.html.haml
+++ b/app/assets/javascripts/templates/admin/modals/image_upload.html.haml
@@ -2,7 +2,7 @@
   %i.fa.fa-times-circle{'aria-hidden' => "true"}
 
 %form#image_upload{ name: 'form', novalidate: true, enctype: 'multipart/form-data', multipart: true, "ng-controller": "ProductImageCtrl" }
-  %div.image-preview
+  .image-preview
     %img.spinner{ src: image_path("/spinning-circles.svg"), "ng-hide": "!imageUploader.isUploading" }
     %img.preview{ "ng-src": "{{imagePreview}}", "ng-class": "{'faded': imageUploader.isUploading}" }
 

--- a/app/assets/javascripts/templates/partials/contact.html.haml
+++ b/app/assets/javascripts/templates/partials/contact.html.haml
@@ -1,5 +1,5 @@
-%div.contact-container
-  %div.modal-centered{"ng-if" => "::enterprise.email_address || enterprise.website || enterprise.phone || enterprise.whatsapp_phone"}
+.contact-container
+  .modal-centered{"ng-if" => "::enterprise.email_address || enterprise.website || enterprise.phone || enterprise.whatsapp_phone"}
     %p.modal-header {{'contact' | t}}
     %p{"ng-if" => "::enterprise.phone", "ng-bind" => "::enterprise.phone"}
 

--- a/app/assets/javascripts/templates/partials/follow.html.haml
+++ b/app/assets/javascripts/templates/partials/follow.html.haml
@@ -1,4 +1,4 @@
-%div.modal-centered{ "ng-if" => "::enterprise.twitter || enterprise.facebook || enterprise.linkedin || enterprise.instagram"}
+.modal-centered{ "ng-if" => "::enterprise.twitter || enterprise.facebook || enterprise.linkedin || enterprise.instagram"}
   %p.modal-header {{'follow' | t}}
   .follow-icons
     %span{"ng-if" => "::enterprise.twitter"}

--- a/app/assets/javascripts/templates/partials/producer_details.html.haml
+++ b/app/assets/javascripts/templates/partials/producer_details.html.haml
@@ -7,7 +7,7 @@
       .columns.small-12.fat
         %div{"ng-if" => "::enterprise.name"}
           %label{"ng-bind-html" => "::'shop_for_products_html' | t:{enterprise: enterprise.name}"}
-        %div.show-for-medium-up{"ng-if" => "::!enterprise.name"}
+        .show-for-medium-up{"ng-if" => "::!enterprise.name"}
           &nbsp;
     .row
       .columns.small-12

--- a/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
+++ b/app/components/multiple_checked_select_component/multiple_checked_select_component.html.haml
@@ -1,12 +1,12 @@
 .ofn-drop-down.ofn-drop-down-v2{ data: { controller: "multiple-checked-select" } }
-  %div.ofn-drop-down-label{ "data-multiple-checked-select-target": "button" }
+  .ofn-drop-down-label{ "data-multiple-checked-select-target": "button" }
     %span{class: "label"}= t('admin.columns')
     %span{ class: "icon-caret-down", "data-multiple-checked-select-target": "caret" }
-  %div.menu{ class: "hidden", "data-multiple-checked-select-target": "options" }
-    %div.filter
+  .menu{ class: "hidden", "data-multiple-checked-select-target": "options" }
+    .filter
       %input{ type: "text", "data-multiple-checked-select-target": "filter", placeholder: I18n.t('components.multiple_checked_select.filter_placeholder') }
     %hr
-    %div.menu_items
+    .menu_items
       - @options.each do |option|
         %label.menu_item{ "data-multiple-checked-select-target": "option", "data-value": option[1], "data-label": option[0] }
           %input{ type: "checkbox", checked: @selected.include?(option[1]), name: "#{@name}[]", value: option[1] }

--- a/app/controllers/spree/admin/overview_controller.rb
+++ b/app/controllers/spree/admin/overview_controller.rb
@@ -5,9 +5,11 @@ module Spree
   module Admin
     class OverviewController < Spree::Admin::BaseController
       def index
-        @enterprises = Enterprise
-          .managed_by(spree_current_user)
+        my_enterprises = Enterprise.managed_by(spree_current_user)
+        @enterprises = my_enterprises
           .order('is_primary_producer ASC, name')
+          .limit(25)
+        @enterprises_count = my_enterprises.count if @enterprises.count >= 25
         @product_count = Spree::Product.active.managed_by(spree_current_user).count
         @order_cycle_count = OrderCycle.active.managed_by(spree_current_user).count
 

--- a/app/views/admin/customers/index.html.haml
+++ b/app/views/admin/customers/index.html.haml
@@ -101,6 +101,6 @@
             %td.actions
               %a{ 'ng-click' => "deleteCustomer(customer)", :class => "delete-customer icon-trash no-text" }
 
-      %div.text-center{ "ng-show": "filteredCustomers.length > customerLimit" }
+      .text-center{ "ng-show": "filteredCustomers.length > customerLimit" }
         %input{ type: 'button', value: t(:show_more), "ng-click": 'customerLimit = customerLimit + 20' }
         %input{ type: 'button', value: t(:show_all_with_more, num: '{{ filteredCustomers.length - customerLimit }}'), "ng-click": 'customerLimit = filteredCustomers.length' }

--- a/app/views/admin/order_cycles/_loading_flash.html.haml
+++ b/app/views/admin/order_cycles/_loading_flash.html.haml
@@ -1,4 +1,4 @@
-%div.sixteen.columns.alpha.omega#loading{ "ng-cloak": true, "ng-if": 'RequestMonitor.loading' }
+.sixteen.columns.alpha.omega#loading{ "ng-cloak": true, "ng-if": 'RequestMonitor.loading' }
   = render partial: "components/admin_spinner"
   %h1{ "ng-hide": 'orderCycles.length > 0' }
     = t('.loading_order_cycles')

--- a/app/views/admin/order_cycles/checkout_options.html.haml
+++ b/app/views/admin/order_cycles/checkout_options.html.haml
@@ -79,12 +79,12 @@
                     = t('.no_payment_methods')
 
   %div#save-bar
-    %div.container
-      %div.seven.columns.alpha
+    .container
+      .seven.columns.alpha
         - if @order_cycle.errors.any?
           %h5#status-message.error
             = @order_cycle.errors.to_a.to_sentence
-      %div.nine.columns.omega.text-right
+      .nine.columns.omega.text-right
         = hidden_field_tag :context, :checkout_options
         = f.submit t('.save'), class: "red", name: :save
         = f.submit t('.save_and_back_to_list'), class: "red", name: :save_and_back_to_list

--- a/app/views/admin/order_cycles/checkout_options.html.haml
+++ b/app/views/admin/order_cycles/checkout_options.html.haml
@@ -78,7 +78,7 @@
                   %p
                     = t('.no_payment_methods')
 
-  %div#save-bar
+  #save-bar
     .container
       .seven.columns.alpha
         - if @order_cycle.errors.any?

--- a/app/views/admin/order_cycles/edit.html.haml
+++ b/app/views/admin/order_cycles/edit.html.haml
@@ -33,7 +33,7 @@
     - else
       = render 'form', f: f
 
-    %div.warning-modal{ data: { controller: 'modal modal-link', 'modal-link-target-value': "linked-order-warning-modal" } }
+    .warning-modal{ data: { controller: 'modal modal-link', 'modal-link-target-value': "linked-order-warning-modal" } }
       %button.modal-target-trigger{ type: 'button', data: { 'action': 'modal-link#open' }, style: 'display: none;' } 
       = render ModalComponent.new(id: "linked-order-warning-modal", close_button: false) do
         .content.flex-column.gap-2

--- a/app/views/admin/order_cycles/index.html.haml
+++ b/app/views/admin/order_cycles/index.html.haml
@@ -35,7 +35,7 @@
         = render 'admin/order_cycles/loading_flash'
         = render 'admin/order_cycles/show_more'
 
-        %div.warning-modal{ data: { controller: 'modal modal-link', 'modal-link-target-value': "linked-order-warning-modal" } }
+        .warning-modal{ data: { controller: 'modal modal-link', 'modal-link-target-value': "linked-order-warning-modal" } }
           %button.modal-target-trigger{ type: 'button', data: { 'action': 'modal-link#open' }, style: 'display: none;' } 
           = render ModalComponent.new(id: "linked-order-warning-modal", close_button: false) do
             .content.flex-column.gap-2

--- a/app/views/admin/product_import/_entries_table.html.haml
+++ b/app/views/admin/product_import/_entries_table.html.haml
@@ -1,4 +1,4 @@
-%div.table-wrap
+.table-wrap
   %table
     %thead
       %th

--- a/app/views/admin/product_import/_errors_list.html.haml
+++ b/app/views/admin/product_import/_errors_list.html.haml
@@ -1,4 +1,4 @@
-%div.import-errors{ "ng-controller": 'ImportFeedbackCtrl', "ng-repeat": "(line_number, entry ) in (entries | entriesFilterValid:'invalid')" }
+.import-errors{ "ng-controller": 'ImportFeedbackCtrl', "ng-repeat": "(line_number, entry ) in (entries | entriesFilterValid:'invalid')" }
   %p.line
     %strong
       #{t('admin.product_import.import.item_line')} {{line_number}}:

--- a/app/views/admin/product_import/_import_options.html.haml
+++ b/app/views/admin/product_import/_import_options.html.haml
@@ -3,34 +3,34 @@
 
 - @importer.enterprises_index.each do |name, attrs|
   - if name and attrs[:id] and @importer.permission_by_id?(attrs[:id])
-    %div.panel-section.import-settings
-      %div.panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active}' }
-        %div.header-icon.success
+    .panel-section.import-settings
+      .panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active}' }
+        .header-icon.success
           %i.fa.fa-check-circle
-        %div.header-description
+        .header-description
           = name
   - elsif name and attrs[:id]
-    %div.panel-section.import-settings
-      %div.panel-header
-        %div.header-icon.error
+    .panel-section.import-settings
+      .panel-header
+        .header-icon.error
           %i.fa.fa-warning
-        %div.header-description
+        .header-description
           = name
           %span.header-error= " - #{t('admin.product_import.import.no_permission')}"
   - elsif name
-    %div.panel-section.import-settings
-      %div.panel-header
-        %div.header-icon.error
+    .panel-section.import-settings
+      .panel-header
+        .header-icon.error
           %i.fa.fa-warning
-        %div.header-description
+        .header-description
           = name
           %span.header-error= " - #{t('admin.product_import.import.not_found')}"
   - else
-    %div.panel-section.import-settings
-      %div.panel-header
-        %div.header-icon.error
+    .panel-section.import-settings
+      .panel-header
+        .header-icon.error
           %i.fa.fa-warning
-        %div.header-description
+        .header-description
           = t('admin.product_import.import.no_name')
           %span.header-error= " - #{t('admin.product_import.import.blank_enterprise')}"
 

--- a/app/views/admin/product_import/_import_review.html.haml
+++ b/app/views/admin/product_import/_import_review.html.haml
@@ -9,101 +9,101 @@
       %em= @non_updatable_fields.keys.join(', ') + "."
       = t('.fields_ignored')
 
-  %div.panel-section{ "ng-controller": 'DropdownPanelsCtrl' }
-    %div.panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"all"))}' }
-      %div.header-caret
+  .panel-section{ "ng-controller": 'DropdownPanelsCtrl' }
+    .panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"all"))}' }
+      .header-caret
         %i{ "ng-class": "{'icon-chevron-down': active, 'icon-chevron-right': !active}", "ng-hide": 'count((entries | entriesFilterValid:"all")) == 0' }
-      %div.header-icon.success
+      .header-icon.success
         %i.fa.fa-info-circle.info
-      %div.header-count
+      .header-count
         %strong.item-count
           {{ count((entries | entriesFilterValid:"all")) }}
-      %div.header-description
+      .header-description
         = t('admin.product_import.import.entries_found')
-    %div.panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"all")) == 0' }
+    .panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"all")) == 0' }
       = render 'entries_table', entries: 'all'
 
-  %div.panel-section{ "ng-controller": 'DropdownPanelsCtrl', "ng-hide": 'count((entries | entriesFilterValid:"invalid")) == 0' }
-    %div.panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"invalid"))}' }
-      %div.header-caret
+  .panel-section{ "ng-controller": 'DropdownPanelsCtrl', "ng-hide": 'count((entries | entriesFilterValid:"invalid")) == 0' }
+    .panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"invalid"))}' }
+      .header-caret
         %i{ "ng-class": "{'icon-chevron-down': active, 'icon-chevron-right': !active}", "ng-hide": 'count((entries | entriesFilterValid:"invalid")) == 0' }
-      %div.header-icon.error
+      .header-icon.error
         %i.fa.fa-warning
-      %div.header-count
+      .header-count
         %strong.invalid-count
           {{ count((entries | entriesFilterValid:"invalid")) }}
-      %div.header-description
+      .header-description
         = t('admin.product_import.import.entries_with_errors')
-    %div.panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"invalid")) == 0' }
+    .panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"invalid")) == 0' }
       = render 'errors_list'
       %br
       = render 'entries_table', entries: 'invalid'
 
-  %div.panel-section{ "ng-controller": 'DropdownPanelsCtrl', "ng-hide": 'count((entries | entriesFilterValid:"create_product")) == 0' }
-    %div.panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"create_product"))}' }
-      %div.header-caret
+  .panel-section{ "ng-controller": 'DropdownPanelsCtrl', "ng-hide": 'count((entries | entriesFilterValid:"create_product")) == 0' }
+    .panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"create_product"))}' }
+      .header-caret
         %i{ "ng-class": "{'icon-chevron-down': active, 'icon-chevron-right': !active}", "ng-hide": 'count((entries | entriesFilterValid:"create_product")) == 0' }
-      %div.header-icon.success
+      .header-icon.success
         %i.fa.fa-check-circle
-      %div.header-count
+      .header-count
         %strong.create-count
           {{ count((entries | entriesFilterValid:"create_product")) }}
-      %div.header-description
+      .header-description
         = t('admin.product_import.import.products_to_create')
-    %div.panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"create_product")) == 0' }
+    .panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"create_product")) == 0' }
       = render 'entries_table', entries: 'create_product'
 
-  %div.panel-section{ "ng-controller": 'DropdownPanelsCtrl', "ng-hide": 'count((entries | entriesFilterValid:"update_product")) == 0' }
-    %div.panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"update_product"))}' }
-      %div.header-caret
+  .panel-section{ "ng-controller": 'DropdownPanelsCtrl', "ng-hide": 'count((entries | entriesFilterValid:"update_product")) == 0' }
+    .panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"update_product"))}' }
+      .header-caret
         %i{ "ng-class": "{'icon-chevron-down': active, 'icon-chevron-right': !active}", "ng-hide": 'count((entries | entriesFilterValid:"update_product")) == 0' }
-      %div.header-icon.success
+      .header-icon.success
         %i.fa.fa-check-circle
-      %div.header-count
+      .header-count
         %strong.update-count
           {{ count((entries | entriesFilterValid:"update_product")) }}
-      %div.header-description
+      .header-description
         = t('admin.product_import.import.products_to_update')
-    %div.panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"update_product")) == 0' }
+    .panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"update_product")) == 0' }
       = render 'entries_table', entries: 'update_product'
 
-  %div.panel-section{ "ng-controller": 'DropdownPanelsCtrl', "ng-hide": 'count((entries | entriesFilterValid:"create_inventory")) == 0' }
-    %div.panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"create_inventory"))}' }
-      %div.header-caret
+  .panel-section{ "ng-controller": 'DropdownPanelsCtrl', "ng-hide": 'count((entries | entriesFilterValid:"create_inventory")) == 0' }
+    .panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"create_inventory"))}' }
+      .header-caret
         %i{ "ng-class": "{'icon-chevron-down': active, 'icon-chevron-right': !active}", "ng-hide": 'count((entries | entriesFilterValid:"create_inventory")) == 0' }
-      %div.header-icon.success
+      .header-icon.success
         %i.fa.fa-check-circle
-      %div.header-count
+      .header-count
         %strong.inv-create-count
           {{ count((entries | entriesFilterValid:"create_inventory")) }}
-      %div.header-description
+      .header-description
         = t('admin.product_import.import.inventory_to_create')
-    %div.panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"create_inventory")) == 0' }
+    .panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"create_inventory")) == 0' }
       = render 'entries_table', entries: 'create_inventory'
 
-  %div.panel-section{ "ng-controller": 'DropdownPanelsCtrl', "ng-hide": 'count((entries | entriesFilterValid:"update_inventory")) == 0' }
-    %div.panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"update_inventory"))}' }
-      %div.header-caret
+  .panel-section{ "ng-controller": 'DropdownPanelsCtrl', "ng-hide": 'count((entries | entriesFilterValid:"update_inventory")) == 0' }
+    .panel-header{ "ng-click": 'togglePanel()', "ng-class": '{active: active && count((entries | entriesFilterValid:"update_inventory"))}' }
+      .header-caret
         %i{ "ng-class": "{'icon-chevron-down': active, 'icon-chevron-right': !active}", "ng-hide": 'count((entries | entriesFilterValid:"update_inventory")) == 0' }
-      %div.header-icon.success
+      .header-icon.success
         %i.fa.fa-check-circle
-      %div.header-count
+      .header-count
         %strong.inv-update-count
           {{ count((entries | entriesFilterValid:"update_inventory")) }}
-      %div.header-description
+      .header-description
         = t('admin.product_import.import.inventory_to_update')
-    %div.panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"update_inventory")) == 0' }
+    .panel-content{ "ng-hide": '!active || count((entries | entriesFilterValid:"update_inventory")) == 0' }
       = render 'entries_table', entries: 'update_inventory'
 
-  %div.panel-section{ "ng-controller": 'ImportOptionsFormCtrl', "ng-hide": 'resetTotal == 0' }
-    %div.panel-header
-      %div.header-caret
-      %div.header-icon.info
+  .panel-section{ "ng-controller": 'ImportOptionsFormCtrl', "ng-hide": 'resetTotal == 0' }
+    .panel-header
+      .header-caret
+      .header-icon.info
         %i.fa.fa-info-circle
-      %div.header-count
+      .header-count
         %strong.reset-count
           {{ resetTotal }}
-      %div.header-description
+      .header-description
         -if @import_into == 'inventories'
           = t('admin.product_import.import.inventory_to_reset')
         - else

--- a/app/views/admin/product_import/_save_results.html.haml
+++ b/app/views/admin/product_import/_save_results.html.haml
@@ -2,7 +2,7 @@
 %h5= t('.final_results')
 %br
 
-%div.post-save-results
+.post-save-results
 
   %p{ "ng-show": 'updates.products_created' }
     %i.fa{ "ng-class": "{'fa-info-circle': updates.products_created == 0, 'fa-check-circle': updates.products_created > 0}" }

--- a/app/views/admin/products_v3/_sort.html.haml
+++ b/app/views/admin/products_v3/_sort.html.haml
@@ -1,5 +1,5 @@
 #sort
-  %div.pagination-description
+  .pagination-description
     - if pagy.present?
       = t(".pagination.products_total_html", count: pagy.count, from: pagy.from, to: pagy.to)
 

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -22,7 +22,7 @@
 %td.col-unit.field.popout{'data-controller': "popout", 'data-popout-update-display-value': "false"}
   = f.button :unit_to_display, class: "popout__button", 'aria-label': t('admin.products_page.columns.unit'), 'data-popout-target': "button" do
     = variant.unit_to_display # Show the generated summary of unit values
-  %div.popout__container{ style: 'display: none;', 'data-controller': 'toggle-control', 'data-popout-target': "dialog" }
+  .popout__container{ style: 'display: none;', 'data-controller': 'toggle-control', 'data-popout-target': "dialog" }
     .field
       -# Show a composite field for unit_value and unit_description
       = f.hidden_field :unit_value
@@ -39,7 +39,7 @@
 %td.col-on_hand.field.popout{'data-controller': "popout"}
   %button.popout__button{'data-popout-target': "button", 'aria-label': t('admin.products_page.columns.on_hand')}
     = variant.on_demand_desired_or_current ? t(:on_demand) : variant.on_hand_desired_or_current
-  %div.popout__container{ style: 'display: none;', 'data-controller': 'toggle-control', 'data-popout-target': "dialog" }
+  .popout__container{ style: 'display: none;', 'data-controller': 'toggle-control', 'data-popout-target': "dialog" }
     .field
       = f.number_field method_on_hand, min: 0, 'aria-label': t('admin.products_page.columns.on_hand'), 'data-toggle-control-target': 'control', disabled: f.object.on_demand_desired_or_current
       = error_message_on variant, method_on_hand

--- a/app/views/admin/shared/_views_dropdown.html.haml
+++ b/app/views/admin/shared/_views_dropdown.html.haml
@@ -1,7 +1,7 @@
 .ofn-drop-down#views-dropdown
   %span{ :class => 'icon-eye-open' }= "&nbsp; #{t('admin.viewing', current_view_name: '{{ currentView().name }}')}".html_safe
   %span{ 'ng-class' => "expanded && 'icon-caret-up' || !expanded && 'icon-caret-down'" }
-  %div.menu{ 'ng-show' => "expanded" }
-    %div.menu_item{ "close-on-click": true, "ng-repeat": "(viewKey, view) in views", "toggle-view": true }
+  .menu{ 'ng-show' => "expanded" }
+    .menu_item{ "close-on-click": true, "ng-repeat": "(viewKey, view) in views", "toggle-view": true }
       %span.check
       %span.name {{ view.name }}

--- a/app/views/admin/subscriptions/_loading_flash.html.haml
+++ b/app/views/admin/subscriptions/_loading_flash.html.haml
@@ -1,4 +1,4 @@
-%div.sixteen.columns.alpha.omega#loading{ "ng-cloak": true, "ng-if": 'shop_id && RequestMonitor.loading' }
+.sixteen.columns.alpha.omega#loading{ "ng-cloak": true, "ng-if": 'shop_id && RequestMonitor.loading' }
   = render partial: "components/admin_spinner"
   %h1
     = t('.loading')

--- a/app/views/admin/subscriptions/_no_results.html.haml
+++ b/app/views/admin/subscriptions/_no_results.html.haml
@@ -1,4 +1,4 @@
-%div.margin-top-30.text-center{ "ng-show": 'shop_id && !RequestMonitor.loading && filteredSubscriptions.length == 0' }
+.margin-top-30.text-center{ "ng-show": 'shop_id && !RequestMonitor.loading && filteredSubscriptions.length == 0' }
   .no-results{ "ng-show": '!filtersApplied()' }
     %h1.margin-bottom-20=t('.no_subscriptions')
     %span.text-big=t('.why_dont_you_add_one')

--- a/app/views/admin/subscriptions/index.html.haml
+++ b/app/views/admin/subscriptions/index.html.haml
@@ -15,7 +15,7 @@
 = render 'data'
 = render 'order_update_issues_dialog'
 
-%div.margin-bottom-50{ "ng-controller": 'SubscriptionsController' }
+.margin-bottom-50{ "ng-controller": 'SubscriptionsController' }
   %save-bar{ dirty: "false", persist: "false" }
   = render 'filters'
   = render 'controls'

--- a/app/views/admin/variant_overrides/_loading_flash.html.haml
+++ b/app/views/admin/variant_overrides/_loading_flash.html.haml
@@ -1,4 +1,4 @@
-%div.sixteen.columns.alpha.omega#loading{ "ng-cloak": true, "ng-if": 'hub_id && products.length == 0 && RequestMonitor.loading' }
+.sixteen.columns.alpha.omega#loading{ "ng-cloak": true, "ng-if": 'hub_id && products.length == 0 && RequestMonitor.loading' }
   = render partial: "components/admin_spinner"
   %h1
     = t('.loading_inventory')

--- a/app/views/admin/variant_overrides/_no_results.html.haml
+++ b/app/views/admin/variant_overrides/_no_results.html.haml
@@ -1,4 +1,4 @@
-%div.text-big.no-results{ "ng-show": 'hub_id && products.length > 0 && filteredProducts.length == 0' }
+.text-big.no-results{ "ng-show": 'hub_id && products.length > 0 && filteredProducts.length == 0' }
   %span{ "ng-show": 'views.inventory.visible && !filtersApplied()' }=t('admin.variant_overrides.index.currently_empty')
   %span{ "ng-show": 'views.inventory.visible && filtersApplied()' }=t('admin.variant_overrides.index.no_matching_products')
   %span{ "ng-show": 'views.hidden.visible && !filtersApplied()' }=t('admin.variant_overrides.index.no_hidden_products')

--- a/app/views/checkout/_details.html.haml
+++ b/app/views/checkout/_details.html.haml
@@ -1,54 +1,54 @@
 = form_with url: checkout_update_path(checkout_step), model: @order, method: :put, data: { remote: "true" } do |f|
   .medium-6
     = f.fields :bill_address, model: @order.bill_address do |bill_address|
-      %div.checkout-substep
+      .checkout-substep
         -# YOUR DETAILS
-        %div.checkout-title
+        .checkout-title
           = t("checkout.step1.contact_information.title")
 
         .two-columns-inputs
-          %div.checkout-input.with-floating-label{ "data-controller": "floating-label" }
+          .checkout-input.with-floating-label{ "data-controller": "floating-label" }
             = f.label :email, t("checkout.step1.contact_information.email.label")
             = f.text_field :email, { placeholder: " " }
             = f.error_message_on :email
 
-          %div.checkout-input.with-floating-label{ "data-controller": "floating-label" }
+          .checkout-input.with-floating-label{ "data-controller": "floating-label" }
             = bill_address.label :phone, t("checkout.step1.contact_information.phone.label")
             = bill_address.text_field :phone, { placeholder: " " }
             = f.error_message_on "bill_address.phone"
 
-      %div.checkout-substep
+      .checkout-substep
         -# BILLING ADDRESS
-        %div.checkout-title
+        .checkout-title
           = t("checkout.step1.billing_address.title")
 
         .two-columns-inputs
-          %div.checkout-input.with-floating-label{ "data-controller": "floating-label" }
+          .checkout-input.with-floating-label{ "data-controller": "floating-label" }
             = bill_address.label :firstname, t("checkout.step1.billing_address.first_name.label")
             = bill_address.text_field :firstname, { placeholder: " " }
             = f.error_message_on "bill_address.firstname"
 
-          %div.checkout-input.with-floating-label{ "data-controller": "floating-label" }
+          .checkout-input.with-floating-label{ "data-controller": "floating-label" }
             = bill_address.label :lastname, t("checkout.step1.billing_address.last_name.label")
             = bill_address.text_field :lastname, { placeholder: " " }
             = f.error_message_on "bill_address.lastname"
 
-        %div.checkout-input.with-floating-label{ "data-controller": "floating-label"}
+        .checkout-input.with-floating-label{ "data-controller": "floating-label"}
           = bill_address.label :address1, t("checkout.step1.address.address1.label")
           = bill_address.text_field :address1, { placeholder: " " }
           = f.error_message_on "bill_address.address1"
 
-        %div.checkout-input.with-floating-label{ "data-controller": "floating-label"}
+        .checkout-input.with-floating-label{ "data-controller": "floating-label"}
           = bill_address.label :address2, t("checkout.step1.address.address2.label")
           = bill_address.text_field :address2, { placeholder: " " }
           = f.error_message_on "bill_address.address2"
 
-        %div.checkout-input.with-floating-label{ "data-controller": "floating-label"}
+        .checkout-input.with-floating-label{ "data-controller": "floating-label"}
           = bill_address.label :city, t("checkout.step1.address.city.label")
           = bill_address.text_field :city, { placeholder: " " }
           = f.error_message_on "bill_address.city"
 
-        %div.checkout-input.with-floating-label{ "data-controller": "floating-label"}
+        .checkout-input.with-floating-label{ "data-controller": "floating-label"}
           = bill_address.label :zipcode, t("checkout.step1.address.zipcode.label")
           = bill_address.text_field :zipcode, { placeholder: " " }
           = f.error_message_on "bill_address.zipcode"
@@ -56,22 +56,22 @@
         %div{ "data-controller": "dependent-select", "data-dependent-select-options-value": countries_with_states }
           - bill_address_country = @order.bill_address.country || DefaultCountry.country
 
-          %div.checkout-input
+          .checkout-input
             = bill_address.label :country_id, t("checkout.step1.address.country_id.label")
             = bill_address.select :country_id, countries, { selected: bill_address_country.id }, { "data-dependent-select-target": "source", "data-action": "dependent-select#handleSelectChange" }
 
-          %div.checkout-input
+          .checkout-input
             = bill_address.label :state_id, t("checkout.step1.address.state_id.label")
             = bill_address.select :state_id, states_for_country(bill_address_country), { selected: @order.bill_address&.state_id }, { "data-dependent-select-target": "select" }
 
         - if spree_current_user
-          %div.checkout-input
+          .checkout-input
             = f.check_box :save_bill_address
             = f.label :save_bill_address, t(:checkout_default_bill_address)
 
-    %div.checkout-substep{ "data-controller": "toggle-control shippingmethod" }
+    .checkout-substep{ "data-controller": "toggle-control shippingmethod" }
       - selected_shipping_method = @order.shipping_method&.id || params[:shipping_method_id]
-      %div.checkout-title
+      .checkout-title
         = t("checkout.step1.shipping_info.title")
 
       - display_ship_address = false
@@ -80,7 +80,7 @@
       - selected_shipping_method ||= @shipping_methods[0].id if @shipping_methods.length == 1
       - @shipping_methods.each do |shipping_method|
         - ship_method_is_selected = shipping_method.id == selected_shipping_method.to_i
-        %div.checkout-input.checkout-input-radio
+        .checkout-input.checkout-input-radio
           = fields_for shipping_method do |shipping_method_form|
             = shipping_method_form.radio_button :name, shipping_method.id,
               id: "shipping_method_#{shipping_method.id}",
@@ -92,35 +92,35 @@
             = shipping_method_form.label shipping_method.id, shipping_method.name, {for: "shipping_method_" + shipping_method.id.to_s }
             %em.fees= payment_or_shipping_price(shipping_method, @order)
             - display_ship_address = display_ship_address || (ship_method_is_selected && shipping_method.require_ship_address)
-        %div.checkout-input{"data-shippingmethod-target": "shippingMethodDescription", "data-shippingmethodid": shipping_method.id , style: "display: #{ship_method_is_selected ? 'block' : 'none'}" }
+        .checkout-input{"data-shippingmethod-target": "shippingMethodDescription", "data-shippingmethodid": shipping_method.id , style: "display: #{ship_method_is_selected ? 'block' : 'none'}" }
           #distributor_address.panel
             - if shipping_method.description.present?
               = simple_format(html_escape(shipping_method.description))
 
       = f.error_message_on :shipping_method, standalone: true
 
-      %div.checkout-input{ "data-toggle-control-target": "content", style: "display: #{display_ship_address ? 'block' : 'none'}" }
+      .checkout-input{ "data-toggle-control-target": "content", style: "display: #{display_ship_address ? 'block' : 'none'}" }
         = f.check_box :ship_address_same_as_billing, { id: "ship_address_same_as_billing", name: "ship_address_same_as_billing", "data-action": "shippingmethod#showHideShippingAddress", "data-shippingmethod-target": "shippingAddressCheckbox", checked: shipping_and_billing_match?(@order) }, 1, nil
         = f.label :ship_address_same_as_billing, t(:checkout_address_same), { for: "ship_address_same_as_billing" }
 
       %div{"data-shippingmethod-target": "shippingMethodAddress", style: "display: #{!display_ship_address || shipping_and_billing_match?(@order) ? 'none' : 'block'}" }
         = f.fields :ship_address, model: @order.ship_address do |ship_address|
-          %div.checkout-input.with-floating-label{ "data-controller": "floating-label"}
+          .checkout-input.with-floating-label{ "data-controller": "floating-label"}
             = ship_address.label :address1, t("checkout.step1.address.address1.label")
             = ship_address.text_field :address1, { placeholder: " " }
             = f.error_message_on "ship_address.address1"
 
-          %div.checkout-input.with-floating-label{ "data-controller": "floating-label"}
+          .checkout-input.with-floating-label{ "data-controller": "floating-label"}
             = ship_address.label :address2, t("checkout.step1.address.address2.label")
             = ship_address.text_field :address2, { placeholder: " " }
             = f.error_message_on "ship_address.address2"
 
-          %div.checkout-input.with-floating-label{ "data-controller": "floating-label"}
+          .checkout-input.with-floating-label{ "data-controller": "floating-label"}
             = ship_address.label :city, t("checkout.step1.address.city.label")
             = ship_address.text_field :city, { placeholder: " " }
             = f.error_message_on "ship_address.city"
 
-          %div.checkout-input.with-floating-label{ "data-controller": "floating-label"}
+          .checkout-input.with-floating-label{ "data-controller": "floating-label"}
             = ship_address.label :zipcode, t("checkout.step1.address.zipcode.label")
             = ship_address.text_field :zipcode, { placeholder: " " }
             = f.error_message_on "ship_address.zipcode"
@@ -128,16 +128,16 @@
           %div{ "data-controller": "dependent-select", "data-dependent-select-options-value": countries_with_states }
             - ship_address_country = @order.ship_address.country || DefaultCountry.country
 
-            %div.checkout-input
+            .checkout-input
               = ship_address.label :country_id, t("checkout.step1.address.country_id.label")
               = ship_address.select :country_id, countries, { selected: ship_address_country.id }, { "data-dependent-select-target": "source", "data-action": "dependent-select#handleSelectChange" }
 
-            %div.checkout-input
+            .checkout-input
               = ship_address.label :state_id, t("checkout.step1.address.state_id.label")
               = ship_address.select :state_id, states_for_country(ship_address_country), { selected: @order.ship_address&.state_id }, { "data-dependent-select-target": "select" }
 
       - if spree_current_user
-        %div.checkout-input{ "data-toggle-control-target": "content", style: "display: #{display_ship_address ? 'block' : 'none'}" }
+        .checkout-input{ "data-toggle-control-target": "content", style: "display: #{display_ship_address ? 'block' : 'none'}" }
           = f.check_box :save_ship_address
           = f.label :save_ship_address, t(:checkout_default_ship_address)
 
@@ -145,7 +145,7 @@
         = f.label :special_instructions, t(:checkout_instructions)
         = f.text_area :special_instructions, size: "60x4"
 
-    %div.checkout-submit
+    .checkout-submit
       = f.submit t("checkout.step1.submit"), class: "button primary", disabled: @terms_and_conditions_accepted == false || @platform_tos_accepted == false
       %a.button.cancel{href: main_app.cart_path}
         = t("checkout.step1.cancel")

--- a/app/views/checkout/_form.html.haml
+++ b/app/views/checkout/_form.html.haml
@@ -1,5 +1,5 @@
 - content_for :injection_data do
   = inject_saved_credit_cards
 
-%div.checkout-step{ class: "#{'checkout-summary' if checkout_step?(:summary)}" }
+.checkout-step{ class: "#{'checkout-summary' if checkout_step?(:summary)}" }
   = render "checkout/#{checkout_step}"

--- a/app/views/checkout/_guest.html.haml
+++ b/app/views/checkout/_guest.html.haml
@@ -1,10 +1,10 @@
 %checkout.row#checkout
   .small-12.medium-12.columns
     .checkout-step
-      %div.checkout-guest-title
+      .checkout-guest-title
         = t :checkout_headline
 
-      %div.checkout-submit{ class: "#{@order.distributor.allow_guest_orders? ? 'checkout-submit-inline' : 'medium-6' }" }
+      .checkout-submit{ class: "#{@order.distributor.allow_guest_orders? ? 'checkout-submit-inline' : 'medium-6' }" }
         %button.button.primary{ "data-action": "click->guest-checkout#login" }
           = t :label_login
         -if @order.distributor.allow_guest_orders?

--- a/app/views/checkout/_payment.html.haml
+++ b/app/views/checkout/_payment.html.haml
@@ -1,11 +1,11 @@
 .medium-6#checkout-payment-methods
   - if @order.distributor.vouchers.present? || @order.distributor.connected_apps.vine.present?
-    %div.checkout-substep
+    .checkout-substep
       = render partial: "checkout/voucher_section", locals: { order: @order, voucher_adjustment: @order.voucher_adjustments.first }
 
   = form_with url: checkout_update_path(local_assigns[:step] || checkout_step), model: @order, method: :put, data: { remote: "true" } do |f|
-    %div.checkout-substep{"data-controller": "paymentmethod"}
-      %div.checkout-title
+    .checkout-substep{"data-controller": "paymentmethod"}
+      .checkout-title
         = t("checkout.step2.payment_method.title")
 
       - if @order.zero_priced_order?
@@ -15,7 +15,7 @@
         - selected_payment_method = @order.payments&.with_state(:checkout)&.first&.payment_method_id
         - selected_payment_method ||= available_payment_methods[0].id if available_payment_methods.length == 1
         - available_payment_methods.each do |payment_method|
-          %div.checkout-input.checkout-input-radio
+          .checkout-input.checkout-input-radio
             = f.radio_button :payment_method_id, payment_method.id,
               id: "payment_method_#{payment_method.id}",
               name: "order[payments_attributes][][payment_method_id]",
@@ -35,10 +35,10 @@
 
         = f.error_message_on :payment_method, standalone: true
 
-    %div.checkout-substep
+    .checkout-substep
       = t("checkout.step2.explaination")
 
-    %div.checkout-submit
+    .checkout-submit
       = f.submit t("checkout.step2.submit"), class: "button primary", disabled: @terms_and_conditions_accepted == false || @platform_tos_accepted == false
       %a.button.cancel{href: main_app.checkout_step_path(:details)}
         = t("checkout.step2.cancel")

--- a/app/views/checkout/_summary.html.haml
+++ b/app/views/checkout/_summary.html.haml
@@ -71,8 +71,8 @@
               = payment_method&.description
 
 
-    %div.checkout-substep
-      %div.checkout-title
+    .checkout-substep
+      .checkout-title
         = t("checkout.step3.order.title")
         %a.summary-edit{ href: main_app.cart_path, data: { action: "guest-checkout#removeUnloadEvent" } }
           = t("checkout.step3.order.edit")

--- a/app/views/checkout/_tabs.html.haml
+++ b/app/views/checkout/_tabs.html.haml
@@ -1,19 +1,19 @@
-%div.flex
-  %div.columns.three.text-center.checkout-tab{"class": [("selected" if checkout_step?(:details)), ("success" unless checkout_step?(:details))]}
+.flex
+  .columns.three.text-center.checkout-tab{"class": [("selected" if checkout_step?(:details)), ("success" unless checkout_step?(:details))]}
     %div
       %span.checkout-tab-number
         1 -
       %span.checkout-tab-label
         = link_to_unless checkout_step?(:details), t("checkout.your_details_without_number"), main_app.checkout_step_path(:details) do
           = t("checkout.your_details_without_number")
-  %div.columns.three.text-center.checkout-tab{"class": [("selected" if checkout_step?(:payment)), ("success" if checkout_step?(:summary))]}
+  .columns.three.text-center.checkout-tab{"class": [("selected" if checkout_step?(:payment)), ("success" if checkout_step?(:summary))]}
     %div
       %span.checkout-tab-number
         2 -
       %span.checkout-tab-label
         = link_to_if checkout_step?(:summary), t("checkout.payment_method_without_number"), main_app.checkout_step_path(:payment) do
           = t("checkout.payment_method_without_number")
-  %div.columns.three.text-center.checkout-tab{"class": ("selected" if checkout_step?(:summary))}
+  .columns.three.text-center.checkout-tab{"class": ("selected" if checkout_step?(:summary))}
     %div
       %span.checkout-tab-number
         3 -

--- a/app/views/checkout/_terms_and_conditions.html.haml
+++ b/app/views/checkout/_terms_and_conditions.html.haml
@@ -1,5 +1,5 @@
-%div.checkout-substep
-  %div.checkout-input
+.checkout-substep
+  .checkout-input
     - if platform_terms_required? && distributor_terms_required?
       = f.check_box :accept_terms, { name: "accept_terms", checked: all_terms_and_conditions_already_accepted? }, 1, nil
       = f.label :accept_terms do

--- a/app/views/checkout/_voucher_section.html.haml
+++ b/app/views/checkout/_voucher_section.html.haml
@@ -1,4 +1,4 @@
-%div#voucher-section
+#voucher-section
   .checkout-title
     = t("checkout.step2.voucher.apply_voucher")
   .checkout-input{"data-controller": "toggle-control"}

--- a/app/views/checkout/_voucher_section.html.haml
+++ b/app/views/checkout/_voucher_section.html.haml
@@ -17,9 +17,9 @@
                 = t("checkout.step2.voucher.warning_forfeit_remaining_amount")
       - else
         .two-columns-inputs
-          %div.checkout-input
+          .checkout-input
             = form.text_field :voucher_code, value: params.dig(:order, :voucher_code), data: { action: "input->toggle-control#enableIfPresent" }, placeholder: t("checkout.step2.voucher.placeholder"), class: "voucher"
             = form.error_message_on :voucher_code
 
-          %div.checkout-input
+          .checkout-input
             = form.submit t("checkout.step2.voucher.apply"), disabled: true, class: "button cancel voucher-button", "data-disable-with": false, data: { "toggle-control-target": "control" }

--- a/app/views/checkout/payment/_stripe_sca.html.haml
+++ b/app/views/checkout/payment/_stripe_sca.html.haml
@@ -24,9 +24,9 @@
           = hidden_field_tag "order[payments_attributes][][source_attributes][cc_type]", nil, { "data-stripe-target": "brand" }
           = hidden_field_tag "order[payments_attributes][][source_attributes][last_digits]", nil, { "data-stripe-target": "last4" }
           = hidden_field_tag "order[payments_attributes][][source_attributes][gateway_payment_profile_id]", nil, { "data-stripe-target": "pmId" }
-          %div.card-element{ "data-stripe-target": "cardElement" }
+          .card-element{ "data-stripe-target": "cardElement" }
 
-        %div.error.card-errors{ "data-stripe-target": "cardErrors" }
+        .error.card-errors{ "data-stripe-target": "cardErrors" }
 
     - if spree_current_user
       .checkout-input

--- a/app/views/groups/_contact.html.haml
+++ b/app/views/groups/_contact.html.haml
@@ -1,6 +1,6 @@
-%div.contact-container
+.contact-container
   - if @group.email.present? || @group.website.present? || @group.phone.present?
-    %div.modal-centered
+    .modal-centered
       %p.modal-header
         = t :groups_contact_web
       - if @group.phone.present?
@@ -18,7 +18,7 @@
 
 %div
   - if @group.facebook.present? || @group.twitter.present? || @group.linkedin.present? || @group.instagram.present?
-    %div.modal-centered.pad-top
+    .modal-centered.pad-top
       %p.modal-header
         = t :groups_contact_web
       .follow-icons
@@ -33,7 +33,7 @@
 
 %div
   - if @group.address1.present? || @group.city.present?
-    %div.modal-centered.pad-top
+    .modal-centered.pad-top
       %p.modal-header
         = t :groups_contact_web
       %p

--- a/app/views/producers/_fat.html.haml
+++ b/app/views/producers/_fat.html.haml
@@ -11,7 +11,7 @@
           = t :producers_about
         %img.right.show-for-medium-up{"ng-src" => "{{::producer.logo}}" }
         %p.text-small{ "ng-bind" => "::producer.description"}
-      %div.show-for-medium-up{"ng-if" => "::producer.description.length==0"}
+      .show-for-medium-up{"ng-if" => "::producer.description.length==0"}
         %label &nbsp;
         %img.right.show-for-medium-up{"ng-src" => "{{::producer.logo}}" }
 
@@ -28,7 +28,7 @@
             %span.fat-properties{"ng-repeat" => "property in producer.supplied_properties"}
               %span{"ng-bind" => "property.presentation"}
 
-      %div.show-for-medium-up{"ng-if" => "producer.supplied_taxons.length==0"}
+      .show-for-medium-up{"ng-if" => "producer.supplied_taxons.length==0"}
         &nbsp;
 
       %div{"ng-if" => "::producer.email_address || producer.website || producer.phone"}
@@ -79,7 +79,7 @@
           %div{"ng-if" => "::producer.name"}
             %label
               = t :producers_buy_at_html, enterprise: '<span class="turquoise" ng-bind="::producer.name"></span>'.html_safe
-          %div.show-for-medium-up{"ng-if" => "::!producer.name"}
+          .show-for-medium-up{"ng-if" => "::!producer.name"}
             &nbsp;
       .row.cta-container
         .columns.small-12

--- a/app/views/registration/_modal.html.haml
+++ b/app/views/registration/_modal.html.haml
@@ -1,5 +1,5 @@
 %script{ type: "text/ng-template", id: "registration.html" }
-  %div#registration-modal{"ng-controller" => "RegistrationCtrl"}
+  #registration-modal{"ng-controller" => "RegistrationCtrl"}
     %div{ "ng-show": "currentStep() == 'introduction'" }
       %ng-include{ src: "'registration/introduction.html'" }
     %div{ "ng-repeat": 'step in steps', "ng-show": "currentStep() == step" }

--- a/app/views/shared/_map.html.haml
+++ b/app/views/shared/_map.html.haml
@@ -1,7 +1,7 @@
 - if ContentConfig.open_street_map_enabled
   .map-container
     %ofn-open-street-map#open-street-map
-    %div#open-street-map--search
+    #open-street-map--search
       %input.autocomplete-input
       %ul.autocomplete-result-list
 

--- a/app/views/shared/menu/_cart_sidebar.html.haml
+++ b/app/views/shared/menu/_cart_sidebar.html.haml
@@ -50,7 +50,7 @@
           = t 'total'
           {{ Cart.total()  | localizeCurrency }}
 
-      %div.fullwidth
+      .fullwidth
         %a.edit-cart.button.large.dark.left{href: main_app.cart_path, "ng-disabled" => "Cart.dirty || Cart.empty()", "ng-class" => "{ dirty: Cart.dirty }"}
           %div{ "ng-if": "Cart.dirty" }= t(:cart_updating)
           %div{ "ng-if": "!Cart.dirty && Cart.empty()" }= t(:cart_empty)

--- a/app/views/shop/products/_form.html.haml
+++ b/app/views/shop/products/_form.html.haml
@@ -11,7 +11,7 @@
             .medium-12.large-9.columns.full
               = render partial: "shop/products/search_feedback"
 
-              %div.pad-top{ "infinite-scroll" => "loadMore()", "infinite-scroll-distance" => "1", "infinite-scroll-disabled" => 'Products.loading', "infinite-scroll-immediate-check": "false" }
+              .pad-top{ "infinite-scroll" => "loadMore()", "infinite-scroll-distance" => "1", "infinite-scroll-disabled" => 'Products.loading', "infinite-scroll-immediate-check": "false" }
                 %product.animate-repeat{"ng-controller" => "ProductNodeCtrl", "ng-repeat" => "product in Products.products track by product.id", "id" => "product-{{ product.id }}"}
                   = render "shop/products/summary"
                   .shop-variants

--- a/app/views/shop/products/_search_feedback.haml
+++ b/app/views/shop/products/_search_feedback.haml
@@ -15,7 +15,7 @@
                 {{ query }}
             = render partial: 'shop/products/applied_filters_feedback'
 
-        %div.no-results-bar{"ng-show" => "Products.products.length == 0 && !Products.loading"}
+        .no-results-bar{"ng-show" => "Products.products.length == 0 && !Products.loading"}
           .row.summary
             .small-12.columns
               %p.no-results

--- a/app/views/shop/products/_searchbar.haml
+++ b/app/views/shop/products/_searchbar.haml
@@ -2,7 +2,7 @@
   .shop-searchbar
     .row
       .small-12.large-5.columns.flex
-        %div.search-wrap
+        .search-wrap
           %input#search.text{"ng-model" => "query",
                 type: 'search',
                 placeholder: t(:products_search),

--- a/app/views/shopping_shared/tabs/_contact.html.haml
+++ b/app/views/shopping_shared/tabs/_contact.html.haml
@@ -2,7 +2,7 @@
   .row
     .small-12.large-4.columns
       - if current_distributor.address.address1 || current_distributor.address.address2 || current_distributor.address.city || current_distributor.address.state || current_distributor.address.zipcode
-        %div.center
+        .center
           .header
             = t :shopping_contact_address
           %span= current_distributor.name
@@ -18,7 +18,7 @@
 
     .small-12.large-4.columns
       - if current_distributor.website || current_distributor.email_address || current_distributor.phone || current_distributor.whatsapp_phone
-        %div.center
+        .center
           .header
             = t :shopping_contact_web
           %p
@@ -41,10 +41,10 @@
 
     .small-12.large-4.columns
       - if current_distributor.twitter.present? || current_distributor.facebook.present? || current_distributor.linkedin.present? || current_distributor.instagram.present?
-        %div.center
+        .center
           .header
             = t :shopping_contact_social
-          %div.follow-icons
+          .follow-icons
             - if current_distributor.twitter.present?
               %span
                 %a{href: "http://twitter.com/#{current_distributor.twitter}", target: "_blank" }

--- a/app/views/shops/_fat.html.haml
+++ b/app/views/shops/_fat.html.haml
@@ -15,7 +15,7 @@
           %div
             %span.fat-properties{"ng-repeat" => "property in hub.distributed_properties"}
               %span{"ng-bind" => "property.presentation"}
-      %div.show-for-medium-up{"ng-if" => "::hub.taxons.length==0"}
+      .show-for-medium-up{"ng-if" => "::hub.taxons.length==0"}
         &nbsp;
     .columns.small-12.medium-3.large-2.fat{"ng-show" => "open() && !shopfront_loading"}
       %div{"ng-if" => "::(hub.pickup || hub.delivery)"}
@@ -50,5 +50,5 @@
               .less
                 = t :label_less
 
-      %div.show-for-medium-up{"ng-if" => "::hub.producers.length==0"}
+      .show-for-medium-up{"ng-if" => "::hub.producers.length==0"}
         &nbsp;

--- a/app/views/spree/admin/mail_methods/_form.html.haml
+++ b/app/views/spree/admin/mail_methods/_form.html.haml
@@ -1,7 +1,7 @@
 %div
   .row
     %fieldset.no-border-bottom
-      %div.notice
+      .notice
         = t('spree.mail_settings_notice_html')
       %legend{align: "center"}= t("spree.general")
       .field

--- a/app/views/spree/admin/orders/_bulk_actions.html.haml
+++ b/app/views/spree/admin/orders/_bulk_actions.html.haml
@@ -3,22 +3,22 @@
     %span{ "data-controller": "checked-feedback", "data-checked-feedback-translation-value": "spree.admin.orders.index.selected" }
       = t("spree.admin.orders.index.selected", count: 0)
 
-  %div.plain.ofn-drop-down.disabled{ "data-checked-target": "disable" }
+  .plain.ofn-drop-down.disabled{ "data-checked-target": "disable" }
     %details{"data-controller": "dropdown"}
       %summary
         %span.icon-reorder
           ="#{t('admin.actions')}".html_safe
-      %div.menu{"data-action": "click->dropdown#closeOnMenu"}
-        %div.menu_item
+      .menu{"data-action": "click->dropdown#closeOnMenu"}
+        .menu_item
           %span.name{ "data-controller": "modal-link", "data-action": "click->modal-link#open", "data-modal-link-target-value": "resend_confirmation" }
             = t('spree.admin.orders.index.resend_confirmation')
         - if Spree::Config[:enable_invoices?]
-          %div.menu_item
+          .menu_item
             %span.name{ "data-controller": "modal-link", "data-action": "click->modal-link#open", "data-modal-link-target-value": "send_invoice" }
               = t('spree.admin.orders.index.send_invoice')
-          %div.menu_item
+          .menu_item
             %span.name{ "data-controller": "bulk-actions", "data-action": "click->bulk-actions#perform", "data-bulk-actions-reflex-value": "Admin::Orders#bulk_invoice" }
               = t('spree.admin.orders.index.print_invoices')
-        %div.menu_item
+        .menu_item
           %span.name{ "data-controller": "modal-link", "data-action": "click->modal-link#open", "data-modal-link-target-value": "cancel_orders" }
             = t('spree.admin.orders.index.cancel_orders')

--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -1,4 +1,4 @@
-%div.admin-orders-index-search{ "data-controller": "search", "data-search-restore-value": @stored_query }
+.admin-orders-index-search{ "data-controller": "search", "data-search-restore-value": @stored_query }
   = form_with url: spree.admin_orders_url, id: "orders_form", method: :get, data: { remote: true, "search-target": "form" } do
     = hidden_field_tag :page, 1, class: "page"
     = hidden_field_tag :per_page, 15, class: "per-page"

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -1,4 +1,4 @@
-%div.admin-order-form-fields
+.admin-order-form-fields
   - if @line_item.try(:errors).present?
     = render :partial => 'spree/shared/error_messages', :locals => { :target => @line_item }
 

--- a/app/views/spree/admin/orders/_insufficient_stock_lines.html.haml
+++ b/app/views/spree/admin/orders/_insufficient_stock_lines.html.haml
@@ -1,4 +1,4 @@
-%div.insufficient-stock-items
+.insufficient-stock-items
   %fieldset.no-border-bottom
     %legend
       = t("spree.orders.line_item.out_of_stock")

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -39,7 +39,7 @@
       - if shipment.can_modify?
         %tr.edit-method.hidden.total
           %td{ :colspan => "5" }
-            %div.field.alpha.five.columns
+            .field.alpha.five.columns
               = label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method)
               = select_tag :selected_shipping_rate_id, options_for_select(shipment.shipping_rates.map { |sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id), { :class => 'select2 fullwidth', :data => { 'shipment-number' => shipment.number } }
 

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -42,7 +42,7 @@
     %span
       = order.display_total
   %td.actions
-    %div.row-loading-icons
+    .row-loading-icons
       - if local_assigns[:success]
         %i.success.icon-ok-sign{"data-controller": "ephemeral"}
     = render AdminTooltipComponent.new(text: t('spree.admin.orders.index.edit'), link_text: "", link: edit_admin_order_path(order), link_class: "icon_link with-tip icon-edit no-text")

--- a/app/views/spree/admin/orders/bulk/_invoice_modal.html.haml
+++ b/app/views/spree/admin/orders/bulk/_invoice_modal.html.haml
@@ -1,7 +1,7 @@
 %div{ id: "bulk_invoices_modal", "data-controller": "modal file-loading", "data-modal-instant-value": true, "data-action": "keyup@document->modal#closeIfEscapeKey" }
   .reveal-modal-bg.fade{ "data-modal-target": "background", "data-action": "click->modal#remove" }
   .reveal-modal.fade.tiny.modal-component{ "data-modal-target": "modal" }
-    %div.fullwidth.align-center
+    .fullwidth.align-center
       %h4.modal-title
         = t('js.admin.orders.index.compiling_invoices')
         %br
@@ -13,5 +13,5 @@
           %br
           %p= t('js.admin.orders.index.please_wait')
           %br
-        %div.hidden{ 'data-file-loading-target': "loaded" }
+        .hidden{ 'data-file-loading-target': "loaded" }
           = render partial: "spree/admin/orders/bulk/invoice_link", locals: { invoice_url: }

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -60,7 +60,7 @@
 
   %hr.divider.sixteen.columns.alpha.omega{ "ng-show": 'unitsVariantSelected()' }
 
-  %div.sixteen.columns.alpha.omega#group_buy_calculation{ "ng-show": 'unitsVariantSelected()', "ng-cloak": true }
+  .sixteen.columns.alpha.omega#group_buy_calculation{ "ng-show": 'unitsVariantSelected()', "ng-cloak": true }
     .one.columns.alpha
     .shared_resource.four.columns.alpha
       %input{ type: 'checkbox', :id => 'shared_resource', 'ng-model' => 'sharedResource'}
@@ -116,7 +116,7 @@
         = render partial: 'admin/shared/angular_per_page_controls', locals: { position: "right", model: "line_items" }
  
 
-  %div.sixteen.columns.alpha#loading{ 'ng-if' => 'RequestMonitor.loading' }
+  .sixteen.columns.alpha#loading{ 'ng-if' => 'RequestMonitor.loading' }
     = render partial: "components/admin_spinner"
     %h1
       = t("admin.orders.bulk_management.loading")

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -28,5 +28,5 @@
       .no-objects-found
         = Spree.t(:your_order_is_empty_add_product)
 
-    %div.admin-order-edit-form
+    .admin-order-edit-form
       = render partial: 'form'

--- a/app/views/spree/admin/orders/invoice4.html.haml
+++ b/app/views/spree/admin/orders/invoice4.html.haml
@@ -101,5 +101,5 @@
 - if @order.note.present?
   = render partial: 'spree/admin/orders/_invoice/order_note'
 
-%div.text-center
+.text-center
   = link_to_platform_terms

--- a/app/views/spree/admin/overview/_enterprises.html.haml
+++ b/app/views/spree/admin/overview/_enterprises.html.haml
@@ -26,6 +26,9 @@
           = t "spree_admin_enterprises_fees"
     .sixteen.columns.alpha.list
       = render partial: 'enterprise_row', collection: @enterprises, as: :enterprise
+      - if defined? @enterprises_count
+        .sixteen.columns.alpha.list-item.centered
+          = t "spree_admin_enterprises_showing", count: @enterprises.count, total: @enterprises_count
 
     %a.sixteen.columns.alpha.button.bottom{ href: "#{main_app.admin_enterprises_path}" }
       = t "spree_admin_overview_enterprises_footer"

--- a/app/views/spree/admin/overview/_enterprises.html.haml
+++ b/app/views/spree/admin/overview/_enterprises.html.haml
@@ -1,8 +1,8 @@
-%div.dashboard_item.sixteen.columns.alpha#enterprises
+.dashboard_item.sixteen.columns.alpha#enterprises
   = render 'enterprises_header'
 
   - if @enterprises.empty?
-    %div.sixteen.columns.alpha.list-item.warning
+    .sixteen.columns.alpha.list-item.warning
       %span.text.fifteen.columns.alpha
         = t "spree_admin_enterprises_none_text"
       %span.one.columns.omega
@@ -12,7 +12,7 @@
       %span.icon-arrow-right
 
   - else
-    %div.sixteen.columns.alpha.list-title
+    .sixteen.columns.alpha.list-title
       %span.five.columns.alpha
         = t "spree_admin_enterprises_hubs_name"
       - if can? :admin, Spree::PaymentMethod
@@ -24,7 +24,7 @@
       - if can? :admin, EnterpriseFee
         %span.centered.three.columns
           = t "spree_admin_enterprises_fees"
-    %div.sixteen.columns.alpha.list
+    .sixteen.columns.alpha.list
       = render partial: 'enterprise_row', collection: @enterprises, as: :enterprise
 
     %a.sixteen.columns.alpha.button.bottom{ href: "#{main_app.admin_enterprises_path}" }

--- a/app/views/spree/admin/overview/_enterprises_header.html.haml
+++ b/app/views/spree/admin/overview/_enterprises_header.html.haml
@@ -1,4 +1,4 @@
-%div.header.sixteen.columns.alpha{ :class => "#{@enterprises.count > 0 ? "" : "warning"}"}
+.header.sixteen.columns.alpha{ :class => "#{@enterprises.count > 0 ? "" : "warning"}"}
   %h3.thirteen.columns.alpha
     = t "spree_admin_overview_enterprises_header"
   - if @enterprises.any?

--- a/app/views/spree/admin/overview/_order_cycles.html.haml
+++ b/app/views/spree/admin/overview/_order_cycles.html.haml
@@ -1,7 +1,7 @@
 - color_class = "warning" unless @order_cycle_count.positive?
 - icon_class = @order_cycle_count.positive? ? "icon-ok-sign" : "icon-warning-sign"
-%div.dashboard_item.seven.columns.omega#order_cycles
-  %div.header.sixteen.columns.alpha{class: color_class}
+.dashboard_item.seven.columns.omega#order_cycles
+  .header.sixteen.columns.alpha{class: color_class}
     %h3.ten.columns.alpha
       = t ".order_cycles"
     - if @order_cycle_count.positive?
@@ -10,8 +10,8 @@
     - else
       %a{ "ofn-with-tip" => t(".order_cycles_tip") }
         = t "admin.whats_this"
-  %div.sixteen.columns.alpha.list
-    %div.sixteen.columns.alpha.list-item{class: color_class}
+  .sixteen.columns.alpha.list
+    .sixteen.columns.alpha.list-item{class: color_class}
       %span.thirteen.columns.alpha
         = t(".you_have_active", count: @order_cycle_count)
       %span.three.columns.omega

--- a/app/views/spree/admin/overview/_products.html.haml
+++ b/app/views/spree/admin/overview/_products.html.haml
@@ -1,7 +1,7 @@
 - color_class = "warning" unless @product_count.positive?
 - icon_class = @product_count.positive? ? "icon-ok-sign" : "icon-remove-sign"
-%div.dashboard_item.seven.columns.alpha#products
-  %div.header.sixteen.columns.alpha{class: color_class}
+.dashboard_item.seven.columns.alpha#products
+  .header.sixteen.columns.alpha{class: color_class}
     %h3.ten.columns.alpha
       = t "products"
     - if @product_count.positive?
@@ -10,8 +10,8 @@
     - else
       %a{ "ofn-with-tip" => t(".products_tip") }
         = t "admin.whats_this"
-  %div.sixteen.columns.alpha.list
-    %div.sixteen.columns.alpha.list-item{class: color_class}
+  .sixteen.columns.alpha.list
+    .sixteen.columns.alpha.list-item{class: color_class}
       %span.thirteen.columns.alpha
         = t(".active_products", count: @product_count)
       %span.three.columns.omega

--- a/app/views/spree/admin/overview/multi_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/multi_enterprise_dashboard.html.haml
@@ -14,7 +14,7 @@
     - if can? :admin, Spree::Product
       = render partial: "products"
 
-      %div.two.columns
+      .two.columns
         &nbsp;
 
     - if can? :admin, OrderCycle

--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -1,4 +1,4 @@
-%div.admin-product-form-fields
+.admin-product-form-fields
   .left.sixteen.columns.alpha
     = f.field_container :name do
       = f.label :name, raw(t(:name) + content_tag(:span, ' *', :class => 'required'))

--- a/app/views/spree/admin/products/index/_indicators.html.haml
+++ b/app/views/spree/admin/products/index/_indicators.html.haml
@@ -1,12 +1,12 @@
-%div.sixteen.columns.alpha#loading{ 'ng-if' => 'RequestMonitor.loading' }
+.sixteen.columns.alpha#loading{ 'ng-if' => 'RequestMonitor.loading' }
   = render partial: "components/admin_spinner"
   %h1
     = t('.title')
 
-%div.sixteen.columns.alpha{ 'ng-show' => '!RequestMonitor.loading && products.length == 0 && q.query.length == 0' }
+.sixteen.columns.alpha{ 'ng-show' => '!RequestMonitor.loading && products.length == 0 && q.query.length == 0' }
   %h1#no_results= t('.no_products')
 
-%div.sixteen.columns.alpha{ 'ng-show' => '!RequestMonitor.loading && products.length == 0 && q.query.length != 0' }
+.sixteen.columns.alpha{ 'ng-show' => '!RequestMonitor.loading && products.length == 0 && q.query.length != 0' }
   %h1#no_results
     = t('.no_results')
     '

--- a/app/views/spree/admin/products/index/_products.html.haml
+++ b/app/views/spree/admin/products/index/_products.html.haml
@@ -1,4 +1,4 @@
-%div.sixteen.columns.alpha{ 'ng-hide' => 'RequestMonitor.loading || products.length == 0' }
+.sixteen.columns.alpha{ 'ng-hide' => 'RequestMonitor.loading || products.length == 0' }
   %form{ name: 'bulk_product_form', autocomplete: "off" }
     %save-bar{ dirty: "bulk_product_form.$dirty", persist: "false" }
       %input.red{ type: "button", value: t(:save_changes), "ng-click": "submitProducts()", "ng-disabled": "!bulk_product_form.$dirty" }

--- a/app/views/spree/admin/products/index/_save_button_row.html.haml
+++ b/app/views/spree/admin/products/index/_save_button_row.html.haml
@@ -1,3 +1,3 @@
-%div.sixteen.columns.alpha{ 'ng-hide' => 'RequestMonitor.loading || products.length == 0', style: "margin-bottom: 10px" }
-  %div.four.columns.alpha
+.sixteen.columns.alpha{ 'ng-hide' => 'RequestMonitor.loading || products.length == 0', style: "margin-bottom: 10px" }
+  .four.columns.alpha
     %input.four.columns.alpha{ :type => 'button', :value => t(:save_changes), 'ng-click' => 'submitProducts()'}

--- a/app/views/spree/admin/shared/_order_links.html.haml
+++ b/app/views/spree/admin/shared/_order_links.html.haml
@@ -5,7 +5,7 @@
         %span
           %i.icon-check
           = I18n.t 'admin.actions'
-      %div.menu{"data-action": "click->dropdown#closeOnMenu"}
+      .menu{"data-action": "click->dropdown#closeOnMenu"}
         - order_links(@order).each do |link|
           - if link[:name] == t(:ship_order)
             %a.menu_item{ href: link[:url], target: link[:target] || "_self", data: { "modal-link-target-value": dom_id(@order, :ship), "action":  "click->modal-link#open", "controller": "modal-link" } }

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -31,7 +31,7 @@
         = content_tag(:span, ' *', class: 'required')
       = f.button :unit_to_display, class: "popout__button", 'aria-label': t('.unit'), 'data-popout-target': "button" do
         = @variant.unit_to_display # Show the generated summary of unit values
-      %div.popout__container{ style: 'display: none;', 'data-controller': 'toggle-control', 'data-popout-target': "dialog" }
+      .popout__container{ style: 'display: none;', 'data-controller': 'toggle-control', 'data-popout-target': "dialog" }
         .field
           -# Show a composite field for unit_value and unit_description
           = f.hidden_field :unit_value

--- a/app/views/spree/orders/_bought.html.haml
+++ b/app/views/spree/orders/_bought.html.haml
@@ -15,7 +15,7 @@
     %tr.bought.line-item{ class: "line-item-#{line_item.id} variant-#{variant.id}", "ng-show": 'showBought' }
       %td.cart-item-description
 
-        %div.item-thumb-image
+        .item-thumb-image
           = render 'spree/shared/variant_thumbnail', variant: variant
 
         = render 'spree/shared/line_item_name', line_item: line_item

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -3,7 +3,7 @@
   %tr.line-item{class: "variant-#{variant.id}"}
     %td.cart-item-description
 
-      %div.item-thumb-image
+      .item-thumb-image
         = render 'spree/shared/variant_thumbnail', variant: variant
 
       = render 'spree/shared/line_item_name', line_item: line_item

--- a/app/views/spree/orders/_summary.html.haml
+++ b/app/views/spree/orders/_summary.html.haml
@@ -16,7 +16,7 @@
     - order.line_items.sorted_by_name_and_unit_value.each do |item|
       %tr.line_item{ class: "variant-#{item.variant.id}" }
         %td
-          %div.item-thumb-image
+          .item-thumb-image
             = render 'spree/shared/variant_thumbnail', variant: item.variant
 
           = render 'spree/shared/line_item_name', line_item: item

--- a/app/views/spree/orders/edit.html.haml
+++ b/app/views/spree/orders/edit.html.haml
@@ -25,7 +25,7 @@
 
   #cart-container
     - if @order.line_items.empty?
-      %div.row
+      .row
         %p= t(:cart_empty)
         %p= link_to t(:orders_edit_continue), current_shop_products_path, :class => 'button continue'
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,182 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `Dir.glob` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `Find.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Directories where method names which should not be part of a relative key resolution.
+  # By default, if a relative translation is used inside a method, the name of the method will be considered part of the resolved key.
+  # Directories listed here will not consider the name of the method part of the resolved key
+  #
+  # relative_exclude_method_name_paths:
+  #  -
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   *.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
+  ##   *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus *.webp *.map *.xlsx
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+    - app/assets/builds
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Allows adding ast_matchers for finding translations using the AST-scanners
+  ## The available matchers are:
+  ## - RailsModelMatcher
+  ##     Matches ActiveRecord translations like
+  ##     User.human_attribute_name(:email) and User.model_name.human
+  ## - DefaultI18nSubjectMatcher
+  ##     Matches ActionMailer's default_i18n_subject method
+  ##
+  ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
+  # ast_matchers:
+  #   - 'I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher'
+  #   - 'I18n::Tasks::Scanners::AstMatchers::DefaultI18nSubjectMatcher'
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Translation Services
+# translation:
+#   # Google Translate
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   google_translate_api_key: "AbC-dEf5"
+#   # DeepL Pro Translate
+#   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
+#   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+#   # deepl_host: "https://api.deepl.com"
+#   # deepl_version: "v2"
+#   # deepl_glossary_ids:
+#   #   - f28106eb-0e06-489e-82c6-8215d6f95089
+#   #   - 2c6415be-1852-4f54-9e1b-d800463496b4
+#   # add additional options to the DeepL.translate call: https://www.deepl.com/docs-api/translate-text/translate-text/
+#   deepl_options:
+#     formality: prefer_less
+#   # OpenAI
+#   openai_api_key: "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+#   # openai_model: "gpt-3.5-turbo" # see https://platform.openai.com/docs/models
+#   # may contain `%{from}` and `%{to}`, which will be replaced by source and target locale codes, respectively (using `Kernel.format`)
+#   # openai_system_prompt: >-
+#   #   You are a professional translator that translates content from the %{from} locale
+#   #   to the %{to} locale in an i18n locale array.
+#   #
+#   #   The array has a structured format and contains multiple strings. Your task is to translate
+#   #   each of these strings and create a new array with the translated strings.
+#   #
+#   #   HTML markups (enclosed in < and > characters) must not be changed under any circumstance.
+#   #   Variables (starting with %%{ and ending with }) must not be changed under any circumstance.
+#   #
+#   #   Keep in mind the context of all the strings for a more accurate translation.
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+ignore_unused:
+- 'activerecord.*'
+- 'activemodel.*'
+- 'devise.*'
+- 'report_header_*' # See Reporting::ReportHeadersBuilder
+- '*.connected_apps_enabled.*'
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3103,13 +3103,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   spree_admin_enterprises_none_create_a_new_enterprise: "CREATE A NEW ENTERPRISE"
   spree_admin_enterprises_none_text: "You don't have any enterprises yet"
   spree_admin_enterprises_showing: "Showing %{count} of %{total}"
-  spree_admin_enterprises_tabs_hubs: "HUBS"
   spree_admin_enterprises_producers_manage_products: "MANAGE PRODUCTS"
   spree_admin_enterprises_create_new_product: "CREATE A NEW PRODUCT"
-  spree_admin_single_enterprise_alert_mail_confirmation: "Please confirm the email address for"
-  spree_admin_single_enterprise_alert_mail_sent: "We've sent an email to"
-  spree_admin_overview_action_required: "Action Required"
-  spree_admin_overview_check_your_inbox: "Please check your inbox for further instructions. Thanks!"
   spree_admin_unit_value: Unit Value
   spree_admin_unit_description: Unit Description
   spree_admin_variant_unit: Variant unit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3102,6 +3102,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   spree_admin_enterprises_fees: "Enterprise Fees"
   spree_admin_enterprises_none_create_a_new_enterprise: "CREATE A NEW ENTERPRISE"
   spree_admin_enterprises_none_text: "You don't have any enterprises yet"
+  spree_admin_enterprises_showing: "Showing %{count} of %{total}"
   spree_admin_enterprises_tabs_hubs: "HUBS"
   spree_admin_enterprises_producers_manage_products: "MANAGE PRODUCTS"
   spree_admin_enterprises_create_new_product: "CREATE A NEW PRODUCT"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3105,13 +3105,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   spree_admin_enterprises_showing: "Showing %{count} of %{total}"
   spree_admin_enterprises_producers_manage_products: "MANAGE PRODUCTS"
   spree_admin_enterprises_create_new_product: "CREATE A NEW PRODUCT"
-  spree_admin_unit_value: Unit Value
-  spree_admin_unit_description: Unit Description
-  spree_admin_variant_unit: Variant unit
-  spree_admin_variant_unit_scale: Variant unit scale
   spree_admin_supplier: Supplier
-  spree_admin_product_category: Product Category
-  spree_admin_variant_unit_name: Variant unit name
   unit_name: "Unit name"
   change_package: "Change Package"
   spree_admin_single_enterprise_hint: "Hint: To allow people to find you, turn on your visibility under"


### PR DESCRIPTION
#### What? Why?
It takes _so_ long to load because there's so many enterprises. We don't need to see those.

This has been bugging me since.. forever.

Also did some code cleanup, and removed some unused translation keys. 
I tried to use gem [i18n-tasks](https://github.com/glebm/i18n-tasks?tab=readme-ov-file) to discover unused keys, but it seemed  too risky to clean up too many at once.

If code review passes, maybe it's worth running this past an instance manager too.

#### What should we test?
- Go to the admin dashboard as super admin
- ~~go make a coffee~~ It loads quickly!
- Scroll to bottom to discover total number of enterprises and click through to browse them all.
- All text on the admin dashboard page still displays correctly.

-----

- Go to the admin dashboard as enterprise admin with multiple enterprises (but less than 25)
- Scroll to bottom, there's no "show all" link.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
