### PR TITLE
Fix reset stock when importing DFC products

### DIFF
--- a/engines/dfc_provider/app/services/catalog_item_builder.rb
+++ b/engines/dfc_provider/app/services/catalog_item_builder.rb
@@ -15,6 +15,7 @@ class CatalogItemBuilder < DfcBuilder
     if limit.to_i.negative?
       variant.stock_items[0].backorderable = true
     else
+      variant.stock_items[0].backorderable = false
       variant.stock_items[0].count_on_hand = limit
     end
   end

--- a/engines/dfc_provider/spec/services/catalog_item_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/catalog_item_builder_spec.rb
@@ -28,4 +28,23 @@ RSpec.describe DfcBuilder do
       )
     end
   end
+
+  describe ".apply_stock" do
+    let(:item) { CatalogItemBuilder.catalog_item(variant) }
+
+    it "updates from on-demand to out-of-stock" do
+      variant.save!
+      variant.on_demand = true
+      variant.on_hand = -3
+
+      item.stockLimitation = 0
+
+      expect {
+        CatalogItemBuilder.apply_stock(item, variant)
+        variant.save!
+      }
+        .to change { variant.on_demand }.to(false)
+        .and change { variant.on_hand }.to(0)
+    end
+  end
 end


### PR DESCRIPTION
**ℹ️ Funded Feature. Please track ALL ASSOCIATED WORK under the associated tracking code https://github.com/openfoodfoundation/openfoodnetwork/issues/11678 DFC Orders**

#### What? Why?

@RaggedStaff reported on Slack:

> We've got some weirdness going on with some DFC Products (Wholesale: 365881, Retail: 365880).  They have been discontinued in the Shopify store,  are still showing as Unlimited in OFN (but with 0 stock),  and not showing up in the OFN store (presumably due to the zero stock). 

I found that we were not resetting the on-demand/backorderable attribute for stock controlled products. I'm not sure why those products were not showing in the shop but that's not the problem here. Maybe they had been excluded from the order cycle.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Import an unlimited product.
- Then declare it as out of stock in Shopify.
- Import it again and it should become out of stock in OFN.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
