### PR TITLE
Fix order of line item based report rows

### DIFF
--- a/lib/reporting/line_items.rb
+++ b/lib/reporting/line_items.rb
@@ -17,7 +17,7 @@ module Reporting
 
     def list(line_item_includes = [variant: [:supplier, :product]])
       line_items = order_permissions.visible_line_items.in_orders(orders.result)
-        .order("supplier.name", "product.name", "variant.display_name")
+        .order("supplier.name", "product.name", "variant.display_name", "variant.unit_description")
 
       if @params[:supplier_id_in].present?
         line_items = line_items.supplied_by_any(@params[:supplier_id_in])


### PR DESCRIPTION

#### What? Why?

The orders_and_fulfillment_spec would sometimes fail when the database would return line items in a different order than they were created. Without specific `order` clause the order of rows can be random.

The additional sorting may lead to more server load but also ensures more consistent results for users.

Related CI fail:

* https://github.com/mkllnk/openfoodnetwork/actions/runs/13321785500/job/37207664583
* May close #11581

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Reports are well tested but we should test the performance impact.
- Observer loading times for the orders and fulfillment reports before and after staging.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
