### PR TITLE
Create styled email for reset password instructions

### DIFF
--- a/app/views/spree/user_mailer/reset_password_instructions.html.haml
+++ b/app/views/spree/user_mailer/reset_password_instructions.html.haml
@@ -1,0 +1,15 @@
+%h3
+  = t('.dear_customer')
+%p
+  = t('.request_sent_text')
+
+%p.callout
+  = t('.link_text')
+  %br
+  %strong
+    = link_to @edit_password_reset_url, @edit_password_reset_url
+
+%p
+  = t('.issue_text')
+
+= render 'shared/mailers/signoff'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4823,6 +4823,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         invoice_attached_text: Please find attached an invoice for your recent order from
     user_mailer:
       reset_password_instructions:
+        dear_customer: "Dear customer,"
         request_sent_text: |
           A request to reset your password has been made.
           If you did not make this request, simply ignore this email.

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -35,15 +35,15 @@ RSpec.describe Spree::UserMailer do
 
   describe "#confirmation_instructions" do
     let(:token) { "random" }
-    subject(:email) { Spree::UserMailer.confirmation_instructions(user, token) }
+    subject(:mail) { Spree::UserMailer.confirmation_instructions(user, token) }
 
     it "sends an email" do
-      expect { email.deliver_now }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect { mail.deliver_now }.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
 
     context 'when the language is English' do
       it 'sends an email with the translated subject' do
-        email.deliver_now
+        mail.deliver_now
 
         expect(ActionMailer::Base.deliveries.first.subject).to include(
           "Please confirm your OFN account"
@@ -55,7 +55,7 @@ RSpec.describe Spree::UserMailer do
       let(:user) { build(:user, locale: 'es') }
 
       it 'sends an email with the translated subject' do
-        email.deliver_now
+        mail.deliver_now
 
         expect(ActionMailer::Base.deliveries.first.subject).to include(
           "Por favor, confirma tu cuenta de OFN"
@@ -67,21 +67,21 @@ RSpec.describe Spree::UserMailer do
   # adapted from https://github.com/spree/spree_auth_devise/blob/70737af/spec/mailers/user_mailer_spec.rb
   describe '#reset_password_instructions' do
     describe 'message contents' do
-      let(:message) { described_class.reset_password_instructions(user, nil).deliver_now }
+      subject(:mail) { described_class.reset_password_instructions(user, nil).deliver_now }
 
       context 'subject includes' do
         it 'translated devise instructions' do
-          expect(message.subject).to include "Reset password instructions"
+          expect(mail.subject).to include "Reset password instructions"
         end
 
         it 'Spree site name' do
-          expect(message.subject).to include Spree::Config[:site_name]
+          expect(mail.subject).to include Spree::Config[:site_name]
         end
       end
 
       context 'body includes' do
         it 'password reset url' do
-          expect(message.body.raw_source).to include spree.edit_spree_user_password_url
+          expect(mail.body.raw_source).to include spree.edit_spree_user_password_url
         end
       end
 
@@ -90,12 +90,12 @@ RSpec.describe Spree::UserMailer do
 
         it 'calls with_locale method with user selected locale' do
           expect(I18n).to receive(:with_locale).with('es')
-          message
+          mail
         end
 
         it 'calls devise reset_password_instructions subject' do
           expect(I18n).to receive(:t).with('spree.user_mailer.reset_password_instructions.subject')
-          message
+          mail
         end
       end
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Spree::UserMailer do
 
       context 'body includes' do
         it 'password reset url' do
-          expect(mail.body.raw_source).to include spree.edit_spree_user_password_url
+          expect(mail.html_part.body).to include spree.edit_spree_user_password_url
         end
       end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Spree::UserMailer do
 
       context 'body includes' do
         it 'password reset url' do
+          expect(mail.text_part.body).to include spree.edit_spree_user_password_url
           expect(mail.html_part.body).to include spree.edit_spree_user_password_url
         end
       end


### PR DESCRIPTION
#### What? Why?

Until now the email which was sent to users who forgot their password wasn't styled at all and it contained plain text only. To unify with our other emails I've now created a styled version of it.

## Before
![image](https://github.com/user-attachments/assets/07c4adf3-5699-49ac-ba9d-9e64afc293fd)

## After
![image](https://github.com/user-attachments/assets/a0aee05e-5587-4a23-bbe7-befc603b10ff)

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit the main page.
- Click Login.
- Select 'Forgot Password?'
- Enter your email address.
- Click 'Reset password'.
- Check the design of the email which is sent to you.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
