### PR TITLE
Add shipping method and shipment state to packing reports

### DIFF
--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -23,6 +23,7 @@ class ReportJob < ApplicationJob
     broadcast_result(channel, format, blob) if channel
   rescue StandardError => e
     Alert.raise(e, { report: { report_class:, user:, params:, format: } })
+    Rails.logger.error(e.message)
 
     broadcast_error(channel)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3352,6 +3352,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   report_header_total_incl_vat: "Total incl. tax (%{currency_symbol})"
   report_header_total_excl_fees_and_tax: "Total excl. fees and tax (%{currency_symbol})"
   report_header_temp_controlled: TempControlled?
+  report_header_shipment_state: "Shipment State"
+  report_header_shipping_method: "Shipping Method"
   report_header_is_producer: Producer?
   report_header_not_confirmed: Not Confirmed
   report_header_gst_on_income: GST on Income

--- a/lib/reporting/queries/joins.rb
+++ b/lib/reporting/queries/joins.rb
@@ -40,6 +40,16 @@ module Reporting
       def joins_order_bill_address
         reflect query.join(association(Spree::Order, :bill_address, bill_address_alias))
       end
+
+      def joins_selected_shipping_methods
+        reflect query.
+          join(association(Spree::Order, :shipments)).
+          join(association(Spree::Shipment, :shipping_rates)).
+          join(shipping_method_table).on(
+            shipping_method_table[:id].eq(shipping_rate_table[:shipping_method_id]).
+            and(shipping_rate_table[:selected].eq(true))
+          )
+      end
     end
   end
 end

--- a/lib/reporting/queries/tables.rb
+++ b/lib/reporting/queries/tables.rb
@@ -42,6 +42,18 @@ module Reporting
       def shipping_category_table
         Spree::ShippingCategory.arel_table
       end
+
+      def shipping_method_table
+        Spree::ShippingMethod.arel_table
+      end
+
+      def shipping_rate_table
+        Spree::ShippingRate.arel_table
+      end
+
+      def shipment_table
+        Spree::Shipment.arel_table
+      end
     end
   end
 end

--- a/lib/reporting/reports/packing/base.rb
+++ b/lib/reporting/reports/packing/base.rb
@@ -20,6 +20,7 @@ module Reporting
             joins_variant_product.
             joins_variant_supplier.
             joins_variant_shipping_category.
+            joins_selected_shipping_methods.
             selecting(select_fields).
             ordered_by(ordering_fields)
         end
@@ -30,7 +31,7 @@ module Reporting
 
         def default_params
           # Prevent breaking change in this report by hidding new columns by default
-          { fields_to_hide: ["phone", "price"],
+          { fields_to_hide: ["phone", "price", "shipment_state", "shipping_method"],
             q: {  order_completed_at_gt: 1.month.ago.beginning_of_day,
                   order_completed_at_lt: 1.day.from_now.beginning_of_day } }
         end
@@ -54,6 +55,8 @@ module Reporting
               depth: line_item_table[:depth],
               quantity: line_item_table[:quantity],
               price: (line_item_table[:quantity] * line_item_table[:price]),
+              shipment_state: order_table[:shipment_state],
+              shipping_method: shipping_method_table[:name],
               temp_controlled: shipping_category_table[:temperature_controlled],
             }
           end

--- a/lib/reporting/reports/packing/customer.rb
+++ b/lib/reporting/reports/packing/customer.rb
@@ -7,7 +7,8 @@ module Reporting
         def table_columns
           Struct.new(:keys).new(
             [:hub, :customer_code, :first_name, :last_name, :phone, :supplier, :product,
-             :variant, :weight, :height, :width, :depth, :quantity, :price, :temp_controlled]
+             :variant, :weight, :height, :width, :depth, :quantity, :price, :temp_controlled,
+             :shipment_state, :shipping_method]
           )
         end
 

--- a/lib/reporting/reports/packing/product.rb
+++ b/lib/reporting/reports/packing/product.rb
@@ -7,7 +7,8 @@ module Reporting
         def table_columns
           Struct.new(:keys).new(
             [:hub, :supplier, :product, :variant, :customer_code, :first_name,
-             :last_name, :phone, :quantity, :price, :temp_controlled]
+             :last_name, :phone, :quantity, :price, :temp_controlled, :shipment_state,
+             :shipping_method]
           )
         end
 

--- a/lib/reporting/reports/packing/supplier.rb
+++ b/lib/reporting/reports/packing/supplier.rb
@@ -7,7 +7,8 @@ module Reporting
         def table_columns
           Struct.new(:keys).new(
             [:hub, :supplier, :customer_code, :first_name, :last_name, :phone,
-             :product, :variant, :quantity, :price, :temp_controlled]
+             :product, :variant, :quantity, :price, :temp_controlled, :shipment_state,
+             :shipping_method]
           )
         end
 

--- a/spec/controllers/api/v0/reports/packing_report_spec.rb
+++ b/spec/controllers/api/v0/reports/packing_report_spec.rb
@@ -59,17 +59,20 @@ RSpec.describe Api::V0::ReportsController, type: :controller do
   end
 
   def distributor_report_row(line_item)
+    order = line_item.order
+    variant = line_item.variant
+
     {
-      "hub" => line_item.order.distributor.name,
-      "customer_code" => line_item.order.customer&.code,
-      "supplier" => line_item.variant.supplier.name,
+      "hub" => order.distributor.name,
+      "customer_code" => order.customer&.code,
+      "supplier" => variant.supplier.name,
       "product" => line_item.product.name,
       "variant" => line_item.full_name,
       "quantity" => line_item.quantity,
       "price" => (line_item.quantity * line_item.price).to_s,
-      "temp_controlled" => line_item.variant.shipping_category&.temperature_controlled,
-      "shipment_state" => line_item.order.shipment_state,
-      "shipping_method" => line_item.order.shipping_method&.name,
+      "temp_controlled" => variant.shipping_category&.temperature_controlled,
+      "shipment_state" => order.shipment_state,
+      "shipping_method" => order.shipping_method&.name,
     }.
       merge(dimensions(line_item)).
       merge(contacts(line_item.order.bill_address))

--- a/spec/controllers/api/v0/reports/packing_report_spec.rb
+++ b/spec/controllers/api/v0/reports/packing_report_spec.rb
@@ -67,7 +67,9 @@ RSpec.describe Api::V0::ReportsController, type: :controller do
       "variant" => line_item.full_name,
       "quantity" => line_item.quantity,
       "price" => (line_item.quantity * line_item.price).to_s,
-      "temp_controlled" => line_item.variant.shipping_category&.temperature_controlled
+      "temp_controlled" => line_item.variant.shipping_category&.temperature_controlled,
+      "shipment_state" => line_item.order.shipment_state,
+      "shipping_method" => line_item.order.shipping_method&.name,
     }.
       merge(dimensions(line_item)).
       merge(contacts(line_item.order.bill_address))
@@ -85,7 +87,9 @@ RSpec.describe Api::V0::ReportsController, type: :controller do
       "variant" => line_item.full_name,
       "quantity" => line_item.quantity,
       "price" => (line_item.quantity * line_item.price).to_s,
-      "temp_controlled" => line_item.variant.shipping_category&.temperature_controlled
+      "temp_controlled" => line_item.variant.shipping_category&.temperature_controlled,
+      "shipment_state" => line_item.order.shipment_state,
+      "shipping_method" => line_item.order.shipping_method&.name,
     }.merge(dimensions(line_item))
   end
 

--- a/spec/lib/reports/packing/packing_report_spec.rb
+++ b/spec/lib/reports/packing/packing_report_spec.rb
@@ -186,5 +186,12 @@ RSpec.describe "Packing Reports" do
         )
       end
     end
+
+    context "shipping method and shipment state" do
+      it "includes shipping method and shipment state" do
+        expect(report_data.first["shipping_method"]).to eq order.shipping_method.name
+        expect(report_data.first["shipment_state"]).to eq order.shipment_state
+      end
+    end
   end
 end

--- a/spec/system/admin/reports/packing_report_spec.rb
+++ b/spec/system/admin/reports/packing_report_spec.rb
@@ -13,6 +13,23 @@ RSpec.describe "Packing Reports" do
   let!(:open_datetime) { 1.month.ago.strftime("%Y-%m-%d 00:00") }
   let!(:close_datetime) { Time.zone.now.strftime("%Y-%m-%d 00:00") }
 
+  shared_examples "shipment state and shipping method specs" do |report_name|
+    it "makes shipping method and shipment state visible in #{report_name}" do
+      find('.ofn-drop-down').click
+      within ".menu" do
+        page.find("span", text: "Shipment State").click
+        page.find("span", text: "Shipping Method").click
+      end
+
+      run_report
+
+      within "table.report__table" do
+        expect(page).to have_selector("th", text: "Shipment State")
+        expect(page).to have_selector("th", text: "Shipping Method")
+      end
+    end
+  end
+
   describe "Packing reports" do
     before do
       login_as_admin
@@ -49,9 +66,9 @@ RSpec.describe "Packing Reports" do
     end
 
     describe "Pack By Customer" do
-      it "displays the report" do
-        click_link "Pack By Customer"
+      before { click_link "Pack By Customer" }
 
+      it "displays the report" do
         # pre-fills with dates
         check_prefilled_dates
 
@@ -71,8 +88,6 @@ RSpec.describe "Packing Reports" do
       end
 
       it "sorts alphabetically" do
-        click_link "Pack By Customer"
-
         # pre-fills with dates
         check_prefilled_dates
 
@@ -91,12 +106,14 @@ RSpec.describe "Packing Reports" do
         # date range is kept after form submission
         check_prefilled_dates
       end
+
+      it_behaves_like "shipment state and shipping method specs", "Pack By Customer"
     end
 
     describe "Pack By Supplier" do
-      it "displays the report" do
-        click_link "Pack By Supplier"
+      before { click_link "Pack By Supplier" }
 
+      it "displays the report" do
         # pre-fills with dates
         check_prefilled_dates
 
@@ -116,6 +133,8 @@ RSpec.describe "Packing Reports" do
         # date range is kept after form submission
         check_prefilled_dates
       end
+
+      it_behaves_like "shipment state and shipping method specs", "Pack By Supplier"
     end
   end
 
@@ -157,6 +176,8 @@ RSpec.describe "Packing Reports" do
           # date range is kept after form submission
           check_prefilled_dates
         end
+
+        it_behaves_like "shipment state and shipping method specs", "Pack By Product"
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

- Closes #13097 
- Add new columns, shipping method and shipment state, into the packing reports
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->