### PR TITLE
Fixes Rails/UniqueValidationWithoutIndex (part of #11482)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -63,7 +63,6 @@ Metrics/ClassLength:
     - 'app/controllers/spree/admin/payment_methods_controller.rb'
     - 'app/controllers/spree/admin/payments_controller.rb'
     - 'app/controllers/spree/admin/products_controller.rb'
-    - 'app/controllers/spree/admin/users_controller.rb'
     - 'app/controllers/spree/orders_controller.rb'
     - 'app/models/enterprise.rb'
     - 'app/models/invoice/data_presenter.rb'
@@ -149,7 +148,7 @@ Metrics/MethodLength:
     - 'lib/spree/localized_number.rb'
     - 'lib/tasks/sample_data/product_factory.rb'
 
-# Offense count: 49
+# Offense count: 47
 # Configuration parameters: CountComments, Max, CountAsOne.
 Metrics/ModuleLength:
   Exclude:
@@ -176,12 +175,10 @@ Metrics/ModuleLength:
     - 'spec/controllers/admin/order_cycles_controller_spec.rb'
     - 'spec/controllers/api/v0/order_cycles_controller_spec.rb'
     - 'spec/controllers/api/v0/orders_controller_spec.rb'
-    - 'spec/controllers/payment_gateways/stripe_controller_spec.rb'
     - 'spec/controllers/spree/admin/adjustments_controller_spec.rb'
     - 'spec/controllers/spree/admin/payment_methods_controller_spec.rb'
     - 'spec/controllers/spree/admin/variants_controller_spec.rb'
     - 'spec/lib/open_food_network/address_finder_spec.rb'
-    - 'spec/lib/open_food_network/enterprise_fee_calculator_spec.rb'
     - 'spec/lib/open_food_network/order_cycle_form_applicator_spec.rb'
     - 'spec/lib/open_food_network/order_cycle_permissions_spec.rb'
     - 'spec/lib/open_food_network/permissions_spec.rb'

--- a/db/migrate/20250214192930_add_unique_index_email_entreprise_to_customers.rb
+++ b/db/migrate/20250214192930_add_unique_index_email_entreprise_to_customers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexEmailEntrepriseToCustomers < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :customers, :email, name: :index_customers_on_email
+    add_index(:customers, [:email, :enterprise_id], unique: true)
+  end
+end

--- a/db/migrate/20250214200526_add_unique_index_sender_id_and_others_to_exchanges.rb
+++ b/db/migrate/20250214200526_add_unique_index_sender_id_and_others_to_exchanges.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexSenderIdAndOthersToExchanges < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :exchanges, :sender_id, name: :index_exchanges_on_sender_id
+    add_index(:exchanges, [:sender_id, :order_cycle_id, :receiver_id, :incoming],
+              unique: true, name: :index_exchanges_on_sender_id)
+  end
+end

--- a/db/migrate/20250215083320_add_unique_index_variant_id_and_deleted_at_to_stock_items.rb
+++ b/db/migrate/20250215083320_add_unique_index_variant_id_and_deleted_at_to_stock_items.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexVariantIdAndDeletedAtToStockItems < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :spree_stock_items, :variant_id, name: :index_spree_stock_items_on_variant_id
+    add_index(:spree_stock_items, [:variant_id, :deleted_at], unique: true)
+  end
+end

--- a/db/migrate/20250215085838_add_unique_index_name_and_deleted_at_to_tax_categories.rb
+++ b/db/migrate/20250215085838_add_unique_index_name_and_deleted_at_to_tax_categories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexNameAndDeletedAtToTaxCategories < ActiveRecord::Migration[7.0]
+  def change
+    add_index(:spree_tax_categories, [:name, :deleted_at], unique: true)
+  end
+end

--- a/db/migrate/20250215091227_add_unique_index_name_to_zones.rb
+++ b/db/migrate/20250215091227_add_unique_index_name_to_zones.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexNameToZones < ActiveRecord::Migration[7.0]
+  def change
+    add_index(:spree_zones, :name, unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -105,7 +105,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_04_234657) do
     t.boolean "created_manually", default: false
     t.index ["bill_address_id"], name: "index_customers_on_bill_address_id"
     t.index ["created_manually"], name: "index_customers_on_created_manually"
-    t.index ["email"], name: "index_customers_on_email"
+    t.index ["email", "enterprise_id"], name: "index_customers_on_email_and_enterprise_id", unique: true
     t.index ["enterprise_id", "code"], name: "index_customers_on_enterprise_id_and_code", unique: true
     t.index ["ship_address_id"], name: "index_customers_on_ship_address_id"
     t.index ["user_id"], name: "index_customers_on_user_id"
@@ -270,7 +270,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_04_234657) do
     t.text "receival_instructions"
     t.index ["order_cycle_id"], name: "index_exchanges_on_order_cycle_id"
     t.index ["receiver_id"], name: "index_exchanges_on_receiver_id"
-    t.index ["sender_id"], name: "index_exchanges_on_sender_id"
+    t.index ["sender_id", "order_cycle_id", "receiver_id", "incoming"], name: "index_exchanges_on_sender_id", unique: true
   end
 
   create_table "flipper_features", id: :serial, force: :cascade do |t|
@@ -834,7 +834,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_04_234657) do
     t.integer "lock_version", default: 0
     t.index ["stock_location_id", "variant_id"], name: "stock_item_by_loc_and_var_id"
     t.index ["stock_location_id"], name: "index_spree_stock_items_on_stock_location_id"
-    t.index ["variant_id"], name: "index_spree_stock_items_on_variant_id", unique: true
+    t.index ["variant_id", "deleted_at"], name: "index_spree_stock_items_on_variant_id_and_deleted_at", unique: true
   end
 
   create_table "spree_stock_locations", id: :serial, force: :cascade do |t|
@@ -872,6 +872,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_04_234657) do
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "is_default", default: false
     t.datetime "deleted_at", precision: nil
+    t.index ["name", "deleted_at"], name: "index_spree_tax_categories_on_name_and_deleted_at", unique: true
   end
 
   create_table "spree_tax_rates", id: :serial, force: :cascade do |t|
@@ -1001,6 +1002,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_04_234657) do
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "default_tax", default: false
     t.integer "zone_members_count", default: 0
+    t.index ["name"], name: "index_spree_zones_on_name", unique: true
   end
 
   create_table "stripe_accounts", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
#### What? Why?

Contributes to #11482

The [Rails/UniqueValidationWithoutIndex](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsuniquevalidationwithoutindex) cop checks (via the db/schema.rb file) that AR models indexes are also defined at the DB level.
Example : -when you define a uniqueness validation in Active Record model, you also should add a unique index for the column.

#### What should we test?
Automatic specs should all pass.
Migration should proceed without any errors. (ie running `rails db:migrate`)

Any error would mean data inserted that do not respect DB constraints.
In dev/test environment, it should be fine.

But the real test would be in instances. Though checks in AR models should have prevented bad data to have been inserted.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.