### PR TITLE
Fix user controlled method execution

### DIFF
--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -69,7 +69,7 @@ module Spree
         @order.send_cancellation_email = params[:send_cancellation_email] != "false"
         @order.restock_items = params.fetch(:restock_items, "true") == "true"
 
-        if @order.public_send(event.to_s)
+        if allowed_events.include?(event) && @order.public_send(event.to_s)
           AmendBackorderJob.perform_later(@order) if @order.completed?
           flash[:success] = Spree.t(:order_updated)
         else
@@ -197,6 +197,10 @@ module Spree
                         ocs.soonest_opening +
                         ocs.closed +
                         ocs.undated
+      end
+
+      def allowed_events
+        %w{cancel resume}
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4047,6 +4047,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
 
   spree:
     order_updated: "Order Updated"
+    cannot_perform_operation: "Can not perform this operation"
     add_country: "Add country"
     add_state: "Add state"
     adjustment: "Adjustment"


### PR DESCRIPTION
#### What? Why?

- Fix brakeman warning : https://github.com/openfoodfoundation/openfoodnetwork/security/code-scanning/203

There is no check on the event parameter e, which means logged in enterprise user could potentially run any method on the `order` object. I added some white listing to mitigate the issue.
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Place an order 
- As an enterprise user, go to the order edit screen
- Click on the Cancel button
  --> the order is cancelled
- Now click on the Resume button
  --> the order is resumed

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.