### PR TITLE
[DFC Orders] Select/deselect all on DFC Product Import

### DIFF
--- a/app/views/admin/dfc_product_imports/index.html.haml
+++ b/app/views/admin/dfc_product_imports/index.html.haml
@@ -23,7 +23,7 @@
         %tr{id: supplied_product.semanticId }
           %td
             %label
-              = form.check_box 'semanticIds[]', { checked: true, data: { "action" => "change->checked#toggleCheckbox", "checked-target" => "checkbox" } }, supplied_product.semanticId, ""
+              = form.check_box 'semanticIds[]', { checked: true, 'data-checked-target': "checkbox" }, supplied_product.semanticId, ""
               = supplied_product.name
           %td
             - if existing_product.present?

--- a/app/views/admin/dfc_product_imports/index.html.haml
+++ b/app/views/admin/dfc_product_imports/index.html.haml
@@ -16,7 +16,7 @@
     %thead
       %tr
         %th
-          %input{ type: 'checkbox', title: t('.select_all'), 'aria-label': t('.select_all'), data: { "checked-target": "all", action: "change->checked#toggleAll" } }
+          %input{ type: 'checkbox', title: t('.select_all'), 'aria-label': t('.select_all'), 'data-checked-target': "all" }
         %th
     %tbody
       - @items.each do |supplied_product, existing_product|

--- a/app/views/admin/dfc_product_imports/index.html.haml
+++ b/app/views/admin/dfc_product_imports/index.html.haml
@@ -1,36 +1,37 @@
 - content_for :page_title do
   #{t(".title")}
 
-= render partial: 'spree/admin/shared/product_sub_menu'
+#dfc_product_imports
+  = render partial: 'spree/admin/shared/product_sub_menu'
 
-%p= t('.catalog_url', count: @items.count, catalog_url: @catalog_url)
-%p= t('.enterprise', enterprise_name: @enterprise.name)
-%br
-
-= form_with url: main_app.import_admin_dfc_product_imports_path do |form|
-  -# This is a very inefficient way of holding a json blob. Maybe base64 encode or store as a temporary file
-  = form.hidden_field :enterprise_id, value: @enterprise.id
-  = form.hidden_field :catalog_json, value: @catalog_json
-
-  %table{"data-controller": "checked" }
-    %thead
-      %tr
-        %th
-          %input{ type: 'checkbox', title: t('.select_all'), 'aria-label': t('.select_all'), 'data-checked-target': "all" }
-        %th
-    %tbody
-      - @items.each do |supplied_product, existing_product|
-        %tr{id: supplied_product.semanticId }
-          %td
-            %label
-              = form.check_box 'semanticIds[]', { checked: true, 'data-checked-target': "checkbox" }, supplied_product.semanticId, ""
-              = supplied_product.name
-          %td
-            - if existing_product.present?
-              = t(".update")
-              = link_to(existing_product.id, edit_admin_product_path(existing_product))
-            - else
-              = t(".new")
-
+  %p= t('.catalog_url', count: @items.count, catalog_url: @catalog_url)
+  %p= t('.enterprise', enterprise_name: @enterprise.name)
   %br
-  = form.submit t(".import")
+
+  = form_with url: main_app.import_admin_dfc_product_imports_path do |form|
+    -# This is a very inefficient way of holding a json blob. Maybe base64 encode or store as a temporary file
+    = form.hidden_field :enterprise_id, value: @enterprise.id
+    = form.hidden_field :catalog_json, value: @catalog_json
+
+    %table{"data-controller": "checked" }
+      %thead
+        %tr
+          %th
+            %input{ type: 'checkbox', title: t('.select_all'), 'aria-label': t('.select_all'), 'data-checked-target': "all" }
+          %th
+      %tbody
+        - @items.each do |supplied_product, existing_product|
+          %tr{id: supplied_product.semanticId }
+            %td
+              %label
+                = form.check_box 'semanticIds[]', { checked: true, 'data-checked-target': "checkbox" }, supplied_product.semanticId, ""
+                = supplied_product.name
+            %td
+              - if existing_product.present?
+                = t(".update")
+                = link_to(existing_product.id, edit_admin_product_path(existing_product))
+              - else
+                = t(".new")
+
+    %br
+    = form.submit t(".import")

--- a/app/views/admin/dfc_product_imports/index.html.haml
+++ b/app/views/admin/dfc_product_imports/index.html.haml
@@ -8,12 +8,12 @@
   %p= t('.enterprise', enterprise_name: @enterprise.name)
   %br
 
-  = form_with url: main_app.import_admin_dfc_product_imports_path do |form|
+  = form_with url: main_app.import_admin_dfc_product_imports_path, html: { "data-controller": "checked" } do |form|
     -# This is a very inefficient way of holding a json blob. Maybe base64 encode or store as a temporary file
     = form.hidden_field :enterprise_id, value: @enterprise.id
     = form.hidden_field :catalog_json, value: @catalog_json
 
-    %table{"data-controller": "checked" }
+    %table
       %thead
         %tr
           %th
@@ -32,6 +32,9 @@
                 = link_to(existing_product.id, edit_admin_product_path(existing_product))
               - else
                 = t(".new")
+
+    %span{ "data-controller": "checked-feedback", "data-checked-feedback-translation-value": "admin.dfc_product_imports.index.selected" }
+      = t(".selected", count: @items.count)
 
     %br
     = form.submit t(".import")

--- a/app/views/admin/dfc_product_imports/index.html.haml
+++ b/app/views/admin/dfc_product_imports/index.html.haml
@@ -12,13 +12,18 @@
   = form.hidden_field :enterprise_id, value: @enterprise.id
   = form.hidden_field :catalog_json, value: @catalog_json
 
-  %table
+  %table{"data-controller": "checked" }
+    %thead
+      %tr
+        %th
+          %input{ type: 'checkbox', title: t('.select_all'), 'aria-label': t('.select_all'), data: { "checked-target": "all", action: "change->checked#toggleAll" } }
+        %th
     %tbody
       - @items.each do |supplied_product, existing_product|
         %tr{id: supplied_product.semanticId }
           %td
             %label
-              = form.check_box 'semanticIds[]', { checked: true }, supplied_product.semanticId, ""
+              = form.check_box 'semanticIds[]', { checked: true, data: { "action" => "change->checked#toggleCheckbox", "checked-target" => "checkbox" } }, supplied_product.semanticId, ""
               = supplied_product.name
           %td
             - if existing_product.present?

--- a/app/views/admin/order_cycles/checkout_options.html.haml
+++ b/app/views/admin/order_cycles/checkout_options.html.haml
@@ -36,7 +36,7 @@
                           distributor_shipping_method.id,
                           @order_cycle.distributor_shipping_methods.include?(distributor_shipping_method),
                           id: "order_cycle_selected_distributor_shipping_method_ids_#{distributor_shipping_method.id}",
-                          data: ({ "action" => "change->checked#toggleCheckbox", "checked-target" => "checkbox" } if distributor_shipping_method.shipping_method.frontend?)
+                          data: ({ "checked-target" => "checkbox" } if distributor_shipping_method.shipping_method.frontend?)
                       = distributor_shipping_method.shipping_method.name
                 - distributor.shipping_methods.backend.each do |shipping_method|
                   %label.disabled
@@ -67,7 +67,7 @@
                           distributor_payment_method.id,
                           @order_cycle.distributor_payment_methods.include?(distributor_payment_method),
                           id: "order_cycle_selected_distributor_payment_method_ids_#{distributor_payment_method.id}",
-                          data: ({ "action" => "change->checked#toggleCheckbox", "checked-target" => "checkbox" } if distributor_payment_method.payment_method.frontend?)
+                          data: ({ "checked-target" => "checkbox" } if distributor_payment_method.payment_method.frontend?)
                       = distributor_payment_method.payment_method.name
                 - distributor.payment_methods.inactive_or_backend.each do |payment_method|
                   %label.disabled

--- a/app/views/admin/order_cycles/checkout_options.html.haml
+++ b/app/views/admin/order_cycles/checkout_options.html.haml
@@ -25,7 +25,7 @@
               %td.text-center
                 - if distributor_shipping_methods.many?
                   %label
-                    = check_box_tag nil, nil, nil, { "data-action": "change->checked#toggleAll", "data-checked-target": "all" }
+                    = check_box_tag nil, nil, nil, { "data-checked-target": "all" }
                     = t(".select_all")
               %td
                 %em= distributor.name

--- a/app/views/spree/admin/orders/_table.html.haml
+++ b/app/views/spree/admin/orders/_table.html.haml
@@ -10,7 +10,7 @@
   %thead
     %tr
       %th
-        %input#selectAll{ type: 'checkbox', data: { "checked-target": "all", action: "change->checked#toggleAll" } }
+        %input#selectAll{ type: 'checkbox', 'data-checked-target': "all" }
       %th
         = t(:products_distributor)
 

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -1,6 +1,6 @@
 %tr{ id: dom_id(order), class: "state-#{order.state}" }
   %td.align-left
-    %input{type: 'checkbox', value: order.id, name: 'bulk_ids[]', "data-checked-target": "checkbox", "data-action": "change->checked#toggleCheckbox" }
+    %input{type: 'checkbox', value: order.id, name: 'bulk_ids[]', "data-checked-target": "checkbox" }
   %td.align-left
     = order.distributor.name
   %td.align-left

--- a/app/webpacker/controllers/checked_controller.js
+++ b/app/webpacker/controllers/checked_controller.js
@@ -7,7 +7,11 @@ export default class extends Controller {
   connect() {
     this.toggleCheckbox();
 
-    this.element.addEventListener("change", this.#toggleChangeListener.bind(this), {passive: true});
+    this.allTarget.addEventListener("change", this.toggleAll.bind(this));
+
+    this.checkboxTargets.forEach((checkbox) => {
+      checkbox.addEventListener("change", this.toggleCheckbox.bind(this));
+    });
   }
 
   toggleAll() {
@@ -34,15 +38,6 @@ export default class extends Controller {
   }
 
   // private
-
-  // Delegate events for targets (this ensures we catch events from newly-added elements after an ajax action)
-  #toggleChangeListener(event) {
-    if (event.target == this.allTarget) {
-      this.toggleAll();
-    } else if (this.checkboxTargets.includes(event.target)) {
-      this.toggleCheckbox();
-    }
-  }
 
   #checkedCount() {
     return this.checkboxTargets.filter((checkbox) => checkbox.checked).length;

--- a/app/webpacker/controllers/checked_controller.js
+++ b/app/webpacker/controllers/checked_controller.js
@@ -7,11 +7,7 @@ export default class extends Controller {
   connect() {
     this.toggleCheckbox();
 
-    this.allTarget.addEventListener("change", this.toggleAll.bind(this));
-
-    this.checkboxTargets.forEach((checkbox) => {
-      checkbox.addEventListener("change", this.toggleCheckbox.bind(this));
-    });
+    this.element.addEventListener("change", this.#toggleChangeListener.bind(this), {passive: true});
   }
 
   toggleAll() {
@@ -38,6 +34,15 @@ export default class extends Controller {
   }
 
   // private
+
+  // Delegate events for targets (this ensures we catch events from newly-added elements after an ajax action)
+  #toggleChangeListener(event) {
+    if (event.target == this.allTarget) {
+      this.toggleAll();
+    } else if (this.checkboxTargets.includes(event.target)) {
+      this.toggleCheckbox();
+    }
+  }
 
   #checkedCount() {
     return this.checkboxTargets.filter((checkbox) => checkbox.checked).length;

--- a/app/webpacker/controllers/checked_controller.js
+++ b/app/webpacker/controllers/checked_controller.js
@@ -8,6 +8,10 @@ export default class extends Controller {
     this.toggleCheckbox();
 
     this.allTarget.addEventListener("change", this.toggleAll.bind(this));
+
+    this.checkboxTargets.forEach((checkbox) => {
+      checkbox.addEventListener("change", this.toggleCheckbox.bind(this));
+    });
   }
 
   toggleAll() {

--- a/app/webpacker/controllers/checked_controller.js
+++ b/app/webpacker/controllers/checked_controller.js
@@ -6,6 +6,8 @@ export default class extends Controller {
 
   connect() {
     this.toggleCheckbox();
+
+    this.allTarget.addEventListener("change", this.toggleAll.bind(this));
   }
 
   toggleAll() {

--- a/app/webpacker/controllers/checked_controller.js
+++ b/app/webpacker/controllers/checked_controller.js
@@ -6,12 +6,14 @@ export default class extends Controller {
 
   connect() {
     this.toggleCheckbox();
+  }
 
-    this.allTarget.addEventListener("change", this.toggleAll.bind(this));
+  allTargetConnected(allTarget) {
+    allTarget.addEventListener("change", this.toggleAll.bind(this));
+  }
 
-    this.checkboxTargets.forEach((checkbox) => {
-      checkbox.addEventListener("change", this.toggleCheckbox.bind(this));
-    });
+  checkboxTargetConnected(checkboxTarget) {
+    checkboxTarget.addEventListener("change", this.toggleCheckbox.bind(this));
   }
 
   toggleAll() {

--- a/app/webpacker/css/admin_v3/all.scss
+++ b/app/webpacker/css/admin_v3/all.scss
@@ -133,3 +133,4 @@
 @import "terms_of_service_banner"; // admin_v3
 
 @import "pages/product_preview"; // admin_v3
+@import "pages/dfc_product_imports"; // admin_v3

--- a/app/webpacker/css/admin_v3/pages/dfc_product_imports.scss
+++ b/app/webpacker/css/admin_v3/pages/dfc_product_imports.scss
@@ -1,0 +1,11 @@
+
+#dfc_product_imports {
+  // Ensure label reaches to edge of table cell
+  td:has(> label) {
+    padding: 0;
+  }
+  td > label {
+    display: block;
+    padding: 7px 5px;
+  }
+}

--- a/app/webpacker/css/admin_v3/pages/dfc_product_imports.scss
+++ b/app/webpacker/css/admin_v3/pages/dfc_product_imports.scss
@@ -7,5 +7,6 @@
   td > label {
     display: block;
     padding: 7px 5px;
+    font-size: inherit;
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -854,6 +854,10 @@ en:
         select_all: "Select/deselect all"
         update: Update
         new: New
+        selected:
+          zero: "0 selected"
+          one: "1 selected"
+          other: "%{count} selected"
         import: Import
       import:
         title: "DFC product catalog import"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -851,6 +851,7 @@ en:
         title: "DFC product catalog"
         catalog_url: "%{count} products to be imported from: %{catalog_url}"
         enterprise: "Import to enterprise: %{enterprise_name}"
+        select_all: "Select/deselect all"
         update: Update
         new: New
         import: Import

--- a/spec/javascripts/stimulus/checked_controller_test.js
+++ b/spec/javascripts/stimulus/checked_controller_test.js
@@ -21,12 +21,10 @@ describe("CheckedController", () => {
         <input
           id="checkboxA"
           type="checkbox"
-          data-action="change->checked#toggleCheckbox"
           data-checked-target="checkbox">
         <input
           id="checkboxB"
           type="checkbox"
-          data-action="change->checked#toggleCheckbox"
           data-checked-target="checkbox">
       </div>
     `;
@@ -90,13 +88,11 @@ describe("CheckedController", () => {
           <input
             id="checkboxA"
             type="checkbox"
-            data-action="change->checked#toggleCheckbox"
             data-checked-target="checkbox"
             checked="checked">
           <input
             id="checkboxB"
             type="checkbox"
-            data-action="change->checked#toggleCheckbox"
             data-checked-target="checkbox"
             checked="checked">
         </div>

--- a/spec/javascripts/stimulus/checked_controller_test.js
+++ b/spec/javascripts/stimulus/checked_controller_test.js
@@ -17,7 +17,6 @@ describe("CheckedController", () => {
         <input
           id="selectAllCheckbox"
           type="checkbox"
-          data-action="change->checked#toggleAll"
           data-checked-target="all">
         <input
           id="checkboxA"
@@ -87,7 +86,6 @@ describe("CheckedController", () => {
           <input
             id="selectAllCheckbox"
             type="checkbox"
-            data-action="change->checked#toggleAll"
             data-checked-target="all">
           <input
             id="checkboxA"

--- a/spec/system/admin/dfc_product_import_spec.rb
+++ b/spec/system/admin/dfc_product_import_spec.rb
@@ -65,7 +65,13 @@ RSpec.describe "DFC Product Import" do
     expect(page).to have_content "Beans - Case, 12 x 400g (can) New"
     expect(page).to have_content "Chia Seed, Organic - Retail pack, 300g"
 
-    uncheck "Chia Seed, Organic - Case, 8 x 300g" # don't import this one
+    # I can select all
+    uncheck "Chia Seed, Organic - Case, 8 x 300g"
+    check "Select/deselect all"
+    expect(page).to have_checked_field "Chia Seed, Organic - Case, 8 x 300g"
+
+    # And deselect one
+    uncheck "Chia Seed, Organic - Case, 8 x 300g"
 
     expect {
       click_button "Import"


### PR DESCRIPTION
#### :information_source: Funded Feature. Please track ALL ASSOCIATED WORK under the associated tracking code `#11678 DFC Orders`


#### What? Why?

- Closes #12301

Adds a checkbox at the top of the table so that you can select or deselect all at once. 
Using (and refactoring) an existing Stimulus controller.

#### What should we test?
See https://github.com/openfoodfoundation/openfoodnetwork/pull/13125#issue-2834395062
