### PR TITLE
Remove true as select default first option

### DIFF
--- a/app/views/admin/enterprise_fees/index.html.haml
+++ b/app/views/admin/enterprise_fees/index.html.haml
@@ -37,7 +37,7 @@
           %td= f.ng_select :fee_type, enterprise_fee_type_options, 'enterprise_fee.fee_type'
           %td= f.ng_text_field :name, { placeholder: t('.name_placeholder') }
           %td
-            %ofn-select{ id: angular_id(:tax_category_id), data: 'tax_categories', include_blank: true, "ng-model": 'enterprise_fee.tax_category_id' }
+            %ofn-select{ id: angular_id(:tax_category_id), data: 'tax_categories', "ng-model": 'enterprise_fee.tax_category_id' }
             %input{ type: "hidden", name: angular_name(:tax_category_id), 'watch-tax-category' => true }
             %input{ type: "hidden", name: angular_name(:inherits_tax_category), "ng-value": "enterprise_fee.inherits_tax_category" }
           %td


### PR DESCRIPTION
#### What? Why?

- Closes #13080 

Hint provided by @MrBowmanXD was the solution.  The 'include_blank' is for placeholders and not for blank default choice.


#### What should we test?
   Steps from @filipefurtad0 test:

    - Log in as an enterprise manager
    - Visit /admin/enterprise_fees
    - For new enterprise fees (Tax Category column), there should be no option by default. The 'true' that appeared previously should have disappeared.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled