### PR TITLE
 Add a 'reply to' email address to some more emails

### DIFF
--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -16,8 +16,7 @@ class PaymentMailer < ApplicationMailer
   end
 
   def authorization_required(payment)
-    @payment = payment
-    @order = @payment.order
+    @order = payment.order
     shop_owner = @order.distributor.owner
     subject = I18n.t('spree.payment_mailer.authorization_required.subject',
                      order: @order)

--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -17,12 +17,14 @@ class PaymentMailer < ApplicationMailer
 
   def authorization_required(payment)
     @payment = payment
-    shop_owner = @payment.order.distributor.owner
+    @order = @payment.order
+    shop_owner = @order.distributor.owner
     subject = I18n.t('spree.payment_mailer.authorization_required.subject',
-                     order: @payment.order)
+                     order: @order)
     I18n.with_locale valid_locale(shop_owner) do
       mail(to: shop_owner.email,
-           subject:)
+           subject:,
+           reply_to: @order.email)
     end
   end
 end

--- a/app/mailers/spree/order_mailer.rb
+++ b/app/mailers/spree/order_mailer.rb
@@ -23,7 +23,8 @@ module Spree
       I18n.with_locale valid_locale(@order.distributor.owner) do
         subject = I18n.t('spree.order_mailer.cancel_email_for_shop.subject')
         mail(to: @order.distributor.contact.email,
-             subject:)
+             subject:,
+             reply_to: @order.email)
       end
     end
 
@@ -43,7 +44,8 @@ module Spree
       I18n.with_locale valid_locale(@order.user) do
         subject = mail_subject(t('spree.order_mailer.confirm_email.subject'), resend)
         mail(to: @order.distributor.contact.email,
-             subject:)
+             subject:,
+             reply_to: @order.email)
       end
     end
 

--- a/app/views/payment_mailer/authorization_required.html.haml
+++ b/app/views/payment_mailer/authorization_required.html.haml
@@ -1,2 +1,2 @@
-= t('spree.payment_mailer.authorization_required.message', order_number: @payment.order.number)
-= link_to spree.edit_admin_order_url(@payment.order), spree.edit_admin_order_url(@payment.order)
+= t('spree.payment_mailer.authorization_required.message', order_number: @order.number)
+= link_to spree.edit_admin_order_url(@order), spree.edit_admin_order_url(@order)

--- a/app/views/payment_mailer/authorization_required.text.haml
+++ b/app/views/payment_mailer/authorization_required.text.haml
@@ -1,3 +1,3 @@
-= t('spree.payment_mailer.authorization_required.message', order_number: @payment.order.number)
+= t('spree.payment_mailer.authorization_required.message', order_number: @order.number)
 
-= link_to spree.edit_admin_order_url(@payment.order), spree.edit_admin_order_url(@payment.order)
+= link_to spree.edit_admin_order_url(@order), spree.edit_admin_order_url(@order)


### PR DESCRIPTION
#### What? Why?

This builds on top of #13139 and follows the discussion [here](https://github.com/openfoodfoundation/wishlist/issues/529#issuecomment-2656869547).

The following should be changed by this PR:
1. The 'authorize payment' email has the customer's email as reply to address.
2. The 'order confirmation' email for shops has the customer's email as reply to address.
3. The 'order cancellation' email for shops has the customer's email as reply to address.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Check that the reply to address has been added as mentioned above.
- Check that the content of the emails is unchanged.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
