### PR TITLE
Fixes some rubocop linting offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -57,26 +57,6 @@ Lint/RedundantDirGlobSort:
     - 'engines/dfc_provider/spec/spec_helper.rb'
     - 'spec/system_helper.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: instance_of?, kind_of?, is_a?, eql?, respond_to?, equal?, presence, present?
-Lint/RedundantSafeNavigation:
-  Exclude:
-    - 'app/models/spree/payment.rb'
-
-# Offense count: 1
-Lint/SelfAssignment:
-  Exclude:
-    - 'app/models/spree/order/checkout.rb'
-
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AutoCorrect.
-Lint/UselessMethodDefinition:
-  Exclude:
-    - 'app/models/spree/gateway.rb'
-
 # Offense count: 24
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes, Max.
 Metrics/AbcSize:

--- a/app/models/spree/gateway.rb
+++ b/app/models/spree/gateway.rb
@@ -17,11 +17,6 @@ module Spree
       CreditCard
     end
 
-    # instantiates the selected gateway and configures with the options stored in the database
-    def self.current
-      super
-    end
-
     def provider
       gateway_options = options
       gateway_options.delete :login if gateway_options.key?(:login) && gateway_options[:login].nil?

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -40,10 +40,7 @@ module Spree
               klass.next_event_transitions.each { |t| transition(t.merge(on: :next)) }
 
               # Persist the state on the order
-              after_transition do |order|
-                order.state = order.state
-                order.save
-              end
+              after_transition ->(order) { order.save }
 
               event :cancel do
                 transition to: :canceled, if: :allow_cancel?

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -129,7 +129,7 @@ module Spree
     end
 
     def actions
-      return [] unless payment_source&.respond_to?(:actions)
+      return [] unless payment_source.respond_to?(:actions)
 
       payment_source.actions.select do |action|
         !payment_source.respond_to?("can_#{action}?") ||


### PR DESCRIPTION
#### What? Why?

  Fixes three rubocop lint issues Cf. #12330

- [Lint/RedundantSafeNavigation](https://docs.rubocop.org/rubocop/cops_lint.html#lintredundantsafenavigation ) `respond_to?` allows for going with `.` alone than `&.`
- [Lint/SelfAssignment](https://docs.rubocop.org/rubocop/cops_lint.html#lintselfassignment) lambda instead of block otherwise rubocop warns it wants `&:save as a parameter`.
- [Lint/UselessMethodDefinition](https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessmethoddefinition)  (parent method does not exist anyway).
  Furthermore: `Spree::Gateway.current` -> `method_missing': super: no superclass method current' for Spree::Gateway:Class (NoMethodError)`. Seems from this error that method self.current is never called. 
Method has been imported as code from spree code, cf. https://github.com/openfoodfoundation/openfoodnetwork/commit/abaa66cc14f13b85661f726cbc9a95046f859000



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.