### PR TITLE
Rescue from invalid DFC catalog URLs

### DIFF
--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -15,7 +15,7 @@ module Admin
     def index
       # Fetch DFC catalog JSON for preview
       api = DfcRequest.new(spree_current_user)
-      @catalog_url = params.require(:catalog_url)
+      @catalog_url = params.require(:catalog_url).strip
       @catalog_json = api.call(@catalog_url)
       graph = DfcIo.import(@catalog_json)
       catalog = DfcCatalog.new(graph)

--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -27,6 +27,9 @@ module Admin
           @enterprise.supplied_variants.linked_to(subject.semanticId)&.product
         ]
       end
+    rescue URI::InvalidURIError
+      flash[:error] = t ".invalid_url"
+      redirect_to admin_product_import_path
     rescue Faraday::Error,
            Addressable::URI::InvalidURIError,
            ActionController::ParameterMissing => e

--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -20,12 +20,7 @@ module Admin
       catalog = DfcCatalog.from_json(@catalog_json)
 
       # Render table and let user decide which ones to import.
-      @items = catalog.products.map do |subject|
-        [
-          subject,
-          @enterprise.supplied_variants.linked_to(subject.semanticId)&.product
-        ]
-      end
+      @items = list_products(catalog)
     rescue URI::InvalidURIError
       flash[:error] = t ".invalid_url"
       redirect_to admin_product_import_path
@@ -74,6 +69,16 @@ module Admin
       @enterprise = OpenFoodNetwork::Permissions.new(spree_current_user)
         .managed_product_enterprises.is_primary_producer
         .find(params.require(:enterprise_id))
+    end
+
+    # List internal and external products for the preview.
+    def list_products(catalog)
+      catalog.products.map do |subject|
+        [
+          subject,
+          @enterprise.supplied_variants.linked_to(subject.semanticId)&.product
+        ]
+      end
     end
   end
 end

--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -17,8 +17,7 @@ module Admin
       api = DfcRequest.new(spree_current_user)
       @catalog_url = params.require(:catalog_url).strip
       @catalog_json = api.call(@catalog_url)
-      graph = DfcIo.import(@catalog_json)
-      catalog = DfcCatalog.new(graph)
+      catalog = DfcCatalog.from_json(@catalog_json)
 
       # Render table and let user decide which ones to import.
       @items = catalog.products.map do |subject|
@@ -48,8 +47,7 @@ module Admin
       ids = params.require(:semanticIds)
 
       # Load DFC catalog JSON
-      graph = DfcIo.import(params.require(:catalog_json))
-      catalog = DfcCatalog.new(graph)
+      catalog = DfcCatalog.from_json(params.require(:catalog_json))
       catalog.apply_wholesale_values!
 
       # Import all selected products for given enterprise.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -862,6 +862,7 @@ en:
           one: "1 selected"
           other: "%{count} selected"
         import: Import
+        invalid_url: This catalog URL is not valid.
       import:
         title: "DFC product catalog import"
         imported_products: "Imported products:"

--- a/engines/dfc_provider/app/services/dfc_catalog.rb
+++ b/engines/dfc_provider/app/services/dfc_catalog.rb
@@ -4,9 +4,12 @@ class DfcCatalog
   def self.load(user, catalog_url)
     api = DfcRequest.new(user)
     catalog_json = api.call(catalog_url)
-    graph = DfcIo.import(catalog_json)
 
-    new(graph)
+    from_json(catalog_json)
+  end
+
+  def self.from_json(catalog_json)
+    new(DfcIo.import(catalog_json))
   end
 
   def initialize(graph)

--- a/spec/system/admin/dfc_product_import_spec.rb
+++ b/spec/system/admin/dfc_product_import_spec.rb
@@ -20,18 +20,17 @@ RSpec.describe "DFC Product Import" do
   it "imports from given catalog" do
     visit admin_product_import_path
 
-    # We are testing against our own catalog for now but we want to replace
-    # this with the URL of another app when available.
-    # We also add a common mistake: copying the URL with an extra space.
-    host = Rails.application.default_url_options[:host]
-    url = " http://#{host}/api/dfc/enterprises/#{enterprise.id}/catalog_items"
-    fill_in "catalog_url", with: url
+    fill_in "catalog_url", with: "invalid url"
     select enterprise.name, from: "Create products for enterprise"
     click_button "Preview"
 
     expect(page).to have_content "This catalog URL is not valid"
 
-    url = "http://#{host}/api/dfc/enterprises/#{enterprise.id}/catalog_items"
+    # We are testing against our own catalog for now but we want to replace
+    # this with the URL of another app when available.
+    # We also add a common mistake: copying the URL with an extra space.
+    host = Rails.application.default_url_options[:host]
+    url = " http://#{host}/api/dfc/enterprises/#{enterprise.id}/catalog_items"
     fill_in "catalog_url", with: url
     select enterprise.name, from: "Create products for enterprise"
     click_button "Preview"

--- a/spec/system/admin/dfc_product_import_spec.rb
+++ b/spec/system/admin/dfc_product_import_spec.rb
@@ -22,7 +22,15 @@ RSpec.describe "DFC Product Import" do
 
     # We are testing against our own catalog for now but we want to replace
     # this with the URL of another app when available.
+    # We also add a common mistake: copying the URL with an extra space.
     host = Rails.application.default_url_options[:host]
+    url = " http://#{host}/api/dfc/enterprises/#{enterprise.id}/catalog_items"
+    fill_in "catalog_url", with: url
+    select enterprise.name, from: "Create products for enterprise"
+    click_button "Preview"
+
+    expect(page).to have_content "This catalog URL is not valid"
+
     url = "http://#{host}/api/dfc/enterprises/#{enterprise.id}/catalog_items"
     fill_in "catalog_url", with: url
     select enterprise.name, from: "Create products for enterprise"


### PR DESCRIPTION
Clockify project **#11678 DFC Orders**

#### What? Why?

- Closes #13175 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

When importing products, DFC catalog URLs are sometimes pasted with additional characters or missing some parts. We were showing the snail on invalid URLs. But now we are showing a friendly message and tidy invalid whitespace ourselves.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Import products from a DFC catalog.
- Try adding whitespace before or ofter the URL. It should still work.
- Enter an invalid URL and you should see a friendly message.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
