### PR TITLE
Add task to reset database with sample data

### DIFF
--- a/lib/tasks/reset.rake
+++ b/lib/tasks/reset.rake
@@ -3,6 +3,11 @@
 require 'sidekiq/api'
 
 namespace :ofn do
+  task reset_sample_data: :environment do
+    Rake::Task["ofn:reset"].invoke
+    Rake::Task["ofn:sample_data"].invoke
+  end
+
   task reset: :environment do
     Rake::Task["ofn:reset_sidekiq"].invoke
     Rake::Task["db:reset"].invoke


### PR DESCRIPTION
#### What? Why?

When I recently worked on emails, one of the easiest ways to trigger emails was to reset the database and generate test data which triggers enterprise and order confirmations. I wanted to do this with one command though and added this little shortcut.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
