### PR TITLE
Fixes some rubocop linting offenses - part II

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,24 +39,6 @@ Lint/FloatComparison:
   Exclude:
     - 'app/models/spree/gateway/pay_pal_express.rb'
 
-# Offense count: 1
-Lint/IneffectiveAccessModifier:
-  Exclude:
-    - 'app/models/spree/user.rb'
-
-# Offense count: 1
-Lint/NoReturnInBeginEndBlocks:
-  Exclude:
-    - 'app/controllers/payment_gateways/stripe_controller.rb'
-
-# Offense count: 3
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/RedundantDirGlobSort:
-  Exclude:
-    - 'engines/catalog/spec/spec_helper.rb'
-    - 'engines/dfc_provider/spec/spec_helper.rb'
-    - 'spec/system_helper.rb'
-
 # Offense count: 24
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes, Max.
 Metrics/AbcSize:

--- a/app/controllers/payment_gateways/stripe_controller.rb
+++ b/app/controllers/payment_gateways/stripe_controller.rb
@@ -68,11 +68,8 @@ module PaymentGateways
     end
 
     def valid_payment_intent?
-      @valid_payment_intent ||= if params["payment_intent"]&.starts_with?("pi_")
-                                  order_and_payment_valid?
-                                else
-                                  false
-                                end
+      @valid_payment_intent ||= params["payment_intent"]&.starts_with?("pi_") &&
+                                order_and_payment_valid?
     end
 
     def order_and_payment_valid?

--- a/app/controllers/payment_gateways/stripe_controller.rb
+++ b/app/controllers/payment_gateways/stripe_controller.rb
@@ -68,11 +68,11 @@ module PaymentGateways
     end
 
     def valid_payment_intent?
-      @valid_payment_intent ||= begin
-        return false unless params["payment_intent"]&.starts_with?("pi_")
-
-        order_and_payment_valid?
-      end
+      @valid_payment_intent ||= if params["payment_intent"]&.starts_with?("pi_")
+                                  order_and_payment_valid?
+                                else
+                                  false
+                                end
     end
 
     def order_and_payment_valid?

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -164,8 +164,6 @@ module Spree
       self.login ||= email if email
     end
 
-    # Generate a friendly string randomically to be used as token.
-
     def limit_owned_enterprises
       return unless owned_enterprises.size > enterprise_limit
 

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -165,10 +165,6 @@ module Spree
     end
 
     # Generate a friendly string randomically to be used as token.
-    def self.friendly_token
-      SecureRandom.base64(15).tr('+/=', '-_ ').strip.delete("\n")
-    end
-    private_class_method :friendly_token
 
     def limit_owned_enterprises
       return unless owned_enterprises.size > enterprise_limit

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -168,6 +168,7 @@ module Spree
     def self.friendly_token
       SecureRandom.base64(15).tr('+/=', '-_ ').strip.delete("\n")
     end
+    private_class_method :friendly_token
 
     def limit_owned_enterprises
       return unless owned_enterprises.size > enterprise_limit

--- a/engines/catalog/spec/spec_helper.rb
+++ b/engines/catalog/spec/spec_helper.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
 require '../../spec/spec_helper'
-
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }

--- a/engines/dfc_provider/spec/spec_helper.rb
+++ b/engines/dfc_provider/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../spec/spec_helper'
 
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.include AuthorizationHelper, type: :request

--- a/spec/system_helper.rb
+++ b/spec/system_helper.rb
@@ -3,4 +3,4 @@
 require "base_spec_helper"
 
 # system/support/ files contain system tests configurations and helpers
-Dir[File.join(__dir__, "system/support/**/*.rb")].sort.each { |file| require file }
+Dir[File.join(__dir__, "system/support/**/*.rb")].each { |file| require file }


### PR DESCRIPTION
#### What? Why?

Fixes three rubocop lint issues Cf. #12330

[Lint/RedundantDirGlobSort](https://docs.rubocop.org/rubocop/cops_lint.html#lintredundantdirglobsort) one import is useless therefore deleted it.
[Lint/NoReturnInBeginEndBlocks](https://docs.rubocop.org/rubocop/cops_lint.html#lintnoreturninbeginendblocks)
[Lint/IneffectiveAccessModifier](https://docs.rubocop.org/rubocop/cops_lint.html#lintineffectiveaccessmodifier)


#### What should we test?
Nothing. Tests should be all green.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.