### PR TITLE
Add shipment state to OC customer totals report

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_customer_totals.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_customer_totals.rb
@@ -67,6 +67,7 @@ module Reporting
             order_number: proc { |line_items| line_items.first.order.number },
             date: proc { |line_items| line_items.first.order.completed_at.strftime("%F %T") },
             final_weight_volume: proc { |line_items| line_items.sum(&:final_weight_volume) },
+            shipment_state: proc { |line_items| line_items.first.order.shipment_state },
           }
         end
         # rubocop:enable Metrics/AbcSize
@@ -107,7 +108,7 @@ module Reporting
         def default_params
           super.merge(
             {
-              fields_to_hide: %i[final_weight_volume voucher_label voucher_amount]
+              fields_to_hide: %i[final_weight_volume voucher_label voucher_amount shipment_state]
             }
           )
         end

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe Reporting::Reports::OrdersAndFulfillment::OrderCycleCustomerTotal
       expect(report.rows.second.quantity).to eq "TOTAL"
       expect(report.rows.second.date).to eq order.completed_at.strftime("%F %T")
     end
+
+    context "shipment state" do
+      # by default, shipment state is hidden, so make fields_to_hide empty for this test
+      let(:params) { { q: search_params, fields_to_hide: [] } }
+
+      it 'includes the shipment state' do
+        expect(report.rows.first.shipment_state).to eq order.shipment_state
+      end
+    end
   end
 
   context "loading shipping methods" do
@@ -155,6 +164,7 @@ RSpec.describe Reporting::Reports::OrdersAndFulfillment::OrderCycleCustomerTotal
           final_weight_volume
           voucher_label
           voucher_amount
+          shipment_state
         ],
         q: {
           completed_at_gt: 1.month.ago.beginning_of_day,


### PR DESCRIPTION
⚠️ Please use clockify code #12476 Flower Farms

#### What? Why?

- Closes #13127
- This PR adds Shipment State in the Order Cycle Customer Total report

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
