### PR TITLE
Reset stock for absent products in DFC catalog

### DIFF
--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -82,6 +82,12 @@ module Admin
       end
     end
 
+    # Reset stock for any variants that were removed from the catalog.
+    #
+    # When variants are removed from the remote catalog, there not for sale
+    # anymore. We prevent them from being sold by reseting stock to zero.
+    # We don't delete the variant because it may come back at a later time and
+    # we don't want to lose the connection to previous orders.
     def reset_absent_variants(catalog)
       present_ids = catalog.products.map(&:semanticId)
       absent_variants = @enterprise.supplied_variants

--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -86,26 +86,8 @@ module Admin
       end
     end
 
-    # Reset stock for any variants that were removed from the catalog.
-    #
-    # When variants are removed from the remote catalog, we can't place
-    # backorders for them anymore. If our copy of the product has limited
-    # stock then we need to set the stock to zero to prevent any more sales.
-    #
-    # But if our product is on-demand/backorderable then our stock level is
-    # a representation of remaining local stock. We then need to limit sales
-    # to this local stock and set on-demand to false.
-    #
-    # We don't delete the variant because it may come back at a later time and
-    # we don't want to lose the connection to previous orders.
     def reset_absent_variants(catalog)
-      absent_variants(catalog).map do |variant|
-        if variant.on_demand
-          variant.on_demand = false
-        else
-          variant.on_hand = 0
-        end
-      end
+      DfcCatalogImporter.new(@enterprise.supplied_variants, catalog).reset_absent_variants
     end
 
     def absent_variants(catalog)

--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -109,18 +109,7 @@ module Admin
     end
 
     def absent_variants(catalog)
-      present_ids = catalog.products.map(&:semanticId)
-      catalog_url = FdcUrlBuilder.new(present_ids.first).catalog_url
-
-      @enterprise.supplied_variants
-        .includes(:semantic_links).references(:semantic_links)
-        .where.not(semantic_links: { semantic_id: present_ids })
-        .select do |variant|
-        # Variants that were in the same catalog before:
-        variant.semantic_links.map(&:semantic_id).any? do |semantic_id|
-          FdcUrlBuilder.new(semantic_id).catalog_url == catalog_url
-        end
-      end
+      DfcCatalogImporter.new(@enterprise.supplied_variants, catalog).absent_variants
     end
   end
 end

--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -14,7 +14,6 @@ module Admin
 
     def index
       # Fetch DFC catalog JSON for preview
-      api = DfcRequest.new(spree_current_user)
       @catalog_url = params.require(:catalog_url).strip
       @catalog_json = api.call(@catalog_url)
       catalog = DfcCatalog.from_json(@catalog_json)
@@ -66,6 +65,10 @@ module Admin
     end
 
     private
+
+    def api
+      @api ||= DfcRequest.new(spree_current_user)
+    end
 
     def load_enterprise
       @enterprise = OpenFoodNetwork::Permissions.new(spree_current_user)

--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -88,14 +88,23 @@ module Admin
 
     # Reset stock for any variants that were removed from the catalog.
     #
-    # When variants are removed from the remote catalog, there not for sale
-    # anymore. We prevent them from being sold by reseting stock to zero.
+    # When variants are removed from the remote catalog, we can't place
+    # backorders for them anymore. If our copy of the product has limited
+    # stock then we need to set the stock to zero to prevent any more sales.
+    #
+    # But if our product is on-demand/backorderable then our stock level is
+    # a representation of remaining local stock. We then need to limit sales
+    # to this local stock and set on-demand to false.
+    #
     # We don't delete the variant because it may come back at a later time and
     # we don't want to lose the connection to previous orders.
     def reset_absent_variants(catalog)
       absent_variants(catalog).map do |variant|
-        variant.on_demand = false
-        variant.on_hand = 0
+        if variant.on_demand
+          variant.on_demand = false
+        else
+          variant.on_hand = 0
+        end
       end
     end
 

--- a/app/controllers/admin/dfc_product_imports_controller.rb
+++ b/app/controllers/admin/dfc_product_imports_controller.rb
@@ -20,7 +20,7 @@ module Admin
 
       # Render table and let user decide which ones to import.
       @items = list_products(catalog)
-      @absent_items = absent_variants(catalog)
+      @absent_items = importer(catalog).absent_variants
     rescue URI::InvalidURIError
       flash[:error] = t ".invalid_url"
       redirect_to admin_product_import_path
@@ -58,7 +58,7 @@ module Admin
       end
 
       @count = imported.compact.count
-      @reset_count = reset_absent_variants(catalog).count
+      @reset_count = importer(catalog).reset_absent_variants.count
     rescue ActionController::ParameterMissing => e
       flash[:error] = e.message
       redirect_to admin_product_import_path
@@ -86,12 +86,8 @@ module Admin
       end
     end
 
-    def reset_absent_variants(catalog)
-      DfcCatalogImporter.new(@enterprise.supplied_variants, catalog).reset_absent_variants
-    end
-
-    def absent_variants(catalog)
-      DfcCatalogImporter.new(@enterprise.supplied_variants, catalog).absent_variants
+    def importer(catalog)
+      DfcCatalogImporter.new(@enterprise.supplied_variants, catalog)
     end
   end
 end

--- a/app/jobs/open_order_cycle_job.rb
+++ b/app/jobs/open_order_cycle_job.rb
@@ -57,6 +57,10 @@ class OpenOrderCycleJob < ApplicationJob
       catalog = DfcCatalog.load(dfc_user, catalog_url)
       catalog.apply_wholesale_values!
 
+      variants = Spree::Variant.where(id: catalog_links.pluck(:subject_id))
+      importer = DfcCatalogImporter.new(variants, catalog)
+      importer.reset_absent_variants
+
       catalog_links.each do |link|
         catalog_item = catalog.item(link.semantic_id)
 

--- a/app/jobs/open_order_cycle_job.rb
+++ b/app/jobs/open_order_cycle_job.rb
@@ -57,14 +57,14 @@ class OpenOrderCycleJob < ApplicationJob
       catalog = DfcCatalog.load(dfc_user, catalog_url)
       catalog.apply_wholesale_values!
 
-      variants = Spree::Variant.where(id: catalog_links.pluck(:subject_id))
-      importer = DfcCatalogImporter.new(variants, catalog)
-      importer.reset_absent_variants
-
       catalog_links.each do |link|
         catalog_item = catalog.item(link.semantic_id)
 
-        SuppliedProductImporter.update_product(catalog_item, link.subject) if catalog_item
+        if catalog_item
+          SuppliedProductImporter.update_product(catalog_item, link.subject)
+        else
+          DfcCatalogImporter.reset_variant(link.subject)
+        end
       end
     end
   end

--- a/app/services/dfc_catalog_importer.rb
+++ b/app/services/dfc_catalog_importer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class DfcCatalogImporter
+  attr_reader :catalog, :existing_variants
+
+  def initialize(existing_variants, catalog)
+    @existing_variants = existing_variants
+    @catalog = catalog
+  end
+
+  def absent_variants
+    present_ids = catalog.products.map(&:semanticId)
+    catalog_url = FdcUrlBuilder.new(present_ids.first).catalog_url
+
+    existing_variants
+      .includes(:semantic_links).references(:semantic_links)
+      .where.not(semantic_links: { semantic_id: present_ids })
+      .select do |variant|
+      # Variants that were in the same catalog before:
+      variant.semantic_links.map(&:semantic_id).any? do |semantic_id|
+        FdcUrlBuilder.new(semantic_id).catalog_url == catalog_url
+      end
+    end
+  end
+end

--- a/app/services/dfc_catalog_importer.rb
+++ b/app/services/dfc_catalog_importer.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class DfcCatalogImporter
+  def self.reset_variant(variant)
+    if variant.on_demand
+      variant.on_demand = false
+    else
+      variant.on_hand = 0
+    end
+  end
+
   attr_reader :catalog, :existing_variants
 
   def initialize(existing_variants, catalog)
@@ -22,11 +30,7 @@ class DfcCatalogImporter
   # we don't want to lose the connection to previous orders.
   def reset_absent_variants
     absent_variants.map do |variant|
-      if variant.on_demand
-        variant.on_demand = false
-      else
-        variant.on_hand = 0
-      end
+      self.class.reset_variant(variant)
     end
   end
 

--- a/app/views/admin/dfc_product_imports/_absent_variant.html.haml
+++ b/app/views/admin/dfc_product_imports/_absent_variant.html.haml
@@ -1,0 +1,8 @@
+%tr
+  %td
+    %label
+      ❌
+      = absent_variant.product_and_full_name
+  %td
+    = t(".reset")
+    = link_to(absent_variant.product_id, edit_admin_product_path(absent_variant.product_id))

--- a/app/views/admin/dfc_product_imports/import.html.haml
+++ b/app/views/admin/dfc_product_imports/import.html.haml
@@ -5,3 +5,6 @@
 
 %p= t(".imported_products")
 = @count
+
+%p= t(".reset_products")
+= @reset_count

--- a/app/views/admin/dfc_product_imports/import.html.haml
+++ b/app/views/admin/dfc_product_imports/import.html.haml
@@ -3,8 +3,6 @@
 
 = render partial: 'spree/admin/shared/product_sub_menu'
 
-%p= t(".imported_products")
-= @count
+%p= t(".imported_products", count: @count)
 
-%p= t(".reset_products")
-= @reset_count
+%p= t(".reset_products", count: @reset_count)

--- a/app/views/admin/dfc_product_imports/import.html.haml
+++ b/app/views/admin/dfc_product_imports/import.html.haml
@@ -5,4 +5,4 @@
 
 %p= t(".imported_products", count: @count)
 
-%p= t(".reset_products", count: @reset_count)
+%p= t(".reset_products", count: @reset_count) if @reset_count.positive?

--- a/app/views/admin/dfc_product_imports/index.html.haml
+++ b/app/views/admin/dfc_product_imports/index.html.haml
@@ -6,6 +6,7 @@
 
   %p= t('.catalog_url', count: @items.count, catalog_url: @catalog_url)
   %p= t('.enterprise', enterprise_name: @enterprise.name)
+  %p= t('.absent_products', count: @absent_items.count)
   %br
 
   = form_with url: main_app.import_admin_dfc_product_imports_path, html: { "data-controller": "checked" } do |form|
@@ -32,6 +33,7 @@
                 = link_to(existing_product.id, edit_admin_product_path(existing_product))
               - else
                 = t(".new")
+        = render partial: "absent_variant", collection: @absent_items
 
     %span{ "data-controller": "checked-feedback", "data-checked-feedback-translation-value": "admin.dfc_product_imports.index.selected" }
       = t(".selected", count: @items.count)

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -725,7 +725,7 @@ el:
           other: "%{count}επιλέχθηκε"
         import: Εισαγωγή
       import:
-        imported_products: "Εισαγόμενα προϊόντα:"
+        imported_products: "Εισαγόμενα προϊόντα: %{count}"
     enterprise_fees:
       index:
         title: "Τέλη επιχείρησης"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -866,6 +866,7 @@ en:
       import:
         title: "DFC product catalog import"
         imported_products: "Imported products:"
+        reset_products: "Stock reset for absent products:"
     enterprise_fees:
       index:
         title: "Enterprise Fees"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -865,8 +865,8 @@ en:
         invalid_url: This catalog URL is not valid.
       import:
         title: "DFC product catalog import"
-        imported_products: "Imported products:"
-        reset_products: "Stock reset for absent products:"
+        imported_products: "Imported products: %{count}"
+        reset_products: "Stock reset for absent products: %{count}"
     enterprise_fees:
       index:
         title: "Enterprise Fees"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -850,9 +850,19 @@ en:
       connection_invalid_html: |
         Connecting with your OIDC account failed.
         Please refresh your OIDC connection at: %{oidc_settings_link}
+      absent_variant:
+        reset: "Reset stock"
       index:
         title: "DFC product catalog"
         catalog_url: "%{count} products to be imported from: %{catalog_url}"
+        absent_products:
+          zero: ""
+          one: |
+            One product is no longer in the catalog.
+            It will be marked as unavailable by resetting stock to zero.
+          other: |
+            %{count} products are no longer in the catalog.
+            They will be marked as unavailable by resetting stock to zero.
         enterprise: "Import to enterprise: %{enterprise_name}"
         select_all: "Select/deselect all"
         update: Update

--- a/config/locales/en_CA.yml
+++ b/config/locales/en_CA.yml
@@ -798,7 +798,7 @@ en_CA:
         invalid_url: This catalog URL is not valid.
       import:
         title: "DFC product catalog import"
-        imported_products: "Imported products:"
+        imported_products: "Imported products: %{count}"
     enterprise_fees:
       index:
         title: "Enterprise Fees"

--- a/config/locales/en_FR.yml
+++ b/config/locales/en_FR.yml
@@ -798,7 +798,7 @@ en_FR:
         invalid_url: This catalog URL is not valid.
       import:
         title: "DFC product catalog import"
-        imported_products: "Imported products:"
+        imported_products: "Imported products: %{count}"
     enterprise_fees:
       index:
         title: "Enterprise Fees"

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -771,7 +771,7 @@ en_GB:
           other: "%{count} selected"
         import: Import
       import:
-        imported_products: "Imported products:"
+        imported_products: "Imported products: %{count}"
     enterprise_fees:
       index:
         title: "Enterprise Fees"

--- a/config/locales/en_IE.yml
+++ b/config/locales/en_IE.yml
@@ -771,7 +771,7 @@ en_IE:
           other: "%{count} selected"
         import: Import
       import:
-        imported_products: "Imported products:"
+        imported_products: "Imported products: %{count}"
     enterprise_fees:
       index:
         title: "Enterprise Fees"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -765,7 +765,7 @@ es:
         new: Nuevo
         import: Importar
       import:
-        imported_products: "Productos importados:"
+        imported_products: "Productos importados: %{count}"
     enterprise_fees:
       index:
         title: "Comisiones de la Organización"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -797,7 +797,7 @@ fr:
         invalid_url: L'URL de ce catalogue n'est pas valide.
       import:
         title: "Import du catalogue produit DFC"
-        imported_products: "Produits importés :"
+        imported_products: "Produits importés : %{count}"
     enterprise_fees:
       index:
         title: "Marges et Commissions"

--- a/config/locales/fr_CA.yml
+++ b/config/locales/fr_CA.yml
@@ -797,7 +797,7 @@ fr_CA:
         import: Importer
       import:
         title: "Import du catalogue produit DFC"
-        imported_products: "Produits importés :"
+        imported_products: "Produits importés : %{count}"
     enterprise_fees:
       index:
         title: "Marges et Commissions"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -760,7 +760,7 @@ hu:
           other: "%{count}kiválasztva"
         import: Importálás
       import:
-        imported_products: "Importált termékek:"
+        imported_products: "Importált termékek: %{count}"
     enterprise_fees:
       index:
         title: "Vállalkozási díjak"

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -771,7 +771,7 @@ nb:
           other: "%{count} valgt"
         import: Import
       import:
-        imported_products: "Importerte produkter:"
+        imported_products: "Importerte produkter: %{count}"
     enterprise_fees:
       index:
         title: "Bedriftsavgifter"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -711,7 +711,7 @@ ru:
           other: "выбрано %{count}"
         import: Импорт
       import:
-        imported_products: "Внесенные товары:"
+        imported_products: "Внесенные товары: %{count}"
     enterprise_fees:
       index:
         title: "Сборы Предприятия"

--- a/spec/system/admin/dfc_product_import_spec.rb
+++ b/spec/system/admin/dfc_product_import_spec.rb
@@ -76,11 +76,13 @@ RSpec.describe "DFC Product Import" do
     click_button "Preview"
 
     expect(page).to have_content "4 products to be imported"
+    expect(page).to have_content "One product is no longer"
     expect(page).to have_content "Saucy preserves"
     expect(page).not_to have_content "Sauce - 1g" # Does not show other product
     expect(page).to have_content "Beans - Retail can, 400g (can) Update" # existing product
     expect(page).to have_content "Beans - Case, 12 x 400g (can) New"
     expect(page).to have_content "Chia Seed, Organic - Retail pack, 300g"
+    expect(page).to have_content "Best Sauce of 1995 - 1g Reset stock"
 
     # I can select all
     uncheck "Chia Seed, Organic - Case, 8 x 300g"

--- a/spec/system/admin/dfc_product_import_spec.rb
+++ b/spec/system/admin/dfc_product_import_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "DFC Product Import" do
       .and change { linked_variant.on_demand }.to(true)
       .and change { linked_variant.on_hand }.by(0)
       .and change { unlinked_variant.on_demand }.to(false)
-      .and change { unlinked_variant.on_hand }.to(0)
+      .and change { unlinked_variant.on_hand }.by(0)
 
     product = Spree::Product.last
     expect(product.variants[0].semantic_links).to be_present

--- a/spec/system/admin/dfc_product_import_spec.rb
+++ b/spec/system/admin/dfc_product_import_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "DFC Product Import" do
   let(:user) { create(:oidc_user, owned_enterprises: [enterprise]) }
   let(:enterprise) { create(:supplier_enterprise, name: "Saucy preserves") }
   let(:source_product) { create(:product, name: "Sauce", supplier_id: enterprise.id) }
+  let(:old_product) { create(:product, name: "Best Sauce of 1995", supplier_id: enterprise.id) }
 
   before do
     login_as user
@@ -52,11 +53,20 @@ RSpec.describe "DFC Product Import" do
 
   it "imports from a FDC catalog", vcr: true do
     user.update!(oidc_account: build(:testdfc_account))
-    # One product is existing in OFN
+
+    # One current product is existing in OFN
     product_id =
       "https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/SuppliedProducts/44519466467635"
     linked_variant = source_product.variants.first
     linked_variant.semantic_links << SemanticLink.new(semantic_id: product_id)
+
+    # One outdated product still exists in OFN
+    old_product_id =
+      "https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/SuppliedProducts/445194664-1995"
+    unlinked_variant = old_product.variants.first
+    unlinked_variant.semantic_links << SemanticLink.new(semantic_id: old_product_id)
+    unlinked_variant.on_demand = true
+    unlinked_variant.on_hand = 3
 
     visit admin_product_import_path
 
@@ -83,14 +93,18 @@ RSpec.describe "DFC Product Import" do
     expect {
       click_button "Import"
       expect(page).to have_content "Imported products: 3"
+      expect(page).to have_content "Stock reset for absent products: 1"
       linked_variant.reload
-    }.to change { enterprise.supplied_products.count }.by(2) # 1 updated, 2 new
+      unlinked_variant.reload
+    }.to change { enterprise.supplied_products.count }.by(2) # 1 updated, 2 new, 1 reset
       .and change { linked_variant.display_name }
       .and change { linked_variant.unit_value }
       # 18.85 wholesale variant price divided by 12 cans in the slab.
       .and change { linked_variant.price }.to(1.57)
       .and change { linked_variant.on_demand }.to(true)
       .and change { linked_variant.on_hand }.by(0)
+      .and change { unlinked_variant.on_demand }.to(false)
+      .and change { unlinked_variant.on_hand }.to(0)
 
     product = Spree::Product.last
     expect(product.variants[0].semantic_links).to be_present


### PR DESCRIPTION
#### :information_source: Funded Feature. Please track ALL ASSOCIATED WORK under the associated tracking code `#11678 DFC Orders`

#### What? Why?

- Closes #13190  <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

During DFC product import, we now reset stock for absent products. The exact conditions are:

* The product belongs to the enterprise we are importing to.
* The product is linked to the catalog we are importing.
* The product does not appear in the catalog anymore.

![DFC Product import preview with product to reset](https://github.com/user-attachments/assets/a077a6ef-8be2-437e-b837-dc5dd71da0b3)

#### Review notes

The pull request includes:

* #13182 

New commits start at: Reset stock for absent products in DFC catalog

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

1. **Product import**
    - Import from a DFC catalog, with stock or on demand.
    - Remove a product from the DFC catalog.
    - Import the catalog again.
    - The removed product should be reset locally so that it disappears from the shop.
      - If the product was on-demand, it should become stock-controlled
2. **Order Cycle Open - Product sync**
    - Import from a DFC catalog, with stock or on demand.
      - Note: the products must be imported to an enterprise that you are the owner of.
    - Remove the product from the DFC catalog.
    - Add imported product to a new order cycle and schedule it to open at the current time.
    - The removed product should be reset locally so that it disappears from the shop.
      - If the product was on-demand, it should become stock-controlled

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Follow-up
* Create a new issue to apply this logic when syncing at order cycle open (ref: https://github.com/openfoodfoundation/openfoodnetwork/pull/13167)
