### PR TITLE
Fix obscure issue when choosing payment method in checkout

### DIFF
--- a/app/services/orders/workflow_service.rb
+++ b/app/services/orders/workflow_service.rb
@@ -92,7 +92,10 @@ module Orders
     # Verifies if the in-memory payment state is different from the one stored in the database
     #   This is be done without reloading the payment so that in-memory data is not changed
     def different_from_db_payment_state?(in_memory_payment_state, payment_id)
-      in_memory_payment_state != Spree::Payment.find(payment_id).state
+      # Re-load payment from the DB (unless it was cleared by clear_invalid_payments)
+      db_payment = Spree::Payment.find_by(id: payment_id)
+
+      db_payment.present? && in_memory_payment_state != db_payment.state
     end
   end
 end

--- a/app/views/checkout/_tabs.html.haml
+++ b/app/views/checkout/_tabs.html.haml
@@ -1,4 +1,5 @@
-.flex
+-# Prevent Turbo pre-fetch which changes cart state
+.flex{'data-turbo': "false"}
   .columns.three.text-center.checkout-tab{"class": [("selected" if checkout_step?(:details)), ("success" unless checkout_step?(:details))]}
     %div
       %span.checkout-tab-number

--- a/app/views/checkout/_tabs.html.haml
+++ b/app/views/checkout/_tabs.html.haml
@@ -1,5 +1,5 @@
 -# Prevent Turbo pre-fetch which changes cart state
-.flex{'data-turbo': "false"}
+.flex{'data-turbo-prefetch': "false"}
   .columns.three.text-center.checkout-tab{"class": [("selected" if checkout_step?(:details)), ("success" unless checkout_step?(:details))]}
     %div
       %span.checkout-tab-number

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -368,8 +368,6 @@ RSpec.describe CheckoutController, type: :controller do
             end
 
             it "deletes invalid (old) payments" do
-              pending "#12693 ActiveRecord::RecordNotFound: Couldn't find Spree::Payment"
-
               put(:update, params:)
               order.payments.reload
               expect(order.payments).not_to include other_payment

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -328,6 +328,23 @@ RSpec.describe CheckoutController, type: :controller do
             expect_cable_ready_redirect(response)
           end
         end
+
+        context "with existing invalid payments" do
+          let(:invalid_payments) { [
+              create(:payment, state: :failed),
+              create(:payment, state: :void),
+            ] }
+
+          before do
+            order.payments = invalid_payments
+          end
+
+          it "deletes invalid payments" do
+            expect{
+              put(:update, params:)
+            }.to change { order.payments.to_a }.from(invalid_payments)
+          end
+        end
       end
 
       context "with no payment source" do


### PR DESCRIPTION
### What? Why?

- Closes #12693

When you perform a very particular set of actions, the checkout fails to proceed, with no feedback to the user at all (see [comment on issue](https://github.com/openfoodfoundation/openfoodnetwork/issues/12693#issuecomment-2702851782)) I'd consider this a bug but haven't bothered to classify it.

This was caused by a clever pre-fetch optimisation of Turbo, when you hover over a link. It makes sense if the web app follows the rule that [GET is a safe HTTP method](https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP). But our web app breaks that rule here 🤦 

I've added a controller test to cover this, because I wasn't sure at first where to start. I now think that it would have been better to add a system test (eg checkout/payment_spec) and/or unit test (workflow_service_spec), but am not sure it's worth the effort. But I'm happy to be told otherwise by reviewers.


### What should we test?
Repeat for both cases "i" and "ii":

1. Add item to cart
2. Proceed to choose payment method (if there's only one option, you'll need to add a second option in admin)
3. From the summary screen, go back to the Payment method step. Repeat test for each:
   1. Hover over  "1. Your details"
   2. Right-click on  "1. Your details" and open in a new tab (then you can close it again)
4. Now choose a different payment method
5. click "Next - order summary".

For method "i", this should now work seamlessly.
For method "ii", you will have to click "next" a few times without getting feedback, but it does work eventually. We can probably improve that but I think it's pretty obscure and not worth bothering.

### Release notes
It's probably worth mentioning as a user-facing change. Users may have been reporting strange issues with checkout to their instance managers, but they probably didn't figure out how to replicate it so didn't escalate further.
<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
