### PR TITLE
Fixes some rubocop linting offenses - part III

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Layout/EmptyLines:
-  Exclude:
-    - 'app/services/products_renderer.rb'
-
 # Offense count: 16
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
 Lint/EmptyBlock:
@@ -27,17 +21,6 @@ Lint/EmptyBlock:
     - 'spec/jobs/order_cycle_opened_job_spec.rb'
     - 'spec/jobs/subscription_placement_job_spec.rb'
     - 'spec/models/product_import/entry_validator_spec.rb'
-
-# Offense count: 4
-# Configuration parameters: AllowComments.
-Lint/EmptyClass:
-  Exclude:
-    - 'spec/lib/reports/report_loader_spec.rb'
-
-# Offense count: 1
-Lint/FloatComparison:
-  Exclude:
-    - 'app/models/spree/gateway/pay_pal_express.rb'
 
 # Offense count: 24
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes, Max.

--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -84,7 +84,7 @@ module Spree
       end
 
       def refund(payment, amount)
-        refund_type = payment.amount == amount.to_f ? "Full" : "Partial"
+        refund_type = payment.amount == amount.to_d ? "Full" : "Partial"
         refund_transaction = provider.build_refund_transaction(
           TransactionID: payment.source.transaction_id,
           RefundType: refund_type,

--- a/app/services/products_renderer.rb
+++ b/app/services/products_renderer.rb
@@ -2,7 +2,6 @@
 
 require 'open_food_network/scope_product_to_hub'
 
-
 class ProductsRenderer
   include Pagy::Backend
 

--- a/spec/lib/reports/report_loader_spec.rb
+++ b/spec/lib/reports/report_loader_spec.rb
@@ -5,13 +5,13 @@ require 'spec_helper'
 module Reporting
   module Reports
     module Bananas
-      class Base; end
-      class Green; end
-      class Yellow; end
+      const_set "Base", Class.new
+      const_set "Green", Class.new
+      const_set "Yellow", Class.new
     end
 
     module Orange
-      class OrangeReport; end
+      const_set "OrangeReport", Class.new
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Fixes three rubocop lint issues Cf. #12330 

[Layout/EmptyLines](https://docs.rubocop.org/rubocop/cops_layout.html#layoutemptylines)
[Lint/EmptyClass](https://docs.rubocop.org/rubocop/cops_lint.html#lintemptyclass)
[Lint/FloatComparison](https://docs.rubocop.org/rubocop/cops_lint.html#lintfloatcomparison) I followed the example of rubocop docs and replaced to_f with to_d. But this piece of code seems to be not called, and not tested. It was taken as it in this commit: https://github.com/openfoodfoundation/openfoodnetwork/commit/2a27da1cc55c9714618f3f8fd9033b2545351f9c

#### What should we test?
Nothing. Tests should be all green.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.