### PR TITLE
Categorise breaking-change labels in release notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -13,6 +13,7 @@ assignees: ''
 - [ ] Include translations: `script/release/update_locales`
     - You need the [Transifex Client] installed on your local dev environement to run the script.
 - [ ] Increment version number: `git push upstream HEAD:refs/tags/vX.Y.Z`
+    Check for [minor or major breaking changes](https://github.com/openfoodfoundation/openfoodnetwork/pulls?q=label%3Abreaking-change%2Cmajor-breaking-change)
     - Major: if server changes are required (eg. provision with ofn-install)
     - Minor: larger change that is irreversible (eg. migration deleting data)
     - Patch: all others. Shortcut: `script/release/tag`

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -13,7 +13,7 @@ assignees: ''
 - [ ] Include translations: `script/release/update_locales`
     - You need the [Transifex Client] installed on your local dev environement to run the script.
 - [ ] Increment version number: `git push upstream HEAD:refs/tags/vX.Y.Z`
-    Check for [minor or major breaking changes](https://github.com/openfoodfoundation/openfoodnetwork/pulls?q=label%3Abreaking-change%2Cmajor-breaking-change)
+    Check for [minor or major breaking changes]
     - Major: if server changes are required (eg. provision with ofn-install)
     - Minor: larger change that is irreversible (eg. migration deleting data)
     - Patch: all others. Shortcut: `script/release/tag`
@@ -57,3 +57,4 @@ The full process is described at https://github.com/openfoodfoundation/openfoodn
 [Create issue]: https://github.com/openfoodfoundation/openfoodnetwork/issues/new?assignees=&labels=&projects=&template=release.md&title=Release
 [#delivery-circle]: https://openfoodnetwork.slack.com/archives/C01T75H6G0Z
 [Transifex Client]: https://developers.transifex.com/docs/cli
+[minor or major breaking changes]: https://github.com/openfoodfoundation/openfoodnetwork/pulls?q=label%3A%22breaking+change%22%2C%22major+breaking+change%22

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -17,8 +17,8 @@ changelog:
     # These will require a minor or major version increment
     - title: "Significant changes 🚀"
       labels:
-        - breaking-change
-        - major-breaking-change
+        - breaking change
+        - major breaking change
 
     # Posted in advance for #instance-managers
     - title: "User-facing changes 👀"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -14,6 +14,12 @@ changelog:
           - technical changes only
           - user facing changes
 
+    # These will require a minor or major version increment
+    - title: "Breaking changes"
+      labels:
+        - breaking-change
+        - major-breaking-change
+
     # Posted in advance for #instance-managers
     - title: "User-facing changes 👀"
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,7 +15,7 @@ changelog:
           - user facing changes
 
     # These will require a minor or major version increment
-    - title: "Breaking changes"
+    - title: "Significant changes 🚀"
       labels:
         - breaking-change
         - major-breaking-change


### PR DESCRIPTION
#### What? Why?
https://openfoodnetwork.slack.com/archives/C01T75H6G0Z/p1741668548086439

> * Create two new labels for PRs, to signal when it contains a “breaking change” which requires a major or minor version increment (the X or Y in vX.Y.Z).
>    * The release template will be updated to categorise these
> * In the future, consider creating a PR for the weekly Transifex update.
>    * This means we can draft the release based on the PR’s last commit (and view the labels, before assigning the version number.

When a release is drafted, it should be easy to see if it contains any breaking changes, so we can set the version number accordingly.

#### What should we test?
We could test this after merging, by assigning the labels to a recently merged PR and draft a release. 
Don't forget to remove the labels after testing!


#### Documentation updates
https://github.com/openfoodfoundation/openfoodnetwork/wiki/Releasing
   - [x] mention this when choosing a version number

