### PR TITLE
[DFC Orders II] Create orders endpoint

### DIFF
--- a/app/models/spree/stock/availability_validator.rb
+++ b/app/models/spree/stock/availability_validator.rb
@@ -5,7 +5,7 @@ module Spree
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
         # OFN specific check for in-memory :skip_stock_check attribute
-        return if line_item.skip_stock_check
+        return if line_item.skip_stock_check || line_item.variant.blank?
 
         quantity_to_validate = line_item.quantity - quantity_in_shipment(line_item)
         return if quantity_to_validate < 1

--- a/app/services/fdc_backorderer.rb
+++ b/app/services/fdc_backorderer.rb
@@ -62,7 +62,7 @@ class FdcBackorderer
     # Suggested by FDC team:
     next_id = order.lines.count + 1
 
-    OrderLineBuilder.build(offer, 0).tap do |line|
+    OrderLineBuilder.build_from_offer(offer, 0).tap do |line|
       line.semanticId = "#{order.semanticId}/OrderLines/#{next_id}"
       order.lines << line
     end

--- a/app/services/fdc_url_builder.rb
+++ b/app/services/fdc_url_builder.rb
@@ -5,12 +5,13 @@
 class FdcUrlBuilder
   attr_reader :catalog_url, :orders_url, :sale_session_url
 
-  # At the moment, we start with a product link like this:
-  #
-  # https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/SuppliedProducts/44519466467635
+  # Known product link formats:
+  # * https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/SuppliedProducts/44519466467635
+  # * http://test.host/api/dfc/enterprises/10000/supplied_products/10001 (OFN)
   def initialize(semantic_id)
     @catalog_url, _slash, _id = semantic_id.rpartition("/")
     @orders_url = @catalog_url.sub("/SuppliedProducts", "/Orders")
+      .sub("/supplied_products", "/orders")
     @sale_session_url = @catalog_url.sub("/SuppliedProducts", "/SalesSession/#")
   end
 end

--- a/app/services/fdc_url_builder.rb
+++ b/app/services/fdc_url_builder.rb
@@ -9,9 +9,10 @@ class FdcUrlBuilder
   # * https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/SuppliedProducts/44519466467635
   # * http://test.host/api/dfc/enterprises/10000/supplied_products/10001 (OFN)
   def initialize(semantic_id)
-    @catalog_url, _slash, _id = semantic_id.rpartition("/")
-    @orders_url = @catalog_url.sub("/SuppliedProducts", "/Orders")
+    base_url, _slash, _id = semantic_id.rpartition("/")
+    @catalog_url = base_url.sub("/supplied_products", "/catalog_items")
+    @orders_url = base_url.sub("/SuppliedProducts", "/Orders")
       .sub("/supplied_products", "/orders")
-    @sale_session_url = @catalog_url.sub("/SuppliedProducts", "/SalesSession/#")
+    @sale_session_url = base_url.sub("/SuppliedProducts", "/SalesSession/#")
   end
 end

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -23,6 +23,9 @@ module DfcProvider
       if order.save
         subject = OrderBuilder.build(order)
         render json: DfcIo.export(subject), status: :created
+      else
+        render json: { error: order.errors.full_messages.to_sentence },
+               status: :unprocessable_entity
       end
     end
 

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Create and update orders
+module DfcProvider
+  class OrdersController < DfcProvider::ApplicationController
+    before_action :check_enterprise
+
+    # POST /api/dfc/enterprises/{enterprise_id}/orders
+    def create
+      if current_enterprise.distributed_orders.create user: current_user
+        head :created
+      end
+    end
+  end
+end

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -8,7 +8,10 @@ module DfcProvider
     # POST /api/dfc/enterprises/{enterprise_id}/orders/{order_id}
     def show
       dfc_order = OrderBuilder.build(order)
-      render json: DfcIo.export(dfc_order)
+      lines = OrderBuilder.build_order_lines(dfc_order, order.line_items)
+      offers = lines.map(&:offer)
+      products = offers.map(&:offeredItem)
+      render json: DfcIo.export(dfc_order, *lines, *offers, *products)
     end
 
     # POST /api/dfc/enterprises/{enterprise_id}/orders

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -7,12 +7,22 @@ module DfcProvider
 
     # POST /api/dfc/enterprises/{enterprise_id}/orders
     def create
+      graph = import
+      dfc_order = select_type(graph, "dfc-b:Order").first if graph
+
+      return head :bad_request unless dfc_order
+
       order = current_enterprise.distributed_orders.build(created_by: current_user)
 
       if order.save
         subject = OrderBuilder.build(order)
         render json: DfcIo.export(subject), status: :created
       end
+    end
+
+    # This is similar to DfcCatalog#select_type. Consider moving to a new DfcGraph class.
+    def select_type(graph, semantic_type)
+      graph.select { |i| i.semanticType == semantic_type }
     end
   end
 end

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -10,9 +10,10 @@ module DfcProvider
       dfc_order = OrderBuilder.build(order)
       lines = OrderBuilder.build_order_lines(dfc_order, order.line_items)
       offers = lines.map(&:offer)
-      # products = offers.map(&:offeredItem) #todo: need offered item
+      catalog_items = offers.map(&:offeredItem) #todo: update so that the product semanticId can be found by complete_backorder_job
+
       sessions = [build_sale_session(order)]
-      render json: DfcIo.export(dfc_order, *lines, *offers, *sessions)
+      render json: DfcIo.export(dfc_order, *lines, *offers, *catalog_items, *sessions)
     end
 
     # POST /api/dfc/enterprises/{enterprise_id}/orders

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -12,7 +12,12 @@ module DfcProvider
 
       return head :bad_request unless dfc_order
 
-      order = current_enterprise.distributed_orders.build(created_by: current_user)
+      order = current_enterprise.distributed_orders.build(
+        user: current_user,
+        created_by: current_user,
+        email: current_user.email,
+        customer: current_user.customers.find_by(enterprise: current_enterprise),
+      )
       OrderBuilder.apply(order, dfc_order)
 
       if order.save

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -7,8 +7,11 @@ module DfcProvider
 
     # POST /api/dfc/enterprises/{enterprise_id}/orders
     def create
-      if current_enterprise.distributed_orders.create user: current_user
-        head :created
+      order = current_enterprise.distributed_orders.build(created_by: current_user)
+
+      if order.save
+        subject = OrderBuilder.build(order)
+        render json: DfcIo.export(subject), status: :created
       end
     end
   end

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -10,8 +10,9 @@ module DfcProvider
       dfc_order = OrderBuilder.build(order)
       lines = OrderBuilder.build_order_lines(dfc_order, order.line_items)
       offers = lines.map(&:offer)
-      products = offers.map(&:offeredItem)
-      render json: DfcIo.export(dfc_order, *lines, *offers, *products)
+      # products = offers.map(&:offeredItem) #todo: need offered item
+      sessions = [build_sale_session(order)]
+      render json: DfcIo.export(dfc_order, *lines, *offers, *sessions)
     end
 
     # POST /api/dfc/enterprises/{enterprise_id}/orders
@@ -46,6 +47,12 @@ module DfcProvider
     # This is similar to DfcCatalog#select_type. Consider moving to a new DfcGraph class.
     def select_type(graph, semantic_type)
       graph.select { |i| i.semanticType == semantic_type }
+    end
+
+    def build_sale_session(order)
+      SaleSessionBuilder.build(order.order_cycle).tap do |session|
+        session.semanticId = "/api/dfc/SalesSession/#" #todo use a route or UrlBuilder
+      end
     end
   end
 end

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -13,6 +13,7 @@ module DfcProvider
       return head :bad_request unless dfc_order
 
       order = current_enterprise.distributed_orders.build(created_by: current_user)
+      OrderBuilder.apply(order, dfc_order)
 
       if order.save
         subject = OrderBuilder.build(order)

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -18,9 +18,8 @@ module DfcProvider
         email: current_user.email,
         customer: current_user.customers.find_by(enterprise: current_enterprise),
       )
-      OrderBuilder.apply(order, dfc_order)
 
-      if order.save
+      if order.save && OrderBuilder.apply(order, dfc_order)
         subject = OrderBuilder.build(order)
         render json: DfcIo.export(subject), status: :created
       else

--- a/engines/dfc_provider/app/services/dfc_builder.rb
+++ b/engines/dfc_provider/app/services/dfc_builder.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class DfcBuilder
-  def self.catalog_item(variant)
+  def self.catalog_item(variant, include_product: true)
     id = urls.enterprise_catalog_item_url(
       enterprise_id: variant.supplier_id,
       id: variant.id,
     )
-    product = SuppliedProductBuilder.supplied_product(variant)
+    product = SuppliedProductBuilder.supplied_product(variant) if include_product
 
     DataFoodConsortium::Connector::CatalogItem.new(
       id, product:,

--- a/engines/dfc_provider/app/services/offer_builder.rb
+++ b/engines/dfc_provider/app/services/offer_builder.rb
@@ -28,15 +28,7 @@ class OfferBuilder < DfcBuilder
   end
 
   def self.add_offered_item(offer, variant)
-    # challenge: include some parts of the graph, without diving into a stack overflow.
-    catalog_item_id = urls.enterprise_catalog_item_url(
-      enterprise_id: variant.supplier_id, id: variant.id
-    )
-    offer.offeredItem = DataFoodConsortium::Connector::CatalogItem.new(
-        catalog_item_id, product: SuppliedProductBuilder.supplied_product(variant, include_catalog_items: false),
-            sku: variant.sku,
-      )
-
+    offer.offeredItem = SuppliedProductBuilder.supplied_product(variant)
   end
 
   def self.price(offer)

--- a/engines/dfc_provider/app/services/offer_builder.rb
+++ b/engines/dfc_provider/app/services/offer_builder.rb
@@ -11,8 +11,9 @@ class OfferBuilder < DfcBuilder
       value: variant.price.to_f,
       unit: price_measure(variant)&.semanticId,
     )
+
     DataFoodConsortium::Connector::Offer.new(
-      id, price:, stockLimitation: stock_limitation(variant),
+      id, price:, stockLimitation: stock_limitation(variant)
     )
   end
 
@@ -24,6 +25,18 @@ class OfferBuilder < DfcBuilder
     return if offer.price.nil?
 
     variant.price = price(offer)
+  end
+
+  def self.add_offered_item(offer, variant)
+    # challenge: include some parts of the graph, without diving into a stack overflow.
+    catalog_item_id = urls.enterprise_catalog_item_url(
+      enterprise_id: variant.supplier_id, id: variant.id
+    )
+    offer.offeredItem = DataFoodConsortium::Connector::CatalogItem.new(
+        catalog_item_id, product: SuppliedProductBuilder.supplied_product(variant, include_catalog_items: false),
+            sku: variant.sku,
+      )
+
   end
 
   def self.price(offer)

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -43,10 +43,12 @@ class OrderBuilder < DfcBuilder
     DfcLoader.vocabulary("vocabulary").STATES.ORDERSTATE
   end
 
+  # Build and attach orderLines with offeredItems
   def self.build_order_lines(dfc_order, ofn_line_items)
     dfc_order.lines = ofn_line_items.map do |line_item|
-      semantic_id = "#{dfc_order.semanticId}/OrderLines/#{line_item.id}"
-      OrderLineBuilder.build(line_item, semantic_id)
+      OrderLineBuilder.build(dfc_order, line_item).tap do |order_line|
+        OfferBuilder.add_offered_item(order_line.offer, line_item.variant)
+      end
     end
   end
 end

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -21,4 +21,13 @@ class OrderBuilder < DfcBuilder
       orderStatus: "dfc-v:Held",
     )
   end
+
+  def self.apply(ofn_order, dfc_order)
+    # Set order state if recognised
+    ofn_order.state = "complete" if dfc_order.orderStatus == order_status.HELD
+  end
+
+  def self.order_status
+    DfcLoader.vocabulary("vocabulary").STATES.ORDERSTATE
+  end
 end

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -24,10 +24,22 @@ class OrderBuilder < DfcBuilder
 
   def self.apply(ofn_order, dfc_order)
     # Set order state if recognised
-    ofn_order.state = "complete" if dfc_order.orderStatus == order_status.HELD
+    ofn_order.state = "complete" if dfc_order.orderStatus == order_states.HELD
+
+    dfc_order.lines.each do |order_line|
+      # We don't need to look at the DFC object, we know the ID is a local variant ID.
+      variant_id = order_line.offer.offeredItem.split('/supplied_products/').last
+
+      ofn_order.line_items.build(
+        variant_id:,
+        quantity: order_line.quantity
+      )
+    end
+
+    ofn_order.save
   end
 
-  def self.order_status
+  def self.order_states
     DfcLoader.vocabulary("vocabulary").STATES.ORDERSTATE
   end
 end

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -42,4 +42,11 @@ class OrderBuilder < DfcBuilder
   def self.order_states
     DfcLoader.vocabulary("vocabulary").STATES.ORDERSTATE
   end
+
+  def self.build_order_lines(dfc_order, ofn_line_items)
+    dfc_order.lines = ofn_line_items.map do |line_item|
+      semantic_id = "#{dfc_order.semanticId}/OrderLines/#{line_item.id}"
+      OrderLineBuilder.build(line_item, semantic_id)
+    end
+  end
 end

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class OrderBuilder < DfcBuilder
+  def self.build(ofn_order)
+    id = urls.enterprise_order_url(
+      enterprise_id: ofn_order.distributor_id,
+      id: ofn_order.id,
+    )
+
+    DataFoodConsortium::Connector::Order.new(
+      id,
+      client: urls.enterprise_url(ofn_order.distributor_id),
+      orderStatus: "dfc-v:Held",
+    )
+  end
+
   def self.new_order(ofn_order, id = nil)
     DataFoodConsortium::Connector::Order.new(
       id,

--- a/engines/dfc_provider/app/services/order_line_builder.rb
+++ b/engines/dfc_provider/app/services/order_line_builder.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class OrderLineBuilder < DfcBuilder
+  def self.build(ofn_line_item, semantic_id)
+    DataFoodConsortium::Connector::OrderLine.new(
+      semantic_id,
+      offer: OfferBuilder.build(ofn_line_item.variant),
+      quantity: ofn_line_item.quantity,
+    )
+  end
+
   def self.build_from_offer(offer, quantity)
     DataFoodConsortium::Connector::OrderLine.new(
       nil, offer:, quantity:,

--- a/engines/dfc_provider/app/services/order_line_builder.rb
+++ b/engines/dfc_provider/app/services/order_line_builder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OrderLineBuilder < DfcBuilder
-  def self.build(offer, quantity)
+  def self.build_from_offer(offer, quantity)
     DataFoodConsortium::Connector::OrderLine.new(
       nil, offer:, quantity:,
     )

--- a/engines/dfc_provider/app/services/order_line_builder.rb
+++ b/engines/dfc_provider/app/services/order_line_builder.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class OrderLineBuilder < DfcBuilder
-  def self.build(ofn_line_item, semantic_id)
+  def self.build(dfc_order, ofn_line_item)
     DataFoodConsortium::Connector::OrderLine.new(
-      semantic_id,
+      "#{dfc_order.semanticId}/OrderLines/#{ofn_line_item.id}",
       offer: OfferBuilder.build(ofn_line_item.variant),
       quantity: ofn_line_item.quantity,
     )

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -24,7 +24,8 @@ class SuppliedProductBuilder < DfcBuilder
       isVariantOf: [product_group],
       spree_product_uri: product_uri,
       spree_product_id: variant.product.id,
-      image_url: variant.product&.image&.url(:product)
+      image_url: variant.product&.image&.url(:product),
+      catalogItems: [catalog_item(variant, include_product: false)],
     )
   end
 

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -8,12 +8,14 @@ class SuppliedProductBuilder < DfcBuilder
     )
   end
 
-  def self.supplied_product(variant)
+  def self.supplied_product(variant, include_catalog_items: true)
     product_uri = urls.enterprise_url(
       variant.supplier_id,
       spree_product_id: variant.product_id
     )
     product_group = ProductGroupBuilder.product_group(variant.product)
+
+    catalogItems = [catalog_item(variant, include_product: false)] if include_catalog_items
 
     DfcProvider::SuppliedProduct.new(
       semantic_id(variant),
@@ -25,7 +27,7 @@ class SuppliedProductBuilder < DfcBuilder
       spree_product_uri: product_uri,
       spree_product_id: variant.product.id,
       image_url: variant.product&.image&.url(:product),
-      catalogItems: [catalog_item(variant, include_product: false)],
+      catalogItems:,
     )
   end
 

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -5,6 +5,7 @@ DfcProvider::Engine.routes.draw do
   resources :enterprises, only: [:show] do
     resources :catalog_items, only: [:index, :show, :update]
     resources :offers, only: [:show, :update]
+    resources :orders, only: [:create]
     resources :supplied_products, only: [:create, :show, :update]
     resources :social_medias, only: [:show]
   end

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -5,7 +5,7 @@ DfcProvider::Engine.routes.draw do
   resources :enterprises, only: [:show] do
     resources :catalog_items, only: [:index, :show, :update]
     resources :offers, only: [:show, :update]
-    resources :orders, only: [:create]
+    resources :orders, only: [:show, :create]
     resources :supplied_products, only: [:create, :show, :update]
     resources :social_medias, only: [:show]
   end

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -128,7 +128,6 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
 
         context "variant not found" do
           run_test! {
-            pending "todo:  Stock::AvailabilityValidator should skip over empty variant"
             expect(enterprise.distributed_orders.first.line_items).to be_empty
 
             expect(response.body).to include "Line items variant must exist"

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
     parameter name: :enterprise_id, in: :path, type: :string
 
     post "Create Order" do
+      produces "application/json"
+
       response "201", "created" do
         before { product }
 
@@ -34,6 +36,17 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
 
           run_test! {
             expect(enterprise.distributed_orders.count).to eq 1
+            ofn_order = enterprise.distributed_orders.first
+            expect(ofn_order.created_by).to eq user
+
+            # Insert static value to keep documentation deterministic:
+            response.body.gsub!(
+              "orders/#{ofn_order.id}",
+              "orders/10001"
+            )
+
+            expect(response.body).to include "dfc-b:Order"
+            expect(response.body).to include "/api/dfc/enterprises/10000/orders/10001"
           }
         end
       end

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
           expect(response.body).to include "dfc-b:Order",       "orders/11000"
           expect(response.body).to include "dfc-b:OrderLine",   "OrderLines/"
           expect(response.body).to include "dfc-b:Offer",       "offers/", "dfc-b:offeredItem"
-          expect(response.body).to include "dfc-b:CatalogItem", "catalog_items/10001"
+          expect(response.body).to include "dfc-b:SuppliedProduct", "supplied_products/10001"
         }
       end
 

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -109,6 +109,17 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
           }
         end
       end
+
+      response "422", "unprocessable entity" do
+        context "with invalid order value" do
+          let(:enterprise_id) { enterprise.id }
+
+          run_test! {
+            pending "haven't got a way to submit invalid values yet.."
+            expect(enterprise.distributed_orders).to be_empty
+          }
+        end
+      end
     end
   end
 end

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative "../swagger_helper"
+
+RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
+  let(:user) { create(:oidc_user, id: 12_345) }
+  let(:enterprise) {
+    create(
+      :distributor_enterprise,
+      id: 10_000, owner: user, name: "Fred's Farm", description: "Beautiful",
+      address: build(:address, id: 40_000),
+    )
+  }
+  let(:product) {
+    create(
+      :base_product,
+      id: 90_000, name: "Apple", description: "Red",
+      variants: [variant],
+    )
+  }
+  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "AR", supplier: enterprise) }
+
+  before { login_as user }
+
+  path "/api/dfc/enterprises/{enterprise_id}/orders" do
+    parameter name: :enterprise_id, in: :path, type: :string
+
+    post "Create Order" do
+      response "201", "created" do
+        before { product }
+
+        context "with given enterprise id" do
+          let(:enterprise_id) { enterprise.id }
+
+          run_test! {
+            expect(enterprise.distributed_orders.count).to eq 1
+          }
+        end
+      end
+
+      response "401", "unauthorized" do
+        let(:enterprise_id) { enterprise.id }
+
+        before { login_as nil }
+
+        run_test! {
+          expect(enterprise.distributed_orders).to be_empty
+        }
+      end
+
+      response "404", "not found" do
+        context "without enterprises" do
+          let(:enterprise_id) { "blah" }
+
+          run_test! {
+            expect(enterprise.distributed_orders).to be_empty
+          }
+        end
+
+        context "with unrelated enterprise" do
+          let(:enterprise_id) { create(:enterprise).id }
+
+          run_test! {
+            expect(enterprise.distributed_orders).to be_empty
+          }
+        end
+      end
+    end
+  end
+end

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
 
         run_test! {
           expect(response.body).to include "dfc-b:Order",       "orders/11000"
+          expect(response.body).to include "dfc-b:OrderLine",   "OrderLines/"
         }
       end
 

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
             expect(enterprise.distributed_orders.count).to eq 1
             ofn_order = enterprise.distributed_orders.first
             expect(ofn_order.created_by).to eq user
+            expect(ofn_order.state).to eq "complete"
 
             # Insert static value to keep documentation deterministic:
             response.body.gsub!(

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
         run_test! {
           expect(response.body).to include "dfc-b:Order",       "orders/11000"
           expect(response.body).to include "dfc-b:OrderLine",   "OrderLines/"
+          expect(response.body).to include "dfc-b:Offer",       "offers/", "dfc-b:offeredItem"
+          expect(response.body).to include "dfc-b:CatalogItem", "catalog_items/10001"
         }
       end
 

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -166,11 +166,13 @@ RSpec.describe "SuppliedProducts", swagger_doc: "dfc.yaml" do
             response.body.gsub!(
               "supplied_products/#{variant_id}",
               "supplied_products/10001"
+            ).gsub!(
+              "catalog_items/#{variant_id}",
+              "catalog_items/10001"
+            ).gsub!(
+              %r{active_storage/[0-9A-Za-z/=-]*/logo-white.png},
+              "active_storage/url/logo-white.png",
             )
-              .gsub!(
-                %r{active_storage/[0-9A-Za-z/=-]*/logo-white.png},
-                "active_storage/url/logo-white.png",
-              )
           end
         end
       end

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -43,8 +43,31 @@ RSpec.describe OrderBuilder do
     }
 
     it "applies attribute changes to order" do
-      subject
+      expect(subject).to be true
       expect(ofn_order.state).to eq "complete"
+    end
+
+    context "with OrderLines" do
+      let!(:variant) { create(:variant, id: 10_000) }
+
+      before do
+        offer = DataFoodConsortium::Connector::Offer.new(
+          nil, offeredItem: "http://test.host/api/dfc/enterprises/blah/supplied_products/10000"
+        )
+        order_line = DataFoodConsortium::Connector::OrderLine.new(
+          nil, offer:, quantity: 3
+        )
+
+        dfc_order.lines = [order_line, order_line]
+      end
+
+      it "creates line items" do
+        expect(subject).to be true
+
+        expect(ofn_order.line_items.count).to eq 2
+        expect(ofn_order.line_items.first.variant).to eq variant
+        expect(ofn_order.line_items.first.quantity).to eq 3
+      end
     end
   end
 end

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -31,4 +31,20 @@ RSpec.describe OrderBuilder do
       expect(result.lines.count).to eq 0
     end
   end
+
+  describe ".apply" do
+    subject { described_class.apply(ofn_order, dfc_order) }
+    let!(:ofn_order) { create(:order, id: 1) }
+    let(:dfc_order) {
+      DataFoodConsortium::Connector::Order.new(
+        nil,
+        orderStatus: DfcLoader.vocabulary("vocabulary").STATES.ORDERSTATE.HELD,
+      )
+    }
+
+    it "applies attribute changes to order" do
+      subject
+      expect(ofn_order.state).to eq "complete"
+    end
+  end
 end

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -18,4 +18,17 @@ RSpec.describe OrderBuilder do
       expect(result.orderStatus).to eq "dfc-v:Held"
     end
   end
+
+  describe '.build' do
+    let(:distributor) { create(:distributor_enterprise, id: 10_000) }
+    let(:ofn_order) { create(:completed_order_with_totals, distributor:, id: 1) }
+    subject(:result) { described_class.build(ofn_order) }
+
+    it "builds and stores a DFC order object" do
+      expect(result.semanticId).to  eq "http://test.host/api/dfc/enterprises/10000/orders/1"
+      expect(result.client).to      eq "http://test.host/api/dfc/enterprises/10000"
+      expect(result.orderStatus).to eq "dfc-v:Held"
+      expect(result.lines.count).to eq 0
+    end
+  end
 end

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Orders backorder integration" do
   }
 
   # Customer orders the distributed product
-  let(:order) {
+  let(:distributor_order) {
     create(:order_with_totals_and_distribution,
            :with_line_item,
            variant: distributor_variant,
@@ -79,18 +79,18 @@ RSpec.describe "Orders backorder integration" do
 
       expect {
         # BackorderJob.perform_now(order) # Cannot perform whole job as it gets stuck on record lock
-        BackorderJob.new.place_backorder(order)
+        BackorderJob.new.place_backorder(distributor_order)
       }.to change { supplier.distributed_orders.count }.by(1)
 
-      order = supplier.distributed_orders.first
-      expect(order.created_by).to eq distributor_owner
-      expect(order.user).to eq distributor_owner
-      expect(order.email).to eq distributor_owner.email
-      expect(order.state).to eq "complete"
+      supplier_order = supplier.distributed_orders.first
+      expect(supplier_order.created_by).to eq distributor_owner
+      expect(supplier_order.user).to eq distributor_owner
+      expect(supplier_order.email).to eq distributor_owner.email
+      expect(supplier_order.state).to eq "complete"
 
-      expect(order.line_items.count).to eq 1
-      expect(order.line_items.first.variant).to eq variant
-      expect(order.line_items.first.quantity).to eq 1
+      expect(supplier_order.line_items.count).to eq 1
+      expect(supplier_order.line_items.first.variant).to eq variant
+      expect(supplier_order.line_items.first.quantity).to eq 1
     rescue Faraday::UnprocessableEntityError => e
       # Output error message for convenient debugging
       expect(e.response[:body]).to be_blank

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe "Orders backorder integration" do
 
     # Pretend that user has authenticated with OIDC
     distributor_owner.oidc_account.update!(token: allow_token_for(email: distributor_owner.email))
+
+    variant.on_hand = 1
   }
 
   xit "debugging: accesses the webserver" do
@@ -85,6 +87,10 @@ RSpec.describe "Orders backorder integration" do
       expect(order.user).to eq distributor_owner
       expect(order.email).to eq distributor_owner.email
       expect(order.state).to eq "complete"
+
+      expect(order.line_items.count).to eq 1
+      expect(order.line_items.first.variant).to eq variant
+      expect(order.line_items.first.quantity).to eq 1
     end
   end
 end

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe "Orders backorder integration" do
 
       order = supplier.distributed_orders.first
       expect(order.created_by).to eq distributor_owner
+      expect(order.state).to eq "complete"
     end
   end
 end

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative "../system_helper"
+
+# Test the dfc/orders endpoint with the backorderer
+RSpec.describe "Orders backorder integration" do
+  include AuthorizationHelper
+
+  let(:host) { Rails.application.default_url_options[:host] }
+
+  # Supplier sells their product on OFN via DFC api
+  let(:supplier_owner) { create(:oidc_user, id: 12_345) }
+  let(:supplier) {
+    create(:distributor_enterprise, id: 10_000, name: "Fred's Farm", owner: supplier_owner)
+  }
+  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "SUP", supplier:, ) }
+  let(:semantic_id) {
+    "http://#{host}/api/dfc/enterprises/#{supplier.id}/supplied_products/#{variant.id}"
+  }
+  let!(:supplier_order_cycle) {
+    create(:simple_order_cycle, distributors: [supplier], variants: [variant])
+  }
+
+  # Distributor has imported a copy of the product and is selling it
+  # The distributor must be authorised with the email address of the supplier owner.
+  # Because they are on the same OFN instance in this test, they must be the same user.
+  let(:distributor_owner) { supplier_owner }
+  let(:distributor) {
+    create(:distributor_enterprise, id: 11_000, owner: distributor_owner, name: "Shane's Shop")
+  }
+  let(:distributor_variant) {
+    create(:variant, id: 11_001, unit_value: 1, sku: "DIST", on_hand: 10,
+                     supplier: distributor).tap { |v|
+      v.semantic_links.create(semantic_id:) # variant is linked to supplier variant
+      v.on_demand = false
+    }
+  }
+  let(:distributor_order_cycle) {
+    create(:simple_order_cycle, distributors: [distributor], variants: [distributor_variant])
+  }
+
+  # Customer orders the distributed product
+  let(:order) {
+    create(:order_with_totals_and_distribution,
+           :with_line_item,
+           variant: distributor_variant,
+           distributor:, order_cycle: distributor_order_cycle)
+  }
+
+  before {
+    # For this test, OFN is talking to itself. We currently don't allow that IRL.
+    allow(PrivateAddressCheck).to receive(:private_address?).and_return(false)
+
+    # Pretend that user has authenticated with OIDC
+    distributor_owner.oidc_account.update!(token: allow_token_for(email: distributor_owner.email))
+  }
+
+  xit "debugging: accesses the webserver" do
+    # try accessing the supplier's catalog
+    url = "http://#{host}/api/dfc/enterprises/#{supplier.id}/catalog_items"
+
+    DfcRequest.new(distributor_owner).call(url)
+    result = DfcRequest.new(distributor_owner).call(url) # make a second http request, also works.
+    DfcIo.import(result)
+
+    puts "\nRequest: #{url}\n"
+    puts "Response includes:"
+    puts result.scan(/[^"]*10001[^"]*/)
+    # http://127.0.0.1:56286/api/dfc/enterprises/10000/catalog_items/10001
+    # http://127.0.0.1:56286/api/dfc/enterprises/10000/supplied_products/10001
+  end
+
+  describe "BackorderJob" do
+    it "creates an order for the source variant" do
+      # For debugging you can check log/test.log, eg:
+      # echo "" > log/test.log; tail -f log/test.log | egrep "(Started|Completed)"
+
+      BackorderJob.perform_now(order)
+
+      order = supplier.distributed_orders.first
+      expect(order.created_by).to eq distributor_owner
+    end
+  end
+end

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe "Orders backorder integration" do
 
       order = supplier.distributed_orders.first
       expect(order.created_by).to eq distributor_owner
+      expect(order.user).to eq distributor_owner
+      expect(order.email).to eq distributor_owner.email
       expect(order.state).to eq "complete"
     end
   end

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -92,13 +92,11 @@ RSpec.describe "Orders backorder integration" do
       expect(supplier_order.line_items.first.variant).to eq variant
       expect(supplier_order.line_items.first.quantity).to eq 1
 
-      # At end of order cycle, the backorder should be finalised.
-      pending "The action 'show' could not be found for DfcProvider::OrdersController"
-      expect {
-        # backorder_url = "http://#{host}/api/dfc/enterprises/#{supplier.id}/orders/#{supplier.distributed_orders.first.id}" # aint no route for this
-        # CompleteBackorderJob.perform_now(distributor_owner, distributor, distributor_order_cycle, backorder_url)
-        perform_enqueued_jobs(only: CompleteBackorderJob)
-      }.to change { supplier.distributed_orders.first.state }.to(:complete)
+      # At end of order cycle, the CompleteBackorderJob should succeed.
+      # backorder_url = "http://#{host}/api/dfc/enterprises/#{supplier.id}/orders/#{supplier.distributed_orders.first.id}" # aint no route for this
+      # CompleteBackorderJob.perform_now(distributor_owner, distributor, distributor_order_cycle, backorder_url)
+      perform_enqueued_jobs(only: CompleteBackorderJob)
+      expect(supplier.distributed_orders.first.state).to eq "complete"
 
     rescue Faraday::UnprocessableEntityError => e
       # Output error message for convenient debugging

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -91,6 +91,9 @@ RSpec.describe "Orders backorder integration" do
       expect(order.line_items.count).to eq 1
       expect(order.line_items.first.variant).to eq variant
       expect(order.line_items.first.quantity).to eq 1
+    rescue Faraday::UnprocessableEntityError => e
+      # Output error message for convenient debugging
+      expect(e.response[:body]).to be_blank
     end
   end
 end

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -91,6 +91,15 @@ RSpec.describe "Orders backorder integration" do
       expect(supplier_order.line_items.count).to eq 1
       expect(supplier_order.line_items.first.variant).to eq variant
       expect(supplier_order.line_items.first.quantity).to eq 1
+
+      # At end of order cycle, the backorder should be finalised.
+      pending "The action 'show' could not be found for DfcProvider::OrdersController"
+      expect {
+        # backorder_url = "http://#{host}/api/dfc/enterprises/#{supplier.id}/orders/#{supplier.distributed_orders.first.id}" # aint no route for this
+        # CompleteBackorderJob.perform_now(distributor_owner, distributor, distributor_order_cycle, backorder_url)
+        perform_enqueued_jobs(only: CompleteBackorderJob)
+      }.to change { supplier.distributed_orders.first.state }.to(:complete)
+
     rescue Faraday::UnprocessableEntityError => e
       # Output error message for convenient debugging
       expect(e.response[:body]).to be_blank

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -75,7 +75,10 @@ RSpec.describe "Orders backorder integration" do
       # For debugging you can check log/test.log, eg:
       # echo "" > log/test.log; tail -f log/test.log | egrep "(Started|Completed)"
 
-      BackorderJob.perform_now(order)
+      expect {
+        # BackorderJob.perform_now(order) # Cannot perform whole job as it gets stuck on record lock
+        BackorderJob.new.place_backorder(order)
+      }.to change { supplier.distributed_orders.count }.by(1)
 
       order = supplier.distributed_orders.first
       expect(order.created_by).to eq distributor_owner

--- a/engines/dfc_provider/spec/system_helper.rb
+++ b/engines/dfc_provider/spec/system_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Load OFN base helpers and system spec support files
+require_relative '../../../spec/system_helper'
+
+# Engine-specific spec helpers
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }

--- a/spec/fixtures/files/fdc-send-backorder.json
+++ b/spec/fixtures/files/fdc-send-backorder.json
@@ -1,0 +1,51 @@
+{
+  "@context": "https://www.datafoodconsortium.org",
+  "@graph": [
+    {
+      "@id": "http://127.0.0.1:52057/api/dfc/enterprises/10000/orders",
+      "@type": "dfc-b:Order",
+      "dfc-b:belongsTo": "http://127.0.0.1:52057/api/dfc/enterprises/10000/supplied_products",
+      "dfc-b:hasPart": "http://127.0.0.1:52057/api/dfc/enterprises/10000/orders/OrderLines/1",
+      "dfc-b:orderedBy": "http://127.0.0.1:52057/api/dfc/enterprises/11000",
+      "dfc-b:hasOrderStatus": "dfc-v:Held"
+    },
+    {
+      "@id": "http://127.0.0.1:52057/api/dfc/enterprises/10000/orders/OrderLines/1",
+      "@type": "dfc-b:OrderLine",
+      "dfc-b:quantity": 1,
+      "dfc-b:concerns": "http://127.0.0.1:52057/api/dfc/enterprises/10000/offers/10001"
+    },
+    {
+      "@id": "http://127.0.0.1:52057/api/dfc/enterprises/10000/offers/10001",
+      "@type": "dfc-b:Offer",
+      "dfc-b:hasPrice": {
+        "@type": "dfc-b:Price",
+        "dfc-b:value": 19.99,
+        "dfc-b:hasUnit": "dfc-m:AustralianDollar"
+      },
+      "dfc-b:stockLimitation": 0,
+      "dfc-b:offeredItem": "http://127.0.0.1:52057/api/dfc/enterprises/10000/supplied_products/10001"
+    },
+    {
+      "@id": "http://127.0.0.1:52057/api/dfc/enterprises/10000/supplied_products/10001",
+      "@type": "dfc-b:SuppliedProduct",
+      "dfc-b:name": "Product #1 - 6206 - 1g",
+      "dfc-b:description": "Reiciendis quia veniam officiis facere magni quibusdam recusandae. Nesciunt ipsa ab libero vel distinctio asperiores architecto. Mollitia laboriosam voluptates sunt dolores pariatur iusto cupiditate quis.\nAliquid itaque a nobis quia in fugiat. Magnam libero dolores in quo nemo sed. Nisi quasi consequuntur pariatur eius odio. Incidunt quos voluptas quam quod asperiores itaque aliquid. Quasi laboriosam ullam ipsam cum aliquid corporis dolorem.\nProvident officiis atque dolorem veniam et est repudiandae nostrum. Est ullam delectus qui at esse consectetur sit. Veniam eius quam commodi rerum cum dignissimos porro. Voluptate consectetur expedita soluta cum. Amet ab architecto beatae fugit qui facilis.",
+      "dfc-b:hasQuantity": {
+        "@type": "dfc-b:QuantitativeValue",
+        "dfc-b:hasUnit": "dfc-m:Gram",
+        "dfc-b:value": 1
+      },
+      "dfc-b:referencedBy": "http://127.0.0.1:52057/api/dfc/enterprises/10000/catalog_items/10001",
+      "dfc-b:isVariantOf": "http://127.0.0.1:52057/api/dfc/product_groups/8002",
+      "ofn:spree_product_id": 8002,
+      "ofn:spree_product_uri": "http://127.0.0.1:52057/api/dfc/enterprises/10000?spree_product_id=8002"
+    },
+    {
+      "@id": "http://127.0.0.1:52057/api/dfc/enterprises/10000/supplied_products",
+      "@type": "dfc-b:SaleSession",
+      "dfc-b:beginDate": "Wed Mar 19 2025 04:40:16 UTC",
+      "dfc-b:endDate": "Thu Mar 27 2025 04:40:16 UTC"
+    }
+  ]
+}

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -7,6 +7,16 @@ module Spree
     RSpec.describe AvailabilityValidator do
       let(:validator) { AvailabilityValidator.new({}) }
 
+      context "new line item without variant" do
+        let(:order) { create(:order) }
+        let(:line_item) { order.line_items.build }
+
+        it "fails gracefully" do
+          validator.validate(line_item)
+          expect(line_item).not_to be_valid
+        end
+      end
+
       context "line item without existing inventory units" do
         let(:order) { create(:order_with_line_items) }
         let(:line_item) { order.line_items.first }

--- a/spec/services/fdc_url_builder_spec.rb
+++ b/spec/services/fdc_url_builder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe FdcUrlBuilder do
     }
 
     it "knows the right URLs" do
-      expect(subject.catalog_url).to eq "http://test.host/api/dfc/enterprises/10000/supplied_products" # but shouldn't it be catalog_items?
+      expect(subject.catalog_url).to eq "http://test.host/api/dfc/enterprises/10000/catalog_items"
       expect(subject.orders_url).to eq "http://test.host/api/dfc/enterprises/10000/orders"
       # expect(subject.sale_session_url).to eq "" # not yet implemented
     end

--- a/spec/services/fdc_url_builder_spec.rb
+++ b/spec/services/fdc_url_builder_spec.rb
@@ -13,4 +13,16 @@ RSpec.describe FdcUrlBuilder do
     expect(subject.orders_url).to eq "https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/Orders"
     expect(subject.sale_session_url).to eq "https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/SalesSession/#"
   end
+
+  context "OFN URLs" do
+    let(:product_link) {
+      "http://test.host/api/dfc/enterprises/10000/supplied_products/10001"
+    }
+
+    it "knows the right URLs" do
+      expect(subject.catalog_url).to eq "http://test.host/api/dfc/enterprises/10000/supplied_products" # but shouldn't it be catalog_items?
+      expect(subject.orders_url).to eq "http://test.host/api/dfc/enterprises/10000/orders"
+      # expect(subject.sale_session_url).to eq "" # not yet implemented
+    end
+  end
 end

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -34,10 +34,15 @@ RSpec.configure do |config|
   # Make sure url helpers in mailers use the Capybara server host.
   config.around(:each, type: :system) do |example|
     original_host = Rails.application.default_url_options[:host]
-    Rails.application.default_url_options[:host] =
-      "#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}"
+    system_host = "#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}"
+
+    Rails.application.default_url_options[:host] = system_host
+    DfcProvider::Engine.routes.default_url_options[:host] = system_host
+
     example.run
+
     Rails.application.default_url_options[:host] = original_host
+    DfcProvider::Engine.routes.default_url_options[:host] = original_host
     remove_downloaded_files
   end
 end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -534,6 +534,24 @@ paths:
                 "@type": dfc-b:Offer
                 dfc-b:hasPrice: 9.99
                 dfc-b:stockLimitation: 7
+  "/api/dfc/enterprises/{enterprise_id}/orders":
+    parameters:
+    - name: enterprise_id
+      in: path
+      required: true
+      schema:
+        type: string
+    post:
+      summary: Create Order
+      tags:
+      - Orders
+      responses:
+        '201':
+          description: created
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
   "/api/dfc/persons/{id}":
     get:
       summary: Show person

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -574,11 +574,8 @@ paths:
               examples:
                 test_example:
                   value:
-                    "@context": https://www.datafoodconsortium.org
-                    "@id": http://test.host/api/dfc/enterprises/10000/orders/4235
-                    "@type": dfc-b:Order
-                    dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
-                    dfc-b:hasOrderStatus: dfc-v:Held
+                    error: Line items variant must exist and Line items price is not
+                      a number
       requestBody:
         content:
           application/json:

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -567,6 +567,18 @@ paths:
           description: unauthorized
         '404':
           description: not found
+        '422':
+          description: unprocessable entity
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@context": https://www.datafoodconsortium.org
+                    "@id": http://test.host/api/dfc/enterprises/10000/orders/4235
+                    "@type": dfc-b:Order
+                    dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
+                    dfc-b:hasOrderStatus: dfc-v:Held
       requestBody:
         content:
           application/json:

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -543,6 +543,7 @@ paths:
         type: string
     post:
       summary: Create Order
+      parameters: []
       tags:
       - Orders
       responses:
@@ -558,10 +559,68 @@ paths:
                     "@type": dfc-b:Order
                     dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
                     dfc-b:hasOrderStatus: dfc-v:Held
+        '400':
+          description: bad request
         '401':
           description: unauthorized
         '404':
           description: not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example: |-
+                {
+                  "@context": "https://www.datafoodconsortium.org",
+                  "@graph": [
+                    {
+                      "@id": "http://127.0.0.1:52057/api/dfc/enterprises/10000/orders",
+                      "@type": "dfc-b:Order",
+                      "dfc-b:belongsTo": "http://127.0.0.1:52057/api/dfc/enterprises/10000/supplied_products",
+                      "dfc-b:hasPart": "http://127.0.0.1:52057/api/dfc/enterprises/10000/orders/OrderLines/1",
+                      "dfc-b:orderedBy": "http://127.0.0.1:52057/api/dfc/enterprises/11000",
+                      "dfc-b:hasOrderStatus": "dfc-v:Held"
+                    },
+                    {
+                      "@id": "http://127.0.0.1:52057/api/dfc/enterprises/10000/orders/OrderLines/1",
+                      "@type": "dfc-b:OrderLine",
+                      "dfc-b:quantity": 1,
+                      "dfc-b:concerns": "http://127.0.0.1:52057/api/dfc/enterprises/10000/offers/10001"
+                    },
+                    {
+                      "@id": "http://127.0.0.1:52057/api/dfc/enterprises/10000/offers/10001",
+                      "@type": "dfc-b:Offer",
+                      "dfc-b:hasPrice": {
+                        "@type": "dfc-b:Price",
+                        "dfc-b:value": 19.99,
+                        "dfc-b:hasUnit": "dfc-m:AustralianDollar"
+                      },
+                      "dfc-b:stockLimitation": 0,
+                      "dfc-b:offeredItem": "http://127.0.0.1:52057/api/dfc/enterprises/10000/supplied_products/10001"
+                    },
+                    {
+                      "@id": "http://127.0.0.1:52057/api/dfc/enterprises/10000/supplied_products/10001",
+                      "@type": "dfc-b:SuppliedProduct",
+                      "dfc-b:name": "Product #1 - 6206 - 1g",
+                      "dfc-b:description": "Reiciendis quia veniam officiis facere magni quibusdam recusandae. Nesciunt ipsa ab libero vel distinctio asperiores architecto. Mollitia laboriosam voluptates sunt dolores pariatur iusto cupiditate quis.\nAliquid itaque a nobis quia in fugiat. Magnam libero dolores in quo nemo sed. Nisi quasi consequuntur pariatur eius odio. Incidunt quos voluptas quam quod asperiores itaque aliquid. Quasi laboriosam ullam ipsam cum aliquid corporis dolorem.\nProvident officiis atque dolorem veniam et est repudiandae nostrum. Est ullam delectus qui at esse consectetur sit. Veniam eius quam commodi rerum cum dignissimos porro. Voluptate consectetur expedita soluta cum. Amet ab architecto beatae fugit qui facilis.",
+                      "dfc-b:hasQuantity": {
+                        "@type": "dfc-b:QuantitativeValue",
+                        "dfc-b:hasUnit": "dfc-m:Gram",
+                        "dfc-b:value": 1
+                      },
+                      "dfc-b:referencedBy": "http://127.0.0.1:52057/api/dfc/enterprises/10000/catalog_items/10001",
+                      "dfc-b:isVariantOf": "http://127.0.0.1:52057/api/dfc/product_groups/8002",
+                      "ofn:spree_product_id": 8002,
+                      "ofn:spree_product_uri": "http://127.0.0.1:52057/api/dfc/enterprises/10000?spree_product_id=8002"
+                    },
+                    {
+                      "@id": "http://127.0.0.1:52057/api/dfc/enterprises/10000/supplied_products",
+                      "@type": "dfc-b:SaleSession",
+                      "dfc-b:beginDate": "Wed Mar 19 2025 04:40:16 UTC",
+                      "dfc-b:endDate": "Thu Mar 27 2025 04:40:16 UTC"
+                    }
+                  ]
+                }
   "/api/dfc/persons/{id}":
     get:
       summary: Show person

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -548,6 +548,16 @@ paths:
       responses:
         '201':
           description: created
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@context": https://www.datafoodconsortium.org
+                    "@id": http://test.host/api/dfc/enterprises/10000/orders/10001
+                    "@type": dfc-b:Order
+                    dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
+                    dfc-b:hasOrderStatus: dfc-v:Held
         '401':
           description: unauthorized
         '404':

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -177,6 +177,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
                       ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -467,6 +468,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -737,6 +739,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000
                     ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -797,6 +800,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 1.0
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                     dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000


### PR DESCRIPTION
**ℹ️ Funded Feature. Please track ALL ASSOCIATED WORK under the associated tracking code #11678 DFC Orders**
### What? Why?

- Part 1 of #12181

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This adds the `create` endpoint. But `update` and `delete` aren't done yet, so we can't test how the backorderer updates orders throughout an order cycle.

It may be helpful to review the DFC object model to understand the concepts: https://docs.google.com/presentation/d/157i0ySW3T89KviZHmderXl7X0ywuvtz0QunaHJcEF_Q/edit?slide=id.g39f6d554c3_0_7#slide=id.g39f6d554c3_0_7

### What should we test?
See issue for summary.

I _think_ it should be possible to import a product from one staging instance to another, and generate backorders.
But I'm not familiar enough with OIDC authentication to figure it out yet. It should be simpler to connect a staging server to itself. 

* **Setup Supplier Enterprise**: 
   * owner has OIDC account linked
   * has a product with some stock.
   * Find the Enterprise ID in the DB and check you can access the DFC catalog. Eg: https://staging.openfoodnetwork.org.uk/api/dfc/enterprises/203926/catalog_items
* **Setup Distributor Enterprise** (could be the same or different instance):
  * owner has same email address as supplier, and OIDC account linked. If on the same instance, this must be the same user.
  * is a primary producer (not sure why but it's necessary to appear in the list for DFC product import)
  * Go to `/admin/products/import`, enter the DFC Catalog URL, and select Distributor. Import the desired product.
  * Add the imported product to a simple order cycle. 
* **Purchase:** As a customer ( I think same user is fine), add distributor product to cart and check out.
  * stock level for Distributor product should be adjusted (normal behaviour)
  * stock level for Supplier product should be adjusted (via DFC backorder)

I tried testing with **testdfc@protonmail.com** on uk_staging, but the product import said "Connecting with your OIDC account failed. Please refresh your OIDC connection at: [OIDC Settings](https://staging.openfoodnetwork.org.uk/admin/oidc_settings)"

### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


### Dependencies
- Depends on https://github.com/openfoodfoundation/openfoodnetwork/pull/13379



### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

## Post merge
Mikel is interested in having a go to add a capture payments endpoint, so I will try to write up an issue for that with notes on how to proceed.
https://openfoodnetwork.slack.com/archives/C2GQ45KNU/p1746437258731909
