### PR TITLE
Fixes some rubocop linting offenses - part IV

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,22 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 16
-# Configuration parameters: AllowComments, AllowEmptyLambdas.
-Lint/EmptyBlock:
-  Exclude:
-    - 'engines/catalog/config/routes.rb'
-    - 'spec/components/distributor_title_component_spec.rb'
-    - 'spec/components/example_component_spec.rb'
-    - 'spec/controllers/admin/subscription_line_items_controller_spec.rb'
-    - 'spec/controllers/api/v0/shipments_controller_spec.rb'
-    - 'spec/controllers/concerns/extra_fields_spec.rb'
-    - 'spec/factories.rb'
-    - 'spec/factories/enterprise_factory.rb'
-    - 'spec/jobs/order_cycle_opened_job_spec.rb'
-    - 'spec/jobs/subscription_placement_job_spec.rb'
-    - 'spec/models/product_import/entry_validator_spec.rb'
-
 # Offense count: 24
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes, Max.
 Metrics/AbcSize:

--- a/engines/catalog/config/routes.rb
+++ b/engines/catalog/config/routes.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-Openfoodnetwork::Application.routes.append do
-end
+# Openfoodnetwork::Application.routes.append do
+# end

--- a/spec/components/distributor_title_component_spec.rb
+++ b/spec/components/distributor_title_component_spec.rb
@@ -2,9 +2,9 @@
 
 require "spec_helper"
 
-RSpec.describe "DistributorTitle tests", type: :component do
+RSpec.describe DistributorTitleComponent, type: :component do
   it "displays distributor title with its name" do
-    render_inline(DistributorTitleComponent.new(name: "Freddy's Farm Shop")) {}
+    render_inline(described_class.new(name: "Freddy's Farm Shop"))
     expect(page).to have_selector "h3", text: "Freddy's Farm Shop"
   end
 end

--- a/spec/components/example_component_spec.rb
+++ b/spec/components/example_component_spec.rb
@@ -2,9 +2,9 @@
 
 require "spec_helper"
 
-RSpec.describe "ExampleComponent tests", type: :component do
+RSpec.describe ExampleComponent, type: :component do
   it "displays the h1 with the given parameter" do
-    render_inline(ExampleComponent.new(title: "Hello")) {}
+    render_inline(described_class.new(title: "Hello"))
     expect(page).to have_selector "h1", text: "Hello"
   end
 end

--- a/spec/controllers/admin/subscription_line_items_controller_spec.rb
+++ b/spec/controllers/admin/subscription_line_items_controller_spec.rb
@@ -5,6 +5,15 @@ require 'spec_helper'
 RSpec.describe Admin::SubscriptionLineItemsController, type: :controller do
   include AuthenticationHelper
 
+  RSpec.configure do |c|
+    c.before(:each) do |test|
+      unless test.metadata[:no_outgoing_exchange]
+        order_cycle.exchanges.create(sender: shop, receiver: shop, variants: [variant],
+                                     enterprise_fees: [enterprise_fee])
+      end
+    end
+  end
+
   describe "build" do
     let(:user) { create(:user) }
     let!(:shop) { create(:enterprise, owner: user) }
@@ -12,10 +21,6 @@ RSpec.describe Admin::SubscriptionLineItemsController, type: :controller do
     let!(:product) { create(:product) }
     let!(:variant) {
       create(:variant, product:, unit_value: '100', price: 15.00)
-    }
-    let!(:outgoing_exchange) {
-      order_cycle.exchanges.create(sender: shop, receiver: shop, variants: [variant],
-                                   enterprise_fees: [enterprise_fee])
     }
     let!(:enterprise_fee) { create(:enterprise_fee, amount: 3.50) }
     let!(:order_cycle) {
@@ -55,9 +60,7 @@ RSpec.describe Admin::SubscriptionLineItemsController, type: :controller do
           before { params.merge!(shop_id: shop.id) }
 
           context "but the shop doesn't have permission to sell product in question" do
-            let!(:outgoing_exchange) {}
-
-            it "returns an error" do
+            it "returns an error", :no_outgoing_exchange do
               spree_post :build, params
               json_response = response.parsed_body
               expect(json_response['errors'])

--- a/spec/controllers/admin/subscription_line_items_controller_spec.rb
+++ b/spec/controllers/admin/subscription_line_items_controller_spec.rb
@@ -5,12 +5,10 @@ require 'spec_helper'
 RSpec.describe Admin::SubscriptionLineItemsController, type: :controller do
   include AuthenticationHelper
 
-  RSpec.configure do |c|
-    c.before(:each) do |test|
-      unless test.metadata[:no_outgoing_exchange]
-        order_cycle.exchanges.create(sender: shop, receiver: shop, variants: [variant],
-                                     enterprise_fees: [enterprise_fee])
-      end
+  before(:each) do |test|
+    unless test.metadata[:no_outgoing_exchange]
+      order_cycle.exchanges.create(sender: shop, receiver: shop, variants: [variant],
+                                   enterprise_fees: [enterprise_fee])
     end
   end
 

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe Api::V0::ShipmentsController, type: :controller do
 
           before do
             allow(Spree::Order).to receive(:find_by!) { fee_order }
-            allow(controller).to receive(:refuse_changing_cancelled_orders) {}
+            allow(controller).to receive(:refuse_changing_cancelled_orders)
             allow(fee_order).to receive(:contents) { contents }
             allow(contents).to receive_messages(add: {}, remove: {})
             allow(fee_order).to receive_message_chain(:shipments, :find_by!) { fee_order_shipment }

--- a/spec/controllers/concerns/extra_fields_spec.rb
+++ b/spec/controllers/concerns/extra_fields_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ExtraFields do
 
   describe "#invalid_query_param" do
     it "renders error" do
-      allow(dummy_controller).to receive(:render) {}
+      allow(dummy_controller).to receive(:render)
       dummy_controller.invalid_query_param("param", :unprocessable_entity, "error message")
       expect(dummy_controller).to have_received(:render).with(
         json:
@@ -44,7 +44,7 @@ RSpec.describe ExtraFields do
 
     context "when fields not in available fields" do
       it "calls invalid_query_param" do
-        allow(dummy_controller).to receive(:invalid_query_param) {}
+        allow(dummy_controller).to receive(:invalid_query_param)
         allow(dummy_controller).to receive(:params).
           and_return({ extra_fields: { customer: "unknown" } })
         dummy_controller.extra_fields(:customer, [:balance])

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -61,9 +61,11 @@ FactoryBot.define do
   end
 
   factory :enterprise_relationship do
+    nil
   end
 
   factory :enterprise_role do
+    nil
   end
 
   factory :enterprise_group, class: EnterpriseGroup do

--- a/spec/factories/enterprise_factory.rb
+++ b/spec/factories/enterprise_factory.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
   factory :enterprise, class: Enterprise do
     transient do
       users { [] }
-      logo {}
-      promo_image {}
+      logo { nil }
+      promo_image { nil }
     end
 
     owner factory: :user

--- a/spec/jobs/order_cycle_opened_job_spec.rb
+++ b/spec/jobs/order_cycle_opened_job_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe OrderCycleOpenedJob do
       breakpoint.lock
       allow(OrderCycleOpenedJob).to(
         receive(:new).and_wrap_original do |method, *args|
-          breakpoint.synchronize {}
+          breakpoint.synchronize { nil }
           method.call(*args)
         end
       )

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe SubscriptionPlacementJob do
       breakpoint.lock
       allow(PlaceProxyOrder).to(
         receive(:new).and_wrap_original do |method, *args|
-          breakpoint.synchronize {}
+          breakpoint.synchronize { nil }
           method.call(*args)
         end
       )

--- a/spec/models/product_import/entry_validator_spec.rb
+++ b/spec/models/product_import/entry_validator_spec.rb
@@ -110,9 +110,9 @@ RSpec.describe ProductImport::EntryValidator do
   describe "inventory validation" do
     before do
       allow(entry_validator).to receive(:import_into_inventory?) { true }
-      allow(entry_validator).to receive(:enterprise_validation) {}
-      allow(entry_validator).to receive(:producer_validation) {}
-      allow(entry_validator).to receive(:variant_of_product_validation) {}
+      allow(entry_validator).to receive(:enterprise_validation)
+      allow(entry_validator).to receive(:producer_validation)
+      allow(entry_validator).to receive(:variant_of_product_validation)
     end
 
     context "products exist" do


### PR DESCRIPTION
#### What? Why?

Fixes last rubocop lint issue Cf. #12330 

[Lint/EmptyBlock](https://docs.rubocop.org/rubocop/cops_lint.html#lintemptyblock)


#### What should we test?
Nothing. Tests should be all green.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled