### PR TITLE
Ensure tests run with specified locale

### DIFF
--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -150,7 +150,8 @@ RSpec.configure do |config|
 
   # Reset locale for all specs.
   config.around(:each) do |example|
-    I18n.with_locale(:en_AU) { example.run }
+    locale = ENV.fetch('LOCALE', 'en_TST')
+    I18n.with_locale(locale) { example.run }
   end
 
   # Reset all feature toggles to prevent leaking.


### PR DESCRIPTION
We changed .env.test a while ago, but I just discovered it hadn't taken any effect because it was overwritten here. Now it's loaded from env var.


#### What should a dev test?
I did these and inspected inside a test with binding.pry: `I18n.locale`

* add different locale to `.env.test.local` => selects desired locale
* remove locale from `.env.test` => falls back to LOCALE in .env
* remove locale from `.env.test` and `.env` => falls back to fetch default ('en_TST')