### PR TITLE
Add order number to notify producer emails and make customer code available for everyone

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -77,11 +77,12 @@ class ProducerMailer < ApplicationMailer
   end
 
   def customer_data(line_items)
-    return unless @coordinator.show_customer_names_to_suppliers?
-
+    @display_customer_names = @coordinator.show_customer_names_to_suppliers?
     @display_business_name = false
+
     line_items.map do |line_item|
-      customer_code = line_item.order.customer&.code
+      order = line_item.order
+      customer_code = order.customer&.code
       @display_business_name = true if customer_code.present?
 
       {
@@ -89,9 +90,10 @@ class ProducerMailer < ApplicationMailer
         supplier_name: line_item.variant.supplier.name,
         product_and_full_name: line_item.product_and_full_name,
         quantity: line_item.quantity,
-        first_name: line_item.order.billing_address.first_name,
-        last_name: line_item.order.billing_address.last_name,
+        first_name: order.billing_address.first_name,
+        last_name: order.billing_address.last_name,
         business_name: customer_code,
+        order_number: order.number
       }
     end.sort_by { |line_item| [line_item[:last_name].downcase, line_item[:first_name].downcase] }
   end

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -77,13 +77,16 @@
           = t :product
         %th.text-right
           = t :quantity
-        %th.text-right
-          = t :first_name
-        %th.text-right
-          = t :last_name
+        - if @display_customer_names
+          %th.text-right
+            = t :first_name
+          %th.text-right
+            = t :last_name
         - if @display_business_name
           %th.text-right
             = t :business_name
+        %th.text-right
+          = t :oc_report_order_number
     %tbody
       - @customer_line_items.each do |line_item|
         %tr
@@ -96,13 +99,16 @@
             = line_item[:product_and_full_name]
           %td.text-right
             = line_item[:quantity]
-          %td
-            = line_item[:first_name]
-          %td
-            = line_item[:last_name]
+          - if @display_customer_names
+            %td
+              = line_item[:first_name]
+            %td
+              = line_item[:last_name]
           - if @display_business_name
             %td
               = line_item[:business_name]
+          %td
+            = line_item[:order_number]
 %p
   = t :producer_mail_text_after
 %p

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -15,7 +15,7 @@
       = @receival_instructions
 %p
   = t :producer_mail_order_text
-  %table.order-summary
+  %table.order-summary.line-items
     %thead
       %tr
         %th

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -86,7 +86,7 @@
           %th.text-right
             = t :business_name
         %th.text-right
-          = t :oc_report_order_number
+          = t '.order_number'
     %tbody
       - @customer_line_items.each do |line_item|
         %tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3482,6 +3482,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     pending: Pending
     shipped: Shipped
   business_name: Business Name
+  oc_report_order_number: Order Number
   js:
     saving: 'Saving...'
     changes_saved: 'Changes saved.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,6 +418,8 @@ en:
   producer_mailer:
     order_cycle:
       subject: "Order cycle report for %{producer}"
+    order_cycle_report:
+      order_number: "Order Number"
   provider_settings: "Provider settings"
   report_mailer:
     report_ready:
@@ -3482,7 +3484,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     pending: Pending
     shipped: Shipped
   business_name: Business Name
-  oc_report_order_number: Order Number
   js:
     saving: 'Saving...'
     changes_saved: 'Changes saved.'

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ProducerMailer, type: :mailer do
   end
 
   it "contains an aggregated list of produce in alphabetical order" do
-    rows = parsed_email.all('table.order-summary tbody tr:not(.total-row)')
+    rows = parsed_email.all('table.order-summary.line-items tbody tr:not(.total-row)')
     actual = rows.map do |row|
       row.all('td').map { |td| td.text.strip }
     end
@@ -153,7 +153,6 @@ RSpec.describe ProducerMailer, type: :mailer do
     end
 
     it "displays last name and first name for each order" do
-      product_name = order.line_items.first.product.name
       last_name = order.billing_address.lastname
       first_name = order.billing_address.firstname
       row = parsed_email.find("table.order-summary.customer-order tbody tr")
@@ -193,24 +192,22 @@ RSpec.describe ProducerMailer, type: :mailer do
 
     context "validate order number" do
       let(:table_header) do
-        html_body(mail).find("table.order-summary.customer-order thead")
+        parsed_email.find("table.order-summary.customer-order thead")
       end
 
       it 'displays order number for the customer' do
         expect(table_header).to have_selector("th", text: 'Order Number')
         expect(
-          html_body(mail).find("table.order-summary.customer-order tbody tr")
+          parsed_email.find("table.order-summary.customer-order tbody tr")
         ).to have_selector("td", text: order.number)
-        expect(customer_details_summary_text(mail)).to include(order.number)
       end
     end
 
     it "adds customer names in the table" do
-      html_body(mail).find(".order-summary.customer-order").tap do |table|
+      parsed_email.find(".order-summary.customer-order").tap do |table|
         expect(table).to have_selector("th", text: "First Name")
         expect(table).to have_selector("th", text: "Last Name")
       end
-      expect(customer_details_summary_text(mail)).to be_present
     end
   end
 
@@ -220,11 +217,10 @@ RSpec.describe ProducerMailer, type: :mailer do
     end
 
     it "does not add customer names in the table" do
-      html_body(mail).find(".order-summary.customer-order").tap do |table|
+      parsed_email.find(".order-summary.customer-order").tap do |table|
         expect(table).not_to have_selector("th", text: "First Name")
         expect(table).not_to have_selector("th", text: "Last Name")
       end
-      expect(customer_details_summary_text(mail)).to be_present
     end
   end
 

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -190,6 +190,28 @@ RSpec.describe ProducerMailer, type: :mailer do
         end
       end
     end
+
+    context "validate order number" do
+      let(:table_header) do
+        html_body(mail).find("table.order-summary.customer-order thead")
+      end
+
+      it 'displays order number for the customer' do
+        expect(table_header).to have_selector("th", text: 'Order Number')
+        expect(
+          html_body(mail).find("table.order-summary.customer-order tbody tr")
+        ).to have_selector("td", text: order.number)
+        expect(customer_details_summary_text(mail)).to include(order.number)
+      end
+    end
+
+    it "adds customer names in the table" do
+      html_body(mail).find(".order-summary.customer-order").tap do |table|
+        expect(table).to have_selector("th", text: "First Name")
+        expect(table).to have_selector("th", text: "Last Name")
+      end
+      expect(customer_details_summary_text(mail)).to be_present
+    end
   end
 
   context 'when flag show_customer_names_to_suppliers is false' do
@@ -197,10 +219,12 @@ RSpec.describe ProducerMailer, type: :mailer do
       order_cycle.coordinator.show_customer_names_to_suppliers = false
     end
 
-    it "does not add customer names table" do
-      expect {
-        parsed_email.find(".order-summary.customer-order")
-      }.to raise_error(Capybara::ElementNotFound)
+    it "does not add customer names in the table" do
+      html_body(mail).find(".order-summary.customer-order").tap do |table|
+        expect(table).not_to have_selector("th", text: "First Name")
+        expect(table).not_to have_selector("th", text: "Last Name")
+      end
+      expect(customer_details_summary_text(mail)).to be_present
     end
   end
 


### PR DESCRIPTION
⚠️ **Please use clockify code #12476 Flower Farms**

#### What? Why?

- Closes #13128
- This PR adds the new order number column in the order cycle report
- Along with this, we are hiding customer names (First Name or Last Name) when the coordinator doesn't allow us to view it rather than hiding the whole customer summary table.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue
- Along with it, we need to make sure that when customer names setting is off, then whole customer summary is displayed except for the customer names (First Name or Last Name).
- They should only display when the setting is on.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
