### PR TITLE
Fix expand notes field when editing order

### DIFF
--- a/app/views/spree/admin/orders/_note.html.haml
+++ b/app/views/spree/admin/orders/_note.html.haml
@@ -3,7 +3,7 @@
     %td{ colspan: "5", data: { controller: "input-char-count" }, style: "position: relative;" }
       %label
         = t(".note_label")
-        = text_field_tag :note, @order.note, { maxLength: 280, data: { "input-char-count-target": "input" } }
+      = text_field_tag :note, @order.note, { maxLength: 280, data: { "input-char-count-target": "input" } }
       %span.edit-note-count{ data: { "input-char-count-target": "count" }, style: "position: absolute; right: 7px; top: 7px; font-size: 11px;" }
 
     %td.actions

--- a/app/views/spree/admin/orders/_note.html.haml
+++ b/app/views/spree/admin/orders/_note.html.haml
@@ -1,9 +1,9 @@
 %table.index.edit-note-table
   %tr.edit-note.hidden.total
     %td{ colspan: "5", data: { controller: "input-char-count" }, style: "position: relative;" }
-      %label
+      %label{ for: "note" }
         = t(".note_label")
-      = text_field_tag :note, @order.note, { maxLength: 280, data: { "input-char-count-target": "input" } }
+      = text_area_tag :note, @order.note, { id: "note", rows: 3, maxLength: 280, data: { "input-char-count-target": "input" }, style: "width: 100%;" }
       %span.edit-note-count{ data: { "input-char-count-target": "count" }, style: "position: absolute; right: 7px; top: 7px; font-size: 11px;" }
 
     %td.actions
@@ -15,7 +15,8 @@
       - if order.note.present?
         %strong
           = t(".note_label")
-        = order.note
+        %pre{ style: "font-family: inherit;" }
+          = order.note
       - else
         = t(".no_note_present")
 


### PR DESCRIPTION
#### What? Why?

- Closes #13179

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This PR resolves an issue where the label element constrains the notes field, limiting its width.
Previously, the notes field was a child of the label element, restricting its size. This PR updates the structure so that the notes field is now a sibling of the label, allowing it to occupy the full column width.

**Demo:**

<!-- https://github.com/user-attachments/assets/57277237-f7e1-44fe-9352-09d5e6d004ee -->
https://github.com/user-attachments/assets/612ce108-cdc7-4742-a549-000230c40015



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Notes field on order edit should expand to give enough room to allow editing easily

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
