### PR TITLE
Fixes Rails TimeZone rubocop offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -516,17 +516,6 @@ Rails/LexicallyScopedActionFilter:
     - 'app/controllers/spree/admin/zones_controller.rb'
     - 'app/controllers/spree/users_controller.rb'
 
-# Offense count: 7
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: strict, flexible
-Rails/TimeZone:
-  Exclude:
-    - 'app/models/spree/gateway/pay_pal_express.rb'
-    - 'spec/controllers/spree/credit_cards_controller_spec.rb'
-    - 'spec/services/order_cycles/webhook_service_spec.rb'
-    - 'spec/services/orders/customer_cancellation_service_spec.rb'
-
 # Offense count: 1
 # Configuration parameters: TransactionMethods.
 Rails/TransactionExitStatement:

--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -97,7 +97,7 @@ module Spree
         refund_transaction_response = provider.refund_transaction(refund_transaction)
         if refund_transaction_response.success?
           payment.source.update(
-            refunded_at: Time.now,
+            refunded_at: Time.zone.now,
             refund_transaction_id: refund_transaction_response.RefundTransactionID,
             state: "refunded",
             refund_type:

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Spree::CreditCardsController, type: :controller do
         {
           format: :json,
           exp_month: 12,
-          exp_year: Time.now.year.next,
+          exp_year: Time.zone.now.year.next,
           last4: 4242,
           token:,
           cc_type: "visa"

--- a/spec/services/order_cycles/webhook_service_spec.rb
+++ b/spec/services/order_cycles/webhook_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe OrderCycles::WebhookService do
     create(
       :simple_order_cycle,
       name: "Order cycle 1",
-      orders_open_at: "2022-09-19 09:00:00".to_time,
-      orders_close_at: "2022-09-19 17:00:00".to_time,
+      orders_open_at: Time.zone.parse("2022-09-19 09:00:00"),
+      orders_close_at: Time.zone.parse("2022-09-19 17:00:00"),
       coordinator:,
     )
   }
@@ -42,8 +42,8 @@ RSpec.describe OrderCycles::WebhookService do
         data = {
           id: order_cycle.id,
           name: "Order cycle 1",
-          orders_open_at: "2022-09-19 09:00:00".to_time,
-          orders_close_at: "2022-09-19 17:00:00".to_time,
+          orders_open_at: Time.zone.parse("2022-09-19 09:00:00"),
+          orders_close_at: Time.zone.parse("2022-09-19 17:00:00"),
           coordinator_id: coordinator.id,
           coordinator_name: "Starship Enterprise",
         }

--- a/spec/services/orders/customer_cancellation_service_spec.rb
+++ b/spec/services/orders/customer_cancellation_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Orders::CustomerCancellationService do
 
   context "when an order is cancelled successfully" do
     it "notifies the distributor by email" do
-      order = create(:order, completed_at: Time.now, state: 'complete')
+      order = create(:order, completed_at: Time.zone.now, state: 'complete')
 
       Orders::CustomerCancellationService.new(order).call
 


### PR DESCRIPTION
#### What? Why?

Contributes to #11482 

[Rails/TimeZone](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstimezone) cop


#### What should we test?
Nothing. All tests should pass

Though some manual examination of the changes in `app/models/spree/gateway/pay_pal_express.rb` should be done to ensure the modification of the time stored has no impact.
#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled