### PR TITLE
Autocorrect rubocop offenses Style/RedundantAssignment and Style/RedundantArgument

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -710,12 +710,6 @@ Style/RedundantArgument:
     - 'engines/dfc_provider/app/services/authorization_control.rb'
 
 # Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantAssignment:
-  Exclude:
-    - 'spec/models/database_spec.rb'
-
-# Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AutoCorrect, AllowComments.
 Style/RedundantInitialize:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -704,13 +704,6 @@ Style/PreferredHashMethods:
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Methods.
-Style/RedundantArgument:
-  Exclude:
-    - 'engines/dfc_provider/app/services/authorization_control.rb'
-
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AutoCorrect, AllowComments.
 Style/RedundantInitialize:
   Exclude:

--- a/engines/dfc_provider/app/services/authorization_control.rb
+++ b/engines/dfc_provider/app/services/authorization_control.rb
@@ -47,7 +47,7 @@ class AuthorizationControl
   end
 
   def access_token
-    @request.headers['Authorization'].to_s.split(' ').last
+    @request.headers['Authorization'].to_s.split.last
   end
 
   def ofn_api_token

--- a/spec/models/database_spec.rb
+++ b/spec/models/database_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Database" do
     orphaned_records_query = generate_orphaned_records_query(model_class, foreign_key_table_name,
                                                              foreign_key_column)
 
-    migration = <<~MIGRATION
+    <<~MIGRATION
       # Orphaned records can be found before running this migration with the following SQL:
 
       #{orphaned_records_query}
@@ -113,8 +113,6 @@ RSpec.describe "Database" do
         end
       end
     MIGRATION
-
-    migration
   end
 
   def generate_orphaned_records_query(model_class, foreign_key_table_name, foreign_key_column)


### PR DESCRIPTION
#### What? Why?

- Applies to #13188 

Autocorrect rubocop offenses `Style/RedundantAssignment` and `Style/RedundantArgument`

#### What should we test?
One change was in a spec file, the other one should be covered by the existing `authorization_control_spec.rb` test.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
