### PR TITLE
Bump puma to v6.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -525,7 +525,7 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (5.0.5)
-    puma (6.4.2)
+    puma (6.5.0)
       nio4r (~> 2.0)
     query_count (1.1.1)
       activerecord (>= 4.2)


### PR DESCRIPTION
#### What? Why?

Bump puma to v6.5.0. To move us slightly closer to #11673 
Because there is a bug that surfaced in the rails 7.1 bump branch that was [fixed in puma v6.5.0](https://github.com/puma/puma/pull/3532) ([changelog](https://github.com/puma/puma/releases/tag/v6.5.0)).



#### What should we test?
This update should resolve the error outlined in the [Rails 7.1 build branch](https://github.com/dacook/openfoodnetwork/actions/runs/13106684816/job/36562598303). You can view the [draft branch](https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/14088760307/job/39459753422?pr=13232) with tests passing (see `system_consumer` and `system_admin`) after applying this bump. 

```
     Failure/Error: register :puma, Puma
     
     NoMethodError:
       undefined method `register' for Rackup::Handler:Module
     
             register :puma, Puma
             ^^^^^^^^
 ```

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
