### PR TITLE
Bump rspec-sql from 0.0.2 to 0.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -658,7 +658,7 @@ GEM
       rspec-support (~> 3.13)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-sql (0.0.2)
+    rspec-sql (0.0.3)
       activesupport
       rspec
     rspec-support (3.13.1)


### PR DESCRIPTION
#### What? Why?

A while ago I updated the rspec-sql gem for better output and I assumed that Dependabot would pick it up. But somehow it didn't. :shrug:

Now I was working on a spec that used `query_database 46`. My change affected the number of queries but the failed expectation didn't tell me how many queries there were now. I would have needed to count myself to 58. No, I solved that problem before. Now it would tell you what the difference is: `+12`.


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
