### PR TITLE
[API change] Remove unused ProductStock concern

### DIFF
--- a/app/models/concerns/product_stock.rb
+++ b/app/models/concerns/product_stock.rb
@@ -4,8 +4,4 @@ require 'active_support/concern'
 
 module ProductStock
   extend ActiveSupport::Concern
-
-  def on_hand
-    variants.map(&:on_hand).reduce(:+)
-  end
 end

--- a/app/models/concerns/product_stock.rb
+++ b/app/models/concerns/product_stock.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'active_support/concern'
-
-module ProductStock
-  extend ActiveSupport::Concern
-end

--- a/app/models/concerns/product_stock.rb
+++ b/app/models/concerns/product_stock.rb
@@ -5,13 +5,6 @@ require 'active_support/concern'
 module ProductStock
   extend ActiveSupport::Concern
 
-  def on_demand
-    raise 'Cannot determine product on_demand value of product with multiple variants' if
-      variants.size > 1
-
-    variants.first.on_demand
-  end
-
   def on_hand
     variants.map(&:on_hand).reduce(:+)
   end

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -18,7 +18,6 @@ require 'open_food_network/property_merge'
 #
 module Spree
   class Product < ApplicationRecord
-    include ProductStock
     include LogDestroyPerformer
 
     self.belongs_to_required_by_default = false

--- a/app/serializers/api/admin/product_serializer.rb
+++ b/app/serializers/api/admin/product_serializer.rb
@@ -3,7 +3,7 @@
 module Api
   module Admin
     class ProductSerializer < ActiveModel::Serializer
-      attributes :id, :name, :sku, :inherits_properties, :on_hand, :price, :import_date, :image_url,
+      attributes :id, :name, :sku, :inherits_properties, :price, :import_date, :image_url,
                  :thumb_url, :variants
 
       def variants

--- a/spec/controllers/api/v0/products_controller_spec.rb
+++ b/spec/controllers/api/v0/products_controller_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
       # stock info - clone is set to zero
       it '(does not) clone the stock info of the product' do
         spree_post :clone, product_id: product.id, format: :json
-        expect(json_response['on_hand']).to eq(0)
+        expect(json_response.dig("variants", 0, "on_hand")).to eq(0)
       end
 
       # variants: only the master variant of the product is cloned

--- a/spec/models/concerns/product_stock_spec.rb
+++ b/spec/models/concerns/product_stock_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require "spec_helper"
-
-RSpec.describe ProductStock do
-  let(:product) { create(:simple_product) }
-end

--- a/spec/models/concerns/product_stock_spec.rb
+++ b/spec/models/concerns/product_stock_spec.rb
@@ -4,25 +4,4 @@ require "spec_helper"
 
 RSpec.describe ProductStock do
   let(:product) { create(:simple_product) }
-
-  context "when product has one variant" do
-    describe "product.on_hand" do
-      it "is the products first variant on_hand" do
-        expect(product.on_hand).to eq(product.variants.first.on_hand)
-      end
-    end
-  end
-
-  context 'when product has more than one variant' do
-    before do
-      product.variants << create(:variant, product:)
-    end
-
-    describe "product.on_hand" do
-      it "is the sum of the products variants on_hand values" do
-        expect(product.on_hand)
-          .to eq(product.variants.first.on_hand + product.variants.second.on_hand)
-      end
-    end
-  end
 end

--- a/spec/models/concerns/product_stock_spec.rb
+++ b/spec/models/concerns/product_stock_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe ProductStock do
   let(:product) { create(:simple_product) }
 
   context "when product has one variant" do
-    describe "product.on_demand" do
-      it "is the products first variant on_demand" do
-        expect(product.on_demand).to eq(product.variants.first.on_demand)
-      end
-    end
-
     describe "product.on_hand" do
       it "is the products first variant on_hand" do
         expect(product.on_hand).to eq(product.variants.first.on_hand)
@@ -22,13 +16,6 @@ RSpec.describe ProductStock do
   context 'when product has more than one variant' do
     before do
       product.variants << create(:variant, product:)
-    end
-
-    describe "product.on_demand" do
-      it "raises error" do
-        expect { product.on_demand }
-          .to raise_error(StandardError, /Cannot determine product on_demand value/)
-      end
     end
 
     describe "product.on_hand" do

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -159,7 +159,6 @@ RSpec.describe ProductImport::ProductImporter do
 
       carrots = Spree::Product.find_by(name: 'Carrots')
       carrots_variant = carrots.variants.first
-      expect(carrots.on_hand).to eq 5
 
       expect(carrots_variant.supplier).to eq enterprise
       expect(carrots_variant.price).to eq 3.20
@@ -167,11 +166,11 @@ RSpec.describe ProductImport::ProductImporter do
       expect(carrots_variant.variant_unit).to eq 'weight'
       expect(carrots_variant.variant_unit_scale).to eq 1
       expect(carrots_variant.on_demand).not_to eq true
+      expect(carrots_variant.on_hand).to eq 5
       expect(carrots_variant.import_date).to be_within(1.minute).of Time.zone.now
 
       potatoes = Spree::Product.find_by(name: 'Potatoes')
       potatoes_variant = potatoes.variants.first
-      expect(potatoes.on_hand).to eq 6
 
       expect(potatoes_variant.supplier).to eq enterprise
       expect(potatoes_variant.price).to eq 6.50
@@ -179,11 +178,11 @@ RSpec.describe ProductImport::ProductImporter do
       expect(potatoes_variant.variant_unit).to eq 'weight'
       expect(potatoes_variant.variant_unit_scale).to eq 1000
       expect(potatoes_variant.on_demand).not_to eq true
+      expect(potatoes_variant.on_hand).to eq 6
       expect(potatoes_variant.import_date).to be_within(1.minute).of Time.zone.now
 
       pea_soup = Spree::Product.find_by(name: 'Pea Soup')
       pea_soup_variant = pea_soup.variants.first
-      expect(pea_soup.on_hand).to eq 8
 
       expect(pea_soup_variant.supplier).to eq enterprise
       expect(pea_soup_variant.price).to eq 5.50
@@ -191,11 +190,11 @@ RSpec.describe ProductImport::ProductImporter do
       expect(pea_soup_variant.variant_unit).to eq 'volume'
       expect(pea_soup_variant.variant_unit_scale).to eq 0.001
       expect(pea_soup_variant.on_demand).not_to eq true
+      expect(pea_soup_variant.on_hand).to eq 8
       expect(pea_soup_variant.import_date).to be_within(1.minute).of Time.zone.now
 
       salad = Spree::Product.find_by(name: 'Salad')
       salad_variant = salad.variants.first
-      expect(salad.on_hand).to eq 7
 
       expect(salad_variant.supplier).to eq enterprise
       expect(salad_variant.price).to eq 4.50
@@ -203,11 +202,11 @@ RSpec.describe ProductImport::ProductImporter do
       expect(salad_variant.variant_unit).to eq 'items'
       expect(salad_variant.variant_unit_scale).to eq nil
       expect(salad_variant.on_demand).not_to eq true
+      expect(salad_variant.on_hand).to eq 7
       expect(salad_variant.import_date).to be_within(1.minute).of Time.zone.now
 
       buns = Spree::Product.find_by(name: 'Hot Cross Buns')
       buns_variant = buns.variants.first
-      expect(buns.on_hand).to eq 7
 
       expect(buns_variant.supplier).to eq enterprise
       expect(buns_variant.price).to eq 3.50
@@ -215,6 +214,7 @@ RSpec.describe ProductImport::ProductImporter do
       expect(buns_variant.variant_unit).to eq 'items'
       expect(buns_variant.variant_unit_scale).to eq nil
       expect(buns_variant.on_demand).to eq true
+      expect(buns_variant.on_hand).to eq 7
       expect(buns_variant.import_date).to be_within(1.minute).of Time.zone.now
     end
   end
@@ -250,7 +250,7 @@ RSpec.describe ProductImport::ProductImporter do
 
       carrots = Spree::Product.find_by(name: 'Good Carrots')
       carrots_variant = carrots.variants.first
-      expect(carrots.on_hand).to eq 5
+      expect(carrots_variant.on_hand).to eq 5
       expect(carrots_variant.supplier).to eq enterprise
       expect(carrots_variant.price).to eq 3.20
       expect(carrots_variant.import_date).to be_within(1.minute).of Time.zone.now
@@ -298,7 +298,7 @@ RSpec.describe ProductImport::ProductImporter do
       carrots = Spree::Product.find_by(name: 'Good Carrots')
       carrots_variant = carrots.variants.first
 
-      expect(carrots.on_hand).to eq 5
+      expect(carrots_variant.on_hand).to eq 5
 
       expect(carrots_variant.primary_taxon.name).to eq "Vegetables"
       expect(carrots_variant.supplier).to eq enterprise
@@ -960,11 +960,11 @@ RSpec.describe ProductImport::ProductImporter do
 
       expect(importer.products_reset_count).to eq 7
 
-      expect(Spree::Product.find_by(name: 'Carrots').on_hand).to eq 5    # Present in file, added
-      expect(Spree::Product.find_by(name: 'Beans').on_hand).to eq 6      # Present in file, updated
-      expect(Spree::Product.find_by(name: 'Sprouts').on_hand).to eq 0    # In enterprise, not file
-      expect(Spree::Product.find_by(name: 'Cabbage').on_hand).to eq 0    # In enterprise, not file
-      expect(Spree::Product.find_by(name: 'Lettuce').on_hand)
+      expect(Spree::Product.find_by(name: 'Carrots').variants.first.on_hand).to eq 5    # Present in file, added
+      expect(Spree::Product.find_by(name: 'Beans').variants.first.on_hand).to eq 6      # Present in file, updated
+      expect(Spree::Product.find_by(name: 'Sprouts').variants.first.on_hand).to eq 0    # In enterprise, not file
+      expect(Spree::Product.find_by(name: 'Cabbage').variants.first.on_hand).to eq 0    # In enterprise, not file
+      expect(Spree::Product.find_by(name: 'Lettuce').variants.first.on_hand)
         .to eq 100 # In different enterprise; unchanged
     end
 

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -157,8 +157,7 @@ RSpec.describe ProductImport::ProductImporter do
       expect(importer.updated_ids).to be_a(Array)
       expect(importer.updated_ids.count).to eq 5
 
-      carrots = Spree::Product.find_by(name: 'Carrots')
-      carrots_variant = carrots.variants.first
+      carrots_variant = find_variant("Carrots")
 
       expect(carrots_variant.supplier).to eq enterprise
       expect(carrots_variant.price).to eq 3.20
@@ -169,8 +168,7 @@ RSpec.describe ProductImport::ProductImporter do
       expect(carrots_variant.on_hand).to eq 5
       expect(carrots_variant.import_date).to be_within(1.minute).of Time.zone.now
 
-      potatoes = Spree::Product.find_by(name: 'Potatoes')
-      potatoes_variant = potatoes.variants.first
+      potatoes_variant = find_variant("Potatoes")
 
       expect(potatoes_variant.supplier).to eq enterprise
       expect(potatoes_variant.price).to eq 6.50
@@ -181,8 +179,7 @@ RSpec.describe ProductImport::ProductImporter do
       expect(potatoes_variant.on_hand).to eq 6
       expect(potatoes_variant.import_date).to be_within(1.minute).of Time.zone.now
 
-      pea_soup = Spree::Product.find_by(name: 'Pea Soup')
-      pea_soup_variant = pea_soup.variants.first
+      pea_soup_variant = find_variant("Pea Soup")
 
       expect(pea_soup_variant.supplier).to eq enterprise
       expect(pea_soup_variant.price).to eq 5.50
@@ -193,8 +190,7 @@ RSpec.describe ProductImport::ProductImporter do
       expect(pea_soup_variant.on_hand).to eq 8
       expect(pea_soup_variant.import_date).to be_within(1.minute).of Time.zone.now
 
-      salad = Spree::Product.find_by(name: 'Salad')
-      salad_variant = salad.variants.first
+      salad_variant = find_variant("Salad")
 
       expect(salad_variant.supplier).to eq enterprise
       expect(salad_variant.price).to eq 4.50
@@ -205,8 +201,7 @@ RSpec.describe ProductImport::ProductImporter do
       expect(salad_variant.on_hand).to eq 7
       expect(salad_variant.import_date).to be_within(1.minute).of Time.zone.now
 
-      buns = Spree::Product.find_by(name: 'Hot Cross Buns')
-      buns_variant = buns.variants.first
+      buns_variant = find_variant("Hot Cross Buns")
 
       expect(buns_variant.supplier).to eq enterprise
       expect(buns_variant.price).to eq 3.50
@@ -248,8 +243,7 @@ RSpec.describe ProductImport::ProductImporter do
       expect(importer.updated_ids).to be_a(Array)
       expect(importer.updated_ids.count).to eq 1
 
-      carrots = Spree::Product.find_by(name: 'Good Carrots')
-      carrots_variant = carrots.variants.first
+      carrots_variant = find_variant("Good Carrots")
       expect(carrots_variant.on_hand).to eq 5
       expect(carrots_variant.supplier).to eq enterprise
       expect(carrots_variant.price).to eq 3.20
@@ -295,11 +289,9 @@ RSpec.describe ProductImport::ProductImporter do
 
       expect(importer.products_created_count).to eq 1
 
-      carrots = Spree::Product.find_by(name: 'Good Carrots')
-      carrots_variant = carrots.variants.first
+      carrots_variant = find_variant("Good Carrots")
 
       expect(carrots_variant.on_hand).to eq 5
-
       expect(carrots_variant.primary_taxon.name).to eq "Vegetables"
       expect(carrots_variant.supplier).to eq enterprise
       expect(carrots_variant.price).to eq 3.20
@@ -565,11 +557,11 @@ RSpec.describe ProductImport::ProductImporter do
       expect(importer.updated_ids).to be_a(Array)
       expect(importer.updated_ids.count).to eq 2
 
-      beetroot = Spree::Product.find_by(name: 'Beetroot').variants.first
+      beetroot = find_variant("Beetroot")
       expect(beetroot.price).to eq 3.50
       expect(beetroot.on_demand).not_to eq true
 
-      tomato = Spree::Product.find_by(name: 'Tomato').variants.first
+      tomato = find_variant("Tomato")
       expect(tomato.price).to eq 5.50
       expect(tomato.on_demand).to eq true
     end
@@ -960,12 +952,11 @@ RSpec.describe ProductImport::ProductImporter do
 
       expect(importer.products_reset_count).to eq 7
 
-      expect(Spree::Product.find_by(name: 'Carrots').variants.first.on_hand).to eq 5    # Present in file, added
-      expect(Spree::Product.find_by(name: 'Beans').variants.first.on_hand).to eq 6      # Present in file, updated
-      expect(Spree::Product.find_by(name: 'Sprouts').variants.first.on_hand).to eq 0    # In enterprise, not file
-      expect(Spree::Product.find_by(name: 'Cabbage').variants.first.on_hand).to eq 0    # In enterprise, not file
-      expect(Spree::Product.find_by(name: 'Lettuce').variants.first.on_hand)
-        .to eq 100 # In different enterprise; unchanged
+      expect(find_variant("Carrots").on_hand).to eq 5    # Present in file, added
+      expect(find_variant("Beans").on_hand).to eq 6      # Present in file, updated
+      expect(find_variant("Sprouts").on_hand).to eq 0    # In enterprise, not file
+      expect(find_variant("Cabbage").on_hand).to eq 0    # In enterprise, not file
+      expect(find_variant("Lettuce").on_hand).to eq 100 # In different enterprise; unchanged
     end
 
     it "can reset all inventory items for an enterprise that are not present " \
@@ -1035,6 +1026,10 @@ RSpec.describe ProductImport::ProductImporter do
         }
       )
     end
+  end
+
+  def find_variant(name)
+    Spree::Product.find_by(name:).variants.first
   end
 end
 

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Product Import" do
       carrots = Spree::Product.find_by(name: 'Carrots')
       potatoes = Spree::Product.find_by(name: 'Potatoes')
       expect(potatoes.variants.first.supplier).to eq enterprise
-      expect(potatoes.on_hand).to eq 6
+      expect(potatoes.variants.first.on_hand).to eq 6
       expect(potatoes.variants.first.price).to eq 6.50
       expect(potatoes.variants.first.import_date).to be_within(1.minute).of Time.zone.now
 
@@ -261,9 +261,9 @@ RSpec.describe "Product Import" do
       expect(page).to have_selector '.created-count', text: '1'
       expect(page).to have_selector '.reset-count', text: '3'
 
-      expect(Spree::Product.find_by(name: 'Carrots').on_hand).to eq 500
-      expect(Spree::Product.find_by(name: 'Cabbage').on_hand).to eq 0
-      expect(Spree::Product.find_by(name: 'Beans').on_hand).to eq 0
+      expect(Spree::Product.find_by(name: 'Carrots').variants.first.on_hand).to eq 500
+      expect(Spree::Product.find_by(name: 'Cabbage').variants.first.on_hand).to eq 0
+      expect(Spree::Product.find_by(name: 'Beans').variants.first.on_hand).to eq 0
     end
 
     it "can save a new product and variant of that product at the same time, " \


### PR DESCRIPTION
#### What? Why?

While looking at our over-complicated stock logic, I found some code I could remove. Stock is associated to variants, not to products. Let's make that clearer and remove the unneeded methods on the product.

This does remove one attribute from the v0 API. The products endpoint will still report stock on the variants but not on the product any more.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
