### PR TITLE
Fixes rubocop offense inverse_of on payment model

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -474,13 +474,12 @@ RSpecRails/InferredSpecType:
     - 'spec/requests/voucher_adjustments_spec.rb'
     - 'spec/routing/stripe_spec.rb'
 
-# Offense count: 2
+# Offense count: 1
 # Configuration parameters: IgnoreScopes, Include.
 # Include: app/models/**/*.rb
 Rails/InverseOf:
   Exclude:
     - 'app/models/spree/order.rb'
-    - 'app/models/spree/payment.rb'
 
 # Offense count: 35
 # Configuration parameters: Include.

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -22,6 +22,7 @@ module Spree
 
     has_many :offsets, -> { where("source_type = 'Spree::Payment' AND amount < 0").completed },
              class_name: "Spree::Payment", foreign_key: :source_id,
+             inverse_of: :source,
              dependent: :restrict_with_exception
     has_many :log_entries, as: :source, dependent: :destroy
 
@@ -113,10 +114,6 @@ module Spree
 
     def credit_allowed
       amount - offsets_total
-    end
-
-    def can_credit?
-      credit_allowed.positive?
     end
 
     def build_source

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -607,19 +607,6 @@ RSpec.describe Spree::Payment do
       end
     end
 
-    context "#can_credit?" do
-      it "is true if credit_allowed > 0" do
-        payment = build_stubbed(:payment)
-        allow(payment).to receive(:credit_allowed) { 100 }
-        expect(payment.can_credit?).to be true
-      end
-      it "is false if credit_allowed is 0" do
-        payment = build_stubbed(:payment)
-        allow(payment).to receive(:credit_allowed) { 0 }
-        expect(payment.can_credit?).to be false
-      end
-    end
-
     context "#save" do
       context "completed payments" do
         it "updates order payment total" do


### PR DESCRIPTION
#### What? Why?

Follow-up on #13226 , that address #11482 
That is, a rubocop offense [https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsinverseof](Rails/InverseOf) for one file.

This is the second issue described on #13226, see here: https://github.com/openfoodfoundation/openfoodnetwork/pull/13226#issuecomment-2753141058
I have followed the advice for the clean-up on `can_credit?` unused method.


#### What should we test?
Nothing. All tests should pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
