### PR TITLE
Fixes button staying disabled after report fail

### DIFF
--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -47,10 +47,14 @@ class ReportJob < ApplicationJob
   end
 
   def broadcast_error(channel)
-    cable_ready[channel].inner_html(
-      selector: "#report-table",
-      html: I18n.t("report_job.report_failed")
-    ).broadcast
+    cable_ready[channel]
+      .inner_html(
+        selector: "#report-go",
+        html: Spree::Admin::BaseController.helpers.button(I18n.t(:go), "report__submit-btn")
+      ).inner_html(
+        selector: "#report-table",
+        html: I18n.t("report_job.report_failed")
+      ).broadcast
   end
 
   def actioncable_content(format, blob)

--- a/spec/support/reports_helper.rb
+++ b/spec/support/reports_helper.rb
@@ -13,6 +13,19 @@ module ReportsHelper
     expect(page).to have_button "Go", disabled: false
   end
 
+  def run_failed_report(report)
+    click_on "Go"
+
+    allow(report).to receive(:new).and_raise(StandardError, 'Provoked error for testing')
+    perform_enqueued_jobs(only: ReportJob)
+
+    expect(page).not_to have_selector ".loading"
+    expect(page).to have_button "Go", disabled: false
+    expect(page).to have_content 'This report failed. It may be too big to process. ' \
+                                 'We will look into it but please let us know ' \
+                                 'if the problem persists.'
+  end
+
   def generate_report
     run_report
     click_on "Download Report"

--- a/spec/support/reports_helper.rb
+++ b/spec/support/reports_helper.rb
@@ -13,19 +13,6 @@ module ReportsHelper
     expect(page).to have_button "Go", disabled: false
   end
 
-  def run_failed_report(report)
-    click_on "Go"
-
-    allow(report).to receive(:new).and_raise(StandardError, 'Provoked error for testing')
-    perform_enqueued_jobs(only: ReportJob)
-
-    expect(page).not_to have_selector ".loading"
-    expect(page).to have_button "Go", disabled: false
-    expect(page).to have_content 'This report failed. It may be too big to process. ' \
-                                 'We will look into it but please let us know ' \
-                                 'if the problem persists.'
-  end
-
   def generate_report
     run_report
     click_on "Download Report"

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -352,7 +352,24 @@ RSpec.describe '
       visit admin_reports_path
 
       click_link 'All products'
-      run_failed_report(Reporting::Reports::ProductsAndInventory::AllProducts)
+      report = Reporting::Reports::ProductsAndInventory::AllProducts
+
+      click_on "Go"
+
+      allow(report).to receive(:new).and_raise(StandardError, 'Provoked error for testing')
+      perform_enqueued_jobs(only: ReportJob)
+
+      expect(page).not_to have_selector ".loading"
+      expect(page).to have_button "Go", disabled: false
+      expect(page).to have_content 'This report failed. It may be too big to process. ' \
+                                   'We will look into it but please let us know ' \
+                                   'if the problem persists.'
+
+      # Admin shoulb be able to make some changes and retry
+      sleep(1)
+      allow(report).to receive(:new).and_call_original
+
+      run_report
     end
 
     it "shows products and inventory report" do

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -366,10 +366,10 @@ RSpec.describe '
                                    'if the problem persists.'
 
       # Admin shoulb be able to make some changes and retry
-      sleep(1)
       allow(report).to receive(:new).and_call_original
 
       run_report
+      expect(page).to have_content "Supplier"
     end
 
     it "shows products and inventory report" do

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -347,6 +347,14 @@ RSpec.describe '
       variant3.update!(sku: "")
     end
 
+    it "shows report error at the bottom of page" do
+      login_as_admin
+      visit admin_reports_path
+
+      click_link 'All products'
+      run_failed_report(Reporting::Reports::ProductsAndInventory::AllProducts)
+    end
+
     it "shows products and inventory report" do
       login_as_admin
       visit admin_reports_path


### PR DESCRIPTION
#### What? Why?

Closes #12801 

After a failed report, "Go" button used to remain disabled.
It was not implemented.
Button is disabled during loading time and is now enabled again in case of report failure.


#### What should we test?
Replaying the steps provided by @drummer83 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.