### PR TITLE
Fix Rubocop InverseOf offense in Order model

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -474,13 +474,6 @@ RSpecRails/InferredSpecType:
     - 'spec/requests/voucher_adjustments_spec.rb'
     - 'spec/routing/stripe_spec.rb'
 
-# Offense count: 1
-# Configuration parameters: IgnoreScopes, Include.
-# Include: app/models/**/*.rb
-Rails/InverseOf:
-  Exclude:
-    - 'app/models/spree/order.rb'
-
 # Offense count: 35
 # Configuration parameters: Include.
 # Include: app/controllers/**/*.rb, app/mailers/**/*.rb

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -43,7 +43,7 @@ module Spree
     has_many :state_changes, as: :stateful, dependent: :destroy
     has_many :line_items, -> {
                             order('created_at ASC')
-                          }, class_name: "Spree::LineItem", dependent: :destroy
+                          }, class_name: "Spree::LineItem", inverse_of: :order, dependent: :destroy
     has_many :payments, dependent: :destroy
     has_many :return_authorizations, dependent: :destroy, inverse_of: :order
     has_many :adjustments, -> { order "#{Spree::Adjustment.table_name}.created_at ASC" },

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -189,8 +189,8 @@ RSpec.describe Spree::OrderContents do
 
         subject.update_item(line_item, { quantity: 3 })
       end
-
       it "updates the order's enterprise fees if completed" do
+        order.shipments << create(:shipment)
         allow(order).to receive(:completed?) { true }
         expect(order).to receive(:update_order_fees!)
 


### PR DESCRIPTION
#### What? Why?

Follow-up on #13226 , that address #11482 
That is, a rubocop offense [https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsinverseof](Rails/InverseOf) for one file.

This is the first issue described on #13226, see here: https://github.com/openfoodfoundation/openfoodnetwork/pull/13226#issuecomment-2752796288
I have so modified the spec that is was failing by adding `inverse_of`


#### What should we test?
Nothing. All tests should pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.