### PR TITLE
Use translation for none in reports

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1760,6 +1760,7 @@ en:
       email_confirmation: "Email confirmation is pending. We've sent a confirmation email to %{email}."
       not_visible: "%{enterprise} is not visible and so cannot be found on the map or in searches"
     reports:
+      none: none
       deprecated: "This report is deprecated and will be removed in a future release."
       hidden: HIDDEN
       unitsize: UNITSIZE

--- a/lib/reporting/report_row_builder.rb
+++ b/lib/reporting/report_row_builder.rb
@@ -79,7 +79,7 @@ module Reporting
 
     # rubocop:disable Metrics/CyclomaticComplexity
     def format_cell(value, column = nil)
-      return "none" if value.nil?
+      return I18n.t("admin.reports.none") if value.nil?
 
       # Currency
       if report.columns_format[column] == :currency


### PR DESCRIPTION
#### What? Why?

- Closes #13021

When tax category is null for a product then by default the row value is set to none. Changing the return value to `I18n("none")` returns the value none in the appropriate translation.



#### What should we test?
1. Login as an admin.
2. Go to profile icon -> administration.
3. Click on Reports.
4. Scroll down to All Products and click on it.
5. Generate a report for a product without a tax category.


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
