### PR TITLE
Fix Order Cycle search on BOM page is not working for more than 5 OCs

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -97,7 +97,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
 
   $scope.loadAssociatedData = ->
     RequestMonitor.load $scope.distributors = Enterprises.index(action: "visible", ams_prefix: "basic", "q[sells_in][]": ["own", "any"])
-    RequestMonitor.load $scope.orderCycles = OrderCycles.index(ams_prefix: "basic", as: "distributor", "q[orders_close_at_gt]": "#{moment().subtract(90,'days').format()}")
+    RequestMonitor.load $scope.orderCycles = OrderCycles.index(ams_prefix: "basic", as: "distributor", "q[orders_close_at_gt]": "#{moment().subtract(1,'year').format()}")
     RequestMonitor.load $scope.suppliers = Enterprises.index(action: "visible", ams_prefix: "basic", "q[is_primary_producer_eq]": "true")
 
   $scope.dereferenceLoadedData = ->

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -704,12 +704,12 @@ RSpec.describe '
                                           completed_at: 1.week.from_now,
                                           order_cycle: oc3 )
         }
-        let!(:o4) {
+        let!(:o3a) {
           create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
                                           completed_at: 2.weeks.from_now,
                                           order_cycle: oc3 )
         }
-        let!(:o5) {
+        let!(:o4) {
           create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
                                           completed_at: 100.days.ago,
                                           order_cycle: oc4 )
@@ -717,7 +717,7 @@ RSpec.describe '
         let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
         let!(:li2) { create(:line_item_with_shipment, order: o2 ) }
         let!(:li3) { create(:line_item_with_shipment, order: o3 ) }
-        let!(:li4) { create(:line_item_with_shipment, order: o4 ) }
+        let!(:li3a) { create(:line_item_with_shipment, order: o3a ) }
 
         before do
           oc3.update!(orders_close_at: 2.weeks.from_now)

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -681,6 +681,14 @@ RSpec.describe '
         let!(:oc1) { create(:simple_order_cycle, distributors: [distributor]) }
         let!(:oc2) { create(:simple_order_cycle, distributors: [distributor]) }
         let!(:oc3) { create(:simple_order_cycle, distributors: [distributor]) }
+        let!(:oc4) do
+          create(
+            :simple_order_cycle,
+            orders_close_at: 364.days.ago,
+            orders_open_at: 400.days.ago,
+            distributors: [distributor]
+          )
+        end
         let!(:o1) {
           create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
                                           completed_at: Time.zone.now,
@@ -700,6 +708,11 @@ RSpec.describe '
           create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
                                           completed_at: 2.weeks.from_now,
                                           order_cycle: oc3 )
+        }
+        let!(:o5) {
+          create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
+                                          completed_at: 100.days.ago,
+                                          order_cycle: oc4 )
         }
         let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
         let!(:li2) { create(:line_item_with_shipment, order: o2 ) }

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -718,13 +718,14 @@ RSpec.describe '
         let!(:li2) { create(:line_item_with_shipment, order: o2 ) }
         let!(:li3) { create(:line_item_with_shipment, order: o3 ) }
         let!(:li3a) { create(:line_item_with_shipment, order: o3a ) }
+        let!(:li4) { create(:line_item_with_shipment, order: o4 ) }
 
         before do
           oc3.update!(orders_close_at: 2.weeks.from_now)
           oc3.update!(orders_open_at: 1.week.from_now)
           visit_bulk_order_management
 
-          expect_line_items(li1, li2)
+          expect_line_items(li1, li2, li3, li3a, li4)
           select2_select oc1.name, from: "order_cycle_filter"
           page.find('.filter-actions .button.icon-search').click
         end
@@ -736,12 +737,14 @@ RSpec.describe '
           expect(page).not_to have_selector "#loading i"
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).not_to have_selector "tr#li_#{li2.id}"
+          expect(page).not_to have_selector "tr#li_#{li3.id}"
+          expect(page).not_to have_selector "tr#li_#{li4.id}"
         end
 
         it "displays all line items when 'All' is selected from order_cycle filter", retry: 3 do
           select2_select "All", from: "order_cycle_filter"
           page.find('.filter-actions .button.icon-search').click
-          expect_line_items(li1, li2)
+          expect_line_items(li1, li2, li3, li3a, li4)
         end
       end
 

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -191,42 +191,42 @@ RSpec.describe '
         fill_in "quick_filter", with: li1.product.name
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
       end
 
       it "by supplier name" do
         fill_in "quick_filter", with: li1.variant.supplier.name
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
       end
 
       it "by email" do
         fill_in "quick_filter", with: o1.email
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
       end
 
       it "by order number" do
         fill_in "quick_filter", with: o1.number
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
       end
 
       it "by phone number" do
         fill_in "quick_filter", with: o1.bill_address.phone
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
       end
 
       it "by distributor name" do
         fill_in "quick_filter", with: o1.distributor.name
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
       end
 
       it "by customer name" do
@@ -234,59 +234,59 @@ RSpec.describe '
         fill_in "quick_filter", with: o1.bill_address.firstname
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
 
         # by lastname
         fill_in "quick_filter", with: o1.bill_address.lastname
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
 
         # by fullname
         fill_in "quick_filter", with: "#{o1.bill_address.firstname} #{o1.bill_address.lastname}"
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
 
         fill_in "quick_filter", with: "#{o2.bill_address.firstname} #{o2.bill_address.lastname}"
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li2, li3], [li1]
+        expect_line_items li2, li3, excluding: [li1]
 
         # by fullname reversed
         fill_in "quick_filter", with: "#{o1.bill_address.lastname} #{o1.bill_address.firstname}"
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
 
         fill_in "quick_filter", with: "#{o2.bill_address.lastname} #{o2.bill_address.firstname}"
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li2, li3], [li1]
+        expect_line_items li2, li3, excluding: [li1]
 
         # by fullname with comma
         fill_in "quick_filter", with: "#{o1.bill_address.firstname}, #{o1.bill_address.lastname}"
 
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
 
         fill_in "quick_filter", with: "#{o2.bill_address.firstname}, #{o2.bill_address.lastname}"
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li2, li3], [li1]
+        expect_line_items li2, li3, excluding: [li1]
 
         # by fullname with comma reversed
         fill_in "quick_filter", with: "#{o1.bill_address.lastname}, #{o1.bill_address.firstname}"
 
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li1], [li2, li3]
+        expect_line_items li1, excluding: [li2, li3]
 
         fill_in "quick_filter", with: "#{o2.bill_address.lastname}, #{o2.bill_address.firstname}"
         page.find('.filter-actions .button.icon-search').click
 
-        expect_line_items_results [li2, li3], [li1]
+        expect_line_items li2, li3, excluding: [li1]
       end
     end
 
@@ -1313,15 +1313,6 @@ RSpec.describe '
     end
     excluding.each do |line_item|
       expect(page).not_to have_selector "tr#li_#{line_item.id}"
-    end
-  end
-
-  def expect_line_items_results(line_items, excluded_line_items)
-    line_items.each do |li|
-      expect(page).to have_selector "tr#li_#{li.id}"
-    end
-    excluded_line_items.each do |li|
-      expect(page).not_to have_selector "tr#li_#{li.id}"
     end
   end
 end

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -735,10 +735,8 @@ RSpec.describe '
           expect(page).to have_select2 'order_cycle_filter',
                                        with_options: OrderCycle.pluck(:name).unshift("All")
           expect(page).not_to have_selector "#loading i"
-          expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).not_to have_selector "tr#li_#{li2.id}"
-          expect(page).not_to have_selector "tr#li_#{li3.id}"
-          expect(page).not_to have_selector "tr#li_#{li4.id}"
+
+          expect_line_items(li1, excluding: [li2, li3, li3a, li4])
         end
 
         it "displays all line items when 'All' is selected from order_cycle filter", retry: 3 do
@@ -1309,9 +1307,12 @@ RSpec.describe '
     expect(page).not_to have_text 'Loading orders'
   end
 
-  def expect_line_items(*line_items)
+  def expect_line_items(*line_items, excluding: [])
     line_items.each do |line_item|
       expect(page).to have_selector "tr#li_#{line_item.id}"
+    end
+    excluding.each do |line_item|
+      expect(page).not_to have_selector "tr#li_#{line_item.id}"
     end
   end
 

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -724,7 +724,7 @@ RSpec.describe '
           oc3.update!(orders_open_at: 1.week.from_now)
           visit_bulk_order_management
 
-          displays_default_orders
+          expect_line_items(li1, li2)
           select2_select oc1.name, from: "order_cycle_filter"
           page.find('.filter-actions .button.icon-search').click
         end
@@ -741,7 +741,7 @@ RSpec.describe '
         it "displays all line items when 'All' is selected from order_cycle filter", retry: 3 do
           select2_select "All", from: "order_cycle_filter"
           page.find('.filter-actions .button.icon-search').click
-          displays_default_orders
+          expect_line_items(li1, li2)
         end
       end
 
@@ -1306,9 +1306,10 @@ RSpec.describe '
     expect(page).not_to have_text 'Loading orders'
   end
 
-  def displays_default_orders
-    expect(page).to have_selector "tr#li_#{li1.id}"
-    expect(page).to have_selector "tr#li_#{li2.id}"
+  def expect_line_items(*line_items)
+    line_items.each do |line_item|
+      expect(page).to have_selector "tr#li_#{line_item.id}"
+    end
   end
 
   def expect_line_items_results(line_items, excluded_line_items)

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -676,7 +676,7 @@ RSpec.describe '
         end
       end
 
-      context "order_cycle filter" do
+      context "order_cycle filter selected" do
         let!(:distributor) { create(:distributor_enterprise) }
         let!(:oc1) { create(:simple_order_cycle, distributors: [distributor]) }
         let!(:oc2) { create(:simple_order_cycle, distributors: [distributor]) }
@@ -723,26 +723,22 @@ RSpec.describe '
           oc3.update!(orders_close_at: 2.weeks.from_now)
           oc3.update!(orders_open_at: 1.week.from_now)
           visit_bulk_order_management
+
+          displays_default_orders
+          select2_select oc1.name, from: "order_cycle_filter"
+          page.find('.filter-actions .button.icon-search').click
         end
 
         it "displays a select box for order cycles, which filters line items " \
            "by the selected order cycle", retry: 3 do
-          displays_default_orders
           expect(page).to have_select2 'order_cycle_filter',
                                        with_options: OrderCycle.pluck(:name).unshift("All")
-          select2_select oc1.name, from: "order_cycle_filter"
-          page.find('.filter-actions .button.icon-search').click
           expect(page).not_to have_selector "#loading i"
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).not_to have_selector "tr#li_#{li2.id}"
         end
 
         it "displays all line items when 'All' is selected from order_cycle filter", retry: 3 do
-          displays_default_orders
-          select2_select oc1.name, from: "order_cycle_filter"
-          page.find('.filter-actions .button.icon-search').click
-          expect(page).to have_selector "tr#li_#{li1.id}"
-          expect(page).not_to have_selector "tr#li_#{li2.id}"
           select2_select "All", from: "order_cycle_filter"
           page.find('.filter-actions .button.icon-search').click
           displays_default_orders


### PR DESCRIPTION
#### What? Why?

- Closes #13180
- Previously, we were displaying only those orders which are closed within 90 days.
- Due to this, OCs that have an active order but have been closed 90 or more days ago to be missing in the filter dropdown.
- This PR made respective changes to display all the available order cycles regardless of the closed date in the dropdown.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
