### PR TITLE
Fix HTML entity display in supplier + product names on /admin/inventory

### DIFF
--- a/app/assets/javascripts/templates/admin/panels/exchange_products_distributed.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_distributed.html.haml
@@ -16,8 +16,8 @@
         .exchange-product-details
           %label
             %img{'ng-src' => '{{ product.image_url }}'}
-            .name {{ product.name }}
-          .supplier {{ product.supplier_name }}
+            .name {{ 'ng-bind' => 'product.name' }}
+          .supplier {{ 'ng-bind' => 'product.supplier_name' }}
 
         .exchange-product-variant{'ng-repeat' => 'variant in product.variants | visibleVariants:exchange:order_cycle.visible_variants_for_outgoing_exchanges | filter:variantSuppliedToOrderCycle as filteredVariants'}
           %label


### PR DESCRIPTION
# Fix HTML Entity Display in Supplier + Product Names on `/admin/inventory`

## What? Why?

This PR fixes an issue where supplier and product names containing HTML character entities (e.g. `&#227;`) were rendered as raw text on the `/admin/inventory` page.

For example, a supplier name intended to appear as:

```
Pãtes du Contentin
```

would incorrectly display as:

```
P&#227;tes du Contentin
```

**Cause:**  
AngularJS’s `{{ ... }}` interpolation inserts raw strings into the DOM without decoding HTML entities.

**Fix:**

Replaced
`.name {{ 'product.name' }}`

With
`.name {{ 'ng-bind' => 'product.name' }}`

Replaced
`.supplier {{ 'product.supplier_name' }}`
With          
`.supplier {{ 'ng-bind' => 'product.supplier_name' }}`

This allows the browser to decode and render characters correctly.


---

## What Should We Test?

- Visit `/admin/inventory`
- Look for supplier names with characters like `ã`, `ü`, `’`, `é`, etc.
- Confirm names display correctly (e.g. `Pãtes`, `Jürgen’s Kürbis-Hof`, `François`)
- Ensure there are no visible HTML entities (e.g. `&#227;`, `&uuml;`, `&rsquo;`)
- Confirm filtering, sorting, and page functionality remain unaffected

---

## Release Notes

**Changelog Category:**
- [x] User facing changes  
- [ ] API changes (V0, V1, DFC or Webhook)  
- [ ] Technical changes only  
- [ ] Feature toggled  

**Pull Request Title:**  
Fix HTML entity display in supplier + product names on /admin/inventory

---

## Dependencies

None.

---

## Documentation Updates

None needed.