### PR TITLE
Fixes Rubocop Naming/AccessorMethodName offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,10 +221,9 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 3
+# Offense count: 2
 Naming/AccessorMethodName:
   Exclude:
-    - 'lib/spree/core/controller_helpers/common.rb'
     - 'spec/support/request/shop_workflow.rb'
     - 'spec/support/request/web_helper.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,10 +221,9 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 7
+# Offense count: 6
 Naming/AccessorMethodName:
   Exclude:
-    - 'app/mailers/producer_mailer.rb'
     - 'app/models/spree/order.rb'
     - 'app/services/checkout/post_checkout_actions.rb'
     - 'lib/spree/core/controller_helpers/common.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,10 +221,9 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 6
+# Offense count: 4
 Naming/AccessorMethodName:
   Exclude:
-    - 'app/models/spree/order.rb'
     - 'app/services/checkout/post_checkout_actions.rb'
     - 'lib/spree/core/controller_helpers/common.rb'
     - 'spec/support/request/shop_workflow.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -222,11 +222,6 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/order/checkout.rb'
 
 # Offense count: 1
-Naming/AccessorMethodName:
-  Exclude:
-    - 'spec/support/request/web_helper.rb'
-
-# Offense count: 1
 # Configuration parameters: ForbiddenDelimiters.
 # ForbiddenDelimiters: (?i-mx:(^|\s)(EO[A-Z]{1}|END)(\s|$))
 Naming/HeredocDelimiterNaming:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,10 +221,9 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 4
+# Offense count: 3
 Naming/AccessorMethodName:
   Exclude:
-    - 'app/services/checkout/post_checkout_actions.rb'
     - 'lib/spree/core/controller_helpers/common.rb'
     - 'spec/support/request/shop_workflow.rb'
     - 'spec/support/request/web_helper.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,10 +221,9 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 2
+# Offense count: 1
 Naming/AccessorMethodName:
   Exclude:
-    - 'spec/support/request/shop_workflow.rb'
     - 'spec/support/request/web_helper.rb'
 
 # Offense count: 1

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -25,6 +25,6 @@ class BaseController < ApplicationController
   def set_order_cycle
     return if @order_cycles.count != 1
 
-    current_order(true).set_order_cycle! @order_cycles.first
+    current_order(true).assign_order_cycle! @order_cycles.first
   end
 end

--- a/app/controllers/concerns/order_completion.rb
+++ b/app/controllers/concerns/order_completion.rb
@@ -26,7 +26,7 @@ module OrderCompletion
   # Builds an order setting the token and distributor of the one specified
   def build_new_order(distributor, token)
     new_order = current_order(true)
-    new_order.set_distributor!(distributor)
+    new_order.assign_distributor!(distributor)
     new_order.tokenized_permission.token = token
     new_order.tokenized_permission.save!
   end

--- a/app/controllers/concerns/order_stock_check.rb
+++ b/app/controllers/concerns/order_stock_check.rb
@@ -25,7 +25,7 @@ module OrderStockCheck
 
     Alert.raise_with_record("Notice: order cycle closed during checkout completion", current_order)
     current_order.empty!
-    current_order.set_order_cycle! nil
+    current_order.assign_order_cycle! nil
 
     flash[:info] = I18n.t('order_cycle_closed')
     respond_to do |format|

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -11,7 +11,7 @@ class ShopController < BaseController
   def order_cycle
     if request.post?
       if oc = OrderCycle.with_distributor(@distributor).active.find_by(id: params[:order_cycle_id])
-        current_order(true).set_order_cycle! oc
+        current_order(true).assign_order_cycle! oc
         @current_order_cycle = oc
         render json: @current_order_cycle, serializer: Api::OrderCycleSerializer
       else

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -37,7 +37,7 @@ class ProducerMailer < ApplicationMailer
     @receival_instructions = @order_cycle.receival_instructions_for(@producer)
     @total = total_from_line_items(line_items)
     @tax_total = tax_total_from_line_items(line_items)
-    @customer_line_items = set_customer_data(line_items)
+    @customer_line_items = customer_data(line_items)
   end
 
   def subject
@@ -76,7 +76,7 @@ class ProducerMailer < ApplicationMailer
     Spree::Money.new line_items.to_a.sum(&:included_tax)
   end
 
-  def set_customer_data(line_items)
+  def customer_data(line_items)
     return unless @coordinator.show_customer_names_to_suppliers?
 
     @display_business_name = false

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -560,7 +560,7 @@ module Spree
       end
     end
 
-    def set_order_cycle!(order_cycle)
+    def assign_order_cycle!(order_cycle)
       return if self.order_cycle == order_cycle
 
       self.order_cycle = order_cycle
@@ -573,7 +573,7 @@ module Spree
       line_items.includes(variant: :stock_items).find_each(&:cap_quantity_at_stock!)
     end
 
-    def set_distributor!(distributor)
+    def assign_distributor!(distributor)
       self.distributor = distributor
       self.order_cycle = nil unless order_cycle&.has_distributor? distributor
       save!

--- a/app/services/checkout/post_checkout_actions.rb
+++ b/app/services/checkout/post_checkout_actions.rb
@@ -8,7 +8,7 @@ module Checkout
     end
 
     def success(params, current_user)
-      set_customer_terms_and_conditions_accepted_at(params)
+      assign_customer_terms_and_conditions_accepted_at(params)
       save_order_addresses_as_user_default(params, current_user)
     end
 
@@ -27,7 +27,7 @@ module Checkout
       user_default_address_setter.set_default_ship_address if params[:order][:default_ship_address]
     end
 
-    def set_customer_terms_and_conditions_accepted_at(params)
+    def assign_customer_terms_and_conditions_accepted_at(params)
       return unless params[:order]
 
       return unless params[:order][:terms_and_conditions_accepted]

--- a/app/services/orders/cart_reset_service.rb
+++ b/app/services/orders/cart_reset_service.rb
@@ -13,7 +13,7 @@ module Orders
     def reset_distributor
       if order.distributor && order.distributor != distributor
         order.empty!
-        order.set_order_cycle! nil
+        order.assign_order_cycle! nil
       end
       order.distributor = distributor
     end

--- a/lib/spree/core/controller_helpers/common.rb
+++ b/lib/spree/core/controller_helpers/common.rb
@@ -10,7 +10,7 @@ module Spree
           helper_method :title=
           helper_method :accurate_title
 
-          layout :get_layout
+          layout :pick_layout
 
           before_action :set_user_language
 
@@ -65,7 +65,7 @@ module Spree
           # Returns which layout to render.
           #   The layout to render can be set inside Spree configuration with the +:layout+ option.
           # Default layout is: +app/views/spree/layouts/spree_application+
-          def get_layout
+          def pick_layout
             Spree::Config[:layout]
           end
         end

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe EnterprisesController, type: :controller do
     }
 
     before do
-      order.set_distributor! current_distributor
+      order.assign_distributor! current_distributor
       order.line_items << line_item
     end
 

--- a/spec/controllers/payment_gateways/stripe_controller_spec.rb
+++ b/spec/controllers/payment_gateways/stripe_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe PaymentGateways::StripeController, type: :controller do
           expect(controller).to receive(:current_order).and_return(order).at_least(:once)
           expect(order_cycle).to receive(:closed?).and_return(true)
           expect(order).to receive(:empty!)
-          expect(order).to receive(:set_order_cycle!).with(nil)
+          expect(order).to receive(:assign_order_cycle!).with(nil)
 
           get :confirm, params: { payment_intent: "pi_123" }
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -796,7 +796,7 @@ RSpec.describe Spree::Order do
   describe "setting the distributor" do
     it "sets the distributor when no order cycle is set" do
       d = create(:distributor_enterprise)
-      subject.set_distributor! d
+      subject.assign_distributor! d
       expect(subject.distributor).to eq(d)
     end
 
@@ -806,7 +806,7 @@ RSpec.describe Spree::Order do
       create(:exchange, order_cycle: oc, sender: oc.coordinator, receiver: d, incoming: false)
 
       subject.order_cycle = oc
-      subject.set_distributor! d
+      subject.assign_distributor! d
 
       expect(subject.distributor).to eq(d)
       expect(subject.order_cycle).to eq(oc)
@@ -817,7 +817,7 @@ RSpec.describe Spree::Order do
       oc = create(:simple_order_cycle)
 
       subject.order_cycle = oc
-      subject.set_distributor! d
+      subject.assign_distributor! d
 
       expect(subject.distributor).to eq(d)
       expect(subject.order_cycle).to be_nil
@@ -825,8 +825,8 @@ RSpec.describe Spree::Order do
 
     it "clears the distributor when setting to nil" do
       d = create(:distributor_enterprise)
-      subject.set_distributor! d
-      subject.set_distributor! nil
+      subject.assign_distributor! d
+      subject.assign_distributor! nil
 
       expect(subject.distributor).to be_nil
     end
@@ -853,16 +853,16 @@ RSpec.describe Spree::Order do
 
     it "empties the cart when changing the order cycle" do
       expect(subject).to receive(:empty!)
-      subject.set_order_cycle! oc
+      subject.assign_order_cycle! oc
     end
 
     it "doesn't empty the cart if the order cycle is not different" do
       expect(subject).not_to receive(:empty!)
-      subject.set_order_cycle! subject.order_cycle
+      subject.assign_order_cycle! subject.order_cycle
     end
 
     it "sets the order cycle when no distributor is set" do
-      subject.set_order_cycle! oc
+      subject.assign_order_cycle! oc
       expect(subject.order_cycle).to eq(oc)
     end
 
@@ -871,7 +871,7 @@ RSpec.describe Spree::Order do
       create(:exchange, order_cycle: oc, sender: oc.coordinator, receiver: d, incoming: false)
 
       subject.distributor = d
-      subject.set_order_cycle! oc
+      subject.assign_order_cycle! oc
 
       expect(subject.order_cycle).to eq(oc)
       expect(subject.distributor).to eq(d)
@@ -881,7 +881,7 @@ RSpec.describe Spree::Order do
       d = create(:distributor_enterprise)
 
       subject.distributor = d
-      subject.set_order_cycle! oc
+      subject.assign_order_cycle! oc
 
       expect(subject.order_cycle).to eq(oc)
       expect(subject.distributor).to be_nil
@@ -889,10 +889,10 @@ RSpec.describe Spree::Order do
 
     it "clears the order cycle when setting to nil" do
       d = create(:distributor_enterprise)
-      subject.set_order_cycle! oc
+      subject.assign_order_cycle! oc
       subject.distributor = d
 
-      subject.set_order_cycle! nil
+      subject.assign_order_cycle! nil
 
       expect(subject.order_cycle).to be_nil
       expect(subject.distributor).to eq(d)

--- a/spec/requests/checkout/concurrency_spec.rb
+++ b/spec/requests/checkout/concurrency_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Concurrent checkouts", concurrency: true do
     order.next # => payment
     order.next # => confirmation
 
-    set_order(order)
+    pick_order(order)
     login_as(order.user)
   end
 

--- a/spec/requests/checkout/paypal_spec.rb
+++ b/spec/requests/checkout/paypal_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "checking out an order with a paypal express payment method", typ
     expect(order.next).to be true # => address
     expect(order.next).to be true # => delivery
     expect(order.next).to be true # => payment
-    set_order order
+    pick_order order
 
     stub_paypal_confirm
   end

--- a/spec/requests/checkout/routes_spec.rb
+++ b/spec/requests/checkout/routes_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'checkout endpoints', type: :request do
     allow(order_cycle_distributed_variants).to receive(:distributes_order_variants?)
       .and_return(true)
 
-    set_order order
+    pick_order order
   end
 
   context "when getting the cart `/checkout/cart`" do

--- a/spec/requests/checkout/stripe_sca_spec.rb
+++ b/spec/requests/checkout/stripe_sca_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "checking out an order with a Stripe SCA payment method", type: :
     Stripe.api_key = "sk_test_12345"
     order.update(distributor_id: enterprise.id, order_cycle_id: order_cycle.id)
     order.reload.update_totals
-    set_order order
+    pick_order order
 
     # Authorizes the payment
     stub_request(:post, "https://api.stripe.com/v1/payment_intents")

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -33,7 +33,7 @@ module ShopWorkflow
     order_cycle.exchanges.outgoing.first.enterprise_fees << enterprise_fee
   end
 
-  def set_order(order)
+  def pick_order(order)
     allow_any_instance_of(ApplicationController).to receive(:session).and_return(
       order_id: order.id, access_token: order.token
     )

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -33,7 +33,7 @@ module WebHelper
     page.execute_script("I18n.locale = '#{locale}'")
   end
 
-  def get_i18n_locale
+  def pick_i18n_locale
     page.evaluate_script("I18n.locale;")
   end
 

--- a/spec/system/admin/multilingual_spec.rb
+++ b/spec/system/admin/multilingual_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe 'Multilingual' do
   end
 
   it 'can switch language by params' do
-    expect(get_i18n_locale).to eq 'en'
+    expect(pick_i18n_locale).to eq 'en'
     expect(get_i18n_translation('spree_admin_overview_enterprises_header')).to eq 'My Enterprises'
     expect(page).to have_content 'My Enterprises'
     expect(admin_user.locale).to be_nil
 
     visit spree.admin_dashboard_path(locale: 'es')
-    expect(get_i18n_locale).to eq 'es'
+    expect(pick_i18n_locale).to eq 'es'
     expect(get_i18n_translation('spree_admin_overview_enterprises_header'))
       .to eq 'Mis Organizaciones'
     expect(page).to have_content 'Mis Organizaciones'
@@ -35,7 +35,7 @@ RSpec.describe 'Multilingual' do
 
   it 'fallbacks to default_locale' do
     visit spree.admin_dashboard_path(locale: 'it')
-    expect(get_i18n_locale).to eq 'en'
+    expect(pick_i18n_locale).to eq 'en'
     expect(get_i18n_translation('spree_admin_overview_enterprises_header')).to eq 'My Enterprises'
     expect(page).to have_content 'My Enterprises'
     expect(admin_user.locale).to be_nil

--- a/spec/system/consumer/checkout/backorder_spec.rb
+++ b/spec/system/consumer/checkout/backorder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Checkout" do
 
   before do
     variant.semantic_links << SemanticLink.new(semantic_id: "https://product")
-    set_order order
+    pick_order order
     login_as create(:user)
   end
 

--- a/spec/system/consumer/checkout/details_spec.rb
+++ b/spec/system/consumer/checkout/details_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "As a consumer, I want to checkout my order" do
 
   before do
     add_enterprise_fee enterprise_fee
-    set_order order
+    pick_order order
 
     distributor.shipping_methods.push(shipping_methods)
   end

--- a/spec/system/consumer/checkout/guest_spec.rb
+++ b/spec/system/consumer/checkout/guest_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "As a consumer, I want to checkout my order" do
 
   before do
     add_enterprise_fee enterprise_fee
-    set_order order
+    pick_order order
 
     distributor.shipping_methods.push(shipping_methods)
   end

--- a/spec/system/consumer/checkout/payment_spec.rb
+++ b/spec/system/consumer/checkout/payment_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "As a consumer, I want to checkout my order" do
 
   before do
     add_enterprise_fee enterprise_fee
-    set_order order
+    pick_order order
 
     distributor.shipping_methods.push(free_shipping_with_required_address)
   end

--- a/spec/system/consumer/checkout/summary_spec.rb
+++ b/spec/system/consumer/checkout/summary_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "As a consumer, I want to checkout my order" do
 
   before do
     add_enterprise_fee enterprise_fee
-    set_order order
+    pick_order order
 
     distributor.shipping_methods.push(free_shipping_with_required_address)
   end

--- a/spec/system/consumer/checkout/tax_incl_spec.rb
+++ b/spec/system/consumer/checkout/tax_incl_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "As a consumer, I want to see adjustment breakdown" do
 
     describe "for a customer with shipping address within the tax zone" do
       before do
-        set_order order_within_zone
+        pick_order order_within_zone
         login_as(user_within_zone)
       end
 
@@ -200,7 +200,7 @@ RSpec.describe "As a consumer, I want to see adjustment breakdown" do
 
     describe "for a customer with shipping address outside the tax zone" do
       before do
-        set_order order_outside_zone
+        pick_order order_outside_zone
         login_as(user_outside_zone)
       end
 

--- a/spec/system/consumer/checkout/tax_not_incl_spec.rb
+++ b/spec/system/consumer/checkout/tax_not_incl_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "As a consumer, I want to see adjustment breakdown" do
 
     describe "for a customer with shipping address within the tax zone" do
       before do
-        set_order order_within_zone
+        pick_order order_within_zone
         login_as(user_within_zone)
       end
 
@@ -211,7 +211,7 @@ RSpec.describe "As a consumer, I want to see adjustment breakdown" do
 
     describe "for a customer with shipping address outside the tax zone" do
       before do
-        set_order order_outside_zone
+        pick_order order_outside_zone
         login_as(user_outside_zone)
       end
 

--- a/spec/system/consumer/multilingual_spec.rb
+++ b/spec/system/consumer/multilingual_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Multilingual' do
       let(:order) { create(:order, order_cycle:, distributor:) }
 
       before do
-        set_order order
+        pick_order order
         add_product_to_cart order, product, quantity: 1
       end
 
@@ -124,7 +124,7 @@ RSpec.describe 'Multilingual' do
         create(:order_ready_for_confirmation, distributor:)
       }
       before do
-        set_order order
+        pick_order order
         login_as user
       end
 

--- a/spec/system/consumer/multilingual_spec.rb
+++ b/spec/system/consumer/multilingual_spec.rb
@@ -25,19 +25,19 @@ RSpec.describe 'Multilingual' do
   context 'can switch language by params' do
     it 'in root path' do
       visit root_path
-      expect(get_i18n_locale).to eq 'en'
+      expect(pick_i18n_locale).to eq 'en'
       expect(get_i18n_translation('label_shops')).to eq 'Shops'
       expect(cookies_name).not_to include('locale')
       expect(page).to have_content 'SHOPS'
 
       visit root_path(locale: 'es')
-      expect(get_i18n_locale).to eq 'es'
+      expect(pick_i18n_locale).to eq 'es'
       expect(get_i18n_translation('label_shops')).to eq 'Tiendas'
       expect_menu_and_cookie_in_es
 
       # it is not in the list of available of available_locales
       visit root_path(locale: 'it')
-      expect(get_i18n_locale).to eq 'es'
+      expect(pick_i18n_locale).to eq 'es'
       expect(get_i18n_translation('label_shops')).to eq 'Tiendas'
       expect_menu_and_cookie_in_es
     end

--- a/spec/system/consumer/shopping/cart_spec.rb
+++ b/spec/system/consumer/shopping/cart_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "full-page cart" do
     let(:order) { create(:order, order_cycle:, distributor:) }
 
     before do
-      set_order order
+      pick_order order
     end
 
     describe "continue shopping" do

--- a/spec/system/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/system/consumer/shopping/checkout_auth_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "As a consumer I want to check out my cart" do
     after { Warden.test_reset! }
 
     before do
-      set_order order
+      pick_order order
       add_product_to_cart order, product
     end
 

--- a/spec/system/consumer/shopping/checkout_paypal_spec.rb
+++ b/spec/system/consumer/shopping/checkout_paypal_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Check out with Paypal" do
 
   before do
     distributor.shipping_methods << free_shipping
-    set_order order
+    pick_order order
     add_product_to_cart order, product
   end
 

--- a/spec/system/consumer/shopping/checkout_stripe_spec.rb
+++ b/spec/system/consumer/shopping/checkout_stripe_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Check out with Stripe" do
 
   before do
     stripe_enable
-    set_order order
+    pick_order order
     add_product_to_cart order, product
     distributor.shipping_methods << [shipping_with_fee, free_shipping]
   end
@@ -205,7 +205,7 @@ RSpec.describe "Check out with Stripe" do
           new_order = create(:order, user:, order_cycle:,
                                      distributor:, bill_address_id: nil,
                                      ship_address_id: nil)
-          set_order(new_order)
+          pick_order(new_order)
           add_product_to_cart(new_order, product, quantity: 10)
           stub_payment_intents_post_request order: new_order
           stub_successful_capture_request order: new_order

--- a/spec/system/consumer/shopping/products_spec.rb
+++ b/spec/system/consumer/shopping/products_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "As a consumer I want to view products" do
     let(:order) { create(:order, distributor:) }
 
     before do
-      set_order order
+      pick_order order
     end
 
     describe "supplier's name is displayed" do

--- a/spec/system/consumer/shopping/shopping_spec.rb
+++ b/spec/system/consumer/shopping/shopping_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "As a consumer I want to shop with a distributor" do
     let(:order) { create(:order, distributor:) }
 
     before do
-      set_order order
+      pick_order order
     end
 
     it "shows a distributor with images" do
@@ -461,7 +461,7 @@ RSpec.describe "As a consumer I want to shop with a distributor" do
         before do
           add_variant_to_order_cycle(exchange, variant)
           set_order_cycle(order, oc1)
-          set_order(order)
+          pick_order(order)
           visit shop_path
         end
 

--- a/spec/system/consumer/shopping/unit_price_spec.rb
+++ b/spec/system/consumer/shopping/unit_price_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "As a consumer, I want to check unit price information for a prod
   let(:user) { create(:user, password: "password", password_confirmation: "password") }
 
   before do
-    set_order order
+    pick_order order
     exchange1.update_attribute :pickup_time, "monday"
     add_variant_to_order_cycle(exchange1, variant)
   end

--- a/spec/system/consumer/white_label_spec.rb
+++ b/spec/system/consumer/white_label_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'White label setting' do
         before do
           order.update_attribute(:state, 'cart')
           order.line_items << create(:line_item, variant: product.variants.first)
-          set_order(order)
+          pick_order(order)
         end
 
         it_behaves_like "hides the OFN navigation when needed only"
@@ -176,7 +176,7 @@ RSpec.describe 'White label setting' do
 
       context "when the user has a complete order" do
         before do
-          set_order(complete_order)
+          pick_order(complete_order)
         end
 
         shared_examples "hides the OFN navigation when needed only for the order confirmation" do
@@ -225,7 +225,7 @@ RSpec.describe 'White label setting' do
     context "when the preference is set to false" do
       before do
         distributor.update_attribute(:hide_ofn_navigation, false)
-        set_order(order)
+        pick_order(order)
         allow_any_instance_of(EnterprisesHelper).to receive(:current_distributor).
           and_return(distributor)
       end
@@ -288,7 +288,7 @@ RSpec.describe 'White label setting' do
         before do
           order.update_attribute(:state, 'cart')
           order.line_items << create(:line_item, variant: product.variants.first)
-          set_order(order)
+          pick_order(order)
           visit main_app.cart_path
         end
 
@@ -299,7 +299,7 @@ RSpec.describe 'White label setting' do
         before do
           order.update_attribute(:state, 'cart')
           order.line_items << create(:line_item, variant: product.variants.first)
-          set_order(order)
+          pick_order(order)
           visit checkout_path
         end
 
@@ -347,7 +347,7 @@ RSpec.describe 'White label setting' do
         before do
           order.update_attribute(:state, 'cart')
           order.line_items << create(:line_item, variant: product.variants.first)
-          set_order(order)
+          pick_order(order)
           visit main_app.cart_path
         end
 
@@ -358,7 +358,7 @@ RSpec.describe 'White label setting' do
         before do
           order.update_attribute(:state, 'cart')
           order.line_items << create(:line_item, variant: product.variants.first)
-          set_order(order)
+          pick_order(order)
           visit checkout_path
         end
 
@@ -399,7 +399,7 @@ RSpec.describe 'White label setting' do
           before do
             order.update_attribute(:state, 'cart')
             order.line_items << create(:line_item, variant: product.variants.first)
-            set_order(order)
+            pick_order(order)
             visit main_app.cart_path
           end
 
@@ -410,7 +410,7 @@ RSpec.describe 'White label setting' do
           before do
             order.update_attribute(:state, 'cart')
             order.line_items << create(:line_item, variant: product.variants.first)
-            set_order(order)
+            pick_order(order)
             visit checkout_path
           end
 


### PR DESCRIPTION
#### What? Why?

- Contributes to #13219 
- [Naming/AccessorMethodName](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/AccessorMethodName) cop

I have made multiple commits for each line in the Gemfile because there is a lot of small changes.

#### What should we test?
Nothing.  All specs should pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled
