### PR TITLE
Reproduces bug #12933, setting the test case as pending

### DIFF
--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -240,16 +240,21 @@ RSpec.describe "Product Import" do
     end
 
     it "can reset product stock to zero for products not present in the CSV" do
+      pending("#12933")
+
       csv_data = <<~CSV
         name, producer, category, on_hand, price, units, unit_type, shipping_category_id
         Carrots, User Enterprise, Vegetables, 500, 3.20, 500, g, #{shipping_category_id_str}
       CSV
       File.write('/tmp/test.csv', csv_data)
 
+      # setting a variant to have negative stock, with the on demand option set to true
+      Spree::Product.find_by(name: 'Cabbage').variants.first.on_demand = true
+      Spree::Product.find_by(name: 'Cabbage').variants.first.on_hand = -30
+
       visit main_app.admin_product_import_path
 
       attach_file 'file', '/tmp/test.csv'
-
       check "settings_reset_all_absent"
 
       click_button 'Upload'

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -249,8 +249,9 @@ RSpec.describe "Product Import" do
       File.write('/tmp/test.csv', csv_data)
 
       # setting a variant to have negative stock, with the on demand option set to true
-      Spree::Product.find_by(name: 'Cabbage').variants.first.on_demand = true
-      Spree::Product.find_by(name: 'Cabbage').variants.first.on_hand = -30
+      cabbage_variant = Spree::Product.find_by(name: 'Cabbage').variants.first
+      cabbage_variant.on_demand = true
+      cabbage_variant.on_hand = -30
 
       visit main_app.admin_product_import_path
 


### PR DESCRIPTION
#### What? Why?

- Reproduces #12933.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Setting a variant to `on_hand` and the stock to a `negative value` throws the error reported on #12933:

`Locking a record with unpersisted changes is not supported. Use `save` to persist the changes, or `reload` to discard them explicitly`

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
