### PR TITLE
Fixes Rubocop HeredocDelimiterNaming offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,13 +221,6 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 1
-# Configuration parameters: ForbiddenDelimiters.
-# ForbiddenDelimiters: (?i-mx:(^|\s)(EO[A-Z]{1}|END)(\s|$))
-Naming/HeredocDelimiterNaming:
-  Exclude:
-    - 'app/models/content_configuration.rb'
-
 # Offense count: 5
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyleForLeadingUnderscores.

--- a/app/models/content_configuration.rb
+++ b/app/models/content_configuration.rb
@@ -74,13 +74,13 @@ class ContentConfiguration < Spree::Preferences::Configuration
   preference :footer_pinterest_url, :string, default: ""
   preference :footer_email, :string, default: "hello@openfoodnetwork.org"
   preference :community_forum_url, :string, default: "http://community.openfoodnetwork.org"
-  preference :footer_links_md, :text, default: <<~EOS
+  preference :footer_links_md, :text, default: <<~FOOTERSTR
     [Newsletter sign-up](/)
 
     [News](/)
 
     [Calendar](/)
-  EOS
+  FOOTERSTR
 
   preference :footer_about_url, :string, default: "http://www.openfoodnetwork.org/ofn-local/open-food-network-australia/"
 


### PR DESCRIPTION
#### What? Why?

- Contributes to #13219 
- [Naming/HeredocDelimiterNaming](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/HeredocDelimiterNaming) cop

#### What should we test?
Nothing.  All specs should pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled