### PR TITLE
Fixes Rubocop Naming NamingMemoizedInstanceVariableName cop

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -86,6 +86,10 @@ Metrics/MethodLength:
   Enabled: true
   Max: 25 # default 10
 
+Naming/MemoizedInstanceVariableName:
+  Exclude:
+    - 'lib/open_food_network/address_finder.rb'
+
 Metrics/ParameterLists:
   CountKeywordArgs: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,16 +221,6 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 5
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyleForLeadingUnderscores.
-# SupportedStylesForLeadingUnderscores: disallowed, required, optional
-Naming/MemoizedInstanceVariableName:
-  Exclude:
-    - 'app/mailers/producer_mailer.rb'
-    - 'app/models/concerns/balance.rb'
-    - 'lib/open_food_network/address_finder.rb'
-
 # Offense count: 1
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: as, at, by, cc, db, id, if, in, io, ip, of, on, os, pp, to

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -59,7 +59,7 @@ class ProducerMailer < ApplicationMailer
   end
 
   def line_items_from(order_cycle, producer)
-    @line_items ||= Spree::LineItem.
+    @line_items_from ||= Spree::LineItem.
       includes(variant: :product).
       joins(variant: :product).
       from_order_cycle(order_cycle).

--- a/app/models/concerns/balance.rb
+++ b/app/models/concerns/balance.rb
@@ -9,7 +9,7 @@ module Balance
 
   # Branches by the OrderBalance abstraction
   def outstanding_balance
-    @order_balance ||= OrderBalance.new(self)
+    @outstanding_balance ||= OrderBalance.new(self)
   end
 
   # Returns the order balance by considering the total as money owed to the order distributor aka.


### PR DESCRIPTION
#### What? Why?

- Contributes to #13219 
- [Naming/MemoizedInstanceVariableName](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/MemoizedInstanceVariableName) cop

I excluded `lib/open_food_network/address_finder.rb` from cop surveillance.
Three methods causes offense:
https://github.com/openfoodfoundation/openfoodnetwork/blob/e02b765463882db9ffaf5d39a4208513ee2f81b9/lib/open_food_network/address_finder.rb#L30-L38

Rubocop wants a variable named `@email=` since metohd is named `email=`
But `method=` is the prefered ruby idiom for setting accessors.
And I won't name the method like `set_xxx` ... which is barred from using by another cop :)




#### What should we test?
Nothing. All specs should pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
