### PR TITLE
Fix #11967 - limit variant unit name input

### DIFF
--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -21,7 +21,7 @@
                 'aria-label': t('items'),
                 'data-toggle-control-target': 'control',
                 style: (variant.variant_unit == "items" ? "" : "display: none;"),
-                maxlength: 10
+                maxlength: 20
     = error_message_on variant, :variant_unit_name, 'data-toggle-control-target': 'control'
 %td.col-unit.field.popout{'data-controller': "popout", 'data-popout-update-display-value': "false"}
   = f.button :unit_to_display, class: "popout__button", 'aria-label': t('admin.products_page.columns.unit'), 'data-popout-target': "button" do

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -17,7 +17,11 @@
       { class: "fullwidth no-input", 'aria-label': t('admin.products_page.columns.unit_scale'), data: { "controller": "tom-select", "tom-select-options-value": '{ "plugins": [] }', action: "change->toggle-control#displayIfMatch" }, required: true }
   = error_message_on variant, :variant_unit, 'data-toggle-control-target': 'control'
   .field
-    = f.text_field :variant_unit_name, 'aria-label': t('items'), 'data-toggle-control-target': 'control', style: (variant.variant_unit == "items" ? "" : "display: none")
+    = f.text_field :variant_unit_name,
+                'aria-label': t('items'),
+                'data-toggle-control-target': 'control',
+                style: (variant.variant_unit == "items" ? "" : "display: none;"),
+                maxlength: 10
     = error_message_on variant, :variant_unit_name, 'data-toggle-control-target': 'control'
 %td.col-unit.field.popout{'data-controller': "popout", 'data-popout-update-display-value': "false"}
   = f.button :unit_to_display, class: "popout__button", 'aria-label': t('admin.products_page.columns.unit'), 'data-popout-target': "button" do

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -57,7 +57,12 @@
           = f.field_container :variant_unit_name do
             = f.label :variant_unit_name, t(".unit_name")
             %span.required *
-            = f.text_field :variant_unit_name, :placeholder => t('admin.products.unit_name_placeholder'), 'ng-model' => 'product.variant_unit_name', class: 'fullwidth', 'ng-init': "product.variant_unit_name='#{@product.variant_unit_name}'"
+            = f.text_field :variant_unit_name,
+               placeholder: t('admin.products.unit_name_placeholder'),
+               'ng-model' => 'product.variant_unit_name',
+               class: 'fullwidth',
+               'ng-init' => "product.variant_unit_name='#{@product.variant_unit_name}'",
+               maxlength: 10
             = f.error_message_on :variant_unit_name
       .sixteen.columns.alpha
         .eight.columns.alpha

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -62,7 +62,7 @@
                'ng-model' => 'product.variant_unit_name',
                class: 'fullwidth',
                'ng-init' => "product.variant_unit_name='#{@product.variant_unit_name}'",
-               maxlength: 10
+               maxlength: 20
             = f.error_message_on :variant_unit_name
       .sixteen.columns.alpha
         .eight.columns.alpha


### PR DESCRIPTION
# Fix #11967 - limit variant unit name input to 20 characters (updated from 10 character during initial testing)

### This PR closes #11967

In both the variant form:
`new.html.haml`

And the editable variant list:
`_variant_row.html.haml`

Entering overly long unit names caused layout issues, especially on mobile devices.

#### **Before:**

![#11967-before](https://github.com/user-attachments/assets/e96f8acc-4767-4f34-ba98-63b9f8af3fa3)

This PR limits the input to 20 characters on the client side — enough for realistic unit names such as:

- “Hand Picked Bunches” (19 characters)

#### **After:**

![#11967-after](https://github.com/user-attachments/assets/c1fb88fd-5f7d-4df7-82b5-555efd6f8976)

This resolves the UI issue without affecting any backend logic. 
I can add a backend model constraint and localisation strings if needed in future.

## What should we test?

- Click the “Manage Products” button on the Dashboard — you’ll land on the “Bulk Edit Products” page.
- Attempt to enter a unit name longer than 20 characters for any variant or new product where the unit size is set to "items" — it should be restricted.
- Confirm that the layout remains clean and aligned on both desktop and mobile.

## Release notes

#### Changelog Category:

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

