### PR TITLE
Fixes StimulusJS error on printing w bulk action

### DIFF
--- a/app/webpacker/controllers/file_loading_controller.js
+++ b/app/webpacker/controllers/file_loading_controller.js
@@ -14,7 +14,7 @@ export default class extends Controller {
   }
 
   checkFile() {
-    if (!this.loadedTarget.classList.contains(HIDE_CLASS)) {
+    if (!this.hasLoadedTarget || !this.loadedTarget.classList.contains(HIDE_CLASS)) {
       // If link already loaded successfully, we don't need to check anymore.
       return;
     }
@@ -29,10 +29,10 @@ export default class extends Controller {
     });
   }
 
-  setTimeout(){
+  setTimeout() {
     this.timeout = setTimeout(this.checkFile.bind(this), NOTIFICATION_TIME);
   }
-  clearTimeout(){
+  clearTimeout() {
     clearTimeout(this.timeout);
   }
 }


### PR DESCRIPTION
#### What? Why?

- Closes #12802 

#### What should we test?
Based on @drummer83 workflow in #12802
- Connect as an admin or shop owner
- click on "Administration"
- Go to `/orders` page.
- Open the browser console (F12 on chrome).
- Select one or more orders.
- Select `Print Invoices` from the actions dropdown menu.
- Notice the console output for a few seconds: there should be no error message (from Stimulus or from anything).


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled