### PR TITLE
Fixes NamingMethodParameterName rubocop offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,13 +221,6 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 1
-# Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
-# AllowedNames: as, at, by, cc, db, id, if, in, io, ip, of, on, os, pp, to
-Naming/MethodParameterName:
-  Exclude:
-    - 'app/services/process_payment_intent.rb'
-
 # Offense count: 26
 # Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers, AllowedPatterns.
 # SupportedStyles: snake_case, normalcase, non_integer

--- a/app/controllers/payment_gateways/stripe_controller.rb
+++ b/app/controllers/payment_gateways/stripe_controller.rb
@@ -24,7 +24,7 @@ module PaymentGateways
 
       result = ProcessPaymentIntent.new(params["payment_intent"], @order).call!
 
-      unless result.ok?
+      unless result.success?
         flash.now[:error] = "#{I18n.t('payment_could_not_process')}. #{result.error}"
       end
 

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -13,13 +13,13 @@ class ProcessPaymentIntent
   class Result
     attr_reader :error
 
-    def initialize(ok:, error: "")
-      @ok = ok
+    def initialize(success:, error: "")
+      @success = success
       @error = error
     end
 
-    def ok?
-      @ok
+    def success?
+      @success
     end
   end
 
@@ -30,8 +30,8 @@ class ProcessPaymentIntent
   end
 
   def call!
-    return Result.new(ok: false) unless payment.present? && ready_for_capture?
-    return Result.new(ok: true) if already_processed?
+    return Result.new(success: false) unless payment.present? && ready_for_capture?
+    return Result.new(success: true) if already_processed?
 
     process_payment
 
@@ -39,16 +39,16 @@ class ProcessPaymentIntent
       payment.complete_authorization
       payment.clear_authorization_url
 
-      Result.new(ok: true)
+      Result.new(success: true)
     else
       payment.fail_authorization
       payment.clear_authorization_url
-      Result.new(ok: false, error: I18n.t("payment_could_not_complete"))
+      Result.new(success: false, error: I18n.t("payment_could_not_complete"))
     end
   rescue Stripe::StripeError => e
     payment.fail_authorization
     payment.clear_authorization_url
-    Result.new(ok: false, error: e.message)
+    Result.new(success: false, error: e.message)
   end
 
   private

--- a/spec/services/process_payment_intent_spec.rb
+++ b/spec/services/process_payment_intent_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ProcessPaymentIntent do
         it "returns false" do
           result = service.call!
 
-          expect(result.ok?).to eq(false)
+          expect(result.success?).to eq(false)
           expect(result.error).to eq("")
         end
 
@@ -58,7 +58,7 @@ RSpec.describe ProcessPaymentIntent do
         it "returns returns the error message" do
           result = service.call!
 
-          expect(result.ok?).to eq(false)
+          expect(result.success?).to eq(false)
           expect(result.error).to eq("error message")
         end
 
@@ -150,7 +150,7 @@ RSpec.describe ProcessPaymentIntent do
       it "does not return any error message" do
         result = service.call!
 
-        expect(result.ok?).to eq(false)
+        expect(result.success?).to eq(false)
         expect(result.error).to eq("")
       end
 
@@ -173,7 +173,7 @@ RSpec.describe ProcessPaymentIntent do
       it "returns a failed result" do
         result = service.call!
 
-        expect(result.ok?).to eq(false)
+        expect(result.success?).to eq(false)
         expect(result.error).to eq('The payment could not be completed')
       end
 


### PR DESCRIPTION
#### What? Why?

- Contributes to https://github.com/openfoodfoundation/openfoodnetwork/issues/13219
- [Naming/MethodParameterName](https://docs.rubocop.org/rubocop/cops_naming.html#namingmethodparametername) cop

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Nothing. All tests should pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.