### PR TITLE
Adds tests to toggle the css sections (distributed products)

### DIFF
--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -555,6 +555,14 @@ RSpec.describe '
         expect(page).to have_selector "tr.distributor-#{distributor_permitted.id}"
         expect(page).to have_selector 'tr.distributor', count: 2
 
+        # Toggling all products displays the css section of the distributed products
+        click_link "Expand all"
+        expect(page).to have_css ".exchange-distributed-products", count: 2
+
+        # Colapsing all products hides the css section of the distributed products
+        click_link "Collapse all"
+        expect(page).not_to have_css ".exchange-distributed-products"
+
         # Open the products list for managed_supplier's incoming exchange
         within "tr.distributor-#{distributor_managed.id}" do
           page.find("td.products").click


### PR DESCRIPTION
Yet another try at this one.

It's a lucky guess, but the idea here is that pre-loading the CSS sections and its contents makes it slightly faster, for following assertions, which are the flaky offenders.

#### What? Why?

- (hopefully!) Closes #11037.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Tests toggling and hiding the CSS sections of the order cycle, where products are displayed. This was not tested before, and perhaps makes the spec slightly more resilient all together.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Consistently green build

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
