### PR TITLE
Fix product reset on import

### DIFF
--- a/engines/catalog/app/services/catalog/product_import/products_reset_strategy.rb
+++ b/engines/catalog/app/services/catalog/product_import/products_reset_strategy.rb
@@ -37,8 +37,10 @@ module Catalog
 
       def reset_variant_on_hand_and_on_demand(variant)
         was_on_demand = variant.on_demand
-        variant.on_demand = false
+        # Reset on_hand value first because a negative level wouldn't be valid
+        # with on_demand being false.
         variant.on_hand = 0
+        variant.on_demand = false
         variant.on_hand.zero? || was_on_demand
       end
     end

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -240,8 +240,6 @@ RSpec.describe "Product Import" do
     end
 
     it "can reset product stock to zero for products not present in the CSV" do
-      pending("#12933")
-
       csv_data = <<~CSV
         name, producer, category, on_hand, price, units, unit_type, shipping_category_id
         Carrots, User Enterprise, Vegetables, 500, 3.20, 500, g, #{shipping_category_id_str}


### PR DESCRIPTION
#### What? Why?

- Closes #12933 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We changed to track negative stock levels for on-demand products. But negative stock levels are invalid for products that are not on demand. So suddenly the order in which we set on_demand and count_on_hand matters and that failed during product import. We tried to set on_demand to false first, which failed, and then tried to set cound_on_hand to zero which still failed because the record wasn't saved.

We could have introduced a new method that sets both values at the same time. But I chose the simpler change of just swapping the order in which the two values are set.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Import products.
- One of the products needs to be on demand with negative stock levels, e.g. after ordering it.
- Then remove that product from the import.
- Import again choosing to reset absent products.

Big, *big* thanks to @filipefurtad0 for providing an automated test to reproduce the scenario. That made my work really quick.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
