### PR TITLE
Fixes dotted shipping method names bad display in select (filters)

### DIFF
--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -38,7 +38,7 @@
       .field
         = label_tag nil, t(:shipping_method)
         = select_tag(:shipping_method_id,
-          options_for_select(Spree::ShippingMethod.managed_by(spree_current_user).collect {|s| [t("spree.shipping_method_names.#{s.name}"), s.id]}),
+          options_for_select(Spree::ShippingMethod.managed_by(spree_current_user).collect {|s| [t("spree.shipping_method_names.#{s.name}", default: s.name), s.id]}),
           { include_blank: true, class: "primary", "data-controller": "tom-select" })
     .field-block.alpha.eight.columns
       = label_tag nil, t(:distributors)

--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -38,7 +38,7 @@
       .field
         = label_tag nil, t(:shipping_method)
         = select_tag(:shipping_method_id,
-          options_for_select(Spree::ShippingMethod.managed_by(spree_current_user).collect {|s| [t("spree.shipping_method_names.#{s.name}", default: s.name), s.id]}),
+          options_for_select(Spree::ShippingMethod.managed_by(spree_current_user).map {|s| [s.name, s.id]}),
           { include_blank: true, class: "primary", "data-controller": "tom-select" })
     .field-block.alpha.eight.columns
       = label_tag nil, t(:distributors)

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -3626,10 +3626,6 @@ ar:
     rma_credit: "رصيد RMA"
     refund: "إعادة المال"
     server_error: "خطأ في الخادم"
-    shipping_method_names:
-      UPS Ground: "UPS الأرضي"
-      pick_up: "التسليم من المزرعة مباشرة"
-      delivery: "موقعة ومختومة وتم التسليم"
     start_date: "تاريخ البدء"
     successfully_removed: "تمت الإزالة بنجاح"
     updating: "تحديث"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3510,10 +3510,6 @@ ca:
     rma_credit: "credit RMA"
     refund: "Reembossament"
     server_error: "Error del servidor"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Recollida a la granja"
-      delivery: "Signat, segellat, lliurat"
     start_date: "Data d'inici"
     successfully_removed: "S'ha suprimit correctament"
     updating: "Actualitzant"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -3748,10 +3748,6 @@ cy:
     rma_credit: "Credyd RMA"
     refund: "Ad-daliad"
     server_error: "Nam gyda'r gweinydd"
-    shipping_method_names:
-      UPS Ground: "UPS dros y tir"
-      pick_up: "Casglu ar y fferm"
-      delivery: "Llofnodwyd, cadarnhawyd a chyflenwyd"
     start_date: "Dyddiad cychwyn"
     successfully_removed: "Llwyddwyd i ddileu"
     updating: "Yn diweddaru"

--- a/config/locales/de_CH.yml
+++ b/config/locales/de_CH.yml
@@ -3440,8 +3440,6 @@ de_CH:
     rma_credit: "Gutschrift aus Retour"
     refund: "Rückerstattung"
     server_error: "Serverfehler"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
     start_date: "Anfangsdatum"
     successfully_removed: "Erfolgreich gelöscht"
     updating: "Aktualisierung"

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -3687,10 +3687,6 @@ de_DE:
     rma_credit: "Gutschrift aus Retour"
     refund: "Rückerstattung"
     server_error: "Serverfehler"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Abholung"
-      delivery: "Lieferung"
     start_date: "Anfangsdatum"
     successfully_removed: "Erfolgreich gelöscht"
     updating: "Aktualisierung"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -3746,10 +3746,6 @@ el:
     rma_credit: "Πίστωση RMA"
     refund: "Επιστροφή χρημάτων"
     server_error: "Σφάλμα Διακομιστή"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Παραλαβή από το αγρόκτημα"
-      delivery: "Υπογράφηκε, σφραγίστηκε, παραδόθηκε"
     start_date: "Ημερομηνία έναρξης"
     successfully_removed: "Καταργήθηκε επιτυχώς"
     updating: "Ενημέρωση"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4117,10 +4117,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     rma_credit: "RMA credit"
     refund: "Refund"
     server_error: "Server error"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Pick-up at the farm"
-      delivery: "Signed, sealed, delivered"
     start_date: "Start date"
     successfully_removed: "Successfully Removed"
     updating: "Updating"

--- a/config/locales/en_CA.yml
+++ b/config/locales/en_CA.yml
@@ -3949,10 +3949,6 @@ en_CA:
     rma_credit: "RMA credit"
     refund: "Refund"
     server_error: "Server error"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Pick-up at the farm"
-      delivery: "Signed, sealed, delivered"
     start_date: "Start date"
     successfully_removed: "Successfully Removed"
     updating: "Updating"

--- a/config/locales/en_FR.yml
+++ b/config/locales/en_FR.yml
@@ -3953,10 +3953,6 @@ en_FR:
     rma_credit: "RMA credit"
     refund: "Refund"
     server_error: "Server error"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Pick-up at the farm"
-      delivery: "Signed, sealed, delivered"
     start_date: "Start date"
     successfully_removed: "Successfully Removed"
     updating: "Updating"

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -3860,10 +3860,6 @@ en_GB:
     rma_credit: "RMA credit"
     refund: "Refund"
     server_error: "Server error"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Pick-up at the farm"
-      delivery: "Signed, sealed, delivered"
     start_date: "Start date"
     successfully_removed: "Successfully Removed"
     updating: "Updating"

--- a/config/locales/en_IE.yml
+++ b/config/locales/en_IE.yml
@@ -3848,10 +3848,6 @@ en_IE:
     rma_credit: "RMA credit"
     refund: "Refund"
     server_error: "Server error"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Pick-up at the farm"
-      delivery: "Signed, sealed, delivered"
     start_date: "Start date"
     successfully_removed: "Successfully Removed"
     updating: "Updating"

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -3365,8 +3365,6 @@ en_US:
     rma_credit: "RMA credit"
     refund: "Refund"
     server_error: "Server error"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
     start_date: "Start date"
     successfully_removed: "Successfully Removed"
     updating: "Updating"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3747,9 +3747,6 @@ es:
     rma_credit: "Crédito RMA"
     refund: "Reembolso"
     server_error: "Error del Servidor"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Recoger en la granja"
     start_date: "Fecha de inicio"
     successfully_removed: "Eliminado con éxito"
     updating: "Actualizando"

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -3623,9 +3623,6 @@ eu:
     rma_credit: "RMA kreditua"
     refund: "Dirua itzultzea"
     server_error: "Zerbitzariaren errorea"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Baserrian jaso"
     start_date: "Hasiera-data"
     successfully_removed: "Arrakastaz ezabatua"
     updating: "Eguneratzen"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4021,10 +4021,6 @@ fr:
     rma_credit: "Crédit ARM"
     refund: "Remboursement"
     server_error: "Erreur serveur"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Retrait"
-      delivery: "Signé, scellé, livré"
     start_date: "Date de début"
     successfully_removed: "Supprimé avec succès"
     updating: "Mettre à jour"

--- a/config/locales/fr_CA.yml
+++ b/config/locales/fr_CA.yml
@@ -3992,10 +3992,6 @@ fr_CA:
     rma_credit: "Crédit ARM"
     refund: "Remboursement"
     server_error: "Erreur serveur"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Retrait"
-      delivery: "Signé, scellé, livré"
     start_date: "Date de début"
     successfully_removed: "Supprimé avec succès"
     updating: "Mettre à jour"

--- a/config/locales/fr_CH.yml
+++ b/config/locales/fr_CH.yml
@@ -3473,8 +3473,6 @@ fr_CH:
     rma_credit: "Crédit ARM"
     refund: "Remboursement"
     server_error: "Erreur serveur"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
     start_date: "Date de début"
     successfully_removed: "Supprimé avec succès"
     updating: "Mettre à jour"

--- a/config/locales/fr_CM.yml
+++ b/config/locales/fr_CM.yml
@@ -3361,8 +3361,6 @@ fr_CM:
     rma_credit: "Crédit ARM"
     refund: "Remboursement"
     server_error: "Erreur serveur"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
     start_date: "Date de début"
     successfully_removed: "Supprimé avec succès"
     updating: "Mettre à jour"

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -3672,10 +3672,6 @@ hi:
     rma_credit: "RMA क्रेडिट"
     refund: "रिफंड"
     server_error: "सर्वर त्रुटि"
-    shipping_method_names:
-      UPS Ground: "UPS ग्राउंड"
-      pick_up: "फार्म/खेत में पिक-अप करें"
-      delivery: "हस्ताक्षरित, सीलबंद, डिलीवर किया गया"
     start_date: "शुरू होने की तिथि"
     successfully_removed: "सफलतापूर्वक हटाया गया"
     updating: "अपडेट किया जा रहा है"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -3850,10 +3850,6 @@ hu:
     rma_credit: "RMA hitel"
     refund: "Visszatérítés"
     server_error: "Szerver hiba"
-    shipping_method_names:
-      UPS Ground: "UPS föld"
-      pick_up: "Átvétel a gazdaságban"
-      delivery: "Aláírva, lepecsételve, kézbesítve"
     start_date: "Kezdő dátum"
     successfully_removed: "Sikeresen eltávolítva"
     updating: "Frissítés"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -3538,10 +3538,6 @@ it:
     rma_credit: "Credito RMA"
     refund: "Rimborsa"
     server_error: "Errore Server"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Ritiro in azienda"
-      delivery: "Firmato, sigillato, consegnato"
     start_date: "Data inizio"
     successfully_removed: "Rimosso con successo"
     updating: "In aggiornamento"

--- a/config/locales/it_CH.yml
+++ b/config/locales/it_CH.yml
@@ -3396,8 +3396,6 @@ it_CH:
     rma_credit: "Credito RMA"
     refund: "Rimborsa"
     server_error: "Errore Server"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
     start_date: "Data inizio"
     successfully_removed: "Rimosso con successo"
     updating: "In aggiornamento"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -3362,8 +3362,6 @@ ko:
     rma_credit: "RMA 거래"
     refund: "환불"
     server_error: "서버 오류"
-    shipping_method_names:
-      UPS Ground: "UPS 배경"
     start_date: "시작 날짜"
     successfully_removed: "성공적으로 제거됨"
     updating: "업데이트 중"

--- a/config/locales/ml.yml
+++ b/config/locales/ml.yml
@@ -3696,10 +3696,6 @@ ml:
     rma_credit: "ആർഎംഎ ക്രെഡിറ്റ്"
     refund: "റീഫണ്ട്"
     server_error: "സെർവർ തകരാർ"
-    shipping_method_names:
-      UPS Ground: "യുപിഎസ് ഗ്രൗണ്ട്"
-      pick_up: "ഫാമിൽ നിന്നും പിക്കപ്പ് ചെയ്യുക"
-      delivery: "ഒപ്പിട്ടു, സീൽ ചെയ്തു, എത്തിച്ചു"
     start_date: "ആരംഭിക്കുന്ന തീയതി"
     successfully_removed: "വിജയകരമായി നീക്കം ചെയ്തു"
     updating: "അപ്ഡേറ്റ് ചെയ്യുന്നു"

--- a/config/locales/mr.yml
+++ b/config/locales/mr.yml
@@ -3585,10 +3585,6 @@ mr:
     rma_credit: "RMA क्रेडिट"
     refund: "परतावा"
     server_error: "सर्व्हर त्रुटी"
-    shipping_method_names:
-      UPS Ground: "UPS  ग्राउंड"
-      pick_up: "शेतात पिक-अप"
-      delivery: "स्वाक्षरी, सीलबंद, वितरित"
     start_date: "प्रारंभ तारीख"
     successfully_removed: "यशस्वीरित्या काढले"
     updating: "अपडेट करत आहे"

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -3839,10 +3839,6 @@ nb:
     rma_credit: "RMA-kreditt"
     refund: "Refusjon"
     server_error: "Serverfeil"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Henting på gården"
-      delivery: "Signert, forseglet, levert"
     start_date: "Startdato"
     successfully_removed: "Fjernet OK"
     updating: "Oppdaterer"

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -3566,10 +3566,6 @@ pa:
     rma_credit: "RMA ਕ੍ਰੈਡਿਟ"
     refund: "ਰਿਫੰਡ"
     server_error: "ਸਰਵਰ ਤਰੁੱਟੀ"
-    shipping_method_names:
-      UPS Ground: "ਯੂਪੀਐਸ ਗਰਾਊਂਡ"
-      pick_up: "ਖੇਤ ਤੋਂ ਪਿਕ-ਅੱਪ"
-      delivery: "ਦਸਤਖਤ ਕੀਤੇ, ਸੀਲ ਕੀਤੇ, ਡਿਲੀਵਰ ਕੀਤੇ ਗਏ"
     start_date: "ਸ਼ੁਰੂ ਕਰਨ ਦੀ ਮਿਤੀ"
     successfully_removed: "ਸਫਲਤਾਪੂਰਵਕ ਹਟਾਇਆ ਗਿਆ"
     updating: "ਅੱਪਡੇਟ ਹੋ ਰਿਹਾ ਹੈ"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -3797,10 +3797,6 @@ ru:
     rma_credit: "Кредит RMA"
     refund: "Возврат"
     server_error: "Ошибка сервера"
-    shipping_method_names:
-      UPS Ground: "UPS Ground"
-      pick_up: "Самовывоз на ферме"
-      delivery: "Подписано, запечатано, доставлено"
     start_date: "Дата начала"
     successfully_removed: "Успешно удалено"
     updating: "Обновление"

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -3856,10 +3856,6 @@ sr:
     rma_credit: "РМА кредит"
     refund: "Враћање новца"
     server_error: "Грешка на серверу"
-    shipping_method_names:
-      UPS Ground: "УПС Гроунд"
-      pick_up: "Преузимање на фарми"
-      delivery: "Потписано, запечаћено, достављено"
     start_date: "Датум почетка"
     successfully_removed: "Успешно уклоњено"
     updating: "Ажурирање"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -3479,8 +3479,6 @@ uk:
     rma_credit: "Кредит RMA"
     refund: "Повернення коштів"
     server_error: "Помилка серверу"
-    shipping_method_names:
-      UPS Ground: "UPS наземна"
     start_date: "Дата початку"
     successfully_removed: "Успішно видалено"
     updating: "Оновлення"

--- a/spec/system/admin/orders/bulk_actions_spec.rb
+++ b/spec/system/admin/orders/bulk_actions_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe '
                                            distributors: [distributor, distributor2, distributor3])
   }
   let!(:shipping_method2) {
-    create(:shipping_method_with, :pickup, name: "delivery",
-                                           distributors: [distributor4, distributor5])
+    create(:shipping_method_with, :delivery, name: "delivery",
+                                             distributors: [distributor4, distributor5])
   }
   let(:order_cycle) do
     create(:simple_order_cycle, name: 'One', distributors: [distributor, distributor2,

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe '
   }
   let(:distributor5) { create(:distributor_enterprise, owner: owner2, charges_sales_tax: true) }
   let!(:shipping_method) {
-    create(:shipping_method_with, :pickup, name: "pick_up",
+    create(:shipping_method_with, :pickup, name: "Pick up at the farm",
                                            distributors: [distributor, distributor2, distributor3])
   }
   let!(:shipping_method2) {
-    create(:shipping_method_with, :pickup, name: "delivery",
-                                           distributors: [distributor4, distributor5])
+    create(:shipping_method_with, :delivery, name: "Home delivery to your convenience",
+                                             distributors: [distributor4, distributor5])
   }
   let(:order_cycle) do
     create(:simple_order_cycle, name: 'One', distributors: [distributor, distributor2,
@@ -190,7 +190,7 @@ RSpec.describe '
         order2.select_shipping_method(shipping_method.id)
         order4.select_shipping_method(shipping_method2.id)
 
-        tomselect_search_and_select "Pick-up at the farm", from: 'shipping_method_id'
+        tomselect_search_and_select "Pick up at the farm", from: 'shipping_method_id'
         page.find('.filter-actions .button[type=submit]').click
         # Order 2 should show, but not 3 and 5
         expect(page).to have_content order2.number
@@ -199,7 +199,7 @@ RSpec.describe '
 
         find("#clear_filters_button").click
 
-        tomselect_search_and_select "Signed, sealed, delivered", from: 'shipping_method_id'
+        tomselect_search_and_select "Home delivery to your convenience", from: 'shipping_method_id'
         page.find('.filter-actions .button[type=submit]').click
         # Order 4 should show, but not 2 and 3
         expect(page).not_to have_content order2.number


### PR DESCRIPTION
#### What? Why?

- Closes #13260

Some more details on this bug below.

#### What should we test?
- connect as an admin/shop owner
- click on Administration
- click under `Edit profile details ` to manage hub
- click on `Shipping methods`
- edit one shipping method name and add something like `. Orders over 5€`on its name. Do not forget the dot.
- go to Orders
- you should see in the shipping methods select box the full name.
- one should not see in the html source things like class = 'missing translation' in title+class attributes (observable with the web dev tool).

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.