### PR TITLE
Prevent error on inventory page when logged out

### DIFF
--- a/app/controllers/admin/variant_overrides_controller.rb
+++ b/app/controllers/admin/variant_overrides_controller.rb
@@ -7,7 +7,7 @@ module Admin
     include OpenFoodNetwork::SpreeApiKeyLoader
     include EnterprisesHelper
 
-    prepend_before_action :load_data
+    prepend_before_action :load_data, if: :spree_current_user
     before_action :load_collection, only: [:bulk_update]
     before_action :load_spree_api_key, only: :index
 

--- a/spec/controllers/admin/variant_overrides_controller_spec.rb
+++ b/spec/controllers/admin/variant_overrides_controller_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe Admin::VariantOverridesController, type: :controller do
   describe "index" do
     context "not logged in" do
       it "redirects to login" do
-        pending
         get :index
-        expect(response).to have_http_status :found
+        expect(response).to redirect_to(
+          root_path(anchor: "/login", after_login: admin_inventory_path)
+        )
       end
     end
 

--- a/spec/controllers/admin/variant_overrides_controller_spec.rb
+++ b/spec/controllers/admin/variant_overrides_controller_spec.rb
@@ -3,6 +3,29 @@
 require 'spec_helper'
 
 RSpec.describe Admin::VariantOverridesController, type: :controller do
+  describe "index" do
+    context "not logged in" do
+      it "redirects to login" do
+        pending
+        get :index
+        expect(response).to have_http_status :found
+      end
+    end
+
+    context "where I manage the variant override hub" do
+      let(:hub) { create(:distributor_enterprise) }
+
+      before do
+        allow(controller).to receive(:spree_current_user) { hub.owner }
+      end
+
+      it "succeeds" do
+        get :index
+        expect(response).to have_http_status :ok
+      end
+    end
+  end
+
   describe "bulk_update" do
     context "json" do
       let(:format) { :json }


### PR DESCRIPTION
#### What? Why?

- Closes #13315

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
- Log out of OFN
- Visit the inventory page (/admin/inventory)
- [ ] You should be redirected to login
- Log in to OFN
- Visit the inventory page (/admin/inventory)
- [ ] It works!
