### PR TITLE
Fixes RSpecRails HaveHttpStatus rubocop offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,28 +221,12 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 137
+# Offense count: 69
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: ResponseMethods.
 # ResponseMethods: response, last_response
 RSpecRails/HaveHttpStatus:
   Exclude:
-    - 'spec/controllers/api/v0/base_controller_spec.rb'
-    - 'spec/controllers/api/v0/customers_controller_spec.rb'
-    - 'spec/controllers/api/v0/enterprises_controller_spec.rb'
-    - 'spec/controllers/api/v0/logos_controller_spec.rb'
-    - 'spec/controllers/api/v0/order_cycles_controller_spec.rb'
-    - 'spec/controllers/api/v0/orders_controller_spec.rb'
-    - 'spec/controllers/api/v0/product_images_controller_spec.rb'
-    - 'spec/controllers/api/v0/products_controller_spec.rb'
-    - 'spec/controllers/api/v0/promo_images_controller_spec.rb'
-    - 'spec/controllers/api/v0/reports/packing_report_spec.rb'
-    - 'spec/controllers/api/v0/reports_controller_spec.rb'
-    - 'spec/controllers/api/v0/shipments_controller_spec.rb'
-    - 'spec/controllers/api/v0/statuses_controller_spec.rb'
-    - 'spec/controllers/api/v0/taxons_controller_spec.rb'
-    - 'spec/controllers/api/v0/terms_and_conditions_controller_spec.rb'
-    - 'spec/controllers/api/v0/variants_controller_spec.rb'
     - 'spec/controllers/cart_controller_spec.rb'
     - 'spec/controllers/checkout_controller_spec.rb'
     - 'spec/controllers/enterprises_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,15 +221,12 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 144
+# Offense count: 137
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: ResponseMethods.
 # ResponseMethods: response, last_response
 RSpecRails/HaveHttpStatus:
   Exclude:
-    - 'spec/controllers/admin/bulk_line_items_controller_spec.rb'
-    - 'spec/controllers/admin/order_cycles_controller_spec.rb'
-    - 'spec/controllers/admin/subscriptions_controller_spec.rb'
     - 'spec/controllers/api/v0/base_controller_spec.rb'
     - 'spec/controllers/api/v0/customers_controller_spec.rb'
     - 'spec/controllers/api/v0/enterprises_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,15 +221,6 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 28
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: ResponseMethods.
-# ResponseMethods: response, last_response
-RSpecRails/HaveHttpStatus:
-  Exclude:
-    - 'spec/services/embedded_page_service_spec.rb'
-    - 'spec/support/api_helper.rb'
-
 # Offense count: 8
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,26 +221,12 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 69
+# Offense count: 39
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: ResponseMethods.
 # ResponseMethods: response, last_response
 RSpecRails/HaveHttpStatus:
   Exclude:
-    - 'spec/controllers/cart_controller_spec.rb'
-    - 'spec/controllers/checkout_controller_spec.rb'
-    - 'spec/controllers/enterprises_controller_spec.rb'
-    - 'spec/controllers/line_items_controller_spec.rb'
-    - 'spec/controllers/shop_controller_spec.rb'
-    - 'spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb'
-    - 'spec/controllers/spree/admin/orders_controller_spec.rb'
-    - 'spec/controllers/spree/admin/products_controller_spec.rb'
-    - 'spec/controllers/spree/credit_cards_controller_spec.rb'
-    - 'spec/controllers/spree/orders_controller_spec.rb'
-    - 'spec/controllers/stripe/callbacks_controller_spec.rb'
-    - 'spec/controllers/stripe/webhooks_controller_spec.rb'
-    - 'spec/controllers/user_passwords_controller_spec.rb'
-    - 'spec/controllers/user_registrations_controller_spec.rb'
     - 'spec/requests/api/routes_spec.rb'
     - 'spec/requests/checkout/stripe_sca_spec.rb'
     - 'spec/requests/home_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,16 +221,12 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 39
+# Offense count: 28
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: ResponseMethods.
 # ResponseMethods: response, last_response
 RSpecRails/HaveHttpStatus:
   Exclude:
-    - 'spec/requests/api/routes_spec.rb'
-    - 'spec/requests/checkout/stripe_sca_spec.rb'
-    - 'spec/requests/home_controller_spec.rb'
-    - 'spec/requests/omniauth_callbacks_controller_spec.rb'
     - 'spec/services/embedded_page_service_spec.rb'
     - 'spec/support/api_helper.rb'
 

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe Admin::BulkLineItemsController, type: :controller do
 
           it 'returns a 204 response' do
             spree_put :update, params
-            expect(response.status).to eq 204
+            expect(response).to have_http_status :no_content
           end
 
           it 'applies enterprise fees locking the order with an exclusive row lock' do
@@ -280,7 +280,7 @@ RSpec.describe Admin::BulkLineItemsController, type: :controller do
 
             it 'returns a 412 response' do
               spree_put :update, params
-              expect(response.status).to eq 412
+              expect(response).to have_http_status :precondition_failed
             end
           end
         end
@@ -341,7 +341,7 @@ RSpec.describe Admin::BulkLineItemsController, type: :controller do
 
       it 'returns a 204 response' do
         spree_delete :destroy, params
-        expect(response.status).to eq 204
+        expect(response).to have_http_status :no_content
       end
     end
   end

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -241,7 +241,7 @@ module Admin
 
           it "can update order cycle even if the variant has been deleted" do
             spree_put :update, { format: :json, id: order_cycle.id, order_cycle: {} }
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
           end
         end
 

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -463,7 +463,7 @@ RSpec.describe Admin::SubscriptionsController, type: :controller do
             context "when no 'open_orders' directive has been provided" do
               it "renders an error, asking what to do" do
                 spree_put :cancel, params
-                expect(response.status).to be 409
+                expect(response).to have_http_status :conflict
                 json_response = response.parsed_body
                 expect(json_response['errors']['open_orders'])
                   .to eq 'Some orders for this subscription are currently open. ' \
@@ -567,7 +567,7 @@ RSpec.describe Admin::SubscriptionsController, type: :controller do
             context "when no 'open_orders' directive has been provided" do
               it "renders an error, asking what to do" do
                 spree_put :pause, params
-                expect(response.status).to be 409
+                expect(response).to have_http_status :conflict
                 json_response = response.parsed_body
                 expect(json_response['errors']['open_orders'])
                   .to eq 'Some orders for this subscription are currently open. ' \
@@ -690,7 +690,7 @@ RSpec.describe Admin::SubscriptionsController, type: :controller do
               context "when no 'canceled_orders' directive has been provided" do
                 it "renders a message, informing the user that canceled order can be resumed" do
                   spree_put :unpause, params
-                  expect(response.status).to be 409
+                  expect(response).to have_http_status :conflict
                   json_response = response.parsed_body
                   expect(json_response['errors']['canceled_orders'])
                     .to eq 'Some orders for this subscription can be resumed right now. ' \

--- a/spec/controllers/api/v0/base_controller_spec.rb
+++ b/spec/controllers/api/v0/base_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V0::BaseController do
     it "can make a request" do
       api_get :index
       expect(json_response).to eq( "products" => [] )
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe Api::V0::BaseController do
     it "without an API key" do
       api_get :index
       expect(json_response["products"]).to eq []
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe Api::V0::BaseController do
       request.headers["X-Spree-Token"] = "fake_key"
       get :index, params: {}
       expect(json_response).to eq( "error" => "Invalid API key (fake_key) specified." )
-      expect(response.status).to eq(401)
+      expect(response).to have_http_status(:unauthorized)
     end
 
     it "using an invalid token param" do
@@ -62,6 +62,6 @@ RSpec.describe Api::V0::BaseController do
     get :index
     expect(json_response)
       .to eq( "error" => "The resource you were looking for could not be found." )
-    expect(response.status).to eq(404)
+    expect(response).to have_http_status(:not_found)
   end
 end

--- a/spec/controllers/api/v0/customers_controller_spec.rb
+++ b/spec/controllers/api/v0/customers_controller_spec.rb
@@ -20,7 +20,7 @@ module Api
 
       it "lists customers associated with the current user" do
         get :index
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(json_response.length).to eq 1
         expect(json_response.first[:id]).to eq customer1.id
       end
@@ -49,7 +49,7 @@ module Api
         context "when the update request is successful" do
           it "returns the id of the updated customer" do
             spree_post :update, params
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
             expect(json_response[:id]).to eq customer.id
           end
         end
@@ -59,7 +59,7 @@ module Api
 
           it "returns a 422, with an error message" do
             spree_post :update, params
-            expect(response.status).to be 422
+            expect(response).to have_http_status :unprocessable_entity
             expect(json_response[:error]).to be
           end
         end

--- a/spec/controllers/api/v0/enterprises_controller_spec.rb
+++ b/spec/controllers/api/v0/enterprises_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::V0::EnterprisesController, type: :controller do
 
       it "changes the external_billing_id field" do
         api_put :update, id: enterprise.id, enterprise: enterprise_params
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
 
         expect(enterprise.reload.external_billing_id).to eq('INV123456')
       end
@@ -55,7 +55,7 @@ RSpec.describe Api::V0::EnterprisesController, type: :controller do
 
       it "creates as sells=any when it is not a producer" do
         api_post :create, { enterprise: new_enterprise_params }
-        expect(response.status).to eq 201
+        expect(response).to have_http_status :created
 
         enterprise = Enterprise.last
         expect(enterprise.sells).to eq('any')
@@ -63,7 +63,7 @@ RSpec.describe Api::V0::EnterprisesController, type: :controller do
 
       it "creates a visible=hidden enterprise" do
         api_post :create, { enterprise: new_enterprise_params }
-        expect(response.status).to eq 201
+        expect(response).to have_http_status :created
 
         enterprise = Enterprise.last
         expect(enterprise.visible).to eq("only_through_links")
@@ -76,7 +76,7 @@ RSpec.describe Api::V0::EnterprisesController, type: :controller do
           enterprise: new_enterprise_params.
             merge({ user_ids: [enterprise_owner.id, manager1.id, manager2.id] })
         }
-        expect(response.status).to eq 201
+        expect(response).to have_http_status :created
 
         enterprise = Enterprise.last
         expect(enterprise.user_ids).to match_array([enterprise_owner.id, manager1.id, manager2.id])
@@ -115,14 +115,14 @@ RSpec.describe Api::V0::EnterprisesController, type: :controller do
 
       it "I can update enterprise logo image" do
         api_post :update_image, logo:, id: enterprise.id
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(response.content_type).to eq "text/html"
         expect(response.body).to match /logo\.png$/
       end
 
       it "I can update enterprise promo image" do
         api_post :update_image, promo: logo, id: enterprise.id
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(response.content_type).to eq "text/html"
         expect(response.body).to match /logo\.png$/
       end

--- a/spec/controllers/api/v0/logos_controller_spec.rb
+++ b/spec/controllers/api/v0/logos_controller_spec.rb
@@ -32,7 +32,7 @@ module Api
         it "removes logo" do
           spree_delete :destroy, enterprise_id: enterprise
 
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
           expect(json_response["id"]).to eq enterprise.id
           enterprise.reload
           expect(enterprise.logo).not_to be_attached
@@ -44,7 +44,7 @@ module Api
           it "responds with error" do
             spree_delete :destroy, enterprise_id: enterprise
 
-            expect(response.status).to eq(409)
+            expect(response).to have_http_status(:conflict)
             expect(json_response['error']).to eq 'Logo does not exist'
           end
         end
@@ -55,7 +55,7 @@ module Api
 
         it "allows removal of logo" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
         end
       end
 
@@ -64,7 +64,7 @@ module Api
 
         it "allows removal of logo" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
         end
       end
 
@@ -73,7 +73,7 @@ module Api
 
         it "does not allow removal of logo" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
           enterprise.reload
           expect(enterprise.logo).to be_attached
         end
@@ -84,7 +84,7 @@ module Api
 
         it "does not allow removal of logo" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
           enterprise.reload
           expect(enterprise.logo).to be_attached
         end

--- a/spec/controllers/api/v0/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/v0/order_cycles_controller_spec.rb
@@ -97,7 +97,7 @@ module Api
           api_get :products, id: order_cycle.id, distributor: distributor.id,
                              q: { with_properties: [property1.id, property2.id] }
 
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
           expect(product_ids).to eq [product1.id, product2.id]
           expect(product_ids).not_to include product3.id
         end
@@ -117,7 +117,7 @@ module Api
             api_get :products, id: order_cycle.id, distributor: distributor.id,
                                q: { with_variants_supplier_properties: [supplier_property.id] }
 
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
             expect(product_ids).to match_array [product1.id, product2.id]
             expect(product_ids).not_to include product3.id
           end

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -378,7 +378,7 @@ module Api
     private
 
     def expect_order
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       expect(json_response[:number]).to eq order.number
     end
 

--- a/spec/controllers/api/v0/product_images_controller_spec.rb
+++ b/spec/controllers/api/v0/product_images_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V0::ProductImagesController, type: :controller do
         product_id: product_without_image.id, file: image, use_route: :product_images
       }
 
-      expect(response.status).to eq 201
+      expect(response).to have_http_status :created
       expect(product_without_image.reload.image.id).to eq json_response['id']
     end
 
@@ -32,7 +32,7 @@ RSpec.describe Api::V0::ProductImagesController, type: :controller do
         product_id: product_with_image.id, file: image, use_route: :product_images
       }
 
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       expect(product_with_image.reload.image.id).to eq json_response['id']
     end
 
@@ -41,7 +41,7 @@ RSpec.describe Api::V0::ProductImagesController, type: :controller do
         product_id: product_without_image.id, file: pdf, use_route: :product_images
       }
 
-      expect(response.status).to eq 422
+      expect(response).to have_http_status :unprocessable_entity
       expect(product_without_image.image).to be_nil
       expect(json_response["id"]).to eq nil
       expect(json_response["errors"]).to include "Attachment has an invalid content type"

--- a/spec/controllers/api/v0/products_controller_spec.rb
+++ b/spec/controllers/api/v0/products_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
       api_get :show, id: "non-existant"
 
       expect(json_response["error"]).to eq("The resource you were looking for could not be found.")
-      expect(response.status).to eq(404)
+      expect(response).to have_http_status(:not_found)
     end
 
     it "cannot create a new product if not an admin" do
@@ -76,7 +76,7 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
       expect(product.deleted_at).to be_nil
       api_delete :destroy, id: product.to_param
 
-      expect(response.status).to eq(204)
+      expect(response).to have_http_status(:no_content)
       expect { product.reload }.not_to raise_error
       expect(product.deleted_at).not_to be_nil
     end
@@ -108,14 +108,14 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
                                    unit_description: "things" }
 
       expect(all_attributes.all?{ |attr| json_response.keys.include? attr }).to eq(true)
-      expect(response.status).to eq(201)
+      expect(response).to have_http_status(:created)
       expect(Spree::Product.last.variants.first.price).to eq 123.45
     end
 
     it "cannot create a new product with invalid attributes" do
       api_post :create, product: {}
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
       errors = json_response["errors"]
       expect(errors.keys).to match_array([
@@ -127,13 +127,13 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
     it "can update a product" do
       api_put :update, id: product.to_param, product: { name: "New and Improved Product!" }
 
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "cannot update a product with an invalid attribute" do
       api_put :update, id: product.to_param, product: { name: "" }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
       expect(json_response["errors"]["name"]).to eq(["can't be blank"])
     end
@@ -142,7 +142,7 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
       expect(product.deleted_at).to be_nil
       api_delete :destroy, id: product.to_param
 
-      expect(response.status).to eq(204)
+      expect(response).to have_http_status(:no_content)
       expect(product.reload.deleted_at).not_to be_nil
     end
   end
@@ -168,7 +168,7 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
       it 'responds with a successful response' do
         spree_post :clone, product_id: product.id, format: :json
 
-        expect(response.status).to eq(201)
+        expect(response).to have_http_status(:created)
       end
 
       it 'clones the product' do
@@ -180,7 +180,7 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
       it 'clones a product with image' do
         spree_post :clone, product_id: product_with_image.id, format: :json
 
-        expect(response.status).to eq(201)
+        expect(response).to have_http_status(:created)
         expect(json_response['name']).to eq("COPY OF #{product_with_image.name}")
       end
 
@@ -208,7 +208,7 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
       it 'responds with a successful response' do
         spree_post :clone, product_id: product.id, format: :json
 
-        expect(response.status).to eq(201)
+        expect(response).to have_http_status(:created)
       end
 
       it 'clones the product' do
@@ -220,7 +220,7 @@ RSpec.describe Api::V0::ProductsController, type: :controller do
       it 'clones a product with image' do
         spree_post :clone, product_id: product_with_image.id, format: :json
 
-        expect(response.status).to eq(201)
+        expect(response).to have_http_status(:created)
         expect(json_response['name']).to eq("COPY OF #{product_with_image.name}")
       end
     end

--- a/spec/controllers/api/v0/promo_images_controller_spec.rb
+++ b/spec/controllers/api/v0/promo_images_controller_spec.rb
@@ -32,7 +32,7 @@ module Api
         it "removes promo image" do
           spree_delete :destroy, enterprise_id: enterprise
 
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
           expect(json_response["id"]).to eq enterprise.id
           enterprise.reload
           expect(enterprise.promo_image).not_to be_attached
@@ -44,7 +44,7 @@ module Api
           it "responds with error" do
             spree_delete :destroy, enterprise_id: enterprise
 
-            expect(response.status).to eq(409)
+            expect(response).to have_http_status(:conflict)
             expect(json_response['error']).to eq 'Promo image does not exist'
           end
         end
@@ -55,7 +55,7 @@ module Api
 
         it "allows removal of promo image" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
         end
       end
 
@@ -64,7 +64,7 @@ module Api
 
         it "allows removal of promo image" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
         end
       end
 
@@ -73,7 +73,7 @@ module Api
 
         it "does not allow removal of promo image" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
           enterprise.reload
           expect(enterprise.promo_image).to be_attached
         end
@@ -84,7 +84,7 @@ module Api
 
         it "does not allow removal of promo image" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
           enterprise.reload
           expect(enterprise.promo_image).to be_attached
         end

--- a/spec/controllers/api/v0/reports/packing_report_spec.rb
+++ b/spec/controllers/api/v0/reports/packing_report_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::V0::ReportsController, type: :controller do
       it "renders results" do
         api_get :show, params
 
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(json_response[:data]).to match_array report_output(order, "distributor")
       end
     end
@@ -44,7 +44,7 @@ RSpec.describe Api::V0::ReportsController, type: :controller do
       it "renders results" do
         api_get :show, params
 
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(json_response[:data]).to match_array report_output(order, "supplier")
       end
     end

--- a/spec/controllers/api/v0/reports_controller_spec.rb
+++ b/spec/controllers/api/v0/reports_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Api::V0::ReportsController, type: :controller do
       it "returns an error" do
         api_get :show, q: { example: 'test' }
 
-        expect(response.status).to eq 422
+        expect(response).to have_http_status :unprocessable_entity
         expect(json_response["error"]).to eq 'Please specify a report type'
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe Api::V0::ReportsController, type: :controller do
       it "returns an error" do
         api_get :show, report_type: "xxxxxx", q: { example: 'test' }
 
-        expect(response.status).to eq 422
+        expect(response).to have_http_status :unprocessable_entity
         expect(json_response["error"]).to eq 'Report not found'
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe Api::V0::ReportsController, type: :controller do
 
       it "returns an error" do
         api_get :show, report_type: "packing"
-        expect(response.status).to eq 422
+        expect(response).to have_http_status :unprocessable_entity
         expect(json_response["error"]).to eq('Please supply Ransack search params in the request')
       end
     end

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Api::V0::ShipmentsController, type: :controller do
       api_put :ready, order_id: shipment.order.to_param, id: shipment.to_param
 
       expect(json_response["error"]).to eq("Cannot ready shipment.")
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_entity)
     end
 
     describe "#add and #remove" do
@@ -150,7 +150,7 @@ RSpec.describe Api::V0::ShipmentsController, type: :controller do
         it 'adds a variant to a shipment' do
           expect {
             api_put :add, params.merge(variant_id: new_variant.to_param)
-            expect(response.status).to eq(200)
+            expect(response).to have_http_status(:ok)
           }.to change { inventory_units_for(new_variant).size }.by(2)
         end
 
@@ -163,7 +163,7 @@ RSpec.describe Api::V0::ShipmentsController, type: :controller do
         it 'removes a variant from a shipment' do
           expect {
             api_put :remove, params.merge(variant_id: existing_variant.to_param)
-            expect(response.status).to eq(200)
+            expect(response).to have_http_status(:ok)
           }.to change { inventory_units_for(existing_variant).size }.by(-2)
         end
 
@@ -189,14 +189,14 @@ RSpec.describe Api::V0::ShipmentsController, type: :controller do
         it "doesn't adjust stock when adding a variant" do
           expect {
             api_put :add, params.merge(variant_id: existing_variant.to_param)
-            expect(response.status).to eq(422)
+            expect(response).to have_http_status(:unprocessable_entity)
           }.not_to change { existing_variant.reload.on_hand }
         end
 
         it "doesn't adjust stock when removing a variant" do
           expect {
             api_put :remove, params.merge(variant_id: existing_variant.to_param)
-            expect(response.status).to eq(422)
+            expect(response).to have_http_status(:unprocessable_entity)
           }.not_to change { existing_variant.reload.on_hand }
         end
       end
@@ -283,7 +283,7 @@ RSpec.describe Api::V0::ShipmentsController, type: :controller do
             expect(order.payment_state).to eq "paid" # order is fully paid for
 
             api_put :update, params
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
 
             order.reload
 
@@ -296,7 +296,7 @@ RSpec.describe Api::V0::ShipmentsController, type: :controller do
           it "updates closed adjustments" do
             expect {
               api_put :update, params
-              expect(response.status).to eq 200
+              expect(response).to have_http_status :ok
             }.to change { order.reload.shipment.fee_adjustment.amount }
           end
         end
@@ -419,7 +419,7 @@ RSpec.describe Api::V0::ShipmentsController, type: :controller do
     end
 
     def expect_valid_response
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       expect(json_response.keys).to include(*attributes)
     end
 
@@ -429,7 +429,7 @@ RSpec.describe Api::V0::ShipmentsController, type: :controller do
     end
 
     def expect_error_response
-      expect(response.status).to eq 422
+      expect(response).to have_http_status :unprocessable_entity
       expect(json_response["exception"]).to eq error_message
     end
   end

--- a/spec/controllers/api/v0/statuses_controller_spec.rb
+++ b/spec/controllers/api/v0/statuses_controller_spec.rb
@@ -10,21 +10,21 @@ module Api
       it "returns alive when up to date" do
         Spree::Config.last_job_queue_heartbeat_at = Time.now.in_time_zone
         get :job_queue
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(response.body).to eq({ alive: true }.to_json)
       end
 
       it "returns dead otherwise" do
         Spree::Config.last_job_queue_heartbeat_at = 10.minutes.ago
         get :job_queue
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(response.body).to eq({ alive: false }.to_json)
       end
 
       it "returns dead when no heartbeat recorded" do
         Spree::Config.last_job_queue_heartbeat_at = nil
         get :job_queue
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(response.body).to eq({ alive: false }.to_json)
       end
     end

--- a/spec/controllers/api/v0/taxons_controller_spec.rb
+++ b/spec/controllers/api/v0/taxons_controller_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Api::V0::TaxonsController do
       api_post :create, taxon: { name: "Colors" }
 
       expect(attributes.all? { |a| json_response.include? a }).to be true
-      expect(response.status).to eq(201)
+      expect(response).to have_http_status(:created)
     end
 
     it "cannot create a new taxon with invalid attributes" do
       api_post :create, taxon: {}
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
       errors = json_response["errors"]
 
@@ -76,7 +76,7 @@ RSpec.describe Api::V0::TaxonsController do
     it "can destroy" do
       api_delete :destroy, id: taxon2.id
 
-      expect(response.status).to eq(204)
+      expect(response).to have_http_status(:no_content)
     end
   end
 end

--- a/spec/controllers/api/v0/terms_and_conditions_controller_spec.rb
+++ b/spec/controllers/api/v0/terms_and_conditions_controller_spec.rb
@@ -26,7 +26,7 @@ module Api
         it "removes terms and conditions file" do
           spree_delete :destroy, enterprise_id: enterprise
 
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
           expect(json_response["id"]).to eq enterprise.id
           enterprise.reload
           expect(enterprise.terms_and_conditions).not_to be_attached
@@ -42,7 +42,7 @@ module Api
           it "responds with error" do
             spree_delete :destroy, enterprise_id: enterprise
 
-            expect(response.status).to eq(409)
+            expect(response).to have_http_status(:conflict)
             expect(json_response['error']).to eq 'Terms and Conditions file does not exist'
           end
         end

--- a/spec/controllers/api/v0/variants_controller_spec.rb
+++ b/spec/controllers/api/v0/variants_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Api::V0::VariantsController, type: :controller do
       it "deletes a variant" do
         api_delete :destroy, id: variant_to_delete.id
 
-        expect(response.status).to eq(204)
+        expect(response).to have_http_status(:no_content)
         expect { variant_to_delete.reload }.not_to raise_error
         expect(variant_to_delete.deleted_at).to be_present
       end
@@ -150,7 +150,7 @@ RSpec.describe Api::V0::VariantsController, type: :controller do
                         product_id: variant.product.id
 
       expect(attributes.all?{ |attr| json_response.include? attr.to_s }).to eq(true)
-      expect(response.status).to eq(201)
+      expect(response).to have_http_status(:created)
       expect(json_response["sku"]).to eq("12345")
       expect(variant.product.variants.count).to eq(original_number_of_variants + 1)
     end
@@ -158,13 +158,13 @@ RSpec.describe Api::V0::VariantsController, type: :controller do
     it "can update a variant" do
       api_put :update, id: variant.to_param, variant: { sku: "12345" }
 
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "can delete a variant" do
       api_delete :destroy, id: variant.to_param
 
-      expect(response.status).to eq(204)
+      expect(response).to have_http_status(:no_content)
       expect { variant.reload }.not_to raise_error
       expect(variant.deleted_at).not_to be_nil
     end

--- a/spec/controllers/cart_controller_spec.rb
+++ b/spec/controllers/cart_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CartController, type: :controller do
       allow(cart_service).to receive(:populate) { true }
       allow(cart_service).to receive(:valid?) { true }
       post :populate, xhr: true, params: { use_route: :spree }, as: :json
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it "returns failure when unsuccessful" do
@@ -26,7 +26,7 @@ RSpec.describe CartController, type: :controller do
       allow(cart_service).to receive(:errors) { errors }
       allow(errors).to receive(:full_messages).and_return(["Error: foo"])
       post :populate, xhr: true, params: { use_route: :spree }, as: :json
-      expect(response.status).to eq(412)
+      expect(response).to have_http_status(:precondition_failed)
     end
 
     it "returns stock levels as JSON on success" do

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CheckoutController, type: :controller do
   describe "#edit" do
     it "renders the checkout" do
       get :edit, params: { step: "details" }
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
     end
 
     it "redirects to current step if no step is given" do
@@ -74,7 +74,7 @@ RSpec.describe CheckoutController, type: :controller do
           it "updates the order state to payment" do
             get :edit, params: { step: "payment" }
 
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
             expect(order.reload.state).to eq("payment")
           end
         end
@@ -83,7 +83,7 @@ RSpec.describe CheckoutController, type: :controller do
           it "updates the order state to address" do
             get :edit, params: { step: "details" }
 
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
             expect(order.reload.state).to eq("address")
           end
         end
@@ -98,7 +98,7 @@ RSpec.describe CheckoutController, type: :controller do
           it "updates the order state to address" do
             get :edit, params: { step: "details" }
 
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
             expect(order.reload.state).to eq("address")
           end
         end
@@ -119,7 +119,7 @@ RSpec.describe CheckoutController, type: :controller do
         it "returns 422 and some feedback" do
           put(:update, params:)
 
-          expect(response.status).to eq 422
+          expect(response).to have_http_status :unprocessable_entity
           expect(flash[:error]).to match "Saving failed, please update the highlighted fields."
           expect(order.reload.state).to eq "cart"
         end
@@ -276,7 +276,7 @@ RSpec.describe CheckoutController, type: :controller do
         it "returns 422 and some feedback" do
           put(:update, params:)
 
-          expect(response.status).to eq 422
+          expect(response).to have_http_status :unprocessable_entity
           expect(flash[:error]).to match "Saving failed, please update the highlighted fields."
           expect(order.reload.state).to eq "payment"
         end
@@ -405,7 +405,7 @@ RSpec.describe CheckoutController, type: :controller do
           it "updates and redirects to summary step" do
             put(:update, params:)
 
-            expect(response.status).to be 302
+            expect(response).to have_http_status :found
             expect(response).to redirect_to checkout_step_path(:summary)
             expect(order.reload.state).to eq "confirmation"
           end
@@ -420,7 +420,7 @@ RSpec.describe CheckoutController, type: :controller do
 
           it "updates and redirects to summary step" do
             put(:update, params:)
-            expect(response.status).to eq 422
+            expect(response).to have_http_status :unprocessable_entity
             expect(flash[:error]).to match "Saving failed, please update the highlighted fields."
             expect(order.reload.state).to eq "payment"
           end
@@ -557,7 +557,7 @@ RSpec.describe CheckoutController, type: :controller do
           it "returns 422 and some feedback" do
             put(:update, params:)
 
-            expect(response.status).to eq 422
+            expect(response).to have_http_status :unprocessable_entity
             expect(flash[:error]).to match "Saving failed, please update the highlighted fields."
             expect(order.reload.state).to eq "confirmation"
           end
@@ -607,7 +607,7 @@ RSpec.describe CheckoutController, type: :controller do
 
             put(:update, params:)
 
-            expect(response.status).to eq 422
+            expect(response).to have_http_status :unprocessable_entity
             expect(flash[:error]).to match "Redeeming the voucher failed"
           end
         end
@@ -621,7 +621,7 @@ RSpec.describe CheckoutController, type: :controller do
 
             put(:update, params:)
 
-            expect(response.status).to eq 422
+            expect(response).to have_http_status :unprocessable_entity
             expect(flash[:error]).to match "There was an error while trying to redeem your voucher"
           end
         end

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -162,16 +162,16 @@ RSpec.describe EnterprisesController, type: :controller do
 
     it "responds with status of 200 when the route does not exist" do
       get :check_permalink, xhr: true, params: { permalink: 'some_nonexistent_route' }, as: :js
-      expect(response.status).to be 200
+      expect(response).to have_http_status :ok
     end
 
     it "responds with status of 409 when the permalink matches an existing route" do
       # get :check_permalink, { permalink: 'enterprise_permalink', format: :js }
       # expect(response.status).to be 409
       get :check_permalink, xhr: true, params: { permalink: 'map' }, as: :js
-      expect(response.status).to be 409
+      expect(response).to have_http_status :conflict
       get :check_permalink, xhr: true, params: { permalink: '' }, as: :js
-      expect(response.status).to be 409
+      expect(response).to have_http_status :conflict
     end
   end
 

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe LineItemsController, type: :controller do
 
     it "lists items bought by the user from the same shop in the same order_cycle" do
       get :bought, format: :json
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       json_response = response.parsed_body
       expect(json_response.length).to eq completed_order.line_items.reload.count
       expect(json_response[0]['id']).to eq completed_order.line_items.first.id
@@ -53,7 +53,7 @@ RSpec.describe LineItemsController, type: :controller do
         context "where the item's order is not associated with the user" do
           it "denies deletion" do
             delete(:destroy, params:)
-            expect(response.status).to eq 403
+            expect(response).to have_http_status :forbidden
           end
         end
 
@@ -66,7 +66,7 @@ RSpec.describe LineItemsController, type: :controller do
           context "without an order cycle or distributor" do
             it "denies deletion" do
               delete(:destroy, params:)
-              expect(response.status).to eq 403
+              expect(response).to have_http_status :forbidden
             end
           end
 
@@ -76,7 +76,7 @@ RSpec.describe LineItemsController, type: :controller do
             context "where changes are not allowed" do
               it "denies deletion" do
                 delete(:destroy, params:)
-                expect(response.status).to eq 403
+                expect(response).to have_http_status :forbidden
               end
             end
 
@@ -85,7 +85,7 @@ RSpec.describe LineItemsController, type: :controller do
 
               it "deletes the line item" do
                 delete(:destroy, params:)
-                expect(response.status).to eq 204
+                expect(response).to have_http_status :no_content
                 expect { item.reload }.to raise_error ActiveRecord::RecordNotFound
               end
 
@@ -144,7 +144,7 @@ RSpec.describe LineItemsController, type: :controller do
         item = order.line_items.first
         allow(controller).to receive_messages spree_current_user: order.user
         delete :destroy, format: :json, params: { id: item }
-        expect(response.status).to eq 204
+        expect(response).to have_http_status :no_content
 
         # Check the fees again
         order.reload
@@ -188,7 +188,7 @@ RSpec.describe LineItemsController, type: :controller do
 
         allow(controller).to receive_messages spree_current_user: user
         delete(:destroy, params:)
-        expect(response.status).to eq 204
+        expect(response).to have_http_status :no_content
 
         expect(order.reload.adjustment_total).to eq calculator.preferred_normal_amount
       end

--- a/spec/controllers/shop_controller_spec.rb
+++ b/spec/controllers/shop_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ShopController, type: :controller do
         oc2 = create(:simple_order_cycle, distributors: [distributor])
 
         spree_post :order_cycle, order_cycle_id: oc2.id
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(controller.current_order_cycle).to eq(oc2)
       end
 
@@ -50,7 +50,7 @@ RSpec.describe ShopController, type: :controller do
           oc2 = create(:simple_order_cycle, distributors: [distributor])
 
           spree_post :order_cycle, order_cycle_id: oc2.id
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
           expect(response.body).to have_content oc2.id
         end
 
@@ -70,7 +70,7 @@ RSpec.describe ShopController, type: :controller do
 
           it "returns the new order cycle details" do
             spree_post :order_cycle, order_cycle_id: oc2.id
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
             expect(response.body).to have_content oc2.id
           end
         end
@@ -82,7 +82,7 @@ RSpec.describe ShopController, type: :controller do
         oc3 = create(:simple_order_cycle, distributors: [create(:distributor_enterprise)])
 
         spree_post :order_cycle, order_cycle_id: oc3.id
-        expect(response.status).to eq(404)
+        expect(response).to have_http_status(:not_found)
         expect(controller.current_order_cycle).to be_nil
       end
     end

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Spree::Admin::PaymentsController, type: :controller do
       end
 
       def expect_redirect_to(path)
-        expect(response.status).to eq 302
+        expect(response).to have_http_status :found
         expect(response.location).to eq path
       end
     end
@@ -280,7 +280,7 @@ RSpec.describe Spree::Admin::PaymentsController, type: :controller do
 
       it "renders the payments tab" do
         spree_get :index, order_id: order.number
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
       end
 
       context "order is then resumed" do
@@ -290,7 +290,7 @@ RSpec.describe Spree::Admin::PaymentsController, type: :controller do
 
         it "still renders the payments tab" do
           spree_get :index, order_id: order.number
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
         end
       end
     end
@@ -304,7 +304,7 @@ RSpec.describe Spree::Admin::PaymentsController, type: :controller do
 
       it "redirects to the order details page" do
         spree_get :index, order_id: order.number
-        expect(response.status).to eq 302
+        expect(response).to have_http_status :found
         expect(response.location).to eq spree.edit_admin_order_url(order)
       end
     end

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
 
         spree_put :update, params
 
-        expect(response.status).to eq 302
+        expect(response).to have_http_status :found
       end
 
       context "recalculating fees and taxes" do
@@ -290,7 +290,7 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
       before { allow(controller).to receive(:spree_current_user) { order.distributor.owner } }
 
       it "should allow access" do
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
       end
     end
   end

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
 
         spree_put :create, product: product_attrs_with_image
 
-        expect(response.status).to eq 200
+        expect(response).to have_http_status 200
       end
     end
 
@@ -179,7 +179,7 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
           { supplier_id: nil, primary_taxon_id: nil }
         ),
                             button: 'create'
-        expect(response.status).to eq 200
+        expect(response).to have_http_status 200
         expect(response).to render_template('spree/admin/products/new')
       end
     end

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Spree::CreditCardsController, type: :controller do
           expect(controller).not_to receive(:destroy_at_stripe)
           spree_delete :destroy, params
           expect(flash[:error]).to eq 'Sorry, the card could not be removed'
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
         end
       end
 
@@ -204,7 +204,7 @@ RSpec.describe Spree::CreditCardsController, type: :controller do
             it "doesn't delete the card" do
               expect{ spree_delete :destroy, params }.not_to change { Spree::CreditCard.count }
               expect(flash[:error]).to eq 'Sorry, the card could not be removed'
-              expect(response.status).to eq 422
+              expect(response).to have_http_status :unprocessable_entity
             end
           end
 
@@ -218,7 +218,7 @@ RSpec.describe Spree::CreditCardsController, type: :controller do
               expect{ spree_delete :destroy, params }.to change { Spree::CreditCard.count }.by(-1)
               expect(flash[:success])
                 .to eq "Your card has been removed (number: %s)" % "x-#{card.last_digits}"
-              expect(response.status).to eq 200
+              expect(response).to have_http_status :ok
             end
 
             context "card is the default card and there are existing authorizations for the user" do

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Spree::OrdersController, type: :controller do
 
       it "loads page" do
         get :show, params: { id: order.number, order_token: order.token }
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
       end
 
       it "stores order token in session as 'access_token'" do
@@ -45,7 +45,7 @@ RSpec.describe Spree::OrdersController, type: :controller do
 
       it "loads page" do
         get :show, params: { id: order.number }
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Spree::OrdersController, type: :controller do
 
       it "loads page" do
         get :show, params: { id: order.number }
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
       end
     end
 
@@ -162,7 +162,7 @@ RSpec.describe Spree::OrdersController, type: :controller do
 
         it "displays a flash message when we view the cart" do
           get :edit
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
           expect(flash[:error]).to eq 'An item in your cart has become unavailable. ' \
                                       'Please update the selected quantities.'
         end
@@ -175,7 +175,7 @@ RSpec.describe Spree::OrdersController, type: :controller do
 
         it "displays a flash message when we view the cart" do
           get :edit
-          expect(response.status).to eq 200
+          expect(response).to have_http_status :ok
           expect(flash[:error]).to eq 'An item in your cart has become unavailable. ' \
                                       'Please update the selected quantities.'
         end
@@ -192,7 +192,7 @@ RSpec.describe Spree::OrdersController, type: :controller do
           "0" => { quantity: "0", id: "9999" },
           "1" => { quantity: "99", id: li.id }
         } } }
-        expect(response.status).to eq(302)
+        expect(response).to have_http_status(:found)
         expect(li.reload.quantity).to eq(99)
       end
     end

--- a/spec/controllers/stripe/callbacks_controller_spec.rb
+++ b/spec/controllers/stripe/callbacks_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Stripe::CallbacksController, type: :controller do
 
       it "returns a 500 error" do
         spree_get :index, params
-        expect(response.status).to be 500
+        expect(response).to have_http_status :internal_server_error
       end
     end
 

--- a/spec/controllers/stripe/webhooks_controller_spec.rb
+++ b/spec/controllers/stripe/webhooks_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Stripe::WebhooksController, type: :controller do
 
       it "responds with a 400" do
         post('create', params:)
-        expect(response.status).to eq 400
+        expect(response).to have_http_status :bad_request
       end
     end
 
@@ -37,7 +37,7 @@ RSpec.describe Stripe::WebhooksController, type: :controller do
 
       it "responds with a 401" do
         post('create', params:)
-        expect(response.status).to eq 401
+        expect(response).to have_http_status :unauthorized
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Stripe::WebhooksController, type: :controller do
 
           it "falls back to 200" do
             post('create', params:)
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
           end
         end
 
@@ -64,7 +64,7 @@ RSpec.describe Stripe::WebhooksController, type: :controller do
 
           it "responds with 202" do
             post('create', params:)
-            expect(response.status).to eq 202
+            expect(response).to have_http_status :accepted
           end
         end
       end
@@ -78,7 +78,7 @@ RSpec.describe Stripe::WebhooksController, type: :controller do
         context "when the stripe_account id on the event does not match any known accounts" do
           it "doesn't delete any Stripe accounts, responds with 204" do
             post('create', params:)
-            expect(response.status).to eq 204
+            expect(response).to have_http_status :no_content
             expect(StripeAccount.all).to include stripe_account
           end
         end
@@ -88,7 +88,7 @@ RSpec.describe Stripe::WebhooksController, type: :controller do
 
           it "deletes Stripe accounts in response to a webhook" do
             post('create', params:)
-            expect(response.status).to eq 200
+            expect(response).to have_http_status :ok
             expect(StripeAccount.all).not_to include stripe_account
           end
         end

--- a/spec/controllers/user_passwords_controller_spec.rb
+++ b/spec/controllers/user_passwords_controller_spec.rb
@@ -15,20 +15,20 @@ RSpec.describe UserPasswordsController, type: :controller do
   describe "create" do
     it "returns 404 if user is not found" do
       spree_post :create, spree_user: { email: "xxxxxxxxxx@example.com" }
-      expect(response.status).to eq 404
+      expect(response).to have_http_status :not_found
       expect(response.body).to match 'Email address not found'
     end
 
     it "returns 422 if user is registered but not confirmed" do
       spree_post :create, spree_user: { email: unconfirmed_user.email }
-      expect(response.status).to eq 422
+      expect(response).to have_http_status :unprocessable_entity
       expect(response.body).to match "You must confirm your email \
 address before you can reset your password."
     end
 
     it "returns 200 when password reset was successful" do
       spree_post :create, spree_user: { email: user.email }
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       expect(response.body).to match "An email with instructions on resetting \
 your password has been sent!"
     end

--- a/spec/controllers/user_registrations_controller_spec.rb
+++ b/spec/controllers/user_registrations_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UserRegistrationsController, type: :controller do
 
     it "returns validation errors" do
       post :create, params: { spree_user: {}, use_route: :spree }, as: :json
-      expect(response.status).to eq(401)
+      expect(response).to have_http_status(:unauthorized)
       json = response.parsed_body
       expect(json).to eq("email" => ["can't be blank"], "password" => ["can't be blank"])
     end
@@ -31,7 +31,7 @@ RSpec.describe UserRegistrationsController, type: :controller do
 
       post :create, params: { spree_user: user_params, use_route: :spree }, as: :json
 
-      expect(response.status).to eq(401)
+      expect(response).to have_http_status(:unauthorized)
       json = response.parsed_body
       expect(json).to eq(
         "message" =>
@@ -41,7 +41,7 @@ RSpec.describe UserRegistrationsController, type: :controller do
 
     it "returns 200 when registration succeeds" do
       post :create, params: { spree_user: user_params, use_route: :spree }, as: :json
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
       json = response.parsed_body
       expect(json).to eq("email" => "test@test.com")
       expect(controller.spree_current_user).to be_nil

--- a/spec/requests/api/routes_spec.rb
+++ b/spec/requests/api/routes_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Orders Cycles endpoint', type: :request do
 
     it "does not redirect" do
       get path
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/checkout/stripe_sca_spec.rb
+++ b/spec/requests/checkout/stripe_sca_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "checking out an order with a Stripe SCA payment method", type: :
       it "should not process the payment" do
         put(update_checkout_path, params:)
 
-        expect(response.status).to be 400
+        expect(response).to have_http_status :bad_request
 
         expect(json_response["flash"]["error"]).to eq "payment-intent-failure"
         expect(order.payments.completed.count).to be 0
@@ -243,7 +243,7 @@ RSpec.describe "checking out an order with a Stripe SCA payment method", type: :
         it "should not process the payment" do
           put(update_checkout_path, params:)
 
-          expect(response.status).to be 400
+          expect(response).to have_http_status :bad_request
 
           expect(json_response["flash"]["error"])
             .to eq(format("There was a problem with your payment information: %s",
@@ -260,7 +260,7 @@ RSpec.describe "checking out an order with a Stripe SCA payment method", type: :
         it "should not process the payment" do
           put(update_checkout_path, params:)
 
-          expect(response.status).to be 400
+          expect(response).to have_http_status :bad_request
 
           expect(json_response["flash"]["error"]).to eq "payment-intent-failure"
           expect(order.payments.completed.count).to be 0
@@ -275,7 +275,7 @@ RSpec.describe "checking out an order with a Stripe SCA payment method", type: :
         it "should not process the payment" do
           put(update_checkout_path, params:)
 
-          expect(response.status).to be 400
+          expect(response).to have_http_status :bad_request
 
           expect(json_response["flash"]["error"]).to include "payment-method-failure"
           expect(order.payments.completed.count).to be 0
@@ -329,7 +329,7 @@ RSpec.describe "checking out an order with a Stripe SCA payment method", type: :
         it "should not process the payment" do
           put(update_checkout_path, params:)
 
-          expect(response.status).to be 400
+          expect(response).to have_http_status :bad_request
 
           expect(json_response["flash"]["error"]).to eq "payment-intent-failure"
           expect(order.payments.completed.count).to be 0
@@ -350,7 +350,7 @@ RSpec.describe "checking out an order with a Stripe SCA payment method", type: :
         it "redirects the user to the authorization stripe url" do
           put(update_checkout_path, params:)
 
-          expect(response.status).to be 200
+          expect(response).to have_http_status :ok
           expect(response.body).to include stripe_redirect_url
         end
       end

--- a/spec/requests/home_controller_spec.rb
+++ b/spec/requests/home_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe HomeController, type: :request do
     it "renders the unauthorized template" do
       get "/unauthorized"
 
-      expect(response.status).to eq 401
+      expect(response).to have_http_status :unauthorized
       expect(response).to render_template("shared/unauthorized", layout: 'darkswarm')
     end
   end

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe '/user/spree_user/auth/openid_connect/callback', type: :request d
       account = OidcAccount.last
       expect(account.provider).to eq "openid_connect"
       expect(account.uid).to eq "ofn@example.com"
-      expect(response.status).to eq(302)
+      expect(response).to have_http_status(:found)
     end
 
     context 'when OIDC account already linked with a different user' do
@@ -45,7 +45,7 @@ RSpec.describe '/user/spree_user/auth/openid_connect/callback', type: :request d
       it 'fails with error message' do
         expect { request! }.not_to change { OidcAccount.count }
 
-        expect(response.status).to eq(302)
+        expect(response).to have_http_status(:found)
         expect(flash[:error]).to match "ofn@example.com is already associated with another account"
       end
     end
@@ -59,7 +59,7 @@ RSpec.describe '/user/spree_user/auth/openid_connect/callback', type: :request d
     it 'fails with bad auth data' do
       expect { request! }.not_to change { OidcAccount.count }
 
-      expect(response.status).to eq(302)
+      expect(response).to have_http_status(:found)
       expect(flash[:error]).to match "Could not sign in"
     end
   end

--- a/spec/services/embedded_page_service_spec.rb
+++ b/spec/services/embedded_page_service_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe EmbeddedPageService do
       end
 
       it "returns a 200 status" do
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
       end
     end
   end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -24,7 +24,7 @@ module OpenFoodNetwork
 
     def assert_unauthorized!
       expect(json_response).to eq("error" => "You are not authorized to perform that action.")
-      expect(response.status).to eq 401
+      expect(response).to have_http_status :unauthorized
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Contributes to #13314 
- [RSpecRails/HaveHttpStatus](https://docs.rubocop.org/rubocop-rspec_rails/cops_rspecrails.html#rspecrailshavehttpstatus) cop

Note every `HaveHttpStatus` offense was paired with a [RSpecRails/HttpStatus](https://docs.rubocop.org/rubocop-rspec_rails/cops_rspecrails.html#rspecrailshttpstatus) since exclusion was lifted in order to correct.
In other words the last offense was shadowed with the `HaveHttpStatus` offense. (`200` instead of `:ok`)

There will be a correction with that cop for files listed in the `todo` file, but I have chosen to correct both cops here as offenses were on the same line.


#### What should we test?
Nothing. All tests should pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled