### PR TITLE
Change the layout for instance configuration options

### DIFF
--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -19,32 +19,26 @@
         .alpha.six.columns
           %fieldset.legal.no-border-bottom
             %legend{:align => "center"}= t('.legal_settings')
-            .label-inline
-              .field
-                = preference_field_tag(:enterprises_require_tos, Spree::Config[:enterprises_require_tos], :type => Spree::Config.preference_type(:enterprises_require_tos))
-                = label_tag(:enterprises_require_tos, t('.enterprises_require_tos')) + tag(:br)
-            .label-inline
-              .field
-                = preference_field_tag(:shoppers_require_tos, Spree::Config[:shoppers_require_tos], :type => Spree::Config.preference_type(:shoppers_require_tos))
-                = label_tag(:shoppers_require_tos, t('.shoppers_require_tos')) + tag(:br)
-            .label-inline
-              .field
-                = preference_field_tag(:cookies_consent_banner_toggle, Spree::Config[:cookies_consent_banner_toggle], :type => Spree::Config.preference_type(:cookies_consent_banner_toggle))
-                = label_tag(:cookies_consent_banner_toggle, t('.cookies_consent_banner_toggle')) + tag(:br)
-            .label-inline
-              .field
-                = preference_field_tag(:cookies_policy_matomo_section, Spree::Config[:cookies_policy_matomo_section], :type => Spree::Config.preference_type(:cookies_policy_matomo_section))
-                = label_tag(:cookies_policy_matomo_section, t('.cookies_policy_matomo_section')) + tag(:br)
-            .label-inline
-              .field
-                = label_tag(:privacy_policy_url, t('.privacy_policy_url')) + tag(:br)
-                = preference_field_tag(:privacy_policy_url, Spree::Config[:privacy_policy_url], type: Spree::Config.preference_type(:privacy_policy_url))
+            .field.label-inline
+              = preference_field_tag(:enterprises_require_tos, Spree::Config[:enterprises_require_tos], :type => Spree::Config.preference_type(:enterprises_require_tos))
+              = label_tag(:enterprises_require_tos, t('.enterprises_require_tos')) + tag(:br)
+            .field.label-inline
+              = preference_field_tag(:shoppers_require_tos, Spree::Config[:shoppers_require_tos], :type => Spree::Config.preference_type(:shoppers_require_tos))
+              = label_tag(:shoppers_require_tos, t('.shoppers_require_tos')) + tag(:br)
+            .field.label-inline
+              = preference_field_tag(:cookies_consent_banner_toggle, Spree::Config[:cookies_consent_banner_toggle], :type => Spree::Config.preference_type(:cookies_consent_banner_toggle))
+              = label_tag(:cookies_consent_banner_toggle, t('.cookies_consent_banner_toggle')) + tag(:br)
+            .field.label-inline
+              = preference_field_tag(:cookies_policy_matomo_section, Spree::Config[:cookies_policy_matomo_section], :type => Spree::Config.preference_type(:cookies_policy_matomo_section))
+              = label_tag(:cookies_policy_matomo_section, t('.cookies_policy_matomo_section')) + tag(:br)
+            .field.label-inline
+              = label_tag(:privacy_policy_url, t('.privacy_policy_url')) + tag(:br)
+              = preference_field_tag(:privacy_policy_url, Spree::Config[:privacy_policy_url], type: Spree::Config.preference_type(:privacy_policy_url))
           %fieldset.embedded_shopfronts.no-border-bottom
             %legend{:align => "center"}= t('admin.shopfront_settings.embedded_shopfront_settings')
-            .label-inline
-              .field
-                = preference_field_tag(:enable_embedded_shopfronts, Spree::Config[:enable_embedded_shopfronts], type: Spree::Config.preference_type(:enable_embedded_shopfronts))
-                = label_tag(:enable_embedded_shopfronts, t('admin.shopfront_settings.enable_embedded_shopfronts')) + tag(:br)
+            .field.label-inline
+              = preference_field_tag(:enable_embedded_shopfronts, Spree::Config[:enable_embedded_shopfronts], type: Spree::Config.preference_type(:enable_embedded_shopfronts))
+              = label_tag(:enable_embedded_shopfronts, t('admin.shopfront_settings.enable_embedded_shopfronts')) + tag(:br)
             .field
               = label_tag(:embedded_shopfronts_whitelist, t('admin.shopfront_settings.embedded_shopfronts_whitelist')) + tag(:br)
               = preference_field_tag(:embedded_shopfronts_whitelist, Spree::Config[:embedded_shopfronts_whitelist], type: Spree::Config.preference_type(:embedded_shopfronts_whitelist))
@@ -79,10 +73,9 @@
               = text_field_tag :currency_thousands_separator, Spree::Config[:currency_thousands_separator], :size => 3
           %fieldset.number_localization.no-border-bottom
             %legend{:align => "center"}= t('admin.number_localization.number_localization_settings')
-            .label-inline
-              .field
-                = preference_field_tag(:enable_localized_number?, Spree::Config[:enable_localized_number?], type: Spree::Config.preference_type(:enable_localized_number?))
-                = label_tag(:enable_localized_number?, t('admin.number_localization.enable_localized_number')) + tag(:br)
+            .field.label-inline
+              = preference_field_tag(:enable_localized_number?, Spree::Config[:enable_localized_number?], type: Spree::Config.preference_type(:enable_localized_number?))
+              = label_tag(:enable_localized_number?, t('admin.number_localization.enable_localized_number')) + tag(:br)
           %fieldset.available_units.no-border-bottom
             %legend{:align => "center"}= t('admin.available_units')
             .field

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -19,26 +19,32 @@
         .alpha.six.columns
           %fieldset.legal.no-border-bottom
             %legend{:align => "center"}= t('.legal_settings')
-            .field
-              = preference_field_tag(:enterprises_require_tos, Spree::Config[:enterprises_require_tos], :type => Spree::Config.preference_type(:enterprises_require_tos))
-              = label_tag(:enterprises_require_tos, t('.enterprises_require_tos')) + tag(:br)
-            .field
-              = preference_field_tag(:shoppers_require_tos, Spree::Config[:shoppers_require_tos], :type => Spree::Config.preference_type(:shoppers_require_tos))
-              = label_tag(:shoppers_require_tos, t('.shoppers_require_tos')) + tag(:br)
-            .field
-              = preference_field_tag(:cookies_consent_banner_toggle, Spree::Config[:cookies_consent_banner_toggle], :type => Spree::Config.preference_type(:cookies_consent_banner_toggle))
-              = label_tag(:cookies_consent_banner_toggle, t('.cookies_consent_banner_toggle')) + tag(:br)
-            .field
-              = preference_field_tag(:cookies_policy_matomo_section, Spree::Config[:cookies_policy_matomo_section], :type => Spree::Config.preference_type(:cookies_policy_matomo_section))
-              = label_tag(:cookies_policy_matomo_section, t('.cookies_policy_matomo_section')) + tag(:br)
-            .field
-              = label_tag(:privacy_policy_url, t('.privacy_policy_url')) + tag(:br)
-              = preference_field_tag(:privacy_policy_url, Spree::Config[:privacy_policy_url], type: Spree::Config.preference_type(:privacy_policy_url))
+            .label-inline
+              .field
+                = preference_field_tag(:enterprises_require_tos, Spree::Config[:enterprises_require_tos], :type => Spree::Config.preference_type(:enterprises_require_tos))
+                = label_tag(:enterprises_require_tos, t('.enterprises_require_tos')) + tag(:br)
+            .label-inline
+              .field
+                = preference_field_tag(:shoppers_require_tos, Spree::Config[:shoppers_require_tos], :type => Spree::Config.preference_type(:shoppers_require_tos))
+                = label_tag(:shoppers_require_tos, t('.shoppers_require_tos')) + tag(:br)
+            .label-inline
+              .field
+                = preference_field_tag(:cookies_consent_banner_toggle, Spree::Config[:cookies_consent_banner_toggle], :type => Spree::Config.preference_type(:cookies_consent_banner_toggle))
+                = label_tag(:cookies_consent_banner_toggle, t('.cookies_consent_banner_toggle')) + tag(:br)
+            .label-inline
+              .field
+                = preference_field_tag(:cookies_policy_matomo_section, Spree::Config[:cookies_policy_matomo_section], :type => Spree::Config.preference_type(:cookies_policy_matomo_section))
+                = label_tag(:cookies_policy_matomo_section, t('.cookies_policy_matomo_section')) + tag(:br)
+            .label-inline
+              .field
+                = label_tag(:privacy_policy_url, t('.privacy_policy_url')) + tag(:br)
+                = preference_field_tag(:privacy_policy_url, Spree::Config[:privacy_policy_url], type: Spree::Config.preference_type(:privacy_policy_url))
           %fieldset.embedded_shopfronts.no-border-bottom
             %legend{:align => "center"}= t('admin.shopfront_settings.embedded_shopfront_settings')
-            .field
-              = preference_field_tag(:enable_embedded_shopfronts, Spree::Config[:enable_embedded_shopfronts], type: Spree::Config.preference_type(:enable_embedded_shopfronts))
-              = label_tag(:enable_embedded_shopfronts, t('admin.shopfront_settings.enable_embedded_shopfronts')) + tag(:br)
+            .label-inline
+              .field
+                = preference_field_tag(:enable_embedded_shopfronts, Spree::Config[:enable_embedded_shopfronts], type: Spree::Config.preference_type(:enable_embedded_shopfronts))
+                = label_tag(:enable_embedded_shopfronts, t('admin.shopfront_settings.enable_embedded_shopfronts')) + tag(:br)
             .field
               = label_tag(:embedded_shopfronts_whitelist, t('admin.shopfront_settings.embedded_shopfronts_whitelist')) + tag(:br)
               = preference_field_tag(:embedded_shopfronts_whitelist, Spree::Config[:embedded_shopfronts_whitelist], type: Spree::Config.preference_type(:embedded_shopfronts_whitelist))
@@ -73,9 +79,10 @@
               = text_field_tag :currency_thousands_separator, Spree::Config[:currency_thousands_separator], :size => 3
           %fieldset.number_localization.no-border-bottom
             %legend{:align => "center"}= t('admin.number_localization.number_localization_settings')
-            .field
-              = preference_field_tag(:enable_localized_number?, Spree::Config[:enable_localized_number?], type: Spree::Config.preference_type(:enable_localized_number?))
-              = label_tag(:enable_localized_number?, t('admin.number_localization.enable_localized_number')) + tag(:br)
+            .label-inline
+              .field
+                = preference_field_tag(:enable_localized_number?, Spree::Config[:enable_localized_number?], type: Spree::Config.preference_type(:enable_localized_number?))
+                = label_tag(:enable_localized_number?, t('admin.number_localization.enable_localized_number')) + tag(:br)
           %fieldset.available_units.no-border-bottom
             %legend{:align => "center"}= t('admin.available_units')
             .field

--- a/app/webpacker/css/admin_v3/shared/forms.scss
+++ b/app/webpacker/css/admin_v3/shared/forms.scss
@@ -79,6 +79,10 @@ label {
   display: block;
 }
 
+.label-inline label {
+  display: inline;
+}
+
 span.info {
   font-style: italic;
   font-size: 85%;


### PR DESCRIPTION


#### What? Why?

In the configuration of the instance some of the options displayed as block and not inline. This is not visible in English on a "normal" monitor but in other translations it is. That makes inconsistency in the UI. Example: 
 
![image](https://github.com/user-attachments/assets/d4ce0174-9ee5-41ae-877d-b5be7d764eb7)

I have introduced another css level to make these elements "inline". That should behave better and have a more consistent look even in smaller screens. Result: 

![image](https://github.com/user-attachments/assets/36db43b6-db30-44c3-8144-018bd24d6f31)

#### What should we test?

- Visit the /admin/general_settings page and check that these options displays all in an "inline" mode making a more fluid look

#### Release notes

User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
Fix layout inconsistency in general settings by enforcing inline display for configuration options