### PR TITLE
Fixes RSpec Rails HttpStatus offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,15 +221,6 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 8
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: numeric, symbolic, be_status
-RSpecRails/HttpStatus:
-  Exclude:
-    - 'spec/controllers/spree/admin/products_controller_spec.rb'
-    - 'spec/requests/api/orders_spec.rb'
-
 # Offense count: 144
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
                      }
                    ]
 
-        expect(response).to have_http_status(302)
+        expect(response).to have_http_status(:found)
       end
 
       it 'does not redirect to bulk_products' do
@@ -169,7 +169,7 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
 
         spree_put :create, product: product_attrs_with_image
 
-        expect(response).to have_http_status 200
+        expect(response).to have_http_status :ok
       end
     end
 
@@ -179,7 +179,7 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
           { supplier_id: nil, primary_taxon_id: nil }
         ),
                             button: 'create'
-        expect(response).to have_http_status 200
+        expect(response).to have_http_status :ok
         expect(response).to render_template('spree/admin/products/new')
       end
     end

--- a/spec/requests/api/orders_spec.rb
+++ b/spec/requests/api/orders_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'api/v0/orders', swagger_doc: 'v0.yaml', type: :request do
 
           context "and there are no query parameters" do
             run_test! do |response|
-              expect(response).to have_http_status(200)
+              expect(response).to have_http_status(:ok)
 
               data = JSON.parse(response.body)
               orders = data["orders"]
@@ -78,7 +78,7 @@ RSpec.describe 'api/v0/orders', swagger_doc: 'v0.yaml', type: :request do
             before { order_dist2.distributor.update owner: user }
 
             run_test! do |response|
-              expect(response).to have_http_status(200)
+              expect(response).to have_http_status(:ok)
 
               data = JSON.parse(response.body)
               orders = data["orders"]
@@ -92,7 +92,7 @@ RSpec.describe 'api/v0/orders', swagger_doc: 'v0.yaml', type: :request do
             let(:'q[completed_at_lt]') { Time.zone.today - 6.days }
 
             run_test! do |response|
-              expect(response).to have_http_status(200)
+              expect(response).to have_http_status(:ok)
 
               data = JSON.parse(response.body)
               orders = data["orders"]
@@ -104,7 +104,7 @@ RSpec.describe 'api/v0/orders', swagger_doc: 'v0.yaml', type: :request do
           context "and queried by complete state" do
             let(:'q[state_eq]') { "complete" }
             run_test! do |response|
-              expect(response).to have_http_status(200)
+              expect(response).to have_http_status(:ok)
 
               data = JSON.parse(response.body)
               orders = data["orders"]
@@ -116,7 +116,7 @@ RSpec.describe 'api/v0/orders', swagger_doc: 'v0.yaml', type: :request do
           context "and queried by credit_owed payment_state" do
             let(:'q[payment_state_eq]') { "credit_owed" }
             run_test! do |response|
-              expect(response).to have_http_status(200)
+              expect(response).to have_http_status(:ok)
 
               data = JSON.parse(response.body)
               orders = data["orders"]
@@ -128,7 +128,7 @@ RSpec.describe 'api/v0/orders', swagger_doc: 'v0.yaml', type: :request do
           context "and queried by buyer email contains a specific string" do
             let(:'q[email_cont]') { order_dist1.email.split("@").first }
             run_test! do |response|
-              expect(response).to have_http_status(200)
+              expect(response).to have_http_status(:ok)
 
               data = JSON.parse(response.body)
               orders = data["orders"]
@@ -145,7 +145,7 @@ RSpec.describe 'api/v0/orders', swagger_doc: 'v0.yaml', type: :request do
             before { order_dist2.distributor.update owner: user }
 
             run_test! do |response|
-              expect(response).to have_http_status(200)
+              expect(response).to have_http_status(:ok)
 
               data = JSON.parse(response.body)
               orders = data["orders"]


### PR DESCRIPTION
#### What? Why?

- Contributes to #13314
- [RSpecRails/HttpStatus](https://docs.rubocop.org/rubocop-rspec_rails/cops_rspecrails.html#rspecrailshttpstatus) cop

The most of the offenses were actually corrected in #13325.
That explains the small amount of corrections here.

#### What should we test?
Nothing. All tests should pass.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.