### PR TITLE
Fix typo in yml files: exiting vs. existing

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1091,7 +1091,7 @@ en:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -628,7 +628,7 @@ en_AU:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_BE.yml
+++ b/config/locales/en_BE.yml
@@ -587,7 +587,7 @@ en_BE:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_CA.yml
+++ b/config/locales/en_CA.yml
@@ -1015,7 +1015,7 @@ en_CA:
         no_name: No name
         blank_enterprise: some products do not have an enterprise associated
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_DE.yml
+++ b/config/locales/en_DE.yml
@@ -594,7 +594,7 @@ en_DE:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_FR.yml
+++ b/config/locales/en_FR.yml
@@ -1015,7 +1015,7 @@ en_FR:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -1015,7 +1015,7 @@ en_GB:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_IE.yml
+++ b/config/locales/en_IE.yml
@@ -974,7 +974,7 @@ en_IE:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_IN.yml
+++ b/config/locales/en_IN.yml
@@ -612,7 +612,7 @@ en_IN:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_NZ.yml
+++ b/config/locales/en_NZ.yml
@@ -768,7 +768,7 @@ en_NZ:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_PH.yml
+++ b/config/locales/en_PH.yml
@@ -604,7 +604,7 @@ en_PH:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level

--- a/config/locales/en_ZA.yml
+++ b/config/locales/en_ZA.yml
@@ -607,7 +607,7 @@ en_ZA:
         no_name: No name
         blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
-        reset_absent_tip: Set stock to zero for all exiting products not present in the file
+        reset_absent_tip: Set stock to zero for all existing products not present in the file
         overwrite_all: Overwrite all
         overwrite_empty: Overwrite if empty
         default_stock: Set stock level


### PR DESCRIPTION
#### What? Why?

While testing #13310 I found a typo and I thought I could fix it:

||Content|
|-|-|
|Before|reset_absent_tip: Set stock to zero for all **exiting** products not present in the file|
|After|reset_absent_tip: Set stock to zero for all **existing** products not present in the file|

![grafik](https://github.com/user-attachments/assets/ba75138b-b7f1-4860-886b-9fb27f3957ff)

#### What should we test?
Native speaker to confirm this is correct English.
Import page shows and works correctly.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
