### PR TITLE
Fixes RSpecRailsInferredSpecType offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,28 +221,11 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 115
+# Offense count: 98
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
 RSpecRails/InferredSpecType:
   Exclude:
-    - 'spec/controllers/api/v0/customers_controller_spec.rb'
-    - 'spec/controllers/api/v0/enterprise_fees_controller_spec.rb'
-    - 'spec/controllers/api/v0/enterprises_controller_spec.rb'
-    - 'spec/controllers/api/v0/exchange_products_controller_spec.rb'
-    - 'spec/controllers/api/v0/logos_controller_spec.rb'
-    - 'spec/controllers/api/v0/order_cycles_controller_spec.rb'
-    - 'spec/controllers/api/v0/orders_controller_spec.rb'
-    - 'spec/controllers/api/v0/product_images_controller_spec.rb'
-    - 'spec/controllers/api/v0/products_controller_spec.rb'
-    - 'spec/controllers/api/v0/promo_images_controller_spec.rb'
-    - 'spec/controllers/api/v0/reports/packing_report_spec.rb'
-    - 'spec/controllers/api/v0/reports_controller_spec.rb'
-    - 'spec/controllers/api/v0/shipments_controller_spec.rb'
-    - 'spec/controllers/api/v0/shops_controller_spec.rb'
-    - 'spec/controllers/api/v0/statuses_controller_spec.rb'
-    - 'spec/controllers/api/v0/terms_and_conditions_controller_spec.rb'
-    - 'spec/controllers/api/v0/variants_controller_spec.rb'
     - 'spec/controllers/base_controller_spec.rb'
     - 'spec/controllers/cart_controller_spec.rb'
     - 'spec/controllers/checkout_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,30 +221,11 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 56
+# Offense count: 37
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
 RSpecRails/InferredSpecType:
   Exclude:
-    - 'spec/helpers/admin/enterprises_helper_spec.rb'
-    - 'spec/helpers/admin/orders_helper_spec.rb'
-    - 'spec/helpers/admin/reports_helper_spec.rb'
-    - 'spec/helpers/admin/subscriptions_helper_spec.rb'
-    - 'spec/helpers/application_helper_spec.rb'
-    - 'spec/helpers/checkout_helper_spec.rb'
-    - 'spec/helpers/i18n_helper_spec.rb'
-    - 'spec/helpers/injection_helper_spec.rb'
-    - 'spec/helpers/link_helper_spec.rb'
-    - 'spec/helpers/navigation_helper_spec.rb'
-    - 'spec/helpers/order_cycles_helper_spec.rb'
-    - 'spec/helpers/serializer_helper_spec.rb'
-    - 'spec/helpers/shop_helper_spec.rb'
-    - 'spec/helpers/spree/admin/base_helper_spec.rb'
-    - 'spec/helpers/spree/admin/general_settings_helper_spec.rb'
-    - 'spec/helpers/spree/admin/orders_helper_spec.rb'
-    - 'spec/helpers/spree/orders_helper_spec.rb'
-    - 'spec/helpers/tax_helper_spec.rb'
-    - 'spec/helpers/terms_and_conditions_helper_spec.rb'
     - 'spec/jobs/connect_app_job_spec.rb'
     - 'spec/mailers/producer_mailer_spec.rb'
     - 'spec/mailers/subscription_mailer_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,21 +221,11 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 144
+# Offense count: 134
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
 RSpecRails/InferredSpecType:
   Exclude:
-    - 'engines/dfc_provider/spec/requests/addresses_spec.rb'
-    - 'engines/dfc_provider/spec/requests/catalog_items_spec.rb'
-    - 'engines/dfc_provider/spec/requests/enterprise_groups/affiliated_by_spec.rb'
-    - 'engines/dfc_provider/spec/requests/enterprise_groups_spec.rb'
-    - 'engines/dfc_provider/spec/requests/enterprises_spec.rb'
-    - 'engines/dfc_provider/spec/requests/offers_spec.rb'
-    - 'engines/dfc_provider/spec/requests/persons_spec.rb'
-    - 'engines/dfc_provider/spec/requests/social_medias_spec.rb'
-    - 'engines/dfc_provider/spec/requests/supplied_products_spec.rb'
-    - 'engines/web/spec/helpers/cookies_policy_helper_spec.rb'
     - 'spec/controllers/admin/bulk_line_items_controller_spec.rb'
     - 'spec/controllers/admin/column_preferences_controller_spec.rb'
     - 'spec/controllers/admin/customers_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,14 +221,11 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 37
+# Offense count: 34
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
 RSpecRails/InferredSpecType:
   Exclude:
-    - 'spec/jobs/connect_app_job_spec.rb'
-    - 'spec/mailers/producer_mailer_spec.rb'
-    - 'spec/mailers/subscription_mailer_spec.rb'
     - 'spec/models/column_preference_spec.rb'
     - 'spec/models/connected_app_spec.rb'
     - 'spec/models/customer_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,22 +221,11 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 98
+# Offense count: 85
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
 RSpecRails/InferredSpecType:
   Exclude:
-    - 'spec/controllers/base_controller_spec.rb'
-    - 'spec/controllers/cart_controller_spec.rb'
-    - 'spec/controllers/checkout_controller_spec.rb'
-    - 'spec/controllers/enterprises_controller_spec.rb'
-    - 'spec/controllers/groups_controller_spec.rb'
-    - 'spec/controllers/line_items_controller_spec.rb'
-    - 'spec/controllers/payment_gateways/paypal_controller_spec.rb'
-    - 'spec/controllers/payment_gateways/stripe_controller_spec.rb'
-    - 'spec/controllers/registration_controller_spec.rb'
-    - 'spec/controllers/shop_controller_spec.rb'
-    - 'spec/controllers/shops_controller_spec.rb'
     - 'spec/controllers/spree/admin/adjustments_controller_spec.rb'
     - 'spec/controllers/spree/admin/base_controller_spec.rb'
     - 'spec/controllers/spree/admin/countries_controller_spec.rb'
@@ -263,10 +252,6 @@ RSpecRails/InferredSpecType:
     - 'spec/controllers/spree/users_controller_spec.rb'
     - 'spec/controllers/stripe/callbacks_controller_spec.rb'
     - 'spec/controllers/stripe/webhooks_controller_spec.rb'
-    - 'spec/controllers/user_confirmations_controller_spec.rb'
-    - 'spec/controllers/user_passwords_controller_spec.rb'
-    - 'spec/controllers/user_registrations_controller_spec.rb'
-    - 'spec/controllers/webhook_endpoints_controller_spec.rb'
     - 'spec/helpers/admin/enterprises_helper_spec.rb'
     - 'spec/helpers/admin/orders_helper_spec.rb'
     - 'spec/helpers/admin/reports_helper_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,28 +221,11 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 18
+# Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
 RSpecRails/InferredSpecType:
   Exclude:
-    - 'spec/requests/admin/images_spec.rb'
-    - 'spec/requests/admin/product_import_spec.rb'
-    - 'spec/requests/admin/vouchers_spec.rb'
-    - 'spec/requests/api/orders_spec.rb'
-    - 'spec/requests/api/routes_spec.rb'
-    - 'spec/requests/api/v1/customers_spec.rb'
-    - 'spec/requests/api_docs_spec.rb'
-    - 'spec/requests/checkout/paypal_spec.rb'
-    - 'spec/requests/checkout/routes_spec.rb'
-    - 'spec/requests/checkout/stripe_sca_spec.rb'
-    - 'spec/requests/errors_spec.rb'
-    - 'spec/requests/home_controller_spec.rb'
-    - 'spec/requests/large_request_spec.rb'
-    - 'spec/requests/omniauth_callbacks_controller_spec.rb'
-    - 'spec/requests/spree/admin/overview_spec.rb'
-    - 'spec/requests/spree/admin/payments_spec.rb'
-    - 'spec/requests/voucher_adjustments_spec.rb'
     - 'spec/routing/stripe_spec.rb'
 
 # Offense count: 1

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -222,13 +222,6 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/order/checkout.rb'
 
 # Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Inferences.
-RSpecRails/InferredSpecType:
-  Exclude:
-    - 'spec/routing/stripe_spec.rb'
-
-# Offense count: 1
 # Configuration parameters: TransactionMethods.
 Rails/TransactionExitStatement:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,30 +221,11 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 85
+# Offense count: 65
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
 RSpecRails/InferredSpecType:
   Exclude:
-    - 'spec/controllers/spree/admin/adjustments_controller_spec.rb'
-    - 'spec/controllers/spree/admin/base_controller_spec.rb'
-    - 'spec/controllers/spree/admin/countries_controller_spec.rb'
-    - 'spec/controllers/spree/admin/general_settings_controller_spec.rb'
-    - 'spec/controllers/spree/admin/orders/customer_details_controller_spec.rb'
-    - 'spec/controllers/spree/admin/orders/invoices_spec.rb'
-    - 'spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb'
-    - 'spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb'
-    - 'spec/controllers/spree/admin/orders_controller_spec.rb'
-    - 'spec/controllers/spree/admin/overview_controller_spec.rb'
-    - 'spec/controllers/spree/admin/payment_methods_controller_spec.rb'
-    - 'spec/controllers/spree/admin/products_controller_spec.rb'
-    - 'spec/controllers/spree/admin/return_authorizations_controller_spec.rb'
-    - 'spec/controllers/spree/admin/search_controller_spec.rb'
-    - 'spec/controllers/spree/admin/shipping_categories_controller_spec.rb'
-    - 'spec/controllers/spree/admin/shipping_methods_controller_spec.rb'
-    - 'spec/controllers/spree/admin/tax_rates_controller_spec.rb'
-    - 'spec/controllers/spree/admin/tax_settings_controller_spec.rb'
-    - 'spec/controllers/spree/admin/variants_controller_spec.rb'
     - 'spec/controllers/spree/api_keys_controller_spec.rb'
     - 'spec/controllers/spree/credit_cards_controller_spec.rb'
     - 'spec/controllers/spree/orders_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,30 +221,11 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 134
+# Offense count: 115
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
 RSpecRails/InferredSpecType:
   Exclude:
-    - 'spec/controllers/admin/bulk_line_items_controller_spec.rb'
-    - 'spec/controllers/admin/column_preferences_controller_spec.rb'
-    - 'spec/controllers/admin/customers_controller_spec.rb'
-    - 'spec/controllers/admin/enterprises_controller_spec.rb'
-    - 'spec/controllers/admin/inventory_items_controller_spec.rb'
-    - 'spec/controllers/admin/invoice_settings_controller_spec.rb'
-    - 'spec/controllers/admin/matomo_settings_controller_spec.rb'
-    - 'spec/controllers/admin/order_cycles_controller_spec.rb'
-    - 'spec/controllers/admin/product_import_controller_spec.rb'
-    - 'spec/controllers/admin/proxy_orders_controller_spec.rb'
-    - 'spec/controllers/admin/reports_controller_spec.rb'
-    - 'spec/controllers/admin/schedules_controller_spec.rb'
-    - 'spec/controllers/admin/stripe_accounts_controller_spec.rb'
-    - 'spec/controllers/admin/stripe_connect_settings_controller_spec.rb'
-    - 'spec/controllers/admin/subscription_line_items_controller_spec.rb'
-    - 'spec/controllers/admin/subscriptions_controller_spec.rb'
-    - 'spec/controllers/admin/tag_rules_controller_spec.rb'
-    - 'spec/controllers/admin/terms_of_service_files_controller_spec.rb'
-    - 'spec/controllers/admin/variant_overrides_controller_spec.rb'
     - 'spec/controllers/api/v0/customers_controller_spec.rb'
     - 'spec/controllers/api/v0/enterprise_fees_controller_spec.rb'
     - 'spec/controllers/api/v0/enterprises_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,27 +221,11 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 34
+# Offense count: 18
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
 RSpecRails/InferredSpecType:
   Exclude:
-    - 'spec/models/column_preference_spec.rb'
-    - 'spec/models/connected_app_spec.rb'
-    - 'spec/models/customer_spec.rb'
-    - 'spec/models/invoice_spec.rb'
-    - 'spec/models/oidc_account_spec.rb'
-    - 'spec/models/proxy_order_spec.rb'
-    - 'spec/models/report_blob_spec.rb'
-    - 'spec/models/semantic_link_spec.rb'
-    - 'spec/models/spree/gateway/stripe_sca_spec.rb'
-    - 'spec/models/subscription_spec.rb'
-    - 'spec/models/tag_rule/filter_order_cycles_spec.rb'
-    - 'spec/models/tag_rule/filter_payment_methods_spec.rb'
-    - 'spec/models/tag_rule/filter_products_spec.rb'
-    - 'spec/models/tag_rule/filter_shipping_methods_spec.rb'
-    - 'spec/models/tag_rule_spec.rb'
-    - 'spec/models/webhook_endpoint_spec.rb'
     - 'spec/requests/admin/images_spec.rb'
     - 'spec/requests/admin/product_import_spec.rb'
     - 'spec/requests/admin/vouchers_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -221,18 +221,11 @@ Metrics/PerceivedComplexity:
     - 'app/models/spree/ability.rb'
     - 'app/models/spree/order/checkout.rb'
 
-# Offense count: 65
+# Offense count: 56
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
 RSpecRails/InferredSpecType:
   Exclude:
-    - 'spec/controllers/spree/api_keys_controller_spec.rb'
-    - 'spec/controllers/spree/credit_cards_controller_spec.rb'
-    - 'spec/controllers/spree/orders_controller_spec.rb'
-    - 'spec/controllers/spree/user_sessions_controller_spec.rb'
-    - 'spec/controllers/spree/users_controller_spec.rb'
-    - 'spec/controllers/stripe/callbacks_controller_spec.rb'
-    - 'spec/controllers/stripe/webhooks_controller_spec.rb'
     - 'spec/helpers/admin/enterprises_helper_spec.rb'
     - 'spec/helpers/admin/orders_helper_spec.rb'
     - 'spec/helpers/admin/reports_helper_spec.rb'

--- a/engines/dfc_provider/spec/requests/addresses_spec.rb
+++ b/engines/dfc_provider/spec/requests/addresses_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../swagger_helper"
 
-RSpec.describe "Addresses", type: :request, swagger_doc: "dfc.yaml" do
+RSpec.describe "Addresses", swagger_doc: "dfc.yaml" do
   let(:user) { create(:oidc_user) }
   let(:address) { create(:address, id: 40_000) }
   let(:result) { json_response }

--- a/engines/dfc_provider/spec/requests/catalog_items_spec.rb
+++ b/engines/dfc_provider/spec/requests/catalog_items_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../swagger_helper"
 
-RSpec.describe "CatalogItems", type: :request, swagger_doc: "dfc.yaml" do
+RSpec.describe "CatalogItems", swagger_doc: "dfc.yaml" do
   let(:user) { create(:oidc_user, id: 12_345) }
   let(:enterprise) {
     create(

--- a/engines/dfc_provider/spec/requests/enterprise_groups/affiliated_by_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprise_groups/affiliated_by_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../swagger_helper"
 
-RSpec.describe "EnterpriseGroups::AffiliatedBy", type: :request, swagger_doc: "dfc.yaml" do
+RSpec.describe "EnterpriseGroups::AffiliatedBy", swagger_doc: "dfc.yaml" do
   let(:user) { create(:oidc_user, id: 12_345) }
   let(:group) {
     create(

--- a/engines/dfc_provider/spec/requests/enterprise_groups_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprise_groups_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../swagger_helper"
 
-RSpec.describe "EnterpriseGroups", type: :request, swagger_doc: "dfc.yaml" do
+RSpec.describe "EnterpriseGroups", swagger_doc: "dfc.yaml" do
   let(:user) { create(:oidc_user, id: 12_345) }
   let(:group) {
     create(

--- a/engines/dfc_provider/spec/requests/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprises_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../swagger_helper"
 
-RSpec.describe "Enterprises", type: :request, swagger_doc: "dfc.yaml" do
+RSpec.describe "Enterprises", swagger_doc: "dfc.yaml" do
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) do
     create(

--- a/engines/dfc_provider/spec/requests/offers_spec.rb
+++ b/engines/dfc_provider/spec/requests/offers_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../swagger_helper"
 
-RSpec.describe "Offers", type: :request, swagger_doc: "dfc.yaml" do
+RSpec.describe "Offers", swagger_doc: "dfc.yaml" do
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) { create(:distributor_enterprise, id: 10_000, owner: user) }
   let!(:product) {

--- a/engines/dfc_provider/spec/requests/persons_spec.rb
+++ b/engines/dfc_provider/spec/requests/persons_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../swagger_helper"
 
-RSpec.describe "Persons", type: :request, swagger_doc: "dfc.yaml" do
+RSpec.describe "Persons", swagger_doc: "dfc.yaml" do
   let(:user) { create(:oidc_user, id: 10_000) }
   let(:other_user) { create(:oidc_user) }
 

--- a/engines/dfc_provider/spec/requests/social_medias_spec.rb
+++ b/engines/dfc_provider/spec/requests/social_medias_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../swagger_helper"
 
-RSpec.describe "SocialMedias", type: :request, swagger_doc: "dfc.yaml" do
+RSpec.describe "SocialMedias", swagger_doc: "dfc.yaml" do
   let(:user) { create(:oidc_user) }
   let(:enterprise) do
     create(

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../swagger_helper"
 
-RSpec.describe "SuppliedProducts", type: :request, swagger_doc: "dfc.yaml" do
+RSpec.describe "SuppliedProducts", swagger_doc: "dfc.yaml" do
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) { create(:distributor_enterprise, id: 10_000, owner: user) }
   let!(:product) {

--- a/engines/web/spec/helpers/cookies_policy_helper_spec.rb
+++ b/engines/web/spec/helpers/cookies_policy_helper_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module Web
-  RSpec.describe CookiesPolicyHelper, type: :helper do
+  RSpec.describe CookiesPolicyHelper do
     # keeps global state unchanged
     around do |example|
       original_locale = I18n.locale

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::BulkLineItemsController, type: :controller do
+RSpec.describe Admin::BulkLineItemsController do
   describe '#index' do
     render_views
 

--- a/spec/controllers/admin/column_preferences_controller_spec.rb
+++ b/spec/controllers/admin/column_preferences_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::ColumnPreferencesController, type: :controller do
+RSpec.describe Admin::ColumnPreferencesController do
   include AuthenticationHelper
 
   describe "bulk_update" do

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module Admin
-  RSpec.describe CustomersController, type: :controller do
+  RSpec.describe CustomersController do
     include AuthenticationHelper
 
     describe "index" do

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'open_food_network/order_cycle_permissions'
 
-RSpec.describe Admin::EnterprisesController, type: :controller do
+RSpec.describe Admin::EnterprisesController do
   let(:user) { create(:user) }
   let(:admin_user) { create(:admin_user) }
   let(:distributor_manager) { create(:user, enterprise_limit: 10, enterprises: [distributor]) }

--- a/spec/controllers/admin/inventory_items_controller_spec.rb
+++ b/spec/controllers/admin/inventory_items_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::InventoryItemsController, type: :controller do
+RSpec.describe Admin::InventoryItemsController do
   describe "create" do
     context "json" do
       let(:format) { :json }

--- a/spec/controllers/admin/invoice_settings_controller_spec.rb
+++ b/spec/controllers/admin/invoice_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::InvoiceSettingsController, type: :controller do
+RSpec.describe Admin::InvoiceSettingsController do
   describe "#update" do
     let(:params) {
       {

--- a/spec/controllers/admin/matomo_settings_controller_spec.rb
+++ b/spec/controllers/admin/matomo_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::MatomoSettingsController, type: :controller do
+RSpec.describe Admin::MatomoSettingsController do
   describe "#update" do
     let(:params) {
       {

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module Admin
-  RSpec.describe OrderCyclesController, type: :controller do
+  RSpec.describe OrderCyclesController do
     let!(:distributor_owner) { create(:user) }
     let(:datetime_confirmation_attrs) {
       { confirm_datetime_change: nil,

--- a/spec/controllers/admin/product_import_controller_spec.rb
+++ b/spec/controllers/admin/product_import_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::ProductImportController, type: :controller do
+RSpec.describe Admin::ProductImportController do
   describe 'validate_file_path' do
     let(:tmp_directory_base) { Rails.root.join("tmp/product_import-") }
 

--- a/spec/controllers/admin/proxy_orders_controller_spec.rb
+++ b/spec/controllers/admin/proxy_orders_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::ProxyOrdersController, type: :controller do
+RSpec.describe Admin::ProxyOrdersController do
   include AuthenticationHelper
 
   describe 'cancel' do

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::ReportsController, type: :controller do
+RSpec.describe Admin::ReportsController do
   # Given two distributors and two suppliers
   let(:bill_address) { create(:address) }
   let(:ship_address) { create(:address) }

--- a/spec/controllers/admin/schedules_controller_spec.rb
+++ b/spec/controllers/admin/schedules_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::SchedulesController, type: :controller do
+RSpec.describe Admin::SchedulesController do
   include AuthenticationHelper
 
   describe "index" do

--- a/spec/controllers/admin/stripe_accounts_controller_spec.rb
+++ b/spec/controllers/admin/stripe_accounts_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::StripeAccountsController, type: :controller do
+RSpec.describe Admin::StripeAccountsController do
   let(:enterprise) { create(:distributor_enterprise) }
 
   describe "#connect" do

--- a/spec/controllers/admin/stripe_connect_settings_controller_spec.rb
+++ b/spec/controllers/admin/stripe_connect_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::StripeConnectSettingsController, type: :controller do
+RSpec.describe Admin::StripeConnectSettingsController do
   let(:user) { create(:user) }
   let(:admin) { create(:admin_user) }
 

--- a/spec/controllers/admin/subscription_line_items_controller_spec.rb
+++ b/spec/controllers/admin/subscription_line_items_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::SubscriptionLineItemsController, type: :controller do
+RSpec.describe Admin::SubscriptionLineItemsController do
   include AuthenticationHelper
 
   describe "build" do

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::SubscriptionsController, type: :controller do
+RSpec.describe Admin::SubscriptionsController do
   include AuthenticationHelper
 
   describe 'index' do

--- a/spec/controllers/admin/tag_rules_controller_spec.rb
+++ b/spec/controllers/admin/tag_rules_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::TagRulesController, type: :controller do
+RSpec.describe Admin::TagRulesController do
   describe "destroy" do
     context "json" do
       let(:format) { :json }

--- a/spec/controllers/admin/terms_of_service_files_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service_files_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::TermsOfServiceFilesController, type: :controller do
+RSpec.describe Admin::TermsOfServiceFilesController do
   context "a non-admin user" do
     let(:user) { create(:user) }
 

--- a/spec/controllers/admin/variant_overrides_controller_spec.rb
+++ b/spec/controllers/admin/variant_overrides_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::VariantOverridesController, type: :controller do
+RSpec.describe Admin::VariantOverridesController do
   describe "index" do
     context "not logged in" do
       it "redirects to login" do

--- a/spec/controllers/api/v0/customers_controller_spec.rb
+++ b/spec/controllers/api/v0/customers_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module Api
-  RSpec.describe V0::CustomersController, type: :controller do
+  RSpec.describe V0::CustomersController do
     include AuthenticationHelper
     render_views
 

--- a/spec/controllers/api/v0/enterprise_fees_controller_spec.rb
+++ b/spec/controllers/api/v0/enterprise_fees_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module Api
-  RSpec.describe V0::EnterpriseFeesController, type: :controller do
+  RSpec.describe V0::EnterpriseFeesController do
     include AuthenticationHelper
 
     let!(:unreferenced_fee) { create(:enterprise_fee) }

--- a/spec/controllers/api/v0/enterprises_controller_spec.rb
+++ b/spec/controllers/api/v0/enterprises_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Api::V0::EnterprisesController, type: :controller do
+RSpec.describe Api::V0::EnterprisesController do
   render_views
 
   let(:enterprise) { create(:distributor_enterprise) }

--- a/spec/controllers/api/v0/exchange_products_controller_spec.rb
+++ b/spec/controllers/api/v0/exchange_products_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module Api
-  RSpec.describe V0::ExchangeProductsController, type: :controller do
+  RSpec.describe V0::ExchangeProductsController do
     include AuthenticationHelper
 
     let(:order_cycle) { create(:order_cycle) }

--- a/spec/controllers/api/v0/logos_controller_spec.rb
+++ b/spec/controllers/api/v0/logos_controller_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Api
-  RSpec.describe V0::LogosController, type: :controller do
+  RSpec.describe V0::LogosController do
     include AuthenticationHelper
     include FileHelper
 

--- a/spec/controllers/api/v0/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/v0/order_cycles_controller_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Api
-  RSpec.describe V0::OrderCyclesController, type: :controller do
+  RSpec.describe V0::OrderCyclesController do
     let!(:distributor) { create(:distributor_enterprise) }
     let!(:order_cycle) { create(:simple_order_cycle, distributors: [distributor]) }
     let!(:exchange) { order_cycle.exchanges.to_enterprises(distributor).outgoing.first }

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module Api
-  RSpec.describe V0::OrdersController, type: :controller do
+  RSpec.describe V0::OrdersController do
     include AuthenticationHelper
     render_views
 

--- a/spec/controllers/api/v0/product_images_controller_spec.rb
+++ b/spec/controllers/api/v0/product_images_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Api::V0::ProductImagesController, type: :controller do
+RSpec.describe Api::V0::ProductImagesController do
   include AuthenticationHelper
   include FileHelper
   render_views

--- a/spec/controllers/api/v0/products_controller_spec.rb
+++ b/spec/controllers/api/v0/products_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'spree/core/product_duplicator'
 
-RSpec.describe Api::V0::ProductsController, type: :controller do
+RSpec.describe Api::V0::ProductsController do
   render_views
 
   let(:supplier) { create(:supplier_enterprise) }

--- a/spec/controllers/api/v0/promo_images_controller_spec.rb
+++ b/spec/controllers/api/v0/promo_images_controller_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Api
-  RSpec.describe V0::PromoImagesController, type: :controller do
+  RSpec.describe V0::PromoImagesController do
     include AuthenticationHelper
     include FileHelper
 

--- a/spec/controllers/api/v0/reports/packing_report_spec.rb
+++ b/spec/controllers/api/v0/reports/packing_report_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe Api::V0::ReportsController, type: :controller do
+RSpec.describe Api::V0::ReportsController do
   let(:params) {
     {
       report_type: 'packing',

--- a/spec/controllers/api/v0/reports_controller_spec.rb
+++ b/spec/controllers/api/v0/reports_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe Api::V0::ReportsController, type: :controller do
+RSpec.describe Api::V0::ReportsController do
   let(:enterprise_user) { create(:user, enterprises: [create(:enterprise)]) }
   let(:params) {
     {

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Api::V0::ShipmentsController, type: :controller do
+RSpec.describe Api::V0::ShipmentsController do
   render_views
 
   let!(:shipment) { create(:shipment) }

--- a/spec/controllers/api/v0/shops_controller_spec.rb
+++ b/spec/controllers/api/v0/shops_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Api::V0::ShopsController, type: :controller do
+RSpec.describe Api::V0::ShopsController do
   include AuthenticationHelper
   render_views
 

--- a/spec/controllers/api/v0/statuses_controller_spec.rb
+++ b/spec/controllers/api/v0/statuses_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module Api
-  RSpec.describe V0::StatusesController, type: :controller do
+  RSpec.describe V0::StatusesController do
     render_views
 
     describe "job queue status" do

--- a/spec/controllers/api/v0/terms_and_conditions_controller_spec.rb
+++ b/spec/controllers/api/v0/terms_and_conditions_controller_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Api
-  RSpec.describe V0::TermsAndConditionsController, type: :controller do
+  RSpec.describe V0::TermsAndConditionsController do
     include AuthenticationHelper
     include FileHelper
 

--- a/spec/controllers/api/v0/variants_controller_spec.rb
+++ b/spec/controllers/api/v0/variants_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Api::V0::VariantsController, type: :controller do
+RSpec.describe Api::V0::VariantsController do
   render_views
 
   let(:supplier) { create(:supplier_enterprise) }

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe BaseController, type: :controller do
+RSpec.describe BaseController do
   let(:oc)    { instance_double(OrderCycle, id: 1) }
   let(:order) { instance_double(Spree::Order) }
   controller(BaseController) do

--- a/spec/controllers/cart_controller_spec.rb
+++ b/spec/controllers/cart_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe CartController, type: :controller do
+RSpec.describe CartController do
   let(:order) { create(:order) }
 
   describe "basic behaviour" do

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe CheckoutController, type: :controller do
+RSpec.describe CheckoutController do
   let(:user) { order.user }
   let(:address) { create(:address) }
   let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe EnterprisesController, type: :controller do
+RSpec.describe EnterprisesController do
   describe "shopping for a distributor" do
     let(:user) { create(:user) }
     let(:order) { controller.current_order(true) }

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe GroupsController, type: :controller do
+RSpec.describe GroupsController do
   render_views
 
   let!(:enterprise) { create(:distributor_enterprise) }

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe LineItemsController, type: :controller do
+RSpec.describe LineItemsController do
   let(:user) { create(:user) }
   let(:distributor) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:simple_order_cycle) }

--- a/spec/controllers/payment_gateways/paypal_controller_spec.rb
+++ b/spec/controllers/payment_gateways/paypal_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe PaymentGateways::PaypalController, type: :controller do
+RSpec.describe PaymentGateways::PaypalController do
   context '#cancel' do
     it 'redirects back to checkout' do
       expect(get(:cancel)).to redirect_to checkout_path

--- a/spec/controllers/payment_gateways/stripe_controller_spec.rb
+++ b/spec/controllers/payment_gateways/stripe_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe PaymentGateways::StripeController, type: :controller do
+RSpec.describe PaymentGateways::StripeController do
   include StripeStubs
 
   let!(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe RegistrationController, type: :controller do
+RSpec.describe RegistrationController do
   describe "redirecting when user not logged in" do
     it "index" do
       get :index

--- a/spec/controllers/shop_controller_spec.rb
+++ b/spec/controllers/shop_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe ShopController, type: :controller do
+RSpec.describe ShopController do
   let!(:pm) { create(:payment_method) }
   let!(:sm) { create(:shipping_method) }
   let(:distributor) {

--- a/spec/controllers/shops_controller_spec.rb
+++ b/spec/controllers/shops_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe ShopsController, type: :controller do
+RSpec.describe ShopsController do
   include WebHelper
   render_views
 

--- a/spec/controllers/spree/admin/adjustments_controller_spec.rb
+++ b/spec/controllers/spree/admin/adjustments_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module Spree
-  RSpec.describe Admin::AdjustmentsController, type: :controller do
+  RSpec.describe Admin::AdjustmentsController do
     include AuthenticationHelper
 
     before { controller_login_as_admin }

--- a/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/spec/controllers/spree/admin/base_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::BaseController, type: :controller do
+RSpec.describe Spree::Admin::BaseController do
   controller(Spree::Admin::BaseController) do
     def index
       before_action :unauthorized

--- a/spec/controllers/spree/admin/countries_controller_spec.rb
+++ b/spec/controllers/spree/admin/countries_controller_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Spree
   module Admin
-    RSpec.describe CountriesController, type: :controller do
+    RSpec.describe CountriesController do
       include AuthenticationHelper
 
       describe "#update" do

--- a/spec/controllers/spree/admin/general_settings_controller_spec.rb
+++ b/spec/controllers/spree/admin/general_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::GeneralSettingsController, type: :controller do
+RSpec.describe Spree::Admin::GeneralSettingsController do
   include AuthenticationHelper
 
   describe 'updating general settings' do

--- a/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
+RSpec.describe Spree::Admin::Orders::CustomerDetailsController do
   include AuthenticationHelper
 
   describe "#update" do

--- a/spec/controllers/spree/admin/orders/invoices_spec.rb
+++ b/spec/controllers/spree/admin/orders/invoices_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::OrdersController, type: :controller do
+RSpec.describe Spree::Admin::OrdersController do
   describe "#invoice" do
     let!(:user) { create(:user) }
     let!(:enterprise_user) { create(:user) }
@@ -106,7 +106,7 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
   end
 end
 
-RSpec.describe Spree::Admin::InvoicesController, type: :controller do
+RSpec.describe Spree::Admin::InvoicesController do
   describe "#index" do
     let(:user) { create(:user) }
     let(:enterprise_user) { create(:user, enterprises: [create(:enterprise)]) }

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::PaymentsController, type: :controller do
+RSpec.describe Spree::Admin::PaymentsController do
   include StripeHelper
   include StripeStubs
 

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::PaymentsController, type: :controller do
+RSpec.describe Spree::Admin::PaymentsController do
   let!(:shop) { create(:enterprise) }
   let!(:user) { shop.owner }
   let!(:order) { create(:order, distributor: shop, state: 'complete') }

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::OrdersController, type: :controller do
+RSpec.describe Spree::Admin::OrdersController do
   describe "#edit" do
     let!(:order) { create(:order_with_totals_and_distribution, ship_address: create(:address)) }
 

--- a/spec/controllers/spree/admin/overview_controller_spec.rb
+++ b/spec/controllers/spree/admin/overview_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::OverviewController, type: :controller do
+RSpec.describe Spree::Admin::OverviewController do
   describe "#index" do
     before do
       allow(controller).to receive(:spree_current_user).and_return(user)

--- a/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -7,7 +7,7 @@ module Spree
     preference :password, :string, default: "password"
   end
 
-  RSpec.describe Admin::PaymentMethodsController, type: :controller do
+  RSpec.describe Admin::PaymentMethodsController do
     let(:user) {
       create(:user, enterprises: [create(:distributor_enterprise)])
     }

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::ProductsController, type: :controller do
+RSpec.describe Spree::Admin::ProductsController do
   describe 'bulk_update' do
     context "updating a product we do not have access to" do
       let(:s_managed) { create(:enterprise) }

--- a/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Spree
   module Admin
-    RSpec.describe ReturnAuthorizationsController, type: :controller do
+    RSpec.describe ReturnAuthorizationsController do
       include AuthenticationHelper
 
       let(:order) { create(:shipped_order, distributor: create(:distributor_enterprise)) }

--- a/spec/controllers/spree/admin/search_controller_spec.rb
+++ b/spec/controllers/spree/admin/search_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::SearchController, type: :controller do
+RSpec.describe Spree::Admin::SearchController do
   context "Distributor Enterprise User" do
     let!(:owner) { create(:user, email: "test1@email.com" ) }
     let!(:manager) { create(:user, email: "test2@email.com" ) }

--- a/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Spree
   module Admin
-    RSpec.describe ShippingCategoriesController, type: :controller do
+    RSpec.describe ShippingCategoriesController do
       include AuthenticationHelper
 
       describe "#create and #update" do

--- a/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::ShippingMethodsController, type: :controller do
+RSpec.describe Spree::Admin::ShippingMethodsController do
   include AuthenticationHelper
 
   describe "#update" do

--- a/spec/controllers/spree/admin/tax_rates_controller_spec.rb
+++ b/spec/controllers/spree/admin/tax_rates_controller_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Spree
   module Admin
-    RSpec.describe TaxRatesController, type: :controller do
+    RSpec.describe TaxRatesController do
       include AuthenticationHelper
 
       let!(:default_tax_zone) { create(:zone, default_tax: true) }

--- a/spec/controllers/spree/admin/tax_settings_controller_spec.rb
+++ b/spec/controllers/spree/admin/tax_settings_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::TaxSettingsController, type: :controller do
+RSpec.describe Spree::Admin::TaxSettingsController do
   describe "#update" do
     let(:params) { { preferences: { products_require_tax_category: "1" } } }
 

--- a/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Spree
   module Admin
-    RSpec.describe VariantsController, type: :controller do
+    RSpec.describe VariantsController do
       context "log in as admin user" do
         before { controller_login_as_admin }
 

--- a/spec/controllers/spree/api_keys_controller_spec.rb
+++ b/spec/controllers/spree/api_keys_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::ApiKeysController, type: :controller, performance: true do
+RSpec.describe Spree::ApiKeysController, performance: true do
   routes { Spree::Core::Engine.routes }
 
   include AuthenticationHelper

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::CreditCardsController, type: :controller do
+RSpec.describe Spree::CreditCardsController do
   describe "using VCR", :vcr, :stripe_version do
     let(:user) { create(:user) }
 

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::OrdersController, type: :controller do
+RSpec.describe Spree::OrdersController do
   include CheckoutHelper
   include StripeStubs
 

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::UserSessionsController, type: :controller do
+RSpec.describe Spree::UserSessionsController do
   let(:user) { create(:user) }
 
   before do

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::UsersController, type: :controller do
+RSpec.describe Spree::UsersController do
   routes { Spree::Core::Engine.routes }
 
   include AuthenticationHelper

--- a/spec/controllers/stripe/callbacks_controller_spec.rb
+++ b/spec/controllers/stripe/callbacks_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Stripe::CallbacksController, type: :controller do
+RSpec.describe Stripe::CallbacksController do
   let(:enterprise) { create(:distributor_enterprise) }
 
   context "#index" do

--- a/spec/controllers/stripe/webhooks_controller_spec.rb
+++ b/spec/controllers/stripe/webhooks_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Stripe::WebhooksController, type: :controller do
+RSpec.describe Stripe::WebhooksController do
   describe "#create" do
     let(:params) do
       {

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe UserConfirmationsController, type: :controller do
+RSpec.describe UserConfirmationsController do
   let!(:user) { create(:user) }
   let!(:confirmed_user) { create(:user, confirmed_at: nil) }
   let!(:unconfirmed_user) { create(:user, confirmed_at: nil) }

--- a/spec/controllers/user_passwords_controller_spec.rb
+++ b/spec/controllers/user_passwords_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe UserPasswordsController, type: :controller do
+RSpec.describe UserPasswordsController do
   render_views
 
   let(:user) { create(:user) }

--- a/spec/controllers/user_registrations_controller_spec.rb
+++ b/spec/controllers/user_registrations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe UserRegistrationsController, type: :controller do
+RSpec.describe UserRegistrationsController do
   before do
     @request.env["devise.mapping"] = Devise.mappings[:spree_user]
   end

--- a/spec/controllers/webhook_endpoints_controller_spec.rb
+++ b/spec/controllers/webhook_endpoints_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'open_food_network/order_cycle_permissions'
 
-RSpec.describe WebhookEndpointsController, type: :controller do
+RSpec.describe WebhookEndpointsController do
   let(:user) { create(:admin_user) }
 
   before { allow(controller).to receive(:spree_current_user) { user } }

--- a/spec/helpers/admin/enterprises_helper_spec.rb
+++ b/spec/helpers/admin/enterprises_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe Admin::EnterprisesHelper, type: :helper do
+RSpec.describe Admin::EnterprisesHelper do
   let(:user) { build(:user) }
 
   before do

--- a/spec/helpers/admin/orders_helper_spec.rb
+++ b/spec/helpers/admin/orders_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe Admin::OrdersHelper, type: :helper do
+RSpec.describe Admin::OrdersHelper do
   describe "#order_adjustments_for_display" do
     let(:order) { create(:order) }
     let(:service) { instance_double(VoucherAdjustmentsService, voucher_included_tax:) }

--- a/spec/helpers/admin/reports_helper_spec.rb
+++ b/spec/helpers/admin/reports_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe ReportsHelper, type: :helper do
+RSpec.describe ReportsHelper do
   describe "#report_payment_method_options" do
     let(:order_with_payments) { create(:order_ready_to_ship) }
     let(:order_without_payments) { create(:order_with_line_items) }

--- a/spec/helpers/admin/subscriptions_helper_spec.rb
+++ b/spec/helpers/admin/subscriptions_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Admin::SubscriptionsHelper, type: :helper do
+RSpec.describe Admin::SubscriptionsHelper do
   describe "checking if setup is complete for any [shop]" do
     let(:shop) { create(:distributor_enterprise) }
     let(:customer) { create(:customer, enterprise: shop) }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe ApplicationHelper, type: :helper do
+RSpec.describe ApplicationHelper do
   describe "#feature?" do
     it "takes several actors" do
       user = Spree::User.new(id: 4)

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe CheckoutHelper, type: :helper do
+RSpec.describe CheckoutHelper do
   it "generates html for validated inputs" do
     expect(helper).to receive(:render).with(
       "shared/validated_input",

--- a/spec/helpers/i18n_helper_spec.rb
+++ b/spec/helpers/i18n_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe I18nHelper, type: :helper do
+RSpec.describe I18nHelper do
   let(:user) { create(:user) }
   let(:cookies) { {} }
 

--- a/spec/helpers/injection_helper_spec.rb
+++ b/spec/helpers/injection_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe InjectionHelper, type: :helper do
+RSpec.describe InjectionHelper do
   let!(:enterprise) { create(:distributor_enterprise, facebook: "roger") }
 
   let!(:distributor1) { create(:distributor_enterprise) }

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe LinkHelper, type: :helper do
+RSpec.describe LinkHelper do
   describe "ext_url" do
     it "adds prefix if missing" do
       expect(helper.ext_url("http://example.com/", "http://example.com/bla")).to eq("http://example.com/bla")

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Spree
   module Admin
-    RSpec.describe NavigationHelper, type: :helper do
+    RSpec.describe NavigationHelper do
       describe "klass_for" do
         it "returns the class when present" do
           expect(helper.klass_for('products')).to eq(Spree::Product)

--- a/spec/helpers/order_cycles_helper_spec.rb
+++ b/spec/helpers/order_cycles_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe OrderCyclesHelper, type: :helper do
+RSpec.describe OrderCyclesHelper do
   let(:oc) { double(:order_cycle) }
 
   describe "finding producer enterprise options" do

--- a/spec/helpers/serializer_helper_spec.rb
+++ b/spec/helpers/serializer_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe SerializerHelper, type: :helper do
+RSpec.describe SerializerHelper do
   let(:serializer) do
     Class.new(ActiveModel::Serializer) do
       attributes :id, :name

--- a/spec/helpers/shop_helper_spec.rb
+++ b/spec/helpers/shop_helper_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 require 'spec_helper'
-RSpec.describe ShopHelper, type: :helper do
+RSpec.describe ShopHelper do
   describe "shop_tabs" do
     context "distributor with groups" do
       let(:group) { create(:enterprise_group) }

--- a/spec/helpers/spree/admin/base_helper_spec.rb
+++ b/spec/helpers/spree/admin/base_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::BaseHelper, type: :helper do
+RSpec.describe Spree::Admin::BaseHelper do
   helper 'spree/admin/navigation'
 
   describe "#link_to_remove_fields" do

--- a/spec/helpers/spree/admin/general_settings_helper_spec.rb
+++ b/spec/helpers/spree/admin/general_settings_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::GeneralSettingsHelper, type: :helper do
+RSpec.describe Spree::Admin::GeneralSettingsHelper do
   describe "#all_units" do
     it "returns all units" do
       expect(helper.all_units).to eq(["mg", "g", "kg", "T", "oz", "lb", "mL", "cL", "dL", "L",

--- a/spec/helpers/spree/admin/orders_helper_spec.rb
+++ b/spec/helpers/spree/admin/orders_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Admin::OrdersHelper, type: :helper do
+RSpec.describe Spree::Admin::OrdersHelper do
   describe "#orders_links" do
     let(:order) { double(:order) }
     let(:distributor) { double(:enterprise) }

--- a/spec/helpers/spree/orders_helper_spec.rb
+++ b/spec/helpers/spree/orders_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::OrdersHelper, type: :helper do
+RSpec.describe Spree::OrdersHelper do
   describe "#changeable_orders" do
     let(:complete_orders) { double(:complete_orders, where: "some_orders") }
 

--- a/spec/helpers/tax_helper_spec.rb
+++ b/spec/helpers/tax_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe TaxHelper, type: :helper do
+RSpec.describe TaxHelper do
   let(:line_item) { create(:line_item) }
   let(:line_item2) { create(:line_item) }
   let(:line_item3) { create(:line_item) }

--- a/spec/helpers/terms_and_conditions_helper_spec.rb
+++ b/spec/helpers/terms_and_conditions_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe TermsAndConditionsHelper, type: :helper do
+RSpec.describe TermsAndConditionsHelper do
   describe "#platform_terms_required?" do
     context 'when ToS file is present' do
       before do

--- a/spec/jobs/connect_app_job_spec.rb
+++ b/spec/jobs/connect_app_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe ConnectAppJob, type: :job do
+RSpec.describe ConnectAppJob do
   subject { ConnectAppJob.new(app, user.spree_api_key) }
 
   let(:app) { ConnectedApp.new(enterprise: ) }

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'yaml'
 
-RSpec.describe ProducerMailer, type: :mailer do
+RSpec.describe ProducerMailer do
   let!(:zone) { create(:zone_with_member) }
   let!(:tax_rate) {
     create(:tax_rate, included_in_price: true, calculator: Calculator::DefaultTax.new, zone:,

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe SubscriptionMailer, type: :mailer do
+RSpec.describe SubscriptionMailer do
   include ActionView::Helpers::SanitizeHelper
 
   describe '#placement_email' do

--- a/spec/models/column_preference_spec.rb
+++ b/spec/models/column_preference_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe ColumnPreference, type: :model do
+RSpec.describe ColumnPreference do
   subject {
     ColumnPreference.new(
       user:, action_name: :customers_index, column_name: :email

--- a/spec/models/connected_app_spec.rb
+++ b/spec/models/connected_app_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe ConnectedApp, type: :model do
+RSpec.describe ConnectedApp do
   it { is_expected.to belong_to :enterprise }
 
   it "stores data as json hash" do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Customer, type: :model do
+RSpec.describe Customer do
   it { is_expected.to belong_to(:enterprise).required }
   it { is_expected.to belong_to(:user).optional }
   it { is_expected.to belong_to(:bill_address).optional }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Invoice, type: :model do
+RSpec.describe Invoice do
   let(:distributor) { create(:distributor_enterprise) }
   let(:order) { create(:order, :with_line_item, :completed, distributor:) }
   describe 'presenter' do

--- a/spec/models/oidc_account_spec.rb
+++ b/spec/models/oidc_account_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe OidcAccount, type: :model do
+RSpec.describe OidcAccount do
   describe "associations and validations" do
     subject {
       OidcAccount.new(

--- a/spec/models/proxy_order_spec.rb
+++ b/spec/models/proxy_order_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe ProxyOrder, type: :model do
+RSpec.describe ProxyOrder do
   describe "cancel" do
     let(:order_cycle) { create(:simple_order_cycle) }
     let(:subscription) { create(:subscription) }

--- a/spec/models/report_blob_spec.rb
+++ b/spec/models/report_blob_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe ReportBlob, type: :model do
+RSpec.describe ReportBlob do
   it "preserves UTF-8 content" do
     content = "This works. ✓"
 

--- a/spec/models/semantic_link_spec.rb
+++ b/spec/models/semantic_link_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe SemanticLink, type: :model do
+RSpec.describe SemanticLink do
   it { is_expected.to belong_to :subject }
   it { is_expected.to validate_presence_of(:semantic_id) }
 end

--- a/spec/models/spree/gateway/stripe_sca_spec.rb
+++ b/spec/models/spree/gateway/stripe_sca_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Spree::Gateway::StripeSCA, :vcr, :stripe_version, type: :model do
+RSpec.describe Spree::Gateway::StripeSCA, :vcr, :stripe_version do
   let(:order) { create(:order_ready_for_payment) }
 
   let(:year_valid) { Time.zone.now.year.next }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Subscription, type: :model do
+RSpec.describe Subscription do
   describe "associations" do
     it { expect(subject).to belong_to(:shop).optional }
     it { expect(subject).to belong_to(:customer).optional }

--- a/spec/models/tag_rule/filter_order_cycles_spec.rb
+++ b/spec/models/tag_rule/filter_order_cycles_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe TagRule::FilterOrderCycles, type: :model do
+RSpec.describe TagRule::FilterOrderCycles do
   let!(:tag_rule) { build_stubbed(:filter_order_cycles_tag_rule) }
 
   describe "determining whether tags match for a given exchange" do

--- a/spec/models/tag_rule/filter_payment_methods_spec.rb
+++ b/spec/models/tag_rule/filter_payment_methods_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe TagRule::FilterPaymentMethods, type: :model do
+RSpec.describe TagRule::FilterPaymentMethods do
   let!(:tag_rule) { build_stubbed(:filter_payment_methods_tag_rule) }
 
   describe "determining whether tags match for a given payment method" do

--- a/spec/models/tag_rule/filter_products_spec.rb
+++ b/spec/models/tag_rule/filter_products_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe TagRule::FilterProducts, type: :model do
+RSpec.describe TagRule::FilterProducts do
   let!(:tag_rule) { build_stubbed(:filter_products_tag_rule) }
 
   describe "determining whether tags match for a given variant" do

--- a/spec/models/tag_rule/filter_shipping_methods_spec.rb
+++ b/spec/models/tag_rule/filter_shipping_methods_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe TagRule::FilterShippingMethods, type: :model do
+RSpec.describe TagRule::FilterShippingMethods do
   let!(:tag_rule) { build_stubbed(:filter_shipping_methods_tag_rule) }
 
   describe "determining whether tags match for a given shipping method" do

--- a/spec/models/tag_rule_spec.rb
+++ b/spec/models/tag_rule_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe TagRule, type: :model do
+RSpec.describe TagRule do
   describe "validations" do
     it "requires a enterprise" do
       expect(subject).to belong_to(:enterprise)

--- a/spec/models/webhook_endpoint_spec.rb
+++ b/spec/models/webhook_endpoint_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe WebhookEndpoint, type: :model do
+RSpec.describe WebhookEndpoint do
   describe "validations" do
     it { is_expected.to validate_presence_of(:url) }
   end

--- a/spec/requests/admin/images_spec.rb
+++ b/spec/requests/admin/images_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "/admin/products/:product_id/images", type: :request do
+RSpec.describe "/admin/products/:product_id/images" do
   include AuthenticationHelper
 
   let!(:product) { create(:product) }

--- a/spec/requests/admin/product_import_spec.rb
+++ b/spec/requests/admin/product_import_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe "Product Import", type: :request do
+RSpec.describe "Product Import" do
   include AuthenticationHelper
 
   describe "validate_data" do

--- a/spec/requests/admin/vouchers_spec.rb
+++ b/spec/requests/admin/vouchers_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "/admin/enterprises/:enterprise_id/vouchers", type: :request do
+RSpec.describe "/admin/enterprises/:enterprise_id/vouchers" do
   let(:enterprise) { create(:supplier_enterprise, name: "Feedme") }
   let(:enterprise_user) { create(:user, enterprise_limit: 1) }
 

--- a/spec/requests/api/orders_spec.rb
+++ b/spec/requests/api/orders_spec.rb
@@ -2,7 +2,7 @@
 
 require 'swagger_helper'
 
-RSpec.describe 'api/v0/orders', swagger_doc: 'v0.yaml', type: :request do
+RSpec.describe 'api/v0/orders', swagger_doc: 'v0.yaml' do
   path '/api/v0/orders' do
     get('list orders') do
       tags 'Orders'

--- a/spec/requests/api/routes_spec.rb
+++ b/spec/requests/api/routes_spec.rb
@@ -3,7 +3,7 @@
 # test a single endpoint to make sure the redirects are working as intended.
 require 'spec_helper'
 
-RSpec.describe 'Orders Cycles endpoint', type: :request do
+RSpec.describe 'Orders Cycles endpoint' do
   let(:distributor) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:order_cycle, distributors: [distributor]) }
 

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "Customers", type: :request, swagger_doc: "v1.yaml", feature: :api_v1 do
+RSpec.describe "Customers", swagger_doc: "v1.yaml", feature: :api_v1 do
   let!(:enterprise1) { create(:enterprise, name: "The Farm") }
   let!(:enterprise2) { create(:enterprise) }
   let!(:enterprise3) { create(:enterprise) }

--- a/spec/requests/api_docs_spec.rb
+++ b/spec/requests/api_docs_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe "API documentation", type: :request do
+RSpec.describe "API documentation" do
   it "shows the OFN API v1" do
     get rswag_ui_path
     expect(response).to redirect_to "/api-docs/index.html"

--- a/spec/requests/checkout/paypal_spec.rb
+++ b/spec/requests/checkout/paypal_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe "checking out an order with a paypal express payment method", type: :request do
+RSpec.describe "checking out an order with a paypal express payment method" do
   include ShopWorkflow
   include PaypalHelper
 

--- a/spec/requests/checkout/routes_spec.rb
+++ b/spec/requests/checkout/routes_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'checkout endpoints', type: :request do
+RSpec.describe 'checkout endpoints' do
   include ShopWorkflow
 
   let!(:shop) { create(:enterprise) }

--- a/spec/requests/checkout/stripe_sca_spec.rb
+++ b/spec/requests/checkout/stripe_sca_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe "checking out an order with a Stripe SCA payment method", type: :request do
+RSpec.describe "checking out an order with a Stripe SCA payment method" do
   include ShopWorkflow
   include AuthenticationHelper
   include OpenFoodNetwork::ApiHelper

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Errors', type: :request do
+RSpec.describe 'Errors' do
   include ExceptionHelper
 
   shared_examples "returning a HTTP 404" do |path|

--- a/spec/requests/home_controller_spec.rb
+++ b/spec/requests/home_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe HomeController, type: :request do
+RSpec.describe HomeController do
   context "#unauthorized" do
     it "renders the unauthorized template" do
       get "/unauthorized"

--- a/spec/requests/large_request_spec.rb
+++ b/spec/requests/large_request_spec.rb
@@ -5,7 +5,7 @@
 # http://daniel.fone.net.nz/blog/2014/11/28/actiondispatch-cookies-cookieoverflow-via-devise-s-user_return_to/
 require 'spec_helper'
 
-RSpec.describe 'A very large request', type: :request do
+RSpec.describe 'A very large request' do
   it 'should not overflow cookies' do
     get '/admin', params: { foo: 'x' * ActionDispatch::Cookies::MAX_COOKIE_SIZE }
     expect(response).to have_http_status(:redirect)

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 # Devise calls OmniauthCallbacksController for OpenID Connect callbacks.
-RSpec.describe '/user/spree_user/auth/openid_connect/callback', type: :request do
+RSpec.describe '/user/spree_user/auth/openid_connect/callback' do
   include AuthenticationHelper
 
   let(:user) { create(:user) }

--- a/spec/requests/spree/admin/overview_spec.rb
+++ b/spec/requests/spree/admin/overview_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "/admin", type: :request do
+RSpec.describe "/admin" do
   let(:enterprise) { create(:supplier_enterprise, name: "Feedme") }
   let(:enterprise_user) { create(:user, enterprise_limit: 1) }
 

--- a/spec/requests/spree/admin/payments_spec.rb
+++ b/spec/requests/spree/admin/payments_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe Spree::Admin::PaymentsController, type: :request do
+RSpec.describe Spree::Admin::PaymentsController do
   let(:user) { order.user }
   let(:order) { create(:completed_order_with_fees) }
 

--- a/spec/requests/voucher_adjustments_spec.rb
+++ b/spec/requests/voucher_adjustments_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe VoucherAdjustmentsController, type: :request do
+RSpec.describe VoucherAdjustmentsController do
   let(:user) { order.user }
   let(:address) { create(:address) }
   let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }

--- a/spec/routing/stripe_spec.rb
+++ b/spec/routing/stripe_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "routing for Stripe return URLS", type: :routing do
+RSpec.describe "routing for Stripe return URLS" do
   context "checkout return URLs" do
     it "routes /checkout to checkout#edit" do
       expect(get: "checkout").


### PR DESCRIPTION
#### What? Why?

- Contributes to #13314 
- [RSpecRails/InferredSpecType](https://docs.rubocop.org/rubocop-rspec_rails/cops_rspecrails.html#rspecrailsinferredspectype) cop

Goal here is to get rid of now redundant `type: :xxx` in RSpec headers because it can be inferred from the location of the spec.

#### What should we test?
Nothing. All tests should pass

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled