### PR TITLE
refactor: move unit price formatting logic out of model into helper

### DIFF
--- a/app/helpers/spree/orders_helper.rb
+++ b/app/helpers/spree/orders_helper.rb
@@ -47,7 +47,7 @@ module Spree
     end
 
     def format_unit_price(unit_price)
-      "#{Spree::Money.new(unit_price[:amount]).to_html}&nbsp;/&nbsp;#{unit_price[:unit]}"
+      "#{Spree::Money.new(unit_price[:amount]).to_html}&nbsp;/&nbsp;#{unit_price[:unit]}".html_safe # rubocop:disable Rails/OutputSafety
     end
   end
 end

--- a/app/helpers/spree/orders_helper.rb
+++ b/app/helpers/spree/orders_helper.rb
@@ -45,5 +45,9 @@ module Spree
         shop: current_distributor.name,
         oc_close: l(current_order_cycle.orders_close_at, format: "%A, %b %d, %Y @ %H:%M"))
     end
+
+    def format_unit_price(unit_price)
+      "#{Spree::Money.new(unit_price[:amount]).to_html}&nbsp;/&nbsp;#{unit_price[:unit]}"
+    end
   end
 end

--- a/app/models/invoice/data_presenter/line_item.rb
+++ b/app/models/invoice/data_presenter/line_item.rb
@@ -4,7 +4,7 @@ class Invoice
   class DataPresenter
     class LineItem < Invoice::DataPresenter::Base
       attributes :id, :added_tax, :currency, :included_tax, :price_with_adjustments, :quantity,
-                 :variant_id, :unit_price_price_and_unit, :unit_presentation,
+                 :variant_id, :unit_price, :unit_presentation,
                  :enterprise_fee_additional_tax, :enterprise_fee_included_tax
       attributes_with_presenter :variant
       invoice_generation_attributes :added_tax, :included_tax, :price_with_adjustments,

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -234,10 +234,13 @@ module Spree
       final_weight_volume / quantity
     end
 
-    def unit_price_price_and_unit
-      unit_price = UnitPrice.new(variant)
-      Spree::Money.new(price_with_adjustments / unit_price.denominator).to_html +
-        "&nbsp;/&nbsp;".html_safe + unit_price.unit
+    def unit_price
+      unit = UnitPrice.new(variant).unit
+      amount = price_with_adjustments / UnitPrice.new(variant).denominator
+      {
+        amount:,
+        unit:,
+      }
     end
 
     def scoper

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -235,11 +235,10 @@ module Spree
     end
 
     def unit_price
-      unit = UnitPrice.new(variant).unit
-      amount = price_with_adjustments / UnitPrice.new(variant).denominator
+      unit_price = UnitPrice.new(variant)
       {
-        amount:,
-        unit:,
+        amount: price_with_adjustments / unit_price.denominator,
+        unit: unit_price.unit,
       }
     end
 

--- a/app/serializers/invoice/line_item_serializer.rb
+++ b/app/serializers/invoice/line_item_serializer.rb
@@ -3,7 +3,7 @@
 class Invoice
   class LineItemSerializer < ActiveModel::Serializer
     attributes :id, :added_tax, :currency, :included_tax, :price_with_adjustments, :quantity,
-               :variant_id, :unit_price_price_and_unit, :unit_presentation,
+               :variant_id, :unit_price, :unit_presentation,
                :enterprise_fee_additional_tax, :enterprise_fee_included_tax
     has_one :variant, serializer: Invoice::VariantSerializer
 

--- a/app/views/spree/admin/orders/_invoice/_line_item_name.html.haml
+++ b/app/views/spree/admin/orders/_invoice/_line_item_name.html.haml
@@ -2,5 +2,6 @@
   = line_item.variant.product.name
   - unless line_item.variant.product.name.include? line_item.name_to_display
     %span= "- #{line_item.name_to_display}"
-- if line_item.unit_price_price_and_unit
-  = raw("(#{line_item.unit_price_price_and_unit})")
+- if line_item.unit_price
+  = raw("(#{format_unit_price(line_item.unit_price)})")
+

--- a/app/views/spree/orders/_bought.html.haml
+++ b/app/views/spree/orders/_bought.html.haml
@@ -24,7 +24,7 @@
         = line_item.single_display_amount_with_adjustments.to_html
         %br
         %span.unit-price
-          = line_item.unit_price_price_and_unit
+          = format_unit_price(line_item.unit_price)
       %td.text-center.cart-item-quantity
         = line_item.quantity
       %td.cart-item-total.text-right

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -22,7 +22,7 @@
       = line_item.single_display_amount_with_adjustments.to_html
       %br
       %span.unit-price
-        = line_item.unit_price_price_and_unit
+        = format_unit_price(line_item.unit_price)
     %td.text-center.cart-item-quantity
       - finalized_quantity = @order.completed? ? line_item.quantity : 0
       = item_form.number_field :quantity,


### PR DESCRIPTION
#### What?

 - Move `unit_price_price_and_unit`'s presentation logic to `orders_helper.rb`.
 - Update `unit_price_price_and_unit` method to return a hash as mentioned in https://github.com/openfoodfoundation/openfoodnetwork/pull/6905#discussion_r578401368
 - Rename `unit_price_price_and_unit` to `unit_price` for simplicity and clarity.

#### Why?

 - Make the code a bit clearer and help with #11673 by solving `Psych::DisallowedClass:
       Tried to dump unspecified class: ActiveSupport::SafeBuffer` serializations [issues found on the Rails 7.1 branch](https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/14739687958/job/41374343627?pr=13232).

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Pure refactor – no changes to functionality or views expected. To double check, see the views modified in this PR:
- `app/views/spree/admin/orders/_invoice/_line_item_name.html.haml`
- `app/views/spree/orders/_bought.html.haml`
- `app/views/spree/orders/_line_item.html.haml`

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
