### PR TITLE
Add Finnish locale support

### DIFF
--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,0 +1,4890 @@
+fi:
+  language_name: "Suomi"
+  time:
+    formats:
+      long: "%d. %B %Y klo %-H:%M %p"
+  activerecord:
+    models:
+      spree/product: Tuote
+      spree/shipping_method: Toimitustapa
+    attributes:
+      spree/image:
+        attachment: Liite
+      spree/order/ship_address:
+        address1: "Toimitusosoite (Katu ja talonumero)"
+        address2: "Toimitusosoite rivi 2"
+        city: "Toimituskaupunki"
+        country: "Toimitusmaa"
+        phone: "Puhelinnumero"
+        firstname: "Etunimi"
+        lastname: "Sukunimi"
+        zipcode: "Toimituspostinumero"
+      spree/order/bill_address:
+        address1: "Laskutusosoite (Katu ja talonumero)"
+        zipcode: "Laskutuspostinumero"
+        city: "Laskutuskaupunki"
+        country: "Laskutusmaa"
+        firstname: "Laskutuksen etunimi"
+        lastname: "Laskutuksen sukunimi"
+        phone: Asiakkaan puhelin
+      spree/user:
+        password: "Salasana"
+        password_confirmation: "Salasanan vahvistus"
+        reset_password_token: Salasanan nollausavain
+      enterprise_fee:
+        fee_type: Maksun tyyppi
+      spree/order:
+        payment_state: Maksun tila
+        shipment_state: Toimituksen tila
+        completed_at: Valmis
+        number: Numero
+        state: Tila
+        email: Asiakkaan sähköposti
+      spree/payment:
+        amount: Summa
+        state: Tila
+        source: Lähde
+      spree/product:
+        name: "Tuotteen nimi"
+        price: "Hinta"
+        primary_taxon_id: "Tuoteryhmä"
+        shipping_category_id: "Toimitusluokka"
+      spree/variant:
+        primary_taxon: "Tuoteryhmä"
+        shipping_category_id: "Toimitusluokka"
+        supplier: "Toimittaja"
+        variant_unit: "Yksikön mittakaava"
+        variant_unit_name: "Muunnoksen yksikön nimi"
+        unit_value: "Yksikön arvo"
+      spree/credit_card:
+        base: "Luottokortti"
+        number: "Numero"
+        month: "Kuukausi"
+        verification_value: "Vahvistuskoodi"
+        year: "Vuosi"
+      order_cycle:
+        orders_close_at: Sulkeutumispäivä
+      variant_override:
+        count_on_hand: "Varastossa"
+      spree/payment_method/calculator:
+        preferred_flat_percent: "Laskimen tasaprosentti:"
+        preferred_amount: "Laskimen summa:"
+        preferred_first_item: "Laskimen ensimmäinen tuote:"
+        preferred_additional_item: "Laskimen lisätuotteen hinta:"
+        preferred_max_items: "Laskimen enimmäismäärä:"
+        preferred_minimal_amount: "Laskimen vähimmäissumma:"
+        preferred_normal_amount: "Laskimen normaalimäärä:"
+        preferred_discount_amount: "Laskimen alennussumma:"
+        preferred_unit_from_list: "Laskimen yksikkö listasta:"
+        preferred_per_unit: "Laskimen per yksikkö:"
+      enterprise:
+        white_label_logo_link: "Linkki kaupan käyttämään logoonsa"
+    errors:
+      models:
+        enterprise_fee:
+          inherit_tax_requires_per_item_calculator: "Veroluokan periyttäminen vaatii kappalekohtaisen laskimen."
+        spree/image:
+          attributes:
+            attachment:
+              integrity_error: "lataaminen epäonnistui. Tarkista, että tiedosto ei ole vioittunut, ja yritä uudelleen."
+        spree/user:
+          attributes:
+            email:
+              taken: "Tälle sähköpostiosoitteelle on jo olemassa tili. Kirjaudu sisään tai nollaa salasanasi."
+            reset_password_token:
+              invalid: on virheellinen
+        spree/order:
+          no_card: Ei saatavilla olevia valtuutettuja luottokortteja veloitukseen
+        spree/credit_card:
+          attributes:
+            base:
+              card_expired: "on vanhentunut"
+        order_cycle:
+          attributes:
+            orders_close_at:
+              after_orders_open_at: täytyy olla avaamispäivän jälkeen
+        variant_override:
+          count_on_hand:
+            using_producer_stock_settings_but_count_on_hand_set: "täytyy olla tyhjä, koska käytetään tuottajan varastoasetuksia"
+            limited_stock_but_no_count_on_hand: "täytyy määrittää, koska pakotetaan rajoitettu varasto"
+        connected_apps:
+          vine:
+            api_request_error: "Virhe yhteyden muodostamisessa Vine APIin"
+      messages:
+        confirmation: "ei vastaa %{attribute}"
+        blank: "ei voi olla tyhjä"
+        too_short: "on liian lyhyt (vähintään %{count} merkkiä)"
+  errors:
+    messages:
+      content_type_invalid: "sisältötyyppi on virheellinen"
+      file_size_out_of_range: "koko %{file_size} ei ole vaaditulla välillä"
+      limit_out_of_range: "kokonaismäärä on sallitun alueen ulkopuolella"
+      image_metadata_missing: "ei ole kelvollinen kuva"
+      dimension_min_inclusion: "täytyy olla vähintään %{width} x %{height} pikseliä."
+      dimension_max_inclusion: "täytyy olla enintään %{width} x %{height} pikseliä."
+      dimension_width_inclusion: "leveys ei ole välillä %{min} ja %{max} pikseliä."
+      dimension_height_inclusion: "korkeus ei ole välillä %{min} ja %{max} pikseliä."
+      dimension_width_greater_than_or_equal_to: "leveyden täytyy olla vähintään %{length} pikseliä."
+      dimension_height_greater_than_or_equal_to: "korkeuden täytyy olla vähintään %{length} pikseliä."
+      dimension_width_less_than_or_equal_to: "leveyden täytyy olla enintään %{length} pikseliä."
+      dimension_height_less_than_or_equal_to: "korkeuden täytyy olla enintään %{length} pikseliä."
+      dimension_width_equal_to: "leveyden täytyy olla %{length} pikseliä."
+      dimension_height_equal_to: "korkeuden täytyy olla %{length} pikseliä."
+      aspect_ratio_not_square: "täytyy olla neliömäinen kuva"
+      aspect_ratio_not_portrait: "täytyy olla pystysuuntainen kuva"
+      aspect_ratio_not_landscape: "täytyy olla vaakasuuntainen kuva"
+      aspect_ratio_is_not: "täytyy olla kuvasuhde %{aspect_ratio}"
+      aspect_ratio_unknown: "on tuntematon kuvasuhde"
+      image_not_processable: "ei ole kelvollinen kuva"
+    not_found:
+      title: "Etsimääsi sivua ei löytynyt (404)"
+      message_html: "<b>Yritä uudelleen</b> <p>Tämä voi olla tilapäinen ongelma. Palaa edelliselle sivulle tai <a href='/'>etusivulle</a> ja yritä uudelleen.</p> <b>Ota yhteyttä tukeen</b> <p>Jos ongelma jatkuu tai on kiireellinen, kerro siitä meille. Löydä yhteystiedot globaalilta <a href='https://openfoodnetwork.org/ofn-local/' target='blank'>Open Food Network Local -sivulta</a>.</p> <p>Autat meitä paljon, jos annat mahdollisimman paljon yksityiskohtia puuttuvasta sivusta.</p>"
+    internal_server_error:
+      title: "Valitettavasti jotain meni pieleen (500)"
+      message_html: "<b>Yritä uudelleen</b> <p>Tämä voi olla tilapäinen ongelma. Palaa edelliselle sivulle tai <a href='/''>etusivulle</a> ja yritä uudelleen.</p> <b>Olemme asialla</b> <p>Jos olet nähnyt tämän ongelman aiemmin, tiedämme siitä todennäköisesti jo ja korjaamme sitä. Kirjaamme kaikki tapahtuneet virheet.</p> <b>Ota yhteyttä tukeen</b> <p>Jos ongelma jatkuu tai on kiireellinen, kerro siitä meille. Löydä yhteystiedot globaalilta <a href='https://openfoodnetwork.org/ofn-local/' target='blank'>Open Food Network Local -sivulta</a>.</p> <p>Autat meitä paljon, jos kerrot mahdollisimman yksityiskohtaisesti, mitä teit virheen sattuessa.</p>"
+    unprocessable_entity:
+      title: "Pyytämäsi muutos hylättiin (422)"
+      message_html: "<p>Pyytämäsi muutos hylättiin. Ehkä yritit muuttaa jotain, johon sinulla ei ole oikeutta. <br><h3><a href='/' >Palaa etusivulle</a></h3> </p>"
+    general_error:
+      message: "Valitettavasti jotain meni pieleen.\nTämä voi olla tilapäinen ongelma, joten yritä uudelleen tai päivitä sivu.\nKirjaamme kaikki virheet ja saatamme olla korjaamassa ongelmaa.\nJos ongelma jatkuu tai on kiireellinen, ota yhteyttä."
+    unauthorized:
+      message: "Sinulla ei ole oikeutta suorittaa tätä toimintoa."
+    network_error:
+      message: "Verkkovirhe: yritä myöhemmin uudelleen."
+  stripe:
+    error_code:
+      incorrect_number: "Korttinumero on väärin."
+      invalid_number: "Korttinumero ei ole kelvollinen luottokorttinumero."
+      invalid_expiry_month: "Kortin vanhenemiskkausi on virheellinen."
+      invalid_expiry_year: "Kortin vanhenemisvuosi on virheellinen."
+      invalid_cvc: "Kortin turvakoodi on virheellinen."
+      expired_card: "Kortti on vanhentunut."
+      incorrect_cvc: "Kortin turvakoodi on väärin."
+      incorrect_zip: "Postinumeron vahvistus epäonnistui."
+      card_declined: "Kortti hylättiin."
+      missing: "Asiakkaalla ei ole korttia, jota veloittaa."
+      processing_error: "Kortin käsittelyssä tapahtui virhe."
+      rate_limit: "Virhe tapahtui, koska pyyntöjä lähetettiin liian nopeasti APIin. Kerro meille, jos kohtaat tämän virheen jatkuvasti."
+      authentication_required: "Kortti hylättiin, koska tapahtuma vaatii tunnistautumisen."
+      approve_with_id: "Maksua ei voida valtuuttaa."
+      call_issuer: "Kortti hylättiin tuntemattomasta syystä."
+      card_not_supported: "Kortti ei tue tällaista ostoa."
+      card_velocity_exceeded: "Asiakas on ylittänyt korttinsa saldon tai luottorajan."
+      currency_not_supported: "Kortti ei tue määritettyä valuuttaa."
+      do_not_honor: "Kortti hylättiin tuntemattomasta syystä."
+      do_not_try_again: "Kortti hylättiin tuntemattomasta syystä."
+      duplicate_transaction: "Samanlainen tapahtuma samalla summalla ja korttitiedoilla lähetettiin äskettäin."
+      fraudulent: "Maksu hylättiin, koska Stripe epäilee sitä petolliseksi."
+      generic_decline: "Kortti hylättiin tuntemattomasta syystä."
+      incorrect_pin: "Syötetty PIN-koodi on väärin. Tämä virhekoodi koskee vain kortinlukijalla tehtyjä maksuja."
+      insufficient_funds: "Kortilla ei ole riittävästi varoja ostoksen suorittamiseen."
+      invalid_account: "Kortti tai korttiin liitetty tili on virheellinen."
+      invalid_amount: "Maksun summa on virheellinen tai ylittää sallitun määrän."
+      invalid_pin: "Syötetty PIN-koodi on väärin. Tämä virhekoodi koskee vain kortinlukijalla tehtyjä maksuja."
+      issuer_not_available: "Kortin liikkeeseenlaskijaa ei saatu yhteyteen, joten maksua ei voitu valtuuttaa."
+      lost_card: "Maksu hylättiin, koska kortti on ilmoitettu kadonneeksi."
+      merchant_blacklist: "Maksu hylättiin, koska se vastaa Stripe-käyttäjän estolistalla olevaa arvoa."
+      new_account_information_available: "Kortti tai korttiin liitetty tili on virheellinen."
+      no_action_taken: "Kortti hylättiin tuntemattomasta syystä."
+      not_permitted: "Maksu ei ole sallittu."
+      offline_pin_required: "Kortti hylättiin, koska se vaatii PIN-koodin."
+      online_or_offline_pin_required: "Kortti hylättiin, koska se vaatii PIN-koodin."
+      pickup_card: "Korttia ei voi käyttää tähän maksuun (se on mahdollisesti ilmoitettu kadonneeksi tai varastetuksi)."
+      pin_try_exceeded: "Sallittu määrä PIN-koodin yrityksiä ylitetty."
+      reenter_transaction: "Maksua ei voitu käsitellä liikkeeseenlaskijan puolella tuntemattomasta syystä."
+      restricted_card: "Korttia ei voi käyttää tähän maksuun (se on mahdollisesti ilmoitettu kadonneeksi tai varastetuksi)."
+      revocation_of_all_authorizations: "Kortti hylättiin tuntemattomasta syystä."
+      revocation_of_authorization: "Kortti hylättiin tuntemattomasta syystä."
+      security_violation: "Kortti hylättiin tuntemattomasta syystä."
+      service_not_allowed: "Kortti hylättiin tuntemattomasta syystä."
+      stolen_card: "Maksu hylättiin, koska kortti on ilmoitettu varastetuksi."
+      stop_payment_order: "Kortti hylättiin tuntemattomasta syystä."
+      testmode_decline: "Käytettiin Stripe-testikortin numeroa."
+      transaction_not_allowed: "Kortti hylättiin tuntemattomasta syystä."
+      try_again_later: "Kortti hylättiin tuntemattomasta syystä."
+      withdrawal_count_limit_exceeded: "Asiakas on ylittänyt korttinsa saldon tai luottorajan."
+      disconnect_failure: "Stripe-tilin irrottaminen epäonnistui."
+    success_code:
+      disconnected: "Stripe-tili irrotettu."
+  activemodel:
+    errors:
+      messages:
+        inclusion: "ei sisälly luetteloon"
+      models:
+        order_management/subscriptions/validator:
+          attributes:
+            subscription_line_items:
+              at_least_one_product: "^Lisää vähintään yksi tuote"
+              not_available: "^%{name} ei ole saatavilla valitusta aikataulusta"
+            ends_at:
+              after_begins_at: "täytyy olla aloituspäivämäärän jälkeen"
+            customer:
+              does_not_belong_to_shop: "ei kuulu kauppaan %{shop}"
+            schedule:
+              not_coordinated_by_shop: "ei ole %{shop}:n koordinoima"
+            payment_method:
+              not_available_to_shop: "ei ole saatavilla kaupalle %{shop}"
+              invalid_type: "täytyy olla Käteinen tai Stripe -maksutapa"
+              charges_not_allowed: "^Tämän asiakkaan luottokorttivelotukset eivät ole sallittuja"
+              no_default_card: "^Asiakkaalla ei ole oletuskorttia"
+            shipping_method:
+              not_available_to_shop: "ei ole saatavilla kaupalle %{shop}"
+  card_details: "Kortin tiedot"
+  card_type: "Korttityyppi"
+  card_type_is: "Korttityyppi on"
+  unrecognized_card_type: "Tunnistamaton korttityyppi"
+  use_new_cc: "Käytä uutta luottokorttia"
+  what_is_this: "Mikä tämä on?"
+  cardholder_name: "Kortin haltijan nimi"
+  community_forum_url: "Yhteisöfoorumin URL"
+  customer_instructions: "Ohjeet asiakkaalle"
+  additional_information: "Lisätiedot"
+  connect_app:
+    url: "https://n8n.openfoodnetwork.org/webhook/regen/connect-enterprise"
+  devise:
+    passwords:
+      spree_user:
+        cannot_be_blank: "Käyttäjän salasana ei voi olla tyhjä. Anna salasana."
+    confirmations:
+      send_instructions: "Saat muutaman minuutin kuluessa sähköpostiin ohjeet tilin vahvistamiseksi."
+      failed_to_send: "Vahvistussähköpostin lähettämisessä tapahtui virhe."
+      resend_confirmation_email: "Lähetä vahvistussähköposti uudelleen."
+      confirmed: "Kiitos sähköpostisi vahvistamisesta! Voit nyt kirjautua sisään."
+      not_confirmed: "Sähköpostiosoitettasi ei voitu vahvistaa. Ehkä olet jo suorittanut tämän vaiheen?"
+    user_confirmations:
+      spree_user:
+        send_instructions: "Saat muutaman minuutin kuluessa sähköpostiin ohjeet tilin vahvistamiseksi."
+        confirmation_sent: "Vahvistussähköposti lähetetty"
+        confirmation_not_sent: "Virhe vahvistussähköpostin lähetyksessä"
+    user_registrations:
+      spree_user:
+        signed_up_but_unconfirmed: "Vahvistuslinkki on lähetetty sähköpostiisi. Avaa linkki aktivoidaksesi tilisi."
+        unknown_error: "Jotain meni pieleen tilin luonnissa. Tarkista sähköpostiosoitteesi ja yritä uudelleen."
+    failure:
+      disabled: "Tilisi on poistettu käytöstä. Ota yhteyttä ylläpitoon ratkaistaksesi asian."
+      invalid: |
+          Virheellinen sähköposti tai salasana.
+          Olitko vierailijana viimeksi? Ehkä sinun täytyy luoda tili tai nollata salasanasi.
+      unconfirmed: "Sinun täytyy vahvistaa tilisi ennen jatkamista."
+      already_registered: "Tämä sähköpostiosoite on jo rekisteröity. Kirjaudu sisään jatkaaksesi tai käytä toista sähköpostiosoitetta."
+    success:
+      logged_in_succesfully: "Kirjautuminen onnistui"
+    sessions:
+      signed_out: "Uloskirjautuminen onnistui."
+      already_signed_out: "Uloskirjautuminen onnistui."
+    user_passwords:
+      spree_user:
+        updated_not_active: "Salasanasi on nollattu, mutta sähköpostiasi ei ole vielä vahvistettu."
+        updated: "Salasanasi vaihdettiin onnistuneesti. Olet nyt kirjautunut sisään."
+        send_instructions: "Saat muutaman minuutin kuluessa sähköpostiin ohjeet tilin vahvistamiseksi."
+    oidc:
+      failure: "Kirjautuminen epäonnistui: %{error}"
+      record_not_unique: "%{uid} on jo liitetty toiseen tiliin"
+  home_page_alert_html: "Kotisivun hälytys HTML"
+  hub_signup_case_studies_html: "Keskuksen rekisteröitymisen tapaustutkimukset HTML"
+  hub_signup_detail_html: "Keskuksen rekisteröitymisen yksityiskohdat HTML"
+  hub_signup_pricing_table_html: "Keskuksen rekisteröitymisen hinnoittelutaulukko HTML"
+  group_signup_case_studies_html: "Ryhmän rekisteröitymisen tapaustutkimukset HTML"
+  group_signup_detail_html: "Ryhmän rekisteröitymisen yksityiskohdat HTML"
+  group_signup_pricing_table_html: "Ryhmän rekisteröitymisen hinnoittelutaulukko HTML"
+  item_description: "Tuotteen kuvaus"
+  menu_1_icon_name: "Valikon 1 kuvakkeen nimi"
+  menu_2_icon_name: "Valikon 2 kuvakkeen nimi"
+  menu_3_icon_name: "Valikon 3 kuvakkeen nimi"
+  menu_4_icon_name: "Valikon 4 kuvakkeen nimi"
+  menu_5_icon_name: "Valikon 5 kuvakkeen nimi"
+  menu_6_icon_name: "Valikon 6 kuvakkeen nimi"
+  menu_7_icon_name: "Valikon 7 kuvakkeen nimi"
+  models:
+    order_cycle:
+      cloned_order_cycle_name: "KOPIO %{order_cycle}"
+    tax_rate:
+      included_in_price: "Sisältyy hintaan"
+  open_street_map_enabled: "Open Street Map käytössä"
+  open_street_map_default_latitude: "Open Street Map oletusleveysaste"
+  open_street_map_default_longitude: "Open Street Map oletuspituusaste"
+  open_street_map_provider_name: "Open Street Map palveluntarjoajan nimi"
+  open_street_map_provider_options: "Open Street Map palveluntarjoajan asetukset"
+  producer_signup_case_studies_html: "Tuottajan rekisteröitymisen tapaustutkimukset HTML"
+  producer_signup_detail_html: "Tuottajan rekisteröitymisen yksityiskohdat HTML"
+  producer_signup_pricing_table_html: "Tuottajan rekisteröitymisen hinnoittelutaulukko HTML"
+  producers_social: "Tuottajien some"
+  resume_order: "Jatka tilausta"
+  sku: "SKU"
+  subtotal: "Välisumma"
+  tax_rate: "Verokanta"
+  with_tax_incl: "%{amount} sis. verot"
+  producer_mail_qty: MÄR
+  validators:
+    date_time_string_validator:
+      not_string_error: "täytyy olla merkkijono"
+      invalid_format_error: "täytyy olla kelvollinen"
+    integer_array_validator:
+      not_array_error: "täytyy olla taulukko"
+      invalid_element_error: "täytyy sisältää vain kelvollisia kokonaislukuja"
+  report_job:
+    report_failed: |
+        Tämä raportti epäonnistui. Se saattaa olla liian suuri käsiteltäväksi.
+        Tutkimme asiaa, mutta kerro meille, jos ongelma jatkuu.
+  backorder_mailer:
+    backorder_failed:
+      subject: "Automaattinen jälkitoimitus epäonnistui"
+      headline: "Jälkitoimitus epäonnistui"
+      description: |
+          Yritimme tehdä tai päivittää jälkitoimitusta loppuneista tuotteista, mutta
+          jotain meni pieleen. Sinulla saattaa olla negatiivinen varasto ja sinun täytyy ratkaista
+          ongelma tilataksesi lisää varastoa.
+      hints: |
+          Sinun täytyy ehkä päivittää OIDC-asetukset ja yhdistää tilisi uudelleen.
+          Tarkista myös, että toimittajasi tuoteluettelo ei ole muuttunut ja että se
+          toimittaa edelleen kaikki tarvitsemasi tuotteet. Ota yhteyttä, jos sinulla on kysyttävää.
+      order: "Liittyvä tilaus: %{number}"
+      stock: "Varasto"
+      product: "Tuote"
+    backorder_incomplete:
+      subject: "Automaattinen jälkitoimitus ei valmistunut"
+      headline: "Jälkitoimituksesi on vielä luonnoksena"
+      description: |
+          Yritimme viimeistellä jälkitoimituksen loppuneista tuotteista, mutta
+          jotain meni pieleen. Jälkitoimitusten määrät saattavat olla liian suuria, jos
+          sinulla on peruutuksia. Jälkitoimitustasi ei toimiteta, kunnes
+          se on valmis tilassa.
+      hints: |
+          Sinun täytyy ehkä päivittää OIDC-asetukset ja yhdistää tilisi uudelleen.
+          Tarkista myös, että toimittajasi tuoteluettelo ei ole muuttunut ja että se
+          toimittaa edelleen kaikki tarvitsemasi tuotteet. Ota yhteyttä, jos sinulla on kysyttävää.
+      affected: "%{enterprise}: %{order_cycle}"
+  enterprise_mailer:
+    confirmation_instructions:
+      subject: "Vahvista sähköpostiosoite yritykselle %{enterprise}"
+    welcome:
+      subject: "%{enterprise} on nyt %{sitename}:ssa"
+      email_welcome: "Tervetuloa"
+      email_registered: "on nyt osa"
+      email_userguide_html: "Käyttöopas yksityiskohtaisine ohjeineen Tuottajan tai Keskuksen perustamiseen on täällä: %{link}"
+      userguide: "Open Food Networkin käyttöopas"
+      email_admin_html: "Voit hallita tiliäsi kirjautumalla %{link} tai klikkaamalla oikeassa yläkulmassa olevaa hammasratasta ja valitsemalla Hallinta."
+      admin_panel: "Hallintapaneeli"
+      email_community_html: "Meillä on myös verkossa oleva foorumi yhteisön keskusteluihin liittyen OFN-ohjelmistoon ja ruokayrityksen pyörittämisen ainutlaatuisiin haasteisiin. Kannustamme sinua osallistumaan. Kehitämme jatkuvasti järjestelmää ja panoksesi tähän foorumiin vaikuttaa siihen, mitä tapahtuu seuraavaksi. %{link}"
+      join_community: "Liity yhteisöön"
+    invite_manager:
+      subject: "%{enterprise} on kutsunut sinut hallinnoijaksi"
+  producer_mailer:
+    order_cycle:
+      subject: "Tilausjakson raportti tuottajalle %{producer}"
+    order_cycle_report:
+      order_number: "Tilausnumero"
+  provider_settings: "Palveluntarjoajan asetukset"
+  report_mailer:
+    report_ready:
+      subject: "Raportti valmis"
+      heading: "Raportti valmiina lataukseen"
+      intro: |
+          Alla oleva linkki vanhenee viikon kuluttua.
+      link_label: "%{name}"
+  shipment_mailer:
+    shipped_email:
+      dear_customer: "Hyvä asiakas,"
+      instructions: "Tilauksesi on lähetetty"
+      shipment_summary: "Lähetyksen yhteenveto"
+      subject: "Lähetyksen ilmoitus"
+      thanks: "Kiitos asioinnistasi."
+      track_information: "Seurantatiedot: %{tracking}"
+      track_link: "Seurantalinkki: %{url}"
+  subscription_mailer:
+    placement_summary_email:
+      subject: Yhteenveto äskettäin tehdyistä tilauksista
+      greeting: "Hei %{name},"
+      intro: "Alla on yhteenveto juuri tehdyistä tilauksista kaupalle %{shop}."
+    confirmation_summary_email:
+      subject: Yhteenveto äskettäin vahvistetuista tilauksista
+      greeting: "Hei %{name},"
+      intro: "Alla on yhteenveto juuri vahvistetuista tilauksista kaupalle %{shop}."
+    summary_overview:
+      total: Yhteensä %{count} tilausta merkattiin automaattista käsittelyä varten.
+      success_zero: Niistä ei yhtään käsitelty onnistuneesti.
+      success_some: Niistä %{count} käsiteltiin onnistuneesti.
+      success_all: Kaikki käsiteltiin onnistuneesti.
+      issues: Alla on tietoja kohdatuista ongelmista.
+    summary_detail:
+      no_message_provided: Ei virheviestiä
+      changes:
+        title: Riittämätön varasto (%{count} tilausta)
+        explainer: Nämä tilaukset käsiteltiin, mutta osan pyydetyistä tuotteista varastotaso oli liian alhainen
+      empty:
+        title: Ei varastoa (%{count} tilausta)
+        explainer: Näitä tilauksia ei voitu käsitellä, koska yksikään pyydetyistä tuotteista ei ollut varastossa
+      complete:
+        title: Jo käsitelty (%{count} tilausta)
+        explainer: Nämä tilaukset oli jo merkitty valmiiksi, joten niitä ei käsitelty uudelleen
+      processing:
+        title: Virhe ilmeni (%{count} tilausta)
+        explainer: Näiden tilausten automaattinen käsittely epäonnistui virheen vuoksi. Virhe on listattu, jos se on saatavilla.
+      failed_payment:
+        title: Maksu epäonnistui (%{count} tilausta)
+        explainer: Näiden tilausten maksun automaattinen käsittely epäonnistui virheen vuoksi. Virhe on listattu, jos se on saatavilla.
+      other:
+        title: Muu virhe (%{count} tilausta)
+        explainer: Näiden tilausten automaattinen käsittely epäonnistui tuntemattomasta syystä. Tämän ei pitäisi tapahtua, ota yhteyttä, jos näet tämän.
+  home: "OFN"
+  title: "Open Food Network"
+  welcome_to: "Tervetuloa"
+  site_meta_description: "Aloitamme maasta. Viljelijöiden ja kasvattajien kanssa, jotka ovat valmiita kertomaan tarinansa ylpeästi ja rehellisesti. Jakelijoiden kanssa, jotka ovat valmiita yhdistämään ihmisiä ja tuotteita reilusti ja rehellisesti. Ostajien kanssa, jotka uskovat, että paremmat viikoittaiset ostopäätökset voivat..."
+  search_by_name: Etsi nimellä tai kaupunginosalla...
+  producers_join: Suomalaiset tuottajat ovat nyt tervetulleita liittymään Open Food Networkiin.
+  charges_sales_tax: Veroja peritään?
+  business_address: "Yrityksen osoite"
+  print_invoice: "Tulosta lasku"
+  print_ticket: "Tulosta lippu"
+  select_ticket_printer: "Valitse lipuntulostin"
+  send_invoice: "Lähetä lasku"
+  resend_confirmation: "Lähetä vahvistus uudelleen"
+  view_order: "Näytä tilaus"
+  edit_order: "Muokkaa tilausta"
+  ship_order: "Toimita tilaus"
+  cancel_order: "Peru tilaus"
+  confirm_send_invoice: "Tämän tilauksen lasku lähetetään asiakkaalle. Haluatko varmasti jatkaa?"
+  confirm_resend_order_confirmation: "Haluatko varmasti lähettää tilausvahvistuksen uudelleen?"
+  must_have_valid_business_number: "%{enterprise_name}:lla täytyy olla voimassa oleva Y-tunnus ennen kuin laskuja voidaan käyttää."
+  invoice: "Lasku"
+  invoices: "Laskut"
+  file: "Tiedosto"
+  active: "Aktiivinen"
+  download: "Lataa"
+  cancelled: "Peruutettu"
+  more: "Lisää"
+  say_no: "Ei"
+  say_yes: "Kyllä"
+  ongoing: Jatkuva
+  bill_address: Laskutusosoite
+  ship_address: Toimitusosoite
+  sort_order_cycles_on_shopfront_by: "Järjestä tilausjaksot kaupan etusivulla"
+  required_fields: Pakolliset kentät on merkitty tähdellä
+  select_continue: Valitse ja jatka
+  remove: Poista
+  collapse_all: Sulje kaikki
+  expand_all: Avaa kaikki
+  loading: Ladataan...
+  show_more: Näytä enemmän
+  show_all: Näytä kaikki
+  show_all_with_more: "Näytä kaikki (%{num} lisää)"
+  cancel: Peruuta
+  edit: Muokkaa
+  clone: Kloonaa
+  distributors: Jakelijat
+  distribution: Jakelu
+  order_cycles: Tilausjaksot
+  bulk_order_management: Tilauksien joukkohallinta
+  enterprises: Yritykset
+  enterprise_groups: Ryhmät
+  reports: Raportit
+  listing_reports: Listausraportit
+  variant_overrides: Varasto
+  import: Tuonti
+  spree_products: Spree-tuotteet
+  all: Kaikki
+  current: Nykyinen
+  available: Saatavilla
+  dashboard: Koontinäyttö
+  undefined: määrittelemätön
+  unused: käyttämätön
+  admin_and_handling: Hallinta & käsittely
+  profile: Profiili
+  supplier_only: Vain toimittaja
+  has_shopfront: On verkkokauppa
+  weight: Paino
+  volume: Tilavuus
+  items: Tuotteet
+  summary: Yhteenveto
+  detailed: Yksityiskohtainen
+  updated: Päivitetty
+  'yes': "Kyllä"
+  'no': "Ei"
+  y: 'K'
+  n: 'E'
+  powered_by: Powered by
+  blocked_cookies_alert: "Selaimesi saattaa estää evästeet, joita tarvitaan tämän verkkokaupan käyttöön. Klikkaa alta salliaksesi evästeet ja päivittääksesi sivun."
+  allow_cookies: "Salli evästeet"
+  none: Ei mitään
+  notes: Huomautukset
+  error: Virhe
+  voucher: Alennuskuponki
+  processing_payment: "Käsitellään maksua..."
+  no_pending_payments: "Ei odottavia maksuja"
+  invalid_payment_state: "Virheellinen maksun tila: %{state}"
+  filter_results: Suodata tulokset
+  clear_filters: Tyhjennä suodattimet
+  quantity: Määrä
+  pick_up: Nouto
+  ok: OK
+  copy: Kopioi
+  change_my_password: "Vaihda salasanani"
+  update_password: "Päivitä salasana"
+  password_confirmation: Salasanan vahvistus
+  reset_password_token: Salasanan nollausavain
+  expired: on vanhentunut, pyydä uusi
+  back_to_payments_list: "Takaisin maksulistaan"
+  maestro_or_solo_cards: "Maestro/Solo-kortit"
+  backordered: "Jälkitoimitettava"
+  on_hand: "Varastossa"
+  on hand: "Varastossa"
+  ship: "Toimita"
+  shipping_category: "Toimitusluokka"
+  height: "Korkeus"
+  width: "Leveys"
+  depth: "Syvyys"
+  payment_could_not_process: "Maksua ei voitu käsitellä"
+  payment_could_not_complete: "Maksua ei voitu suorittaa loppuun"
+  vine_voucher_validator_service:
+    errors:
+      vine_api: "API-yhteydessä tapahtui virhe, yritä myöhemmin uudelleen."
+      invalid_voucher: "Alennuskuponki ei ole kelvollinen"
+      not_found_voucher: "Anteeksi, emme löytäneet tätä alennuskuponkia, tarkista koodi."
+  vine_voucher_redeemer_service:
+    errors:
+      vine_api: "API-yhteydessä tapahtui virhe"
+      redeeming_failed: "Alennuskupongin lunastaminen epäonnistui"
+  actions:
+    create_and_add_another: "Luo ja lisää toinen"
+    create: "Luo"
+    cancel: "Peruuta"
+    resume: "Jatka"
+    save: "Tallenna"
+    edit: "Muokkaa"
+    update: "Päivitä"
+    delete: "Poista"
+    add: "Lisää"
+    cut: "Leikkaa"
+    paste: "Liitä"
+    destroy: "Tuhoa"
+    rename: "Nimeä uudelleen"
+  admin:
+    products_page:
+      title: Tuotteet
+      filters:
+        categories:
+          title: Kategoriat
+          selected_categories: "%{count} kategoriaa valittu"
+        producers:
+          title: Tuottajat
+          selected_producers: "%{count} tuottajaa valittu"
+        per_page: "%{count} kohdetta per sivu"
+        colums: Sarakkeet
+      columns:
+        image: Kuva
+        name: Nimi
+        unit_scale: Yksikön mittakaava
+        unit: Yksikkö
+        unit_value: Yksikön arvo
+        display_as: Näytä yksikkönä
+        price: Hinta
+        producer: Tuottaja
+        category: Kategoria
+        sku: SKU
+        on_hand: "Varastossa"
+        on_demand: "Tilauksesta"
+        tax_category: "Veroluokka"
+        inherits_properties: "Perii ominaisuudet?"
+        import_date: "Tuontipäivä"
+        actions: Toiminnot
+        tags: Tägit
+      columns_selector:
+        unit: Yksikkö
+        price: Hinta
+        producer: Tuottaja
+        category: Kategoria
+        sku: SKU
+        on_hand: "Varastossa"
+        on_demand: "Tilauksesta"
+        tax_category: "Veroluokka"
+        inherits_properties: "Perii ominaisuudet?"
+        import_date: "Tuontipäivä"
+      actions:
+        edit: Muokkaa
+        clone: Kloonaa
+        delete: Poista
+        remove: Poista
+        preview: Esikatsele
+      image:
+        edit: Muokkaa
+      product_preview:
+        product_preview: Tuotteen esikatselu
+        shop_tab: Kauppa
+        product_details_tab: Tuotteen tiedot
+    adjustments:
+      skipped_changing_canceled_order: "Peruutettua tilausta ei voi muuttaa."
+    begins_at: Alkaa
+    begins_on: Alkaa
+    bill_address: "Laskutusosoite"
+    ship_address: "Toimitusosoite"
+    customer: Asiakas
+    date: Päivämäärä
+    email: Sähköposti
+    ends_at: Päättyy
+    ends_on: Päättyy
+    name: Nimi
+    first_name: Etunimi
+    last_name: Sukunimi
+    on_hand: Varastossa
+    on_demand: Tilauksesta
+    on_demand?: Tilauksesta?
+    order_cycle: Tilausjakso
+    payment: Maksu
+    payment_method: Maksutapa
+    phone: Puhelin
+    price: Hinta
+    producer: Tuottaja
+    image: Kuva
+    product: Tuote
+    quantity: Määrä
+    schedule: Aikataulu
+    shipping: Toimitus
+    shipping_method: Toimitustapa
+    shop: Kauppa
+    sku: SKU
+    status_state: Tila
+    tags: Tägit
+    variant: Muunnos
+    weight: Paino
+    volume: Tilavuus
+    items: Tuotteet
+    select_all: Valitse kaikki
+    quick_search: Pikahaku
+    clear_all: Tyhjennä kaikki
+    start_date: "Aloituspäivä"
+    end_date: "Päättymispäivä"
+    unsaved_changes: "Sinulla on tallentamattomia muutoksia"
+    form_invalid: "Lomake sisältää puuttuvia tai virheellisiä kenttiä"
+    clear_filters: Tyhjennä suodattimet
+    clear: Tyhjennä
+    save: Tallenna
+    cancel: Peruuta
+    back: Takaisin
+    show_more: Näytä enemmän
+    show_n_more: Näytä %{num} lisää
+    choose: "Valitse..."
+    please_select: Valitse...
+    column_save_as_default: Tallenna oletukseksi
+    columns: Sarakkeet
+    actions: Toiminnot
+    viewing: "Näytetään: %{current_view_name}"
+    description: Kuvaus
+    whats_this: Mikä tämä on?
+    tag_has_rules: "Tämän tägin säännöt: %{num}"
+    has_one_rule: "on yksi sääntö"
+    has_n_rules: "on %{num} sääntöä"
+    unsaved_confirm_leave: "Sivulla on tallentamattomia muutoksia. Jatketaanko tallentamatta?"
+    available_units: "Saatavilla olevat yksiköt"
+    terms_of_service_have_been_updated_html: "Open Food Networkin käyttöehdot on päivitetty: %{tos_link}"
+    terms_of_service: Lue käyttöehdot
+    accept_terms_of_service: Hyväksy käyttöehdot
+    shopfront_settings:
+      embedded_shopfront_settings: "Upotetun verkkokaupan asetukset"
+      enable_embedded_shopfronts: "Ota upotetut verkkokaupat käyttöön"
+      embedded_shopfronts_whitelist: "Sallittujen ulkoisten verkkotunnusten lista"
+    terms_of_service_files:
+      create:
+        select_file: "Valitse ensin tiedosto."
+      show:
+        title: "Käyttöehtojen tiedostot"
+        no_files: "Käyttöehtoja ei ole vielä ladattu."
+        current_terms_html: "Katso nykyiset %{tos_link}. Latausaika: %{datetime}."
+        terms_of_service: "Käyttöehdot"
+        delete: "Poista tiedosto"
+        confirm_delete: "Haluatko varmasti poistaa nykyisen käyttöehtotiedoston?"
+        attachment: "Liite"
+        create_terms_of_service: "Luo käyttöehtotiedosto"
+    number_localization:
+      number_localization_settings: "Numeroiden paikallistusasetukset"
+      enable_localized_number: "Käytä kansainvälistä tuhansien/desimaalien erotinlogiikkaa"
+    invoice_settings:
+      edit:
+        title: "Laskutusasetukset"
+        enable_invoices?: "Käytä laskuja?"
+        invoice_style2?: "Käytä vaihtoehtoista laskumallia, joka sisältää verokannan tiedot kullekin verokannalle ja verokannan tiedot kohdetta kohden (ei vielä sovellu maihin, joissa hinnat näytetään ilman veroja)"
+        enterprise_number_required_on_invoices?: "Vaadi Y-tunnus laskun luomiseen?"
+    stripe_connect_settings:
+      edit:
+        title: "Stripe Connect"
+        settings: "Asetukset"
+        stripe_connect_enabled: Salli kauppojen hyväksyä maksuja Stripe Connectin kautta?
+        no_api_key_msg: Tälle yritykselle ei ole Stripe-tiliä.
+        configuration_explanation_html: Yksityiskohtaiset ohjeet Stripe Connect -integraation määrittämiseen löytyvät <a href='https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance' target='_blank'>tästä oppaasta</a>.
+        status: Tila
+        ok: Ok
+        instance_secret_key: Instanssin salainen avain
+        instance_publishable_key: Instanssin julkaistava avain
+        account_id: Tilin ID
+        business_name: Yrityksen nimi
+        charges_enabled: Velotukset käytössä
+        charges_enabled_warning: "Varoitus: Velotukset eivät ole käytössä tililläsi"
+        auth_fail_error: Antamasi API-avain on virheellinen
+        empty_api_key_error_html: Stripe API -avainta ei ole annettu. Asettaaksesi API-avaimen, noudata <a href="https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance" target="_blank">näitä ohjeita</a>
+    matomo_settings:
+      edit:
+        title: "Matomo-asetukset"
+        matomo_url: "Matomo URL"
+        matomo_site_id: "Matomo-sivuston ID"
+        matomo_tag_manager_url: "Matomo Tag Manager URL"
+        info_html: "Matomo on verkkosivujen ja mobiilien analytiikkasovellus. Voit joko isännöidä Matomoa omilla palvelimillasi tai käyttää pilvipohjaista palvelua. Katso lisätietoja osoitteesta <a href='http://matomo.org' target='_blank'>matomo.org</a>."
+        config_instructions_html: "Täällä voit määrittää OFN-Matomo-integraation. Matomo URL -kenttään tulee osoittaa Matomo-instanssi, johon käyttäjien seurantatiedot lähetetään; jos se jätetään tyhjäksi, Matomo-käyttäjien seuranta poistetaan käytöstä. Sivuston ID -kenttä ei ole pakollinen, mutta hyödyllinen, jos seuraat useampaa kuin yhtä verkkosivua yhdessä Matomo-instanssissa; sen löydät Matomo-instanssin konsolista."
+        config_instructions_tag_manager_html: "Matomo Tag Manager URL:n asettaminen ottaa Matomo Tag Managerin käyttöön. Tämän työkalun avulla voit määrittää analytiikkatapahtumia. Matomo Tag Manager URL kopioidaan Matomo Tag Managerin Asennuskoodi -osiosta. Varmista, että valitset oikean säiliön ja ympäristön, koska nämä vaihtoehdot muuttavat URL-osoitetta."
+    connected_app_settings:
+      edit:
+        title: "Yhdistettyjen sovellusten asetukset"
+        info_html: "Käytössä olevat sovellukset näkyvät Yritysasetukset > Yhdistetyt sovellukset -kohdassa."
+        enabled_legend: "Käytössä olevat yhdistetyt sovellukset"
+        connected_apps_enabled:
+          discover_regen: Löydä Regeneratiivinen portaali
+          affiliate_sales_data: DFC anonymisoitujen tilausten API tutkimustarkoituksiin
+          vine: Alennuskuponkien integrointimoottori (VINE)
+      update:
+        resource: Yhdistettyjen sovellusten asetukset
+    customers:
+      index:
+        new_customer: "Uusi asiakas"
+        code: Koodi
+        duplicate_code: "Tätä koodia käytetään jo."
+        bill_address: "Laskutusosoite"
+        ship_address: "Toimitusosoite"
+        balance: "Saldo"
+        update_address_success: "Osoite päivitetty onnistuneesti."
+        update_address_error: "Anteeksi! Täytä kaikki vaaditut kentät!"
+        edit_bill_address: "Muokkaa laskutusosoitetta"
+        edit_ship_address: "Muokkaa toimitusosoitetta"
+        required_fileds: "Pakolliset kentät on merkitty tähdellä "
+        select_country: "Valitse maa"
+        select_state: "Valitse osavaltio"
+        edit: "Muokkaa"
+        update_address: "Päivitä osoite"
+        confirm_delete: "Varmista poisto?"
+        search_by_email: "Hae sähköpostilla/koodilla..."
+        guest_label: "Vierailijan kassa"
+        credit_owed: "Luottoa"
+        balance_due: "Erääntynyt saldo"
+      destroy:
+        has_associated_subscriptions: "Poisto epäonnistui: Tällä asiakkaalla on aktiivisia tilauksia. Peruuta ne ensin."
+    column_preferences:
+      bulk_update:
+        success: "Sarakemääritykset tallennettu"
+    contents:
+      edit:
+        title: Sisältö
+        header: Ylätunniste
+        home_page: Kotisivu
+        producer_signup_page: Tuottajan rekisteröitymissivu
+        hub_signup_page: Keskuksen rekisteröitymissivu
+        group_signup_page: Ryhmän rekisteröitymissivu
+        main_links: Päävalikon linkit
+        footer_and_external_links: Alatunniste ja ulkoiset linkit
+        your_content: Sisältösi
+        user_guide: Käyttöopas
+        map: Kartta
+    dfc_product_imports:
+      connection_invalid_html: |
+          OIDC-tilin yhdistäminen epäonnistui.
+          Päivitä OIDC-yhteys osoitteessa: %{oidc_settings_link}
+      absent_variant:
+        reset: "Nollaa varasto"
+      index:
+        title: "DFC-tuoteluettelo"
+        catalog_url: "%{count} tuotetta tuotava osoitteesta: %{catalog_url}"
+        absent_products:
+          one: |
+              Yksi tuote ei enää ole luettelossa.
+              Se merkitään ei-saatavaksi nollaamalla varasto.
+          other: |
+              %{count} tuotetta ei enää ole luettelossa.
+              Ne merkitään ei-saataviksi nollaamalla varasto.
+        enterprise: "Tuonti yritykseen: %{enterprise_name}"
+        select_all: "Valitse/poista kaikki"
+        update: Päivitä
+        new: Uusi
+        selected:
+          zero: "0 valittu"
+          one: "1 valittu"
+          other: "%{count} valittu"
+        import: Tuo
+        invalid_url: Tämä luettelon URL-osoite ei ole kelvollinen.
+      import:
+        title: "DFC-tuoteluettelon tuonti"
+        imported_products: "Tuodut tuotteet: %{count}"
+        reset_products: "Varasto nollattu puuttuville tuotteille: %{count}"
+    enterprise_fees:
+      index:
+        title: "Yritysmaksut"
+        enterprise: "Yritys"
+        fee_type: "Maksun tyyppi"
+        name: "Nimi"
+        tax_category: "Veroluokka"
+        calculator: "Laskin"
+        calculator_values: "Laskimen arvot"
+        search: "Haku"
+        name_placeholder: "esim. pakkausmaksu"
+    enterprise_groups:
+      index:
+        new_button: Uusi yritysryhmä
+      form_primary_details:
+        primary_details: "Perustiedot"
+      form_users:
+        users: "Käyttäjät"
+      form_about:
+        about: "Tietoja"
+      form_images:
+        images: "Kuvat"
+      form_address:
+        contact: "Yhteystiedot"
+      form_web:
+        web: "Verkkoresurssit"
+    enterprise_roles:
+      form:
+        manages: hallinnoi
+      enterprise_role:
+        manages: hallinnoi
+    products:
+      unit_name_placeholder: 'esim. nippu'
+      index:
+        unit: Yksikkö
+        display_as: Näytä nimellä
+        category: Kategoria
+        tax_category: Veroluokka
+        inherits_properties?: Perii ominaisuudet?
+        av_on: "Saat. päiv."
+        import_date: Tuotu
+        upload_an_image: Lataa kuva
+      seo:
+        product_search_keywords: "Tuotehakusanat"
+        product_search_tip: "Kirjoita sanoja, jotka auttavat hakemaan tuotteitasi kaupoista. Käytä välilyöntiä erottaaksesi jokainen hakusana."
+        seo_tip: "Kirjoita sanoja, jotka auttavat hakemaan tuotteitasi verkosta. Käytä välilyöntiä erottaaksesi jokainen hakusana."
+      search: "Haku"
+      properties:
+        property_name: "Ominaisuuden nimi"
+        inherited_property: "Peritty ominaisuus"
+      variants:
+        infinity: "Ääretön"
+        to_order_tip: "Tilauksesta tehtävillä tuotteilla ei ole kiinteää varastotasoa, kuten tilauksesta leivottu leipä."
+      back_to_products_list: "Takaisin tuotelistaan"
+      editing_product: "Tuotteen muokkaaminen"
+      tabs:
+        product_details: "Tuotteen tiedot"
+        group_buy_options: "Ryhmäostovaihtoehdot"
+        images: "Kuvat"
+        variants: "Muunnokset"
+        product_properties: "Tuotteen ominaisuudet"
+    products_v3:
+      index:
+        header:
+          title: Tuotteiden joukkomuokkaus
+      content:
+        loading: Ladataan tuotteitasi
+      delete_modal:
+        delete_product_modal:
+          heading: "Poista tuote"
+          prompt: "Tämä poistaa sen pysyvästi listaltasi."
+          confirmation_text: "Poista tuote"
+          cancellation_text: "Pidä tuote"
+        delete_variant_modal:
+          heading: "Poista muunnos"
+          prompt: "Tämä poistaa sen pysyvästi listaltasi."
+          confirmation_text: "Poista muunnos"
+          cancellation_text: "Pidä muunnos"
+      filters:
+        search_products: Etsi tuotteita
+        search_for_producers: Etsi tuottajia
+        select_producer: Valitse tuottaja
+        all_producers: Kaikki tuottajat
+        search_for_categories: Etsi kategorioita
+        select_category: Valitse kategoria
+        all_categories: Kaikki kategoriat
+        select_tag: Valitse tägi
+        producers:
+          label: Tuottajat
+        categories:
+          label: Kategoriat
+        tags:
+          label: Tägit
+        search: Haku
+      sort:
+        pagination:
+          products_total_html:
+            one: "<strong>%{count} tuote</strong> löytyi hakuehtoihisi. Näytetään %{from} - %{to}."
+            other: "<strong>%{count} tuotetta</strong> löytyi hakuehtoihisi. Näytetään %{from} - %{to}."
+          per_page:
+            show: Näytä
+            per_page: "%{num} per sivu"
+          clear_search: Tyhjennä haku
+      no_products:
+        no_products_found: Tuotteita ei löytynyt
+        import_products: Tuo useita tuotteita
+        no_products_found_for_search: Hakuehtoihisi ei löytynyt tuotteita
+      table:
+        changed_summary:
+          one: "%{count} tuote muokattu."
+          other: "%{count} tuotetta muokattu."
+        error_summary:
+          saved:
+            one: "%{count} tuote tallennettiin oikein, mutta "
+            other: "%{count} tuotetta tallennettiin oikein, mutta "
+          invalid:
+            one: "%{count} tuotetta ei voitu tallentaa. Tarkista virheet ja yritä uudelleen."
+            other: "%{count} tuotetta ei voitu tallentaa. Tarkista virheet ja yritä uudelleen."
+        reset: Hylkää muutokset
+        save: Tallenna muutokset
+      product_variant_row:
+        new_variant: Uusi muunnos
+      bulk_update:
+        success: Muutokset tallennettu
+      delete_product:
+        success: Tuote poistettiin onnistuneesti
+        error: Tuotteen poistaminen epäonnistui
+      delete_variant:
+        success: Muunnos poistettiin onnistuneesti
+        error: Muunnoksen poistaminen epäonnistui
+      variant_row:
+        none_tax_category: Ei mitään
+        search_for_tax_categories: "Etsi veroluokkia"
+        category_field_name: "Kategoria"
+        tax_category_field_name: "Veroluokka"
+        producer_field_name: "Tuottaja"
+        select_unit_scale: Valitse yksikön mittakaava
+        add_a_tag: Lisää tägi
+      clone:
+        success: Tuote kloonattiin onnistuneesti
+        error: Tuotteen kloonaaminen epäonnistui
+    product_import:
+      title: Tuontituotteet
+      file_not_found: Tiedostoa ei löytynyt tai sitä ei voitu avata
+      no_data: Taulukosta ei löytynyt tietoja
+      confirm_reset: "Tämä nollaa varastomäärän nollaan kaikille tämän yrityksen tuotteille, joita ei ole ladatussa tiedostossa"
+      model:
+        no_file: "virhe: tiedostoa ei ladattu"
+        could_not_process: "tiedoston käsittely epäonnistui: virheellinen tiedostotyyppi"
+        incorrect_value: virheellinen arvo
+        conditional_blank: ei voi olla tyhjä, jos unit_type on tyhjä
+        no_product: ei vastannut yhtään tietokannan tuotetta
+        not_found: ei löytynyt tietokannasta
+        category_not_found: ei vastaa sallittuja kategorioita. Katso oikeat kategoriat tuontisivulta tai tarkista, ettei ole kirjoitusvirhettä.
+        not_updatable: ei voi päivittää olemassa oleviin tuotteisiin tuonnin kautta
+        values_must_be_same: on oltava sama tuotteille, joilla on sama nimi
+        blank: ei voi olla tyhjä
+        products_no_permission: sinulla ei ole oikeuksia hallita tämän yrityksen tuotteita
+        inventory_no_permission: sinulla ei ole oikeuksia luoda varastoa tälle tuottajalle
+        none_saved: ei tallentanut yhtään tuotetta onnistuneesti
+        line_number: "Rivi %{number}:"
+        encoding_error: "Tarkista lähdetiedostosi kieliasetus ja varmista, että se on tallennettu UTF-8-koodauksella"
+        unexpected_error: "Tuontituotteet kohtasivat odottamattoman virheen tiedoston avaamisessa: %{error_message}"
+        malformed_csv: "Tuontituotteet kohtasivat virheellisen CSV-tiedoston: %{error_message}"
+      index:
+        notice: "Huomio"
+        beta_notice: "Tämä ominaisuus on vielä beetavaiheessa: saatat kohdata joitain virheitä käytön aikana. Älä epäröi ottaa yhteyttä tukeen."
+        select_file: Valitse tuotava taulukko
+        spreadsheet: Taulukko
+        choose_import_type: Valitse tuontityyppi
+        import_into: Tuontityyppi
+        product_list: Tuotelista
+        inventories: Varastot
+        import: Tuo
+        upload: Lataa
+        csv_templates: CSV-mallit
+        product_list_template: Lataa tuoteluettelon malli
+        inventory_template: Lataa varastomalli
+        category_values: Saatavilla olevat kategoria-arvot
+        product_categories: Tuotekategoriat
+        tax_categories: Veroluokat
+        shipping_categories: Toimitusluokat
+      dfc_import_form:
+        title: "Tuo DFC-luettelosta"
+        enterprise: "Luo tuotteet yritykselle"
+        catalog_url: "DFC-luettelon URL"
+        preview: Esikatsele
+      import:
+        review: Tarkista
+        import: Tuo
+        save: Tallenna
+        results: Tulokset
+        save_imported: Tallenna tuodut tuotteet
+        no_valid_entries: Kelvollisia merkintöjä ei löytynyt
+        none_to_save: Ei tallennettavia merkintöjä
+        some_invalid_entries: Tuodussa tiedostossa on virheellisiä merkintöjä
+        fix_before_import: Korjaa nämä virheet ja yritä tuoda tiedosto uudelleen
+        save_valid?: Tallenna kelvolliset merkinnät ja hylkääkö muut?
+        no_errors: Virheitä ei havaittu!
+        save_all_imported?: Tallennetaanko kaikki tuodut tuotteet?
+        options_and_defaults: Tuontivaihtoehdot ja oletusarvot
+        no_permission: sinulla ei ole oikeuksia hallita tätä yritystä
+        not_found: yritystä ei löytynyt tietokannasta
+        no_name: Ei nimeä
+        blank_enterprise: joillakin tuotteilla ei ole määriteltyä yritystä
+        reset_absent?: Nollaa puuttuvat tuotteet
+        reset_absent_tip: Aseta varasto nollaan kaikille olemassa oleville tuotteille, joita ei ole tiedostossa
+        overwrite_all: Korvaa kaikki
+        overwrite_empty: Korvaa, jos tyhjä
+        default_stock: Aseta varastomäärä
+        default_tax_cat: Aseta veroluokka
+        default_shipping_cat: Aseta toimitusluokka
+        default_available_date: Aseta saatavuspäivä
+        validation_overview: Tuontitarkistuksen yleiskatsaus
+        entries_found: Tuodussa tiedostossa löytyi merkintöjä
+        entries_with_errors: Kohteissa on virheitä, eikä niitä tuoda
+        products_to_create: Tuotteet luodaan
+        products_to_update: Tuotteet päivitetään
+        inventory_to_create: Varastokohteet luodaan
+        inventory_to_update: Varastokohteet päivitetään
+        products_to_reset: Olemassa olevien tuotteiden varasto nollataan
+        inventory_to_reset: Olemassa olevien varastokohteiden varasto nollataan
+        line: Rivi
+        item_line: Kohteen rivi
+      import_review:
+        not_updatable_tip: "Seuraavia kenttiä ei voi päivittää joukkotuonnilla olemassa oleville tuotteille:"
+        fields_ignored: Nämä kentät jätetään huomiotta tuotujen tuotteiden tallennuksessa.
+      entries_table:
+        not_updatable: Tätä kenttää ei voi päivittää joukkotuonnilla olemassa oleville tuotteille
+      save_results:
+        final_results: Tuonnin lopputulokset
+        products_created: Tuotteet luotiin
+        products_updated: Tuotteet päivitettiin
+        inventory_created: Varastokohteet luotiin
+        inventory_updated: Varastokohteet päivitettiin
+        products_reset: Tuotteiden varasto nollattiin
+        inventory_reset: Varastokohteiden varasto nollattiin
+        all_saved: "Kaikki kohteet tallennettiin onnistuneesti"
+        some_saved: "kohdetta tallennettiin onnistuneesti"
+        save_errors: Tallennusvirheet
+        import_again: Lataa toinen tiedosto
+        view_products: Siirry tuotesivulle
+        view_inventory: Siirry varastosivulle
+      product_headings:
+        distributor: Jakelija
+        producer: Tuottaja
+        sku: SKU
+        name: Nimi
+        display_name: Näyttönimi
+        category: Kategoria
+        description: Kuvaus
+        units: Yksiköt
+        unit_type: Yksikön tyyppi
+        variant_unit_name: Muunnoksen yksikön nimi
+        price: Hinta
+        on_hand: Varastossa
+        on_demand: Tilauksesta
+        shipping_category: Toimitusluokka
+        tax_category: Veroluokka
+    variant_overrides:
+      loading_flash:
+        loading_inventory: LADATAAN VARASTOA
+      index:
+        title: Varasto
+        description: Käytä tätä sivua yrityksiesi varastojen hallintaan. Tässä asetetut tuotetiedot ohittavat 'Tuotteet'-sivulla asetetut tiedot
+        enable_reset?: Ota varaston nollaus käyttöön?
+        default_stock: "Oletusvarasto"
+        inherit?: Periikö?
+        add: Lisää
+        hide: Piilota
+        import_date: Tuotu
+        select_a_shop: Valitse kauppa
+        review_now: Tarkista nyt
+        new_products_alert_message: Sinulla on %{new_product_count} uutta tuotetta, joita voit lisätä varastoosi.
+        currently_empty: Varastosi on tällä hetkellä tyhjä
+        no_matching_products: Varastostasi ei löytynyt vastaavia tuotteita
+        no_hidden_products: Yhtään tuotetta ei ole piilotettu tästä varastosta
+        no_matching_hidden_products: Piilotetuista tuotteista ei löytynyt hakuehtoihisi vastaavia
+        no_new_products: Ei uusia tuotteita lisättäväksi tähän varastoon
+        no_matching_new_products: Uusista tuotteista ei löytynyt hakuehtoihisi vastaavia
+        inventory_powertip: Tämä on varastosi tuotteista. Lisätäksesi tuotteita varastoosi, valitse 'Uudet tuotteet' Näytä-pudotusvalikosta.
+        hidden_powertip: Nämä tuotteet on piilotettu varastostasi, eivätkä ne ole saatavilla kaupallesi. Voit lisätä tuotteen varastoosi klikkaamalla 'Lisää'.
+        new_powertip: Nämä tuotteet ovat saatavilla lisättäväksi varastoosi. Klikkaa 'Lisää' lisätäksesi tuotteen varastoosi tai 'Piilota' piilottaaksesi sen näkyvistä. Voit aina muuttaa mieltäsi myöhemmin!
+      controls:
+        back_to_my_inventory: Takaisin omaan varastooni
+    orders:
+      edit:
+        order_sure_want_to: Haluatko varmasti %{event} tämän tilauksen?
+        voucher_tax_included_in_price: "%{label} (vero sisältyy alennuskuponkiin)"
+        tax_on_fees: "Vero maksuista"
+      invoice_email_sent: 'Laskusähköposti on lähetetty'
+      order_email_resent: 'Tilausvahvistus on lähetetty uudelleen'
+      bulk_management:
+        tip: "Käytä tätä sivua muokataksesi tuotemääriä useissa tilauksissa. Tuotteita voidaan myös poistaa kokonaan tilauksista, jos tarpeen."
+        shared: "Jaettu resurssi?"
+        order_no: "Tilausnro."
+        order_date: "Valmistunut"
+        max: "Enint."
+        product_unit: "Tuote: Yksikkö"
+        weight_volume: "Paino/Tilavuus (g)"
+        ask: "Kysy?"
+        page_title: "Tilausten joukkomuokkaus"
+        actions_delete: "Poista valitut"
+        loading: "Ladataan tilauksia"
+        no_results: "Tilauksia ei löytynyt."
+        group_buy_unit_size: "Ryhmäostoyksikön koko"
+        total_qtt_ordered: "Tilattu määrä yhteensä"
+        max_qtt_ordered: "Tilattu enimmäismäärä"
+        current_fulfilled_units: "Nykyiset toimitetyt yksiköt"
+        max_fulfilled_units: "Enimmäistoimitetyt yksiköt"
+        order_error: "Jotkin virheet on ratkaistava ennen kuin voit päivittää tilauksia.\nKaikissa punaisella reunustetuissa kentissä on virheitä."
+        variants_without_unit_value: "VAROITUS: Joillakin muunnoksilla ei ole yksikköarvoa"
+        all: "Kaikki"
+      select_variant: "Valitse muunnos"
+      note:
+        note_label: "Huomautus:"
+        no_note_present: "Ei huomautuksia."
+    enterprise:
+      select_outgoing_oc_products_from: Valitse lähtevät OC-tuotteet
+    enterprises:
+      index:
+        title: Yritykset
+        new_enterprise: Uusi yritys
+        producer?: "Tuottaja?"
+        package: Paketti
+        status: Tila
+        manage: Hallinnoi
+      form:
+        about_us:
+          legend: "Tietoja"
+          desc_short: Lyhyt kuvaus
+          desc_short_placeholder: Kerro yrityksestäsi yhdessä tai kahdessa lauseessa
+          desc_long: Tietoja meistä
+          desc_long_placeholder: Kerro asiakkaillesi itsestäsi. Tämä tieto näkyy julkisessa profiilissasi.
+        address:
+          legend: "Osoite"
+        business_details:
+          legend: "Yrityksen tiedot"
+          upload: 'lataa'
+          abn: Y-tunnus
+          abn_placeholder: esim. 99 123 456 789
+          acn: Rekisteröintinumero
+          acn_placeholder: esim. 123 456 789
+          display_invoice_logo: Näytä logo laskuissa
+          invoice_text: Lisää mukautettu teksti laskun loppuun
+          terms_and_conditions: "Käyttöehdot"
+          remove_terms_and_conditions: "Poista tiedosto"
+          uploaded_on: "ladattu"
+          reset_form: "Nollaa lomake"
+          business_address_legend: "Yrityksen osoite"
+          invoice_item_sorting_legend: "lasku kohde lajittelu"
+          sort_items_by_supplier?: Lajittele kohteet toimittaja mukaan?
+          sort_items_by_supplier_tip: "Kun tämä on käytössä, kohteet lajittelee toimittaja nimi ."
+          enabled: Ota käyttöön
+          disabled: Poista käytöstä
+        business_address:
+          company_legal_name: Yrityksen virallinen nimi
+          company_placeholder: Example Inc.
+          address1: Virallinen osoite
+          address1_placeholder: 123 High St.
+          address2: Osoite (jatkuu)
+          legal_phone_number: Virallinen puhelinnumero
+          phone_placeholder: "98 123 4565"
+          select_country: "Valitse maa"
+          select_state: "Valitse lääni"
+        contact:
+          legend: "Yhteystieto"
+          name: Nimi
+          name_placeholder: eg. Gustav Plum
+          email_address: Julkinen sähköpostiosoite
+          email_address_placeholder: eg. inquiries@fresh-food.com
+          email_address_tip: "Tämä osoite näytetään julkisessa profiilissasi"
+          phone: Puhelin
+          phone_placeholder: eg. 98 7654 3210
+          whatsapp_phone: WhatsApp puhelinnumero
+          whatsapp_phone_placeholder: esim. +61 8 9876 5432
+          whatsapp_phone_tip: "Tämä numero näkyy julkisessa profiilissasi, joka avataan WhatsApp-linkkinä."
+          website: Verkkosivu
+          website_placeholder: esim. www.truffles.com
+        enterprise_fees:
+          legend: "Yritysmaksut"
+          name: Nimi
+          fee_type: Maksun tyyppi
+          manage_fees: Hallitse yrityksen maksuja
+          no_fees_yet: Sinulla ei ole vielä yritysmaksuja.
+          create_button: Luo nyt uusi
+        enterprise_permissions:
+          legend: "Yrityksen käyttöoikeudet"
+          enterprise_relationships: Yrityssuhteet
+        images:
+          legend: "Kuvat"
+          logo: Logo
+          logo_size: "300 x 300 pixeliä"
+        inventory_settings:
+          legend: "Varaston asetukset"
+          text1: Voit halutessasi hallita varastotasoja ja hintoja käyttäen
+          inventory: varasto
+          text2: >
+              Jos käytät inventaariotyökalua, voit valita, pitääkö toimittajien lisäämät
+              uudet tuotteet lisätä varastoosi ennen kuin ne voidaan varastoida. Jos
+              et käytä varastoasi tuotteiden hallintaan, valitse "suositeltu" vaihtoehto
+              alta:
+          preferred_product_selection_from_inventory_only_yes: Uusia tuotteita voidaan lisätä myymälääni (suositus)
+          preferred_product_selection_from_inventory_only_no: Uusia tuotteita on lisättävä varastoon ennen kuin ne voidaan laittaa myymälään
+        payment_methods:
+          legend: "Maksutavat"
+          name: Nimi
+          applies: Pätee?
+          manage: Hallitse maksutapoja
+          no_method_yet: Sinulla ei ole vielä maksutapoja.
+          create_button: Luo uusi maksutapa
+          create_one_button: Luo uusi nyt
+        primary_details:
+          legend: "Ensisijaiset tiedot"
+          name: Nimi
+          name_placeholder: esim. Professori Luumun tryffelit
+          groups: Ryhmät
+          groups_tip: Valitse ryhmät tai alueet, joiden jäsen olet. Tämä auttaa asiakkaita löytämään yrityksesi.
+          groups_placeholder: Aloita kirjoittaminen etsiäksesi käytettävissä olevia ryhmiä...
+          primary_producer: Ensijainen tuottaja?
+          primary_producer_tip: Valitse "Tuottaja", jos olet elintarvikkeiden päätuottaja.
+          producer: Tuottaja
+          any: Mikä tahansa
+          none: Ei yhtään
+          own: Omistaa
+          sells: Myydä
+          sells_tip: "Ei mitään - yritys ei myy suoraan asiakkaille.<br />Oma - Yritys myy omia tuotteita asiakkaille.<br />Mikä tahansa - Yritys voi myydä omia tai muiden yritysten tuotteita.<br />"
+          external_billing_id: Ulkoinen laskutustunnus
+          external_billing_id_placeholder: esim. INV-2024-123456
+          external_billing_id_tip: "Tämä on tunnus, jota ulkoinen laskutusjärjestelmä käyttää yrityksen tunnistamiseen."
+          visible_in_search: Näkyy haussa?
+          visible_in_search_tip: "Kaupat voivat olla <br />1. julkisesti näkyvissä, näkyä OFN-kartalla ja -listauksissa. <br />2. Piilotettu kartoille ja listauksille, mutta muut kaupat viittaavat niihin ja linkitetty heidän profiilissaan. <br />3. Täysin piilotettu."
+          visible: Julkinen
+          not_visible: Piilotettu
+          hidden: Piilota kaikki viittaukset
+          admin_only_legend: Vain ylläpito
+        properties:
+          legend: "Ominaisuudet"
+        permalink:
+          permalink: Pysyvä linkki (ilman välilyöntejä)
+          permalink_tip: "Tätä pysyvää linkkiä käytetään myymäläsi URL-osoitteen luomiseen: %{link}kauppasi-nimi/kauppa"
+          link_to_front: Linkki kaupan etusivulle
+          link_to_front_tip: Suora linkki myymälään Open Food Networkissa.
+          ofn_uid: OFN UID
+          ofn_uid_tip: Yksilöllinen tunnus, jota käytetään yrityksen tunnistamiseen Open Food Networkissa.
+        shipping_methods:
+          legend: "Toimitustavat"
+          name: "Nimi"
+          applies: "Aktiivinen?"
+          manage: "Hallitse toimitustapoja"
+          create_button: "Luo uusi toimitustapa"
+          create_one_button: "Luo uusi nyt"
+          no_method_yet: "Sinulla ei ole vielä toimitustapoja."
+        shop_preferences:
+          legend: "Kaupan asetukset"
+          shopfront_requires_login: "Julkisesti näkyvä myymälä?"
+          shopfront_requires_login_tip: "Valitse, onko asiakkaiden kirjauduttava sisään nähdäkseen myymälän vai näkyykö se kaikille."
+          shopfront_requires_login_false: "Julkinen"
+          shopfront_requires_login_true: "Näkyy vain rekisteröityneille asiakkaille"
+          recommend_require_login: "Suosittelemme vaatimaan käyttäjiä kirjautumaan sisään, jotta tilauksia voidaan muuttaa."
+          allow_guest_orders: "Vierastilaukset"
+          allow_guest_orders_tip: "Salli tilaaminen vieraana tai vaadi rekisteröitynyt käyttäjä."
+          allow_guest_orders_false: "Tilaaminen edellyttää kirjautumista"
+          allow_guest_orders_true: "Salli vieraiden tilata"
+          allow_order_changes: "Muuta tilauksia"
+          allow_order_changes_tip: "Salli asiakkaiden muuttaa tilauksiaan niin kauan kuin tilausjakso on auki."
+          allow_order_changes_false: "Tehtyjä tilauksia ei voi muuttaa/peruuttaa"
+          allow_order_changes_true: "Asiakkaat voivat muuttaa / peruuttaa tilauksia tilausjakson ollessa auki"
+          enable_subscriptions: "Tilaukset"
+          enable_subscriptions_tip: "Otetaanko tilaustoiminto käyttöön?"
+          enable_subscriptions_false: "Pois käytöstä"
+          enable_subscriptions_true: "Käytössä"
+          customer_names_in_reports: "Asiakkaiden nimet raporteissa"
+          customer_names_tip: "Salli toimittajasi nähdä asiakkaidesi nimet raporteissa"
+          producers_to_edit_orders: "Tuottajien mahdollisuus muokata tilauksia"
+          producers_to_edit_orders_tip: "Salli toimittajasi nähdä heidän tuotteitaan sisältävät tilaukset ja muokata vain omien tuotteidensa määrää ja painoa."
+          customer_names_false: "Pois käytöstä"
+          customer_names_true: "Käytössä"
+          customer_contacts_in_reports: "Asiakkaiden yhteystiedot raporteissa"
+          customer_contacts_tip: "Salli toimittajiesi nähdä asiakkaiden sähköpostiosoitteet ja puhelinnumerot raporteissa"
+          customer_contacts_false: "Pois käytöstä"
+          customer_contacts_true: "Käytössä"
+          producers_edit_orders_false: "Pois käytöstä"
+          producers_edit_orders_true: "Käytössä"
+          shopfront_message: "Myymälän viesti"
+          shopfront_message_placeholder: >
+              Valinnainen viesti toivottaa asiakkaat tervetulleiksi ja selittää, kuinka
+              tehdä ostoksia kanssasi. Jos tekstiä kirjoitetaan tähän, se näytetään
+              etusivulla, kun asiakkaat saapuvat ensimmäistä kertaa myymälään.
+          shopfront_closed_message: "Viesti kun myymälä on suljettuna"
+          shopfront_closed_message_placeholder: >
+              Viesti, jossa kerrotaan tarkemmin, miksi myymäläsi on suljettu ja/tai
+              milloin asiakkaat voivat odottaa sen avautuvan uudelleen. Tämä näkyy
+              kaupassasi vain, kun sinulla ei ole aktiivisia tilausjaksoja (eli kauppa
+              on suljettu).
+          shopfront_category_ordering: "Myymälän kategoria tilaaminen"
+          shopfront_category_ordering_note: "(ylhäältä alas)"
+          open_date: "Avauspäivä"
+          close_date: "Sulkemispäivä"
+          display_ordering_in_shopfront: "Näytä tilaaminen myymälässä:"
+          shopfront_sort_by_product: "Tuotteen mukaan"
+          shopfront_sort_by_category: "Luokan mukaan"
+          shopfront_sort_by_producer: "Tuottajan mukaan"
+          shopfront_sort_by_category_placeholder: "Luokka"
+          shopfront_sort_by_producer_placeholder: "Tuottaja"
+          display_remaining_stock: "Näytä jäljellä olevat varastot liikkeessä, jos niitä on vähän"
+          display_remaining_stock_tip: "Kerro ostajille, kun tuotteita on jäljellä vain 3 tai vähemmän."
+          enabled: "Käytössä"
+          disabled: "Pois käytöstä"
+        social:
+          legend: "Sosiaalinen"
+          twitter_placeholder: "esim. @the_prof"
+          instagram_placeholder: "esim. the_prof"
+          facebook_placeholder: "esim. www.facebook.com/PageNameHere"
+          linkedin_placeholder: "esim. www.linkedin.com/in/YourNameHere"
+        stripe_connect:
+          connect_with_stripe: "Yhdistä Stripen kanssa"
+          stripe_connect_intro: "Jotta voit hyväksyä maksuja luottokortilla, sinun on yhdistettävä stripe-tilisi Open Food Networkiin. Käytä oikealla olevaa painiketta aloittaaksesi."
+          stripe_account_connected: "Stripe-tili yhdistetty."
+          disconnect: "Katkaise tiliyhteys"
+          confirm_modal:
+            title: Yhdistä Stripen kanssa
+            part1: Stripe on maksujenkäsittelypalvelu, jonka avulla OFN:n kaupat voivat ottaa vastaan ​​asiakkaiden luottokorttimaksuja.
+            part2: Jotta voit käyttää tätä ominaisuutta, sinun on yhdistettävä Stripe-tilisi OFN:ään. Napsauttamalla alla olevaa Hyväksyn-painiketta ohjaat sinut Stripe-verkkosivustolle, jossa voit yhdistää olemassa olevan Stripe-tilin tai luoda uuden, jos sinulla ei vielä ole sellaista.
+            part3: Näin Open Food Network voi hyväksyä luottokorttimaksuja asiakkailta puolestasi. Huomaa, että sinun on ylläpidettävä omaa Stripe-tiliäsi, maksettava Stripen veloittamat maksut ja hoidettava mahdolliset takaisinveloitukset ja asiakaspalvelu itse.
+            i_agree: Suostun
+            cancel: Peruuta
+        tag_rules:
+          legend: "Tägisäännöt"
+          default_rules:
+            by_default: Oletuksena
+            no_rules_yet: Mitään oletussääntöjä ei vielä sovelleta
+            add_new_button: '+ Lisää uusi oletussääntö'
+          no_tags_yet: Tähän yritykseen ei vielä liity tägejä
+          no_rules_yet: Tähän tägiin ei vielä sovelleta sääntöjä
+          for_customers_tagged: 'Asiakkaille, jotka on tägätty:'
+          add_new_rule: '+ Lisää uusi sääntö'
+          add_new_tag: '+ Lisää uusi tägi'
+        users:
+          legend: "Käyttäjät"
+          email_confirmation_notice_html: "Sähköpostivahvistus odottaa. Olemme lähettäneet vahvistussähköpostin osoitteeseen %{email}."
+          resend: Lähete uudelleen
+          owner: 'Omistaja'
+          contact: "Yhteystieto"
+          contact_tip: "Ylläpitäjä, joka vastaanottaa yrityssähköpostiviestejä tilauksista ja ilmoituksista. Täytyy olla vahvistettu sähköpostiosoite."
+          owner_tip: Ensisijainen käyttäjä, joka on vastuussa tästä yrityksestä.
+          notifications: Ilmoitukset
+          notifications_tip: Ilmoitukset tilauksista lähetetään tähän sähköpostiosoitteeseen.
+          notifications_placeholder: esim. gustav@truffles.com
+          notifications_note: 'Huomautus: Uusi sähköpostiosoite on ehkä vahvistettava ennen käyttöä'
+          managers: 'Ylläpitäjät '
+          managers_tip: Muut käyttäjät, joilla on lupa hallita tätä yritystä.
+          invite_manager: "Kutsu ylläpitäjä"
+          invite_manager_tip: "Kutsu rekisteröimätön käyttäjä rekisteröitymään ja ryhtymään tämän yrityksen ylläpitäjäksi."
+          add_unregistered_user: "Lisää rekisteröitymätön käyttäjä"
+          email_confirmed: "Sähköposti vahvistettu"
+          email_not_confirmed: "Sähköpostia ei vahvistettu"
+        vouchers:
+          legend: Kupongit
+          voucher_code: Kuponkikoodi
+          rate: Määrä
+          label: etiketti
+          purpose: Tarkoitus
+          expiry: Vanheneminen
+          use_limit: Käyttö/rajoitus
+          customers: Asiakas
+          net_value: Nettoarvo
+          active: Aktiivinen?
+          add_new: Lisää uusi
+          no_voucher_yet: Ei vielä kuponkeja
+        white_label:
+          legend: "White Label"
+          hide_ofn_navigation: "Piilota OFN navigointi"
+          white_label_logo_link_label: "Linkki myymälässä käytettävään logoon"
+          hide_groups_tab: "Piilota ryhmät-välilehti myymälässä"
+          create_custom_tab: "Luo mukautettu välilehti myymälässä"
+          custom_tab_title: "Mukautetun välilehden otsikko"
+          custom_tab_content: "Mukautetun välilehden sisältö"
+        connected_apps:
+          legend: "Yhdistetyt sovellukset"
+          affiliate_sales_data:
+            title: "INRAE / UFC QUE CHOISIR Research"
+            tagline: "Anna tälle tutkimusprojektille pääsy tilaustietoihisi nimettömästi."
+            enable: "Salli tietojen jakaminen"
+            disable: "Lopeta jakaminen"
+            loading: "Ladataan"
+            need_to_be_manager: "Vain ylläpitäjät voivat yhdistää sovelluksia."
+            description: "INRAE ​​ja UFC QUE CHOISIR tekevät yhteistyötä tutkiakseen elintarvikkeiden hintoja lyhyissä ruokajärjestelmissä ja vertaillakseen niitä tietyn tuotesarjan hintoihin supermarketissa. INRAE:n käyttämät tiedot sekoitetaan muiden Ranskan lyhyen elintarvikeketjun alustojen tietojen kanssa. Yksittäisten tuotteiden hintoja ei julkisteta tämän projektin aikana."
+            link_label_html: "Lue lisää tästä tutkimusprojektista <i class=\"icon-external-link\"></i>"
+            link_url: "https://apropos.coopcircuits.fr/"
+          discover_regen:
+            title: "Discover Regenerative"
+            tagline: "Anna Discover Regenerativen julkaista yrityksesi tiedot."
+            enable: "Salli tietojen jakaminen"
+            disable: "Lopeta jakaminen"
+            loading: "Ladataan"
+            need_to_be_manager: "Vain ylläpitäjät voivat yhdistää sovelluksia."
+            note: |
+                Open Food Network -tilisi on yhdistetty Discover Regenerativeen.
+                Lisää tai päivitä Discover Regenerative -tietosi täällä.
+            link_label: "Hallinnoi listausta"
+            description: "Kelvolliset tuottajat voivat esitellä uusiutuvia valtuuksiaan, viljelykäytäntöjään ja paljon muuta profiililuettelon kautta. Yksinkertaistaa, kuinka ostajat voivat löytää uusiutuvia tuotteita ja ottaa yhteyttä kiinnostaviin tuottajiin."
+            link_label_html: "Lue lisää Discover Regenerative <i class=\"icon-external-link\"></i>"
+            link_url: "https://about.openfoodnetwork.org.au/regen-produce-portal/"
+          vine:
+            title: "Voucher Integration Engine (VINE)"
+            tagline: "Salli VINE-kuponkien lunastaminen myymälässäsi."
+            enable: "Yhdistä"
+            disable: "Katkaise yhteys"
+            need_to_be_manager: "Vain ylläpitäjät voivat yhdistää sovelluksia."
+            vine_api_key: "VINE API avain"
+            vine_secret: "VINE salaisuus"
+            description: "Ota VINE käyttöön yrityksellesi kirjoittamalla API-avain ja salaisuus."
+            link_label_html: "VINE <i class=\"icon-external-link\"></i>"
+            link_url: "https://vine.openfoodnetwork.org.au"
+            api_parameters_empty: "Anna API-avain ja salaisuus"
+            api_parameters_error: "Tarkista, että annoit API-avaimen ja salaisuuden oikein. Ota yhteyttä palvelimen ylläpitäjään, jos virhe jatkuu"
+            connection_error: "API-yhteysvirhe, yritä uudelleen"
+            setup_error: "VINE API:ta ei ole määritetty, ota yhteyttä palvleimen ylläpitäjään"
+      actions:
+        edit_profile: Asetukset
+        properties: Ominaisuudet
+        payment_methods: Maksutavat
+        payment_methods_tip: Tällä yrityksellä ei ole maksutapoja
+        shipping_methods: Toimitustavat
+        shipping_methods_tip: Tällä yrityksellä on toimitustapoja
+        enterprise_fees: Yritysmaksut
+        enterprise_fees_tip: Tällä yrityksellä ei ole maksuja
+      admin_index:
+        name: Nimi
+        role: Rooli
+        sells: Myy
+        visible: Näkyvissä?
+        owner: Omistaja
+        producer: Tuottaja
+      change_type_form:
+        producer_profile: Tuottajan profiili
+        connect_ofn: Yhdistä OFN:n kautta
+        always_free: AINA ILMAISEKSI
+        producer_description_text: Lisää tuotteesi Open Food Networkiin, jolloin hubit voivat varastoida tuotteitasi myymälöihinsä.
+        producer_shop: Tuottajan kauppa
+        sell_your_produce: Myy omia tuotteitasi
+        producer_shop_description_text: Myy tuotteitasi suoraan asiakkaille oman Open Food Network -myymäläsi kautta.
+        producer_shop_description_text2: Tuottajamyymälä on tarkoitettu vain tuotteillesi. Jos haluat myydä ulkomailla kasvatettua/tuotettua tuotetta, valitse Tuottajakeskus.
+        producer_hub: Tuottajakeskus
+        producer_hub_text: Myy tuotteita itseltäsi ja muilta
+        producer_hub_description_text: Yrityksesi on paikallisen ruokajärjestelmäsi selkäranka. Avoin ruokaverkostossa voit myydä omia tuotteitasi sekä muiden yritysten koottuja tuotteita myymäläsi kautta.
+        profile: Vain profiili
+        get_listing: Hanki listaus
+        profile_description_text: Ihmiset voivat löytää sinut ja ottaa sinuun yhteyttä Open Food Networkissa. Yrityksesi näkyy kartalla, ja se on haettavissa listauksista.
+        hub_shop: Keskuskauppa
+        hub_shop_text: Myy tuotteita muilta
+        hub_shop_description_text: Yrityksesi on paikallisen ruokajärjestelmäsi selkäranka. Kokoat muiden yritysten tuotteita ja voit myydä ne myymäläsi kautta Open Food Networkissa.
+        choose_option: Valitse jokin yllä olevista vaihtoehdoista.
+        change_now: Vaihda nyt
+      enterprise_user_index:
+        loading_enterprises: LADATAAN YRITYKSIÄ
+        no_enterprises_found: Yrityksiä ei löytynyt.
+        search_placeholder: Hae nimellä
+        manage: Hallinnoi
+        manage_link: Asetukset
+        producer?: "Tuottaja?"
+        package: "Paketti"
+        status: "Tila"
+      new_form:
+        owner: Omistaja
+        owner_tip: Ensisijainen käyttäjä, joka on vastuussa tästä yrityksestä.
+        i_am_producer: Olen tuottaja
+        contact_name: Yhteystiedon nimi
+      edit:
+        editing: 'Asetukset:'
+        back_link: Takaisin yritysluetteloon
+      new:
+        title: Uusi yritys
+        back_link: Takaisin yritysluetteloon
+      welcome:
+        welcome_title: Tervetuloa Open Food Networkiin!
+        welcome_text: 'Olet onnistuneesti luonut '
+        next_step: Seuraava askel
+        choose_starting_point: 'Valitse pakettisi:'
+        profile: 'Profiili'
+        producer_profile: 'tuottaja -profiili'
+      invite_manager:
+        user_already_exists: "Käyttäjä on jo olemassa"
+        error: "Jotain meni pieleen"
+    order_cycles:
+      loading_flash:
+        loading_order_cycles: LADATAAN TILAUSJAKSOJA
+        loading: LADATAAN...
+      new:
+        create: "Luoda"
+        cancel: "Peruuttaa"
+        back_to_list: "Takaisin listaan"
+      create:
+        success: 'Tilausjaksosi on luotu.'
+      update:
+        success: 'tilausjakso on päivitetty.'
+      clone:
+        success: "Tilausjaksosi %{name} on kloonattu."
+      notify_producers:
+        success: 'Tuottajille lähetettävät sähköpostit on asetettu lähetysjonoon.'
+      edit:
+        save: "tallenna"
+        save_and_next: "tallenna ja Next"
+        next: "Seuraava"
+        cancel: "Peruuttaa"
+        back_to_list: "Takaisin listaan"
+        save_and_back_to_list: "tallenna ja Takaisin listaan"
+        choose_products_from: "Valitse tuotteita joukosta:"
+        re_notify_producers: Ilmoita tuottajille uudelleen
+        notify_producers_tip: Tämä lähettää sähköpostin jokaiselle tuottajalle, jossa on luettelo heidän tilauksistaan.
+      date_time_warning_modal_content:
+        title: 'Tilaukset on linkitetty tähän tilausjaksoon.'
+        content: 'Jos haluat luoda uuden tilausjakson, on suositeltavaa kopioida tilausjakso ensin ja muuttaa päivämäärät sitten.'
+        proceed: 'Jatka silti'
+        cancel: 'Peruuta'
+      incoming:
+        incoming: "Saapuvat"
+        supplier: "toimittaja"
+        products: "Tuotteet"
+        receival_details: "Vastaanoton tiedot"
+        fees: "Maksut"
+        save: "tallenna"
+        save_and_next: "tallenna ja Next"
+        next: "Seuraava"
+        cancel: "Peruuttaa"
+        back_to_list: "Takaisin listaan"
+      outgoing:
+        outgoing: "Lähtevä"
+        distributor: "Jakelija"
+        products: "Tuotteet"
+        tags: "Tägit"
+        delivery_details: "Toimitustiedot"
+        fees: "Maksut"
+        next: "Seuraava"
+        previous: "Edellinen"
+        save: "tallenna"
+        save_and_next: "tallenna ja Next"
+        cancel: "Peruuttaa"
+        back_to_list: "Takaisin listaan"
+      checkout_options:
+        back_end: "Vain taustatoimisto"
+        cancel: "Peruuttaa"
+        checkout_options: "Kassavaihtoehdot"
+        distributor: "Jakelija"
+        no_payment_methods: Jokainen tällä tilausjaksolla oleva jakelija vaatii vähintään yhden maksutavan.
+        no_shipping_methods: Jokainen tällä tilausjaksolla oleva jakelija vaatii vähintään yhden toimitustavan.
+        payment_methods: "maksu -menetelmät"
+        save: "tallenna"
+        save_and_back_to_list: "tallenna ja Takaisin listaan"
+        select_all: "Valitse kaikki"
+        shipping_methods: "Toimitustavat"
+      wizard_progress:
+        edit: "1. Yleiset asetukset"
+        incoming: "2. Saapuvat tuotteet"
+        outgoing: "3. Lähtevät tuotteet"
+        checkout_options: "4. Kassavaihtoehdot"
+      exchange_form:
+        pickup_time_tip: Milloin tämän OC:n tilaukset ovat valmiita asiakkaalle
+        pickup_instructions_placeholder: "Nouto-ohjeet"
+        pickup_instructions_tip: Nämä ohjeet näytetään asiakkaille tilauksen tekemisen jälkeen
+        pickup_time_placeholder: "Valmiina (päivämäärä / aika)"
+        receival_instructions_placeholder: "Vastaanotto-ohjeet"
+        add_fee: 'Lisää maksu'
+        remove: 'Poistaa'
+        selected: 'valittu'
+      add_exchange_form:
+        add_supplier: 'Lisää toimittaja'
+        add_distributor: 'Lisää jakelija'
+      advanced_settings:
+        automatic_notifications: Automaattiset ilmoitukset
+        automatic_notifications_tip: Ilmoita tuottajille automaattisesti heidän tilauksistaan ​​sähköpostitse, kun tilausjaksot sulkeutuvat
+        title: kehittynyt Asetukset
+        choose_product_tip: Voit rajoittaa tuotteiden saapumisen ja lähtemisen vain %{inventory}varastoon.
+        preferred_product_selection_from_coordinator_inventory_only_here: Vain koordinaattorin inventaario
+        preferred_product_selection_from_coordinator_inventory_only_all: Kaikki saatavilla olevat tuotteet
+        save_reload: Tallenna ja lataa sivu uudelleen
+      order_cycle_top_buttons:
+        advanced_settings: "Advanced Settings"
+      coordinator_fees:
+        add: Lisää koordinaattorin maksu
+      filters:
+        search_by_order_cycle_name: "Hae tilausjakson nimellä..."
+        involving: "Mukana"
+        any_enterprise: "Mikä tahansa yritys"
+        any_schedule: "Mikä tahansa aikataulu"
+      form:
+        general_settings: "Yleiset asetukset"
+        incoming: Saapuvat
+        supplier: toimittaja
+        products: Tuotteet
+        receival_details: Vastaanoton tiedot
+        fees: Maksut
+        outgoing: Lähtevä
+        distributor: Jakelija
+        tags: Tägit
+        add_a_tag: Lisää tägi
+        delivery_details: Nouto-/toimitustiedot
+      index:
+        schedule: Aikataulu
+        schedules: Aikataulut
+        new_schedule: Uusi aikataulu
+        new_schedule_tooltip: Toistuvuus jolloin tilaus on tehty
+      name_and_timing_form:
+        name: nimi
+        orders_open: Tilaukset avataan klo
+        coordinator: koordinaattori
+        orders_close: Tilaukset sulkeutuvat
+      row:
+        suppliers: toimittajat
+        distributors: jakelijat
+        variants: variantit
+      simple_form:
+        ready_for: Valmis
+        ready_for_placeholder: Päivämäärä / aika
+        customer_instructions: asiakas -ohjeet
+        customer_instructions_placeholder: Nouto- tai toimitustiedot
+        products: Tuotteet
+        fees: Maksut
+        tags: Tägit
+      destroy_errors:
+        orders_present: Asiakas on valinnut kyseisen tilausjakson, eikä sitä voida poistaa. Jos haluat estää asiakkaita käyttämästä sitä, sulje se sen sijaan.
+        schedule_present: Tuo tilausjakso on linkitetty aikatauluun, eikä sitä voida poistaa. Irrota linkitys tai poista aikataulu ensin.
+      bulk_update:
+        no_data: Hmm, jokin meni pieleen. Tilaussyklitietoja ei löytynyt.
+      date_warning:
+        msg: Tämä tilausjakso on linkitetty %{n} avoimeen tilaukseen. Päivämäärän muuttaminen nyt ei vaikuta jo tehtyihin tilauksiin, mutta sitä tulisi välttää mahdollisuuksien mukaan. Oletko varma, että haluat jatkaa?
+        cancel: Peruuttaa
+        proceed: Jatka
+      status:
+        undated: päiväämätön
+        upcoming: tuleva
+        open: avoinna
+        closed: suljettu
+    producer_properties:
+      index:
+        title: Tuottajan ominaisuudet
+    proxy_orders:
+      cancel:
+        could_not_cancel_the_order: Tilausta ei voitu peruuttaa
+      resume:
+        could_not_resume_the_order: Tilausta ei voitu jatkaa
+    select2:
+      minimal_search_length: Syötä %{count} tai enemmän merkkiä
+      searching: Haetaan...
+      no_matches: Ei osumia
+    shared:
+      attachment_field:
+        logo_label: "Logo"
+        logo_hint: 300 x 300 pixeliä
+        logo_remove: "Poista kuva"
+        logo_remove_confirm: "Logo poistetaan heti vahvistuksen jälkeen."
+        promo_image_label: "Mainoskuva"
+        promo_image_note1: 'HUOMAA:'
+        promo_image_note2: Kaikki tänne ladatut mainoskuvat rajataan kokoon 1200 x 260.
+        promo_image_note3: Mainoskuva näkyy yrityksen profiilisivun yläosassa ja ponnahdusikkunoissa.
+        promo_image_placeholder: 'Tämä kuva näkyy kohdassa "Tietoja meistä"'
+        promo_image_remove: "Poista kuva"
+        promo_image_remove_confirm: "Mainoskuva poistetaan heti vahvistuksen jälkeen."
+        white_label_logo_label: "Myymälän julkisivussa käytetty logo"
+        white_label_logo_hint: 217 x 44 pikseliä
+        white_label_logo_remove: "Poista kuva"
+        white_label_logo_remove_confirm: "Haluatko varmasti poistaa tämän logon?"
+      user_guide_link:
+        user_guide: Käyttöopas
+      enterprises_hubs_tabs:
+        has_no_payment_methods: "%{enterprise} ei ole maksutapoja"
+        has_no_shipping_methods: "%{enterprise} ei ole toimitustapoja"
+        has_no_enterprise_fees: "%{enterprise} ei ole yritysmaksuja"
+      flashes:
+        dismiss: Poistu
+      side_menu:
+        enterprise:
+          primary_details: "Ensisijaiset tiedot"
+          address: "Osoite"
+          contact: "Yhteystiedot"
+          social: "Sosiaalinen"
+          about: "about"
+          business_details: "Yrityksen tiedot"
+          images: "Kuvat"
+          properties: "Ominaisuudet"
+          shipping_methods: "Toimitustavat"
+          payment_methods: "maksu -menetelmät"
+          enterprise_fees: "yritys Maksut"
+          enterprise_permissions: "yritys -käyttöoikeudet"
+          inventory_settings: "varasto asetukset"
+          tag_rules: "Tägisäännöt"
+          shop_preferences: "kauppa -asetukset"
+          users: "Käyttäjät"
+          vouchers: Kuponkeja
+          white_label: "White Label"
+          connected_apps: "Yhdistetyt sovellukset"
+        enterprise_group:
+          primary_details: "Ensisijaiset tiedot"
+          users: "Käyttäjät"
+          about: "about"
+          images: "Kuvat"
+          contact: "Yhteystiedot"
+          web: "Resurssit"
+    enterprise_issues:
+      create_new: Luo uusi
+      resend_email: Lähetä sähköposti uudelleen
+      has_no_payment_methods: "%{enterprise} ei tällä hetkellä ole maksutapoja"
+      has_no_shipping_methods: "%{enterprise} ei tällä hetkellä tarjoa toimitustapoja"
+      email_confirmation: "Sähköpostivahvistus odottaa. Olemme lähettäneet vahvistussähköpostin osoitteeseen %{email} ."
+      not_visible: "%{enterprise} ei ole näkyvissä, joten sitä ei löydy kartalta tai hauista"
+    reports:
+      none: ei yhtään
+      deprecated: "Tämä raportti on vanhentunut ja se poistetaan tulevasta julkaisusta."
+      hidden_field: "< Piilotettu >"
+      unitsize: YKSIKKÖKOKO
+      total: yhteensä
+      total_items: YHTEENSÄ TUOTTEET
+      total_by_customer: Yhteensä asiakkaalta
+      total_by_supplier: Yhteensä toimittajan mukaan
+      supplier_totals: Tilausjakson toimittajan kokonaissummat
+      percentage: "%{value} %"
+      supplier_totals_by_distributor: Tilausjakson toimittajan kokonaissummat jakelijan mukaan
+      totals_by_supplier: Tilausjakson jakelijan kokonaissummat toimittajan mukaan
+      customer_totals: Tilausjakson asiakassummat
+      all_products: Kaikki tuotteet
+      inventory: Varasto (saatavilla)
+      lettuce_share: LettuceShare
+      payment_methods: Maksutaparaportti
+      delivery: Toimitusraportti
+      sales_tax_totals_by_producer: Myyntiverojen kokonaismäärät tuottajan mukaan
+      sales_tax_totals_by_order: Myyntiverojen kokonaissummat tilauksen mukaan
+      tax_types: Verotyypit
+      tax_rates: Verokannat
+      pack_by_customer: Pakkaus asiakkaan toimesta
+      pack_by_supplier: Pakkaus toimittajan toimesta
+      pack_by_product: Pakkaus tuotteen mukaan
+      pay_your_suppliers: Maksa toimittajillesi
+      display:
+        report_is_big: "Tämä raportti on laaja ja saattaa hidastaa laitettasi."
+        display_anyway: "Näytä joka tapauksessa"
+      download:
+        button: "Lataa raportti"
+      show:
+        report_taking_longer: >
+            Valitettavasti tämän raportin käsittely kesti liian kauan. Se saattaa
+            sisältää paljon tietoa tai olemme kiireisiä muiden raporttien kanssa.
+            Voit yrittää myöhemmin uudelleen.
+        report_taking_longer_html: >
+            Tämän raportin käsittely kestää kauemmin. Se saattaa sisältää paljon tietoa
+            tai olemme kiireisiä muiden raporttien kanssa. Ilmoitamme sinulle sähköpostitse,
+            kun se on valmis.
+        report_link_label: Lataa raportti (kun saatavilla)
+      revenues_by_hub:
+        name: Tulot Hub-kohtaisesti
+        description: Tulot keskuksittain
+      orders_and_distributors:
+        name: Tilaukset ja jakelijat
+        description: Tilaukset jakelijan tiedoilla
+      bulk_coop:
+        name: Bulk Co-Op
+        description: Raportit Co-op-massatilauksista
+      payments:
+        name: Maksuraportit
+        description: Maksuraportit
+      orders_and_fulfillment:
+        name: Tilaukset ja toimitusraportit
+      customers:
+        name: Asiakkaat
+      products_and_inventory:
+        name: Tuotteet ja varasto
+      users_and_enterprises:
+        name: Käyttäjät ja yritykset
+        description: Yrityksen omistajuus ja asema
+      order_cycle_management:
+        name: Tilausjakson hallinta
+      sales_tax:
+        name: Myyntivero
+      xero_invoices:
+        name: Xero-laskut
+        description: Xeroon tuotavat laskut
+      enterprise_fee_summary:
+        name: "Yritysmaksuyhteenveto"
+        description: "Yhteenveto kerätyistä yritysmaksuista"
+      suppliers:
+        name: Toimittajat
+      enterprise_fees_with_tax_report_by_order: "Yritysmaksut veroilmoituksen kera tilauksen mukaan"
+      enterprise_fees_with_tax_report_by_producer: "Yritysmaksut veroilmoituksella tuottajan mukaan"
+      errors:
+        no_report_type: "Määritä raportin tyyppi"
+        report_not_found: "Raporttia ei löytynyt"
+        missing_ransack_params: "Anna pyynnössä Ransack-hakuparametrit."
+      summary_row:
+        total: "yhteensä"
+      table:
+        select_and_search: "Valitse suodattimet ja napsauta %{option} nähdäksesi tietosi."
+        headings:
+          hub: "keskus"
+          customer_code: "Koodi"
+          first_name: "Ensimmäinen nimi"
+          last_name: "Viimeinen nimi"
+          supplier: "toimittaja"
+          product: "tuote"
+          variant: "Variantti"
+          quantity: "Määrä"
+          is_temperature_controlled: "Lämpötilaohjattu?"
+          temp_controlled: "Lämpötilaohjattu?"
+          price: "Hinta"
+      rendering_options:
+        generate_report: "Luo raportti"
+        on_screen: "Näytöllä"
+        spreadsheet: "Taulukkolaskentaohjelma (Excel, OpenOffice..)"
+        display: Näyttö
+        summary_row: Yhteenvetorivi
+        header_row: Otsikkorivi
+        raw_data: Raakadata
+        formatted_data: Muotoiltu data
+      packing:
+        name: "Pakkausraportit"
+    oidc_settings:
+      index:
+        title: "OIDC-asetukset"
+        connect: "Yhdistä tilisi"
+        disconnect: "Katkaise yhteys"
+        connected: "Tili on yhdistetty %{uid}."
+        les_communs_link: "Les Communs Avaa tunniste palvelin"
+        link_your_account: "Sinun on ensin linkitettävä tilisi DFC:n (Les Communs Open ID Connect) käyttämään valtuutuspalveluntarjoajaan."
+        link_account_button: "Linkitä Les Communs OIDC -tilisi"
+        note_expiry: |
+            Yhdistettyjen sovellusten käyttöoikeudet ovat vanhentuneet. Päivitä
+            tilisi yhteys, jotta kaikki integraatiot toimivat.
+        refresh: "Päivitä valtuutus"
+        view_account: "Voit tarkastella tiliäsi seuraavasti:"
+    subscriptions:
+      index:
+        title: "Tilaukset"
+        new: "Uusi tilaus"
+      issue: "Asia"
+      new:
+        title: "Uusi tilaus"
+      edit:
+        title: "muokata tilaus"
+      table:
+        edit_subscription: muokata tilaus
+        pause_subscription: Keskeytä tilaus
+        unpause_subscription: Poista tilauksen keskeytys
+        cancel_subscription: Peruuta tilaus
+      filters:
+        query_placeholder: "Hae sähköpostitse..."
+      setup_explanation:
+        title: "Tilaukset"
+        just_a_few_more_steps: 'Vain muutama vaihe ennen kuin voit aloittaa:'
+        enable_subscriptions: "Ota tilaukset käyttöön ainakin yhdessä kaupassasi"
+        enable_subscriptions_step_1_html: 1. Siirry %{enterprises_link}-sivulle, etsi kauppasi ja napsauta "Hallinnoi"
+        enable_subscriptions_step_2: 2. Ota Tilaukset-vaihtoehto käyttöön kohdassa "Kaupan asetukset"
+        set_up_shipping_and_payment_methods_html: Määritä %{shipping_link}- ja %{payment_link}menetelmät
+        set_up_shipping_and_payment_methods_note_html: Huomaa, että tilausten kanssa voi <br />maksaa vain Cash- ja Stripe-maksutavoilla.
+        ensure_at_least_one_customer_html: Varmista, että vähintään yksi %{customer_link} on olemassa
+        create_at_least_one_schedule: Luo vähintään yksi aikataulu
+        create_at_least_one_schedule_step_1_html: 1. Siirry %{order_cycles_link}-sivulle
+        create_at_least_one_schedule_step_2: 2. Luo tilausjakso, jos et ole jo tehnyt niin
+        create_at_least_one_schedule_step_3: 3. Napsauta '+ Uusi aikataulu' ja täytä lomake
+        once_you_are_done_you_can_html: Kun olet valmis, voit %{reload_this_page_link}
+        reload_this_page: lataa tämä sivu uudelleen
+      form:
+        create: "Luo tilaus"
+      steps:
+        details: 1. Perustiedot
+        address: 2. Osoite
+        products: 3. Lisää tuotteita
+        review: 4. Tarkista ja tallenna
+      subscription_line_items:
+        this_is_an_estimate: |
+            Näytetyt hinnat ovat vain arvioita ja lasketaan tilauksen muutoshetkellä.
+            Jos muutat hintoja tai maksuja, tilaukset päivittyvät, mutta tilauksessa näkyvät edelleen vanhat arvot.
+        not_in_open_and_upcoming_order_cycles_warning: "Tälle tuotteelle ei ole avoimia tai tulevia tilausjaksoja."
+      autocomplete:
+        name_or_sku: "nimi TAI SKU"
+        quantity: "Määrä"
+        add: "lisää"
+      details:
+        details: Tiedot
+        invalid_error: Hupsista! Täytä kaikki pakolliset kentät...
+        allowed_payment_method_types_tip: Maksutavat tällä hetkellä ovat vain käteinen ja Stripe.
+        credit_card: Luottokortti
+        charges_not_allowed: Tämä asiakas ei salli veloituksia
+        no_default_card: Asiakkaalla ei ole käytettävissä kortteja veloitusta varten
+        card_ok: Asiakkaalla on kortti käytettävissään veloitusta varten
+        begins_at_placeholder: "Valitse päivämäärä"
+        ends_at_placeholder: "Valinnainen"
+      loading_flash:
+        loading: TILAUKSIEN LATAAMINEN
+      review:
+        details: Tiedot
+        address: Osoite
+        products: Tuotteet
+        no_open_or_upcoming_order_cycle: "Ei tulevaa tilausjaksoa"
+      products_panel:
+        save: "tallenna"
+        saving: "SÄÄSTÖ"
+        saved: "TALLENNETTU"
+      product_already_in_order: Tämä tuote on jo lisätty tilaukseen. Muokkaa määrää suoraan.
+      stock:
+        insufficient_stock: "Riittämätön varastossa oleva määrä"
+        out_of_stock: "Loppu varastosta"
+      orders:
+        number: Määrä
+        confirm_edit: Haluatko varmasti muokata tätä tilausta? Muokkaaminen voi vaikeuttaa muutosten automaattista synkronointia tilaukseen tulevaisuudessa.
+      confirm_cancel_msg: "Haluatko varmasti peruuttaa tämän tilauksen? Tätä toimintoa ei voi perua."
+      cancel_failure_msg: "Peruutus epäonnistui, anteeksi!"
+      confirm_pause_msg: "Haluatko varmasti keskeyttää tämän tilauksen?"
+      pause_failure_msg: "Pahoittelut, tauko epäonnistui!"
+      confirm_unpause_msg: "Jos tämän tilauksen aikataulussa on avoin tilausjakso, tälle asiakkaalle luodaan tilaus. Haluatko varmasti poistaa tämän tilauksen keskeytyksen?"
+      unpause_failure_msg: "Pahoittelut, tauon poistaminen epäonnistui!"
+      confirm_cancel_open_orders_msg: "Jotkin tämän tilauksen tilaukset ovat tällä hetkellä avoinna. Asiakkaalle on jo ilmoitettu tilauksen tekemisestä. Haluatko peruuttaa nämä tilaukset vai pitää ne?"
+      resume_canceled_orders_msg: "Joitakin tämän tilauksen tilauksia voidaan jatkaa juuri nyt. Voit jatkaa niitä tilausten alasvetovalikosta."
+      yes_cancel_them: Peruuta ne
+      no_keep_them: Pidä ne
+      yes_i_am_sure: Kyllä, olen varma
+      number: "Määrä"
+      order_update_issues_msg: Joitakin tilauksia ei voitu päivittää automaattisesti. Tämä johtuu todennäköisesti siitä, että niitä on muokattu manuaalisesti. Tarkista alla luetellut ongelmat ja tee tarvittaessa muutoksia yksittäisiin tilauksiin.
+      no_results:
+        no_subscriptions: Ei vielä tilauksia...
+        why_dont_you_add_one: Mikset lisäisi yhtä? :)
+        no_matching_subscriptions: Ei vastaavia tilauksia
+    schedules:
+      destroy:
+        associated_subscriptions_error: Tätä aikataulua ei voida poistaa, koska siihen liittyy tilauksia.
+    vouchers:
+      new:
+        legend: Uusi kuponki
+        back: Takaisin
+        save: tallenna
+        voucher_code: Kuponkikoodi
+        voucher_amount: Määrä
+        voucher_type: Kupongin tyyppi
+        flat_rate: Kiinteä
+        percentage_rate: Prosenttiosuus (%)
+    controllers:
+      enterprises:
+        stripe_connect_cancelled: "Yhteys Stripe-palveluun on peruutettu"
+        stripe_connect_success: "Stripe-tili yhdistetty onnistuneesti"
+        stripe_connect_fail: Stripe-tilisi yhdistäminen epäonnistui.
+        remove_logo_success: "Logo poistettu onnistuneesti"
+        remove_promo_image_success: "Mainoskuvan poisto onnistui"
+        remove_white_label_logo_success: "Logo poistettu onnistuneesti"
+      stripe_connect_settings:
+        resource: Stripe Connect -määritys
+    resend_confirmation_emails_feedback:
+      one: "Vahvistussähköposti lähetetty yhdelle tilaukselle."
+      other: "Vahvistussähköpostit lähetetty %{count} tilauksille."
+    send_invoice_feedback:
+      one: "Yhden tilauksen laskutussähköposti lähetetty."
+      other: "Laskusähköpostit lähetetty %{count} tilauksille."
+  api:
+    unknown_error: "Jotain meni pieleen. Tiimimme on saanut tiedon."
+    invalid_api_key: "Määritetty API-avain ( %{key} ) on virheellinen."
+    unauthorized: "Sinulla ei ole oikeutta suorittaa kyseistä toimintoa."
+    unpermitted_parameters: "Tässä pyynnössä ei sallita seuraavia parametreja: %{params}"
+    missing_parameter: "Pakollinen parametri puuttuu tai on tyhjä: %{param}"
+    invalid_resource: "Virheellinen resurssi. Korjaa virheet ja yritä uudelleen."
+    resource_not_found: "Etsimääsi resurssia ei löytynyt."
+    enterprise_logo:
+      destroy_attachment_does_not_exist: "Logoa ei ole olemassa"
+    enterprise_promo_image:
+      destroy_attachment_does_not_exist: "Mainoskuvaa ei ole olemassa"
+    enterprise_terms_and_conditions:
+      destroy_attachment_does_not_exist: "Käyttöehtotiedostoa ei ole olemassa"
+    orders:
+      failed_to_update: "Tilauksen päivittäminen epäonnistui"
+    query_param:
+      error:
+        title: Virheellinen kyselyparametri
+        extra_fields: "Ei-tuetut kentät: %{fields}"
+  checkout:
+    failed: "Maksu epäonnistui. Kerro meille, jotta voimme käsitellä tilauksesi."
+    payment_cancelled_due_to_stock: "Maksu peruutettu: kassalle siirtymistä ei voitu suorittaa varasto-ongelmien vuoksi."
+    order_not_loaded: "Ei kelvollista tilausta kassalle käsittelyä varten"
+    your_details_without_number: Omat tietosi
+    payment_method_without_number: Maksutapa
+    order_summary_without_number: Tilauksen yhteenveto
+    already_ordered:
+      cart: "ostoskori"
+      message_html: "Sinulla on jo tilaus tälle tilausjaksolle. Tarkista %{cart} nähdäksesi aiemmin tilaamasi tuotteet. Voit myös peruuttaa tuotteita niin kauan kuin tilausjakso on käynnissä."
+    step1:
+      contact_information:
+        title: Yhteystiedot
+        email:
+          label: Sähköposti
+        phone:
+          label: Puhelinnumero
+      billing_address:
+        title: Laskutusosoite
+        first_name:
+          label: Etunimi
+        last_name:
+          label: Sukunimi
+      address:
+        address1:
+          label: Osoite (katu + talonumero)
+        address2:
+          label: Lisäosoitetiedot (valinnainen)
+        city:
+          label: Kaupunki
+        state_id:
+          label: Lääni
+        zipcode:
+          label: Postinumero
+        country_id:
+          label: Maa
+      shipping_info:
+        title: Toimitustiedot
+      submit: Seuraava - Maksutapa
+      cancel: Takaisin ostoskorin muokkaamiseen
+    step2:
+      payment_method:
+        title: Maksutapa
+      form:
+        card_number:
+          label: Kortin numero
+          placeholder: esim. 4242 4242 4242 4242 4242
+        card_verification_value:
+          label: CVC-koodi
+        card_month:
+          label: Kuukausi
+        card_year:
+          label: Vuosi
+        stripe:
+          use_saved_card: Käytä tallennettua korttia
+          use_new_card: Syötä korttisi tunnisteet
+          save_card: Säilytä kortti myöhempää käyttöä varten
+          create_new_card: tai anna uudet kortin tiedot alla
+      explaination: Voit tarkastella ja vahvistaa tilauksesi seuraavassa vaiheessa, joka sisältää lopulliset kustannukset.
+      submit: Seuraava - Tilauksen yhteenveto
+      cancel: Takaisin omiin tietoihisi
+      voucher:
+        voucher: "%{voucher_amount} Kuponki"
+        apply_voucher: Käytä kuponkia
+        apply: Käytä
+        placeholder: Syötä kuponkikoodi
+        remove_code: Poista koodi
+        confirm_delete: Haluatko varmasti poistaa kupongin?
+        warning_forfeit_remaining_amount: "Huomautus: jos tilauksesi kokonaissumma on pienempi kuin kuponkisi arvo, et välttämättä voi käyttää jäljellä olevaa arvoa."
+    step3:
+      delivery_details:
+        title: Toimitustiedot
+        edit: muokata
+        address: Toimitusosoite
+        instructions: Ohjeet
+      payment_method:
+        title: Maksutapa
+        edit: muokata
+        instructions: Ohjeet
+      order:
+        title: Tilauksen tiedot
+        edit: muokata
+      terms_and_conditions:
+        message_html: "Hyväksyn myyjän ehdot %{terms_and_conditions_link} ."
+        link_text: "Ehdot"
+      platform_terms_of_service:
+        message_html: "Hyväksyn alustan %{tos_link} ehdot."
+      all_terms_and_conditions:
+        message_html: "Hyväksyn myyjän ehdot %{terms_and_conditions_link} ja alustan %{tos_link} ."
+        terms_and_conditions: "Ehdot"
+      submit: Viimeistele tilaus
+      cancel: Takaisin maksutapaan
+    errors:
+      saving_failed: "Tallennus epäonnistui, päivitä korostetut kentät."
+      terms_not_accepted: Hyväksy käyttöehdot
+      required: Kenttä ei voi olla tyhjä
+      invalid_number: "Anna kelvollinen puhelinnumero"
+      invalid_email: "Anna kelvollinen sähköpostiosoite"
+      select_a_shipping_method: Valitse toimitustapa
+      select_a_payment_method: Valitse maksutapa
+      no_shipping_methods_available: Maksu ei ole mahdollista toimitusvaihtoehtojen puuttumisen vuoksi. Ota yhteyttä kaupan omistajaan.
+      voucher_not_found: Ei löytynyt
+      add_voucher_error: Kupongin lisäämisessä tapahtui virhe
+      create_voucher_error: "Tositetta luotaessa tapahtui virhe: %{error}"
+      voucher_redeeming_error: Kuponkisi lunastamisessa tapahtui virhe
+  shops:
+    hubs:
+      show_closed_shops: "Näytä suljetut kaupat"
+      hide_closed_shops: "Piilota suljetut kaupat"
+      show_on_map: "Näytä kaikki kartalla"
+  shared:
+    mailers:
+      powered_by:
+        open_food_network: "Open Food Network"
+        powered_html: "Ostokokemuksesi perustuu %{open_food_network} palveluun."
+    menu:
+      cart:
+        cart: "ostoskori"
+      cart_sidebar:
+        checkout: "mene kassalle"
+        edit_cart: "Muokkaa ostoskoria"
+        items_in_cart_singular: "%{num} tuotetta ostoskorissasi"
+        items_in_cart_plural: "%{num} tuotetta ostoskorissasi"
+        close: "Lähellä"
+        cart_empty: "Ostoskorisi on tyhjä"
+        take_me_shopping: "Vie minut ostoksille!"
+      signed_in:
+        profile: "Profiili"
+      mobile_menu:
+        cart: "ostoskori"
+    register_call:
+      selling_on_ofn: "Kiinnostaako liittyä Open Food Networkiin?"
+      register: "Rekisteröidy tästä"
+    footer:
+      footer_secure: "Turvallinen ja luotettava."
+      footer_secure_text: "Open Food Network käyttää SSL-salausta (2048-bittinen RSA) kaikkialla pitääkseen osto- ja maksutietosi yksityisinä. Palvelimemme eivät tallenna luottokorttitietojasi, ja maksut käsitellään PCI-yhteensopivien palveluiden kautta."
+      footer_contact_headline: "Pidä yhteyttä"
+      footer_contact_email: "Lähetä meille sähköpostia"
+      footer_nav_headline: "Navigoida"
+      footer_join_headline: "Liity mukaan"
+      footer_join_body: "Luo listaus, kauppa tai ryhmähakemisto Open Food Networkissa."
+      footer_join_cta: "Kerro lisää!"
+      footer_legal_call: "Lue lisää"
+      footer_legal_visit: "Löydät meidät täältä"
+      footer_legal_text_html: "Open Food Network on ilmainen ja avoimen lähdekoodin ohjelmistoalusta. Sisältömme on lisensoitu lisenssillä %{content_license} ja koodimme lisenssillä %{code_license} ."
+      footer_data_text_with_privacy_policy_html: "Pidämme hyvää huolta tiedoistasi. Katso %{privacy_policy} ja %{cookies_policy}"
+      footer_data_text_without_privacy_policy_html: "Pidämme hyvää huolta tiedoistasi. Katso %{cookies_policy}"
+      footer_data_privacy_policy: "tietosuojakäytäntö"
+      footer_data_cookies_policy: "evästekäytäntö"
+  shop:
+    messages:
+      customer_required:
+        login: "kirjautuminen"
+        contact: "yhteystiedot"
+        require_customer_login: "Vain hyväksytyt asiakkaat voivat käyttää tätä kauppaa."
+        require_login_link_html: "Jos olet jo hyväksytty asiakas, jatka lähettämällä %{login} ."
+        require_login_2_html: "Haluatko aloittaa ostokset täällä? Lähetä viesti %{contact} %{enterprise} ja kysy liittymisestä."
+        require_customer_html: "Jos haluat aloittaa ostokset täällä, kysy liittymisestä osoitteessa %{contact} %{enterprise} ."
+      select_oc:
+        select_oc_html: "<span class='highlighted'>Valitse tilauksesi ajankohta</span> nähdäksesi saatavilla olevat tuotteet."
+    products:
+      summary:
+        bulk: "Irtotavarana"
+  card_could_not_be_updated: Korttia ei voitu päivittää
+  card_could_not_be_saved: korttia ei voitu tallentaa
+  spree_gateway_error_flash_for_checkout: "Maksutiedoissasi oli ongelma: %{error}"
+  invoice_billing_address: "Laskutusosoite:"
+  invoice_column_tax: "ALV-vero"
+  invoice_column_price: "Hinta"
+  invoice_column_item: "kohde"
+  invoice_column_qty: "Määrä"
+  invoice_column_weight_volume: "Paino / tilavuus"
+  invoice_column_unit_price_with_taxes: "Yksikköhinta (sis. alv)"
+  invoice_column_unit_price_without_taxes: "Yksikköhinta (ilman alv:tä)"
+  invoice_column_price_with_taxes: "Kokonaishinta (sis. alv)"
+  invoice_column_price_without_taxes: "Kokonaishinta (ilman alv:tä)"
+  invoice_column_price_per_unit_without_taxes: "Hinta per yksikkö (ilman alv:tä)"
+  invoice_column_tax_rate: "korko"
+  invoice_tax_total: "ALV-yhteensä:"
+  invoice_cancel_and_replace_invoice: "peruuttaa ja korvaa laskun"
+  tax_invoice: "VERO lasku"
+  tax_total: "Verot yhteensä ( %{rate} ):"
+  invoice_shipping_category_delivery: "Toimitus"
+  invoice_shipping_category_pickup: "Nouto"
+  total_excl_tax: "Yhteensä (ilman alv.):"
+  total_incl_tax: "Yhteensä (sis. alv):"
+  total_all_tax: "Verot yhteensä:"
+  abn: "ABN:"
+  acn: "ACN:"
+  invoice_issued_on: "Lasku lähetetty:"
+  order_number: "Tilausnumero:"
+  date_of_transaction: "Tapahtuman päivämäärä:"
+  menu_1_title: "kaupat"
+  menu_1_url: "/kaupat"
+  menu_2_title: "Kartta"
+  menu_2_url: "/kartta"
+  menu_3_title: "Tuottajat"
+  menu_3_url: "/tuottajat"
+  menu_4_title: "Ryhmät"
+  menu_4_url: "/ryhmät"
+  menu_5_title: "about"
+  menu_5_url: "https://about.openfoodnetwork.org.au/"
+  menu_6_title: "Yhdistä"
+  menu_6_url: "https://openfoodnetwork.org/au/connect/"
+  menu_7_title: "Oppia"
+  menu_7_url: "https://openfoodnetwork.org/au/learn/"
+  logo: "Logo (640x130)"
+  logo_mobile: "Mobiililogo (75x26)"
+  logo_mobile_svg: "Mobiililogo (SVG)"
+  home_hero: "Pääkuva"
+  home_show_stats: "Näytä tilastot"
+  footer_logo: "Logo (220x76)"
+  footer_facebook_url: "Facebookin URL-osoite"
+  footer_twitter_url: "Twitterin URL-osoite"
+  footer_instagram_url: "Instagram-URL-osoite"
+  footer_linkedin_url: "LinkedIn-URL-osoite"
+  footer_googleplus_url: "Google Plus -URL-osoite"
+  footer_pinterest_url: "Pinterestin URL-osoite"
+  footer_email: "Sähköposti"
+  footer_links_md: "Linkit"
+  footer_about_url: "Tietoja URL-osoitteesta"
+  user_guide_link: "Käyttöoppaan linkki"
+  name: nimi
+  first_name: Ensimmäinen nimi
+  last_name: Viimeinen nimi
+  email: Sähköposti
+  phone: Puhelin
+  next: Seuraava
+  address: Osoite
+  address_placeholder: eg. 123 High Street
+  address2: Osoite (jatkuu)
+  city: Kaupunki
+  city_placeholder: eg. Northcote
+  latitude: Leveysaste
+  latitude_placeholder: esim. -37.4713077
+  latitude_longitude_tip: Leveys- ja pituusasteet tarvitaan yrityksesi näyttämiseksi kartalla.
+  longitude: Pituusaste
+  longitude_placeholder: esim. 144.7851531
+  use_geocoder: Lasketaanko leveys- ja pituusaste automaattisesti osoitteesta?
+  state: Lääni
+  postcode: Postinumero
+  postcode_placeholder: eg. 3070
+  suburb: lähiö
+  country: Maa
+  unauthorized: Luvaton
+  terms_of_service: "Palveluehdot"
+  on_demand: Pyynnöstä
+  not_allowed: Ei sallittu
+  no_shipping: ei toimitustapoja
+  no_payment: ei maksutapoja
+  no_shipping_or_payment: ei toimitus- tai maksutapoja
+  unconfirmed: vahvistamaton
+  days: päivää
+  authorization_failure: "Valtuutusvirhe"
+  description: "Kuvaus"
+  label_shop: "kauppa"
+  label_shops: "kaupat"
+  label_map: "Kartta"
+  label_producer: "Tuottaja"
+  label_producers: "Tuottajat"
+  label_groups: "Ryhmät"
+  label_about: "about"
+  label_blog: "Blogi"
+  label_support: "Tukea"
+  label_shopping: "Ostokset"
+  label_login: "Kirjaudu sisään"
+  label_logout: "Kirjaudu ulos"
+  label_signup: "Rekisteröidy"
+  label_administration: "Hallinto"
+  label_admin: "Ylläpitäjä"
+  label_account: "Tili"
+  label_more: "Näytä lisää"
+  label_less: "Näytä vähemmän"
+  cart_items: "kohteet"
+  cart_headline: "ostoskori"
+  total: "yhteensä"
+  cart_updating: "Päivitetään ostoskori ..."
+  cart_empty: "ostoskori tyhjä"
+  cart_edit: "muokata ostoskori"
+  item: "kohde"
+  qty: "Määrä"
+  card_number: Kortin numero
+  card_securitycode: "Turvakoodi"
+  card_expiry_date: Voimassaolopäivä
+  card_masked_digit: "X"
+  card_expiry_abbreviation: "Kokemus"
+  new_credit_card: "Uusi luottokortti"
+  my_credit_cards: Luottokorttini
+  add_new_credit_card: Lisää uusi luottokortti
+  saved_cards: Tallennetut kortit
+  add_a_card: Lisää kortti
+  add_card: Lisää kortti
+  you_have_no_saved_cards: Et ole vielä tallentanut kortteja
+  saving_credit_card: Tallennetaan luottokorttia...
+  card_has_been_removed: "Korttisi on poistettu (numero: %{number} )"
+  card_could_not_be_removed: Korttia ei valitettavasti voitu poistaa
+  invalid_credit_card: "Virheellinen luottokortti"
+  legal:
+    cookies_policy:
+      header: "Kuinka käytämme evästeitä"
+      desc_part_1: "Evästeet ovat hyvin pieniä tekstitiedostoja, jotka tallennetaan tietokoneellesi, kun vierailet joillakin verkkosivustoilla."
+      desc_part_2: "OFN:ssä kunnioitamme täysin yksityisyyttäsi. Käytämme vain niitä evästeitä, jotka ovat välttämättömiä ruoan verkkokaupan tarjoamiseksi sinulle. Emme myy mitään tietojasi. Saatamme tulevaisuudessa ehdottaa, että jaat osan tiedoistasi rakentaaksemme uusia yhteisiä palveluita, jotka voisivat olla hyödyllisiä ekosysteemille (kuten logistiikkapalvelut lyhyille ruokajärjestelmille), mutta emme ole vielä siinä vaiheessa, emmekä tee sitä ilman lupaasi :-)"
+      desc_part_3: "Käytämme evästeitä pääasiassa muistaaksemme kuka olet, jos kirjaudut sisään palveluun, tai muistaaksemme ostoskoriisi lisäämäsi tuotteet, vaikka et olisi kirjautunut sisään. Jos jatkat verkkosivustolla navigointia napsauttamatta &quot;Hyväksy evästeet&quot;, oletamme, että annat meille suostumuksen verkkosivuston toiminnan kannalta välttämättömien evästeiden tallentamiseen. Tässä on luettelo käyttämistämme evästeistä!"
+      essential_cookies: "Välttämättömät evästeet"
+      essential_cookies_desc: "Seuraavat evästeet ovat ehdottoman välttämättömiä verkkosivustomme toiminnan kannalta."
+      essential_cookies_note: "Useimmat evästeet sisältävät vain yksilöllisen tunnisteen, mutta eivät muita tietoja, joten esimerkiksi sähköpostiosoitettasi ja salasanaasi ei koskaan sisällytetä niihin eivätkä ne koskaan paljastu."
+      cookie_domain: "Asettanut:"
+      cookie_session_desc: "Käytetään, jotta verkkosivusto muistaa käyttäjät sivuvierailujen välillä, esimerkiksi ostoskorissa olevien tuotteiden muistamiseksi."
+      cookie_consent_desc: "Käytetään ylläpitämään käyttäjän evästeiden tallentamiseen antaman suostumuksen tilaa"
+      cookie_remember_me_desc: "Käytetään, jos käyttäjä on pyytänyt verkkosivustoa muistamaan hänet. Tämä eväste poistetaan automaattisesti 12 päivän kuluttua. Jos käyttäjänä haluat evästeen poistettavan, sinun tarvitsee vain kirjautua ulos. Jos et halua evästeen asennettavan tietokoneellesi, sinun ei tule valita &quot;muista minut&quot; -valintaruutua kirjautumisen yhteydessä."
+      cookie_openstreemap_desc: "Ystävällisen avoimen lähdekoodin karttapalveluntarjoajamme (OpenStreetMap) käyttää tätä varmistaakseen, ettei se saa liian montaa pyyntöä tietyn ajanjakson aikana ja estääkseen palveluidensa väärinkäyttöä."
+      cookie_stripe_desc: "Maksupalveluntarjoajamme Stripen keräämät tiedot petosten havaitsemiseksi https://stripe.com/cookies-policy/legal. Kaikki kaupat eivät käytä Stripeä maksutapana, mutta petosten estämiseksi on hyvä käytäntö käyttää sitä kaikilla sivuilla. Stripe todennäköisesti muodostaa kuvan siitä, mitkä sivuistamme yleensä ovat vuorovaikutuksessa heidän API:nsa kanssa, ja merkitsee sitten kaikki epätavalliset asiat. Stripe-evästeen asettamisella on siis laajempi tehtävä kuin pelkkä maksutavan tarjoaminen käyttäjälle. Sen poistaminen voi vaikuttaa itse palvelun turvallisuuteen. Voit lukea lisää Stripestä ja sen tietosuojakäytännön osoitteesta https://stripe.com/privacy."
+      statistics_cookies: "Tilastoevästeet"
+      statistics_cookies_desc: "Seuraavat eivät ole ehdottoman välttämättömiä, mutta auttavat meitä tarjoamaan sinulle parhaan mahdollisen käyttökokemuksen analysoimalla käyttäjien käyttäytymistä, tunnistamalla, mitä ominaisuuksia käytät eniten tai et käytä, ymmärtämällä käyttökokemukseen liittyviä ongelmia jne."
+      statistics_cookies_matomo_desc_html: "Alustan käyttötietojen keräämiseen ja analysointiin käytämme <a href='https://matomo.org/' target='_blank'>Matomoa</a> (entinen Piwik), avoimen lähdekoodin analytiikkatyökalua, joka on GDPR-yhteensopiva ja suojaa yksityisyyttäsi."
+      statistics_cookies_matomo_optout: "Haluatko kieltäytyä Matomon analytiikasta? Emme kerää henkilötietoja, ja Matomo auttaa meitä parantamaan palveluamme, mutta kunnioitamme valintaasi :-)"
+      cookie_matomo_basics_desc: "Matomon ensimmäisen osapuolen evästeet tilastojen keräämiseen."
+      cookie_matomo_heatmap_desc: "Matomon lämpökartta- ja istunnon tallennuseväste."
+      cookie_matomo_ignore_desc: "Evästettä käytetään käyttäjän seurannan poissulkemiseen."
+      disabling_cookies_header: "Varoitus evästeiden poistamisesta käytöstä"
+      disabling_cookies_desc: "Käyttäjänä voit aina sallia, estää tai poistaa Open Food Networkin tai minkä tahansa muun verkkosivuston evästeet selaimesi asetuksista. Jokaisella selaimella on omat toimintonsa. Tässä linkit:"
+      disabling_cookies_firefox_link: "https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences"
+      disabling_cookies_chrome_link: "https://support.google.com/chrome/answer/95647"
+      disabling_cookies_ie_link: "https://support.microsoft.com/en-us/help/17442/windows-internet-explorer-delete-manage-cookies"
+      disabling_cookies_safari_link: "https://www.apple.com/legal/privacy/en-ww/cookies/"
+      disabling_cookies_note: "Mutta huomaa, että jos poistat tai muokkaat Open Food Networkin käyttämiä välttämättömiä evästeitä, verkkosivusto ei toimi, etkä voi lisätä mitään ostoskoriisi etkä esimerkiksi kassalle."
+    cookies_banner:
+      cookies_usage: "Tämä sivusto käyttää evästeitä, jotta navigointisi olisi kitkatonta ja turvallista, ja jotta voimme ymmärtää, miten käytät sivustoa, jotta voimme parantaa tarjoamiamme ominaisuuksia."
+      cookies_definition: "Evästeet ovat hyvin pieniä tekstitiedostoja, jotka tallennetaan tietokoneellesi, kun vierailet joillakin verkkosivustoilla."
+      cookies_desc: "Käytämme vain evästeitä, jotka ovat välttämättömiä voidaksemme tarjota sinulle verkkokaupan myynti-/ostopalvelun. Emme myy mitään tietojasi. Käytämme evästeitä pääasiassa muistaaksemme kuka olet, jos kirjaudut sisään palveluun, tai muistaaksemme ostoskoriisi lisäämäsi tuotteet, vaikka et olisi kirjautunut sisään. Jos jatkat verkkosivustolla navigointia napsauttamatta &quot;Hyväksy evästeet&quot;, oletamme, että annat meille suostumuksen verkkosivuston toiminnan kannalta välttämättömien evästeiden tallentamiseen."
+      cookies_policy_link_desc: "Jos haluat lisätietoja, tutustu"
+      cookies_policy_link: "evästekäytäntö"
+      cookies_accept_button: "Hyväksy evästeet"
+  home_shop: Osta nyt
+  brandstory_headline: "Ruoka, rekisteröimätön."
+  brandstory_intro: "Joskus paras tapa korjata järjestelmä on aloittaa uusi…"
+  brandstory_part1: "Aloitamme aivan alusta. Viljelijöistä ja tuottajista, jotka ovat valmiita kertomaan tarinansa ylpeänä ja aidosti. Jakelijoista, jotka ovat valmiita yhdistämään ihmiset tuotteisiin oikeudenmukaisesti ja rehellisesti. Ostajista, jotka uskovat, että paremmat viikoittaiset ostospäätökset voivat muuttaa maailmaa vakavasti."
+  brandstory_part2: "Sitten tarvitsemme tavan tehdä siitä totta. Tavan voimaannuttaa kaikkia, jotka viljelevät, myyvät ja ostavat ruokaa. Tavan kertoa kaikki tarinat, hoitaa kaikki logistiikka. Tavan muuttaa transaktiot muutokseksi joka päivä."
+  brandstory_part3: "Joten rakennamme verkkomarkkinapaikan, joka tasoittaa toimintaedellytyksiä. Se on läpinäkyvä, joten se luo aitoja suhteita. Se on avoimen lähdekoodin, joten se on kaikkien omistuksessa. Se skaalautuu alueille ja maille, joten ihmiset voivat perustaa versioita ympäri maailmaa."
+  brandstory_part4: "Se toimii kaikkialla. Se muuttaa kaiken."
+  brandstory_part5_strong: "Kutsumme sitä avoimeksi ruokaverkostoksi."
+  brandstory_part6: "Me kaikki rakastamme ruokaa. Nyt voimme rakastaa myös ruokajärjestelmäämme."
+  system_headline: "Ostokset – näin se toimii."
+  system_step1: "1. Haku"
+  system_step1_text: "Hae monipuolisista ja itsenäisistä myymälöistämme sesonginmukaisia lähiruokia. Hae naapuruston ja ruokakategorian mukaan tai sen mukaan, haluatko mieluummin kotiinkuljetuksen vai noudon."
+  system_step2: "2. Kauppa"
+  system_step2_text: "Muuta asiointisi edullisten paikallisten ruokien avulla eri tuottajilta ja keskuksilta. Tunne ruokasi taustalla olevat tarinat ja ihmiset, jotka sitä valmistavat!"
+  system_step3: "3. Nouto / Toimitus"
+  system_step3_text: "Odota toimitusta tai käy tuottajallasi tai ostoskeskuksessa saadaksesi henkilökohtaisemman yhteyden ruokaan. Ruokaostokset ovat yhtä monipuolisia kuin luonto on tarkoittanut."
+  cta_headline: "Ostoksia, jotka tekevät maailmasta paremman paikan."
+  cta_label: "Olen valmis"
+  stats_headline: "Olemme luomassa uutta ruokajärjestelmää."
+  stats_producers: "elintarviketuottajat"
+  stats_shops: "ruokakaupat"
+  stats_shoppers: "ruokaostajat"
+  stats_orders: "ruokatilaukset"
+  checkout_title: mene kassalle
+  checkout_now: Kassalle nyt
+  checkout_order_ready: tilaa valmis
+  checkout_hide: Piilottaa
+  checkout_expand: Laajentaa
+  checkout_headline: "Okei, valmis kassalle?"
+  checkout_as_guest: "Kassalle vieraana"
+  checkout_details: "Tietosi"
+  checkout_billing: "Laskutustiedot"
+  checkout_default_bill_address: "Tallenna oletuslaskutusosoitteeksi"
+  checkout_shipping: Toimitustiedot
+  checkout_default_ship_address: "Tallenna oletusarvoiseksi toimitusosoitteeksi"
+  checkout_method_free: Ilmainen
+  checkout_address_same: Toimitusosoite sama kuin laskutusosoite?
+  checkout_ready_for: "Valmis:"
+  checkout_instructions: "Onko kommentteja tai erityisohjeita?"
+  checkout_payment: maksu
+  checkout_send: Tee tilaus nyt
+  checkout_your_order: Tilauksesi
+  checkout_cart_total: Ostoskorin kokonaissumma
+  checkout_shipping_price: Toimitus
+  checkout_total_price: yhteensä
+  checkout_back_to_cart: "Takaisin ostoskoriin"
+  cost_currency: "Kustannusvaluutta"
+  order_paid: MAKSETTU
+  order_not_paid: EI MAKSETTU
+  order_total: Kokonaistilaus
+  order_payment: "Maksutapa:"
+  no_payment_required: "Maksua ei vaadita"
+  order_billing_address: Laskutusosoite
+  order_delivery_on: Toimitus
+  order_delivery_address: Toimitusosoite
+  order_delivery_time: Toimitusaika
+  order_special_instructions: "Muistiinpanosi:"
+  order_pickup_time: Noutovalmis
+  order_pickup_instructions: Keräysohjeet
+  order_produce: Tuottaa
+  order_amount_paid: Maksettu summa
+  order_total_price: yhteensä
+  order_balance_due: Erääntynyt saldo
+  order_includes_tax: (sisältää veron)
+  order_payment_paypal_successful: Maksusi PayPalin kautta on käsitelty onnistuneesti.
+  order_hub_info: Hub-tiedot
+  order_back_to_store: Takaisin kauppaan
+  order_back_to_cart: Takaisin ostoskoriin
+  order_back_to_website: Takaisin verkkosivustolle
+  checkout_details_title: Kassan tiedot
+  checkout_payment_title: Kassalla maksaminen
+  checkout_summary_title: Kassayhteenveto
+  bom_tip: "Tällä sivulla voit muuttaa tuote useiden tilaukset välillä. Tuotteet voidaan myös poistaa tilaukset kokonaan, jos vaaditaan ."
+  unsaved_changes_warning: "Tallentamattomia muutoksia on olemassa ja ne menetetään, jos jatkat."
+  unsaved_changes_error: "Punareunaisissa kentissä on virheitä."
+  products: "Tuotteet"
+  products_in: "kohdassa %{oc}"
+  products_at: "osoitteessa %{distributor}"
+  products_elsewhere: "Muualta löytyviä tuotteita"
+  email_confirmed: "Kiitos sähköpostiosoitteesi vahvistamisesta."
+  email_confirmation_activate_account: "Ennen kuin voimme aktivoida uuden tilisi, meidän on vahvistettava sähköpostiosoitteesi."
+  email_confirmation_greeting: "Hei, %{contact} !"
+  email_confirmation_profile_created: "Profiili käyttäjälle %{name} on luotu onnistuneesti! Profiilisi aktivoimiseksi meidän on vahvistettava tämä sähköpostiosoite."
+  email_confirmation_click_link: "Vahvista sähköpostiosoitteesi ja jatka profiilisi luomista napsauttamalla alla olevaa linkkiä."
+  email_confirmation_link_label: "Vahvista tämä sähköpostiosoite »"
+  email_confirmation_help_html: "Vahvistettuasi sähköpostiosoitteesi voit käyttää tämän yrityksen järjestelmänvalvojan tiliäsi. Katso %{link} saadaksesi lisätietoja %{sitename} :n ominaisuuksista ja aloittaaksesi profiilisi tai verkkokauppasi käytön."
+  email_confirmation_notice_unexpected: "Sait tämän viestin, koska rekisteröidyit palvelussa %{sitename} tai joku luultavasti tuntemasi henkilö kutsui sinut rekisteröitymään. Jos et ymmärrä, miksi saat tämän sähköpostin, kirjoita osoitteeseen %{contact} ."
+  email_social: "Ota yhteyttä:"
+  email_contact: "Lähetä meille sähköpostia:"
+  email_signoff: "Kippis,"
+  email_signature: "%{sitename} tiimi"
+  email_confirm_customer_greeting: "Hei %{name} ,"
+  email_confirm_customer_intro_html: "Kiitos ostoksestasi <strong>%{distributor}</strong> :ssa!"
+  email_confirm_customer_number_html: "tilaa vahvistus <strong># %{number}</strong>"
+  email_confirm_customer_details_html: "Tässä ovat tilauksesi tiedot osoitteesta <strong>%{distributor}</strong> :"
+  email_confirm_customer_signoff: "Ystävällisin terveisin,"
+  email_confirm_shop_greeting: "Hei %{name} ,"
+  email_confirm_shop_order_html: "Hienoa! Sinulla on uusi tilaus tuotteelle <strong>%{distributor}</strong> !"
+  email_confirm_shop_number_html: "tilaa vahvistus <strong># %{number}</strong>"
+  email_order_summary_item: "kohde"
+  email_order_summary_quantity: "Määrä"
+  email_order_summary_sku: "SKU"
+  email_order_summary_price: "Hinta"
+  email_order_summary_subtotal: "Välisumma:"
+  email_order_summary_total: "Kokonais:"
+  email_order_summary_includes_tax: "(sisältää veron):"
+  email_order_summary_voucher_label: "Kuponki ( %{code} ):"
+  email_payment_paid: MAKSETTU
+  email_payment_not_paid: EI MAKSETTU
+  email_payment_description: Maksun kuvaus kassalla
+  email_payment_summary: Maksun yhteenveto
+  email_payment_method: "Maksutapa:"
+  email_so_placement_intro_html: "Sinulla on uusi tilaus osoitteesta <strong>%{distributor}</strong>"
+  email_so_placement_details_html: "Tässä ovat tilauksesi tiedot tuotteelle <strong>%{distributor}</strong> :"
+  email_so_placement_changes: "Valitettavasti kaikkia pyytämiäsi tuotteita ei ollut saatavilla. Alkuperäiset pyytämäsi määrät näkyvät yliviivattuina alla."
+  email_so_payment_success_intro_html: "Tilauksellesi käyttäjältä <strong>%{distributor}</strong> on käsitelty automaattinen maksu."
+  email_so_placement_explainer_html: "Tämä tilaus luotiin sinulle automaattisesti."
+  email_so_edit_true_html: "Voit <a href='%{order_url}'>tehdä muutoksia</a>, kunnes tilaukset sulkeutuvat %{orders_close_at} ."
+  email_so_edit_false_html: "Voit </a>katsoa tilauksen tiedot</a> milloin vain."
+  email_so_contact_distributor_html: "Jos sinulla on kysyttävää, voit ottaa yhteyttä <strong>%{distributor}</strong> sähköpostitse %{email} ."
+  email_so_contact_distributor_to_change_order_html: "Tämä tilaus luotiin sinulle automaattisesti. Voit tehdä muutoksia tilausten sulkeutumiseen asti osoitteessa %{orders_close_at} ottamalla yhteyttä <strong>%{distributor}</strong> numeroon %{email} ."
+  email_so_confirmation_intro_html: "Tilauksesi yritykselle <strong>%{distributor}</strong> on nyt vahvistettu."
+  email_so_confirmation_explainer_html: "Tämä tilaus tehtiin sinulle automaattisesti, ja se on nyt viimeistelty."
+  email_so_confirmation_details_html: "Tässä on kaikki mitä sinun tarvitsee tietää tilauksestasi <strong>%{distributor}</strong> ltä:"
+  email_so_empty_intro_html: "Yritimme tehdä uuden tilauksen osoitteeseen <strong>%{distributor}</strong> , mutta siinä oli ongelmia..."
+  email_so_empty_explainer_html: "Valitettavasti mikään tilaamistasi tuotteista ei ollut saatavilla, joten tilausta ei ole tehty. Alkuperäiset pyytämäsi määrät näkyvät yliviivattuina alla."
+  email_so_empty_details_html: "Tässä ovat tiedot tekemättä jääneestä tilauksesta kohteelle <strong>%{distributor}</strong> :"
+  email_so_failed_payment_intro_html: "Yritimme käsitellä maksua, mutta siinä oli joitakin ongelmia..."
+  email_so_failed_payment_explainer_html: "Tilauksesi maksu käyttäjälle <strong>%{distributor}</strong> epäonnistui luottokorttiongelmasi vuoksi. <strong>%{distributor}</strong> on ilmoitettu tästä epäonnistuneesta maksusta."
+  email_so_failed_payment_details_html: "Tässä ovat maksuyhdyskäytävän toimittamat tiedot epäonnistumisesta:"
+  email_shipping_delivery_details: Toimitustiedot
+  email_shipping_delivery_time: "Toimitus:"
+  email_shipping_delivery_address: "Toimitusosoite:"
+  email_shipping_collection_details: Kokoelman tiedot
+  email_shipping_collection_time: "Noutovalmiina:"
+  email_shipping_collection_instructions: "Keräysohjeet:"
+  email_special_instructions: "Muistiinpanosi:"
+  email_signup_greeting: Hei!
+  email_signup_welcome: "Tervetuloa %{sitename} :een!"
+  email_signup_confirmed_email: "Kiitos sähköpostiosoitteesi vahvistamisesta."
+  email_signup_shop_html: "Voit nyt kirjautua sisään osoitteessa %{link} ."
+  email_signup_text: "Kiitos liittymisestä verkostoomme. Jos olet asiakas, esittelemme mielellämme sinulle monia upeita viljelijöitä, ihania ruokakeskuksia ja herkullista ruokaa! Jos olet tuottaja tai elintarvikealan yritys, olemme innoissamme voidessamme toivottaa sinut osaksi verkostoamme."
+  email_signup_help_html: "Otamme mielellämme vastaan kaikki kysymyksesi ja palautteesi; voit käyttää sivuston <em>Lähetä palautetta</em> -painiketta tai lähettää meille sähköpostia osoitteeseen %{email}"
+  invite_email:
+    greeting: "Hei!"
+    invited_to_manage: "Sinut on kutsuttu hallinnoimaan %{enterprise} %{instance} sivustolla."
+    confirm_your_email: "Sinun olisi pitänyt saada tai saat pian sähköpostin, jossa on vahvistuslinkki. Et voi käyttää %{enterprise} :n profiilia ennen kuin olet vahvistanut sähköpostiosoitteesi."
+    set_a_password: "Sinua pyydetään sitten asettamaan salasana, ennen kuin voit hallita yritystä."
+    mistakenly_sent: "Etkö ole varma, miksi sait tämän sähköpostin? Ota yhteyttä numeroon %{owner_email} saadaksesi lisätietoja."
+  producer_mail_greeting: "Hyvä"
+  producer_mail_text_before: "Alla on päivitys tilaussyklistä, joka on valmis:"
+  producer_mail_order_text: "Tässä on yhteenveto tuotteidesi tilauksista:"
+  producer_mail_delivery_instructions: "Varaston nouto-/toimitusohjeet:"
+  producer_mail_signoff: "Kiitos ja parhaat toivotukset"
+  producer_mail_order_customer_text: "Tässä on yhteenveto tilauksista asiakkaiden ryhmiteltynä"
+  shopping_oc_closed: Tilaukset on suljettu
+  shopping_oc_closed_description: "Odotathan seuraavan tilausjakson alkamista (tai ota meihin suoraan yhteyttä ja kysy, voimmeko ottaa vastaan myöhästyneitä tilauksia)."
+  shopping_oc_last_closed: "Viimeisin sykli päättyi %{distance_of_time} sitten"
+  shopping_oc_next_open: "Seuraava sykli alkaa kohdassa %{distance_of_time}"
+  shopping_oc_select: "Valitse..."
+  shopping_tabs_home: "Kotiin"
+  shopping_tabs_shop: "kauppa"
+  shopping_tabs_about: "about"
+  shopping_tabs_producers: "Tuottajat"
+  shopping_tabs_contact: "Yhteystiedot"
+  shopping_tabs_groups: "Ryhmät"
+  shopping_contact_address: "Osoite"
+  shopping_contact_web: "Yhteystiedot"
+  shopping_contact_social: "Seuraa"
+  shopping_groups_part_of: "on osa:"
+  shopping_producers_of_hub: "%{hub} :n tuottajat:"
+  enterprises_next_closing: "Seuraavan tilauksen sulkeminen"
+  enterprises_currently_open: "Tilaukset ovat tällä hetkellä avoinna"
+  enterprises_ready_for: "Valmis"
+  enterprises_choose: "Valitse milloin haluat tilauksesi:"
+  maps_open: "Avata"
+  maps_closed: "Suljettu"
+  map_title: "Kartta"
+  hubs_buy: "Osta:"
+  hubs_shopping_here: "Ostokset täällä"
+  hubs_orders_closed: "Tilaukset suljettu"
+  hubs_profile_only: "Vain profiili"
+  hubs_delivery_options: "Toimitusvaihtoehdot"
+  hubs_pickup: "nouto"
+  hubs_delivery: "Toimitus"
+  hubs_producers: "Tuottajamme"
+  hubs_filter_by: "Suodata"
+  hubs_filter_type: "Tyyppi"
+  hubs_filter_delivery: "Toimitus"
+  hubs_filter_property: "Omaisuus"
+  hubs_matches: "Tarkoititko?"
+  hubs_intro: Osta lähialueeltasi
+  hubs_distance: Lähimpänä
+  hubs_distance_filter: "Näytä minulle lähellä %{location} kauppoja"
+  shop_changeable_orders_alert_html:
+    one: Tilauksesi, jonka <a href='%{path} &#39; target=&#39;_blank&#39;&gt; <span class='notranslate'>%{shop} / %{order} ,</a> on avoinna tarkistettavaksi. Voit tehdä muutoksia %{oc_close} asti.
+    few: Sinulla on <a href='%{path} &#39;target=&#39;_blank&#39;&gt; <span class='notranslate'>%{count} tilaukset ja %{shop}</a> tällä hetkellä avoinna tarkistettavaksi. Voit tehdä muutoksia %{oc_close} asti.
+    many: Sinulla on <a href='%{path} &#39;target=&#39;_blank&#39;&gt; <span class='notranslate'>%{count} tilaukset ja %{shop}</a> tällä hetkellä avoinna tarkistettavaksi. Voit tehdä muutoksia %{oc_close} asti.
+    other: Sinulla on <a href='%{path} &#39;target=&#39;_blank&#39;&gt; <span class='notranslate'>%{count} tilaukset ja %{shop}</a> tällä hetkellä avoinna tarkistettavaksi. Voit tehdä muutoksia %{oc_close} asti.
+  orders_changeable_orders_alert_html: Tämä tilaus on vahvistettu, mutta voit tehdä muutoksia päivämäärään <strong>%{oc_close}</strong> asti.
+  products_clear: Tyhjennä
+  products_showing: "Näytetään:"
+  products_results_for: "Tulokset haulle"
+  products_or: "tai"
+  products_and: "ja"
+  products_filters_in: "sisään"
+  products_with: kanssa
+  products_search: "Haku..."
+  products_filter_by: "Suodata"
+  products_filter_selected: "valittu"
+  products_filter_heading: "Suodattimet"
+  products_filter_clear: "Tyhjennä"
+  products_filter_done: "Tehty"
+  products_loading: "Tuotteita ladataan..."
+  products_updating_cart: "Päivitetään ostoskori ..."
+  products_cart_empty: "ostoskori tyhjä"
+  products_edit_cart: "muokkaa ostoskoria"
+  products_from: alkaen
+  products_change: "Ei tallennettavia muutoksia."
+  products_update_error: "Tallennus epäonnistui virheen (tai virheiden) vuoksi:"
+  products_update_error_msg: "Tallennus epäonnistui."
+  products_update_error_data: "Tallennus epäonnistui virheellisten tietojen vuoksi:"
+  products_changes_saved: "Muutokset tallennettu."
+  products_no_results_html: "Valitettavasti haulle %{query} ei löytynyt tuloksia."
+  products_clear_search: "Tyhjennä haku"
+  search_no_results_html: "Ei tuloksia haulle %{query} . Kokeile toista hakua?"
+  components_profiles_popover: "Profiileilla ei ole myymälää Open Food Networkissa, mutta niillä voi olla oma fyysinen kauppa tai verkkokauppa muualla."
+  components_profiles_show: "Näytä profiilit"
+  components_filters_nofilters: "Ei suodattimia"
+  components_filters_clearfilters: "Tyhjennä kaikki suodattimet"
+  groups_title: Ryhmät
+  groups_headline: Ryhmät / alueet
+  groups_text: "Jokainen tuottaja on ainutlaatuinen. Jokaisella yrityksellä on tarjottavanaan jotain erilaista. Ryhmämme ovat tuottajien, keskuksien ja jakelijoiden kollektiiveja, joilla on jokin yhteinen tekijä, kuten sijainti, maanviljelijöiden markkinat tai filosofia. Tämä helpottaa ostokokemustasi. Joten tutustu ryhmiimme ja anna kuratoinnin tehdä puolestasi."
+  groups_search: "Hae nimeä tai avainsanaa"
+  groups_no_groups: "Ei ryhmiä löytynyt"
+  groups_about: "about meistä"
+  groups_producers: "Tuottajamme"
+  groups_hubs: "Keskuksemme"
+  groups_contact_web: Yhteystiedot
+  groups_contact_social: Seuraa
+  groups_contact_address: Osoite
+  groups_contact_email: Lähetä meille sähköpostia
+  groups_contact_website: Käy verkkosivuillamme
+  groups_contact_facebook: Seuraa meitä Facebookissa
+  groups_signup_title: Ilmoittaudu ryhmänä
+  groups_signup_headline: Ryhmien ilmoittautuminen
+  groups_signup_intro: "Olemme upea alusta yhteistyöhön perustuvalle markkinoinnille, helpoin tapa jäsenillesi ja sidosryhmillesi tavoittaa uusia markkinoita. Olemme voittoa tavoittelemattomia, edullisia ja yksinkertaisia."
+  groups_signup_email: Lähetä meille sähköpostia
+  groups_signup_motivation1: Muutamme ruokajärjestelmiä oikeudenmukaisesti.
+  groups_signup_motivation2: Siksi nousemme sängystä joka päivä. Olemme maailmanlaajuinen voittoa tavoittelematon järjestö, joka perustuu avoimeen lähdekoodiin. Pelaamme reilusti. Voit aina luottaa meihin.
+  groups_signup_motivation3: Tiedämme, että sinulla on suuria ideoita, ja haluamme auttaa. Jaamme tietomme, verkostomme ja resurssimme. Tiedämme, että eristäytyminen ei luo muutosta, joten teemme yhteistyötä kanssasi.
+  groups_signup_motivation4: Tapaamme sinut siellä missä olet.
+  groups_signup_motivation5: Saatat olla elintarvikekeskusten, tuottajien tai jakelijoiden sekä alan elimen tai paikallishallinnon yhteenliittymä.
+  groups_signup_motivation6: Olipa roolisi paikallisessa ruokaliikkeessä mikä tahansa, olemme valmiita auttamaan. Olipa pohditpa sitten, miltä Open Food Network näyttäisi tai tekee omalla alueellasi, aloitetaan keskustelu.
+  groups_signup_motivation7: Teemme ruokaliikkeistä järkevämpiä.
+  groups_signup_motivation8: Sinun on aktivoitava ja mahdollistettava verkostosi. Me tarjoamme alustan keskustelulle ja toiminnalle. Tarvitset aitoa sitoutumista. Autamme tavoittamaan kaikki toimijat, kaikki sidosryhmät ja kaikki sektorit.
+  groups_signup_motivation9: Tarvitset resursseja. Me käytämme kaiken kokemuksemme. Tarvitset yhteistyötä. Me yhdistämme sinut paremmin globaaliin vertaisverkostoon.
+  groups_signup_pricing: Ryhmätili
+  groups_signup_studies: Case-tutkimukset
+  groups_signup_contact: Valmiina keskustelemaan?
+  groups_signup_contact_text: "Ota yhteyttä ja ota selvää, mitä OFN voi tehdä hyväksesi:"
+  groups_signup_detail: "Tässä yksityiskohta."
+  login_invalid: "Virheellinen sähköpostiosoite tai salasana"
+  producers_about: Tietoa meistä
+  producers_buy: Osta
+  producers_contact: Yhteystiedot
+  producers_contact_phone: Soittaa
+  producers_contact_social: Seuraa
+  producers_buy_at_html: "Osta %{enterprise} -tuotteita osoitteesta:"
+  producers_filter: Suodata
+  producers_filter_type: Tyyppi
+  producers_filter_property: Omaisuus
+  producers_title: Tuottajat
+  producers_headline: Etsi paikallisia tuottajia
+  producers_signup_title: Rekisteröidy tuottajaksi
+  producers_signup_headline: Elintarviketuottajat, vaikutusvaltaisempia.
+  producers_signup_motivation: Myy ruokaasi ja kerro tarinasi monimuotoisille uusille markkinoille. Säästä aikaa ja rahaa jokaisessa yleiskulussa. Tuemme innovaatioita ilman riskiä. Olemme luoneet tasapuoliset toimintaedellytykset.
+  producers_signup_send: Liity nyt
+  producers_signup_enterprise: yritys
+  producers_signup_studies: Tarinoita tuottajiltamme.
+  producers_signup_cta_headline: Liity nyt!
+  producers_signup_cta_action: Liity nyt
+  producers_signup_detail: Tässä yksityiskohta.
+  producer: tuottaja
+  products_item: kohde
+  products_description: Kuvaus
+  products_variant: Variantti
+  products_quantity: Määrä
+  products_available: Saatavilla?
+  products_producer: "tuottaja"
+  products_price: "Hinta"
+  name_or_sku: "nimi TAI SKU"
+  register_title: Rekisteröidy
+  sell_title: "Rekisteröidy"
+  sell_headline: "Liity Open Food Networkiin!"
+  sell_motivation: "Esittele kaunista ruokaasi."
+  sell_producers: "Tuottajat"
+  sell_hubs: "Keskukset"
+  sell_groups: "Ryhmät"
+  sell_producers_detail: "Luo yrityksellesi profiili OFN:ään vain muutamassa minuutissa. Voit milloin tahansa päivittää profiilisi verkkokaupaksi ja myydä tuotteitasi suoraan asiakkaille."
+  sell_hubs_detail: "Luo elintarvikeyrityksellesi tai -organisaatiollesi profiili OFN:ään. Voit milloin tahansa päivittää profiilisi usean tuottajan kauppaan."
+  sell_groups_detail: "Laadi räätälöity hakemisto yrityksistä (tuottajista ja muista elintarvikeyrityksistä) alueellesi tai organisaatiollesi."
+  sell_user_guide: "Lisätietoja on käyttöoppaassamme."
+  sell_listing_price: "Listautuminen OFN:ään on ilmaista. Kaupan avaaminen ja pyörittäminen OFN:ssä on ilmaista 500 dollariin asti kuukausittaisesta myynnistä. Jos myyt enemmän, voit valita yhteisölahjoituksesi 1–3 prosentin väliltä myynnistä. Lisätietoja hinnoittelusta on Ohjelmistoalusta-osiossa ylävalikon Tietoja-linkin kautta."
+  sell_embed: "Voimme myös upottaa OFN-kaupan omalle räätälöidylle verkkosivustollesi tai rakentaa räätälöidyn paikallisen ruokaverkoston verkkosivuston alueellesi."
+  sell_ask_services: "Kysy meiltä OFN-palveluista."
+  shops_title: kaupat
+  shops_headline: Ostokset, muuttuneet.
+  shops_text: Ruoka kasvaa sykleissä, maanviljelijät korjaavat sadon sykleissä ja me tilaamme ruokaa sykleissä. Jos huomaat tilaussyklin sulkeutuneen, tarkista tilanne pian uudelleen.
+  shops_signup_title: Rekisteröidy keskuskumppaniksi
+  shops_signup_headline: Ruokakeskuksia, rajattomasti.
+  shops_signup_motivation: Olipa mallisi mikä tahansa, tuemme sinua. Olivatpa muutokset mitkä tahansa, olemme rinnallasi. Olemme voittoa tavoittelemattomia, itsenäisiä ja avoimen lähdekoodin ohjelmistoja. Olemme ohjelmistokumppanit, joista olet unelmoinut.
+  shops_signup_action: Liity nyt
+  shops_signup_pricing: yritys
+  shops_signup_stories: Tarinoita keskuksistamme.
+  shops_signup_help: Olemme valmiita auttamaan.
+  shops_signup_help_text: Tarvitset paremman tuoton. Tarvitset uusia ostajia ja logistiikkakumppaneita. Tarinasi täytyy kertoa tukku- ja vähittäiskaupassa sekä keittiön pöydällä.
+  shops_signup_detail: Tässä yksityiskohta.
+  orders: "tilaukset"
+  orders_fees: "Maksut..."
+  orders_edit_title: "Ostoskori"
+  orders_edit_headline: "ostoskori"
+  orders_edit_time: "tilaa valmis"
+  orders_edit_continue: "Jatka ostoksia"
+  orders_edit_checkout: "mene kassalle"
+  orders_form_empty_cart: "Tyhjä ostoskori"
+  orders_form_update_cart: "päivitä"
+  orders_form_subtotal: "Tuota välisumma"
+  orders_form_total: "yhteensä"
+  orders_oc_expired_headline: "Tilaukset ovat päättyneet tälle tilausjaksolle"
+  orders_oc_expired_text: "Valitettavasti tämän tilausjakson tilaukset suljettiin %{time} sitten! Ota yhteyttä suoraan keskusliikkeeseesi ja kysy, voivatko he ottaa vastaan myöhästyneitä tilauksia."
+  orders_oc_expired_text_others_html: "Valitettavasti tämän tilausjakson tilaukset suljettiin %{time} sitten! Ota yhteyttä suoraan keskusliikkeeseesi ja kysy, voivatko he hyväksyä myöhästyneitä tilauksia <strong>%{link}</strong> ."
+  orders_oc_expired_text_link: "tai katso muita saatavilla olevia tilausjaksoja tässä keskuksessa"
+  orders_oc_expired_email: "Sähköposti:"
+  orders_oc_expired_phone: "Puhelin:"
+  orders_show_title: "tilaa -vahvistus"
+  orders_show_time: "Tilaus valmis"
+  orders_show_order_number: "Tilausnumero %{number}"
+  orders_show_cancelled: "Peruutettu"
+  orders_show_confirmed: "Vahvistettu"
+  orders_your_order_has_been_cancelled: "Tilauksesi on peruutettu"
+  orders_could_not_cancel: "Tilausta ei voitu peruuttaa"
+  orders_cannot_remove_the_final_item: "Viimeistä tuotetta ei voida poistaa tilauksesta, peruuta sen sijaan tilaus."
+  orders_bought_items_notice:
+    one: "Tälle tilausjaksolle on jo vahvistettu lisätuote"
+    few: "%{count} kohteet jo vahvistettu tälle tilausjakso"
+    many: "%{count} kohteet jo vahvistettu tälle tilausjakso"
+    other: "%{count} kohteet jo vahvistettu tälle tilausjakso"
+  orders_bought_edit_button: "Muokkaa vahvistettuja kohteita"
+  orders_bought_already_confirmed: "*jo vahvistettu"
+  orders_confirm_cancel: "Haluatko varmasti peruuttaa tämän tilauksen?"
+  order_processed_successfully: "Tilauksesi on käsitelty onnistuneesti"
+  thank_you_for_your_order: "Kiitos tilauksestasi"
+  products_cart_distributor_choice: "Tilauksesi jakelija:"
+  products_cart_distributor_change: "Tämän tilauksen jakelijaksi vaihtuu %{name} , jos lisäät tämän tuotteen ostoskoriisi."
+  products_cart_distributor_is: "Tämän tilauksen jakelija on %{name} ."
+  products_distributor_error: "Viimeistele tilauksesi osoitteessa %{link} ennen kuin ostat toiselta jälleenmyyjältä."
+  products_oc: "Tilauksesi tilaussykli:"
+  products_oc_change: "Tämän tilauksen tilausjakso muuttuu muotoon %{name} jos lisäät tämän tuotteen ostoskoriisi."
+  products_oc_is: "Tämän tilauksen tilaussykli on %{name} ."
+  products_oc_error: "Viimeistele tilauksesi osoitteesta %{link} ennen kuin ostat toisella tilausjaksolla."
+  products_oc_current: "nykyinen tilausjaksosi"
+  products_max_quantity: Maksimimäärä
+  products_distributor: Jakelija
+  products_distributor_info: Kun valitset tilauksellesi jakelijan, heidän osoitteensa ja noutoaikansa näkyvät tässä.
+  password: salasana
+  remember_me: Muista minut
+  are_you_sure: "Oletko varma?"
+  orders_open: "Tilaukset avoinna"
+  closing: "Sulkeminen"
+  going_back_to_home_page: "Palaa takaisin kotisivulle"
+  creating: Luominen
+  updating: Päivittäminen
+  failed_to_create_enterprise: "Yrityksesi luominen epäonnistui."
+  failed_to_create_enterprise_unknown: "Yrityksesi luominen epäonnistui.\n Varmista, että kaikki kentät on täytetty kokonaan."
+  failed_to_update_enterprise_unknown: "Yritystietojesi päivittäminen epäonnistui.\n Varmista, että kaikki kentät on täytetty kokonaan."
+  enterprise_confirm_delete_message: "Tämä poistaa myös yrityksen toimittaman %{product} tiedoston. Haluatko varmasti jatkaa?"
+  order_not_saved_yet: "Tilaustasi ei ole vielä tallennettu. Anna meille muutama sekunti aikaa viimeistelyyn!"
+  filter_by: "Suodata"
+  hide_filters: "Piilota suodattimet"
+  one_filter_applied: "1 suodatin käytössä"
+  x_filters_applied: " suodattimet käytössä"
+  submitting_order: "Tilauksen lähettäminen: odota hetki"
+  confirm_hub_change: "Oletko varma? Tämä vaihtaa valitsemasi keskuksen ja poistaa kaikki tuotteet ostoskoristasi."
+  confirm_oc_change: "Oletko varma? Tämä muuttaa valitsemaasi tilausjaksoa ja poistaa kaikki tuotteet ostoskoristasi."
+  location_placeholder: "Kirjoita sijainti..."
+  gmap_load_failure: "Kartan lataaminen epäonnistui. Tarkista selaimesi asetukset ja salli 3. osapuolen evästeet tälle verkkosivustolle."
+  error_required: "ei voi olla tyhjä"
+  error_number: "täytyy olla numero"
+  error_email: "täytyy olla sähköpostiosoite"
+  error_not_found_in_database: "%{name} ei löydy tietokannasta"
+  error_not_primary_producer: "%{name} ei ole käytössä tuottajana"
+  error_no_permission_for_enterprise: "&quot; %{name} &quot;: sinulla ei ole oikeutta hallita tämän yrityksen tuotteita"
+  item_handling_fees: "Lähetyksen käsittelymaksut (sisältyvät lähetysten kokonaishintaan)"
+  january: "tammikuu"
+  february: "helmikuu"
+  march: "maaliskuu"
+  april: "huhtikuu"
+  may: "toukokuu"
+  june: "kesäkuu"
+  july: "heinäkuu"
+  august: "elokuu"
+  september: "syyskuu"
+  october: "lokakuu"
+  november: "marraskuu"
+  december: "joulukuu"
+  email_not_found: "Sähköpostiosoitetta ei löytynyt"
+  email_unconfirmed: "Sinun on vahvistettava sähköpostiosoitteesi ennen kuin voit palauttaa salasanasi."
+  email_required: "Sinun on annettava sähköpostiosoite"
+  logging_in: "Odota hetki, kirjaamme sinut sisään"
+  signup_email: "Sähköpostiosoitteesi"
+  choose_password: "Valitse salasana"
+  confirm_password: "Vahvista salasana"
+  action_signup: "Rekisteröidy nyt"
+  forgot_password: "Unohditko salasanasi?"
+  password_reset_sent: "Sähköposti, jossa on ohjeet salasanan palauttamiseen, on lähetetty!"
+  reset_password: "Palauta salasana"
+  update_and_recalculate_fees: "Päivitä ja laske maksut uudelleen"
+  registration:
+    steps:
+      introduction:
+        registration_greeting: "Hei vaan!"
+        registration_intro: "Voit nyt luoda profiilin tuottajallesi tai keskusryhmällesi."
+        registration_checklist: "Mitä tarvitsen?"
+        registration_time: "5-10 minuuttia"
+        registration_enterprise_address: "Yrityksen osoite"
+        registration_contact_details: "Ensisijaiset yhteystiedot"
+        registration_logo: "Logokuvasi"
+        registration_promo_image: "Vaakasuuntainen kuva profiiliisi"
+        registration_about_us: "&#39;Tietoja meistä&#39; -teksti"
+        registration_outcome_headline: "Mitä saan?"
+        registration_outcome1_html: "Profiilisi avulla ihmiset <strong>löytävät</strong> sinut ja ottavat sinuun <strong>yhteyttä</strong> Open Food Networkissa."
+        registration_outcome2: "Käytä tätä tilaa kertoaksesi yrityksesi tarinan ja luodaksesi yhteyksiä sosiaaliseen mediaan ja verkkoon."
+        registration_outcome3: "Se on myös ensimmäinen askel kohti kaupankäyntiä Open Food Networkissa tai verkkokaupan avaamista."
+        registration_action: "Aloitetaan!"
+      details:
+        title: "Tiedot"
+        headline: "Aloitetaan"
+        enterprise: "Jes! Ensin meidän täytyy tietää hieman yrityksestäsi:"
+        producer: "Jes! Ensin meidän täytyy tietää hieman tilastasi:"
+        enterprise_name_field: "Yrityksen nimi:"
+        producer_name_field: "Tilan nimi:"
+        producer_name_field_placeholder: "esim. Charlien mahtava maatila"
+        producer_name_field_error: "Valitse yrityksellesi yksilöivä nimi"
+        address1_field: "Osoiterivi 1:"
+        address1_field_placeholder: "esim. Cranberry Drive 123"
+        address1_field_error: "Anna osoite"
+        address2_field: "Osoiterivi 2:"
+        suburb_field: "Lähiö:"
+        suburb_field_placeholder: "esim. Northcote"
+        suburb_field_error: "Anna lähiö"
+        postcode_field: "Postinumero:"
+        postcode_field_placeholder: "esim. 3070"
+        postcode_field_error: "Postinumero vaaditaan"
+        state_field: "Lääni:"
+        state_field_error: "Lääni vaaditaan"
+        country_field: "Maa:"
+        country_field_error: "Valitse maa"
+        map_location: "Karttasijainti"
+        locate_address: "Paikanna osoite kartalla"
+        drag_pin: "Vedä ja pudota nastan oikeaan paikkaan, jos se ei ole tarkka."
+        confirm_address: "Vahvistan, että yrityksen sijainti kartalla on oikein."
+        drag_map_marker: "Koska monet tuottajat toimivat maaseudulla, karttojen tarkkuutta parannetaan jatkuvasti. Auta meitä ymmärtämään sijaintiasi paremmin käyttämällä yllä olevaa karttaa ja siirtämällä nastan paikkaa napsauttamalla tai napauttamalla sitä ja vetämällä sitä sitten sijaintiin, joka on tietämyksesi perusteella tarkempi."
+      contact:
+        title: "Yhteystiedot"
+        who_is_managing_enterprise: "Kuka on vastuussa %{enterprise} n hallinnasta?"
+        contact_field: "Ensisijainen yhteyshenkilö"
+        contact_field_placeholder: "Ota yhteyttä nimi"
+        contact_field_required: "Sinun on annettava ensisijainen yhteyshenkilö."
+        phone_field: "Puhelinnumero"
+        whatsapp_phone_field: "WhatsApp-puhelinnumero"
+        whatsapp_phone_tooltip: "Tämä numero näkyy julkinen -profiilissasi, jonka voit avata WhatsApp-linkkinä."
+        phone_field_placeholder: "esim. (03) 1234 5678"
+        whatsapp_phone_field_placeholder: "esim. +61 4 1234 5678"
+      type:
+        title: "Tyyppi"
+        headline: "Viimeinen vaihe %{enterprise} lisäämiseksi!"
+        question: "Oletko tuottaja?"
+        yes_producer: "Kyllä, olen tuottaja"
+        no_producer: "Ei, en ole tuottaja"
+        producer_field_error: "Valitse yksi. Oletko tuottaja?"
+        yes_producer_help: "Tuottajat valmistavat herkullisia ruokia ja/tai juomia. Olet tuottaja, jos kasvatat, kannat, haudutat, leivot, käyt, lypsät tai muovaat sitä."
+        no_producer_help: "Jos et ole tuottaja, olet todennäköisesti joku, joka myy ja jakelee ruokaa. Saatat olla keskus, osuuskunta, ostoryhmä, vähittäismyyjä, tukkumyyjä tai jokin muu."
+        create_profile: "Luo profiili"
+      about:
+        title: "about"
+        headline: "Hieno juttu!"
+        message: "Tarkastellaanpa nyt yksityiskohtia aiheesta"
+        success: "Onnistui! %{enterprise} lisätty Open Food Networkiin"
+        registration_exit_message: "Jos poistut tästä ohjatusta toiminnosta missä tahansa vaiheessa, voit jatkaa profiilisi luomista siirtymällä hallintakäyttöliittymään."
+        enterprise_description: "Lyhyt kuvaus"
+        enterprise_description_placeholder: "Lyhyt lause, joka kuvaa yritystäsi"
+        enterprise_long_desc: "Pitkä kuvaus"
+        enterprise_long_desc_placeholder: "Tämä on tilaisuutesi kertoa yrityksesi tarina – mikä tekee sinusta erilaisen ja upean? Suosittelemme, että pidät kuvauksesi alle 600 merkissä tai 150 sanassa."
+        enterprise_long_desc_length: "%{num} merkkiä / enintään 600 suositus"
+        enterprise_abn: "ABN"
+        enterprise_abn_placeholder: "eg. 99 123 456 789"
+        enterprise_acn: "ACN"
+        enterprise_acn_placeholder: "eg. 123 456 789"
+        enterprise_tax_required: "Sinun täytyy tehdä valinta."
+      images:
+        title: "Kuvat"
+        headline: "Kiitos!"
+        description: "Lataapa tänne pari nättiä kuvaa, jotta profiilisi näyttää hyvältä! :)"
+        uploading: "Ladataan..."
+        continue: "Jatkaa"
+        back: "Takaisin"
+      logo:
+        select_logo: "Vaihe 1. Valitse logokuva"
+        logo_tip: "Vinkki: Neliönmuotoiset kuvat toimivat parhaiten, mieluiten vähintään 300 × 300 pikseliä."
+        logo_label: "Valitse logokuva"
+        logo_drag: "Vedä ja pudota logosi tähän"
+        review_logo: "Vaihe 2. Tarkista logosi"
+        review_logo_tip: "Vinkki: parhaan tuloksen saavuttamiseksi logon tulisi täyttää käytettävissä oleva tila"
+        logo_placeholder: "Logosi näkyy täällä tarkistettavana latauksen jälkeen."
+      promo:
+        select_promo_image: "Vaihe 3. Valitse mainoskuva"
+        promo_image_tip: "Vinkki: Näytetään bannerina, suositeltu koko on 1200 × 260 pikseliä"
+        promo_image_label: "Valitse mainoskuva"
+        promo_image_drag: "Vedä ja pudota mainoskampanjasi tähän"
+        review_promo_image: "Vaihe 4. Tarkista mainosbannerisi"
+        review_promo_image_tip: "Vinkki: parhaan tuloksen saavuttamiseksi mainoskuvan tulisi täyttää käytettävissä oleva tila"
+        promo_image_placeholder: "Logosi näkyy täällä tarkistettavana latauksen jälkeen."
+      social:
+        title: "Sosiaalinen"
+        enterprise_final_step: "Viimeinen vaihe!"
+        enterprise_social_text: "Miten ihmiset löytävät %{enterprise} n verkosta?"
+        website: "Verkkosivusto"
+        website_placeholder: "esim. openfoodnetwork.org.au"
+        facebook: "Facebook"
+        facebook_placeholder: "eg. www.facebook.com/PageNameHere"
+        linkedin: "LinkedIn"
+        linkedin_placeholder: "esim. www.linkedin.com/YourNameHere"
+        twitter: "Twitter"
+        twitter_placeholder: "esim. @twitter_handle"
+        instagram: "Instagramissa"
+        instagram_placeholder: "esim. @instagram_handle"
+      limit_reached:
+        headline: "Voi ei!"
+        message: "Olet saavuttanut rajan!"
+        text: "Olet saavuttanut omistamiesi yritysten enimmäismäärän."
+        action: "Palaa kotisivulle"
+      finished:
+        headline: "Valmis!"
+        thanks: "Kiitos, että täytit %{enterprise} lomakkeen tiedot."
+        login: "Voit muuttaa tai päivittää yritystäsi milloin tahansa kirjautumalla Open Food Networkiin ja siirtymällä hallintaan."
+        action: "Siirry yrityksen hallintapaneeliin"
+  back: "Takaisin"
+  continue: "Jatkaa"
+  action_or: "TAI"
+  enterprise_limit: yritys
+  shipping_method_destroy_error: "Kyseistä toimitustapaa ei voida poistaa, koska siihen viittaa tilaus: %{number} ."
+  fees: "Maksut"
+  fee_name: "maksu nimi"
+  fee_owner: "Maksun omistaja"
+  item_cost: "Nimikkeen hinta"
+  bulk: "Irtotavarana"
+  shop_variant_quantity_min: "min"
+  shop_variant_quantity_max: "maks"
+  contact: "Yhteystiedot"
+  follow: "Seuraa"
+  shop_for_products_html: "Osta <span class=\"turquoise\">%{enterprise}</span> -tuotteita osoitteesta:"
+  change_shop: "Vaihda kauppaan:"
+  shop_at: "Osta nyt osoitteesta:"
+  admin_fee: "Hallinnollinen maksu"
+  sales_fee: "Myyntimaksu"
+  packing_fee: "Pakkausmaksu"
+  transport_fee: "Kuljetusmaksu"
+  fundraising_fee: "Varainhankintamaksu"
+  price_graph: "Hintakaavio"
+  included_tax: "Sisältyy veroon"
+  tax: "Verottaa"
+  tax_amount_included: "%{amount} (sisältyy hintaan)"
+  remove_tax: "Poista vero"
+  balance: "Balance"
+  transaction: "Tapahtuma"
+  transaction_date: "Päivämäärä"
+  payment_state: "Maksun tila"
+  shipping_state: "Toimituksen tila"
+  value: "Arvo"
+  balance_due: "Erääntyvä saldo"
+  credit: "Luotto"
+  Paid: "Maksettu"
+  Ready: "Valmis"
+  not_visible: ei näkyvissä
+  you_have_no_orders_yet: "Sinulla ei ole vielä tilauksia"
+  show_only_complete_orders: "Näytä vain täydelliset tilaukset"
+  successfully_created: '%{resource} has been successfully created!'
+  successfully_removed: '%{resource} on poistettu onnistuneesti!'
+  successfully_updated: '%{resource} has been successfully updated!'
+  running_balance: "Juokseva saldo"
+  outstanding_balance: "Maksamaton saldo"
+  admin_enterprise_relationships: "yritys -käyttöoikeudet"
+  admin_enterprise_relationships_everything: "Kaikki"
+  admin_enterprise_relationships_permits: "luvat"
+  admin_enterprise_relationships_seach_placeholder: "Haku"
+  admin_enterprise_relationships_button_create: "Luoda"
+  admin_enterprise_relationships_to: "että"
+  admin_enterprise_groups: "Yritysryhmät"
+  admin_enterprise_groups_name: "nimi"
+  admin_enterprise_groups_owner: "Omistaja"
+  admin_enterprise_groups_on_front_page: "Etusivulla?"
+  admin_enterprise_groups_enterprise: "yritykset"
+  admin_enterprise_groups_data_powertip: "Tästä ryhmästä ensisijainen vastuussa oleva käyttäjä."
+  admin_enterprise_groups_data_powertip_logo: "Tämä on ryhmän logo"
+  admin_enterprise_groups_data_powertip_promo_image: "Tämä kuva näkyy ryhmäprofiilin yläosassa."
+  admin_enterprise_groups_contact_phone_placeholder: "eg. 98 7654 3210"
+  admin_enterprise_groups_contact_address1_placeholder: "eg. 123 High Street"
+  admin_enterprise_groups_contact_city: "lähiö"
+  admin_enterprise_groups_contact_city_placeholder: "eg. Northcote"
+  admin_enterprise_groups_contact_zipcode: "Postinumero"
+  admin_enterprise_groups_contact_zipcode_placeholder: "eg. 3070"
+  admin_enterprise_groups_contact_state_id: "Lääni"
+  admin_enterprise_groups_contact_country_id: "Maa"
+  admin_enterprise_groups_web_twitter: "eg. @the_prof"
+  admin_enterprise_groups_web_website_placeholder: "eg. www.truffles.com"
+  admin_order_cycles: "Ylläpitäjän tilausjaksot"
+  open: "Avata"
+  close: "Lähellä"
+  create: "Luoda"
+  search: "Haku"
+  supplier: "toimittaja"
+  product_name: "tuote nimi"
+  product_description: "tuote kuvaus"
+  permalink: "Pysyvä linkki"
+  shipping_categories: "Toimituskategoriat"
+  units: "yksikkökoko"
+  coordinator: "koordinaattori"
+  distributor: "Jakelija"
+  enterprise_fees: "yritys Maksut"
+  process_my_order: "Käsittele tilaukseni"
+  delivery_instructions: Toimitusohjeet
+  delivery_method: Toimitustapa
+  fee_type: "maksu -tyyppi"
+  tax_category: "Verokategoria"
+  display: "Näyttö"
+  tags: "Tägit"
+  calculator: "Laskin"
+  calculator_values: "Laskimen arvot"
+  calculator_settings_warning: "Jos muutat laskimen tyyppiä, sinun on ensin tallennettava muutokset ennen kuin voit muokata laskimen asetuksia."
+  calculator_preferred_unit_error: "täytyy olla kg tai lb"
+  calculator_preferred_value_error: "Virheellinen syöte. Käytä vain numeroita. Esimerkiksi: 10, 5,5, -20"
+  flat_percent_per_item: "Kiinteä prosenttiosuus (tuotetta kohden)"
+  flat_rate_per_item: "Kiinteä hinta (tuotetta kohden)"
+  flat_rate_per_order: "Kiinteä hinta (tilausta kohden)"
+  flexible_rate: "Joustava hinta"
+  price_sack: "Hintasäkki"
+  new_order_cycles: "Uudet tilaussyklit"
+  new_order_cycle: "Uusi tilaussykli"
+  new_order_cycle_tooltip: "Avoinna myymälä tietyn ajan"
+  select_a_coordinator_for_your_order_cycle: "Valitse tilaussyklillesi koordinaattori"
+  notify_producers: 'Ilmoita tuottajille'
+  edit_order_cycle: "Muokkaa tilaussykliä"
+  roles: "Roolit"
+  update: "päivitä"
+  delete: Poistaa
+  add_producer_property: "Lisää tuottajan ominaisuus"
+  in_progress: "Käynnissä"
+  started_at: "Alkoi klo"
+  queued: "Jonossa"
+  scheduled_for: "Aikataulutettu"
+  customers: "Asiakkaat"
+  please_select_hub: "Valitse keskus"
+  loading_customers: "Asiakkaiden lataaminen"
+  no_customers_found: "Ei asiakkaita löytynyt"
+  go: "Mennä"
+  hub: "keskus"
+  product: "tuote"
+  price: "Hinta"
+  review: "Arvostelu"
+  save_changes: "Tallenna muutokset"
+  order_saved: "Tilaus tallennettu"
+  no_products: Ei tuotteita
+  spree_admin_overview_enterprises_header: "Yritykseni"
+  spree_admin_overview_enterprises_footer: "HALLINNOI YRITYKSIÄNI"
+  spree_admin_enterprises_hubs_name: "nimi"
+  spree_admin_enterprises_create_new: "LUO UUSI"
+  spree_admin_enterprises_shipping_methods: "Toimitustavat"
+  spree_admin_enterprises_fees: "yritys Maksut"
+  spree_admin_enterprises_none_create_a_new_enterprise: "LUO UUSI YRITYS"
+  spree_admin_enterprises_none_text: "Sinulla ei ole vielä yrityksiä"
+  spree_admin_enterprises_showing: "Näytetään %{count} / %{total}"
+  spree_admin_enterprises_producers_manage_products: "HALLINNOI TUOTTEITA"
+  spree_admin_enterprises_create_new_product: "LUO UUSI TUOTE"
+  spree_admin_supplier: toimittaja
+  unit_name: "yksikkö nimi"
+  change_package: "Vaihda pakettia"
+  spree_admin_single_enterprise_hint: "Vihje: Jotta ihmiset löytävät sinut, ota näkyvyys käyttöön kohdassa"
+  spree_admin_eg_pickup_from_school: "esim. &#39;Nouto alakoulusta&#39;"
+  spree_admin_eg_collect_your_order: "esim. &quot;Nouda tilauksesi osoitteesta 123 Imaginary St, Northcote, 3070&quot;"
+  spree_order_availability_error: "Jälleenmyyjä tai tilaussykli ei voi toimittaa ostoskorissasi olevia tuotteita"
+  spree_order_populator_error: "Tuo jakelija tai tilaussykli ei pysty toimittamaan kaikkia ostoskorissasi olevia tuotteita. Valitse toinen."
+  spree_order_cycle_error: "Valitse tilausjakso tälle tilaukselle."
+  spree_order_populator_availability_error: "Tuotetta ei ole saatavilla valitulta jakelijalta tai tilausjaksolta."
+  spree_distributors_error: "Vähintään yksi keskus on valittava"
+  spree_user_enterprise_limit_error: "^ %{email} ei saa omistaa enempää yritykset (raja on %{enterprise_limit} )."
+  spree_variant_product_error: on oltava vähintään yksi variantti
+  your_profil_live: "Profiilisi on julkaistu"
+  see: "Katso"
+  live: "elää"
+  manage: "hallinnoi"
+  resend: "Lähetä uudelleen"
+  add_and_manage_products: "Lisää ja hallinnoi tuotteita"
+  add_and_manage_order_cycles: "Lisää ja hallinnoi tilaussyklejä"
+  manage_order_cycles: "Hallitse tilaussyklejä"
+  manage_products: "Hallinnoi tuotteita"
+  edit_profile_details: "Muokkaa profiilitietoja"
+  edit_profile_details_etc: "Muuta profiilikuvaustasi, kuviasi jne."
+  order_cycle: "tilausjakso"
+  enterprise_relationships: "Yritysoikeudet"
+  first_name_begins_with: "Etunimi alkaa"
+  last_name_begins_with: "Sukunimi alkaa"
+  shipping_method: "Toimitustapa"
+  new_order: "Uusi tilaa"
+  enterprise_tos_link: "Yrityskäyttöehtojen linkki"
+  enterprise_tos_message: "Haluamme työskennellä ihmisten kanssa, jotka jakavat tavoitteemme ja arvomme. Siksi pyydämme uusia yrityksiä hyväksymään sopimuksemme. "
+  enterprise_tos_agree: "Hyväksyn yllä olevat käyttöehdot"
+  tax_settings: "Veroasetukset"
+  products_require_tax_category: "tuotteet vaativat veroluokan"
+  admin_shared_address_1: "Osoite"
+  admin_shared_address_2: "Osoite (jatkuu)"
+  admin_share_city: "Kaupunki"
+  admin_share_zipcode: "Postinumero"
+  admin_share_country: "Maa"
+  admin_share_state: "Lääni"
+  hub_sidebar_hubs: "Keskukset"
+  hub_sidebar_none_available: "Ei saatavilla"
+  hub_sidebar_manage: "hallinnoi"
+  hub_sidebar_at_least: "Vähintään yksi keskus on valittava"
+  hub_sidebar_blue: "sininen"
+  hub_sidebar_red: "punainen"
+  order_cycles_closed_for_hub: "Valitsemasi keskus on tilapäisesti suljettu tilauksilta. Yritä myöhemmin uudelleen."
+  report_customers_distributor: "Jakelija"
+  report_customers_hub: "keskus"
+  report_customers_supplier: "toimittaja"
+  report_customers_cycle: "tilausjakso"
+  report_customers_type: "raportoi raportti tyyppi"
+  report_customers_csv: "Lataa csv-tiedostona"
+  report_customers: asiakas
+  report_producers: "Tuottajat"
+  report_type: "raportoi raportti tyyppi"
+  report_hubs: "Keskukset"
+  report_payment: "maksu -menetelmät"
+  report_distributor: "Jakelija"
+  report_payment_by: 'Maksut tyypin mukaan'
+  report_itemised_payment: 'Eritellyt maksusummat'
+  report_payment_totals: 'Maksujen kokonaissummat'
+  report_all: 'kaikki'
+  report_order_cycle: "tilausjakso"
+  report_hide_columns: Piilotettavat sarakkeet
+  report_columns: Sarakkeet
+  report_enterprises: "yritykset"
+  report_enterprise_fee: "Maksujen nimet"
+  report_users: "Käyttäjät"
+  report_tax_rates: Verokannat
+  report_tax_types: Verotyypit
+  report_filters: Raporttisuodattimet
+  report_print: Tulosta raportti
+  report_render_options: Renderöintiasetukset
+  report_header_ofn_uid: OFN UID
+  report_header_order_cycle: tilausjakso
+  report_header_order_cycle_start_date: OC-aloituspäivämäärä
+  report_header_order_cycle_end_date: OC-päättymispäivä
+  report_header_user: Käyttäjä
+  report_header_email: Sähköposti
+  report_header_status: tila
+  report_header_comments: Kommentit
+  report_header_first_name: Ensimmäinen nimi
+  report_header_last_name: Viimeinen nimi
+  report_header_suburb: lähiö
+  report_header_phone: Puhelin
+  report_header_address: Osoite
+  report_header_billing_address: Laskutusosoite
+  report_header_relationship: Suhde
+  report_header_hub: keskus
+  report_header_hub_address: Keskuksen osoite
+  report_header_to_hub: Keskukseen
+  report_header_hub_code: Keskus-koodi
+  report_header_hub_id: Keskus-tunnus
+  report_header_hub_business_number: "Keskus-yrityksen numero"
+  report_header_hub_external_billing_id: "Keskuksen ulkoisen laskutuksen tunnus"
+  report_header_hub_legal_name: "Keskuksen virallinen nimi"
+  report_header_hub_contact_name: "Keskuksen yhteyshenkilön nimi"
+  report_header_hub_email: "Keskuksen julkinen sähköposti"
+  report_header_hub_contact_email: Keskuksen yhteyshenkilön sähköpostiosoite
+  report_header_hub_owner_email: Keskuksen omistajan sähköpostiosoite
+  report_header_hub_phone: "Keskuksen puhelinnumero"
+  report_header_hub_address_line1: "Keskuksen osoiterivi 1"
+  report_header_hub_address_line2: "Keskuksen osoiterivi 2"
+  report_header_hub_address_city: "Keskuksen lähiö"
+  report_header_hub_address_zipcode: "Keskuksen postinumero"
+  report_header_hub_address_state_name: "Keskuksen lääni"
+  report_header_code: Koodi
+  report_header_paid: Maksettu?
+  report_header_delivery: Toimitus?
+  report_header_shipping: Toimitus
+  report_header_shipping_instructions: Toimitusohjeet
+  report_header_ship_street: Toimituskatu
+  report_header_ship_street_2: Toimituskatu 2
+  report_header_ship_city: Toimituskaupunki
+  report_header_ship_postcode: Toimituksen postinumero
+  report_header_ship_state: Toimitusvaltio
+  report_header_billing_street: Laskutuskatu
+  report_header_billing_street_2: Laskutuskatu 2
+  report_header_billing_street_3: Laskutuskatu 3
+  report_header_billing_street_4: Laskutuskatu 4
+  report_header_billing_city: Laskutuskaupunki
+  report_header_billing_postcode: Laskutuspostinumero
+  report_header_billing_state: Laskutuslääni
+  report_header_incoming_transport: Saapuva kuljetus
+  report_header_special_instructions: Erityisohjeet
+  report_header_order_number: Tilausnumero
+  report_header_date: Päivämäärä
+  report_header_confirmation_date: Vahvistuspäivämäärä
+  report_header_tags: Tägit
+  report_header_items: kohteet
+  report_header_items_total: "Tuotteiden kokonaismäärä %{currency_symbol}"
+  report_header_taxable_items_total: "Verotettavat erät yhteensä ( %{currency_symbol} )"
+  report_header_sales_tax: "Myyntivero ( %{currency_symbol} )"
+  report_header_delivery_charge: "Toimituskulut ( %{currency_symbol} )"
+  report_header_tax: "Verottaa"
+  report_header_tax_on_delivery: "Toimitusvero ( %{currency_symbol} )"
+  report_header_tax_on_fees: "Maksujen vero ( %{currency_symbol} )"
+  report_header_tax_category: "Verokategoria"
+  report_header_tax_rate_name: "Veroprosentin nimi"
+  report_header_tax_rate: "Verokanta"
+  report_header_total_tax: "Vero yhteensä ( %{currency_symbol} )"
+  report_header_total_excl_tax: "yhteensä ilman vero ( %{currency_symbol} )"
+  report_header_total_incl_tax: "yhteensä sis. vero ( %{currency_symbol} )"
+  report_header_total_orders: "Tilausten kokonaismäärä"
+  report_header_enterprise: yritys
+  report_header_enterprise_fee_name: nimi
+  report_header_enterprise_fee_type: Tyyppi
+  report_header_enterprise_fee_owner: Omistaja
+  report_header_customer: asiakas
+  report_header_customer_first_name: Ensimmäinen nimi
+  report_header_customer_last_name: Viimeinen nimi
+  report_header_customer_code: Asiakaskoodi
+  report_header_product: tuote
+  report_header_product_properties: tuote ominaisuudet
+  report_header_product_tax_category: Tuotteen veroluokka
+  report_header_quantity: Määrä
+  report_header_max_quantity: Maksimimäärä
+  report_header_variant: Variantti
+  report_header_variant_unit_name: varianttiyksikkö nimi
+  report_header_variant_value: Variantin arvo
+  report_header_variant_unit: Varianttiyksikkö
+  report_header_total_available: Yhteensä käytettävissä
+  report_header_unallocated: Kohdistamaton
+  report_header_max_quantity_excess: Maksimimäärän ylitys
+  report_header_taxons: Taksonit
+  report_header_supplier: toimittaja
+  report_header_producer: tuottaja
+  report_header_producer_suburb: Tuottajan lähiö
+  report_header_producer_tax_status: Tuottajan verotusasema
+  report_header_producer_charges_sales_tax?: ALV-rekisteröity
+  report_header_producer_abn_acn: Tuottaja ABN/ACN
+  report_header_producer_address: Tuottajan osoite
+  report_header_unit: yksikkö
+  report_header_group_buy_unit_quantity: Ryhmäosto Yksikkömäärä
+  report_header_cost: Maksaa
+  report_header_shipping_cost: Toimituskulut
+  report_header_curr_cost_per_unit: Nykyinen yksikköhinta
+  report_header_total_shipping_cost: Toimituskulut yhteensä
+  report_header_payment_method: Maksutapa
+  report_header_sells: Myy
+  report_header_visible: Näkyvä
+  report_header_price: Hinta
+  report_header_unit_size: yksikkökoko
+  report_header_distributor: Jakelija
+  report_header_distributor_address: Jälleenmyyjän osoite
+  report_header_distributor_city: Jälleenmyyjäkaupunki
+  report_header_distributor_postcode: Jälleenmyyjän postinumero
+  report_header_distributor_tax_status: Jakelijan verotusasema
+  report_header_delivery_address: Toimitusosoite
+  report_header_delivery_postcode: Toimitus Postinumero
+  report_header_bulk_unit_size: Irtotavarayksikön koko
+  report_header_weight: Paino
+  report_header_final_weight_volume: Lopullinen (paino/tilavuus)
+  report_header_height: Korkeus
+  report_header_width: Leveys
+  report_header_depth: Syvyys
+  report_header_sum_total: Yhteensä
+  report_header_date_of_order: Tilauspäivämäärä
+  report_header_amount_owing: Maksun määrä
+  report_header_amount_paid: Maksettu summa
+  report_header_units_required: Vaaditut yksiköt
+  report_header_remainder: Jäännös
+  report_header_order_date: Tilauspäivämäärä
+  report_header_order_id: Tilaustunnus
+  report_header_item_name: Tuotteen nimi
+  report_header_temp_controlled_items: Väliaikaisesti säädellyt tuotteet?
+  report_header_customer_name: Asiakkaan nimi
+  report_header_customer_email: Asiakkaan sähköposti
+  report_header_customer_phone: Asiakkaan puhelinnumero
+  report_header_customer_city: Asiakkaan kaupunki
+  report_header_payment_state: maksu Lääni
+  report_header_payment_type: Maksutyyppi
+  report_header_item_price: "Kohde ( %{currency} )"
+  report_header_item_fees_price: "Tuote + maksut ( %{currency} )"
+  report_header_admin_handling_fees: "Hallinta ja käsittely ( %{currency} )"
+  report_header_ship_price: "Laiva ( %{currency} )"
+  report_header_producer_charges_gst: Veloittaako tuottaja GST:tä?
+  report_header_total_tax_on_product: "Tuotteen kokonaisvero ( %{currency} )"
+  report_header_pay_fee_price: "Maksu ( %{currency} )"
+  report_header_total_price: "Yhteensä ( %{currency} )"
+  report_header_product_total_price: "Tuotteen kokonaishinta ( %{currency} )"
+  report_header_shipping_total_price: "Toimituskulut yhteensä ( %{currency} )"
+  report_header_outstanding_balance_price: "Maksamatta oleva saldo ( %{currency} )"
+  report_header_eft_price: "Sähköinen varainsiirto ( %{currency} )"
+  report_header_paypal_price: "PayPal ( %{currency} )"
+  report_header_sku: SKU
+  report_header_amount: Määrä
+  report_header_balance: Saldo
+  report_header_total_cost: "Kokonaiskustannukset"
+  report_header_total_ordered: Yhteensä tilattu
+  report_header_total_max: Kokonaismaks.
+  report_header_total_units: Yksiköiden kokonaismäärä
+  report_header_sum_max_total: "Yhteensä enintään"
+  report_header_total_excl_vat: "yhteensä ilman vero ( %{currency_symbol} )"
+  report_header_total_fees_excl_tax: "Kokonaismaksut ilman veroja ( %{currency_symbol} )"
+  report_header_total_tax_on_fees: "Maksujen kokonaisvero ( %{currency_symbol} )"
+  report_header_total: "Yhteensä ( %{currency_symbol} )"
+  report_header_total_incl_vat: "yhteensä sis. vero ( %{currency_symbol} )"
+  report_header_total_excl_fees_and_tax: "Yhteensä ilman maksuja ja veroja ( %{currency_symbol} )"
+  report_header_temp_controlled: Lämpötilaohjattu?
+  report_header_shipment_state: "Toimituksen tila"
+  report_header_shipping_method: "Toimitustapa"
+  report_header_is_producer: tuottaja ?
+  report_header_not_confirmed: Ei vahvistettu
+  report_header_gst_on_income: GST tuloista
+  report_header_gst_free_income: ALV-vapaat tulot
+  report_header_total_untaxable_produce: Verottoman tuotannon kokonaismäärä (ei veroa)
+  report_header_total_taxable_produce: Verotettavan tuotannon kokonaismäärä (sisältää verot)
+  report_header_total_untaxable_fees: Verottomat maksut yhteensä (ei veroa)
+  report_header_total_taxable_fees: Verotettavat maksut yhteensä (sisältäen verot)
+  report_header_delivery_shipping_cost: Toimituskulut (sisältää verot)
+  report_header_transaction_fee: Transaktiomaksu (ei veroa)
+  report_header_total_untaxable_admin: Veroa vailla olevat hallinnolliset oikaisut yhteensä (ei veroa)
+  report_header_total_taxable_admin: Verotettavat hallinnolliset oikaisut yhteensä (sisältäen verot)
+  report_header_voucher_label: Kupongin otsikko
+  report_header_voucher_amount: "Kupongin määrä ( %{currency_symbol} )"
+  report_line_cost_of_produce: Tuotantokustannukset
+  report_line_line_items: rivikohdat
+  report_header_last_completed_order_date: Viimeisin tilauksen valmistumispäivämäärä
+  report_xero_configuration: Xero-konfiguraatio
+  initial_invoice_number: "Alkuperäinen laskun numero"
+  invoice_date: "Laskun päivämäärä"
+  due_date: "Eräpäivä"
+  account_code: "Tilikoodi"
+  equals: "Yhtä suuri kuin"
+  contains: "sisältää"
+  discount: "Alennus"
+  filter_products: "Suodata tuotteita"
+  delete_product_variant: "Viimeistä varianttia ei voi poistaa!"
+  progress: "edistyminen"
+  saving: "Tallennetaan.."
+  success: "menestys"
+  failure: "epäonnistuminen"
+  unsaved_changes_confirmation: "Tallentamattomat muutokset menetetään. Jatketaanko silti?"
+  one_product_unsaved: "Yhden tuotteen muutoksia ei tallenneta."
+  products_unsaved: "Muutoksia %{n} tuotteisiin ei tallenneta."
+  is_already_manager: "on jo esimies!"
+  no_change_to_save: " Ei tallennettavaa muutosta"
+  user_invited: "%{email} on kutsuttu hallinnoimaan tätä yritystä"
+  add_manager: "Lisää olemassa oleva käyttäjä"
+  users: "Käyttäjät"
+  about: "about"
+  images: "Kuvat"
+  web: "Verkko"
+  primary_details: "Ensisijaiset tiedot"
+  social: "Sosiaalinen"
+  shipping: "Toimitus"
+  shipping_methods: "Toimitustavat"
+  payment_methods: "maksu -menetelmät"
+  payment_method_fee: "Transaktiomaksu"
+  payment_processing_failed: "Payment could not be processed, please check the details you entered"
+  payment_method_not_supported: "Maksutapaa ei tueta. Valitse toinen."
+  payment_updated: "Maksu päivitetty"
+  cannot_perform_operation: "Maksua ei voitu päivittää"
+  action_required: "Toimenpide vaaditaan"
+  tag_rules: "Tägisäännöt"
+  enterprise_fee_whole_order: Koko tilaus
+  enterprise_fee_by_name: "%{name} maksu %{role} %{enterprise_name}"
+  validation_msg_relationship_already_established: "^Se suhde on jo vakiintunut."
+  validation_msg_at_least_one_hub: "^Ainakin yksi keskitin on valittava"
+  validation_msg_tax_category_cant_be_blank: "^Verokategoria ei voi olla tyhjä"
+  validation_msg_is_associated_with_an_exising_customer: "on liitetty olemassa olevaan asiakkaaseen"
+  content_configuration_pricing_table: "(TODO: Hinnasto)"
+  content_configuration_case_studies: "(TODO: Tapaustutkimukset)"
+  content_configuration_detail: "(TODO: Yksityiskohtainen)"
+  enterprise_name_error: "on jo varattu. Jos tämä on yrityksesi ja haluat vaatia omistajuutta tai jos haluat käydä kauppaa tämän yrityksen kanssa, ota yhteyttä profiilin nykyiseen ylläpitäjään osoitteessa %{email} ."
+  enterprise_owner_error: "^ %{email} ei saa omistaa enempää yritykset (raja on %{enterprise_limit} )."
+  enterprise_role_uniqueness_error: "^Se rooli on jo olemassa."
+  enterprise_terms_and_conditions_type_error: "Vain PDF-tiedostot sallitaan"
+  inventory_item_visibility_error: täytyy olla totta tai tarua
+  product_importer_file_error: "virhe : tiedostoa ei ladattu"
+  product_importer_spreadsheet_error: "tiedostoa ei voitu käsitellä: virheellinen tiedostotyyppi"
+  product_importer_products_save_error: did not save any products successfully
+  product_import_file_not_found_notice: 'Tiedostoa ei löytynyt tai sitä ei voitu avata'
+  product_import_no_data_in_spreadsheet_notice: 'Laskentataulukosta ei löytynyt tietoja'
+  order_choosing_hub_notice: Keskittimesi on valittu.
+  order_cycle_selecting_notice: Tilausjaksosi on valittu.
+  adjustments_tax_rate_error: "^Tarkista, että tämän oikaisun veroprosentti on oikea."
+  active_distributors_not_ready_for_checkout_message_singular: >-
+      Hub %{distributor_names} on aktiivisessa tilaussyklissä, mutta sillä ei ole
+      voimassa olevia toimitus- ja maksutapoja. Asiakkaat eivät voi tehdä ostoksia
+      tässä hubissa, ennen kuin määrität nämä.
+  active_distributors_not_ready_for_checkout_message_plural: >-
+      Hubit %{distributor_names} on listattu aktiivisessa tilaussyklissä, mutta niillä
+      ei ole voimassa olevia toimitus- ja maksutapoja. Asiakkaat eivät voi tehdä ostoksia
+      näissä hubeissa, ennen kuin määrität nämä.
+  enterprise_fees_update_notice: Yritysmaksusi on päivitetty.
+  enterprise_register_package_error: "Valitse paketti"
+  enterprise_register_error: "Rekisteröintiä %{enterprise} sivustolle ei voitu suorittaa loppuun."
+  enterprise_register_success_notice: "Onnittelut! Rekisteröinti %{enterprise} -sivustolle on valmis!"
+  enterprise_bulk_update_success_notice: "Yritykset päivitetty onnistuneesti"
+  enterprise_bulk_update_error: 'Päivitys epäonnistui'
+  enterprise_shop_show_error: "Etsimääsi kauppaa ei ole olemassa tai se ei ole aktiivinen OFN:ssä. Tarkista muut kaupat."
+  order_cycles_bulk_update_notice: 'Tilaussyklit on päivitetty.'
+  order_cycles_no_permission_to_coordinate_error: "Yhdelläkään yritykselläsi ei ole lupaa koordinoida tilauskiertoa."
+  order_cycles_no_permission_to_create_error: "Sinulla ei ole oikeutta luoda kyseisen yrityksen koordinoimaa tilaussykliä."
+  order_cycle_closed: "Valitsemasi tilausjakso on juuri päättynyt. Yritä uudelleen!"
+  back_to_orders_list: "Takaisin tilauslistaan"
+  no_orders_found: "Ei tilaukset löytynyt"
+  order_information: "Tilaustiedot"
+  new_payment: "Uusi maksu"
+  create_or_update_invoice: "Luo tai päivitä lasku"
+  date_completed: "Valmistumispäivämäärä"
+  amount: "Määrä"
+  invoice_number: "lasku -numero"
+  invoice_file: "Tiedosto"
+  invalid_url: "&#39; %{url} &#39; on virheellinen URL-osoite"
+  state_names:
+    ready: Valmis
+    pending: Odottaa
+    shipped: Lähetetty
+  business_name: Yrityksen nimi
+  js:
+    saving: 'Tallennetaan...'
+    changes_saved: 'Muutokset tallennettu.'
+    authorising: "Valtuutetaan..."
+    save_changes_first: Tallenna muutokset ensin.
+    all_changes_saved: Kaikki muutokset tallennettu
+    unsaved_changes: Sinulla on tallentamattomia muutoksia
+    all_changes_saved_successfully: Kaikki muutokset tallennettu onnistuneesti
+    oh_no: "Voi ei! En pystynyt tallenna muutoksiasi."
+    unauthorized: "Sinulla ei ole oikeutta käyttää tätä sivua."
+    error: virhe
+    unavailable: Ei saatavilla
+    profile: Profiili
+    hub: keskus
+    shop: kauppa
+    choose: Valita
+    resolve_errors: Korjaa seuraavat virheet
+    more_items: "+ %{count} Lisää"
+    default_card_updated: Oletuskortti päivitetty
+    default_card_voids_auth: Oletuskortin vaihtaminen poistaa kauppojen olemassa olevat veloitusvaltuutukset. Voit valtuuttaa kauppoja uudelleen oletuskortin päivittämisen jälkeen. Haluatko vaihtaa oletuskortin?
+    cart:
+      add_to_cart_failed: >
+          Tuotteen lisäämisessä ostoskoriin tapahtui ongelma. Se ei ehkä ole enää
+          saatavilla tai kauppa on sulkemassa ovensa.
+    admin:
+      unit_price_tooltip: "yksikköhinta lisää läpinäkyvyyttä mahdollistamalla asiakkaillesi helpon hintavertailun eri tuotteiden ja pakkauskokojen välillä. Huomaa, että myymälä näkyvä lopullinen yksikköhinta voi poiketa aiemmista, koska se sisältää verot ja Maksut ."
+      enterprise_limit_reached: "Olet saavuttanut yritystilin vakiomäärän. Lähetä osoitteeseen %{contact_email} , jos sinun on korotettava sitä."
+      deleting_item_will_cancel_order: "Tämä toiminto johtaa yhteen tai useampaan tyhjään tilaukseen, jotka peruutetaan. Haluatko jatkaa?"
+      modals:
+        got_it: "Selvä"
+        confirm: "Vahvistaa"
+        close: "Lähellä"
+        continue: "Jatkaa"
+        cancel: "Peruuttaa"
+        invite: "Kutsu"
+        invite_title: "Kutsu rekisteröitymätön käyttäjä"
+        tag_rule_help:
+          title: Tägisäännöt
+          overview: Yleiskatsaus
+          overview_text: >
+              Tagisäännöt tarjoavat tavan kuvata, mitkä tuotteet ovat näkyvissä ja
+              mitkä eivät ole näkyvissä millekin asiakkaille. Tuotteet voivat olla
+              toimitustapoja, maksutapoja, tuotteita ja tilaussyklejä.
+          by_default_rules: "&#39;Oletusarvoisesti...&#39; -säännöt"
+          by_default_rules_text: >
+              Oletussääntöjen avulla voit piilottaa kohteita, jotta ne eivät ole oletusarvoisesti
+              näkyvissä. Tämän toiminnan voi sitten ohittaa muilla kuin oletusarvoisilla
+              säännöillä asiakkaille, joilla on tietyt tunnisteet.
+          customer_tagged_rules: "&#39;Asiakkaat merkitty tägillä...&#39; -säännöt"
+          customer_tagged_rules_text: >
+              Luomalla tiettyyn asiakastunnisteeseen liittyviä sääntöjä voit ohittaa
+              oletustoiminnon (olipa kyseessä sitten tuotteiden näyttäminen tai piilottaminen)
+              asiakkaille, joilla on määritetty tunniste.
+        terms_and_conditions_info:
+          title: "Ehdot lataaminen"
+          message_1: "Ehdot ovat sopimus sinun, myyjän ja ostajan välillä. Jos lataat tiedoston tänne, ostajien on hyväksyttävä käyttöehtosi voidakseen suorittaa maksun loppuun. Ostajalle tämä näkyy kassalla valintaruutuna, joka on valittava, jotta maksua voidaan jatkaa. Suosittelemme, että lataat käyttöehdot kansallisen lainsäädännön mukaisesti."
+          message_2: "Ostajien tarvitsee hyväksyä käyttöehdot vain kerran. Jos kuitenkin muutat käyttöehtoja, ostajien on hyväksyttävä ne uudelleen ennen kuin he voivat siirtyä kassalle."
+        terms_and_conditions_warning:
+          title: "Ehdot lataaminen"
+          message_1: "Kaikkien ostajiesi on hyväksyttävä ne kerran kassalla. Jos päivität tiedostoa, kaikkien ostajiesi on hyväksyttävä ne uudelleen kassalla."
+          message_2: "Tilauksen tehneiden ostajien on lähetettävä heille sähköpostitse käyttöehdot (tai niiden muutokset) toistaiseksi. Heille ei ilmoiteta näistä uusista käyttöehdoista."
+        business_address_info:
+          message: "Yrityksen laillista nimeä, laillista osoitetta ja laillista puhelinnumeroa käytetään yrityksille, jotka laskuttavat oikeushenkilöltä, jonka tiedot poikkeavat niiden julkisista kauppatiedoista. Näitä tietoja käytetään VAIN laskuissa. Jos nämä tiedot ovat tyhjiä, laskuissa käytetään julkista nimeäsi, osoitettasi ja puhelinnumeroasi."
+      panels:
+        save: tallenna
+        saved: TALLENNETTU
+        saving: SÄÄSTÖ
+        enterprise_package:
+          hub_profile: Hub-profiili
+          hub_profile_cost: "HINTA: AINA ILMAINEN"
+          hub_profile_text1: >
+              Ihmiset voivat löytää sinut ja ottaa sinuun yhteyttä Open Food Networkin
+              kautta. Yrityksesi näkyy kartalla ja on haettavissa listauksissa.
+          hub_profile_text2: >
+              Profiilin luominen ja yhteyksien luominen paikalliseen ruokajärjestelmään
+              Open Food Networkin kautta on aina ilmaista.
+          hub_shop: keskus kauppa
+          hub_shop_text1: >
+              Yrityksesi on paikallisen ruokajärjestelmäsi selkäranka. Kokoat tuotteita
+              muilta yrityksiltä ja voit myydä niitä Open Food Network -kauppasi kautta.
+          hub_shop_text2: >
+              Keskukset voivat olla monenlaisia, olipa kyseessä sitten ruokaosuuskunta,
+              ostoryhmä, kasvisruokaohjelma tai paikallinen ruokakauppa.
+          hub_shop_text3: >
+              Jos haluat myös myydä omia tuotteitasi, sinun on muutettava tämä yritys
+              tuottajaksi.
+          choose_package: Valitse paketti
+          choose_package_text1: >
+              Yritystäsi ei aktivoida täysin, ennen kuin olet valinnut paketin vasemmalla
+              olevista vaihtoehdoista.
+          choose_package_text2: >
+              Napsauta vaihtoehtoa nähdäksesi lisätietoja kustakin paketista ja paina
+              punaista TALLENNA-painiketta, kun olet valmis!
+          profile_only: Vain profiili
+          profile_only_cost: "HINTA: AINA ILMAINEN"
+          profile_only_text1: >
+              Profiili tekee sinusta näkyvän ja tavoitettavan muille ja on tapa jakaa
+              tarinasi.
+          profile_only_text2: >
+              Jos haluat keskittyä ruoan tuotantoon ja jättää sen myymisen jonkun
+              muun tehtäväksi, et tarvitse Open Food Network -kauppaa.
+          profile_only_text3: >
+              Lisää tuotteesi Open Food Networkiin, jolloin keskukset voivat varastoida
+              tuotteitasi myymälöissään.
+          producer_shop: tuottaja kauppa
+          producer_shop_text1: >
+              Myy tuotteitasi suoraan asiakkaille oman Open Food Network -myymäläsi
+              kautta.
+          producer_shop_text2: >
+              Tuottajakauppa on tarkoitettu vain omille tuotteillesi. Jos haluat myydä
+              muualla kasvatettuja/tuotettuja tuotteita, valitse &#39;Tuottajakeskus&#39;.
+          producer_hub: tuottaja keskus
+          producer_hub_text1: >
+              Yrityksesi on paikallisen ruokajärjestelmäsi selkäranka. Voit myydä
+              omia tuotteitasi sekä muiden yritysten tuotteita Open Food Network -myymäläsi
+              kautta.
+          producer_hub_text2: >
+              Tuottajakeskukset voivat olla monenlaisia, olipa kyseessä sitten yhteisötuottajajärjestö,
+              kasvisruokailuohjelma tai kattopuutarhan sisältävä ruokaosuuskunta.
+          producer_hub_text3: >
+              Open Food Network pyrkii tukemaan mahdollisimman montaa keskusmallia,
+              joten tilanteestasi riippumatta haluamme tarjota sinulle tarvittavat
+              työkalut organisaatiosi tai paikallisen ruokayrityksesi pyörittämiseen.
+          get_listing: Hanki listaus
+          always_free: AINA ILMAINEN
+          sell_produce_others: Myy muiden tuotteita
+          sell_own_produce: Myy omia tuotteitasi
+          sell_both: Myy itse ja muiden tuottamia tuotteita
+        enterprise_producer:
+          producer: tuottaja
+          producer_text1: >
+              Tuottajat tekevät herkullisia syötäviä tai juotavia asioita. Olet tuottaja,
+              jos kasvatat, kannattelet, haudutat, leivot, käyt, lypsät tai muovaat
+              sitä.
+          producer_text2: >
+              Tuottajat voivat suorittaa myös muita toimintoja, kuten koota ruokaa
+              muilta yrityksiltä ja myydä sitä Open Food Network -verkoston myymälän
+              kautta.
+          non_producer: Ei-tuottaja
+          non_producer_text1: >
+              Ei-tuottajat eivät itse tuota ruokaa, mikä tarkoittaa, että he eivät
+              voi luoda omia tuotteitaan myytäväksi Open Food Networkin kautta.
+          non_producer_text2: >
+              Sen sijaan ei-tuottajat ovat erikoistuneet yhdistämään tuottajat loppukäyttäjään,
+              olipa kyse sitten elintarvikkeiden kokoamisesta, luokittelusta, pakkaamisesta,
+              myymisestä tai toimittamisesta.
+          producer_desc: Elintarvikkeiden tuottajat
+          producer_example: esim. VILJELIJÄT, LEIPURIT, PANIMOT, VALMISTAJAT
+          non_producer_desc: Kaikki muut elintarvikeyritykset
+          non_producer_example: esim. ruokakaupat, ruokaosuuskunnat, ostoryhmät
+        enterprise_status:
+          status_title: "%{name} on asennettu ja käyttövalmis!"
+          severity: Vakavuusaste
+          description: Kuvaus
+          resolve: Ratkaista
+        exchange_products:
+          load_more_variants: "Lataa lisää variantteja"
+          load_all_variants: "Lataa kaikki variantit"
+          select_all_variants: "Valitse kaikki %{total_number_of_variants} -muunnelmat"
+          variants_loaded: "%{num_of_variants_loaded} / %{total_number_of_variants} Ladatut variantit"
+          loading_variants: "Varianttien lataaminen"
+          no_variants: "Tälle tuotteelle ei ole saatavilla versioita (piilotettu varastoasetuksissa)."
+          some_variants_hidden: "(Jotkin versiot saattavat olla piilotettuja varastoasetusten kautta)"
+      tag_rules:
+        shipping_method_tagged_top: "Toimitustavat merkitty tägillä"
+        shipping_method_tagged_bottom: "ovat:"
+        payment_method_tagged_top: "Maksutavat merkitty tägillä"
+        payment_method_tagged_bottom: "ovat:"
+        order_cycle_tagged_top: "Tilaussyklit merkitty tägillä"
+        order_cycle_tagged_bottom: "ovat:"
+        inventory_tagged_top: "Tägätyt varastomuunnelmat"
+        inventory_tagged_bottom: "ovat:"
+      new_tag_rule_dialog:
+        select_rule_type: "Valitse säännön tyyppi:"
+        add_rule: "Lisää sääntö"
+      enterprise_fees:
+        inherit_from_product: "Periytyy tuotteesta"
+      orders:
+        index:
+          per_page: "%{results} sivua kohden"
+          view_file: "Näytä tiedosto"
+          compiling_invoices: "Laskujen laatiminen"
+          bulk_invoice_created: "Joukkolasku luotu"
+          bulk_invoice_failed: "Joukkolaskun luominen epäonnistui"
+          please_wait: "Odota, kunnes PDF-tiedosto on valmis, ennen kuin suljet tämän ikkunan."
+        order_state:
+          address: "osoite"
+          adjustments: "säädöt"
+          awaiting_return: "odottaa paluuta"
+          canceled: "peruttu"
+          cart: "ostoskori"
+          complete: "täydellinen"
+          confirm: "vahvistaa"
+          delivery: "toimitus"
+          paused: "keskeytetty"
+          payment: "maksu"
+          pending: "vireillä"
+          resumed: "jatkui"
+          returned: "palasi"
+          confirmation: "vahvistus"
+        shipment_states:
+          backorder: "jälkitoimitus"
+          partial: "osittainen"
+          pending: "vireillä"
+          ready: "valmis"
+          shipped: "lähetetty"
+          canceled: "peruttu"
+        payment_states:
+          balance_due: "Saldo erääntyy"
+          completed: "valmistunut"
+          checkout: "mene kassalle"
+          credit_owed: "luottovelka"
+          failed: "epäonnistui"
+          paid: "maksettu"
+          pending: "vireillä"
+          requires_authorization: "valtuutus vaaditaan"
+          processing: "käsittely"
+          void: "tyhjä"
+          invalid: "virheellinen"
+        quantity_unavailable: "Varastossa ei ole riittävästi varastoa. Rivikohtaa ei tallennettu!"
+        quantity_unchanged: "Määrä ei muuttunut edellisestä."
+        cancel_the_order_html: "Tämä peruu nykyisen tilauksen.<br /> Oletko varma, että haluat jatkaa?"
+        cancel_the_order_send_cancelation_email: "Lähetä peruutusviesti asiakkaalle"
+        restock_item: "Lisää varastoon: palauta tämä tuote varastoon"
+        restock_items: "Lisää varastoon: palauta kaikki tuotteet varastoon"
+        delete_line_items_html:
+          one: "Tämä poistaa yhden rivikohdan tilauksesta.<br /> Oletko varma, että haluat jatkaa?"
+          other: "Tämä poistaa tilauksesta rivikohdat %{count} .<br /> Oletko varma, että haluat jatkaa?"
+      resend_user_email_confirmation:
+        resend: "Lähetä uudelleen"
+        sending: "Lähetä uudelleen..."
+        done: "Uudelleenlähetys tehty ✓"
+        failed: "Uudelleenlähetys epäonnistui ✗"
+      order_cycles:
+        schedules:
+          adding_a_new_schedule: "Uuden aikataulun lisääminen"
+          updating_a_schedule: "Aikataulun päivittäminen"
+          create_schedule: "Luo aikataulu"
+          update_schedule: "Päivitysaikataulu"
+          delete_schedule: "Poista aikataulu"
+          schedule_name_placeholder: "Aikataulun nimi"
+          created_schedule: "Aikataulu luotu"
+          updated_schedule: "Päivitetty aikataulu"
+          deleted_schedule: "Poistettu aikataulu"
+          name_required_error: "Anna tälle aikataululle nimi"
+          no_order_cycles_error: "Valitse vähintään yksi tilausjakso (vedä ja pudota)"
+          available: "Saatavilla"
+          selected: "Valittu"
+      customers:
+        index:
+          add_customer: "Lisää asiakas"
+          add_a_new_customer_for: "Lisää uusi asiakas osoitteeseen %{shop_name}"
+          customer_placeholder: "customer@example.org"
+          valid_email_error: "Anna kelvollinen sähköpostiosoite"
+      subscriptions:
+        error_saving: "Virhe tilauksen tallentamisessa"
+        new:
+          please_select_a_shop: "Valitse myymälä"
+      enterprises:
+        form:
+          images:
+            immediate_terms_and_conditions_removal_warning: "Käyttöehtojen tiedosto poistetaan heti vahvistuksesi jälkeen."
+            removed_terms_and_conditions_successfully: "Käyttöehtotiedosto poistettu onnistuneesti"
+    insufficient_stock: "Riittämätön varastossa, jäljellä vain %{on_hand}"
+    out_of_stock:
+      reduced_stock_available: Alennettu varasto saatavilla
+      out_of_stock_text: >
+          Ostoskorisi yhden tai useamman tuotteen varastotasot ovat laskeneet ostosten
+          teon aikana. Tässä on muutoksia:
+      now_out_of_stock: on nyt loppu varastosta.
+      only_n_remaining: "jäljellä on enää %{num} ."
+    shopfront:
+      variant:
+        add_to_cart: "lisää"
+        in_cart: "ostoskorissa"
+        quantity_in_cart: "%{quantity} ostoskorissa"
+        remaining_in_stock: "Vain %{quantity} jäljellä"
+      bulk_buy_modal:
+        min_quantity: "Minimimäärä"
+        max_quantity: "Maksimimäärä"
+      price_breakdown: "Hintaerittely"
+      unit_price_tooltip: "Tämä on tuotteen yksikköhinta. Sen avulla voit vertailla tuotteiden hintoja pakkauskoosta ja -painosta riippumatta."
+    variants:
+      on_demand:
+        'yes': "Pyynnöstä"
+    variant_overrides:
+      on_demand:
+        use_producer_settings: "Käytä tuottajan osakeasetuksia"
+        'yes': "Kyllä"
+        'no': "Ei"
+      inventory_products: "Varastotuotteet"
+      hidden_products: "Piilotetut tuotteet"
+      new_products: "Uudet tuotteet"
+      reset_stock_levels: Palauta varastotasot oletusarvoihin
+      changes_to: Muutokset
+      one_override: yksi ohitus
+      overrides: ohitukset
+      remain_unsaved: jäävät tallentamatta.
+      no_changes_to_save: Ei tallennettavia muutoksia.
+      no_authorisation: "En saanut lupaa tallentaa noita muutoksia, joten ne pysyvät tallentamattomina."
+      some_trouble: "Minulla oli hieman ongelmia tallentaessani: %{errors}"
+      changing_on_hand_stock: Varastotilanteen muutos...
+      stock_reset: Osakkeet palautettu oletusarvoihin.
+    tag_rules:
+      show_hide_variants: 'Näytä tai piilota versiot verkkokaupassani'
+      show_hide_shipping: 'Näytä tai piilota toimitustavat kassalla'
+      show_hide_payment: 'Näytä tai piilota maksutavat kassalla'
+      show_hide_order_cycles: 'Näytä tai piilota tilaussyklit verkkokaupassani'
+      visible: NÄKYVÄ
+      not_visible: EI NÄKYVÄ
+    services:
+      unsaved_changes_message: Tallentamattomia muutoksia on tällä hetkellä olemassa. Tallenna nyt vai jätä se huomiotta?
+      save: tallenna
+      ignore: SIVUUTTAA
+      add_to_order_cycle: "lisää tilausjaksoon"
+      manage_products: "hallita tuotteita"
+      edit_profile: "muokkaa profiilia"
+      add_products_to_inventory: "lisää tuotteita varastoon"
+    resources:
+      could_not_delete_customer: 'Asiakasta ei voitu poistaa'
+    product_import:
+      confirmation: |
+          Tämä asettaa kaikkien tämän tuotteen varastotason nollaan.
+          yritys, joita ei ole ladatussa tiedostossa.
+    order_cycles:
+      unsaved_changes: "Sinulla on tallentamattomia muutoksia"
+      bulk_save_error: "Voi ei! En voinut tallentaa muutoksiasi."
+      create_failure: "Tilaussyklin luominen epäonnistui"
+      update_success: 'tilausjakso on päivitetty.'
+      update_failure: "Tilausjakson päivittäminen epäonnistui"
+      no_distributors: Tässä tilausjaksossa ei ole jakelijoita. Tämä tilausjakso ei ole näkyvissä asiakkaille, ennen kuin lisäät sellaisen. Haluatko jatkaa tämän tilausjakson tallentamista?
+    enterprises:
+      producer: "tuottaja"
+      non_producer: "Ei-tuottaja"
+    customers:
+      select_shop: 'Valitse ensin myymälä'
+      could_not_create: Pahoittelut! Luonti epäonnistui.
+    subscriptions:
+      closes: sulkeutuu
+      closed: suljettu
+      close_date_not_set: Sulkemispäivämäärää ei ole asetettu
+    spree:
+      users:
+        order: "tilaa"
+    registration:
+      welcome_to_ofn: "Tervetuloa Open Food Networkiin!"
+      signup_or_login: "Aloita rekisteröitymällä (tai kirjautumalla sisään)"
+      have_an_account: "Onko sinulla jo tili?"
+      action_login: "Kirjaudu sisään nyt."
+    stripe_elements:
+      unknown_error_from_stripe: |
+          Korttisi asettamisessa maksuyhdyskäytäväämme tapahtui ongelma.
+          Päivitä sivu ja yritä uudelleen. Jos se epäonnistuu toisen kerran,
+          ota meihin yhteyttä tukea varten.
+    trix:
+      bold: "Lihavoitu"
+      bullets: "Pisteet"
+      code: "Koodi"
+      heading1: "Otsikko"
+      hr: "Vaakasuora viiva"
+      indent: "Nosta tasoa"
+      italic: "Kursiivi"
+      link: "Linkki"
+      numbers: "Numerot"
+      outdent: "Alenna tasoa"
+      quote: "Lainata"
+      redo: "Tee uudelleen"
+      strike: "Yliviivaus"
+      undo: "Kumoa"
+      unlink: "Irrota linkitys"
+      url: "URL-osoite"
+      urlPlaceholder: "Anna lisättävä URL-osoite"
+  inflections:
+    each:
+      one: "jokainen"
+      other: "jokainen"
+    bunch:
+      one: "nippu"
+      other: "rypäleet"
+    pack:
+      one: "pakata"
+      other: "pakkaukset"
+    box:
+      one: "laatikko"
+      other: "laatikot"
+    bottle:
+      one: "pullo"
+      other: "pullot"
+    jar:
+      one: "purkki"
+      other: "purkit"
+    head:
+      one: "pää"
+      other: "päät"
+    bag:
+      one: "laukku"
+      other: "laukut"
+    loaf:
+      one: "leipä"
+      other: "leivät"
+    single:
+      one: "yksittäinen"
+      other: "sinkkuja"
+    tub:
+      one: "kylpyamme"
+      other: "ammeet"
+    punnet:
+      one: "rasia"
+      other: "rasiat"
+    packet:
+      one: "paketti"
+      other: "paketteja"
+    item:
+      one: "item"
+      other: "items"
+    dozen:
+      one: "tusina"
+      other: "kymmeniä"
+    unit:
+      one: "yksikkö"
+      other: "yksiköitä"
+    serve:
+      one: "palvella"
+      other: "palvelee"
+    tray:
+      one: "tarjotin"
+      other: "tarjottimia"
+    piece:
+      one: "pala"
+      other: "palasia"
+    pot:
+      one: "ruukku"
+      other: "ruukut"
+    flask:
+      one: "pullo"
+      other: "pullot"
+    basket:
+      one: "kori"
+      other: "korit"
+    sack:
+      one: "säkki"
+      other: "säkit"
+    bucket:
+      one: "ämpäri"
+      other: "ämpärit"
+    pail:
+      one: sanko
+      other: ämpärit
+    stem:
+      one: "varsi"
+      other: "varret"
+    plug:
+      one: "pistoke"
+      other: "pistokkeet"
+    plant:
+      one: "kasvi"
+      other: "kasvit"
+    bundle:
+      one: "nippu"
+      other: "niput"
+    bulb:
+      one: "lamppu"
+      other: "sipulit"
+    root:
+      one: "juuri"
+      other: "juuret"
+    tuber:
+      one: "mukula"
+      other: "mukulat"
+    corm:
+      one: "varsimukula"
+      other: "mukulat"
+    crate:
+      one: "laatikko"
+      other: "laatikot"
+  producers:
+    signup:
+      start_free_profile: "Aloita ilmaisella profiililla ja laajenna sitä, kun olet valmis!"
+  order_management:
+    reports:
+      bulk_coop:
+        filters:
+          bulk_coop_allocation: "Osuuskunta-alueiden joukkoallokaatio"
+          bulk_coop_customer_payments: "Osuuskaupan asiakkaiden joukkomaksut"
+          bulk_coop_packing_sheets: "Osuuskaupan pakkausarkit irtotavarana"
+          bulk_coop_supplier_report: "Osuuskaupan toimittajien raportti"
+      enterprise_fee_summaries:
+        filters:
+          date_range: "Ajanjakso"
+          report_format_csv: "Lataa CSV-tiedostona"
+          generate_report: "Luo raportti"
+        report:
+          none: "Ei mitään"
+          select_and_search: "Valitse suodattimet ja napsauta LUO RAPORTTI nähdäksesi tietosi."
+      enterprise_fee_summary:
+        date_end_before_start_error: "täytyy olla aloituksen jälkeen"
+        parameter_not_allowed_error: "Sinulla ei ole oikeutta käyttää yhtä tai useampaa valittua suodatinta tässä raportissa."
+        fee_calculated_on_transfer_through_all: "Kaikki"
+        fee_calculated_on_transfer_through_entire_orders: "Kokonaiset tilaukset %{distributor} n kautta"
+        tax_category_various: "Eri"
+        fee_type:
+          payment_method: "Maksutapahtuma"
+          shipping_method: "Toimitus"
+        fee_placements:
+          supplier: "Saapuvat"
+          distributor: "Lähtevä"
+          coordinator: "koordinaattori"
+        tax_category_name:
+          shipping_instance_rate: "Alustan hinta"
+        formats:
+          csv:
+            header:
+              fee_type: "maksu -tyyppi"
+              enterprise_name: "yritys"
+              fee_name: "maksu nimi"
+              customer_name: "asiakas"
+              fee_placement: "maksu sijoittelu"
+              fee_calculated_on_transfer_through_name: "maksu Calc siirrosta"
+              tax_category_name: "Verokategoria"
+              total_amount: "$$ SUMMA"
+          html:
+            header:
+              fee_type: "maksu -tyyppi"
+              enterprise_name: "yritys"
+              fee_name: "maksu nimi"
+              customer_name: "asiakas"
+              fee_placement: "maksu sijoittelu"
+              fee_calculated_on_transfer_through_name: "maksu Calc siirrosta"
+              tax_category_name: "Verokategoria"
+              total_amount: "$$ SUMMA"
+        invalid_filter_parameters: "Tälle raportille valitsemasi suodattimet ovat virheellisiä."
+      report:
+        none: "Ei mitään"
+  order: "tilaa"
+  order_details: "Tilauksen tiedot"
+  customer_details: "asiakas -tiedot"
+  adjustments: "Säädöt"
+  payments: "maksut"
+  return_authorizations: "Palautusluvat"
+  credit_owed: "Luottovelka"
+  new_adjustment: "Uusi säätö"
+  payment: "maksu"
+  payment_method: "Maksutapa"
+  shipment: "Toimitus"
+  shipment_inc_vat: "Toimitus sis. ALV"
+  shipping_tax_rate: "Toimituskulujen veroprosentti"
+  category: "Kategoria"
+  import_date: "Tuontipäivämäärä"
+  delivery: "Toimitus"
+  temperature_controlled: "Lämpötilasäädelty"
+  new_product: "Uusi tuote"
+  administration: "Hallinto"
+  logged_in_as: "Kirjautunut sisään nimellä"
+  account: "Tili"
+  logout: "Kirjaudu ulos"
+  date_range: "Ajanjakso"
+  status: "tila"
+  new: "Uusi"
+  start: "Aloita"
+  end: "Loppu"
+  stop: "Stop"
+  first: "Ensimmäinen"
+  previous: "Edellinen"
+  last: "Kestää"
+  webhook_endpoints:
+    create:
+      success: Webhook-päätepiste luotu onnistuneesti
+      error: Webhook-päätepisteen luominen epäonnistui
+    destroy:
+      success: Webhook-päätepiste poistettu onnistuneesti
+      error: Webhook-päätepisteen poistaminen epäonnistui
+  spree:
+    order_updated: "Tilaus päivitetty"
+    cannot_perform_operation: "Tätä toimintoa ei voida suorittaa"
+    add_country: "Lisää maa"
+    add_state: "Lisää osavaltio"
+    adjustment: "Säätö"
+    all: "All"
+    associated_adjustment_closed: "Liittyvä oikaisu suljettu"
+    back_to_adjustments_list: "Takaisin säätöihin"
+    back_to_users_list: "Takaisin käyttäjiin"
+    back_to_zones_list: "Takaisin vyöhykkeisiin"
+    card_code: "Kortin koodi"
+    card_number: "Kortin numero"
+    category: "Kategoria"
+    created_successfully: "Luotu onnistuneesti"
+    credit: "Luotto"
+    editing_tax_category: "Verokategorian muokkaaminen"
+    editing_tax_rate: "Veroprosentin muokkaaminen"
+    editing_zone: "Muokkausalue"
+    editing_state: "Muokkaustila"
+    expiration: "Vanheneminen"
+    invalid_payment_provider: "Virheellinen maksupalveluntarjoaja"
+    items_cannot_be_shipped: "Tuotteita ei voida lähettää"
+    gateway_config_unavailable: "Yhdyskäytävän määritys ei ole käytettävissä"
+    gateway_error: "Maksu epäonnistui"
+    more: "Lisää"
+    new_adjustment: "Uusi säätö"
+    new_tax_category: "Uusi veroluokka"
+    new_user: "Uusi käyttäjä"
+    no_pending_payments: "Ei vireillä olevia maksut"
+    remove: "Poista"
+    none: "Ei mitään"
+    not_found: "Ei löytynyt"
+    notice_messages:
+      variant_deleted: "Muunnelma poistettu"
+    payment_method_not_supported: "Maksutapaa ei tueta"
+    resend_authorization_email: "Lähetä valtuutussähköposti uudelleen"
+    rma_credit: "RMA-hyvitys"
+    refund: "Palauttaa"
+    server_error: "Palvelinvirhe"
+    start_date: "Aloituspäivämäärä"
+    successfully_removed: "Poistettu onnistuneesti"
+    updating: "Päivittäminen"
+    your_order_is_empty_add_product: "Tilauksesi on tyhjä, hae ja lisää tuote yllä"
+    add_product: "Lisää tuote"
+    name_or_sku: "Nimi tai SKU (kirjoita vähintään 4 ensimmäistä merkkiä tuotteen nimestä)"
+    resend: "Lähetä uudelleen"
+    back_to_orders_list: "Takaisin tilaukset listaan"
+    back_to_payments_list: "Takaisin maksut"
+    back_to_states_list: "Takaisin osavaltioiden luetteloon"
+    return_authorizations: "Palautusluvat"
+    cannot_create_returns: "Palautuksia ei voida luoda, koska tällä tilaa ei ole lähetettyjä yksiköitä."
+    select_stock: "Valitse osake"
+    location: "Sijainti"
+    count_on_hand: "Lasketaan käsillä"
+    quantity: "Määrä"
+    on_demand: "Pyynnöstä"
+    on_hand: "Kätevällä"
+    package_from: "paketti"
+    item_description: "Kohteen kuvaus"
+    price: "Hinta"
+    total: "yhteensä"
+    edit: "muokata"
+    split: "Jakaa"
+    delete: "Poistaa"
+    cannot_set_shipping_method_without_address: "Toimitustapaa ei voi asettaa ennen kuin asiakastiedot on annettu."
+    no_tracking_present: "Seurantatietoja ei annettu."
+    tracking: "Seuranta"
+    tracking_number: "Seurantanumero"
+    order_total: "tilaa yhteensä"
+    customer_details: "asiakas -tiedot"
+    customer_details_updated: "Asiakkaan tiedot päivitetty"
+    customer_search: "Asiakashaku"
+    choose_a_customer: "Valitse asiakas"
+    account: "Tili"
+    billing_address: "Laskutusosoite"
+    shipping_address: "Toimitusosoite"
+    first_name: "Ensimmäinen nimi"
+    last_name: "Viimeinen nimi"
+    street_address: "Katuosoite"
+    street_address_2: "Katuosoite (jatkuu)"
+    city: "Kaupunki"
+    zip: "Postinumero"
+    country: "Maa"
+    state: "Lääni"
+    phone: "Puhelin"
+    update: "päivitä"
+    use_billing_address: "Käytä laskutusosoitetta"
+    adjustments: "Säädöt"
+    continue: "Jatkaa"
+    fill_in_customer_info: "Täytä asiakastiedot"
+    credit_card: "Luottokortti"
+    new_payment: "Uusi maksu"
+    capture: "Kaapata"
+    capture_and_complete_order: "Kaappaa ja suorita tilaus loppuun"
+    void: "Mitätön"
+    login: "Kirjaudu sisään"
+    password: "salasana"
+    signature: "Allekirjoitus"
+    solution: "Ratkaisu"
+    landing_page: "Aloitussivu"
+    server: "Palvelin"
+    test_mode: "Testitila"
+    logourl: "Logourl"
+    are_you_sure_delete: "Haluatko varmasti poistaa tämän tietueen?"
+    confirm_delete: "Vahvista poisto"
+    configurations: "Kokoonpanot"
+    general_settings: "Yleiset asetukset"
+    site_name: "Sivuston nimi"
+    site_url: "Sivuston URL-osoite"
+    default_seo_title: "Oletushakukoneoptimoinnin otsikko"
+    default_meta_description: "Oletusmetakuvaus"
+    default_meta_keywords: "Oletusmeta-avainsanat"
+    currency_decimal_mark: "Valuutan desimaalierotin"
+    currency_settings: "Valuutta-asetukset"
+    currency_symbol_position: Laita &quot;valuuttasymboli ennen dollarimäärää vai sen jälkeen?&quot;
+    currency_thousands_separator: "Valuutan tuhaterotin"
+    hide_cents: "Piilota sentit"
+    display_currency: "Näyttövaluutta"
+    choose_currency: "Valitse valuutta"
+    mail_method_settings: "Postitusmenetelmän asetukset"
+    mail_settings_notice_html: "<b>Tässä tehdyt muutokset ovat väliaikaisia ja tarkoitettu</b> vain virheenkorjaukseen, ja ne voidaan peruuttaa tulevaisuudessa.<br> Pysyviä muutoksia voidaan tehdä päivittämällä instanssin salaisuudet ja ottamalla ne käyttöön <a href='https://github.com/openfoodfoundation/ofn-install'>ofn-install-komennolla</a> . Lisätietoja saat ottamalla yhteyttä OFN:n globaaliin tiimiin."
+    general: "Yleistä"
+    enable_mail_delivery: "Ota postin toimitus käyttöön"
+    send_mails_as: "Lähetä sähköpostit nimellä"
+    smtp_send_all_emails_as_from_following_address: "Lähetä kaikki sähköpostit seuraavasta osoitteesta."
+    send_copy_of_all_mails_to: "Lähetä kopio kaikista sähköposteista osoitteeseen"
+    smtp_send_copy_to_this_addresses: "Lähettää kopion kaikista lähtevistä sähköposteista tähän osoitteeseen. Jos osoitteita on useita, erota ne pilkuilla."
+    tax_categories: "Veroluokat"
+    listing_tax_categories: "Listausveroluokat"
+    back_to_tax_categories_list: "Takaisin veroluokkien luetteloon"
+    tax rate: "Verokannat"
+    new_tax_rate: "Uusi verokanta"
+    tax_category: "Verokategoria"
+    tax_rates: "Verokannat"
+    rate: "korko"
+    tax_rate_amount_explanation: "Veroprosentit ovat desimaalilukuja laskelmien helpottamiseksi (esim. jos veroprosentti on 5 %, syötä 0,05)"
+    included_in_price: "Hintaan sisältyy"
+    show_rate_in_label: "Näytä hinta otsikossa"
+    back_to_tax_rates_list: "Takaisin verokantaluetteloon"
+    tax_settings: "Veroasetukset"
+    zones: "Vyöhykkeet"
+    new_zone: "Uusi vyöhyke"
+    default_tax: "Oletusvero"
+    default_tax_zone: "Oletusveroalue"
+    country_based: "Maakohtainen"
+    state_based: "Valtiopohjainen"
+    countries: "Maat"
+    listing_countries: "Listausmaat"
+    iso_name: "ISO-nimi"
+    states_required: "Vaaditut läänit"
+    editing_country: "Maata muokataan"
+    back_to_countries_list: "Takaisin maiden luetteloon"
+    states: "Läänit"
+    abbreviation: "Lyhenne"
+    new_state: "Uusi lääni"
+    payment_methods: "maksu -menetelmät"
+    taxons: "Tuotekategoriat"
+    shipping_methods: "Toimitustavat"
+    shipping_method: "Toimitustapa"
+    shipment: "Toimitus"
+    payment: "maksu"
+    status: "tila"
+    shipping_categories: "Toimituskategoriat"
+    new_shipping_category: "Uusi toimituskategoria"
+    back_to_shipping_categories: "Takaisin toimitusluokkiin"
+    editing_shipping_category: "Toimituskategorian muokkaaminen"
+    name: "nimi"
+    description: "Kuvaus"
+    type: "Tyyppi"
+    default: "oletusarvo"
+    calculator: "Laskin"
+    zone: "Vyöhyke"
+    display: "Näyttö"
+    environment: "Ympäristö"
+    active: "Aktiivinen"
+    nore: "Lisää"
+    no_results: "Ei tuloksia"
+    create: "Luoda"
+    loading: "Ladataan"
+    flat_percent: "Tasainen prosenttiosuus"
+    per_kg: "Kiloa kohden"
+    amount: "Määrä"
+    currency: "Valuutta"
+    first_item: "Ensimmäisen nimikkeen hinta"
+    additional_item: "Lisähinta"
+    max_items: "Kohteiden enimmäismäärä"
+    minimal_amount: "Minimimäärä"
+    normal_amount: "Normaali määrä"
+    discount_amount: "Alennusmäärä"
+    no_images_found: "Ei kuvia löytynyt"
+    new_image: "Uusi kuva"
+    filename: "Tiedostonimi"
+    alt_text: "Vaihtoehtoinen teksti"
+    thumbnail: "Pienoiskuva"
+    back_to_images_list: "Takaisin kuvaluetteloon"
+    email: Sähköposti
+    account_updated: "Tili päivitetty!"
+    email_updated: "Tili päivitetään, kun uusi sähköpostiosoite on vahvistettu."
+    show_api_key_view_toggled: "Näytä API-avain -näkymää on muutettu!"
+    my_account: "Oma tili"
+    date: "Päivämäärä"
+    time: "Aika"
+    inventory_error_flash_for_insufficient_quantity: "Ostoskorissasi oleva tuote on poistunut valikoimasta."
+    inventory: varasto
+    zipcode: Postinumero
+    weight: Paino (kg tai lb)
+    error_user_destroy_with_orders: "Käyttäjiä, joilla on suoritettuja tilauksia, ei voida poistaa"
+    cannot_create_payment_without_payment_methods: "Et voi luoda maksua tilaukselle ilman määriteltyjä maksutapoja."
+    please_define_payment_methods: "Määrittele ensin joitakin maksutapoja."
+    options: "Vaihtoehdot"
+    has_no_shipped_units: "ei ole toimitettuja yksiköitä"
+    successfully_created: '%{resource} on luotu onnistuneesti!'
+    successfully_updated: '%{resource} on päivitetty onnistuneesti!'
+    payment_method: "Maksutapa"
+    payment_processing_failed: "maksu ei voitu käsitellä, tarkista antamasi tiedot"
+    not_available: "Ei saatavilla"
+    sku: "SKU"
+    there_are_no_items_for_this_order: "Tässä tilauksessa ei ole tuotteita."
+    order_populator:
+      out_of_stock: '%{item} on loppu varastosta.'
+    actions:
+      update: "päivitä"
+      cancel: "Peruuttaa"
+    shared:
+      error_messages:
+        errors_prohibited_this_record_from_being_saved:
+          one: "1 virhe esti tämän tietueen tallentamisen:"
+          few: "%{count} -virheet estivät tämän tietueen tallentamisen:"
+          many: "%{count} -virheet estivät tämän tietueen tallentamisen:"
+          other: "%{count} -virheet estivät tämän tietueen tallentamisen:"
+        there_were_problems_with_the_following_fields: "Seuraavien kenttien kanssa oli ongelmia"
+      payments_list:
+        date_time: "Päivämäärä/aika"
+        amount: "Määrä"
+        payment_method: "Maksutapa"
+        payment_state: "maksu Lääni"
+    errors:
+      messages:
+        included_price_validation: "ei voida valita, ellet ole asettanut oletusveroaluetta"
+        blank: "ei voi olla tyhjä"
+        invalid_instagram_url: "Vain käyttäjätunnus, esim. the_prof"
+    layouts:
+      admin:
+        login_nav:
+          header:
+            store: Kauppa
+    validation:
+      must_be_int: "täytyy olla kokonaisluku"
+    admin:
+      images:
+        edit:
+          title: Muokkaa tuotekuvaa
+          close: Takaisin
+          upload: Lähetä kuva
+      mail_methods:
+        send_testmail: "Lähetä testisähköposti"
+        testmail:
+          delivery_success: "Testisähköposti lähetetty."
+          error: "Testisähköpostin lähettämisessä tapahtui virhe."
+      unit_price_tooltip: "yksikköhinta lisää läpinäkyvyyttä mahdollistamalla asiakkaillesi helpon hintavertailun eri tuotteiden ja pakkauskokojen välillä. Huomaa, että myymälä näkyvä lopullinen yksikköhinta voi poiketa aiemmista, koska se sisältää verot ja Maksut ."
+      subscriptions:
+        number: "Määrä"
+      tab:
+        dashboard: "Kojelauta"
+        orders: "tilaukset"
+        bulk_order_management: "Irtotavarana tilaa hallinta"
+        subscriptions: "Tilaukset"
+        products: "Tuotteet"
+        products_v3: "Tuotteet"
+        option_types: "Vaihtoehtotyypit"
+        properties: "Ominaisuudet"
+        variant_overrides: "varasto"
+        reports: "raportoi raportti"
+        configuration: "Kokoonpano"
+        users: "Käyttäjät"
+        roles: "Roolit"
+        order_cycles: "tilaa Cycles"
+        enterprises: "yritykset"
+        enterprise_relationships: "Käyttöoikeudet"
+        customers: "Asiakkaat"
+        groups: "Ryhmät"
+        oidc_settings: "OIDC-asetukset"
+        overview: "Yleiskatsaus"
+        product_import: "Tuo"
+        enterprise_roles: "Roolit"
+        payment_methods: "Maksutavat"
+      product_properties:
+        index:
+          inherits_properties_checkbox_hint: "Peritäänkö ominaisuudet tiedostosta %{supplier} ? (ellei toisin ole tehty yllä)"
+          add_product_properties: "Lisää tuotteen ominaisuudet"
+      properties:
+        index:
+          properties: "Ominaisuudet"
+          new_property: "Uusi Omaisuus"
+          name: "nimi"
+          presentation: "Esitys"
+        new:
+          new_property: "Uusi Omaisuus"
+        edit:
+          editing_property: "Ominaisuuden muokkaaminen"
+          back_to_properties_list: "Takaisin kiinteistöluetteloon"
+        form:
+          name: "nimi"
+          presentation: "Esitys"
+      return_authorizations:
+        index:
+          new_return_authorization: "Uusi palautuslupa"
+          return_authorizations: "Palautusluvat"
+          back_to_orders_list: "Takaisin tilaukset listaan"
+          rma_number: "RMA-numero"
+          status: "tila"
+          amount: "Määrä"
+          cannot_create_returns: "Palautuksia ei voida luoda, koska tällä tilaa ei ole lähetettyjä yksiköitä."
+          continue: "Jatkaa"
+        new:
+          new_return_authorization: "Uusi palautuslupa"
+          back_to_return_authorizations_list: "Takaisin palautusvaltuutusluetteloon"
+          continue: "Jatkaa"
+        edit:
+          receive: "vastaanottaa"
+          are_you_sure: "Oletko varma?"
+          return_authorization: "Palautuslupa"
+        form:
+          product: "tuote"
+          quantity_shipped: "Toimitettu määrä"
+          quantity_returned: "Palautettu määrä"
+          return_quantity: "Palautusmäärä"
+          amount: "Määrä"
+          rma_value: "RMA-arvo"
+          reason: "Syy"
+          stock_location: "Varastopaikka"
+        states:
+          authorized: "Valtuutettu"
+          received: "Vastaanotettu"
+          canceled: "Peruutettu"
+      line_items:
+        index:
+          results_found: "%{number} Tuloksia löytyi."
+          viewing: "Katsellaan %{start} - %{end} ."
+      orders:
+        add_product:
+          cannot_add_item_to_canceled_order: "Tuotetta ei voi lisätä peruutettuun tilaukseen"
+          cannot_add_item_to_shipped_order: "Lähetettyyn tilaukseen ei voi lisätä tuotetta"
+          include_out_of_stock_variants: "Sisällytä versiot, joita ei ole saatavilla varastossa"
+        shipment:
+          mark_as_shipped_message_html: "Tämä merkitsee tilauksen lähetetyksi.<br /> Oletko varma, että haluat jatkaa?"
+          mark_as_shipped_label_message: "Lähetä asiakkaalle sähköposti-ilmoitus lähetys-/noutoilmoituksesta."
+        index:
+          listing_orders: "Listaustilaukset"
+          new_order: "Uusi tilaa"
+          capture: "Kaapata"
+          ship: "Toimittaa"
+          edit: "muokata"
+          order_not_updated: "Tilausta ei voitu päivittää"
+          note: "Huomautus"
+          first: "Ensimmäinen"
+          last: "Kestää"
+          previous: "Edellinen"
+          next: "Seuraava"
+          loading: "Ladataan"
+          no_orders_found: "Ei tilaukset löytynyt"
+          results_found: "%{number} Tuloksia löytyi."
+          viewing: "Katsellaan %{start} - %{end} ."
+          print_invoices: "Tulosta laskuja"
+          cancel_orders: "Peruuta tilaukset"
+          resend_confirmation: "Lähetä vahvistus uudelleen"
+          resend_confirmation_confirm_html: "Tämä lähettää vahvistussähköpostin uudelleen asiakkaalle.<br /> Oletko varma, että haluat jatkaa?"
+          send_invoice: "Lähetä laskuja"
+          send_invoice_confirm_html: "Tämä lähettää sähköpostitse asiakkaille laskut kaikista valituista, valmiista tilauksista.<br> Oletko varma, että haluat jatkaa?"
+          selected:
+            zero: "Ei valittua tilausta"
+            one: "1 tilaus valittu"
+            other: "%{count} tilauksia valittu"
+        sortable_header:
+          payment_state: "maksu Lääni"
+          shipment_state: "Toimitus Lääni"
+          completed_at: "Valmistui klo"
+          number: "Määrä"
+          state: "Lääni"
+          email: "asiakas"
+        invoice:
+          issued_on: "Myönnetty"
+          tax_invoice: "VERO lasku"
+          code: "Koodi"
+          from: "Alkaen"
+          to: "Laskutusosoite"
+          shipping: "Toimitus"
+          order_number: "tilaa numero"
+          invoice_number: "lasku -numero"
+          payments_list:
+            date_time: "Päivämäärä/aika"
+            payment_method: "Maksutapa"
+            payment_state: "Maksun tila"
+            amount: "Määrä"
+        note:
+          note_label: "Huomautus:"
+          no_note_present: "Ei annettu muistiinpanoa."
+        form:
+          distribution_fields:
+            title: "Jakelu"
+            distributor: "Jakelija:"
+            order_cycle: "Tilaussykli:"
+          line_item_adjustments: "Rivikohdan oikaisut"
+          order_adjustments: "Tilauksen muutokset"
+          order_total: "tilaa yhteensä"
+      invoices:
+        index:
+          order_has_changed: "Tilaus on muuttunut viimeisimmän laskun päivityksen jälkeen. Tässä näkyvä lasku ei ehkä ole enää ajan tasalla."
+      overview:
+        enterprises_header:
+          ofn_with_tip: Yritykset ovat tuottajia ja/tai keskuksia ja ne ovat Open Food Networkin organisaation perusyksikkö.
+        enterprise_row:
+          has_no_enterprise_fees: "ei ole yritysmaksuja"
+          has_no_payment_methods: "ei ole maksutapoja"
+          has_no_shipping_methods: "ei ole toimitustapoja"
+        products:
+          products_tip: "Tuotteet, joita myyt Open Food Networkin kautta."
+          active_products:
+            zero: "Sinulla ei ole aktiivisia tuotteita."
+            one: "Sinulla on yksi aktiivinen tuote"
+            few: "Sinulla on %{count} aktiivisia tuotteita"
+            many: "Sinulla on %{count} aktiivisia tuotteita"
+            other: "Sinulla on %{count} aktiivisia tuotteita"
+        order_cycles:
+          order_cycles: "tilaa Cycles"
+          order_cycles_tip: "Tilaussyklit määrittävät, milloin ja missä tuotteesi ovat asiakkaiden saatavilla."
+          you_have_active:
+            zero: "Sinulla ei ole aktiivisia tilausjaksoja."
+            one: "Sinulla on yksi aktiivinen tilausjakso."
+            few: "Sinulla on %{count} aktiivisia tilaa ."
+            many: "Sinulla on %{count} aktiivisia tilaa ."
+            other: "Sinulla on %{count} aktiivisia tilaa ."
+          manage_order_cycles: "HALLINNOI TILAUSJAKSOJA"
+        version:
+          view_all_releases: Näytä kaikki julkaisut
+      shipping_methods:
+        index:
+          shipping_methods: "Toimitustavat"
+          new_shipping_method: "Uusi toimitustapa"
+          name: "nimi"
+          products_distributor: "Jakelija"
+          zone: "Vyöhyke"
+          calculator: "Laskin"
+          display: "Näyttö"
+          both: "Sekä mene kassalle että Back officessa"
+          back_end: "Vain taustatoimisto"
+          no_shipping_methods_found: "Ei toimitustapoja"
+        new:
+          new_shipping_method: "Uusi toimitustapa"
+          back_to_shipping_methods_list: "Takaisin toimitustapojen luetteloon"
+        edit:
+          editing_shipping_method: "Toimitustavan muokkaaminen"
+          new: "Uusi"
+          back_to_shipping_methods_list: "Takaisin toimitustapojen luetteloon"
+        form:
+          categories: "Luokat"
+          tax_category: "Verokategoria"
+          zones: "Vyöhykkeet"
+          both: "Sekä mene kassalle että Back officessa"
+          back_end: "Vain taustatoimisto"
+          deactivation_warning: "Toimitustavan deaktivointi voi poistaa toimitustavan listaltasi. Vaihtoehtoisesti voit piilottaa toimitustavan kassasivulta asettamalla &quot;Näytä&quot;-asetukseksi &quot;vain taustatoimisto&quot;."
+      payment_methods:
+        index:
+          payment_methods: "maksu -menetelmät"
+          new_payment_method: "Uusi Maksutapa"
+          name: "nimi"
+          products_distributor: "Jakelija"
+          provider: "Palveluntarjoaja"
+          environment: "Ympäristö"
+          display: "Näyttö"
+          active: "Aktiivinen"
+          both: "Molemmat"
+          back_end: "Vain taustatoimisto"
+          active_yes: "Kyllä"
+          active_no: "Ei"
+          no_payment_methods_found: "Maksutapoja ei löytynyt"
+        new:
+          new_payment_method: "Uusi Maksutapa"
+          back_to_payment_methods_list: "Takaisin maksu metodiluetteloon"
+        edit:
+          new: "Uusi"
+          editing_payment_method: "Maksutavan muokkaaminen"
+          back_to_payment_methods_list: "Takaisin maksu metodiluetteloon"
+        stripe_connect:
+          enterprise_select_placeholder: Valita...
+          loading_account_information_msg: Ladataan tilitietoja Stripestä, odota...
+          stripe_disabled_msg: Järjestelmänvalvoja on poistanut Stripe-maksut käytöstä.
+          request_failed_msg: Pahoittelut. Jotain meni pieleen yritettäessä vahvistaa tilitietoja Stripen avulla...
+          account_missing_msg: Tälle yritys ei ole olemassa Stripe-tiliä.
+          connect_one: Yhdistä yksi
+          access_revoked_msg: Tämän Stripe-tilin käyttöoikeus on peruutettu. Yhdistä tilisi uudelleen.
+          status: tila
+          connected: Yhdistetty
+          account_id: tunniste
+          business_name: Yrityksen nimi
+          charges_enabled: Veloitukset käytössä
+        form:
+          name: "nimi"
+          description: "Kuvaus"
+          environment: "Ympäristö"
+          display: "Näyttö"
+          active: "Aktiivinen"
+          active_yes: "Kyllä"
+          active_no: "Ei"
+          both: "Sekä mene kassalle että Back officessa"
+          back_end: "Vain taustatoimisto"
+          tags: "Tägit"
+          deactivation_warning: "Maksutavan deaktivointi voi poistaa maksutavan listaltasi. Vaihtoehtoisesti voit piilottaa maksutavan kassasivulta asettamalla &quot;Näytä&quot;-asetukseksi &quot;vain taustatoimisto&quot;."
+        providers:
+          provider: "Palveluntarjoaja"
+          check: "Käteinen/sähköinen maksu/jne. (maksut, joille ei vaadita automaattista vahvistusta)"
+          pin: "PIN-maksut"
+          paypalexpress: "PayPal Express"
+          stripeconnect: "Stripe"
+          stripesca: "Stripe SCA"
+      payments:
+        source_forms:
+          stripe:
+            error_saving_payment: Maksun tallentaminen epäonnistui
+            submitting_payment: Maksun lähettäminen...
+          paypal:
+            no_payment_via_admin_backend: PayPal-maksuja ei voi tallentaa Backofficeen
+      products:
+        image_upload_error: "Lataa kuva JPG-, PNG-, GIF-, SVG- tai WEBP-muodossa."
+        image_not_processable: "Kuvaliite ei ole kelvollinen kuva."
+        new:
+          title: "Uusi tuote"
+          new_product: "Uusi tuote"
+          supplier: "toimittaja"
+          supplier_select_placeholder: "Valitse toimittaja"
+          search_for_suppliers: "Hae toimittajia"
+          search_for_units: "Hae yksiköitä"
+          product_name: "tuote nimi"
+          units: "yksikkökoko"
+          value: "Arvo"
+          unit_name: "yksikkö nimi"
+          price: "Hinta"
+          unit_price: "yksikköhinta"
+          unit_price_legend: "Laskettu tuotteen hinnan perusteella"
+          on_hand: "Kätevällä"
+          on_demand: "Pyynnöstä"
+          product_description: "tuote kuvaus"
+          image: "kuva"
+        unit_name_placeholder: 'esim. rypäleet'
+        index:
+          header:
+            title: Irtotavarana muokata -tuotteet
+          indicators:
+            title: TUOTTEIDEN LATAAMINEN
+            no_products: "Ei vielä tuotteita. Mikset lisäisi niitä?"
+            no_results: "Valitettavasti ei tuloksia"
+          products_head:
+            name: nimi
+            unit: yksikkö
+            display_as: Näytä muodossa
+            category: Kategoria
+            tax_category: Verokategoria
+            inherits_properties?: Periikö ominaisuudet?
+            av_on: "Keskim. päällä"
+            import_date: "Tuontipäivämäärä"
+          products_variant:
+            variant_has_n_overrides: "Tässä variantissa on %{n} -ohitus (tai ohituksia)"
+            new_variant: "Uusi variantti"
+          product_name: tuote nimi
+        primary_taxon_form:
+          product_category: tuote kategoria
+          search_for_categories: "Etsi kategorioita"
+        group_buy_form:
+          group_buy: "Ryhmäostos?"
+          bulk_unit_size: Irtotavarayksikön koko
+        display_as:
+          display_as: Näytä muodossa
+        clone:
+          success: Tuote kloonattu
+      reports:
+        table:
+          select_and_search: "Valitse suodattimet ja napsauta %{option} nähdäksesi tietosi."
+        hidden_customer_details_tip: "Jos asiakkaiden nimet ja/tai yhteystiedot on piilotettu, voit pyytää jakelijaa päivittämään kauppansa asetukset niin, että heidän toimittajat voivat nähdä asiakastiedot raporteissa."
+        products_and_inventory:
+          all_products:
+            message: "Huomaa, että raportoidut varastotasot ovat peräisin vain toimittajan tuotelistoista. Jos käytät varastosaldoa varastomäärien hallintaan, näitä arvoja ei oteta huomioon tässä raportissa."
+      users:
+        index:
+          listing_users: "Listauksen käyttäjät"
+          new_user: "Uusi käyttäjä"
+          user: "User"
+          enterprise_limit: "yritys"
+          search: "Haku"
+          email: "Sähköposti"
+        edit:
+          editing_user: "Käyttäjän muokkaaminen"
+          back_to_users_list: "Takaisin käyttäjäluetteloon"
+          general_settings: "Yleiset asetukset"
+        form:
+          disabled: "Pois käytöstä?"
+          email: "Sähköposti"
+          admin: "Superylläpitäjä?"
+          enterprise_limit: "yritys"
+          confirm_password: "Vahvista salasana"
+          password: "salasana"
+          locale: "Kieli"
+        email_confirmation:
+          confirmation_pending: "Sähköpostivahvistus odottaa. Olemme lähettäneet vahvistussähköpostin osoitteeseen %{address} ."
+      variants:
+        index:
+          sku: "SKU"
+          price: "Hinta"
+          options: "Vaihtoehdot"
+          no_results: "Ei tuloksia"
+          option_types: "Vaihtoehtotyypit"
+          option_values: "Vaihtoehtojen arvot"
+          and: "ja"
+          new_variant: "Uusi variantti"
+          show_active: "Näytä aktiiviset"
+          show_deleted: "Näytä poistetut"
+        new:
+          new_variant: "Uusi variantti"
+        form:
+          sku: "SKU"
+          unit_price: "yksikköhinta"
+          display_as: "Näytä muodossa"
+          display_name: "Näytä nimi"
+          display_as_placeholder: 'esim. 2 kg'
+          display_name_placeholder: 'esim. tomaatit'
+          unit_scale: "Yksikköasteikko"
+          unit: Yksikkö
+          price: Hinta
+          unit_value: Yksikön arvo
+          variant_category: Luokka
+        autocomplete:
+          out_of_stock: "Loppu varastosta"
+          producer_name: "tuottaja"
+          unit: "yksikkö"
+      shared:
+        configuration_menu:
+          terms_of_service: "Palveluehdot"
+        sortable_header:
+          name: "nimi"
+          number: "Määrä"
+          completed_at: "Valmistui klo"
+          state: "Lääni"
+          payment_state: "maksu Lääni"
+          shipment_state: "Toimitus Lääni"
+          email: "Sähköposti"
+          total: "yhteensä"
+          billing_address_name: "nimi"
+      taxons:
+        back_to_list: "Takaisin tuotekategorioiden luetteloon"
+        index:
+          title: "Tuotekategoriat"
+          new_taxon: 'Uusi tuotekategoria'
+        new:
+          title: "Uusi tuotekategoria"
+        edit:
+          title: "Muokkaa tuoteluokkaa"
+        destroy:
+          delete_taxon:
+            success: "Tuotekategoria poistettu onnistuneesti"
+            error: "Tuotekategoriaa ei voitu poistaa määritettyjen tuotteiden vuoksi."
+        form:
+          name: nimi
+          meta_title: Meta-otsikko
+          meta_description: Metakuvaus
+          meta_keywords: Meta-avainsanat
+          description: Kuvaus
+          dfc_id: DFC URI
+      general_settings:
+        edit:
+          legal_settings: "Lakiasetukset"
+          cookies_consent_banner_toggle: "Näytä evästeiden suostumusbanneri"
+          privacy_policy_url: "Tietosuojakäytännön URL-osoite"
+          enterprises_require_tos: "Yritysten on hyväksyttävä käyttöehdot"
+          shoppers_require_tos: "Ostajien on hyväksyttävä käyttöehdot"
+          cookies_policy_matomo_section: "Näytä Matomo-osio evästekäytäntösivulla"
+          footer_tos_url: "Palveluehtojen URL-osoite"
+    checkout:
+      payment:
+        stripe:
+          choose_one: Valitse yksi
+          enter_new_card: Anna uuden kortin tiedot
+          used_saved_card: "Käytä tallennettua korttia:"
+          or_enter_new_card: "Tai anna uuden kortin tiedot:"
+          remember_this_card: Muistatko tämän kortin?
+        stripe_sca:
+          choose_one: Valitse yksi
+          enter_new_card: Anna uuden kortin tiedot
+          used_saved_card: "Käytä tallennettua korttia:"
+          or_enter_new_card: "Tai anna uuden kortin tiedot:"
+          remember_this_card: Muistatko tämän kortin?
+    date_picker:
+      flatpickr_date_format: "Vuosi"
+      flatpickr_datetime_format: "Vuosi H:i"
+      today: "Tänään"
+      now: "Nyt"
+      close: "Lähellä"
+    orders:
+      error_flash_for_unavailable_items: "Ostoskorissasi oleva tuote on poistunut valikoimasta. Päivitä valitut määrät."
+      edit:
+        login_to_view_order: "Kirjaudu sisään nähdäksesi tilauksesi."
+      bought:
+        item: "Jo tilattu tässä tilausjaksossa"
+      line_item:
+        insufficient_stock: "Riittämätön varastossa, jäljellä vain %{on_hand}"
+        out_of_stock: "Loppu varastosta"
+        unavailable_item: "Tällä hetkellä ei saatavilla"
+    shipment_states:
+      backorder: jälkitoimitus
+      partial: osittainen
+      pending: vireillä
+      ready: valmis
+      shipped: lähetetty
+      canceled: peruttu
+    payment_states:
+      balance_due: Saldo erääntyy
+      completed: valmistunut
+      checkout: mene kassalle
+      credit_owed: luottovelka
+      failed: epäonnistui
+      paid: maksettu
+      pending: vireillä
+      processing: käsittely
+      requires_authorization: "valtuutus vaaditaan"
+      void: tyhjä
+      invalid: virheellinen
+      authorise: valtuuttaa
+    order_mailer:
+      cancel_email:
+        customer_greeting: "Hyvä %{name},"
+        instructions_html: "Tilauksesi osoitteeseen <strong>%{distributor}</strong> on PERUTTU. Säilytä peruutustiedot tiedostoissasi."
+        dont_cancel: "Jos olet muuttanut mielesi tai et halua peruuttaa tätä tilausta, ota yhteyttä %{email}"
+        order_summary_canceled_html: "<strong>Tilausyhteenveto # %{number} [PERUTTU]</strong>"
+        details: "Tässä ovat tilauksesi tiedot:"
+        unpaid_order: "Tilauksesi oli maksamatta, joten hyvitystä ei ole tehty"
+        paid_order: "Tilauksesi on maksettu, joten %{distributor} on hyvittänyt koko summan."
+        credit_order: "Tilauksesi on maksettu, joten tilillesi on hyvitetty rahaa"
+        subject: "tilaa peruuttaminen"
+      cancel_email_for_shop:
+        greeting: "Hyvä %{name} ,"
+        subject: "tilaa peruuttaminen"
+        intro: "Asiakas on peruuttanut tilauksensa # %{number} ."
+        view_cancelled_order: "Näytä peruutettu tilaus"
+      confirm_email:
+        subject: "tilaa -vahvistus"
+      invoice_email:
+        hi: "Hei %{name}"
+        invoice_attached_text: Liitteenä on lasku viimeisimmästä tilauksestasi, jonka teit
+    user_mailer:
+      reset_password_instructions:
+        dear_customer: "Hyvä asiakas,"
+        request_sent_text: |
+            Salasanan vaihtamista on pyydetty.
+            Jos et tehnyt tätä pyyntöä, jätä tämä sähköposti huomiotta.
+        link_text: >
+            Jos teit tämän pyynnön, napsauta alla olevaa linkkiä:
+        issue_text: |
+            Jos yllä oleva URL-osoite ei toimi, yritä kopioida ja liittää se selaimeesi.
+            Jos ongelmat jatkuvat, ota rohkeasti yhteyttä.
+        subject: "Salasanan palauttamisen ohjeet"
+      confirmation_instructions:
+        subject: "Vahvista OFN-tilisi"
+    payment_mailer:
+      authorize_payment:
+        subject: "Valtuuta maksusi käyttäjälle %{distributor} OFN-palvelussa"
+        instructions: "Maksusi summalle %{amount} maksuun %{distributor} vaatii lisätunnistuksen. Valtuuta maksusi seuraavasta URL-osoitteesta:"
+      authorization_required:
+        subject: "Maksu vaatii asiakkaan valtuutuksen"
+        message: "Tilauksen %{order_number} maksu vaatii asiakkaalta lisävaltuutuksen. Asiakkaalle on ilmoitettu sähköpostitse, ja maksu näkyy odottavana, kunnes se on hyväksytty."
+    shipment_mailer:
+      shipped_email:
+        dear_customer: "Hyvät asiakas ,"
+        instructions: "Tilauksesi osoitteesta %{distributor} on lähetetty."
+        shipment_summary: "Toimitus -yhteenveto"
+        subject: "Toimitus"
+        thanks: "Kiitos kaupoista."
+        track_information: "Seurantatiedot: %{tracking}"
+        track_link: "Seurantalinkki: %{url}"
+        picked_up_instructions: "Tilauksesi osoitteesta %{distributor} on noudettu."
+        picked_up_subject: "Noutoilmoitus"
+    test_mailer:
+      test_email:
+        greeting: "Onnittelut!"
+        message: "Jos olet saanut tämän sähköpostin, sähköpostiasetuksesi ovat oikein."
+        subject: "Testiposti"
+    order_state:
+      address: osoite
+      adjustments: säädöt
+      awaiting_return: odottaa paluuta
+      canceled: peruttu
+      cart: ostoskori
+      confirmation: "vahvistus"
+      complete: täydellinen
+      confirm: vahvistaa
+      delivery: toimitus
+      paused: keskeytetty
+      payment: maksu
+      pending: vireillä
+      resumed: jatkui
+      returned: palasi
+    subscription_state:
+      active: aktiivinen
+      pending: vireillä
+      ended: päättynyt
+      paused: keskeytetty
+      canceled: peruttu
+    paypal:
+      already_refunded: "Tämä maksu on palautettu, eikä sille voida tehdä jatkotoimia."
+      no_payment_via_admin_backend: "Et voi tällä hetkellä veloittaa PayPal-tilejä admin-taustajärjestelmän kautta."
+      transaction: "PayPal-tapahtuma"
+      payer_id: "Maksajan tunnus"
+      transaction_id: "Tapahtumatunnus"
+      token: "Tunnus"
+      refund: "Palauttaa"
+      refund_amount: "Määrä"
+      original_amount: "Alkuperäinen summa: %{amount}"
+      refund_successful: "PayPal-hyvitys onnistui"
+      refund_unsuccessful: "PayPal-hyvitys epäonnistui"
+      actions:
+        refund: "Palauttaa"
+      flash:
+        cancel: "Etkö halua käyttää PayPalia? Ei ongelmia."
+        connection_failed: "PayPaliin ei saatu yhteyttä."
+        generic_error: "PayPal epäonnistui. %{reasons}"
+    users:
+      api_keys:
+        regenerate_key: "Luo avain uudelleen"
+        title: API-avain
+      webhook_endpoints:
+        title: Webhook-päätepisteet
+        description: Järjestelmän tapahtumat voivat laukaista webhookeja ulkoisiin järjestelmiin.
+        event_types:
+          order_cycle_opened: Tilausjakso avattu
+        event_type:
+          header: Tapahtuman tyyppi
+        url:
+          header: Päätepisteen URL-osoite
+          create_placeholder: Anna etäwebhook-päätepisteen URL-osoite
+      developer_settings:
+        title: Kehittäjäasetukset
+      form:
+        account_settings: Tilin asetukset
+      show:
+        tabs:
+          developer_settings: Kehittäjäasetukset
+          orders: tilaukset
+          cards: Luottokortit
+          transactions: Transaktiot
+          settings: Tilin asetukset
+        unconfirmed_email: "Sähköpostivahvistusta odotetaan osoitteelle: %{unconfirmed_email} . Sähköpostiosoitteesi päivitetään, kun uusi sähköpostiosoite on vahvistettu."
+      orders:
+        open_orders: Avoimet tilaukset
+        past_orders: Aiemmat tilaukset
+      transactions:
+        transaction_history: Tapahtumahistoria
+        authorisation_required: Valtuutus vaaditaan
+        authorise: Valtuuta
+      open_orders:
+        order: tilaa
+        shop: kauppa
+        changes_allowed_until: Muutokset sallittu asti
+        items: kohteet
+        total: yhteensä
+        edit: muokata
+        cancel: Peruuttaa
+        closed: Suljettu
+        until: Kunnes
+      past_orders:
+        order: tilaa
+        shop: kauppa
+        completed_at: Valmistui klo
+        items: kohteet
+        total: yhteensä
+        paid?: Maksettu?
+        status: tila
+        completed: Valmis
+        cancelled: Peruutettu
+      saved_cards:
+        default?: Oletusarvo?
+        delete?: Poistaa?
+      cards:
+        authorised_shops: Valtuutetut myymälät
+        authorised_shops_agreement: Tämä on luettelo kaupoista, jotka saavat veloittaa oletusluottokortiltasi mahdollisista tilauksistasi (eli toistuvista tilauksista). Korttitietosi säilytetään turvallisesti, eikä niitä jaeta kauppojen omistajille. Saat aina ilmoituksen, kun sinulta veloitetaan. Rastitamalla kaupan ruudun hyväksyt, että kyseinen kauppa lähettää ohjeet korttisi myöntäneelle rahoituslaitokselle maksujen vastaanottamiseksi kyseisen kaupan kanssa tekemäsi tilauksen ehtojen mukaisesti.
+        saved_cards_popover: Tämä on luettelo korteista, jotka olet valinnut tallentaa myöhempää käyttöä varten. Oletuskorttisi valitaan automaattisesti, kun maksat tilausta, ja sitä voidaan veloittaa kaikissa kaupoissa, joille olet antanut siihen luvan (katso oikealta).
+      authorised_shops:
+        shop_name: "Kaupan nimi"
+        allow_charges?: "Sallitaanko veloitukset oletuskortilta?"
+        no_default_saved_cards_tooltip: Sinun on merkittävä yksi luottokortti oletusarvoiseksi, jotta veloitukset voidaan tehdä.
+    localized_number:
+      invalid_format: on virheellisessä muodossa. Anna numero.
+    api:
+      invalid_api_key: "Määritetty API-avain ( %{key} ) on virheellinen."
+      unauthorized: "Sinulla ei ole oikeutta suorittaa kyseistä toimintoa."
+      invalid_resource: "Virheellinen resurssi. Korjaa virheet ja yritä uudelleen."
+      resource_not_found: "Etsimääsi resurssia ei löytynyt."
+      access: "API-käyttöoikeus"
+      key: "Avain"
+      clear_key: "Tyhjennä näppäin"
+      regenerate_key: "Luo avain uudelleen"
+      no_key: "Ei avainta"
+      generate_key: "Luo API-avain"
+      key_generated: "Avain luotu"
+      key_cleared: "Avain tyhjennetty"
+      shipment:
+        cannot_ready: "Lähetystä ei voida valmistella."
+      toggle_api_key_view: "Näytä käyttäjän API-avainnäkymä"
+    activerecord:
+      models:
+        spree/payment:
+          one: maksu
+          other: maksu t
+    unit: yksikkö
+    per_unit: yksikköä kohden
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: noin tunnin
+        other: noin %{count} tuntia
+      about_x_months:
+        one: noin 1 kuukausi
+        other: noin %{count} kuukautta
+      about_x_years:
+        one: noin 1 vuosi
+        other: noin %{count} vuotta
+      almost_x_years:
+        one: lähes vuoden
+        other: lähes %{count} vuotta
+      half_a_minute: puoli minuuttia
+      less_than_x_seconds:
+        one: alle 1 sekunti
+        other: alle %{count} sekuntia
+      less_than_x_minutes:
+        one: alle minuutin
+        other: alle %{count} minuuttia
+      over_x_years:
+        one: yli vuoden
+        other: yli %{count} vuotta
+      x_seconds:
+        one: "1 sekunti"
+        other: "%{count} sekuntia"
+      x_minutes:
+        one: "1 minuutti"
+        other: "%{count} minuuttia"
+      x_days:
+        one: "1 päivä"
+        other: "%{count} päivää"
+      x_months:
+        one: "1 kuukausi"
+        other: "%{count} kuukautta"
+      x_years:
+        one: "1 vuosi"
+        other: "%{count} vuotta"
+  components:
+    multiple_checked_select:
+      filter_placeholder: "Suodatinvaihtoehdot"
+    search_input:
+      placeholder: Haku
+    selector_with_filter:
+      selected_items: "%{count} valittu"
+      search_placeholder: Haku
+    pagination:
+      next: Seuraava
+      previous: Edellinen
+    tag_list_input:
+      default_placeholder: Lisää tägi
+  invisible_captcha:
+    sentence_for_humans: "Jätä tyhjäksi"
+    timestamp_error_message: "Yritä uudelleen 5 sekunnin kuluttua."


### PR DESCRIPTION
#### What? Why?

This pull request adds support for the Finnish locale (fi) to the Open Food Network.
This allows the application interface to be displayed in Finnish, improving accessibility and usability for Finnish-speaking users.


#### What should we test?
Visit any page with a Finnish user profile or switch locale manually to Finnish (e.g., by appending ?locale=fi to URLs).
Check that interface texts appear in Finnish and are contextually accurate.
Ensure that no fallback to English occurs when a Finnish translation exists.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

Add Finnish locale support to the platform.