### PR TITLE
Clarify voucher code not found can mean fully redeemed

### DIFF
--- a/app/controllers/voucher_adjustments_controller.rb
+++ b/app/controllers/voucher_adjustments_controller.rb
@@ -5,7 +5,7 @@ class VoucherAdjustmentsController < BaseController
 
   def create
     if voucher_params[:voucher_code].blank?
-      @order.errors.add(:voucher_code, I18n.t('checkout.errors.voucher_not_found'))
+      @order.errors.add(:voucher_code, I18n.t('checkout.errors.voucher_code_blank'))
       return render_error
     end
 
@@ -43,7 +43,7 @@ class VoucherAdjustmentsController < BaseController
     return false if @order.errors.present?
 
     if voucher.nil?
-      @order.errors.add(:voucher_code, I18n.t('checkout.errors.voucher_not_found'))
+      @order.errors.add(:voucher_code, I18n.t('checkout.errors.voucher_code_not_found'))
       return false
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2172,7 +2172,8 @@ en:
       select_a_shipping_method: Select a shipping method
       select_a_payment_method: Select a payment method
       no_shipping_methods_available: Checkout is not possible due to absence of shipping options. Please contact the shop owner.
-      voucher_not_found: Not found
+      voucher_code_blank: Please enter a valid voucher code
+      voucher_code_not_found: invalid. It either doesn't exist or has been redeemed fully
       add_voucher_error: There was an error while adding the voucher
       create_voucher_error: "There was an error while creating the voucher: %{error}"
       voucher_redeeming_error: There was an error while trying to redeem your voucher

--- a/spec/requests/voucher_adjustments_spec.rb
+++ b/spec/requests/voucher_adjustments_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe VoucherAdjustmentsController do
         post("/voucher_adjustments", params:)
 
         expect(response).to be_unprocessable
-        expect(flash[:error]).to match "Voucher code Not found"
+        expect(flash[:error]).to match "Voucher code invalid."
       end
     end
 
@@ -123,7 +123,7 @@ RSpec.describe VoucherAdjustmentsController do
             post("/voucher_adjustments", params:)
 
             expect(response).to be_unprocessable
-            expect(flash[:error]).to match "Voucher code Not found"
+            expect(flash[:error]).to match "Voucher code invalid."
           end
         end
 
@@ -149,7 +149,7 @@ RSpec.describe VoucherAdjustmentsController do
             post("/voucher_adjustments", params:)
 
             expect(response).to be_unprocessable
-            expect(flash[:error]).to match "Voucher code Not found"
+            expect(flash[:error]).to match "Voucher code invalid"
           end
         end
 

--- a/spec/system/consumer/checkout/payment_spec.rb
+++ b/spec/system/consumer/checkout/payment_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe "As a consumer, I want to checkout my order" do
                 fill_in "Enter voucher code", with: "non_code"
                 click_button("Apply")
 
-                expect(page).to have_content("Voucher code Not found")
+                expect(page).to have_content("Voucher code invalid")
               end
             end
 


### PR DESCRIPTION
#### What? Why?

- Closes #13348 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

When a voucher is redeemed, its short code is deleted and it can't be found anymore. The message "not found" was confusing though when you had a valid voucher code. So I'm improving the error message here to account for both cases:

* invalid code / not found / mistyped
* voucher valid but fully redeemed / no money left

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Go to a Vine enabled shop.
-  Add to the cart, and go through the checkout.
- In the payment step try to add a voucher that has been fully redeemed (or doesn't exist).
- It should say: "Code invalid. It either doesn't exist or has been redeemed fully."



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
