### PR TITLE
Add respond_to_missing? to classes defining method_missing to improve respond_to? behavior

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -273,13 +273,6 @@ Style/MapToHash:
     - 'lib/reporting/reports/enterprise_fee_summary/fee_summary.rb'
     - 'lib/tasks/sample_data/user_factory.rb'
 
-# Offense count: 3
-Style/MissingRespondToMissing:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/models/spree/gateway.rb'
-    - 'app/models/spree/preferences/configuration.rb'
-
 # Offense count: 38
 Style/OpenStructUse:
   Exclude:

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,6 +45,11 @@ module ApplicationHelper
     form_for(name, *(args << options.merge(builder: AngularFormBuilder)), &)
   end
 
+  def respond_to_missing?(method_name, include_private = false)
+    (method_name.to_s.end_with?('_path',
+                                '_url') && spree.respond_to?(method_name, include_private)) || super
+  end
+
   # Pass URL helper calls on to spree where applicable so that we don't need to use
   # spree.foo_path in any view rendered from non-spree-namespaced controllers.
   def method_missing(method, *args, &)

--- a/app/models/spree/gateway.rb
+++ b/app/models/spree/gateway.rb
@@ -30,6 +30,10 @@ module Spree
       preferences.transform_keys(&:to_sym)
     end
 
+    def respond_to_missing?(method_name, include_private = false)
+      provider.respond_to?(method_name, include_private) || super
+    end
+
     def method_missing(method, *args)
       if @provider.nil? || !@provider.respond_to?(method)
         super

--- a/app/models/spree/preferences/configuration.rb
+++ b/app/models/spree/preferences/configuration.rb
@@ -57,6 +57,11 @@ module Spree
         set_preference args[0], args[1]
       end
 
+      def respond_to_missing?(method_name, include_private = false)
+        name = method_name.to_s.chomp('=')
+        has_preference?(name) || super
+      end
+
       def method_missing(method, *args)
         name = method.to_s.gsub('=', '')
         if has_preference? name

--- a/app/models/spree/preferences/configuration.rb
+++ b/app/models/spree/preferences/configuration.rb
@@ -27,6 +27,20 @@ module Spree
     class Configuration
       include Spree::Preferences::Preferable
 
+      class << self
+        def preference(name, type, *args)
+          super
+
+          define_method(name) do
+            get_preference(name)
+          end
+
+          define_method("#{name}=") do |value|
+            set_preference(name, value)
+          end
+        end
+      end
+
       def configure
         yield(self) if block_given?
       end
@@ -55,24 +69,6 @@ module Spree
         return unless args.size == 2
 
         set_preference args[0], args[1]
-      end
-
-      def respond_to_missing?(method_name, include_private = false)
-        name = method_name.to_s.chomp('=')
-        has_preference?(name) || super
-      end
-
-      def method_missing(method, *args)
-        name = method.to_s.gsub('=', '')
-        if has_preference? name
-          if method.to_s =~ /=$/
-            set_preference(name, args.first)
-          else
-            get_preference name
-          end
-        else
-          super
-        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

- Applies to #13188 

Add `respond_to_missing?` to classes defining `method_missing` to improve respond_to? behavior.
  - Solves `Style/MissingRespondToMissing` rubocop offenses.


#### What should we test?
These should be safe changes covered by the test suite.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
