### PR TITLE
Adds Unit price checks

### DIFF
--- a/spec/system/admin/unit_price_spec.rb
+++ b/spec/system/admin/unit_price_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe '
     end
   end
 
-  describe "when admin use es as default language (and comma as decimal separator)", :debug do
+  describe "when admin use es as default language (and comma as decimal separator)" do
     it "creating a new product with a comma separated decimal price" do
       login_as_admin
       visit spree.admin_dashboard_path(locale: 'es')

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -170,7 +170,9 @@ RSpec.describe "Order Management" do
         expect(page).to have_button 'Save Changes'
 
         expect(find("tr.variant-#{item2.variant.id}")).to have_content item2.product.name
+        expect(find("tr.variant-#{item2.variant.id}")).to have_content("$10,000.00 / kg")
         expect(find("tr.variant-#{item3.variant.id}")).to have_content item3.product.name
+        expect(find("tr.variant-#{item3.variant.id}")).to have_content("$10,000.00 / kg")
         expect(find("tr.order-adjustment")).to have_content "Shipping"
         expect(find("tr.order-adjustment")).to have_content "5.00"
 

--- a/spec/system/consumer/shopping/unit_price_spec.rb
+++ b/spec/system/consumer/shopping/unit_price_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "As a consumer, I want to check unit price information for a prod
       expect(page).to have_selector '.variant-unit-price'
       within '.variant-unit-price' do
         expect(page).to have_selector '.question-mark-icon'
+        expect(page).to have_content("$19,990.00 / kg") # displays the unit price value
       end
       find('.question-mark-icon').click
       expect(page).to have_selector '.joyride-tip-guide.question-mark-tooltip'
@@ -62,7 +63,10 @@ RSpec.describe "As a consumer, I want to check unit price information for a prod
 
     it "shows/hide the unit price information with the question mark icon in the sidebar" do
       expect(page).to have_selector ".cart-content .question-mark-icon"
-      find(".cart-content .question-mark-icon").click
+      within ".cart-content" do
+        expect(page).to have_content("$19,990.00 / kg") # displays the unit price value
+        find(".question-mark-icon").click
+      end
       expect(page).to have_selector '.joyride-tip-guide.question-mark-tooltip'
       within '.joyride-tip-guide.question-mark-tooltip' do
         expect(page).to have_content('This is the unit price of this product. ' \
@@ -74,6 +78,8 @@ RSpec.describe "As a consumer, I want to check unit price information for a prod
       expect(page).not_to have_content('This is the unit price of this product. ' \
                                        'It allows you to compare the price of products ' \
                                        'independent of packaging sizes & weights.')
+
+      expect(page).to have_content("$19,990.00 / kg")
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Recent manual tests on a PR (#13342) revealed a regression on the items' unit price, signalling that a few customer-facing places on the app were not covered by automated tests.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds assertions on unit price on:
- cart
- shopfront
- order confirmation page

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
