### PR TITLE
Fixes offenses Metrics/ModuleLength in engines spec

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/reports/users_and_enterprises_report_spec.rb'
     - 'spec/models/spree/adjustment_spec.rb'
     - 'spec/models/spree/credit_card_spec.rb'
     - 'spec/models/spree/line_item_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/services/variant_units/option_value_namer_spec.rb'
     - 'spec/support/request/stripe_stubs.rb'
 
 # Offense count: 7

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/open_food_network/tag_rule_applicator_spec.rb'
     - 'spec/lib/reports/customers_report_spec.rb'
     - 'spec/lib/reports/enterprise_fee_summary/authorizer_spec.rb'
     - 'spec/lib/reports/order_cycle_management_report_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,7 +160,6 @@ Metrics/ModuleLength:
     - 'app/helpers/spree/admin/orders_helper.rb'
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
-    - 'engines/order_management/spec/services/order_management/stock/package_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/estimator_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/form_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/open_food_network/order_cycle_form_applicator_spec.rb'
     - 'spec/lib/open_food_network/order_cycle_permissions_spec.rb'
     - 'spec/lib/open_food_network/permissions_spec.rb'
     - 'spec/lib/open_food_network/scope_variant_to_hub_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/models/spree/adjustment_spec.rb'
     - 'spec/models/spree/credit_card_spec.rb'
     - 'spec/models/spree/line_item_spec.rb'
     - 'spec/models/spree/order/tax_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/open_food_network/address_finder_spec.rb'
     - 'spec/lib/open_food_network/order_cycle_form_applicator_spec.rb'
     - 'spec/lib/open_food_network/order_cycle_permissions_spec.rb'
     - 'spec/lib/open_food_network/permissions_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/models/spree/credit_card_spec.rb'
     - 'spec/models/spree/line_item_spec.rb'
     - 'spec/models/spree/order/tax_spec.rb'
     - 'spec/models/spree/product_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/open_food_network/permissions_spec.rb'
     - 'spec/lib/open_food_network/scope_variant_to_hub_spec.rb'
     - 'spec/lib/open_food_network/tag_rule_applicator_spec.rb'
     - 'spec/lib/reports/customers_report_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/models/spree/shipping_method_spec.rb'
     - 'spec/models/spree/tax_rate_spec.rb'
     - 'spec/services/permissions/order_spec.rb'
     - 'spec/services/variant_units/option_value_namer_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/models/spree/product_spec.rb'
     - 'spec/models/spree/shipping_method_spec.rb'
     - 'spec/models/spree/tax_rate_spec.rb'
     - 'spec/services/permissions/order_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/reports/customers_report_spec.rb'
     - 'spec/lib/reports/enterprise_fee_summary/authorizer_spec.rb'
     - 'spec/lib/reports/order_cycle_management_report_spec.rb'
     - 'spec/lib/reports/products_and_inventory_report_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/models/spree/order/tax_spec.rb'
     - 'spec/models/spree/product_spec.rb'
     - 'spec/models/spree/shipping_method_spec.rb'
     - 'spec/models/spree/tax_rate_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/open_food_network/scope_variant_to_hub_spec.rb'
     - 'spec/lib/open_food_network/tag_rule_applicator_spec.rb'
     - 'spec/lib/reports/customers_report_spec.rb'
     - 'spec/lib/reports/enterprise_fee_summary/authorizer_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,7 +160,6 @@ Metrics/ModuleLength:
     - 'app/helpers/spree/admin/orders_helper.rb'
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
-    - 'engines/order_management/spec/services/order_management/subscriptions/validator_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/variants_list_spec.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
     - 'spec/lib/open_food_network/address_finder_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,7 +160,6 @@ Metrics/ModuleLength:
     - 'app/helpers/spree/admin/orders_helper.rb'
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
-    - 'engines/order_management/spec/services/order_management/subscriptions/summary_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/validator_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/variants_list_spec.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,7 +160,6 @@ Metrics/ModuleLength:
     - 'app/helpers/spree/admin/orders_helper.rb'
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
-    - 'engines/order_management/spec/services/order_management/subscriptions/form_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/summarizer_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/summary_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/models/spree/tax_rate_spec.rb'
     - 'spec/services/permissions/order_spec.rb'
     - 'spec/services/variant_units/option_value_namer_spec.rb'
     - 'spec/support/request/stripe_stubs.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,7 +160,6 @@ Metrics/ModuleLength:
     - 'app/helpers/spree/admin/orders_helper.rb'
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
-    - 'engines/order_management/spec/services/order_management/subscriptions/variants_list_spec.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
     - 'spec/lib/open_food_network/address_finder_spec.rb'
     - 'spec/lib/open_food_network/order_cycle_form_applicator_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/open_food_network/order_cycle_permissions_spec.rb'
     - 'spec/lib/open_food_network/permissions_spec.rb'
     - 'spec/lib/open_food_network/scope_variant_to_hub_spec.rb'
     - 'spec/lib/open_food_network/tag_rule_applicator_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,7 +160,6 @@ Metrics/ModuleLength:
     - 'app/helpers/spree/admin/orders_helper.rb'
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
-    - 'engines/order_management/spec/services/order_management/subscriptions/estimator_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/form_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/summarizer_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,7 +160,6 @@ Metrics/ModuleLength:
     - 'app/helpers/spree/admin/orders_helper.rb'
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
-    - 'engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/summarizer_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/summary_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/validator_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,7 +160,6 @@ Metrics/ModuleLength:
     - 'app/helpers/spree/admin/orders_helper.rb'
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
-    - 'engines/order_management/spec/services/order_management/order/updater_spec.rb'
     - 'engines/order_management/spec/services/order_management/stock/package_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/estimator_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/form_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,7 +160,6 @@ Metrics/ModuleLength:
     - 'app/helpers/spree/admin/orders_helper.rb'
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
-    - 'engines/order_management/spec/services/order_management/subscriptions/summarizer_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/summary_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/validator_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/variants_list_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/reports/enterprise_fee_summary/authorizer_spec.rb'
     - 'spec/lib/reports/order_cycle_management_report_spec.rb'
     - 'spec/lib/reports/products_and_inventory_report_spec.rb'
     - 'spec/lib/reports/users_and_enterprises_report_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,7 +160,6 @@ Metrics/ModuleLength:
     - 'app/helpers/spree/admin/orders_helper.rb'
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
-    - 'engines/catalog/spec/services/catalog/product_import/products_reset_strategy_spec.rb'
     - 'engines/order_management/spec/services/order_management/order/updater_spec.rb'
     - 'engines/order_management/spec/services/order_management/stock/package_spec.rb'
     - 'engines/order_management/spec/services/order_management/subscriptions/estimator_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/models/spree/line_item_spec.rb'
     - 'spec/models/spree/order/tax_spec.rb'
     - 'spec/models/spree/product_spec.rb'
     - 'spec/models/spree/shipping_method_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/reports/order_cycle_management_report_spec.rb'
     - 'spec/lib/reports/products_and_inventory_report_spec.rb'
     - 'spec/lib/reports/users_and_enterprises_report_spec.rb'
     - 'spec/models/spree/adjustment_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/lib/reports/products_and_inventory_report_spec.rb'
     - 'spec/lib/reports/users_and_enterprises_report_spec.rb'
     - 'spec/models/spree/adjustment_spec.rb'
     - 'spec/models/spree/credit_card_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Metrics/ModuleLength:
     - 'app/models/spree/order/checkout.rb'
     - 'app/models/spree/payment/processing.rb'
     - 'lib/open_food_network/column_preference_defaults.rb'
-    - 'spec/services/permissions/order_spec.rb'
     - 'spec/services/variant_units/option_value_namer_spec.rb'
     - 'spec/support/request/stripe_stubs.rb'
 

--- a/engines/catalog/spec/services/catalog/product_import/products_reset_strategy_spec.rb
+++ b/engines/catalog/spec/services/catalog/product_import/products_reset_strategy_spec.rb
@@ -2,134 +2,130 @@
 
 require 'spec_helper'
 
-module Catalog
-  module ProductImport
-    RSpec.describe ProductsResetStrategy do
-      let(:products_reset) { described_class.new(excluded_items_ids) }
+RSpec.describe Catalog::ProductImport::ProductsResetStrategy do
+  let(:products_reset) { described_class.new(excluded_items_ids) }
 
-      describe '#reset' do
-        let(:supplier_ids) { enterprise.id }
-        let(:product) { create(:product) }
-        let(:variant) { product.variants.first }
-        let(:enterprise) { variant.supplier }
+  describe '#reset' do
+    let(:supplier_ids) { enterprise.id }
+    let(:product) { create(:product) }
+    let(:variant) { product.variants.first }
+    let(:enterprise) { variant.supplier }
 
-        before { variant.on_hand = 2 }
+    before { variant.on_hand = 2 }
 
-        context 'when there are excluded_items_ids' do
-          let(:excluded_items_ids) { [variant.id] }
+    context 'when there are excluded_items_ids' do
+      let(:excluded_items_ids) { [variant.id] }
 
-          context 'and supplier_ids is []' do
-            let(:supplier_ids) { [] }
+      context 'and supplier_ids is []' do
+        let(:supplier_ids) { [] }
 
-            it 'does not reset the variant.on_hand' do
-              products_reset.reset(supplier_ids)
-              expect(variant.reload.on_hand).to eq(2)
-            end
+        it 'does not reset the variant.on_hand' do
+          products_reset.reset(supplier_ids)
+          expect(variant.reload.on_hand).to eq(2)
+        end
+      end
+
+      context 'and supplier_ids is nil' do
+        let(:supplier_ids) { nil }
+
+        it 'does not reset the variant.on_hand' do
+          products_reset.reset(supplier_ids)
+          expect(variant.reload.on_hand).to eq(2)
+        end
+      end
+
+      context 'and supplier_ids is set' do
+        it 'does not update the on_hand of the excluded items' do
+          products_reset.reset(supplier_ids)
+          expect(variant.reload.on_hand).to eq(2)
+        end
+
+        it 'updates the on_hand of the non-excluded items' do
+          non_excluded_variant = create(
+            :variant,
+            product: variant.product
+          )
+          non_excluded_variant.on_hand = 3
+          products_reset.reset(supplier_ids)
+          expect(non_excluded_variant.reload.on_hand).to eq(0)
+        end
+      end
+    end
+
+    context 'when there are no excluded_items_ids' do
+      let(:excluded_items_ids) { [] }
+
+      context 'and supplier_ids is []' do
+        let(:supplier_ids) { [] }
+
+        it 'does not reset the variant.on_hand' do
+          products_reset.reset(supplier_ids)
+          expect(variant.reload.on_hand).to eq(2)
+        end
+      end
+
+      context 'and supplier_ids is nil' do
+        let(:supplier_ids) { nil }
+
+        it 'does not reset the variant.on_hand' do
+          products_reset.reset(supplier_ids)
+          expect(variant.reload.on_hand).to eq(2)
+        end
+      end
+
+      context 'and supplier_ids is not nil' do
+        it 'sets all on_hand to 0' do
+          updated_records_count = products_reset.reset(supplier_ids)
+          expect(variant.reload.on_hand).to eq(0)
+          expect(updated_records_count).to eq(1)
+        end
+
+        context 'and there is an unresetable variant' do
+          before do
+            variant.stock_items = [] # this makes variant.on_hand raise an error
           end
 
-          context 'and supplier_ids is nil' do
-            let(:supplier_ids) { nil }
-
-            it 'does not reset the variant.on_hand' do
-              products_reset.reset(supplier_ids)
-              expect(variant.reload.on_hand).to eq(2)
-            end
-          end
-
-          context 'and supplier_ids is set' do
-            it 'does not update the on_hand of the excluded items' do
-              products_reset.reset(supplier_ids)
-              expect(variant.reload.on_hand).to eq(2)
-            end
-
-            it 'updates the on_hand of the non-excluded items' do
-              non_excluded_variant = create(
-                :variant,
-                product: variant.product
-              )
-              non_excluded_variant.on_hand = 3
-              products_reset.reset(supplier_ids)
-              expect(non_excluded_variant.reload.on_hand).to eq(0)
-            end
+          it 'returns correct number of resetted variants' do
+            expect { products_reset.reset(supplier_ids) }.to raise_error RuntimeError
           end
         end
 
-        context 'when there are no excluded_items_ids' do
-          let(:excluded_items_ids) { [] }
+        context 'and the variant is on demand' do
+          before { variant.on_demand = true }
 
-          context 'and supplier_ids is []' do
-            let(:supplier_ids) { [] }
+          it 'turns off the on demand setting on the variant' do
+            products_reset.reset(supplier_ids)
 
-            it 'does not reset the variant.on_hand' do
-              products_reset.reset(supplier_ids)
-              expect(variant.reload.on_hand).to eq(2)
-            end
-          end
-
-          context 'and supplier_ids is nil' do
-            let(:supplier_ids) { nil }
-
-            it 'does not reset the variant.on_hand' do
-              products_reset.reset(supplier_ids)
-              expect(variant.reload.on_hand).to eq(2)
-            end
-          end
-
-          context 'and supplier_ids is not nil' do
-            it 'sets all on_hand to 0' do
-              updated_records_count = products_reset.reset(supplier_ids)
-              expect(variant.reload.on_hand).to eq(0)
-              expect(updated_records_count).to eq(1)
-            end
-
-            context 'and there is an unresetable variant' do
-              before do
-                variant.stock_items = [] # this makes variant.on_hand raise an error
-              end
-
-              it 'returns correct number of resetted variants' do
-                expect { products_reset.reset(supplier_ids) }.to raise_error RuntimeError
-              end
-            end
-
-            context 'and the variant is on demand' do
-              before { variant.on_demand = true }
-
-              it 'turns off the on demand setting on the variant' do
-                products_reset.reset(supplier_ids)
-
-                expect(variant.reload.on_demand).to eq(false)
-              end
-            end
+            expect(variant.reload.on_demand).to eq(false)
           end
         end
+      end
+    end
 
-        context 'when excluded_items_ids is nil' do
-          let(:excluded_items_ids) { nil }
+    context 'when excluded_items_ids is nil' do
+      let(:excluded_items_ids) { nil }
 
-          context 'and supplier_ids is []' do
-            let(:supplier_ids) { [] }
+      context 'and supplier_ids is []' do
+        let(:supplier_ids) { [] }
 
-            it 'does not reset the variant.on_hand' do
-              products_reset.reset(supplier_ids)
-              expect(variant.reload.on_hand).to eq(2)
-            end
-          end
+        it 'does not reset the variant.on_hand' do
+          products_reset.reset(supplier_ids)
+          expect(variant.reload.on_hand).to eq(2)
+        end
+      end
 
-          context 'and supplier_ids is nil' do
-            let(:supplier_ids) { nil }
-            it 'does not reset the variant.on_hand' do
-              products_reset.reset(supplier_ids)
-              expect(variant.reload.on_hand).to eq(2)
-            end
-          end
+      context 'and supplier_ids is nil' do
+        let(:supplier_ids) { nil }
+        it 'does not reset the variant.on_hand' do
+          products_reset.reset(supplier_ids)
+          expect(variant.reload.on_hand).to eq(2)
+        end
+      end
 
-          context 'and supplier_ids is nil' do
-            it 'sets all on_hand to 0' do
-              products_reset.reset(supplier_ids)
-              expect(variant.reload.on_hand).to eq(0)
-            end
-          end
+      context 'and supplier_ids is nil' do
+        it 'sets all on_hand to 0' do
+          products_reset.reset(supplier_ids)
+          expect(variant.reload.on_hand).to eq(0)
         end
       end
     end

--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -2,487 +2,483 @@
 
 require 'spec_helper'
 
-module OrderManagement
-  module Order
-    RSpec.describe Updater do
-      let(:order) { create(:order) }
-      let(:updater) { OrderManagement::Order::Updater.new(order) }
-
-      describe "#update_totals" do
-        before do
-          2.times { create(:line_item, order:, price: 10) }
-        end
-
-        it "updates payment totals" do
-          allow(order).to receive_message_chain(:payments, :completed, :sum).and_return(10)
-
-          updater.update_totals
-          expect(order.payment_total).to eq(10)
-        end
-      end
-
-      describe "#update_item_total" do
-        before do
-          2.times { create(:line_item, order:, price: 10) }
-        end
-
-        it "updates item total" do
-          updater.update_item_total
-          expect(order.item_total).to eq(20)
-        end
-      end
-
-      describe "#update_adjustment_total" do
-        before do
-          2.times { create(:line_item, order:, price: 10) }
-        end
-
-        it "updates adjustment totals" do
-          allow(order).to receive_message_chain(:all_adjustments, :additional, :eligible,
-                                                :sum).and_return(-5)
-          allow(order).to receive_message_chain(:all_adjustments, :tax, :additional,
-                                                :sum).and_return(20)
-          allow(order).to receive_message_chain(:all_adjustments, :tax, :inclusive,
-                                                :sum).and_return(15)
-
-          updater.update_adjustment_total
-          expect(order.adjustment_total).to eq(-5)
-          expect(order.additional_tax_total).to eq(20)
-          expect(order.included_tax_total).to eq(15)
-        end
-      end
-
-      describe "#update_shipment_state" do
-        let(:shipment) { build(:shipment) }
-
-        before do
-          allow(order).to receive(:shipments).and_return([shipment])
-        end
-
-        it "is backordered" do
-          allow(shipment).to receive(:backordered?) { true }
-          updater.update_shipment_state
-
-          expect(order.shipment_state).to eq 'backorder'
-        end
-
-        it "is nil" do
-          allow(shipment).to receive(:state).and_return(nil)
-
-          updater.update_shipment_state
-          expect(order.shipment_state).to be_nil
-        end
-
-        ["shipped", "ready", "pending", "canceled"].each do |state|
-          it "is #{state}" do
-            allow(shipment).to receive(:state).and_return(state)
-            updater.update_shipment_state
-            expect(order.shipment_state).to eq state.to_s
-          end
-        end
-      end
-
-      it "state change" do
-        order = create(:order)
-        order.shipment_state = 'shipped'
-        state_changes = double
-        allow(order).to receive(:state_changes) { state_changes }
-        expect(state_changes).to receive(:create).with(
-          previous_state: nil,
-          next_state: 'shipped',
-          name: 'shipment',
-          user_id: order.user_id
-        )
-
-        order.state_changed('shipment')
-      end
-
-      describe "#update" do
-        it "updates totals once" do
-          expect(updater).to receive(:update_totals).once
-          updater.update
-        end
-
-        it "updates all adjustments" do
-          expect(updater).to receive(:update_all_adjustments)
-          updater.update
-        end
-
-        context "completed order" do
-          before { allow(order).to receive(:completed?) { true } }
-
-          it "updates payment state" do
-            expect(updater).to receive(:update_payment_state)
-            updater.update
-          end
-
-          it "updates shipment state" do
-            expect(updater).to receive(:update_shipment_state)
-            updater.update
-          end
-
-          context "with pending payments" do
-            let(:order) { create(:completed_order_with_totals) }
-
-            it "updates pending payments" do
-              payment = create(:payment, order:, amount: order.total)
-
-              # update order so the order total will change
-              update_order_quantity(order)
-              order.payments.reload
-
-              expect { updater.update }.to change { payment.reload.amount }.from(50).to(60)
-            end
-          end
-        end
-
-        context "incompleted order" do
-          before { allow(order).to receive_messages completed?: false }
-
-          it "doesnt update payment state" do
-            expect(updater).not_to receive(:update_payment_state)
-            updater.update
-          end
-
-          it "doesnt update shipment state" do
-            expect(updater).not_to receive(:update_shipment_state)
-            updater.update
-          end
-
-          it "doesnt update the order shipment" do
-            shipment = build(:shipment)
-            allow(order).to receive_messages shipments: [shipment]
-
-            expect(shipment).not_to receive(:update!).with(order)
-            expect(updater).not_to receive(:update_shipments).with(order)
-            updater.update
-          end
-
-          context "with pending payments" do
-            let!(:payment) { create(:payment, order:, amount: order.total) }
-
-            context "with order in payment state" do
-              let(:order) { create(:order_with_totals, state: "payment") }
-
-              it "updates pending payments" do
-                # update order so the order total will change
-                update_order_quantity(order)
-                order.payments.reload
-
-                expect { updater.update }.to change { payment.reload.amount }.from(10).to(20)
-              end
-            end
-
-            context "with order in confirmation state" do
-              let(:order) { create(:order_with_totals, state: "confirmation") }
-
-              it "updates pending payments" do
-                # update order so the order total will change
-                update_order_quantity(order)
-                order.payments.reload
-
-                expect { updater.update }.to change { payment.reload.amount }.from(10).to(20)
-              end
-
-              it "updates pending payments fees" do
-                calculator = build(:calculator_flat_percent_per_item, preferred_flat_percent: 10)
-                payment_method = create(:payment_method, name: "Percentage cash", calculator:)
-                payment = create(:payment, payment_method:, order:, amount: order.total)
-
-                # update order so the order total will change
-                update_order_quantity(order)
-                order.payments.reload
-
-                expect { updater.update }.to change { payment.reload.amount }.from(10).to(22)
-                  .and change { payment.reload.adjustment.amount }.from(1).to(2)
-              end
-            end
-
-            context "with order in cart" do
-              let(:order) { create(:order_with_totals) }
-
-              it "doesn't update pending payments" do
-                # update order so the order total will change
-                update_order_quantity(order)
-
-                expect { updater.update }.not_to change { payment.reload.amount }
-              end
-            end
-          end
-        end
-      end
-
-      describe "#update_shipments" do
-        before { allow(order).to receive(:completed?) { true } }
-
-        it "updates the order shipment" do
-          shipment = build(:shipment)
-          allow(order).to receive_messages shipments: [shipment]
-
-          expect(shipment).to receive(:update!).with(order)
-          updater.update_shipments
-        end
-      end
-
-      describe "#update_payment_state" do
-        context "when the order has no valid payments" do
-          it "is failed" do
-            allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(true)
-
-            updater.update_payment_state
-            expect(order.payment_state).to eq('failed')
-          end
-        end
-
-        context "when the order has a payment that requires authorization" do
-          let!(:payment) { create(:payment, order:, state: "requires_authorization") }
-
-          it "returns requires_authorization" do
-            expect {
-              updater.update_payment_state
-            }.to change { order.payment_state }.to 'requires_authorization'
-          end
-        end
-
-        context "when order has a payment that requires authorization and a completed payment" do
-          let!(:payment) { create(:payment, order:, state: "requires_authorization") }
-          let!(:completed_payment) { create(:payment, :completed, order:) }
-
-          it "returns paid" do
-            updater.update_payment_state
-            expect(order.payment_state).not_to eq("requires_authorization")
-          end
-        end
-
-        context "payment total is greater than order total" do
-          it "is credit_owed" do
-            order.payment_total = 2
-            order.total = 1
-
-            expect {
-              updater.update_payment_state
-            }.to change { order.payment_state }.to 'credit_owed'
-          end
-        end
-
-        context "order total is greater than payment total" do
-          it "is credit_owed" do
-            order.payment_total = 1
-            order.total = 2
-
-            expect {
-              updater.update_payment_state
-            }.to change { order.payment_state }.to 'balance_due'
-          end
-        end
-
-        context "order total equals payment total" do
-          it "is paid" do
-            order.payment_total = 30
-            order.total = 30
-
-            expect {
-              updater.update_payment_state
-            }.to change { order.payment_state }.to 'paid'
-          end
-        end
-
-        context "order is canceled" do
-          before { order.state = 'canceled' }
-
-          context "and is still unpaid" do
-            it "is void" do
-              order.payment_total = 0
-              order.total = 30
-
-              expect {
-                updater.update_payment_state
-              }.to change { order.payment_state }.to 'void'
-            end
-          end
-
-          context "and is paid" do
-            it "is credit_owed" do
-              order.payment_total = 30
-              order.total = 30
-              allow(order).to receive_message_chain(:payments, :valid, :empty?) { false }
-              allow(order).to receive_message_chain(:payments, :completed, :empty?) { false }
-              allow(order).to receive_message_chain(:payments, :requires_authorization, :any?) {
-                                false
-                              }
-
-              expect {
-                updater.update_payment_state
-              }.to change { order.payment_state }.to 'credit_owed'
-            end
-          end
-
-          context "and payment is refunded" do
-            it "is void" do
-              order.payment_total = 0
-              order.total = 30
-              allow(order).to receive_message_chain(:payments, :valid, :empty?) { false }
-              allow(order).to receive_message_chain(:payments, :completed, :empty?) { false }
-
-              expect {
-                updater.update_payment_state
-              }.to change { order.payment_state }.to 'void'
-            end
-          end
-        end
-
-        context 'when the set payment_state matches the last payment_state' do
-          before { order.payment_state = 'paid' }
-
-          it 'does not create any state_change' do
-            expect { updater.update_payment_state }
-              .not_to change { order.state_changes.size }
-          end
-        end
-
-        context 'when the set payment_state does not match the last payment_state' do
-          before { order.payment_state = 'previous_to_paid' }
-
-          context 'and the order is being updated' do
-            before { allow(order).to receive(:persisted?) { true } }
-
-            it 'creates a new state_change for the order' do
-              expect { updater.update_payment_state }
-                .to change { order.state_changes.size }.by(1)
-            end
-          end
-
-          context 'and the order is being created' do
-            before { allow(order).to receive(:persisted?) { false } }
-
-            it 'creates a new state_change for the order' do
-              expect { updater.update_payment_state }
-                .not_to change { order.state_changes.size }
-            end
-          end
-        end
-
-        context "when unused payments records exist which require authorization, " \
-                "but the order is fully paid" do
-          let!(:cash_payment) {
-            build(:payment, state: "completed", amount: order.new_outstanding_balance)
-          }
-          let!(:stripe_payment) { build(:payment, state: "requires_authorization") }
-          before do
-            order.payments << cash_payment
-            order.payments << stripe_payment
-          end
-
-          it "cancels unused payments requiring authorization" do
-            expect(stripe_payment).to receive(:void_transaction!)
-            expect(cash_payment).not_to receive(:void_transaction!)
-
-            order.updater.update_payment_state
-          end
-        end
-      end
-
-      describe '#shipping_address_from_distributor' do
-        let(:distributor) { build(:distributor_enterprise) }
-        let(:shipment) {
-          create(:shipment_with, :shipping_method, shipping_method:)
-        }
-
-        before do
-          order.distributor = distributor
-          order.shipments = [shipment]
-        end
-
-        context 'when shipping method is pickup' do
-          let(:shipping_method) { create(:shipping_method_with, :pickup) }
-          let(:address) { build(:address, firstname: 'joe') }
-          before { distributor.address = address }
-
-          it "populates the shipping address from distributor" do
-            updater.shipping_address_from_distributor
-            expect(order.ship_address.address1).to eq(distributor.address.address1)
-          end
-        end
-
-        context 'when shipping_method is delivery' do
-          let(:shipping_method) { create(:shipping_method_with, :delivery) }
-          let(:address) { build(:address, firstname: 'will') }
-          before { order.ship_address = address }
-
-          it "does not populate the shipping address from distributor" do
-            updater.shipping_address_from_distributor
-            expect(order.ship_address.firstname).to eq("will")
-          end
-        end
-      end
-
-      describe "#update_totals_and_states" do
-        it "deals with legacy taxes" do
-          expect(updater).to receive(:handle_legacy_taxes)
-
-          updater.update_totals_and_states
-        end
-      end
-
-      describe "#handle_legacy_taxes" do
-        context "when the order is incomplete" do
-          it "doesn't touch taxes" do
-            allow(order).to receive(:completed?) { false }
-
-            expect(order).not_to receive(:create_tax_charge!)
-            updater.__send__(:handle_legacy_taxes)
-          end
-        end
-
-        context "when the order is complete" do
-          before { allow(order).to receive(:completed?) { true } }
-
-          context "and the order has legacy taxes" do
-            let!(:legacy_tax_adjustment) {
-              create(:adjustment, order:, adjustable: order, included: false,
-                                  originator_type: "Spree::TaxRate")
-            }
-
-            it "re-applies order taxes" do
-              expect(order).to receive(:create_tax_charge!)
-
-              updater.__send__(:handle_legacy_taxes)
-            end
-          end
-
-          context "and the order has no legacy taxes" do
-            it "leaves taxes untouched" do
-              expect(order).not_to receive(:create_tax_charge!)
-
-              updater.__send__(:handle_legacy_taxes)
-            end
-          end
-        end
-      end
-
-      describe "#update_voucher" do
-        let(:voucher_service) { instance_double(VoucherAdjustmentsService) }
-
-        it "calls VoucherAdjustmentsService" do
-          expect(VoucherAdjustmentsService).to receive(:new).and_return(voucher_service)
-          expect(voucher_service).to receive(:update)
-
-          updater.update_voucher
-        end
-
-        it "calls update_totals_and_states" do
-          allow(VoucherAdjustmentsService).to receive(:new).and_return(voucher_service)
-          allow(voucher_service).to receive(:update)
-
-          expect(updater).to receive(:update_totals_and_states)
-
-          updater.update_voucher
-        end
-      end
-
-      def update_order_quantity(order)
-        order.line_items.first.update_attribute(:quantity, 2)
+RSpec.describe OrderManagement::Order::Updater do
+  let(:order) { create(:order) }
+  let(:updater) { OrderManagement::Order::Updater.new(order) }
+
+  describe "#update_totals" do
+    before do
+      2.times { create(:line_item, order:, price: 10) }
+    end
+
+    it "updates payment totals" do
+      allow(order).to receive_message_chain(:payments, :completed, :sum).and_return(10)
+
+      updater.update_totals
+      expect(order.payment_total).to eq(10)
+    end
+  end
+
+  describe "#update_item_total" do
+    before do
+      2.times { create(:line_item, order:, price: 10) }
+    end
+
+    it "updates item total" do
+      updater.update_item_total
+      expect(order.item_total).to eq(20)
+    end
+  end
+
+  describe "#update_adjustment_total" do
+    before do
+      2.times { create(:line_item, order:, price: 10) }
+    end
+
+    it "updates adjustment totals" do
+      allow(order).to receive_message_chain(:all_adjustments, :additional, :eligible,
+                                            :sum).and_return(-5)
+      allow(order).to receive_message_chain(:all_adjustments, :tax, :additional,
+                                            :sum).and_return(20)
+      allow(order).to receive_message_chain(:all_adjustments, :tax, :inclusive,
+                                            :sum).and_return(15)
+
+      updater.update_adjustment_total
+      expect(order.adjustment_total).to eq(-5)
+      expect(order.additional_tax_total).to eq(20)
+      expect(order.included_tax_total).to eq(15)
+    end
+  end
+
+  describe "#update_shipment_state" do
+    let(:shipment) { build(:shipment) }
+
+    before do
+      allow(order).to receive(:shipments).and_return([shipment])
+    end
+
+    it "is backordered" do
+      allow(shipment).to receive(:backordered?) { true }
+      updater.update_shipment_state
+
+      expect(order.shipment_state).to eq 'backorder'
+    end
+
+    it "is nil" do
+      allow(shipment).to receive(:state).and_return(nil)
+
+      updater.update_shipment_state
+      expect(order.shipment_state).to be_nil
+    end
+
+    ["shipped", "ready", "pending", "canceled"].each do |state|
+      it "is #{state}" do
+        allow(shipment).to receive(:state).and_return(state)
+        updater.update_shipment_state
+        expect(order.shipment_state).to eq state.to_s
       end
     end
+  end
+
+  it "state change" do
+    order = create(:order)
+    order.shipment_state = 'shipped'
+    state_changes = double
+    allow(order).to receive(:state_changes) { state_changes }
+    expect(state_changes).to receive(:create).with(
+      previous_state: nil,
+      next_state: 'shipped',
+      name: 'shipment',
+      user_id: order.user_id
+    )
+
+    order.state_changed('shipment')
+  end
+
+  describe "#update" do
+    it "updates totals once" do
+      expect(updater).to receive(:update_totals).once
+      updater.update
+    end
+
+    it "updates all adjustments" do
+      expect(updater).to receive(:update_all_adjustments)
+      updater.update
+    end
+
+    context "completed order" do
+      before { allow(order).to receive(:completed?) { true } }
+
+      it "updates payment state" do
+        expect(updater).to receive(:update_payment_state)
+        updater.update
+      end
+
+      it "updates shipment state" do
+        expect(updater).to receive(:update_shipment_state)
+        updater.update
+      end
+
+      context "with pending payments" do
+        let(:order) { create(:completed_order_with_totals) }
+
+        it "updates pending payments" do
+          payment = create(:payment, order:, amount: order.total)
+
+          # update order so the order total will change
+          update_order_quantity(order)
+          order.payments.reload
+
+          expect { updater.update }.to change { payment.reload.amount }.from(50).to(60)
+        end
+      end
+    end
+
+    context "incompleted order" do
+      before { allow(order).to receive_messages completed?: false }
+
+      it "doesnt update payment state" do
+        expect(updater).not_to receive(:update_payment_state)
+        updater.update
+      end
+
+      it "doesnt update shipment state" do
+        expect(updater).not_to receive(:update_shipment_state)
+        updater.update
+      end
+
+      it "doesnt update the order shipment" do
+        shipment = build(:shipment)
+        allow(order).to receive_messages shipments: [shipment]
+
+        expect(shipment).not_to receive(:update!).with(order)
+        expect(updater).not_to receive(:update_shipments).with(order)
+        updater.update
+      end
+
+      context "with pending payments" do
+        let!(:payment) { create(:payment, order:, amount: order.total) }
+
+        context "with order in payment state" do
+          let(:order) { create(:order_with_totals, state: "payment") }
+
+          it "updates pending payments" do
+            # update order so the order total will change
+            update_order_quantity(order)
+            order.payments.reload
+
+            expect { updater.update }.to change { payment.reload.amount }.from(10).to(20)
+          end
+        end
+
+        context "with order in confirmation state" do
+          let(:order) { create(:order_with_totals, state: "confirmation") }
+
+          it "updates pending payments" do
+            # update order so the order total will change
+            update_order_quantity(order)
+            order.payments.reload
+
+            expect { updater.update }.to change { payment.reload.amount }.from(10).to(20)
+          end
+
+          it "updates pending payments fees" do
+            calculator = build(:calculator_flat_percent_per_item, preferred_flat_percent: 10)
+            payment_method = create(:payment_method, name: "Percentage cash", calculator:)
+            payment = create(:payment, payment_method:, order:, amount: order.total)
+
+            # update order so the order total will change
+            update_order_quantity(order)
+            order.payments.reload
+
+            expect { updater.update }.to change { payment.reload.amount }.from(10).to(22)
+              .and change { payment.reload.adjustment.amount }.from(1).to(2)
+          end
+        end
+
+        context "with order in cart" do
+          let(:order) { create(:order_with_totals) }
+
+          it "doesn't update pending payments" do
+            # update order so the order total will change
+            update_order_quantity(order)
+
+            expect { updater.update }.not_to change { payment.reload.amount }
+          end
+        end
+      end
+    end
+  end
+
+  describe "#update_shipments" do
+    before { allow(order).to receive(:completed?) { true } }
+
+    it "updates the order shipment" do
+      shipment = build(:shipment)
+      allow(order).to receive_messages shipments: [shipment]
+
+      expect(shipment).to receive(:update!).with(order)
+      updater.update_shipments
+    end
+  end
+
+  describe "#update_payment_state" do
+    context "when the order has no valid payments" do
+      it "is failed" do
+        allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(true)
+
+        updater.update_payment_state
+        expect(order.payment_state).to eq('failed')
+      end
+    end
+
+    context "when the order has a payment that requires authorization" do
+      let!(:payment) { create(:payment, order:, state: "requires_authorization") }
+
+      it "returns requires_authorization" do
+        expect {
+          updater.update_payment_state
+        }.to change { order.payment_state }.to 'requires_authorization'
+      end
+    end
+
+    context "when order has a payment that requires authorization and a completed payment" do
+      let!(:payment) { create(:payment, order:, state: "requires_authorization") }
+      let!(:completed_payment) { create(:payment, :completed, order:) }
+
+      it "returns paid" do
+        updater.update_payment_state
+        expect(order.payment_state).not_to eq("requires_authorization")
+      end
+    end
+
+    context "payment total is greater than order total" do
+      it "is credit_owed" do
+        order.payment_total = 2
+        order.total = 1
+
+        expect {
+          updater.update_payment_state
+        }.to change { order.payment_state }.to 'credit_owed'
+      end
+    end
+
+    context "order total is greater than payment total" do
+      it "is credit_owed" do
+        order.payment_total = 1
+        order.total = 2
+
+        expect {
+          updater.update_payment_state
+        }.to change { order.payment_state }.to 'balance_due'
+      end
+    end
+
+    context "order total equals payment total" do
+      it "is paid" do
+        order.payment_total = 30
+        order.total = 30
+
+        expect {
+          updater.update_payment_state
+        }.to change { order.payment_state }.to 'paid'
+      end
+    end
+
+    context "order is canceled" do
+      before { order.state = 'canceled' }
+
+      context "and is still unpaid" do
+        it "is void" do
+          order.payment_total = 0
+          order.total = 30
+
+          expect {
+            updater.update_payment_state
+          }.to change { order.payment_state }.to 'void'
+        end
+      end
+
+      context "and is paid" do
+        it "is credit_owed" do
+          order.payment_total = 30
+          order.total = 30
+          allow(order).to receive_message_chain(:payments, :valid, :empty?) { false }
+          allow(order).to receive_message_chain(:payments, :completed, :empty?) { false }
+          allow(order).to receive_message_chain(:payments, :requires_authorization, :any?) {
+                            false
+                          }
+
+          expect {
+            updater.update_payment_state
+          }.to change { order.payment_state }.to 'credit_owed'
+        end
+      end
+
+      context "and payment is refunded" do
+        it "is void" do
+          order.payment_total = 0
+          order.total = 30
+          allow(order).to receive_message_chain(:payments, :valid, :empty?) { false }
+          allow(order).to receive_message_chain(:payments, :completed, :empty?) { false }
+
+          expect {
+            updater.update_payment_state
+          }.to change { order.payment_state }.to 'void'
+        end
+      end
+    end
+
+    context 'when the set payment_state matches the last payment_state' do
+      before { order.payment_state = 'paid' }
+
+      it 'does not create any state_change' do
+        expect { updater.update_payment_state }
+          .not_to change { order.state_changes.size }
+      end
+    end
+
+    context 'when the set payment_state does not match the last payment_state' do
+      before { order.payment_state = 'previous_to_paid' }
+
+      context 'and the order is being updated' do
+        before { allow(order).to receive(:persisted?) { true } }
+
+        it 'creates a new state_change for the order' do
+          expect { updater.update_payment_state }
+            .to change { order.state_changes.size }.by(1)
+        end
+      end
+
+      context 'and the order is being created' do
+        before { allow(order).to receive(:persisted?) { false } }
+
+        it 'creates a new state_change for the order' do
+          expect { updater.update_payment_state }
+            .not_to change { order.state_changes.size }
+        end
+      end
+    end
+
+    context "when unused payments records exist which require authorization, " \
+            "but the order is fully paid" do
+      let!(:cash_payment) {
+        build(:payment, state: "completed", amount: order.new_outstanding_balance)
+      }
+      let!(:stripe_payment) { build(:payment, state: "requires_authorization") }
+      before do
+        order.payments << cash_payment
+        order.payments << stripe_payment
+      end
+
+      it "cancels unused payments requiring authorization" do
+        expect(stripe_payment).to receive(:void_transaction!)
+        expect(cash_payment).not_to receive(:void_transaction!)
+
+        order.updater.update_payment_state
+      end
+    end
+  end
+
+  describe '#shipping_address_from_distributor' do
+    let(:distributor) { build(:distributor_enterprise) }
+    let(:shipment) {
+      create(:shipment_with, :shipping_method, shipping_method:)
+    }
+
+    before do
+      order.distributor = distributor
+      order.shipments = [shipment]
+    end
+
+    context 'when shipping method is pickup' do
+      let(:shipping_method) { create(:shipping_method_with, :pickup) }
+      let(:address) { build(:address, firstname: 'joe') }
+      before { distributor.address = address }
+
+      it "populates the shipping address from distributor" do
+        updater.shipping_address_from_distributor
+        expect(order.ship_address.address1).to eq(distributor.address.address1)
+      end
+    end
+
+    context 'when shipping_method is delivery' do
+      let(:shipping_method) { create(:shipping_method_with, :delivery) }
+      let(:address) { build(:address, firstname: 'will') }
+      before { order.ship_address = address }
+
+      it "does not populate the shipping address from distributor" do
+        updater.shipping_address_from_distributor
+        expect(order.ship_address.firstname).to eq("will")
+      end
+    end
+  end
+
+  describe "#update_totals_and_states" do
+    it "deals with legacy taxes" do
+      expect(updater).to receive(:handle_legacy_taxes)
+
+      updater.update_totals_and_states
+    end
+  end
+
+  describe "#handle_legacy_taxes" do
+    context "when the order is incomplete" do
+      it "doesn't touch taxes" do
+        allow(order).to receive(:completed?) { false }
+
+        expect(order).not_to receive(:create_tax_charge!)
+        updater.__send__(:handle_legacy_taxes)
+      end
+    end
+
+    context "when the order is complete" do
+      before { allow(order).to receive(:completed?) { true } }
+
+      context "and the order has legacy taxes" do
+        let!(:legacy_tax_adjustment) {
+          create(:adjustment, order:, adjustable: order, included: false,
+                              originator_type: "Spree::TaxRate")
+        }
+
+        it "re-applies order taxes" do
+          expect(order).to receive(:create_tax_charge!)
+
+          updater.__send__(:handle_legacy_taxes)
+        end
+      end
+
+      context "and the order has no legacy taxes" do
+        it "leaves taxes untouched" do
+          expect(order).not_to receive(:create_tax_charge!)
+
+          updater.__send__(:handle_legacy_taxes)
+        end
+      end
+    end
+  end
+
+  describe "#update_voucher" do
+    let(:voucher_service) { instance_double(VoucherAdjustmentsService) }
+
+    it "calls VoucherAdjustmentsService" do
+      expect(VoucherAdjustmentsService).to receive(:new).and_return(voucher_service)
+      expect(voucher_service).to receive(:update)
+
+      updater.update_voucher
+    end
+
+    it "calls update_totals_and_states" do
+      allow(VoucherAdjustmentsService).to receive(:new).and_return(voucher_service)
+      allow(voucher_service).to receive(:update)
+
+      expect(updater).to receive(:update_totals_and_states)
+
+      updater.update_voucher
+    end
+  end
+
+  def update_order_quantity(order)
+    order.line_items.first.update_attribute(:quantity, 2)
   end
 end

--- a/engines/order_management/spec/services/order_management/stock/package_spec.rb
+++ b/engines/order_management/spec/services/order_management/stock/package_spec.rb
@@ -2,177 +2,173 @@
 
 require 'spec_helper'
 
-module OrderManagement
-  module Stock
-    RSpec.describe Package do
-      context "base tests" do
-        let(:variant) { build(:variant, weight: 25.0) }
-        let(:distributor) { create(:enterprise) }
-        let(:order) { build(:order, distributor:) }
+RSpec.describe OrderManagement::Stock::Package do
+  context "base tests" do
+    let(:variant) { build(:variant, weight: 25.0) }
+    let(:distributor) { create(:enterprise) }
+    let(:order) { build(:order, distributor:) }
 
-        subject { Package.new(order) }
+    subject { described_class.new(order) }
 
-        it 'calculates the weight of all the contents' do
-          subject.add variant, 4
-          expect(subject.weight).to eq 100.0
-        end
+    it 'calculates the weight of all the contents' do
+      subject.add variant, 4
+      expect(subject.weight).to eq 100.0
+    end
 
-        it 'filters by on_hand and backordered' do
-          subject.add variant, 4, :on_hand
-          subject.add variant, 3, :backordered
-          expect(subject.on_hand.count).to eq 1
-          expect(subject.backordered.count).to eq 1
-        end
+    it 'filters by on_hand and backordered' do
+      subject.add variant, 4, :on_hand
+      subject.add variant, 3, :backordered
+      expect(subject.on_hand.count).to eq 1
+      expect(subject.backordered.count).to eq 1
+    end
 
-        it 'calculates the quantity by state' do
-          subject.add variant, 4, :on_hand
-          subject.add variant, 3, :backordered
+    it 'calculates the quantity by state' do
+      subject.add variant, 4, :on_hand
+      subject.add variant, 3, :backordered
 
-          expect(subject.quantity).to eq 7
-          expect(subject.quantity(:on_hand)).to eq 4
-          expect(subject.quantity(:backordered)).to eq 3
-        end
+      expect(subject.quantity).to eq 7
+      expect(subject.quantity(:on_hand)).to eq 4
+      expect(subject.quantity(:backordered)).to eq 3
+    end
 
-        it 'returns nil for content item not found' do
-          item = subject.find_item(variant, :on_hand)
-          expect(item).to be_nil
-        end
+    it 'returns nil for content item not found' do
+      item = subject.find_item(variant, :on_hand)
+      expect(item).to be_nil
+    end
 
-        it 'finds content item for a variant' do
-          subject.add variant, 4, :on_hand
-          item = subject.find_item(variant, :on_hand)
-          expect(item.quantity).to eq 4
-        end
+    it 'finds content item for a variant' do
+      subject.add variant, 4, :on_hand
+      item = subject.find_item(variant, :on_hand)
+      expect(item.quantity).to eq 4
+    end
 
-        it 'get flattened contents' do
-          subject.add variant, 4, :on_hand
-          subject.add variant, 2, :backordered
-          flattened = subject.flattened
-          expect(flattened.select { |i| i.state == :on_hand }.size).to eq 4
-          expect(flattened.select { |i| i.state == :backordered }.size).to eq 2
-        end
+    it 'get flattened contents' do
+      subject.add variant, 4, :on_hand
+      subject.add variant, 2, :backordered
+      flattened = subject.flattened
+      expect(flattened.select { |i| i.state == :on_hand }.size).to eq 4
+      expect(flattened.select { |i| i.state == :backordered }.size).to eq 2
+    end
 
-        it 'set contents from flattened' do
-          flattened = [Package::ContentItem.new(variant, 1, :on_hand),
-                       Package::ContentItem.new(variant, 1, :on_hand),
-                       Package::ContentItem.new(variant, 1, :backordered),
-                       Package::ContentItem.new(variant, 1, :backordered)]
+    it 'set contents from flattened' do
+      flattened = [described_class::ContentItem.new(variant, 1, :on_hand),
+                   described_class::ContentItem.new(variant, 1, :on_hand),
+                   described_class::ContentItem.new(variant, 1, :backordered),
+                   described_class::ContentItem.new(variant, 1, :backordered)]
 
-          subject.flattened = flattened
-          expect(subject.on_hand.size).to eq 1
-          expect(subject.on_hand.first.quantity).to eq 2
+      subject.flattened = flattened
+      expect(subject.on_hand.size).to eq 1
+      expect(subject.on_hand.first.quantity).to eq 2
 
-          expect(subject.backordered.size).to eq 1
-        end
+      expect(subject.backordered.size).to eq 1
+    end
 
-        # Contains regression test for #2804
-        it 'builds a list of shipping methods from all categories' do
-          shipping_method1 = create(:shipping_method, distributors: [distributor])
-          shipping_method2 = create(:shipping_method, distributors: [distributor])
-          variant1 = create(:variant,
-                            shipping_category: shipping_method1.shipping_categories.first)
-          variant2 = create(:variant,
-                            shipping_category: shipping_method2.shipping_categories.first)
-          variant3 = create(:variant, shipping_category: nil)
-          contents = [Package::ContentItem.new(variant1, 1),
-                      Package::ContentItem.new(variant1, 1),
-                      Package::ContentItem.new(variant2, 1),
-                      Package::ContentItem.new(variant3, 1)]
+    # Contains regression test for #2804
+    it 'builds a list of shipping methods from all categories' do
+      shipping_method1 = create(:shipping_method, distributors: [distributor])
+      shipping_method2 = create(:shipping_method, distributors: [distributor])
+      variant1 = create(:variant,
+                        shipping_category: shipping_method1.shipping_categories.first)
+      variant2 = create(:variant,
+                        shipping_category: shipping_method2.shipping_categories.first)
+      variant3 = create(:variant, shipping_category: nil)
+      contents = [described_class::ContentItem.new(variant1, 1),
+                  described_class::ContentItem.new(variant1, 1),
+                  described_class::ContentItem.new(variant2, 1),
+                  described_class::ContentItem.new(variant3, 1)]
 
-          package = Package.new(order, contents)
-          expect(package.shipping_methods.size).to eq 2
-        end
+      package = described_class.new(order, contents)
+      expect(package.shipping_methods.size).to eq 2
+    end
 
-        it "can convert to a shipment" do
-          flattened = [Package::ContentItem.new(variant, 2, :on_hand),
-                       Package::ContentItem.new(variant, 1, :backordered)]
-          subject.flattened = flattened
+    it "can convert to a shipment" do
+      flattened = [described_class::ContentItem.new(variant, 2, :on_hand),
+                   described_class::ContentItem.new(variant, 1, :backordered)]
+      subject.flattened = flattened
 
-          shipping_method = build(:shipping_method)
-          subject.shipping_rates = [
-            Spree::ShippingRate.new(shipping_method:, cost: 10.00, selected: true)
-          ]
+      shipping_method = build(:shipping_method)
+      subject.shipping_rates = [
+        Spree::ShippingRate.new(shipping_method:, cost: 10.00, selected: true)
+      ]
 
-          shipment = subject.to_shipment
-          expect(shipment.order).to eq subject.order
-          expect(shipment.inventory_units.size).to eq 3
+      shipment = subject.to_shipment
+      expect(shipment.order).to eq subject.order
+      expect(shipment.inventory_units.size).to eq 3
 
-          first_unit = shipment.inventory_units.first
-          expect(first_unit.variant).to eq variant
-          expect(first_unit.state).to eq 'on_hand'
-          expect(first_unit.order).to eq subject.order
-          expect(first_unit).to be_pending
+      first_unit = shipment.inventory_units.first
+      expect(first_unit.variant).to eq variant
+      expect(first_unit.state).to eq 'on_hand'
+      expect(first_unit.order).to eq subject.order
+      expect(first_unit).to be_pending
 
-          last_unit = shipment.inventory_units.last
-          expect(last_unit.variant).to eq variant
-          expect(last_unit.state).to eq 'backordered'
-          expect(last_unit.order).to eq subject.order
+      last_unit = shipment.inventory_units.last
+      expect(last_unit.variant).to eq variant
+      expect(last_unit.state).to eq 'backordered'
+      expect(last_unit.order).to eq subject.order
 
-          expect(shipment.shipping_method).to eq shipping_method
-        end
+      expect(shipment.shipping_method).to eq shipping_method
+    end
 
-        describe "#inpsect" do
-          it "prints the package contents" do
-            subject.add variant, 5
-            expect(subject.inspect).to match("#{variant.name} 5")
-          end
-        end
+    describe "#inpsect" do
+      it "prints the package contents" do
+        subject.add variant, 5
+        expect(subject.inspect).to match("#{variant.name} 5")
+      end
+    end
+  end
+
+  context "#shipping_methods and #shipping_categories" do
+    subject(:package) { described_class.new(order, contents) }
+
+    let(:enterprise) { create(:enterprise) }
+    let(:other_enterprise) { create(:enterprise) }
+
+    let(:order) { build(:order, distributor: enterprise) }
+
+    let(:variant1) do
+      instance_double(
+        Spree::Variant,
+        shipping_category: shipping_method1.shipping_categories.first
+      )
+    end
+    let(:variant2) do
+      instance_double(
+        Spree::Variant,
+        shipping_category: shipping_method2.shipping_categories.first
+      )
+    end
+    let(:variant3) do
+      instance_double(Spree::Variant, shipping_category: nil)
+    end
+
+    let(:contents) do
+      [
+        described_class::ContentItem.new(variant1, 1),
+        described_class::ContentItem.new(variant1, 1),
+        described_class::ContentItem.new(variant2, 1),
+        described_class::ContentItem.new(variant3, 1)
+      ]
+    end
+
+    let(:shipping_method1) { create(:shipping_method, distributors: [enterprise]) }
+    let(:shipping_method2) { create(:shipping_method, distributors: [other_enterprise]) }
+    let!(:shipping_method3) {
+      create(:shipping_method, distributors: [enterprise], deleted_at: Time.zone.now)
+    }
+
+    describe "#shipping_methods" do
+      it "does not return shipping methods not used by the package's order distributor" do
+        expect(package.shipping_methods).to eq [shipping_method1]
       end
 
-      context "#shipping_methods and #shipping_categories" do
-        subject(:package) { Package.new(order, contents) }
+      it "does not return soft-deleted shipping methods" do
+        expect(package.shipping_methods).not_to include shipping_method3
+      end
 
-        let(:enterprise) { create(:enterprise) }
-        let(:other_enterprise) { create(:enterprise) }
+      it "returns an empty array if distributor is nil" do
+        allow(order).to receive(:distributor) { nil }
 
-        let(:order) { build(:order, distributor: enterprise) }
-
-        let(:variant1) do
-          instance_double(
-            Spree::Variant,
-            shipping_category: shipping_method1.shipping_categories.first
-          )
-        end
-        let(:variant2) do
-          instance_double(
-            Spree::Variant,
-            shipping_category: shipping_method2.shipping_categories.first
-          )
-        end
-        let(:variant3) do
-          instance_double(Spree::Variant, shipping_category: nil)
-        end
-
-        let(:contents) do
-          [
-            Package::ContentItem.new(variant1, 1),
-            Package::ContentItem.new(variant1, 1),
-            Package::ContentItem.new(variant2, 1),
-            Package::ContentItem.new(variant3, 1)
-          ]
-        end
-
-        let(:shipping_method1) { create(:shipping_method, distributors: [enterprise]) }
-        let(:shipping_method2) { create(:shipping_method, distributors: [other_enterprise]) }
-        let!(:shipping_method3) {
-          create(:shipping_method, distributors: [enterprise], deleted_at: Time.zone.now)
-        }
-
-        describe "#shipping_methods" do
-          it "does not return shipping methods not used by the package's order distributor" do
-            expect(package.shipping_methods).to eq [shipping_method1]
-          end
-
-          it "does not return soft-deleted shipping methods" do
-            expect(package.shipping_methods).not_to include shipping_method3
-          end
-
-          it "returns an empty array if distributor is nil" do
-            allow(order).to receive(:distributor) { nil }
-
-            expect(package.shipping_methods).to eq []
-          end
-        end
+        expect(package.shipping_methods).to eq []
       end
     end
   end

--- a/engines/order_management/spec/services/order_management/subscriptions/estimator_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/estimator_spec.rb
@@ -2,171 +2,167 @@
 
 require 'spec_helper'
 
-module OrderManagement
-  module Subscriptions
-    RSpec.describe Estimator do
-      describe "estimating prices for subscription line items" do
-        let!(:subscription) { create(:subscription, with_items: true) }
-        let!(:sli1) { subscription.subscription_line_items.first }
-        let!(:sli2) { subscription.subscription_line_items.second }
-        let!(:sli3) { subscription.subscription_line_items.third }
-        let(:estimator) { Estimator.new(subscription) }
+RSpec.describe OrderManagement::Subscriptions::Estimator do
+  describe "estimating prices for subscription line items" do
+    let!(:subscription) { create(:subscription, with_items: true) }
+    let!(:sli1) { subscription.subscription_line_items.first }
+    let!(:sli2) { subscription.subscription_line_items.second }
+    let!(:sli3) { subscription.subscription_line_items.third }
+    let(:estimator) { described_class.new(subscription) }
 
-        before do
-          sli1.update(price_estimate: 4.0)
-          sli2.update(price_estimate: 5.0)
-          sli3.update(price_estimate: 6.0)
-          sli1.variant.update(price: 1.0)
-          sli2.variant.update(price: 2.0)
-          sli3.variant.update(price: 3.0)
+    before do
+      sli1.update(price_estimate: 4.0)
+      sli2.update(price_estimate: 5.0)
+      sli3.update(price_estimate: 6.0)
+      sli1.variant.update(price: 1.0)
+      sli2.variant.update(price: 2.0)
+      sli3.variant.update(price: 3.0)
 
-          # Simulating assignment of attrs from params
-          sli1.assign_attributes(price_estimate: 7.0)
-          sli2.assign_attributes(price_estimate: 8.0)
-          sli3.assign_attributes(price_estimate: 9.0)
-        end
+      # Simulating assignment of attrs from params
+      sli1.assign_attributes(price_estimate: 7.0)
+      sli2.assign_attributes(price_estimate: 8.0)
+      sli3.assign_attributes(price_estimate: 9.0)
+    end
 
-        context "when a insufficient information exists to calculate price estimates" do
-          before do
-            # This might be because a shop has not been assigned yet, or no
-            # current or future order cycles exist for the schedule
-            allow(estimator).to receive(:fee_calculator) { nil }
-          end
+    context "when a insufficient information exists to calculate price estimates" do
+      before do
+        # This might be because a shop has not been assigned yet, or no
+        # current or future order cycles exist for the schedule
+        allow(estimator).to receive(:fee_calculator) { nil }
+      end
 
-          it "resets the price estimates for all items" do
-            estimator.estimate!
-            expect(sli1.price_estimate).to eq 4.0
-            expect(sli2.price_estimate).to eq 5.0
-            expect(sli3.price_estimate).to eq 6.0
-          end
-        end
+      it "resets the price estimates for all items" do
+        estimator.estimate!
+        expect(sli1.price_estimate).to eq 4.0
+        expect(sli2.price_estimate).to eq 5.0
+        expect(sli3.price_estimate).to eq 6.0
+      end
+    end
 
-        context "when sufficient information to calculate price estimates exists" do
-          let(:fee_calculator) { instance_double(OpenFoodNetwork::EnterpriseFeeCalculator) }
+    context "when sufficient information to calculate price estimates exists" do
+      let(:fee_calculator) { instance_double(OpenFoodNetwork::EnterpriseFeeCalculator) }
 
-          before do
-            allow(estimator).to receive(:fee_calculator) { fee_calculator }
-            allow(fee_calculator).to receive(:indexed_fees_for).with(sli1.variant) { 1.0 }
-            allow(fee_calculator).to receive(:indexed_fees_for).with(sli2.variant) { 0.0 }
-            allow(fee_calculator).to receive(:indexed_fees_for).with(sli3.variant) { 3.0 }
-          end
+      before do
+        allow(estimator).to receive(:fee_calculator) { fee_calculator }
+        allow(fee_calculator).to receive(:indexed_fees_for).with(sli1.variant) { 1.0 }
+        allow(fee_calculator).to receive(:indexed_fees_for).with(sli2.variant) { 0.0 }
+        allow(fee_calculator).to receive(:indexed_fees_for).with(sli3.variant) { 3.0 }
+      end
 
-          context "when no variant overrides apply" do
-            it "recalculates price_estimates based on variant prices and associated fees" do
-              estimator.estimate!
-              expect(sli1.price_estimate).to eq 2.0
-              expect(sli2.price_estimate).to eq 2.0
-              expect(sli3.price_estimate).to eq 6.0
-            end
-          end
-
-          context "when variant overrides apply" do
-            let!(:override1) {
-              create(:variant_override, hub: subscription.shop, variant: sli1.variant, price: 1.2)
-            }
-            let!(:override2) {
-              create(:variant_override, hub: subscription.shop, variant: sli2.variant, price: 2.3)
-            }
-
-            it "recalculates price_estimates based on override prices and associated fees" do
-              estimator.estimate!
-              expect(sli1.price_estimate).to eq 2.2
-              expect(sli2.price_estimate).to eq 2.3
-              expect(sli3.price_estimate).to eq 6.0
-            end
-          end
+      context "when no variant overrides apply" do
+        it "recalculates price_estimates based on variant prices and associated fees" do
+          estimator.estimate!
+          expect(sli1.price_estimate).to eq 2.0
+          expect(sli2.price_estimate).to eq 2.0
+          expect(sli3.price_estimate).to eq 6.0
         end
       end
 
-      describe "updating estimates for shipping and payment fees" do
-        let(:subscription) {
-          create(:subscription, with_items: true,
-                                payment_method:,
-                                shipping_method:)
+      context "when variant overrides apply" do
+        let!(:override1) {
+          create(:variant_override, hub: subscription.shop, variant: sli1.variant, price: 1.2)
         }
-        let!(:sli1) { subscription.subscription_line_items.first }
-        let!(:sli2) { subscription.subscription_line_items.second }
-        let!(:sli3) { subscription.subscription_line_items.third }
-        let(:estimator) { OrderManagement::Subscriptions::Estimator.new(subscription) }
+        let!(:override2) {
+          create(:variant_override, hub: subscription.shop, variant: sli2.variant, price: 2.3)
+        }
 
-        before do
-          allow(estimator).to receive(:assign_price_estimates)
-          sli1.update(price_estimate: 4.0)
-          sli2.update(price_estimate: 5.0)
-          sli3.update(price_estimate: 6.0)
+        it "recalculates price_estimates based on override prices and associated fees" do
+          estimator.estimate!
+          expect(sli1.price_estimate).to eq 2.2
+          expect(sli2.price_estimate).to eq 2.3
+          expect(sli3.price_estimate).to eq 6.0
         end
+      end
+    end
+  end
 
-        context "using flat rate calculators" do
-          let(:shipping_method) {
-            create(:shipping_method,
-                   calculator: Calculator::FlatRate.new(preferred_amount: 12.34))
-          }
-          let(:payment_method) {
-            create(:payment_method,
-                   calculator: Calculator::FlatRate.new(preferred_amount: 9.12))
-          }
+  describe "updating estimates for shipping and payment fees" do
+    let(:subscription) {
+      create(:subscription, with_items: true,
+                            payment_method:,
+                            shipping_method:)
+    }
+    let!(:sli1) { subscription.subscription_line_items.first }
+    let!(:sli2) { subscription.subscription_line_items.second }
+    let!(:sli3) { subscription.subscription_line_items.third }
+    let(:estimator) { described_class.new(subscription) }
 
-          it "calculates fees based on the rates provided" do
-            estimator.estimate!
-            expect(subscription.shipping_fee_estimate.to_f).to eq 12.34
-            expect(subscription.payment_fee_estimate.to_f).to eq 9.12
-          end
-        end
+    before do
+      allow(estimator).to receive(:assign_price_estimates)
+      sli1.update(price_estimate: 4.0)
+      sli2.update(price_estimate: 5.0)
+      sli3.update(price_estimate: 6.0)
+    end
 
-        context "using flat percent item total calculators" do
-          let(:shipping_method) {
-            create(:shipping_method,
-                   calculator: Calculator::FlatPercentItemTotal.new(
-                     preferred_flat_percent: 10
-                   ))
-          }
-          let(:payment_method) {
-            create(:payment_method,
-                   calculator: Calculator::FlatPercentItemTotal.new(
-                     preferred_flat_percent: 20
-                   ))
-          }
+    context "using flat rate calculators" do
+      let(:shipping_method) {
+        create(:shipping_method,
+               calculator: Calculator::FlatRate.new(preferred_amount: 12.34))
+      }
+      let(:payment_method) {
+        create(:payment_method,
+               calculator: Calculator::FlatRate.new(preferred_amount: 9.12))
+      }
 
-          it "calculates fees based on the estimated item total and percentage provided" do
-            estimator.estimate!
-            expect(subscription.shipping_fee_estimate.to_f).to eq 1.5
-            expect(subscription.payment_fee_estimate.to_f).to eq 3.0
-          end
-        end
+      it "calculates fees based on the rates provided" do
+        estimator.estimate!
+        expect(subscription.shipping_fee_estimate.to_f).to eq 12.34
+        expect(subscription.payment_fee_estimate.to_f).to eq 9.12
+      end
+    end
 
-        context "using flat percent per item calculators" do
-          let(:shipping_method) {
-            create(:shipping_method,
-                   calculator: Calculator::FlatPercentPerItem.new(preferred_flat_percent: 5))
-          }
-          let(:payment_method) {
-            create(:payment_method,
-                   calculator: Calculator::FlatPercentPerItem.new(preferred_flat_percent: 10))
-          }
+    context "using flat percent item total calculators" do
+      let(:shipping_method) {
+        create(:shipping_method,
+               calculator: Calculator::FlatPercentItemTotal.new(
+                 preferred_flat_percent: 10
+               ))
+      }
+      let(:payment_method) {
+        create(:payment_method,
+               calculator: Calculator::FlatPercentItemTotal.new(
+                 preferred_flat_percent: 20
+               ))
+      }
 
-          it "calculates fees based on the estimated item prices and percentage provided" do
-            estimator.estimate!
-            expect(subscription.shipping_fee_estimate.to_f).to eq 0.75
-            expect(subscription.payment_fee_estimate.to_f).to eq 1.5
-          end
-        end
+      it "calculates fees based on the estimated item total and percentage provided" do
+        estimator.estimate!
+        expect(subscription.shipping_fee_estimate.to_f).to eq 1.5
+        expect(subscription.payment_fee_estimate.to_f).to eq 3.0
+      end
+    end
 
-        context "using per item calculators" do
-          let(:shipping_method) {
-            create(:shipping_method,
-                   calculator: Calculator::PerItem.new(preferred_amount: 1.2))
-          }
-          let(:payment_method) {
-            create(:payment_method,
-                   calculator: Calculator::PerItem.new(preferred_amount: 0.3))
-          }
+    context "using flat percent per item calculators" do
+      let(:shipping_method) {
+        create(:shipping_method,
+               calculator: Calculator::FlatPercentPerItem.new(preferred_flat_percent: 5))
+      }
+      let(:payment_method) {
+        create(:payment_method,
+               calculator: Calculator::FlatPercentPerItem.new(preferred_flat_percent: 10))
+      }
 
-          it "calculates fees based on the number of items and rate provided" do
-            estimator.estimate!
-            expect(subscription.shipping_fee_estimate.to_f).to eq 3.6
-            expect(subscription.payment_fee_estimate.to_f).to eq 0.9
-          end
-        end
+      it "calculates fees based on the estimated item prices and percentage provided" do
+        estimator.estimate!
+        expect(subscription.shipping_fee_estimate.to_f).to eq 0.75
+        expect(subscription.payment_fee_estimate.to_f).to eq 1.5
+      end
+    end
+
+    context "using per item calculators" do
+      let(:shipping_method) {
+        create(:shipping_method,
+               calculator: Calculator::PerItem.new(preferred_amount: 1.2))
+      }
+      let(:payment_method) {
+        create(:payment_method,
+               calculator: Calculator::PerItem.new(preferred_amount: 0.3))
+      }
+
+      it "calculates fees based on the number of items and rate provided" do
+        estimator.estimate!
+        expect(subscription.shipping_fee_estimate.to_f).to eq 3.6
+        expect(subscription.payment_fee_estimate.to_f).to eq 0.9
       end
     end
   end

--- a/engines/order_management/spec/services/order_management/subscriptions/form_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/form_spec.rb
@@ -2,147 +2,143 @@
 
 require 'spec_helper'
 
-module OrderManagement
-  module Subscriptions
-    RSpec.describe Form do
-      describe "creating a new subscription" do
-        let!(:shop) { create(:distributor_enterprise) }
-        let!(:customer) { create(:customer, enterprise: shop) }
-        let!(:product1) { create(:product) }
-        let!(:product2) { create(:product) }
-        let!(:product3) { create(:product) }
-        let!(:variant1) {
-          create(:variant, product: product1, unit_value: '100', price: 12.00, supplier: shop)
-        }
-        let!(:variant2) {
-          create(:variant, product: product2, unit_value: '1000', price: 6.00, supplier: shop)
-        }
-        let!(:variant3) {
-          create(:variant, product: product2, unit_value: '1000',
-                           price: 2.50, on_hand: 1, supplier: shop)
-        }
-        let!(:enterprise_fee) { create(:enterprise_fee, amount: 1.75) }
-        let!(:order_cycle1) {
-          create(:simple_order_cycle, coordinator: shop,
-                                      orders_open_at: 9.days.ago,
-                                      orders_close_at: 2.days.ago)
-        }
-        let!(:order_cycle2) {
-          create(:simple_order_cycle, coordinator: shop,
-                                      orders_open_at: 2.days.ago,
-                                      orders_close_at: 5.days.from_now)
-        }
-        let!(:order_cycle3) {
-          create(:simple_order_cycle, coordinator: shop,
-                                      orders_open_at: 5.days.from_now,
-                                      orders_close_at: 12.days.from_now)
-        }
-        let!(:order_cycle4) {
-          create(:simple_order_cycle, coordinator: shop,
-                                      orders_open_at: 12.days.from_now,
-                                      orders_close_at: 19.days.from_now)
-        }
-        let!(:outgoing_exchange1) {
-          order_cycle1.exchanges.create(sender: shop,
-                                        receiver: shop,
-                                        variants: [variant1, variant2, variant3],
-                                        enterprise_fees: [enterprise_fee])
-        }
-        let!(:outgoing_exchange2) {
-          order_cycle2.exchanges.create(sender: shop,
-                                        receiver: shop,
-                                        variants: [variant1, variant2, variant3],
-                                        enterprise_fees: [enterprise_fee])
-        }
-        let!(:outgoing_exchange3) {
-          order_cycle3.exchanges.create(sender: shop,
-                                        receiver: shop,
-                                        variants: [variant1, variant3],
-                                        enterprise_fees: [])
-        }
-        let!(:outgoing_exchange4) {
-          order_cycle4.exchanges.create(sender: shop,
-                                        receiver: shop,
-                                        variants: [variant1, variant2, variant3],
-                                        enterprise_fees: [enterprise_fee])
-        }
-        let!(:schedule) {
-          create(:schedule, order_cycles: [order_cycle1, order_cycle2, order_cycle3, order_cycle4])
-        }
-        let!(:payment_method) { create(:payment_method, distributors: [shop]) }
-        let!(:shipping_method) { create(:shipping_method, distributors: [shop]) }
-        let!(:address) { create(:address) }
-        let(:subscription) { Subscription.new }
+RSpec.describe OrderManagement::Subscriptions::Form do
+  describe "creating a new subscription" do
+    let!(:shop) { create(:distributor_enterprise) }
+    let!(:customer) { create(:customer, enterprise: shop) }
+    let!(:product1) { create(:product) }
+    let!(:product2) { create(:product) }
+    let!(:product3) { create(:product) }
+    let!(:variant1) {
+      create(:variant, product: product1, unit_value: '100', price: 12.00, supplier: shop)
+    }
+    let!(:variant2) {
+      create(:variant, product: product2, unit_value: '1000', price: 6.00, supplier: shop)
+    }
+    let!(:variant3) {
+      create(:variant, product: product2, unit_value: '1000',
+                       price: 2.50, on_hand: 1, supplier: shop)
+    }
+    let!(:enterprise_fee) { create(:enterprise_fee, amount: 1.75) }
+    let!(:order_cycle1) {
+      create(:simple_order_cycle, coordinator: shop,
+                                  orders_open_at: 9.days.ago,
+                                  orders_close_at: 2.days.ago)
+    }
+    let!(:order_cycle2) {
+      create(:simple_order_cycle, coordinator: shop,
+                                  orders_open_at: 2.days.ago,
+                                  orders_close_at: 5.days.from_now)
+    }
+    let!(:order_cycle3) {
+      create(:simple_order_cycle, coordinator: shop,
+                                  orders_open_at: 5.days.from_now,
+                                  orders_close_at: 12.days.from_now)
+    }
+    let!(:order_cycle4) {
+      create(:simple_order_cycle, coordinator: shop,
+                                  orders_open_at: 12.days.from_now,
+                                  orders_close_at: 19.days.from_now)
+    }
+    let!(:outgoing_exchange1) {
+      order_cycle1.exchanges.create(sender: shop,
+                                    receiver: shop,
+                                    variants: [variant1, variant2, variant3],
+                                    enterprise_fees: [enterprise_fee])
+    }
+    let!(:outgoing_exchange2) {
+      order_cycle2.exchanges.create(sender: shop,
+                                    receiver: shop,
+                                    variants: [variant1, variant2, variant3],
+                                    enterprise_fees: [enterprise_fee])
+    }
+    let!(:outgoing_exchange3) {
+      order_cycle3.exchanges.create(sender: shop,
+                                    receiver: shop,
+                                    variants: [variant1, variant3],
+                                    enterprise_fees: [])
+    }
+    let!(:outgoing_exchange4) {
+      order_cycle4.exchanges.create(sender: shop,
+                                    receiver: shop,
+                                    variants: [variant1, variant2, variant3],
+                                    enterprise_fees: [enterprise_fee])
+    }
+    let!(:schedule) {
+      create(:schedule, order_cycles: [order_cycle1, order_cycle2, order_cycle3, order_cycle4])
+    }
+    let!(:payment_method) { create(:payment_method, distributors: [shop]) }
+    let!(:shipping_method) { create(:shipping_method, distributors: [shop]) }
+    let!(:address) { create(:address) }
+    let(:subscription) { Subscription.new }
 
-        let!(:params) {
-          {
-            shop_id: shop.id,
-            customer_id: customer.id,
-            schedule_id: schedule.id,
-            bill_address_attributes: address.clone.attributes,
-            ship_address_attributes: address.clone.attributes,
-            payment_method_id: payment_method.id,
-            shipping_method_id: shipping_method.id,
-            begins_at: 4.days.ago,
-            ends_at: 14.days.from_now,
-            subscription_line_items_attributes: [
-              { variant_id: variant1.id, quantity: 1, price_estimate: 7.0 },
-              { variant_id: variant2.id, quantity: 2, price_estimate: 8.0 },
-              { variant_id: variant3.id, quantity: 3, price_estimate: 9.0 }
-            ]
-          }
-        }
+    let!(:params) {
+      {
+        shop_id: shop.id,
+        customer_id: customer.id,
+        schedule_id: schedule.id,
+        bill_address_attributes: address.clone.attributes,
+        ship_address_attributes: address.clone.attributes,
+        payment_method_id: payment_method.id,
+        shipping_method_id: shipping_method.id,
+        begins_at: 4.days.ago,
+        ends_at: 14.days.from_now,
+        subscription_line_items_attributes: [
+          { variant_id: variant1.id, quantity: 1, price_estimate: 7.0 },
+          { variant_id: variant2.id, quantity: 2, price_estimate: 8.0 },
+          { variant_id: variant3.id, quantity: 3, price_estimate: 9.0 }
+        ]
+      }
+    }
 
-        let(:form) { OrderManagement::Subscriptions::Form.new(subscription, params) }
+    let(:form) { described_class.new(subscription, params) }
 
-        it "creates orders for each order cycle in the schedule" do
-          expect(form.save).to be true
+    it "creates orders for each order cycle in the schedule" do
+      expect(form.save).to be true
 
-          expect(subscription.proxy_orders.count).to be 2
-          expect(subscription.subscription_line_items.count).to be 3
-          expect(subscription.subscription_line_items[0].price_estimate).to eq 13.75
-          expect(subscription.subscription_line_items[1].price_estimate).to eq 7.75
-          expect(subscription.subscription_line_items[2].price_estimate).to eq 4.25
+      expect(subscription.proxy_orders.count).to be 2
+      expect(subscription.subscription_line_items.count).to be 3
+      expect(subscription.subscription_line_items[0].price_estimate).to eq 13.75
+      expect(subscription.subscription_line_items[1].price_estimate).to eq 7.75
+      expect(subscription.subscription_line_items[2].price_estimate).to eq 4.25
 
-          # This order cycle has already closed, so no order is initialized
-          proxy_order1 = subscription.proxy_orders.find_by(order_cycle_id: order_cycle1.id)
-          expect(proxy_order1).to be nil
+      # This order cycle has already closed, so no order is initialized
+      proxy_order1 = subscription.proxy_orders.find_by(order_cycle_id: order_cycle1.id)
+      expect(proxy_order1).to be nil
 
-          # Currently open order cycle, closing after begins_at and before ends_at
-          proxy_order2 = subscription.proxy_orders.find_by(order_cycle_id: order_cycle2.id)
-          expect(proxy_order2).to be_a ProxyOrder
-          order2 = proxy_order2.initialise_order!
-          expect(order2.line_items.count).to eq 3
-          expect(order2.line_items.find_by(variant_id: variant3.id).quantity).to be 3
-          expect(order2.shipments.count).to eq 1
-          expect(order2.shipments.first.shipping_method).to eq shipping_method
-          expect(order2.payments.count).to eq 1
-          expect(order2.payments.first.payment_method).to eq payment_method
-          expect(order2.payments.first.state).to eq 'checkout'
-          expect(order2.total).to eq 42
-          expect(order2.completed?).to be false
+      # Currently open order cycle, closing after begins_at and before ends_at
+      proxy_order2 = subscription.proxy_orders.find_by(order_cycle_id: order_cycle2.id)
+      expect(proxy_order2).to be_a ProxyOrder
+      order2 = proxy_order2.initialise_order!
+      expect(order2.line_items.count).to eq 3
+      expect(order2.line_items.find_by(variant_id: variant3.id).quantity).to be 3
+      expect(order2.shipments.count).to eq 1
+      expect(order2.shipments.first.shipping_method).to eq shipping_method
+      expect(order2.payments.count).to eq 1
+      expect(order2.payments.first.payment_method).to eq payment_method
+      expect(order2.payments.first.state).to eq 'checkout'
+      expect(order2.total).to eq 42
+      expect(order2.completed?).to be false
 
-          # Future order cycle, closing after begins_at and before ends_at
-          # Adds line items for variants that aren't yet available from the order cycle
-          proxy_order3 = subscription.proxy_orders.find_by(order_cycle_id: order_cycle3.id)
-          expect(proxy_order3).to be_a ProxyOrder
-          order3 = proxy_order3.initialise_order!
-          expect(order3).to be_a Spree::Order
-          expect(order3.line_items.count).to eq 3
-          expect(order2.line_items.find_by(variant_id: variant3.id).quantity).to be 3
-          expect(order3.shipments.count).to eq 1
-          expect(order3.shipments.first.shipping_method).to eq shipping_method
-          expect(order3.payments.count).to eq 1
-          expect(order3.payments.first.payment_method).to eq payment_method
-          expect(order3.payments.first.state).to eq 'checkout'
-          expect(order3.total).to eq 31.50
-          expect(order3.completed?).to be false
+      # Future order cycle, closing after begins_at and before ends_at
+      # Adds line items for variants that aren't yet available from the order cycle
+      proxy_order3 = subscription.proxy_orders.find_by(order_cycle_id: order_cycle3.id)
+      expect(proxy_order3).to be_a ProxyOrder
+      order3 = proxy_order3.initialise_order!
+      expect(order3).to be_a Spree::Order
+      expect(order3.line_items.count).to eq 3
+      expect(order2.line_items.find_by(variant_id: variant3.id).quantity).to be 3
+      expect(order3.shipments.count).to eq 1
+      expect(order3.shipments.first.shipping_method).to eq shipping_method
+      expect(order3.payments.count).to eq 1
+      expect(order3.payments.first.payment_method).to eq payment_method
+      expect(order3.payments.first.state).to eq 'checkout'
+      expect(order3.total).to eq 31.50
+      expect(order3.completed?).to be false
 
-          # Future order cycle closing after ends_at
-          proxy_order4 = subscription.proxy_orders.find_by(order_cycle_id: order_cycle4.id)
-          expect(proxy_order4).to be nil
-        end
-      end
+      # Future order cycle closing after ends_at
+      proxy_order4 = subscription.proxy_orders.find_by(order_cycle_id: order_cycle4.id)
+      expect(proxy_order4).to be nil
     end
   end
 end

--- a/engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb
@@ -2,483 +2,479 @@
 
 require 'spec_helper'
 
-module OrderManagement
-  module Subscriptions
-    RSpec.describe ProxyOrderSyncer do
-      describe "initialization" do
-        let!(:subscription) { create(:subscription) }
+RSpec.describe OrderManagement::Subscriptions::ProxyOrderSyncer do
+  describe "initialization" do
+    let!(:subscription) { create(:subscription) }
 
-        it "raises an error when initialized with an object
-            that is not a Subscription or an ActiveRecord::Relation" do
-          expect{ ProxyOrderSyncer.new(subscription) }.not_to raise_error
-          expect{ ProxyOrderSyncer.new(Subscription.where(id: subscription.id)) }.not_to raise_error
-          expect{ ProxyOrderSyncer.new("something") }.to raise_error RuntimeError
+    it "raises an error when initialized with an object
+        that is not a Subscription or an ActiveRecord::Relation" do
+      expect{ described_class.new(subscription) }.not_to raise_error
+      expect{ described_class.new(Subscription.where(id: subscription.id)) }.not_to raise_error
+      expect{ described_class.new("something") }.to raise_error RuntimeError
+    end
+  end
+
+  describe "#sync!" do
+    let(:now) { Time.zone.now }
+    let(:schedule) { create(:schedule, order_cycles: [oc]) }
+
+    let(:closed_oc) {
+      create(:simple_order_cycle, orders_open_at: now - 1.minute, orders_close_at: now)
+    }
+    let(:open_oc_closes_before_begins_at_oc) { # Open, but closes before begins at
+      create(:simple_order_cycle,
+             orders_open_at: now - 1.minute, orders_close_at: now + 59.seconds)
+    }
+    let(:open_oc) { # Open & closes between begins at and ends at
+      create(:simple_order_cycle,
+             orders_open_at: now - 1.minute, orders_close_at: now + 90.seconds)
+    }
+    let(:upcoming_closes_before_begins_at_oc) { # Upcoming, but closes before begins at
+      create(:simple_order_cycle,
+             orders_open_at: now + 30.seconds, orders_close_at: now + 59.seconds)
+    }
+    let(:upcoming_closes_on_begins_at_oc) { # Upcoming & closes on begins at
+      create(:simple_order_cycle,
+             orders_open_at: now + 30.seconds, orders_close_at: now + 1.minute)
+    }
+    let(:upcoming_closes_on_ends_at_oc) { # Upcoming & closes on ends at
+      create(:simple_order_cycle,
+             orders_open_at: now + 30.seconds, orders_close_at: now + 2.minutes)
+    }
+    let(:upcoming_closes_after_ends_at_oc) { # Upcoming & closes after ends at
+      create(:simple_order_cycle,
+             orders_open_at: now + 30.seconds, orders_close_at: now + 121.seconds)
+    }
+
+    let(:subscription) {
+      build(:subscription, begins_at: now + 1.minute, ends_at: now + 2.minutes)
+    }
+    let(:proxy_orders) { subscription.reload.proxy_orders }
+    let(:order_cycles) { proxy_orders.map(&:order_cycle) }
+    let(:syncer) { described_class.new(subscription) }
+
+    context "when the subscription is not persisted" do
+      let(:schedule) { create(:schedule, order_cycles: [oc]) }
+      let(:subscription) do
+        build(
+          :subscription,
+          begins_at: now + 1.minute,
+          ends_at: now + 2.minutes,
+          schedule:
+        )
+      end
+
+      context "and the schedule includes a closed oc (ie. closed before opens_at)" do
+        let!(:oc) { closed_oc }
+
+        it "does not create a new proxy order for that oc" do
+          expect{ subscription.save! }.not_to change { ProxyOrder.count }.from(0)
+          expect(order_cycles).not_to include oc
         end
       end
 
-      describe "#sync!" do
-        let(:now) { Time.zone.now }
-        let(:schedule) { create(:schedule, order_cycles: [oc]) }
+      context "and the schedule includes an open oc that closes before begins_at" do
+        let!(:oc) { open_oc_closes_before_begins_at_oc }
 
-        let(:closed_oc) {
-          create(:simple_order_cycle, orders_open_at: now - 1.minute, orders_close_at: now)
-        }
-        let(:open_oc_closes_before_begins_at_oc) { # Open, but closes before begins at
-          create(:simple_order_cycle,
-                 orders_open_at: now - 1.minute, orders_close_at: now + 59.seconds)
-        }
-        let(:open_oc) { # Open & closes between begins at and ends at
-          create(:simple_order_cycle,
-                 orders_open_at: now - 1.minute, orders_close_at: now + 90.seconds)
-        }
-        let(:upcoming_closes_before_begins_at_oc) { # Upcoming, but closes before begins at
-          create(:simple_order_cycle,
-                 orders_open_at: now + 30.seconds, orders_close_at: now + 59.seconds)
-        }
-        let(:upcoming_closes_on_begins_at_oc) { # Upcoming & closes on begins at
-          create(:simple_order_cycle,
-                 orders_open_at: now + 30.seconds, orders_close_at: now + 1.minute)
-        }
-        let(:upcoming_closes_on_ends_at_oc) { # Upcoming & closes on ends at
-          create(:simple_order_cycle,
-                 orders_open_at: now + 30.seconds, orders_close_at: now + 2.minutes)
-        }
-        let(:upcoming_closes_after_ends_at_oc) { # Upcoming & closes after ends at
-          create(:simple_order_cycle,
-                 orders_open_at: now + 30.seconds, orders_close_at: now + 121.seconds)
-        }
-
-        let(:subscription) {
-          build(:subscription, begins_at: now + 1.minute, ends_at: now + 2.minutes)
-        }
-        let(:proxy_orders) { subscription.reload.proxy_orders }
-        let(:order_cycles) { proxy_orders.map(&:order_cycle) }
-        let(:syncer) { ProxyOrderSyncer.new(subscription) }
-
-        context "when the subscription is not persisted" do
-          let(:schedule) { create(:schedule, order_cycles: [oc]) }
-          let(:subscription) do
-            build(
-              :subscription,
-              begins_at: now + 1.minute,
-              ends_at: now + 2.minutes,
-              schedule:
-            )
-          end
-
-          context "and the schedule includes a closed oc (ie. closed before opens_at)" do
-            let!(:oc) { closed_oc }
-
-            it "does not create a new proxy order for that oc" do
-              expect{ subscription.save! }.not_to change { ProxyOrder.count }.from(0)
-              expect(order_cycles).not_to include oc
-            end
-          end
-
-          context "and the schedule includes an open oc that closes before begins_at" do
-            let!(:oc) { open_oc_closes_before_begins_at_oc }
-
-            it "does not create a new proxy order for that oc" do
-              expect{ subscription.save! }.not_to change { ProxyOrder.count }.from(0)
-              expect(order_cycles).not_to include oc
-            end
-          end
-
-          context "and the schedule has an open OC that closes between begins_at and ends_at" do
-            let!(:oc) { open_oc }
-
-            it "creates a new proxy order for that oc" do
-              syncer.sync!
-
-              expect{ subscription.save! }.to change { ProxyOrder.count }.from(0).to(1)
-              expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
-            end
-          end
-
-          context "and the schedule includes upcoming oc that closes before begins_at" do
-            let!(:oc) { upcoming_closes_before_begins_at_oc }
-
-            it "does not create a new proxy order for that oc" do
-              expect{ subscription.save! }.not_to change { ProxyOrder.count }.from(0)
-              expect(order_cycles).not_to include oc
-            end
-          end
-
-          context "and the schedule includes upcoming oc that closes on begins_at" do
-            let!(:oc) { upcoming_closes_on_begins_at_oc }
-
-            it "creates a new proxy order for that oc" do
-              syncer.sync!
-
-              expect{ subscription.save! }.to change { ProxyOrder.count }.from(0).to(1)
-              expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
-            end
-          end
-
-          context "and the schedule includes upcoming oc that closes after ends_at" do
-            let!(:oc) { upcoming_closes_on_ends_at_oc }
-
-            it "creates a new proxy order for that oc" do
-              syncer.sync!
-
-              expect{ subscription.save! }.to change { ProxyOrder.count }.from(0).to(1)
-              expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
-            end
-          end
-
-          context "and the schedule includes upcoming oc that closes after ends_at" do
-            let!(:oc) { upcoming_closes_after_ends_at_oc }
-
-            it "does not create a new proxy order for that oc" do
-              expect{ subscription.save! }.not_to change { ProxyOrder.count }.from(0)
-              expect(order_cycles).not_to include oc
-            end
-          end
+        it "does not create a new proxy order for that oc" do
+          expect{ subscription.save! }.not_to change { ProxyOrder.count }.from(0)
+          expect(order_cycles).not_to include oc
         end
+      end
 
-        context "when the subscription is persisted" do
-          before { expect(subscription.save!).to be true }
+      context "and the schedule has an open OC that closes between begins_at and ends_at" do
+        let!(:oc) { open_oc }
 
-          context "when a proxy order exists" do
-            let!(:proxy_order) { create(:proxy_order, subscription:, order_cycle: oc) }
+        it "creates a new proxy order for that oc" do
+          syncer.sync!
 
-            context "for an oc included in the relevant schedule" do
-              context "and the proxy order has already been placed" do
-                before { proxy_order.update(placed_at: 5.minutes.ago) }
+          expect{ subscription.save! }.to change { ProxyOrder.count }.from(0).to(1)
+          expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
+        end
+      end
 
-                context "the oc is closed (ie. closed before opens_at)" do
-                  let(:oc) { closed_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
+      context "and the schedule includes upcoming oc that closes before begins_at" do
+        let!(:oc) { upcoming_closes_before_begins_at_oc }
 
-                context "and the schedule includes an open oc that closes before begins_at" do
-                  let(:oc) { open_oc_closes_before_begins_at_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
+        it "does not create a new proxy order for that oc" do
+          expect{ subscription.save! }.not_to change { ProxyOrder.count }.from(0)
+          expect(order_cycles).not_to include oc
+        end
+      end
 
-                context "and the oc is open and closes between begins_at and ends_at" do
-                  let(:oc) { open_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
+      context "and the schedule includes upcoming oc that closes on begins_at" do
+        let!(:oc) { upcoming_closes_on_begins_at_oc }
 
-                context "and the oc is upcoming and closes before begins_at" do
-                  let(:oc) { upcoming_closes_before_begins_at_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
+        it "creates a new proxy order for that oc" do
+          syncer.sync!
 
-                context "and the oc is upcoming and closes on begins_at" do
-                  let(:oc) { upcoming_closes_on_begins_at_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
+          expect{ subscription.save! }.to change { ProxyOrder.count }.from(0).to(1)
+          expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
+        end
+      end
 
-                context "and the oc is upcoming and closes on ends_at" do
-                  let(:oc) { upcoming_closes_on_ends_at_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
+      context "and the schedule includes upcoming oc that closes after ends_at" do
+        let!(:oc) { upcoming_closes_on_ends_at_oc }
 
-                context "and the oc is upcoming and closes after ends_at" do
-                  let(:oc) { upcoming_closes_after_ends_at_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
-              end
+        it "creates a new proxy order for that oc" do
+          syncer.sync!
 
-              context "and the proxy order has not already been placed" do
-                context "the oc is closed (ie. closed before opens_at)" do
-                  let(:oc) { closed_oc }
+          expect{ subscription.save! }.to change { ProxyOrder.count }.from(0).to(1)
+          expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
+        end
+      end
 
-                  it "removes the proxy order" do
-                    expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
-                    expect(proxy_orders).not_to include proxy_order
-                  end
-                end
+      context "and the schedule includes upcoming oc that closes after ends_at" do
+        let!(:oc) { upcoming_closes_after_ends_at_oc }
 
-                context "and the schedule includes an open oc that closes before begins_at" do
-                  let(:oc) { open_oc_closes_before_begins_at_oc }
+        it "does not create a new proxy order for that oc" do
+          expect{ subscription.save! }.not_to change { ProxyOrder.count }.from(0)
+          expect(order_cycles).not_to include oc
+        end
+      end
+    end
 
-                  it "removes the proxy order" do
-                    expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
-                    expect(proxy_orders).not_to include proxy_order
-                  end
-                end
+    context "when the subscription is persisted" do
+      before { expect(subscription.save!).to be true }
 
-                context 'and the proxy orders are already synced' do
-                  let(:subscription) do
-                    build(
-                      :subscription,
-                      begins_at: now + 1.minute,
-                      ends_at: now + 2.minutes,
-                      schedule:
-                    )
-                  end
+      context "when a proxy order exists" do
+        let!(:proxy_order) { create(:proxy_order, subscription:, order_cycle: oc) }
 
-                  before { syncer.sync! }
+        context "for an oc included in the relevant schedule" do
+          context "and the proxy order has already been placed" do
+            before { proxy_order.update(placed_at: 5.minutes.ago) }
 
-                  context "and the oc is open and closes between begins_at and ends_at" do
-                    let(:oc) { open_oc }
-
-                    it "keeps the proxy order" do
-                      expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                      expect(proxy_orders).to include proxy_order
-                    end
-                  end
-
-                  context "and the oc is upcoming and closes on begins_at" do
-                    let(:oc) { upcoming_closes_on_begins_at_oc }
-
-                    it "keeps the proxy order" do
-                      expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                      expect(proxy_orders).to include proxy_order
-                    end
-                  end
-
-                  context "and the oc is upcoming and closes on ends_at" do
-                    let(:oc) { upcoming_closes_on_ends_at_oc }
-
-                    it "keeps the proxy order" do
-                      expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                      expect(proxy_orders).to include proxy_order
-                    end
-                  end
-                end
-
-                context "and the oc is upcoming and closes before begins_at" do
-                  let(:oc) { upcoming_closes_before_begins_at_oc }
-
-                  it "removes the proxy order" do
-                    expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
-                    expect(proxy_orders).not_to include proxy_order
-                  end
-                end
-
-                context "and the oc is upcoming and closes after ends_at" do
-                  let(:oc) { upcoming_closes_after_ends_at_oc }
-
-                  it "removes the proxy order" do
-                    expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
-                    expect(proxy_orders).not_to include proxy_order
-                  end
-                end
+            context "the oc is closed (ie. closed before opens_at)" do
+              let(:oc) { closed_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
               end
             end
 
-            context "for an oc not included in the relevant schedule" do
-              let!(:proxy_order) {
-                create(:proxy_order, subscription:, order_cycle: open_oc)
-              }
-              before do
-                open_oc.schedule_ids = []
-                expect(open_oc.save!).to be true
+            context "and the schedule includes an open oc that closes before begins_at" do
+              let(:oc) { open_oc_closes_before_begins_at_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
               end
+            end
 
-              context "and the proxy order has already been placed" do
-                before { proxy_order.update(placed_at: 5.minutes.ago) }
-
-                context "the oc is closed (ie. closed before opens_at)" do
-                  let(:oc) { closed_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
-
-                context "and the schedule includes an open oc that closes before begins_at" do
-                  let(:oc) { open_oc_closes_before_begins_at_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
-
-                context "and the oc is open and closes between begins_at and ends_at" do
-                  let(:oc) { open_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
-
-                context "and the oc is upcoming and closes before begins_at" do
-                  let(:oc) { upcoming_closes_before_begins_at_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
-
-                context "and the oc is upcoming and closes on begins_at" do
-                  let(:oc) { upcoming_closes_on_begins_at_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
-
-                context "and the oc is upcoming and closes on ends_at" do
-                  let(:oc) { upcoming_closes_on_ends_at_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
-
-                context "and the oc is upcoming and closes after ends_at" do
-                  let(:oc) { upcoming_closes_after_ends_at_oc }
-                  it "keeps the proxy order" do
-                    expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
-                    expect(proxy_orders).to include proxy_order
-                  end
-                end
+            context "and the oc is open and closes between begins_at and ends_at" do
+              let(:oc) { open_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
               end
+            end
 
-              context "and the proxy order has not already been placed" do
-                # This shouldn't really happen, but it is possible
-                context "the oc is closed (ie. closed before opens_at)" do
-                  let(:oc) { closed_oc }
-                  it "removes the proxy order" do
-                    expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
-                    expect(proxy_orders).not_to include proxy_order
-                  end
-                end
+            context "and the oc is upcoming and closes before begins_at" do
+              let(:oc) { upcoming_closes_before_begins_at_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
+              end
+            end
 
-                # This shouldn't really happen, but it is possible
-                context "and the oc is open and closes between begins_at and ends_at" do
-                  let(:oc) { open_oc }
-                  it "removes the proxy order" do
-                    expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
-                    expect(proxy_orders).not_to include proxy_order
-                  end
-                end
+            context "and the oc is upcoming and closes on begins_at" do
+              let(:oc) { upcoming_closes_on_begins_at_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
+              end
+            end
 
-                context "and the oc is upcoming and closes before begins_at" do
-                  let(:oc) { upcoming_closes_before_begins_at_oc }
-                  it "removes the proxy order" do
-                    expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
-                    expect(proxy_orders).not_to include proxy_order
-                  end
-                end
+            context "and the oc is upcoming and closes on ends_at" do
+              let(:oc) { upcoming_closes_on_ends_at_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
+              end
+            end
 
-                context "and the oc is upcoming and closes on begins_at" do
-                  let(:oc) { upcoming_closes_on_begins_at_oc }
-                  it "removes the proxy order" do
-                    expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
-                    expect(proxy_orders).not_to include proxy_order
-                  end
-                end
-
-                context "and the oc is upcoming and closes on ends_at" do
-                  let(:oc) { upcoming_closes_on_ends_at_oc }
-                  it "removes the proxy order" do
-                    expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
-                    expect(proxy_orders).not_to include proxy_order
-                  end
-                end
-
-                context "and the oc is upcoming and closes after ends_at" do
-                  let(:oc) { upcoming_closes_after_ends_at_oc }
-                  it "removes the proxy order" do
-                    expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
-                    expect(proxy_orders).not_to include proxy_order
-                  end
-                end
+            context "and the oc is upcoming and closes after ends_at" do
+              let(:oc) { upcoming_closes_after_ends_at_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
               end
             end
           end
 
-          context "when a proxy order does not exist" do
-            let(:schedule) { create(:schedule, order_cycles: [oc]) }
-            let(:subscription) do
-              create(
-                :subscription,
-                begins_at: now + 1.minute,
-                ends_at: now + 2.minutes,
-                schedule:
-              )
-            end
-            let(:syncer) { ProxyOrderSyncer.new(subscription) }
+          context "and the proxy order has not already been placed" do
+            context "the oc is closed (ie. closed before opens_at)" do
+              let(:oc) { closed_oc }
 
-            context "and the schedule includes a closed oc (ie. closed before opens_at)" do
-              let!(:oc) { closed_oc }
-
-              it "does not create a new proxy order for that oc" do
-                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(0)
-                expect(order_cycles).not_to include oc
+              it "removes the proxy order" do
+                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
+                expect(proxy_orders).not_to include proxy_order
               end
             end
 
             context "and the schedule includes an open oc that closes before begins_at" do
               let(:oc) { open_oc_closes_before_begins_at_oc }
 
-              it "does not create a new proxy order for that oc" do
-                expect{ subscription.save! }.not_to change { ProxyOrder.count }.from(0)
-                expect(order_cycles).not_to include oc
+              it "removes the proxy order" do
+                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
+                expect(proxy_orders).not_to include proxy_order
               end
             end
 
-            context "and the schedule has an open oc that closes between begins_at and ends_at" do
-              let!(:oc) { open_oc }
+            context 'and the proxy orders are already synced' do
+              let(:subscription) do
+                build(
+                  :subscription,
+                  begins_at: now + 1.minute,
+                  ends_at: now + 2.minutes,
+                  schedule:
+                )
+              end
 
-              it "creates a new proxy order for that oc" do
-                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(0).to(1)
-                expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
+              before { syncer.sync! }
+
+              context "and the oc is open and closes between begins_at and ends_at" do
+                let(:oc) { open_oc }
+
+                it "keeps the proxy order" do
+                  expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                  expect(proxy_orders).to include proxy_order
+                end
+              end
+
+              context "and the oc is upcoming and closes on begins_at" do
+                let(:oc) { upcoming_closes_on_begins_at_oc }
+
+                it "keeps the proxy order" do
+                  expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                  expect(proxy_orders).to include proxy_order
+                end
+              end
+
+              context "and the oc is upcoming and closes on ends_at" do
+                let(:oc) { upcoming_closes_on_ends_at_oc }
+
+                it "keeps the proxy order" do
+                  expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                  expect(proxy_orders).to include proxy_order
+                end
               end
             end
 
-            context "and the schedule includes upcoming oc that closes before begins_at" do
-              let!(:oc) { upcoming_closes_before_begins_at_oc }
+            context "and the oc is upcoming and closes before begins_at" do
+              let(:oc) { upcoming_closes_before_begins_at_oc }
 
-              it "does not create a new proxy order for that oc" do
-                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(0)
-                expect(order_cycles).not_to include oc
+              it "removes the proxy order" do
+                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
+                expect(proxy_orders).not_to include proxy_order
               end
             end
 
-            context "and the schedule includes upcoming oc that closes on begins_at" do
-              let!(:oc) { upcoming_closes_on_begins_at_oc }
+            context "and the oc is upcoming and closes after ends_at" do
+              let(:oc) { upcoming_closes_after_ends_at_oc }
 
-              it "creates a new proxy order for that oc" do
-                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(0).to(1)
-                expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
+              it "removes the proxy order" do
+                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
+                expect(proxy_orders).not_to include proxy_order
+              end
+            end
+          end
+        end
+
+        context "for an oc not included in the relevant schedule" do
+          let!(:proxy_order) {
+            create(:proxy_order, subscription:, order_cycle: open_oc)
+          }
+          before do
+            open_oc.schedule_ids = []
+            expect(open_oc.save!).to be true
+          end
+
+          context "and the proxy order has already been placed" do
+            before { proxy_order.update(placed_at: 5.minutes.ago) }
+
+            context "the oc is closed (ie. closed before opens_at)" do
+              let(:oc) { closed_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
               end
             end
 
-            context "and the schedule includes upcoming oc that closes on ends_at" do
-              let!(:oc) { upcoming_closes_on_ends_at_oc }
-
-              it "creates a new proxy order for that oc" do
-                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(0).to(1)
-                expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
+            context "and the schedule includes an open oc that closes before begins_at" do
+              let(:oc) { open_oc_closes_before_begins_at_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
               end
             end
 
-            context "and the schedule includes upcoming oc that closes after ends_at" do
-              let!(:oc) { upcoming_closes_after_ends_at_oc }
-
-              it "does not create a new proxy order for that oc" do
-                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(0)
-                expect(order_cycles).not_to include oc
+            context "and the oc is open and closes between begins_at and ends_at" do
+              let(:oc) { open_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
               end
             end
+
+            context "and the oc is upcoming and closes before begins_at" do
+              let(:oc) { upcoming_closes_before_begins_at_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
+              end
+            end
+
+            context "and the oc is upcoming and closes on begins_at" do
+              let(:oc) { upcoming_closes_on_begins_at_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
+              end
+            end
+
+            context "and the oc is upcoming and closes on ends_at" do
+              let(:oc) { upcoming_closes_on_ends_at_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
+              end
+            end
+
+            context "and the oc is upcoming and closes after ends_at" do
+              let(:oc) { upcoming_closes_after_ends_at_oc }
+              it "keeps the proxy order" do
+                expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(1)
+                expect(proxy_orders).to include proxy_order
+              end
+            end
+          end
+
+          context "and the proxy order has not already been placed" do
+            # This shouldn't really happen, but it is possible
+            context "the oc is closed (ie. closed before opens_at)" do
+              let(:oc) { closed_oc }
+              it "removes the proxy order" do
+                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
+                expect(proxy_orders).not_to include proxy_order
+              end
+            end
+
+            # This shouldn't really happen, but it is possible
+            context "and the oc is open and closes between begins_at and ends_at" do
+              let(:oc) { open_oc }
+              it "removes the proxy order" do
+                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
+                expect(proxy_orders).not_to include proxy_order
+              end
+            end
+
+            context "and the oc is upcoming and closes before begins_at" do
+              let(:oc) { upcoming_closes_before_begins_at_oc }
+              it "removes the proxy order" do
+                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
+                expect(proxy_orders).not_to include proxy_order
+              end
+            end
+
+            context "and the oc is upcoming and closes on begins_at" do
+              let(:oc) { upcoming_closes_on_begins_at_oc }
+              it "removes the proxy order" do
+                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
+                expect(proxy_orders).not_to include proxy_order
+              end
+            end
+
+            context "and the oc is upcoming and closes on ends_at" do
+              let(:oc) { upcoming_closes_on_ends_at_oc }
+              it "removes the proxy order" do
+                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
+                expect(proxy_orders).not_to include proxy_order
+              end
+            end
+
+            context "and the oc is upcoming and closes after ends_at" do
+              let(:oc) { upcoming_closes_after_ends_at_oc }
+              it "removes the proxy order" do
+                expect{ syncer.sync! }.to change { ProxyOrder.count }.from(1).to(0)
+                expect(proxy_orders).not_to include proxy_order
+              end
+            end
+          end
+        end
+      end
+
+      context "when a proxy order does not exist" do
+        let(:schedule) { create(:schedule, order_cycles: [oc]) }
+        let(:subscription) do
+          create(
+            :subscription,
+            begins_at: now + 1.minute,
+            ends_at: now + 2.minutes,
+            schedule:
+          )
+        end
+        let(:syncer) { described_class.new(subscription) }
+
+        context "and the schedule includes a closed oc (ie. closed before opens_at)" do
+          let!(:oc) { closed_oc }
+
+          it "does not create a new proxy order for that oc" do
+            expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(0)
+            expect(order_cycles).not_to include oc
+          end
+        end
+
+        context "and the schedule includes an open oc that closes before begins_at" do
+          let(:oc) { open_oc_closes_before_begins_at_oc }
+
+          it "does not create a new proxy order for that oc" do
+            expect{ subscription.save! }.not_to change { ProxyOrder.count }.from(0)
+            expect(order_cycles).not_to include oc
+          end
+        end
+
+        context "and the schedule has an open oc that closes between begins_at and ends_at" do
+          let!(:oc) { open_oc }
+
+          it "creates a new proxy order for that oc" do
+            expect{ syncer.sync! }.to change { ProxyOrder.count }.from(0).to(1)
+            expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
+          end
+        end
+
+        context "and the schedule includes upcoming oc that closes before begins_at" do
+          let!(:oc) { upcoming_closes_before_begins_at_oc }
+
+          it "does not create a new proxy order for that oc" do
+            expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(0)
+            expect(order_cycles).not_to include oc
+          end
+        end
+
+        context "and the schedule includes upcoming oc that closes on begins_at" do
+          let!(:oc) { upcoming_closes_on_begins_at_oc }
+
+          it "creates a new proxy order for that oc" do
+            expect{ syncer.sync! }.to change { ProxyOrder.count }.from(0).to(1)
+            expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
+          end
+        end
+
+        context "and the schedule includes upcoming oc that closes on ends_at" do
+          let!(:oc) { upcoming_closes_on_ends_at_oc }
+
+          it "creates a new proxy order for that oc" do
+            expect{ syncer.sync! }.to change { ProxyOrder.count }.from(0).to(1)
+            expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
+          end
+        end
+
+        context "and the schedule includes upcoming oc that closes after ends_at" do
+          let!(:oc) { upcoming_closes_after_ends_at_oc }
+
+          it "does not create a new proxy order for that oc" do
+            expect{ syncer.sync! }.not_to change { ProxyOrder.count }.from(0)
+            expect(order_cycles).not_to include oc
           end
         end
       end

--- a/engines/order_management/spec/services/order_management/subscriptions/summarizer_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/summarizer_spec.rb
@@ -2,145 +2,141 @@
 
 require 'spec_helper'
 
-module OrderManagement
-  module Subscriptions
-    RSpec.describe Summarizer do
-      let(:order) { create(:order) }
-      let(:summarizer) { OrderManagement::Subscriptions::Summarizer.new }
+RSpec.describe OrderManagement::Subscriptions::Summarizer do
+  let(:order) { create(:order) }
+  let(:summarizer) { described_class.new }
 
-      before { allow(JobLogger.logger).to receive(:info) }
+  before { allow(JobLogger.logger).to receive(:info) }
 
-      describe "#summary_for" do
-        let(:order) { double(:order, distributor_id: 123) }
+  describe "#summary_for" do
+    let(:order) { double(:order, distributor_id: 123) }
 
-        context "when a summary for the order's distributor doesn't already exist" do
-          it "initializes a new summary object, and returns it" do
-            expect(summarizer.instance_variable_get(:@summaries).count).to be 0
-            summary = summarizer.__send__(:summary_for, order)
-            expect(summary.shop_id).to be 123
-            expect(summarizer.instance_variable_get(:@summaries).count).to be 1
-          end
-        end
+    context "when a summary for the order's distributor doesn't already exist" do
+      it "initializes a new summary object, and returns it" do
+        expect(summarizer.instance_variable_get(:@summaries).count).to be 0
+        summary = summarizer.__send__(:summary_for, order)
+        expect(summary.shop_id).to be 123
+        expect(summarizer.instance_variable_get(:@summaries).count).to be 1
+      end
+    end
 
-        context "when a summary for the order's distributor already exists" do
-          let(:summary) { double(:summary) }
+    context "when a summary for the order's distributor already exists" do
+      let(:summary) { double(:summary) }
 
-          before do
-            summarizer.instance_variable_set(:@summaries, 123 => summary)
-          end
-
-          it "returns the existing summary object" do
-            expect(summarizer.instance_variable_get(:@summaries).count).to be 1
-            expect(summarizer.__send__(:summary_for, order)).to eq summary
-            expect(summarizer.instance_variable_get(:@summaries).count).to be 1
-          end
-        end
+      before do
+        summarizer.instance_variable_set(:@summaries, 123 => summary)
       end
 
-      describe "recording events" do
-        let(:order) { double(:order) }
-        let(:summary) { double(:summary) }
-        before { allow(summarizer).to receive(:summary_for).with(order) { summary } }
+      it "returns the existing summary object" do
+        expect(summarizer.instance_variable_get(:@summaries).count).to be 1
+        expect(summarizer.__send__(:summary_for, order)).to eq summary
+        expect(summarizer.instance_variable_get(:@summaries).count).to be 1
+      end
+    end
+  end
 
-        describe "#record_order" do
-          it "requests a summary for the order and calls #record_order on it" do
-            expect(summary).to receive(:record_order).with(order).once
-            summarizer.record_order(order)
-          end
-        end
+  describe "recording events" do
+    let(:order) { double(:order) }
+    let(:summary) { double(:summary) }
+    before { allow(summarizer).to receive(:summary_for).with(order) { summary } }
 
-        describe "#record_success" do
-          it "requests a summary for the order and calls #record_success on it" do
-            expect(summary).to receive(:record_success).with(order).once
-            summarizer.record_success(order)
-          end
-        end
+    describe "#record_order" do
+      it "requests a summary for the order and calls #record_order on it" do
+        expect(summary).to receive(:record_order).with(order).once
+        summarizer.record_order(order)
+      end
+    end
 
-        describe "#record_issue" do
-          it "requests a summary for the order and calls #record_issue on it" do
-            expect(order).to receive(:id)
-            expect(summary).to receive(:record_issue).with(:type, order, "message").once
-            summarizer.record_issue(:type, order, "message")
-          end
-        end
+    describe "#record_success" do
+      it "requests a summary for the order and calls #record_success on it" do
+        expect(summary).to receive(:record_success).with(order).once
+        summarizer.record_success(order)
+      end
+    end
 
-        describe "#record_and_log_error" do
-          before do
-            allow(order).to receive(:number) { "123" }
-          end
+    describe "#record_issue" do
+      it "requests a summary for the order and calls #record_issue on it" do
+        expect(order).to receive(:id)
+        expect(summary).to receive(:record_issue).with(:type, order, "message").once
+        summarizer.record_issue(:type, order, "message")
+      end
+    end
 
-          context "when errors exist on the order" do
-            before do
-              allow(order).to receive(:errors) {
-                double(:errors, any?: true, full_messages: ["Some error"])
-              }
-            end
-
-            it "sends error info to rails logger and calls #record_issue with an error message" do
-              expect(summarizer).to receive(:record_issue).with(:processing,
-                                                                order, "Errors: Some error")
-              summarizer.record_and_log_error(:processing, order)
-            end
-          end
-
-          context "when no errors exist on the order" do
-            before do
-              allow(order).to receive(:errors) { double(:errors, any?: false) }
-            end
-
-            it "falls back to calling record_issue" do
-              expect(summarizer).to receive(:record_issue).with(:processing, order)
-              summarizer.record_and_log_error(:processing, order)
-            end
-          end
-        end
-
-        describe "#record_subscription_issue" do
-          let(:subscription) { double(:subscription, shop_id: 1) }
-
-          before do
-            allow(summarizer).to receive(:summary_for_shop_id).
-              with(subscription.shop_id) { summary }
-          end
-
-          it "records a subscription issue" do
-            expect(summary).to receive(:record_subscription_issue).with(subscription).once
-            summarizer.record_subscription_issue(subscription)
-          end
-        end
+    describe "#record_and_log_error" do
+      before do
+        allow(order).to receive(:number) { "123" }
       end
 
-      describe "#send_placement_summary_emails" do
-        let(:summary1) { double(:summary) }
-        let(:summary2) { double(:summary) }
-        let(:summaries) { { 1 => summary1, 2 => summary2 } }
-        let(:mail_mock) { double(:mail, deliver_now: true) }
-
+      context "when errors exist on the order" do
         before do
-          summarizer.instance_variable_set(:@summaries, summaries)
+          allow(order).to receive(:errors) {
+            double(:errors, any?: true, full_messages: ["Some error"])
+          }
         end
 
-        it "sends a placement summary email for each summary" do
-          expect(SubscriptionMailer).to receive(:placement_summary_email).twice { mail_mock }
-          summarizer.send_placement_summary_emails
+        it "sends error info to rails logger and calls #record_issue with an error message" do
+          expect(summarizer).to receive(:record_issue).with(:processing,
+                                                            order, "Errors: Some error")
+          summarizer.record_and_log_error(:processing, order)
         end
       end
 
-      describe "#send_confirmation_summary_emails" do
-        let(:summary1) { double(:summary) }
-        let(:summary2) { double(:summary) }
-        let(:summaries) { { 1 => summary1, 2 => summary2 } }
-        let(:mail_mock) { double(:mail, deliver_now: true) }
-
+      context "when no errors exist on the order" do
         before do
-          summarizer.instance_variable_set(:@summaries, summaries)
+          allow(order).to receive(:errors) { double(:errors, any?: false) }
         end
 
-        it "sends a placement summary email for each summary" do
-          expect(SubscriptionMailer).to receive(:confirmation_summary_email).twice { mail_mock }
-          summarizer.send_confirmation_summary_emails
+        it "falls back to calling record_issue" do
+          expect(summarizer).to receive(:record_issue).with(:processing, order)
+          summarizer.record_and_log_error(:processing, order)
         end
       end
+    end
+
+    describe "#record_subscription_issue" do
+      let(:subscription) { double(:subscription, shop_id: 1) }
+
+      before do
+        allow(summarizer).to receive(:summary_for_shop_id).
+          with(subscription.shop_id) { summary }
+      end
+
+      it "records a subscription issue" do
+        expect(summary).to receive(:record_subscription_issue).with(subscription).once
+        summarizer.record_subscription_issue(subscription)
+      end
+    end
+  end
+
+  describe "#send_placement_summary_emails" do
+    let(:summary1) { double(:summary) }
+    let(:summary2) { double(:summary) }
+    let(:summaries) { { 1 => summary1, 2 => summary2 } }
+    let(:mail_mock) { double(:mail, deliver_now: true) }
+
+    before do
+      summarizer.instance_variable_set(:@summaries, summaries)
+    end
+
+    it "sends a placement summary email for each summary" do
+      expect(SubscriptionMailer).to receive(:placement_summary_email).twice { mail_mock }
+      summarizer.send_placement_summary_emails
+    end
+  end
+
+  describe "#send_confirmation_summary_emails" do
+    let(:summary1) { double(:summary) }
+    let(:summary2) { double(:summary) }
+    let(:summaries) { { 1 => summary1, 2 => summary2 } }
+    let(:mail_mock) { double(:mail, deliver_now: true) }
+
+    before do
+      summarizer.instance_variable_set(:@summaries, summaries)
+    end
+
+    it "sends a placement summary email for each summary" do
+      expect(SubscriptionMailer).to receive(:confirmation_summary_email).twice { mail_mock }
+      summarizer.send_confirmation_summary_emails
     end
   end
 end

--- a/engines/order_management/spec/services/order_management/subscriptions/summary_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/summary_spec.rb
@@ -2,152 +2,148 @@
 
 require 'spec_helper'
 
-module OrderManagement
-  module Subscriptions
-    RSpec.describe Summary do
-      let(:summary) { OrderManagement::Subscriptions::Summary.new(123) }
+RSpec.describe OrderManagement::Subscriptions::Summary do
+  let(:summary) { described_class.new(123) }
 
-      describe "#initialize" do
-        it "initializes instance variables: shop_id, order_count, success_count and issues" do
-          expect(summary.shop_id).to be 123
-          expect(summary.order_count).to be 0
-          expect(summary.success_count).to be 0
-          expect(summary.issues).to be_a Hash
-        end
+  describe "#initialize" do
+    it "initializes instance variables: shop_id, order_count, success_count and issues" do
+      expect(summary.shop_id).to be 123
+      expect(summary.order_count).to be 0
+      expect(summary.success_count).to be 0
+      expect(summary.issues).to be_a Hash
+    end
+  end
+
+  describe "#record_order" do
+    let(:order) { double(:order, id: 37) }
+    it "adds the order id to the order_ids array" do
+      summary.record_order(order)
+      expect(summary.instance_variable_get(:@order_ids)).to eq [order.id]
+    end
+  end
+
+  describe "#record_success" do
+    let(:order) { double(:order, id: 37) }
+    it "adds the order id to the success_ids array" do
+      summary.record_success(order)
+      expect(summary.instance_variable_get(:@success_ids)).to eq [order.id]
+    end
+  end
+
+  describe "#record_issue" do
+    let(:order) { double(:order, id: 1) }
+
+    context "when no issues of the same type have been recorded yet" do
+      it "adds a new type to the issues hash, and stores a new issue against it" do
+        summary.record_issue(:some_type, order, "message")
+        expect(summary.issues.keys).to include :some_type
+        expect(summary.issues[:some_type][order.id]).to eq "message"
+      end
+    end
+
+    context "when an issue of the same type has already been recorded" do
+      let(:existing_issue) { double(:existing_issue) }
+
+      before { summary.issues[:some_type] = [existing_issue] }
+
+      it "stores a new issue against the existing type" do
+        summary.record_issue(:some_type, order, "message")
+        expect(summary.issues[:some_type]).to include existing_issue
+        expect(summary.issues[:some_type][order.id]).to eq "message"
+      end
+    end
+  end
+
+  describe "record_subscription_issue" do
+    let(:subscription) { double(:subscription, id: 101) }
+
+    it "stores a new subscription issue" do
+      summary.record_subscription_issue(subscription)
+      expect(summary.subscription_issues).to eq [101]
+    end
+  end
+
+  describe "#order_count" do
+    let(:order_ids) { [1, 2, 3, 4, 5, 6, 7] }
+    it "counts the number of items in the order_ids instance_variable" do
+      summary.instance_variable_set(:@order_ids, order_ids)
+      expect(summary.order_count).to be 7
+    end
+  end
+
+  describe "#success_count" do
+    let(:success_ids) { [1, 2, 3, 4, 5, 6, 7] }
+    it "counts the number of items in the success_ids instance_variable" do
+      summary.instance_variable_set(:@success_ids, success_ids)
+      expect(summary.success_count).to be 7
+    end
+  end
+
+  describe "#issue_count" do
+    let(:order_ids) { [1, 3, 5, 7, 9] }
+    let(:success_ids) { [1, 2, 3, 4, 5] }
+
+    it "counts the number of items in order_ids that are not in success_ids" do
+      summary.instance_variable_set(:@order_ids, order_ids)
+      summary.instance_variable_set(:@success_ids, success_ids)
+      expect(summary.issue_count).to be 2 # 7 & 9
+    end
+
+    context "when there are also subscription issues" do
+      let(:subscription) { double(:subscription, id: 101) }
+      let(:order) { double(:order, id: 1) }
+
+      before do
+        summary.record_order(order)
+        summary.record_success(order)
+        summary.record_subscription_issue(subscription)
       end
 
-      describe "#record_order" do
-        let(:order) { double(:order, id: 37) }
-        it "adds the order id to the order_ids array" do
-          summary.record_order(order)
-          expect(summary.instance_variable_get(:@order_ids)).to eq [order.id]
-        end
+      it "includes subscription issues in the count" do
+        expect(summary.issue_count).to eq 1
       end
+    end
+  end
 
-      describe "#record_success" do
-        let(:order) { double(:order, id: 37) }
-        it "adds the order id to the success_ids array" do
-          summary.record_success(order)
-          expect(summary.instance_variable_get(:@success_ids)).to eq [order.id]
-        end
+  describe "#orders_affected_by" do
+    let(:order1) { create(:order) }
+    let(:order2) { create(:order) }
+
+    before do
+      allow(summary).to receive(:unrecorded_ids) { [order1.id] }
+      allow(summary).to receive(:issues) { { failure: { order2.id => "A message" } } }
+    end
+
+    context "when the issue type is :other" do
+      let(:orders) { summary.orders_affected_by(:other) }
+
+      it "returns orders specified by unrecorded_ids" do
+        expect(orders).to include order1
+        expect(orders).not_to include order2
       end
+    end
 
-      describe "#record_issue" do
-        let(:order) { double(:order, id: 1) }
+    context "when the issue type is :other" do
+      let(:orders) { summary.orders_affected_by(:failure) }
 
-        context "when no issues of the same type have been recorded yet" do
-          it "adds a new type to the issues hash, and stores a new issue against it" do
-            summary.record_issue(:some_type, order, "message")
-            expect(summary.issues.keys).to include :some_type
-            expect(summary.issues[:some_type][order.id]).to eq "message"
-          end
-        end
-
-        context "when an issue of the same type has already been recorded" do
-          let(:existing_issue) { double(:existing_issue) }
-
-          before { summary.issues[:some_type] = [existing_issue] }
-
-          it "stores a new issue against the existing type" do
-            summary.record_issue(:some_type, order, "message")
-            expect(summary.issues[:some_type]).to include existing_issue
-            expect(summary.issues[:some_type][order.id]).to eq "message"
-          end
-        end
+      it "returns orders specified by the relevant issue hash" do
+        expect(orders).to include order2
+        expect(orders).not_to include order1
       end
+    end
+  end
 
-      describe "record_subscription_issue" do
-        let(:subscription) { double(:subscription, id: 101) }
+  describe "#unrecorded_ids" do
+    let(:issues) { { type: { 7 => "message", 8 => "message" } } }
 
-        it "stores a new subscription issue" do
-          summary.record_subscription_issue(subscription)
-          expect(summary.subscription_issues).to eq [101]
-        end
-      end
+    before do
+      summary.instance_variable_set(:@order_ids, [1, 3, 5, 7, 9])
+      summary.instance_variable_set(:@success_ids, [1, 2, 3, 4, 5])
+      summary.instance_variable_set(:@issues, issues)
+    end
 
-      describe "#order_count" do
-        let(:order_ids) { [1, 2, 3, 4, 5, 6, 7] }
-        it "counts the number of items in the order_ids instance_variable" do
-          summary.instance_variable_set(:@order_ids, order_ids)
-          expect(summary.order_count).to be 7
-        end
-      end
-
-      describe "#success_count" do
-        let(:success_ids) { [1, 2, 3, 4, 5, 6, 7] }
-        it "counts the number of items in the success_ids instance_variable" do
-          summary.instance_variable_set(:@success_ids, success_ids)
-          expect(summary.success_count).to be 7
-        end
-      end
-
-      describe "#issue_count" do
-        let(:order_ids) { [1, 3, 5, 7, 9] }
-        let(:success_ids) { [1, 2, 3, 4, 5] }
-
-        it "counts the number of items in order_ids that are not in success_ids" do
-          summary.instance_variable_set(:@order_ids, order_ids)
-          summary.instance_variable_set(:@success_ids, success_ids)
-          expect(summary.issue_count).to be 2 # 7 & 9
-        end
-
-        context "when there are also subscription issues" do
-          let(:subscription) { double(:subscription, id: 101) }
-          let(:order) { double(:order, id: 1) }
-
-          before do
-            summary.record_order(order)
-            summary.record_success(order)
-            summary.record_subscription_issue(subscription)
-          end
-
-          it "includes subscription issues in the count" do
-            expect(summary.issue_count).to eq 1
-          end
-        end
-      end
-
-      describe "#orders_affected_by" do
-        let(:order1) { create(:order) }
-        let(:order2) { create(:order) }
-
-        before do
-          allow(summary).to receive(:unrecorded_ids) { [order1.id] }
-          allow(summary).to receive(:issues) { { failure: { order2.id => "A message" } } }
-        end
-
-        context "when the issue type is :other" do
-          let(:orders) { summary.orders_affected_by(:other) }
-
-          it "returns orders specified by unrecorded_ids" do
-            expect(orders).to include order1
-            expect(orders).not_to include order2
-          end
-        end
-
-        context "when the issue type is :other" do
-          let(:orders) { summary.orders_affected_by(:failure) }
-
-          it "returns orders specified by the relevant issue hash" do
-            expect(orders).to include order2
-            expect(orders).not_to include order1
-          end
-        end
-      end
-
-      describe "#unrecorded_ids" do
-        let(:issues) { { type: { 7 => "message", 8 => "message" } } }
-
-        before do
-          summary.instance_variable_set(:@order_ids, [1, 3, 5, 7, 9])
-          summary.instance_variable_set(:@success_ids, [1, 2, 3, 4, 5])
-          summary.instance_variable_set(:@issues, issues)
-        end
-
-        it "returns order_ids that are not marked as an issue or a success" do
-          expect(summary.unrecorded_ids).to eq [9]
-        end
-      end
+    it "returns order_ids that are not marked as an issue or a success" do
+      expect(summary.unrecorded_ids).to eq [9]
     end
   end
 end

--- a/engines/order_management/spec/services/order_management/subscriptions/validator_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/validator_spec.rb
@@ -2,116 +2,382 @@
 
 require "spec_helper"
 
-module OrderManagement
-  module Subscriptions
-    RSpec.describe Validator do
-      let(:owner) { create(:user) }
-      let(:shop) { create(:enterprise, name: "Shop", owner:) }
+RSpec.describe OrderManagement::Subscriptions::Validator do
+  let(:owner) { create(:user) }
+  let(:shop) { create(:enterprise, name: "Shop", owner:) }
 
-      describe "delegation" do
-        let(:subscription) { create(:subscription, shop:) }
-        let(:validator) { Validator.new(subscription) }
+  describe "delegation" do
+    let(:subscription) { create(:subscription, shop:) }
+    let(:validator) { described_class.new(subscription) }
 
-        it "delegates to subscription" do
-          expect(validator.shop).to eq subscription.shop
-          expect(validator.customer).to eq subscription.customer
-          expect(validator.schedule).to eq subscription.schedule
-          expect(validator.shipping_method).to eq subscription.shipping_method
-          expect(validator.payment_method).to eq subscription.payment_method
-          expect(validator.bill_address).to eq subscription.bill_address
-          expect(validator.ship_address).to eq subscription.ship_address
-          expect(validator.begins_at).to eq subscription.begins_at
-          expect(validator.ends_at).to eq subscription.ends_at
+    it "delegates to subscription" do
+      expect(validator.shop).to eq subscription.shop
+      expect(validator.customer).to eq subscription.customer
+      expect(validator.schedule).to eq subscription.schedule
+      expect(validator.shipping_method).to eq subscription.shipping_method
+      expect(validator.payment_method).to eq subscription.payment_method
+      expect(validator.bill_address).to eq subscription.bill_address
+      expect(validator.ship_address).to eq subscription.ship_address
+      expect(validator.begins_at).to eq subscription.begins_at
+      expect(validator.ends_at).to eq subscription.ends_at
+    end
+  end
+
+  describe "validations" do
+    let(:subscription_stubs) do
+      {
+        shop:,
+        customer: true,
+        schedule: true,
+        shipping_method: true,
+        payment_method: true,
+        bill_address: true,
+        ship_address: true,
+        begins_at: true,
+        ends_at: true,
+      }
+    end
+
+    let(:validation_stubs) do
+      {
+        shipping_method_allowed?: true,
+        payment_method_allowed?: true,
+        payment_method_type_allowed?: true,
+        ends_at_after_begins_at?: true,
+        customer_allowed?: true,
+        schedule_allowed?: true,
+        credit_card_ok?: true,
+        subscription_line_items_present?: true,
+        requested_variants_available?: true
+      }
+    end
+
+    let(:subscription) { instance_double(Subscription, subscription_stubs) }
+    let(:validator) { OrderManagement::Subscriptions::Validator.new(subscription) }
+
+    def stub_validations(validator, methods)
+      methods.each do |name, value|
+        allow(validator).to receive(name) { value }
+      end
+    end
+
+    describe "shipping method validation" do
+      let(:subscription) {
+        instance_double(Subscription, subscription_stubs.except(:shipping_method))
+      }
+      before { stub_validations(validator, validation_stubs.except(:shipping_method_allowed?)) }
+
+      context "when no shipping method is present" do
+        before { expect(subscription).to receive(:shipping_method).at_least(:once) { nil } }
+
+        it "adds an error and returns false" do
+          expect(validator.valid?).to be false
+          expect(validator.errors[:shipping_method]).not_to be_empty
         end
       end
 
-      describe "validations" do
-        let(:subscription_stubs) do
-          {
-            shop:,
-            customer: true,
-            schedule: true,
-            shipping_method: true,
-            payment_method: true,
-            bill_address: true,
-            ship_address: true,
-            begins_at: true,
-            ends_at: true,
-          }
-        end
+      context "when a shipping method is present" do
+        let(:shipping_method) { instance_double(Spree::ShippingMethod, distributors: [shop]) }
+        before {
+          expect(subscription).to receive(:shipping_method).at_least(:once) { shipping_method }
+        }
 
-        let(:validation_stubs) do
-          {
-            shipping_method_allowed?: true,
-            payment_method_allowed?: true,
-            payment_method_type_allowed?: true,
-            ends_at_after_begins_at?: true,
-            customer_allowed?: true,
-            schedule_allowed?: true,
-            credit_card_ok?: true,
-            subscription_line_items_present?: true,
-            requested_variants_available?: true
-          }
-        end
+        context "and the shipping method is not associated with the shop" do
+          before { allow(shipping_method).to receive(:distributors) { [double(:enterprise)] } }
 
-        let(:subscription) { instance_double(Subscription, subscription_stubs) }
-        let(:validator) { OrderManagement::Subscriptions::Validator.new(subscription) }
-
-        def stub_validations(validator, methods)
-          methods.each do |name, value|
-            allow(validator).to receive(name) { value }
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:shipping_method]).not_to be_empty
           end
         end
 
-        describe "shipping method validation" do
-          let(:subscription) {
-            instance_double(Subscription, subscription_stubs.except(:shipping_method))
-          }
-          before { stub_validations(validator, validation_stubs.except(:shipping_method_allowed?)) }
+        context "and the shipping method is associated with the shop" do
+          before { allow(shipping_method).to receive(:distributors) { [shop] } }
 
-          context "when no shipping method is present" do
-            before { expect(subscription).to receive(:shipping_method).at_least(:once) { nil } }
-
-            it "adds an error and returns false" do
-              expect(validator.valid?).to be false
-              expect(validator.errors[:shipping_method]).not_to be_empty
-            end
+          it "returns true" do
+            expect(validator.valid?).to be true
+            expect(validator.errors[:shipping_method]).to be_empty
           end
+        end
+      end
+    end
 
-          context "when a shipping method is present" do
-            let(:shipping_method) { instance_double(Spree::ShippingMethod, distributors: [shop]) }
-            before {
-              expect(subscription).to receive(:shipping_method).at_least(:once) { shipping_method }
-            }
+    describe "payment method validation" do
+      let(:subscription) {
+        instance_double(Subscription, subscription_stubs.except(:payment_method))
+      }
+      before { stub_validations(validator, validation_stubs.except(:payment_method_allowed?)) }
 
-            context "and the shipping method is not associated with the shop" do
-              before { allow(shipping_method).to receive(:distributors) { [double(:enterprise)] } }
+      context "when no payment method is present" do
+        before { expect(subscription).to receive(:payment_method).at_least(:once) { nil } }
 
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:shipping_method]).not_to be_empty
-              end
-            end
+        it "adds an error and returns false" do
+          expect(validator.valid?).to be false
+          expect(validator.errors[:payment_method]).not_to be_empty
+        end
+      end
 
-            context "and the shipping method is associated with the shop" do
-              before { allow(shipping_method).to receive(:distributors) { [shop] } }
+      context "when a payment method is present" do
+        let(:payment_method) { instance_double(Spree::PaymentMethod, distributors: [shop]) }
+        before {
+          expect(subscription).to receive(:payment_method).at_least(:once) { payment_method }
+        }
 
-              it "returns true" do
-                expect(validator.valid?).to be true
-                expect(validator.errors[:shipping_method]).to be_empty
-              end
-            end
+        context "and the payment method is not associated with the shop" do
+          before { allow(payment_method).to receive(:distributors) { [double(:enterprise)] } }
+
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:payment_method]).not_to be_empty
           end
         end
 
-        describe "payment method validation" do
-          let(:subscription) {
-            instance_double(Subscription, subscription_stubs.except(:payment_method))
-          }
-          before { stub_validations(validator, validation_stubs.except(:payment_method_allowed?)) }
+        context "and the payment method is associated with the shop" do
+          before { allow(payment_method).to receive(:distributors) { [shop] } }
 
-          context "when no payment method is present" do
-            before { expect(subscription).to receive(:payment_method).at_least(:once) { nil } }
+          it "returns true" do
+            expect(validator.valid?).to be true
+            expect(validator.errors[:payment_method]).to be_empty
+          end
+        end
+      end
+    end
+
+    describe "payment method type validation" do
+      let(:subscription) {
+        instance_double(Subscription, subscription_stubs.except(:payment_method))
+      }
+      before {
+        stub_validations(validator, validation_stubs.except(:payment_method_type_allowed?))
+      }
+
+      context "when a payment method is present" do
+        let(:payment_method) { instance_double(Spree::PaymentMethod, distributors: [shop]) }
+        before {
+          expect(subscription).to receive(:payment_method).at_least(:once) { payment_method }
+        }
+
+        context "and the payment method type is not in the approved list" do
+          before { allow(payment_method).to receive(:type) { "Blah" } }
+
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:payment_method]).not_to be_empty
+          end
+        end
+
+        context "and the payment method is in the approved list" do
+          let(:approved_type) { Subscription::ALLOWED_PAYMENT_METHOD_TYPES.first }
+          before { allow(payment_method).to receive(:type) { approved_type } }
+
+          it "returns true" do
+            expect(validator.valid?).to be true
+            expect(validator.errors[:payment_method]).to be_empty
+          end
+        end
+      end
+    end
+
+    describe "dates" do
+      let(:subscription) {
+        instance_double(Subscription, subscription_stubs.except(:begins_at, :ends_at))
+      }
+      before { stub_validations(validator, validation_stubs.except(:ends_at_after_begins_at?)) }
+      before { expect(subscription).to receive(:begins_at).at_least(:once) { begins_at } }
+
+      context "when no begins_at is present" do
+        let(:begins_at) { nil }
+
+        it "adds an error and returns false" do
+          expect(validator.valid?).to be false
+          expect(validator.errors[:begins_at]).not_to be_empty
+        end
+      end
+
+      context "when a start date is present" do
+        let(:begins_at) { Time.zone.today }
+        before { expect(subscription).to receive(:ends_at).at_least(:once) { ends_at } }
+
+        context "when no ends_at is present" do
+          let(:ends_at) { nil }
+
+          it "returns true" do
+            expect(validator.valid?).to be true
+            expect(validator.errors[:ends_at]).to be_empty
+          end
+        end
+
+        context "when ends_at is equal to begins_at" do
+          let(:ends_at) { Time.zone.today }
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:ends_at]).not_to be_empty
+          end
+        end
+
+        context "when ends_at is before begins_at" do
+          let(:ends_at) { Time.zone.today - 1.day }
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:ends_at]).not_to be_empty
+          end
+        end
+
+        context "when ends_at is after begins_at" do
+          let(:ends_at) { Time.zone.today + 1.day }
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be true
+            expect(validator.errors[:ends_at]).to be_empty
+          end
+        end
+      end
+    end
+
+    describe "addresses" do
+      before { stub_validations(validator, validation_stubs) }
+      let(:subscription) {
+        instance_double(Subscription, subscription_stubs.except(:bill_address, :ship_address))
+      }
+      before { expect(subscription).to receive(:bill_address).at_least(:once) { bill_address } }
+      before { expect(subscription).to receive(:ship_address).at_least(:once) { ship_address } }
+
+      context "when bill_address and ship_address are not present" do
+        let(:bill_address) { nil }
+        let(:ship_address) { nil }
+
+        it "adds an error and returns false" do
+          expect(validator.valid?).to be false
+          expect(validator.errors[:bill_address]).not_to be_empty
+          expect(validator.errors[:ship_address]).not_to be_empty
+        end
+      end
+
+      context "when bill_address and ship_address are present" do
+        let(:bill_address) { instance_double(Spree::Address) }
+        let(:ship_address) { instance_double(Spree::Address) }
+
+        it "returns true" do
+          expect(validator.valid?).to be true
+          expect(validator.errors[:bill_address]).to be_empty
+          expect(validator.errors[:ship_address]).to be_empty
+        end
+      end
+    end
+
+    describe "customer" do
+      let(:subscription) { instance_double(Subscription, subscription_stubs.except(:customer)) }
+      before { stub_validations(validator, validation_stubs.except(:customer_allowed?)) }
+      before { expect(subscription).to receive(:customer).at_least(:once) { customer } }
+
+      context "when no customer is present" do
+        let(:customer) { nil }
+
+        it "adds an error and returns false" do
+          expect(validator.valid?).to be false
+          expect(validator.errors[:customer]).not_to be_empty
+        end
+      end
+
+      context "when a customer is present" do
+        let(:customer) { instance_double(Customer) }
+
+        context "and the customer is not associated with the shop" do
+          before { allow(customer).to receive(:enterprise) { double(:enterprise) } }
+
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:customer]).not_to be_empty
+          end
+        end
+
+        context "and the customer is associated with the shop" do
+          before { allow(customer).to receive(:enterprise) { shop } }
+
+          it "returns true" do
+            expect(validator.valid?).to be true
+            expect(validator.errors[:customer]).to be_empty
+          end
+        end
+      end
+    end
+
+    describe "schedule" do
+      let(:subscription) { instance_double(Subscription, subscription_stubs.except(:schedule)) }
+      before { stub_validations(validator, validation_stubs.except(:schedule_allowed?)) }
+      before { expect(subscription).to receive(:schedule).at_least(:once) { schedule } }
+
+      context "when no schedule is present" do
+        let(:schedule) { nil }
+
+        it "adds an error and returns false" do
+          expect(validator.valid?).to be false
+          expect(validator.errors[:schedule]).not_to be_empty
+        end
+      end
+
+      context "when a schedule is present" do
+        let(:schedule) { instance_double(Schedule) }
+
+        context "and the schedule is not associated with the shop" do
+          before { allow(schedule).to receive(:coordinators) { [double(:enterprise)] } }
+
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:schedule]).not_to be_empty
+          end
+        end
+
+        context "and the schedule is associated with the shop" do
+          before { allow(schedule).to receive(:coordinators) { [shop] } }
+
+          it "returns true" do
+            expect(validator.valid?).to be true
+            expect(validator.errors[:schedule]).to be_empty
+          end
+        end
+      end
+    end
+
+    describe "credit card" do
+      let(:subscription) {
+        instance_double(Subscription, subscription_stubs.except(:payment_method))
+      }
+      before { stub_validations(validator, validation_stubs.except(:credit_card_ok?)) }
+      before {
+        expect(subscription).to receive(:payment_method).at_least(:once) { payment_method }
+      }
+
+      context "when using a Check payment method" do
+        let(:payment_method) {
+          instance_double(Spree::PaymentMethod, type: "Spree::PaymentMethod::Check")
+        }
+
+        it "returns true" do
+          expect(validator.valid?).to be true
+          expect(validator.errors[:subscription_line_items]).to be_empty
+        end
+      end
+
+      context "when using the StripeSCA payment gateway" do
+        let(:payment_method) {
+          instance_double(Spree::PaymentMethod, type: "Spree::Gateway::StripeSCA")
+        }
+        before { expect(subscription).to receive(:customer).at_least(:once) { customer } }
+
+        context "when the customer does not allow charges" do
+          let(:customer) { instance_double(Customer, allow_charges: false) }
+
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:payment_method]).not_to be_empty
+          end
+        end
+
+        context "when the customer allows charges" do
+          let(:customer) { instance_double(Customer, allow_charges: true) }
+
+          context "and the customer is not associated with a user" do
+            before { allow(customer).to receive(:user) { nil } }
 
             it "adds an error and returns false" do
               expect(validator.valid?).to be false
@@ -119,14 +385,11 @@ module OrderManagement
             end
           end
 
-          context "when a payment method is present" do
-            let(:payment_method) { instance_double(Spree::PaymentMethod, distributors: [shop]) }
-            before {
-              expect(subscription).to receive(:payment_method).at_least(:once) { payment_method }
-            }
+          context "and the customer is associated with a user" do
+            before { expect(customer).to receive(:user).once { user } }
 
-            context "and the payment method is not associated with the shop" do
-              before { allow(payment_method).to receive(:distributors) { [double(:enterprise)] } }
+            context "and the user has no default card set" do
+              let(:user) { instance_double(Spree::User, default_card: nil) }
 
               it "adds an error and returns false" do
                 expect(validator.valid?).to be false
@@ -134,8 +397,8 @@ module OrderManagement
               end
             end
 
-            context "and the payment method is associated with the shop" do
-              before { allow(payment_method).to receive(:distributors) { [shop] } }
+            context "and the user has a default card set" do
+              let(:user) { instance_double(Spree::User, default_card: 'some card') }
 
               it "returns true" do
                 expect(validator.valid?).to be true
@@ -144,414 +407,147 @@ module OrderManagement
             end
           end
         end
+      end
+    end
 
-        describe "payment method type validation" do
-          let(:subscription) {
-            instance_double(Subscription, subscription_stubs.except(:payment_method))
+    describe "subscription line items" do
+      let(:subscription) { instance_double(Subscription, subscription_stubs) }
+      before {
+        stub_validations(validator, validation_stubs.except(:subscription_line_items_present?))
+      }
+      before {
+        expect(subscription).to receive(:subscription_line_items).at_least(:once) {
+          subscription_line_items
+        }
+      }
+
+      context "when no subscription line items exist" do
+        let(:subscription_line_items) { [] }
+
+        it "adds an error and returns false" do
+          expect(validator.valid?).to be false
+          expect(validator.errors[:subscription_line_items]).not_to be_empty
+        end
+      end
+
+      context "when some subscription line items exist" do
+        context "and they have some quantity but all are marked for destruction" do
+          let(:subscription_line_item1) {
+            instance_double(SubscriptionLineItem, marked_for_destruction?: true, quantity: 1)
           }
-          before {
-            stub_validations(validator, validation_stubs.except(:payment_method_type_allowed?))
-          }
+          let(:subscription_line_items) { [subscription_line_item1] }
 
-          context "when a payment method is present" do
-            let(:payment_method) { instance_double(Spree::PaymentMethod, distributors: [shop]) }
-            before {
-              expect(subscription).to receive(:payment_method).at_least(:once) { payment_method }
-            }
-
-            context "and the payment method type is not in the approved list" do
-              before { allow(payment_method).to receive(:type) { "Blah" } }
-
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:payment_method]).not_to be_empty
-              end
-            end
-
-            context "and the payment method is in the approved list" do
-              let(:approved_type) { Subscription::ALLOWED_PAYMENT_METHOD_TYPES.first }
-              before { allow(payment_method).to receive(:type) { approved_type } }
-
-              it "returns true" do
-                expect(validator.valid?).to be true
-                expect(validator.errors[:payment_method]).to be_empty
-              end
-            end
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:subscription_line_items]).not_to be_empty
           end
         end
 
-        describe "dates" do
-          let(:subscription) {
-            instance_double(Subscription, subscription_stubs.except(:begins_at, :ends_at))
+        context "and at least one has some quantity and is not marked for destruction" do
+          let(:subscription_line_item1) {
+            instance_double(SubscriptionLineItem, marked_for_destruction?: true, quantity: 1)
           }
-          before { stub_validations(validator, validation_stubs.except(:ends_at_after_begins_at?)) }
-          before { expect(subscription).to receive(:begins_at).at_least(:once) { begins_at } }
+          let(:subscription_line_item2) {
+            instance_double(SubscriptionLineItem, marked_for_destruction?: false, quantity: 1)
+          }
+          let(:subscription_line_items) { [subscription_line_item1, subscription_line_item2] }
 
-          context "when no begins_at is present" do
-            let(:begins_at) { nil }
-
-            it "adds an error and returns false" do
-              expect(validator.valid?).to be false
-              expect(validator.errors[:begins_at]).not_to be_empty
-            end
-          end
-
-          context "when a start date is present" do
-            let(:begins_at) { Time.zone.today }
-            before { expect(subscription).to receive(:ends_at).at_least(:once) { ends_at } }
-
-            context "when no ends_at is present" do
-              let(:ends_at) { nil }
-
-              it "returns true" do
-                expect(validator.valid?).to be true
-                expect(validator.errors[:ends_at]).to be_empty
-              end
-            end
-
-            context "when ends_at is equal to begins_at" do
-              let(:ends_at) { Time.zone.today }
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:ends_at]).not_to be_empty
-              end
-            end
-
-            context "when ends_at is before begins_at" do
-              let(:ends_at) { Time.zone.today - 1.day }
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:ends_at]).not_to be_empty
-              end
-            end
-
-            context "when ends_at is after begins_at" do
-              let(:ends_at) { Time.zone.today + 1.day }
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be true
-                expect(validator.errors[:ends_at]).to be_empty
-              end
-            end
+          it "returns true" do
+            expect(validator.valid?).to be true
+            expect(validator.errors[:subscription_line_items]).to be_empty
           end
         end
 
-        describe "addresses" do
-          before { stub_validations(validator, validation_stubs) }
-          let(:subscription) {
-            instance_double(Subscription, subscription_stubs.except(:bill_address, :ship_address))
+        context "and they are not marked for destruction but all have no quantity" do
+          let(:subscription_line_item1) {
+            instance_double(SubscriptionLineItem, marked_for_destruction?: false, quantity: 0)
           }
-          before { expect(subscription).to receive(:bill_address).at_least(:once) { bill_address } }
-          before { expect(subscription).to receive(:ship_address).at_least(:once) { ship_address } }
+          let(:subscription_line_items) { [subscription_line_item1] }
 
-          context "when bill_address and ship_address are not present" do
-            let(:bill_address) { nil }
-            let(:ship_address) { nil }
-
-            it "adds an error and returns false" do
-              expect(validator.valid?).to be false
-              expect(validator.errors[:bill_address]).not_to be_empty
-              expect(validator.errors[:ship_address]).not_to be_empty
-            end
-          end
-
-          context "when bill_address and ship_address are present" do
-            let(:bill_address) { instance_double(Spree::Address) }
-            let(:ship_address) { instance_double(Spree::Address) }
-
-            it "returns true" do
-              expect(validator.valid?).to be true
-              expect(validator.errors[:bill_address]).to be_empty
-              expect(validator.errors[:ship_address]).to be_empty
-            end
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:subscription_line_items]).not_to be_empty
           end
         end
 
-        describe "customer" do
-          let(:subscription) { instance_double(Subscription, subscription_stubs.except(:customer)) }
-          before { stub_validations(validator, validation_stubs.except(:customer_allowed?)) }
-          before { expect(subscription).to receive(:customer).at_least(:once) { customer } }
+        context "but all have no quantity and are marked for destruction" do
+          let(:subscription_line_item1) {
+            instance_double(SubscriptionLineItem, marked_for_destruction?: true, quantity: 0)
+          }
+          let(:subscription_line_items) { [subscription_line_item1] }
 
-          context "when no customer is present" do
-            let(:customer) { nil }
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:subscription_line_items]).not_to be_empty
+          end
+        end
+      end
+    end
 
-            it "adds an error and returns false" do
-              expect(validator.valid?).to be false
-              expect(validator.errors[:customer]).not_to be_empty
-            end
+    describe "variant availability" do
+      let(:subscription) { instance_double(Subscription, subscription_stubs) }
+      before {
+        stub_validations(validator, validation_stubs.except(:requested_variants_available?))
+      }
+      before {
+        expect(subscription).to receive(:subscription_line_items).at_least(:once) {
+          subscription_line_items
+        }
+      }
+
+      context "when no subscription line items exist" do
+        let(:subscription_line_items) { [] }
+
+        it "returns true" do
+          expect(validator.valid?).to be true
+          expect(validator.errors[:subscription_line_items]).to be_empty
+        end
+      end
+
+      context "when subscription line items exist" do
+        let(:variant1) { instance_double(Spree::Variant, id: 1, deleted_at: nil) }
+        let(:variant2) { instance_double(Spree::Variant, id: 2) }
+        let(:variant3) { instance_double(Spree::Variant, id: 1, deleted_at: Time.zone.now ) }
+        let(:subscription_line_item1) {
+          instance_double(SubscriptionLineItem,
+                          variant: variant1,
+                          marked_for_destruction?: false)
+        }
+        let(:subscription_line_item2) {
+          instance_double(SubscriptionLineItem,
+                          variant: variant2,
+                          marked_for_destruction?: false)
+        }
+        let(:subscription_line_item3) {
+          instance_double(SubscriptionLineItem,
+                          variant: variant3,
+                          marked_for_destruction?: true)
+        }
+        let(:subscription_line_items) { [subscription_line_item1, subscription_line_item3] }
+
+        context "but some variants are unavailable" do
+          let(:product) { instance_double(Spree::Product, name: "some_name") }
+
+          before do
+            allow(validator).to receive(:available_variant_ids) { [variant2.id] }
+            allow(variant1).to receive(:product) { product }
+            allow(variant1).to receive(:full_name) { "some name" }
           end
 
-          context "when a customer is present" do
-            let(:customer) { instance_double(Customer) }
-
-            context "and the customer is not associated with the shop" do
-              before { allow(customer).to receive(:enterprise) { double(:enterprise) } }
-
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:customer]).not_to be_empty
-              end
-            end
-
-            context "and the customer is associated with the shop" do
-              before { allow(customer).to receive(:enterprise) { shop } }
-
-              it "returns true" do
-                expect(validator.valid?).to be true
-                expect(validator.errors[:customer]).to be_empty
-              end
-            end
+          it "adds an error and returns false" do
+            expect(validator.valid?).to be false
+            expect(validator.errors[:subscription_line_items]).not_to be_empty
           end
         end
 
-        describe "schedule" do
-          let(:subscription) { instance_double(Subscription, subscription_stubs.except(:schedule)) }
-          before { stub_validations(validator, validation_stubs.except(:schedule_allowed?)) }
-          before { expect(subscription).to receive(:schedule).at_least(:once) { schedule } }
-
-          context "when no schedule is present" do
-            let(:schedule) { nil }
-
-            it "adds an error and returns false" do
-              expect(validator.valid?).to be false
-              expect(validator.errors[:schedule]).not_to be_empty
-            end
+        context "and all requested variants are available" do
+          before do
+            allow(validator).to receive(:available_variant_ids) { [variant1.id, variant2.id] }
           end
 
-          context "when a schedule is present" do
-            let(:schedule) { instance_double(Schedule) }
-
-            context "and the schedule is not associated with the shop" do
-              before { allow(schedule).to receive(:coordinators) { [double(:enterprise)] } }
-
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:schedule]).not_to be_empty
-              end
-            end
-
-            context "and the schedule is associated with the shop" do
-              before { allow(schedule).to receive(:coordinators) { [shop] } }
-
-              it "returns true" do
-                expect(validator.valid?).to be true
-                expect(validator.errors[:schedule]).to be_empty
-              end
-            end
-          end
-        end
-
-        describe "credit card" do
-          let(:subscription) {
-            instance_double(Subscription, subscription_stubs.except(:payment_method))
-          }
-          before { stub_validations(validator, validation_stubs.except(:credit_card_ok?)) }
-          before {
-            expect(subscription).to receive(:payment_method).at_least(:once) { payment_method }
-          }
-
-          context "when using a Check payment method" do
-            let(:payment_method) {
-              instance_double(Spree::PaymentMethod, type: "Spree::PaymentMethod::Check")
-            }
-
-            it "returns true" do
-              expect(validator.valid?).to be true
-              expect(validator.errors[:subscription_line_items]).to be_empty
-            end
-          end
-
-          context "when using the StripeSCA payment gateway" do
-            let(:payment_method) {
-              instance_double(Spree::PaymentMethod, type: "Spree::Gateway::StripeSCA")
-            }
-            before { expect(subscription).to receive(:customer).at_least(:once) { customer } }
-
-            context "when the customer does not allow charges" do
-              let(:customer) { instance_double(Customer, allow_charges: false) }
-
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:payment_method]).not_to be_empty
-              end
-            end
-
-            context "when the customer allows charges" do
-              let(:customer) { instance_double(Customer, allow_charges: true) }
-
-              context "and the customer is not associated with a user" do
-                before { allow(customer).to receive(:user) { nil } }
-
-                it "adds an error and returns false" do
-                  expect(validator.valid?).to be false
-                  expect(validator.errors[:payment_method]).not_to be_empty
-                end
-              end
-
-              context "and the customer is associated with a user" do
-                before { expect(customer).to receive(:user).once { user } }
-
-                context "and the user has no default card set" do
-                  let(:user) { instance_double(Spree::User, default_card: nil) }
-
-                  it "adds an error and returns false" do
-                    expect(validator.valid?).to be false
-                    expect(validator.errors[:payment_method]).not_to be_empty
-                  end
-                end
-
-                context "and the user has a default card set" do
-                  let(:user) { instance_double(Spree::User, default_card: 'some card') }
-
-                  it "returns true" do
-                    expect(validator.valid?).to be true
-                    expect(validator.errors[:payment_method]).to be_empty
-                  end
-                end
-              end
-            end
-          end
-        end
-
-        describe "subscription line items" do
-          let(:subscription) { instance_double(Subscription, subscription_stubs) }
-          before {
-            stub_validations(validator, validation_stubs.except(:subscription_line_items_present?))
-          }
-          before {
-            expect(subscription).to receive(:subscription_line_items).at_least(:once) {
-              subscription_line_items
-            }
-          }
-
-          context "when no subscription line items exist" do
-            let(:subscription_line_items) { [] }
-
-            it "adds an error and returns false" do
-              expect(validator.valid?).to be false
-              expect(validator.errors[:subscription_line_items]).not_to be_empty
-            end
-          end
-
-          context "when some subscription line items exist" do
-            context "and they have some quantity but all are marked for destruction" do
-              let(:subscription_line_item1) {
-                instance_double(SubscriptionLineItem, marked_for_destruction?: true, quantity: 1)
-              }
-              let(:subscription_line_items) { [subscription_line_item1] }
-
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:subscription_line_items]).not_to be_empty
-              end
-            end
-
-            context "and at least one has some quantity and is not marked for destruction" do
-              let(:subscription_line_item1) {
-                instance_double(SubscriptionLineItem, marked_for_destruction?: true, quantity: 1)
-              }
-              let(:subscription_line_item2) {
-                instance_double(SubscriptionLineItem, marked_for_destruction?: false, quantity: 1)
-              }
-              let(:subscription_line_items) { [subscription_line_item1, subscription_line_item2] }
-
-              it "returns true" do
-                expect(validator.valid?).to be true
-                expect(validator.errors[:subscription_line_items]).to be_empty
-              end
-            end
-
-            context "and they are not marked for destruction but all have no quantity" do
-              let(:subscription_line_item1) {
-                instance_double(SubscriptionLineItem, marked_for_destruction?: false, quantity: 0)
-              }
-              let(:subscription_line_items) { [subscription_line_item1] }
-
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:subscription_line_items]).not_to be_empty
-              end
-            end
-
-            context "but all have no quantity and are marked for destruction" do
-              let(:subscription_line_item1) {
-                instance_double(SubscriptionLineItem, marked_for_destruction?: true, quantity: 0)
-              }
-              let(:subscription_line_items) { [subscription_line_item1] }
-
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:subscription_line_items]).not_to be_empty
-              end
-            end
-          end
-        end
-
-        describe "variant availability" do
-          let(:subscription) { instance_double(Subscription, subscription_stubs) }
-          before {
-            stub_validations(validator, validation_stubs.except(:requested_variants_available?))
-          }
-          before {
-            expect(subscription).to receive(:subscription_line_items).at_least(:once) {
-              subscription_line_items
-            }
-          }
-
-          context "when no subscription line items exist" do
-            let(:subscription_line_items) { [] }
-
-            it "returns true" do
-              expect(validator.valid?).to be true
-              expect(validator.errors[:subscription_line_items]).to be_empty
-            end
-          end
-
-          context "when subscription line items exist" do
-            let(:variant1) { instance_double(Spree::Variant, id: 1, deleted_at: nil) }
-            let(:variant2) { instance_double(Spree::Variant, id: 2) }
-            let(:variant3) { instance_double(Spree::Variant, id: 1, deleted_at: Time.zone.now ) }
-            let(:subscription_line_item1) {
-              instance_double(SubscriptionLineItem,
-                              variant: variant1,
-                              marked_for_destruction?: false)
-            }
-            let(:subscription_line_item2) {
-              instance_double(SubscriptionLineItem,
-                              variant: variant2,
-                              marked_for_destruction?: false)
-            }
-            let(:subscription_line_item3) {
-              instance_double(SubscriptionLineItem,
-                              variant: variant3,
-                              marked_for_destruction?: true)
-            }
-            let(:subscription_line_items) { [subscription_line_item1, subscription_line_item3] }
-
-            context "but some variants are unavailable" do
-              let(:product) { instance_double(Spree::Product, name: "some_name") }
-
-              before do
-                allow(validator).to receive(:available_variant_ids) { [variant2.id] }
-                allow(variant1).to receive(:product) { product }
-                allow(variant1).to receive(:full_name) { "some name" }
-              end
-
-              it "adds an error and returns false" do
-                expect(validator.valid?).to be false
-                expect(validator.errors[:subscription_line_items]).not_to be_empty
-              end
-            end
-
-            context "and all requested variants are available" do
-              before do
-                allow(validator).to receive(:available_variant_ids) { [variant1.id, variant2.id] }
-              end
-
-              it "returns true" do
-                expect(validator.valid?).to be true
-                expect(validator.errors[:subscription_line_items]).to be_empty
-              end
-            end
+          it "returns true" do
+            expect(validator.valid?).to be true
+            expect(validator.errors[:subscription_line_items]).to be_empty
           end
         end
       end

--- a/engines/order_management/spec/services/order_management/subscriptions/variants_list_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/variants_list_spec.rb
@@ -2,162 +2,158 @@
 
 require "spec_helper"
 
-module OrderManagement
-  module Subscriptions
-    RSpec.describe VariantsList do
-      describe "variant eligibility for subscription" do
-        let!(:shop) { create(:distributor_enterprise) }
-        let!(:producer) { create(:supplier_enterprise) }
-        let!(:variant) { create(:variant, supplier: producer) }
+RSpec.describe OrderManagement::Subscriptions::VariantsList do
+  describe "variant eligibility for subscription" do
+    let!(:shop) { create(:distributor_enterprise) }
+    let!(:producer) { create(:supplier_enterprise) }
+    let!(:variant) { create(:variant, supplier: producer) }
 
-        let!(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
-        let!(:subscription) { create(:subscription, shop:, schedule:) }
-        let!(:subscription_line_item) do
-          create(:subscription_line_item, subscription:, variant:)
-        end
+    let!(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
+    let!(:subscription) { create(:subscription, shop:, schedule:) }
+    let!(:subscription_line_item) do
+      create(:subscription_line_item, subscription:, variant:)
+    end
 
-        let(:current_order_cycle) do
-          create(:simple_order_cycle, coordinator: shop, orders_open_at: 1.week.ago,
-                                      orders_close_at: 1.week.from_now)
-        end
+    let(:current_order_cycle) do
+      create(:simple_order_cycle, coordinator: shop, orders_open_at: 1.week.ago,
+                                  orders_close_at: 1.week.from_now)
+    end
 
-        let(:future_order_cycle) do
-          create(:simple_order_cycle, coordinator: shop, orders_open_at: 1.week.from_now,
-                                      orders_close_at: 2.weeks.from_now)
-        end
+    let(:future_order_cycle) do
+      create(:simple_order_cycle, coordinator: shop, orders_open_at: 1.week.from_now,
+                                  orders_close_at: 2.weeks.from_now)
+    end
 
-        let(:past_order_cycle) do
-          create(:simple_order_cycle, coordinator: shop, orders_open_at: 2.weeks.ago,
-                                      orders_close_at: 1.week.ago)
-        end
+    let(:past_order_cycle) do
+      create(:simple_order_cycle, coordinator: shop, orders_open_at: 2.weeks.ago,
+                                  orders_close_at: 1.week.ago)
+    end
 
-        let!(:order_cycle) { current_order_cycle }
+    let!(:order_cycle) { current_order_cycle }
 
-        context "if the shop is the supplier for the product" do
-          let!(:producer) { shop }
+    context "if the shop is the supplier for the product" do
+      let!(:producer) { shop }
 
-          it "is eligible" do
-            expect(described_class.eligible_variants(shop)).to include(variant)
-          end
-        end
+      it "is eligible" do
+        expect(described_class.eligible_variants(shop)).to include(variant)
+      end
+    end
 
-        context "if the supplier is permitted for the shop" do
-          let!(:enterprise_relationship) {
-            create(:enterprise_relationship, child: shop,
-                                             parent: variant.supplier,
-                                             permissions_list: [:add_to_order_cycle])
-          }
+    context "if the supplier is permitted for the shop" do
+      let!(:enterprise_relationship) {
+        create(:enterprise_relationship, child: shop,
+                                         parent: variant.supplier,
+                                         permissions_list: [:add_to_order_cycle])
+      }
 
-          it "is eligible" do
-            expect(described_class.eligible_variants(shop)).to include(variant)
-          end
-        end
+      it "is eligible" do
+        expect(described_class.eligible_variants(shop)).to include(variant)
+      end
+    end
 
-        context "if the variant is involved in an exchange" do
-          let!(:order_cycle) { create(:simple_order_cycle, coordinator: shop) }
-          let!(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
+    context "if the variant is involved in an exchange" do
+      let!(:order_cycle) { create(:simple_order_cycle, coordinator: shop) }
+      let!(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
 
-          context "if it is an incoming exchange where the shop is the receiver" do
-            let!(:incoming_exchange) {
-              order_cycle.exchanges.create(sender: variant.supplier,
-                                           receiver: shop,
-                                           incoming: true, variants: [variant])
-            }
+      context "if it is an incoming exchange where the shop is the receiver" do
+        let!(:incoming_exchange) {
+          order_cycle.exchanges.create(sender: variant.supplier,
+                                       receiver: shop,
+                                       incoming: true, variants: [variant])
+        }
 
-            it "is not eligible" do
-              expect(described_class.eligible_variants(shop)).not_to include(variant)
-            end
-          end
-
-          context "if it is an outgoing exchange where the shop is the receiver" do
-            let!(:outgoing_exchange) {
-              order_cycle.exchanges.create(sender: variant.supplier,
-                                           receiver: shop,
-                                           incoming: false,
-                                           variants: [variant])
-            }
-
-            context "if the order cycle is currently open" do
-              let!(:order_cycle) { current_order_cycle }
-
-              it "is eligible" do
-                expect(described_class.eligible_variants(shop)).to include(variant)
-              end
-            end
-
-            context "if the order cycle opens in the future" do
-              let!(:order_cycle) { future_order_cycle }
-
-              it "is eligible" do
-                expect(described_class.eligible_variants(shop)).to include(variant)
-              end
-            end
-
-            context "if the order cycle closed in the past" do
-              let!(:order_cycle) { past_order_cycle }
-
-              it "is eligible" do
-                expect(described_class.eligible_variants(shop)).to include(variant)
-              end
-            end
-          end
-        end
-
-        context "if the variant is unrelated" do
-          it "is not eligible" do
-            expect(described_class.eligible_variants(shop)).not_to include(variant)
-          end
+        it "is not eligible" do
+          expect(described_class.eligible_variants(shop)).not_to include(variant)
         end
       end
 
-      describe "checking if variant in open and upcoming order cycles" do
-        let!(:shop) { create(:enterprise) }
-        let!(:product) { create(:product) }
-        let!(:variant) { product.variants.first }
-        let!(:schedule) { create(:schedule) }
+      context "if it is an outgoing exchange where the shop is the receiver" do
+        let!(:outgoing_exchange) {
+          order_cycle.exchanges.create(sender: variant.supplier,
+                                       receiver: shop,
+                                       incoming: false,
+                                       variants: [variant])
+        }
 
-        context "if the variant is involved in an exchange" do
-          let!(:order_cycle) { create(:simple_order_cycle, coordinator: shop) }
-          let!(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
+        context "if the order cycle is currently open" do
+          let!(:order_cycle) { current_order_cycle }
 
-          context "if it is an incoming exchange where the shop is the receiver" do
-            let!(:incoming_exchange) {
-              order_cycle.exchanges.create(sender: variant.supplier,
-                                           receiver: shop,
-                                           incoming: true,
-                                           variants: [variant])
-            }
-
-            it "is is false" do
-              expect(described_class).not_to be_in_open_and_upcoming_order_cycles(shop,
-                                                                                  schedule,
-                                                                                  variant)
-            end
+          it "is eligible" do
+            expect(described_class.eligible_variants(shop)).to include(variant)
           end
+        end
 
-          context "if it is an outgoing exchange where the shop is the receiver" do
-            let!(:outgoing_exchange) {
-              order_cycle.exchanges.create(sender: variant.supplier,
-                                           receiver: shop,
-                                           incoming: false,
-                                           variants: [variant])
-            }
+        context "if the order cycle opens in the future" do
+          let!(:order_cycle) { future_order_cycle }
 
-            it "is true" do
-              expect(described_class).to be_in_open_and_upcoming_order_cycles(shop,
+          it "is eligible" do
+            expect(described_class.eligible_variants(shop)).to include(variant)
+          end
+        end
+
+        context "if the order cycle closed in the past" do
+          let!(:order_cycle) { past_order_cycle }
+
+          it "is eligible" do
+            expect(described_class.eligible_variants(shop)).to include(variant)
+          end
+        end
+      end
+    end
+
+    context "if the variant is unrelated" do
+      it "is not eligible" do
+        expect(described_class.eligible_variants(shop)).not_to include(variant)
+      end
+    end
+  end
+
+  describe "checking if variant in open and upcoming order cycles" do
+    let!(:shop) { create(:enterprise) }
+    let!(:product) { create(:product) }
+    let!(:variant) { product.variants.first }
+    let!(:schedule) { create(:schedule) }
+
+    context "if the variant is involved in an exchange" do
+      let!(:order_cycle) { create(:simple_order_cycle, coordinator: shop) }
+      let!(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
+
+      context "if it is an incoming exchange where the shop is the receiver" do
+        let!(:incoming_exchange) {
+          order_cycle.exchanges.create(sender: variant.supplier,
+                                       receiver: shop,
+                                       incoming: true,
+                                       variants: [variant])
+        }
+
+        it "is is false" do
+          expect(described_class).not_to be_in_open_and_upcoming_order_cycles(shop,
                                                                               schedule,
                                                                               variant)
-            end
-          end
         end
+      end
 
-        context "if the variant is unrelated" do
-          it "is false" do
-            expect(described_class).not_to be_in_open_and_upcoming_order_cycles(shop,
-                                                                                schedule,
-                                                                                variant)
-          end
+      context "if it is an outgoing exchange where the shop is the receiver" do
+        let!(:outgoing_exchange) {
+          order_cycle.exchanges.create(sender: variant.supplier,
+                                       receiver: shop,
+                                       incoming: false,
+                                       variants: [variant])
+        }
+
+        it "is true" do
+          expect(described_class).to be_in_open_and_upcoming_order_cycles(shop,
+                                                                          schedule,
+                                                                          variant)
         end
+      end
+    end
+
+    context "if the variant is unrelated" do
+      it "is false" do
+        expect(described_class).not_to be_in_open_and_upcoming_order_cycles(shop,
+                                                                            schedule,
+                                                                            variant)
       end
     end
   end

--- a/spec/lib/open_food_network/address_finder_spec.rb
+++ b/spec/lib/open_food_network/address_finder_spec.rb
@@ -3,248 +3,246 @@
 require 'spec_helper'
 require 'open_food_network/address_finder'
 
-module OpenFoodNetwork
-  RSpec.describe AddressFinder do
-    let(:email) { 'test@example.com' }
+RSpec.describe OpenFoodNetwork::AddressFinder do
+  let(:email) { 'test@example.com' }
 
-    describe "initialisation" do
-      let(:user) { create(:user) }
-      let(:customer) { create(:customer) }
+  describe "initialisation" do
+    let(:user) { create(:user) }
+    let(:customer) { create(:customer) }
 
-      context "when passed any combination of instances of String, Customer or Spree::User" do
-        let(:finder1) { AddressFinder.new(email:, customer:, user:) }
+    context "when passed any combination of instances of String, Customer or Spree::User" do
+      let(:finder1) { described_class.new(email:, customer:, user:) }
 
-        it "stores arguments" do
-          expect(finder1.email).to eq email
-          expect(finder1.customer).to be customer
-          expect(finder1.user).to be user
+      it "stores arguments" do
+        expect(finder1.email).to eq email
+        expect(finder1.customer).to be customer
+        expect(finder1.user).to be user
+      end
+    end
+  end
+
+  describe "fallback_bill_address" do
+    let(:finder) { described_class.new(email:) }
+    let(:address) { double(:address, clone: 'address_clone') }
+
+    context "when a last_used_bill_address is found" do
+      before { allow(finder).to receive(:last_used_bill_address) { address } }
+
+      it "returns a clone of the bill_address" do
+        expect(finder.__send__(:fallback_bill_address)).to eq "address_clone"
+      end
+    end
+
+    context "when no last_used_bill_address is found" do
+      before { allow(finder).to receive(:last_used_bill_address) { nil } }
+
+      it "returns a new empty address" do
+        expect(finder.__send__(:fallback_bill_address)).to eq Spree::Address.default
+      end
+    end
+  end
+
+  describe "fallback_ship_address" do
+    let(:finder) { described_class.new(email:) }
+    let(:address) { double(:address, clone: 'address_clone') }
+
+    context "when a last_used_ship_address is found" do
+      before { allow(finder).to receive(:last_used_ship_address) { address } }
+
+      it "returns a clone of the ship_address" do
+        expect(finder.__send__(:fallback_ship_address)).to eq "address_clone"
+      end
+    end
+
+    context "when no last_used_ship_address is found" do
+      before { allow(finder).to receive(:last_used_ship_address) { nil } }
+
+      it "returns a new empty address" do
+        expect(finder.__send__(:fallback_ship_address)).to eq Spree::Address.default
+      end
+    end
+  end
+
+  describe "last_used_bill_address" do
+    let(:distributor) { create(:distributor_enterprise) }
+    let(:address) { create(:address) }
+    let(:order) {
+      create(:completed_order_with_totals, user: nil, email:, distributor:,
+                                           bill_address: nil)
+    }
+    let(:finder) { described_class.new(email:) }
+
+    context "when searching by email is not allowed" do
+      before do
+        allow(finder).to receive(:allow_search_by_email?) { false }
+      end
+
+      context "and an order with a bill address exists" do
+        before do
+          order.update_attribute(:bill_address, address)
+        end
+
+        it "returns nil" do
+          expect(finder.__send__(:last_used_bill_address)).to eq nil
         end
       end
     end
 
-    describe "fallback_bill_address" do
-      let(:finder) { AddressFinder.new(email:) }
-      let(:address) { double(:address, clone: 'address_clone') }
+    context "when searching by email is allowed" do
+      before do
+        allow(finder).to receive(:allow_search_by_email?) { true }
+      end
 
-      context "when a last_used_bill_address is found" do
-        before { allow(finder).to receive(:last_used_bill_address) { address } }
+      context "and an order with a bill address exists" do
+        before { order.update_attribute(:bill_address, address) }
 
-        it "returns a clone of the bill_address" do
-          expect(finder.__send__(:fallback_bill_address)).to eq "address_clone"
+        it "returns the bill_address" do
+          expect(finder.__send__(:last_used_bill_address)).to eq address
         end
       end
 
-      context "when no last_used_bill_address is found" do
-        before { allow(finder).to receive(:last_used_bill_address) { nil } }
+      context "and an order without a bill address exists" do
+        before { order }
 
-        it "returns a new empty address" do
-          expect(finder.__send__(:fallback_bill_address)).to eq Spree::Address.default
+        it "return nil" do
+          expect(finder.__send__(:last_used_bill_address)).to eq nil
+        end
+      end
+
+      context "when no orders exist" do
+        it "returns nil" do
+          expect(finder.__send__(:last_used_bill_address)).to eq nil
+        end
+      end
+    end
+  end
+
+  describe "last_used_ship_address" do
+    let(:address) { create(:address) }
+    let(:distributor) { create(:distributor_enterprise) }
+    let(:finder) { described_class.new(email:) }
+
+    context "when searching by email is not allowed" do
+      before do
+        allow(finder).to receive(:allow_search_by_email?) { false }
+      end
+
+      context "and an order with a required ship address exists" do
+        let(:order) {
+          create(:shipped_order, user: nil, email:, distributor:, shipments: [],
+                                 ship_address: address)
+        }
+
+        before do
+          order.shipping_method.update_attribute(:require_ship_address, true)
+        end
+
+        it "returns nil" do
+          expect(finder.__send__(:last_used_ship_address)).to eq nil
         end
       end
     end
 
-    describe "fallback_ship_address" do
-      let(:finder) { AddressFinder.new(email:) }
-      let(:address) { double(:address, clone: 'address_clone') }
-
-      context "when a last_used_ship_address is found" do
-        before { allow(finder).to receive(:last_used_ship_address) { address } }
-
-        it "returns a clone of the ship_address" do
-          expect(finder.__send__(:fallback_ship_address)).to eq "address_clone"
-        end
+    context "when searching by email is allowed" do
+      before do
+        allow(finder).to receive(:allow_search_by_email?) { true }
       end
 
-      context "when no last_used_ship_address is found" do
-        before { allow(finder).to receive(:last_used_ship_address) { nil } }
+      context "and an order with a ship address exists" do
+        let(:order) {
+          create(:shipped_order, user: nil, email:, distributor:, shipments: [],
+                                 ship_address: address)
+        }
 
-        it "returns a new empty address" do
-          expect(finder.__send__(:fallback_ship_address)).to eq Spree::Address.default
-        end
-      end
-    end
+        context "and the shipping method requires an address" do
+          before { order.shipping_method.update_attribute(:require_ship_address, true) }
 
-    describe "last_used_bill_address" do
-      let(:distributor) { create(:distributor_enterprise) }
-      let(:address) { create(:address) }
-      let(:order) {
-        create(:completed_order_with_totals, user: nil, email:, distributor:,
-                                             bill_address: nil)
-      }
-      let(:finder) { AddressFinder.new(email:) }
-
-      context "when searching by email is not allowed" do
-        before do
-          allow(finder).to receive(:allow_search_by_email?) { false }
-        end
-
-        context "and an order with a bill address exists" do
-          before do
-            order.update_attribute(:bill_address, address)
-          end
-
-          it "returns nil" do
-            expect(finder.__send__(:last_used_bill_address)).to eq nil
-          end
-        end
-      end
-
-      context "when searching by email is allowed" do
-        before do
-          allow(finder).to receive(:allow_search_by_email?) { true }
-        end
-
-        context "and an order with a bill address exists" do
-          before { order.update_attribute(:bill_address, address) }
-
-          it "returns the bill_address" do
-            expect(finder.__send__(:last_used_bill_address)).to eq address
+          it "returns the ship_address" do
+            expect(finder.__send__(:last_used_ship_address)).to eq address
           end
         end
 
-        context "and an order without a bill address exists" do
-          before { order }
+        context "and the shipping method does not require an address" do
+          before { order.shipping_method.update_attribute(:require_ship_address, false) }
 
-          it "return nil" do
-            expect(finder.__send__(:last_used_bill_address)).to eq nil
-          end
-        end
-
-        context "when no orders exist" do
-          it "returns nil" do
-            expect(finder.__send__(:last_used_bill_address)).to eq nil
-          end
-        end
-      end
-    end
-
-    describe "last_used_ship_address" do
-      let(:address) { create(:address) }
-      let(:distributor) { create(:distributor_enterprise) }
-      let(:finder) { AddressFinder.new(email:) }
-
-      context "when searching by email is not allowed" do
-        before do
-          allow(finder).to receive(:allow_search_by_email?) { false }
-        end
-
-        context "and an order with a required ship address exists" do
-          let(:order) {
-            create(:shipped_order, user: nil, email:, distributor:, shipments: [],
-                                   ship_address: address)
-          }
-
-          before do
-            order.shipping_method.update_attribute(:require_ship_address, true)
-          end
-
-          it "returns nil" do
-            expect(finder.__send__(:last_used_ship_address)).to eq nil
-          end
-        end
-      end
-
-      context "when searching by email is allowed" do
-        before do
-          allow(finder).to receive(:allow_search_by_email?) { true }
-        end
-
-        context "and an order with a ship address exists" do
-          let(:order) {
-            create(:shipped_order, user: nil, email:, distributor:, shipments: [],
-                                   ship_address: address)
-          }
-
-          context "and the shipping method requires an address" do
-            before { order.shipping_method.update_attribute(:require_ship_address, true) }
-
-            it "returns the ship_address" do
-              expect(finder.__send__(:last_used_ship_address)).to eq address
-            end
-          end
-
-          context "and the shipping method does not require an address" do
-            before { order.shipping_method.update_attribute(:require_ship_address, false) }
-
-            it "returns nil" do
-              expect(finder.__send__(:last_used_ship_address)).to eq nil
-            end
-          end
-        end
-
-        context "and an order without a ship address exists" do
-          let!(:order) {
-            create(:shipped_order, user: nil, email:, distributor:, shipments: [],
-                                   ship_address: nil)
-          }
-
-          it "return nil" do
-            expect(finder.__send__(:last_used_ship_address)).to eq nil
-          end
-        end
-
-        context "when no orders exist" do
           it "returns nil" do
             expect(finder.__send__(:last_used_ship_address)).to eq nil
           end
         end
       end
+
+      context "and an order without a ship address exists" do
+        let!(:order) {
+          create(:shipped_order, user: nil, email:, distributor:, shipments: [],
+                                 ship_address: nil)
+        }
+
+        it "return nil" do
+          expect(finder.__send__(:last_used_ship_address)).to eq nil
+        end
+      end
+
+      context "when no orders exist" do
+        it "returns nil" do
+          expect(finder.__send__(:last_used_ship_address)).to eq nil
+        end
+      end
     end
+  end
 
-    describe "allow_search_by_email?" do
-      let(:finder) { AddressFinder.new }
-      context "when an email address has been provided" do
-        before{ allow(finder).to receive(:email) { "email@email.com" } }
+  describe "allow_search_by_email?" do
+    let(:finder) { described_class.new }
+    context "when an email address has been provided" do
+      before{ allow(finder).to receive(:email) { "email@email.com" } }
 
-        context "when a customer has been provided" do
-          let(:customer) { double(:customer) }
-          before{ allow(finder).to receive(:customer) { customer } }
+      context "when a customer has been provided" do
+        let(:customer) { double(:customer) }
+        before{ allow(finder).to receive(:customer) { customer } }
 
-          context "when the customer email matches the raw email" do
-            before{ allow(customer).to receive(:email) { "email@email.com" } }
-            it "returns true" do
-              expect(finder.__send__(:allow_search_by_email?)).to be true
-            end
-          end
-
-          context "when the customer email does not match the raw email" do
-            before{ allow(customer).to receive(:email) { "nah@email.com" } }
-            it "returns false" do
-              expect(finder.__send__(:allow_search_by_email?)).to be false
-            end
+        context "when the customer email matches the raw email" do
+          before{ allow(customer).to receive(:email) { "email@email.com" } }
+          it "returns true" do
+            expect(finder.__send__(:allow_search_by_email?)).to be true
           end
         end
 
-        context "when a user has been provided" do
-          let(:user) { double(:user) }
-          before{ allow(finder).to receive(:user) { user } }
-
-          context "when the user email matches the raw email" do
-            before{ allow(user).to receive(:email) { "email@email.com" } }
-            it "returns true" do
-              expect(finder.__send__(:allow_search_by_email?)).to be true
-            end
-          end
-
-          context "when the user email does not match the raw email" do
-            before{ allow(user).to receive(:email) { "nah@email.com" } }
-            it "returns false" do
-              expect(finder.__send__(:allow_search_by_email?)).to be false
-            end
-          end
-        end
-
-        context "when neither a customer nor a user has been provided" do
+        context "when the customer email does not match the raw email" do
+          before{ allow(customer).to receive(:email) { "nah@email.com" } }
           it "returns false" do
             expect(finder.__send__(:allow_search_by_email?)).to be false
           end
         end
       end
 
-      context "when an email address is not provided" do
+      context "when a user has been provided" do
+        let(:user) { double(:user) }
+        before{ allow(finder).to receive(:user) { user } }
+
+        context "when the user email matches the raw email" do
+          before{ allow(user).to receive(:email) { "email@email.com" } }
+          it "returns true" do
+            expect(finder.__send__(:allow_search_by_email?)).to be true
+          end
+        end
+
+        context "when the user email does not match the raw email" do
+          before{ allow(user).to receive(:email) { "nah@email.com" } }
+          it "returns false" do
+            expect(finder.__send__(:allow_search_by_email?)).to be false
+          end
+        end
+      end
+
+      context "when neither a customer nor a user has been provided" do
         it "returns false" do
           expect(finder.__send__(:allow_search_by_email?)).to be false
         end
+      end
+    end
+
+    context "when an email address is not provided" do
+      it "returns false" do
+        expect(finder.__send__(:allow_search_by_email?)).to be false
       end
     end
   end

--- a/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
@@ -4,540 +4,538 @@ require "spec_helper"
 
 require 'open_food_network/order_cycle_form_applicator'
 
-module OpenFoodNetwork
-  RSpec.describe OrderCycleFormApplicator do
-    let!(:user) { create(:user) }
+RSpec.describe OpenFoodNetwork::OrderCycleFormApplicator do
+  let!(:user) { create(:user) }
 
-    context "unit specs" do
-      it "creates new exchanges for incoming_exchanges" do
+  context "unit specs" do
+    it "creates new exchanges for incoming_exchanges" do
+      coordinator_id = 123
+      supplier_id = 456
+
+      incoming_exchange = { enterprise_id: supplier_id, incoming: true,
+                            variants: { '1' => true, '2' => false, '3' => true },
+                            enterprise_fee_ids: [1, 2],
+                            receival_instructions: 'receival instructions' }
+
+      oc = double(:order_cycle, coordinator_id:, exchanges: [],
+                                incoming_exchanges: [incoming_exchange], outgoing_exchanges: [])
+
+      applicator = described_class.new(oc, user)
+
+      expect(applicator).to receive(:incoming_exchange_variant_ids)
+        .with(incoming_exchange).and_return([1, 3])
+      expect(applicator).to receive(:exchange_exists?).with(supplier_id, coordinator_id,
+                                                            true).and_return(false)
+      expect(applicator).to receive(:add_exchange)
+        .with(supplier_id, coordinator_id, true,
+              variant_ids: [1, 3],
+              enterprise_fee_ids: [1, 2],
+              receival_instructions: 'receival instructions')
+      expect(applicator).to receive(:destroy_untouched_exchanges)
+
+      applicator.go!
+    end
+
+    it "creates new exchanges for outgoing_exchanges" do
+      coordinator_id = 123
+      distributor_id = 456
+
+      outgoing_exchange = { enterprise_id: distributor_id, incoming: false,
+                            variants: { '1' => true, '2' => false, '3' => true },
+                            enterprise_fee_ids: [1, 2], pickup_time: 'pickup time',
+                            pickup_instructions: 'pickup instructions', tag_list: 'wholesale' }
+
+      oc = double(:order_cycle, coordinator_id:, exchanges: [],
+                                incoming_exchanges: [], outgoing_exchanges: [outgoing_exchange])
+
+      applicator = described_class.new(oc, user)
+
+      expect(applicator).to receive(:outgoing_exchange_variant_ids)
+        .with(outgoing_exchange).and_return([1, 3])
+      expect(applicator).to receive(:exchange_exists?).with(coordinator_id, distributor_id,
+                                                            false).and_return(false)
+      expect(applicator).to receive(:add_exchange)
+        .with(coordinator_id, distributor_id, false,
+              variant_ids: [1, 3],
+              enterprise_fee_ids: [1, 2],
+              pickup_time: 'pickup time',
+              pickup_instructions: 'pickup instructions',
+              tag_list: 'wholesale')
+      expect(applicator).to receive(:destroy_untouched_exchanges)
+
+      applicator.go!
+    end
+
+    it "updates existing exchanges for incoming_exchanges" do
+      coordinator_id = 123
+      supplier_id = 456
+
+      incoming_exchange = { enterprise_id: supplier_id, incoming: true,
+                            variants: { '1' => true, '2' => false, '3' => true },
+                            enterprise_fee_ids: [1, 2],
+                            receival_instructions: 'receival instructions' }
+
+      oc = double(:order_cycle,
+                  coordinator_id:,
+                  exchanges: [double(:exchange, sender_id: supplier_id,
+                                                receiver_id: coordinator_id, incoming: true)],
+                  incoming_exchanges: [incoming_exchange],
+                  outgoing_exchanges: [])
+
+      applicator = described_class.new(oc, user)
+
+      expect(applicator).to receive(:incoming_exchange_variant_ids)
+        .with(incoming_exchange).and_return([1, 3])
+      expect(applicator).to receive(:exchange_exists?).with(supplier_id, coordinator_id,
+                                                            true).and_return(true)
+      expect(applicator).to receive(:update_exchange)
+        .with(supplier_id, coordinator_id, true,
+              variant_ids: [1, 3],
+              enterprise_fee_ids: [1, 2],
+              receival_instructions: 'receival instructions')
+      expect(applicator).to receive(:destroy_untouched_exchanges)
+
+      applicator.go!
+    end
+
+    it "updates existing exchanges for outgoing_exchanges" do
+      coordinator_id = 123
+      distributor_id = 456
+
+      outgoing_exchange = { enterprise_id: distributor_id, incoming: false,
+                            variants: { '1' => true, '2' => false, '3' => true },
+                            enterprise_fee_ids: [1, 2], pickup_time: 'pickup time',
+                            pickup_instructions: 'pickup instructions', tag_list: 'wholesale' }
+
+      oc = double(:order_cycle,
+                  coordinator_id:,
+                  exchanges: [double(:exchange, sender_id: coordinator_id,
+                                                receiver_id: distributor_id, incoming: false)],
+                  incoming_exchanges: [],
+                  outgoing_exchanges: [outgoing_exchange])
+
+      applicator = described_class.new(oc, user)
+
+      expect(applicator).to receive(:outgoing_exchange_variant_ids)
+        .with(outgoing_exchange).and_return([1, 3])
+      expect(applicator).to receive(:exchange_exists?).with(coordinator_id, distributor_id,
+                                                            false).and_return(true)
+      expect(applicator).to receive(:update_exchange)
+        .with(coordinator_id, distributor_id, false,
+              variant_ids: [1, 3],
+              enterprise_fee_ids: [1, 2],
+              pickup_time: 'pickup time',
+              pickup_instructions: 'pickup instructions',
+              tag_list: 'wholesale')
+      expect(applicator).to receive(:destroy_untouched_exchanges)
+
+      applicator.go!
+    end
+
+    describe "removing exchanges that are no longer present" do
+      it "destroys untouched exchanges" do
         coordinator_id = 123
         supplier_id = 456
-
-        incoming_exchange = { enterprise_id: supplier_id, incoming: true,
-                              variants: { '1' => true, '2' => false, '3' => true },
-                              enterprise_fee_ids: [1, 2],
-                              receival_instructions: 'receival instructions' }
-
-        oc = double(:order_cycle, coordinator_id:, exchanges: [],
-                                  incoming_exchanges: [incoming_exchange], outgoing_exchanges: [])
-
-        applicator = OrderCycleFormApplicator.new(oc, user)
-
-        expect(applicator).to receive(:incoming_exchange_variant_ids)
-          .with(incoming_exchange).and_return([1, 3])
-        expect(applicator).to receive(:exchange_exists?).with(supplier_id, coordinator_id,
-                                                              true).and_return(false)
-        expect(applicator).to receive(:add_exchange)
-          .with(supplier_id, coordinator_id, true,
-                variant_ids: [1, 3],
-                enterprise_fee_ids: [1, 2],
-                receival_instructions: 'receival instructions')
-        expect(applicator).to receive(:destroy_untouched_exchanges)
-
-        applicator.go!
-      end
-
-      it "creates new exchanges for outgoing_exchanges" do
-        coordinator_id = 123
-        distributor_id = 456
-
-        outgoing_exchange = { enterprise_id: distributor_id, incoming: false,
-                              variants: { '1' => true, '2' => false, '3' => true },
-                              enterprise_fee_ids: [1, 2], pickup_time: 'pickup time',
-                              pickup_instructions: 'pickup instructions', tag_list: 'wholesale' }
-
-        oc = double(:order_cycle, coordinator_id:, exchanges: [],
-                                  incoming_exchanges: [], outgoing_exchanges: [outgoing_exchange])
-
-        applicator = OrderCycleFormApplicator.new(oc, user)
-
-        expect(applicator).to receive(:outgoing_exchange_variant_ids)
-          .with(outgoing_exchange).and_return([1, 3])
-        expect(applicator).to receive(:exchange_exists?).with(coordinator_id, distributor_id,
-                                                              false).and_return(false)
-        expect(applicator).to receive(:add_exchange)
-          .with(coordinator_id, distributor_id, false,
-                variant_ids: [1, 3],
-                enterprise_fee_ids: [1, 2],
-                pickup_time: 'pickup time',
-                pickup_instructions: 'pickup instructions',
-                tag_list: 'wholesale')
-        expect(applicator).to receive(:destroy_untouched_exchanges)
-
-        applicator.go!
-      end
-
-      it "updates existing exchanges for incoming_exchanges" do
-        coordinator_id = 123
-        supplier_id = 456
-
-        incoming_exchange = { enterprise_id: supplier_id, incoming: true,
-                              variants: { '1' => true, '2' => false, '3' => true },
-                              enterprise_fee_ids: [1, 2],
-                              receival_instructions: 'receival instructions' }
+        exchange = double(:exchange, id: 1, sender_id: supplier_id, receiver_id: coordinator_id,
+                                     incoming: true)
 
         oc = double(:order_cycle,
                     coordinator_id:,
-                    exchanges: [double(:exchange, sender_id: supplier_id,
-                                                  receiver_id: coordinator_id, incoming: true)],
-                    incoming_exchanges: [incoming_exchange],
+                    exchanges: [exchange],
+                    incoming_exchanges: [],
                     outgoing_exchanges: [])
 
-        applicator = OrderCycleFormApplicator.new(oc, user)
+        applicator = described_class.new(oc, user)
 
-        expect(applicator).to receive(:incoming_exchange_variant_ids)
-          .with(incoming_exchange).and_return([1, 3])
-        expect(applicator).to receive(:exchange_exists?).with(supplier_id, coordinator_id,
-                                                              true).and_return(true)
-        expect(applicator).to receive(:update_exchange)
-          .with(supplier_id, coordinator_id, true,
-                variant_ids: [1, 3],
-                enterprise_fee_ids: [1, 2],
-                receival_instructions: 'receival instructions')
         expect(applicator).to receive(:destroy_untouched_exchanges)
 
         applicator.go!
+        expect(applicator.__send__(:untouched_exchanges)).to eq([exchange])
       end
 
-      it "updates existing exchanges for outgoing_exchanges" do
-        coordinator_id = 123
-        distributor_id = 456
+      it "compares exchanges by id only" do
+        e1 = double(:exchange1, id: 1, foo: 1)
+        e2 = double(:exchange2, id: 1, foo: 2)
+        oc = double(:order_cycle, exchanges: [e1])
 
-        outgoing_exchange = { enterprise_id: distributor_id, incoming: false,
-                              variants: { '1' => true, '2' => false, '3' => true },
-                              enterprise_fee_ids: [1, 2], pickup_time: 'pickup time',
-                              pickup_instructions: 'pickup instructions', tag_list: 'wholesale' }
+        applicator = described_class.new(oc, user)
+        applicator.instance_eval do
+          @touched_exchanges = [e2]
+        end
 
-        oc = double(:order_cycle,
-                    coordinator_id:,
-                    exchanges: [double(:exchange, sender_id: coordinator_id,
-                                                  receiver_id: distributor_id, incoming: false)],
-                    incoming_exchanges: [],
-                    outgoing_exchanges: [outgoing_exchange])
-
-        applicator = OrderCycleFormApplicator.new(oc, user)
-
-        expect(applicator).to receive(:outgoing_exchange_variant_ids)
-          .with(outgoing_exchange).and_return([1, 3])
-        expect(applicator).to receive(:exchange_exists?).with(coordinator_id, distributor_id,
-                                                              false).and_return(true)
-        expect(applicator).to receive(:update_exchange)
-          .with(coordinator_id, distributor_id, false,
-                variant_ids: [1, 3],
-                enterprise_fee_ids: [1, 2],
-                pickup_time: 'pickup time',
-                pickup_instructions: 'pickup instructions',
-                tag_list: 'wholesale')
-        expect(applicator).to receive(:destroy_untouched_exchanges)
-
-        applicator.go!
+        expect(applicator.__send__(:untouched_exchanges)).to eq([])
       end
 
-      describe "removing exchanges that are no longer present" do
-        it "destroys untouched exchanges" do
-          coordinator_id = 123
-          supplier_id = 456
-          exchange = double(:exchange, id: 1, sender_id: supplier_id, receiver_id: coordinator_id,
-                                       incoming: true)
+      context "as a manager of the coordinator" do
+        let(:applicator) { described_class.new(nil, user) }
+        before { allow(applicator).to receive(:manages_coordinator?) { true } }
 
-          oc = double(:order_cycle,
-                      coordinator_id:,
-                      exchanges: [exchange],
-                      incoming_exchanges: [],
-                      outgoing_exchanges: [])
+        it "destroys exchanges" do
+          exchanges = [double(:exchange), double(:exchange)]
+          expect(applicator).to receive(:untouched_exchanges) { exchanges }
+          exchanges.each { |ex| expect(ex).to receive(:destroy) }
 
-          applicator = OrderCycleFormApplicator.new(oc, user)
-
-          expect(applicator).to receive(:destroy_untouched_exchanges)
-
-          applicator.go!
-          expect(applicator.__send__(:untouched_exchanges)).to eq([exchange])
-        end
-
-        it "compares exchanges by id only" do
-          e1 = double(:exchange1, id: 1, foo: 1)
-          e2 = double(:exchange2, id: 1, foo: 2)
-          oc = double(:order_cycle, exchanges: [e1])
-
-          applicator = OrderCycleFormApplicator.new(oc, user)
-          applicator.instance_eval do
-            @touched_exchanges = [e2]
-          end
-
-          expect(applicator.__send__(:untouched_exchanges)).to eq([])
-        end
-
-        context "as a manager of the coordinator" do
-          let(:applicator) { OrderCycleFormApplicator.new(nil, user) }
-          before { allow(applicator).to receive(:manages_coordinator?) { true } }
-
-          it "destroys exchanges" do
-            exchanges = [double(:exchange), double(:exchange)]
-            expect(applicator).to receive(:untouched_exchanges) { exchanges }
-            exchanges.each { |ex| expect(ex).to receive(:destroy) }
-
-            applicator.__send__(:destroy_untouched_exchanges)
-          end
-        end
-
-        context "as a non-manager of the coordinator" do
-          let(:applicator) { OrderCycleFormApplicator.new(nil, user) }
-          before { allow(applicator).to receive(:manages_coordinator?) { false } }
-
-          it "does not destroy any exchanges" do
-            expect(applicator).not_to receive(:with_permission)
-            applicator.__send__(:destroy_untouched_exchanges)
-          end
+          applicator.__send__(:destroy_untouched_exchanges)
         end
       end
 
-      describe "updating the list of variants for a given outgoing exchange" do
-        let!(:v1) { create(:variant) } # Not Existing + Request Add + Editable + Incoming
-        let!(:v2) { create(:variant) } # Not Existing + Request Add + Not Editable + Incoming
-        let!(:v3) { create(:variant) } # Existing + Request Add + Editable + Incoming
-        let!(:v4) { create(:variant) } # Existing + Not mentioned + Editable + Incoming
-        let!(:v5) { create(:variant) } # Existing + Request Remove + Editable + Incoming
-        let!(:v6) { create(:variant) } # Existing + Request Remove + Not Editable + Incoming
-        let!(:v7) { create(:variant) } # Existing + Request Add + Not Editable + Not Incoming
-        let!(:v8) { create(:variant) } # Existing + Request Add + Editable + Not Incoming
-        let!(:v9) { create(:variant) } # Not Existing + Request Add + Editable + Not Incoming
-        let!(:exchange) {
-          create(:exchange, incoming: false,
-                            variant_ids: [v3.id, v4.id, v5.id, v6.id, v7.id, v8.id])
-        }
-        let!(:oc) { exchange.order_cycle }
-        let!(:enterprise) { exchange.receiver }
-        let!(:coordinator) { oc.coordinator }
-        let!(:applicator) { OrderCycleFormApplicator.new(oc, user) }
-        let(:ids) do
-          applicator.__send__(:outgoing_exchange_variant_ids,
-                              enterprise_id: enterprise.id,
-                              variants: {
-                                v1.id.to_s => true,
-                                v2.id.to_s => true,
-                                v3.id.to_s => true,
-                                v5.id.to_s => false,
-                                v6.id.to_s => false,
-                                v7.id.to_s => true,
-                                v8.id.to_s => true,
-                                v9.id.to_s => true
-                              })
-        end
+      context "as a non-manager of the coordinator" do
+        let(:applicator) { described_class.new(nil, user) }
+        before { allow(applicator).to receive(:manages_coordinator?) { false } }
 
-        before do
-          allow(applicator).to receive(:incoming_variant_ids) {
-                                 [v1.id, v2.id, v3.id, v4.id, v5.id, v6.id]
-                               }
-          allow(applicator).to receive(:editable_variant_ids_for_outgoing_exchange_between) {
-                                 [v1.id, v3.id, v4.id, v5.id, v8.id, v9.id]
-                               }
-        end
-
-        it "updates the list of variants for the exchange" do
-          # Adds variants that are editable
-          expect(ids).to include v1.id
-
-          # Does not add variants that are not editable
-          expect(ids).not_to include v2.id
-
-          # Keeps existing variants, when they are explicitly mentioned in the request
-          expect(ids).to include v3.id
-
-          # Removes existing variants that are editable, when they are not mentioned in the request
-          expect(ids).not_to include v4.id
-
-          # Removes existing variants that are editable, when the request explicitly removes them
-          expect(ids).not_to include v5.id
-
-          # Keeps existing variants that are not editable
-          expect(ids).to include v6.id
-
-          # Removes existing variants that are not in an incoming exchange,
-          # regardless of whether they are not editable
-          expect(ids).not_to include v7.id, v8.id
-
-          # Does not add variants that are not in an incoming exchange
-          expect(ids).not_to include v9.id
-        end
-      end
-
-      describe "updating the list of variants for a given incoming exchange" do
-        let!(:v1) { create(:variant) } # Not Existing + Request Add + Editable
-        let!(:v2) { create(:variant) } # Not Existing + Request Add + Not Editable
-        let!(:v3) { create(:variant) } # Existing + Request Add + Editable
-        let!(:v4) { create(:variant) } # Existing + Request Remove + Not Editable
-        let!(:v5) { create(:variant) } # Existing + Request Remove + Editable
-        let!(:v6) { create(:variant) } # Existing + Request Remove + Not Editable
-        let!(:v7) { create(:variant) } # Existing + Not mentioned + Editable
-        let!(:exchange) {
-          create(:exchange, incoming: true, variant_ids: [v3.id, v4.id, v5.id, v6.id, v7.id])
-        }
-        let!(:oc) { exchange.order_cycle }
-        let!(:enterprise) { exchange.sender }
-        let!(:coordinator) { oc.coordinator }
-        let!(:applicator) { OrderCycleFormApplicator.new(oc, user) }
-        let(:ids) do
-          applicator.__send__(:incoming_exchange_variant_ids,
-                              enterprise_id: enterprise.id,
-                              variants: {
-                                v1.id.to_s => true,
-                                v2.id.to_s => true,
-                                v3.id.to_s => true,
-                                v4.id.to_s => false,
-                                v5.id.to_s => false,
-                                v6.id.to_s => false
-                              })
-        end
-
-        before do
-          allow(applicator).to receive(:editable_variant_ids_for_incoming_exchange_between) {
-                                 [v1.id, v3.id, v5.id, v7.id]
-                               }
-        end
-
-        it "updates the list of variants for the exchange" do
-          # Adds variants that are editable
-          expect(ids).to include v1.id
-
-          # Does not add variants that are not editable
-          expect(ids).not_to include v2.id
-
-          # Keeps existing variants, if they are editable and requested
-          expect(ids).to include v3.id
-
-          # Keeps existing variants if they are non-editable, regardless of request
-          expect(ids).to include v4.id
-
-          # Removes existing variants that are editable, when the request explicitly removes them
-          expect(ids).not_to include v5.id
-
-          # Keeps existing variants that are not editable
-          expect(ids).to include v6.id
-
-          # Removes existing variants that are editable, when they are not mentioned in the request
-          expect(ids).not_to include v7.id
-        end
-      end
-
-      describe "filtering exchanges for permission" do
-        describe "checking permission on a single exchange" do
-          it "returns true when it has permission" do
-            e = double(:enterprise)
-            ex = double(:exchange, participant: e)
-
-            applicator = OrderCycleFormApplicator.new(nil, user)
-            allow(applicator).to receive(:permitted_enterprises) { [e] }
-
-            expect(applicator.__send__(:permission_for, ex)).to be true
-          end
-
-          it "returns false otherwise" do
-            e = double(:enterprise)
-            ex = double(:exchange, participant: e)
-
-            applicator = OrderCycleFormApplicator.new(nil, user)
-            allow(applicator).to receive(:permitted_enterprises) { [] }
-
-            expect(applicator.__send__(:permission_for, ex)).to be false
-          end
+        it "does not destroy any exchanges" do
+          expect(applicator).not_to receive(:with_permission)
+          applicator.__send__(:destroy_untouched_exchanges)
         end
       end
     end
 
-    context "integration specs" do
-      before(:all) do
-        require 'spec_helper'
+    describe "updating the list of variants for a given outgoing exchange" do
+      let!(:v1) { create(:variant) } # Not Existing + Request Add + Editable + Incoming
+      let!(:v2) { create(:variant) } # Not Existing + Request Add + Not Editable + Incoming
+      let!(:v3) { create(:variant) } # Existing + Request Add + Editable + Incoming
+      let!(:v4) { create(:variant) } # Existing + Not mentioned + Editable + Incoming
+      let!(:v5) { create(:variant) } # Existing + Request Remove + Editable + Incoming
+      let!(:v6) { create(:variant) } # Existing + Request Remove + Not Editable + Incoming
+      let!(:v7) { create(:variant) } # Existing + Request Add + Not Editable + Not Incoming
+      let!(:v8) { create(:variant) } # Existing + Request Add + Editable + Not Incoming
+      let!(:v9) { create(:variant) } # Not Existing + Request Add + Editable + Not Incoming
+      let!(:exchange) {
+        create(:exchange, incoming: false,
+                          variant_ids: [v3.id, v4.id, v5.id, v6.id, v7.id, v8.id])
+      }
+      let!(:oc) { exchange.order_cycle }
+      let!(:enterprise) { exchange.receiver }
+      let!(:coordinator) { oc.coordinator }
+      let!(:applicator) { described_class.new(oc, user) }
+      let(:ids) do
+        applicator.__send__(:outgoing_exchange_variant_ids,
+                            enterprise_id: enterprise.id,
+                            variants: {
+                              v1.id.to_s => true,
+                              v2.id.to_s => true,
+                              v3.id.to_s => true,
+                              v5.id.to_s => false,
+                              v6.id.to_s => false,
+                              v7.id.to_s => true,
+                              v8.id.to_s => true,
+                              v9.id.to_s => true
+                            })
       end
 
-      it "checks whether exchanges exist" do
-        oc = FactoryBot.create(:simple_order_cycle)
-        exchange = FactoryBot.create(:exchange, order_cycle: oc)
-        applicator = OrderCycleFormApplicator.new(oc, user)
-
-        expect(applicator.__send__(:exchange_exists?, exchange.sender_id, exchange.receiver_id,
-                                   exchange.incoming)).to be true
-        expect(applicator.__send__(:exchange_exists?, exchange.sender_id, exchange.receiver_id,
-                                   !exchange.incoming)).to be false
-        expect(applicator.__send__(:exchange_exists?, exchange.receiver_id, exchange.sender_id,
-                                   exchange.incoming)).to be false
-        expect(applicator.__send__(:exchange_exists?, exchange.sender_id, 999_999,
-                                   exchange.incoming)).to be false
-        expect(applicator.__send__(:exchange_exists?, 999_999, exchange.receiver_id,
-                                   exchange.incoming)).to be false
-        expect(applicator.__send__(:exchange_exists?, 999_999, 888_888,
-                                   exchange.incoming)).to be false
+      before do
+        allow(applicator).to receive(:incoming_variant_ids) {
+                               [v1.id, v2.id, v3.id, v4.id, v5.id, v6.id]
+                             }
+        allow(applicator).to receive(:editable_variant_ids_for_outgoing_exchange_between) {
+                               [v1.id, v3.id, v4.id, v5.id, v8.id, v9.id]
+                             }
       end
 
-      describe "adding exchanges" do
-        let!(:sender) { create(:enterprise) }
-        let!(:receiver) { create(:enterprise) }
-        let!(:oc) { create(:simple_order_cycle) }
-        let!(:applicator) { OrderCycleFormApplicator.new(oc, user) }
-        let!(:incoming) { true }
-        let!(:variant1) { create(:variant) }
-        let!(:variant2) { create(:variant) }
-        let!(:enterprise_fee1) { create(:enterprise_fee) }
-        let!(:enterprise_fee2) { create(:enterprise_fee) }
+      it "updates the list of variants for the exchange" do
+        # Adds variants that are editable
+        expect(ids).to include v1.id
 
-        context "as a manager of the coorindator" do
-          before do
-            allow(applicator).to receive(:manages_coordinator?) { true }
-            applicator.__send__(:touched_exchanges=, [])
-            applicator.__send__(:add_exchange, sender.id, receiver.id, incoming,
-                                variant_ids: [variant1.id, variant2.id],
-                                enterprise_fee_ids: [enterprise_fee1.id, enterprise_fee2.id])
-          end
+        # Does not add variants that are not editable
+        expect(ids).not_to include v2.id
 
-          it "adds new exchanges" do
-            exchange = Exchange.last
-            expect(exchange.sender).to eq sender
-            expect(exchange.receiver).to eq receiver
-            expect(exchange.incoming).to eq incoming
-            expect(exchange.variants).to match_array [variant1, variant2]
-            expect(exchange.enterprise_fees).to match_array [enterprise_fee1, enterprise_fee2]
+        # Keeps existing variants, when they are explicitly mentioned in the request
+        expect(ids).to include v3.id
 
-            expect(applicator.__send__(:touched_exchanges)).to eq([exchange])
-          end
-        end
+        # Removes existing variants that are editable, when they are not mentioned in the request
+        expect(ids).not_to include v4.id
 
-        context "as a user which does not manage the coorindator" do
-          before do
-            allow(applicator).to receive(:manages_coordinator?) { false }
-            applicator.__send__(:add_exchange, sender.id, receiver.id, incoming,
-                                variant_ids: [variant1.id, variant2.id],
-                                enterprise_fee_ids: [enterprise_fee1.id, enterprise_fee2.id])
-          end
+        # Removes existing variants that are editable, when the request explicitly removes them
+        expect(ids).not_to include v5.id
 
-          it "does not add new exchanges" do
-            expect(Exchange.last).to be_nil
-          end
-        end
+        # Keeps existing variants that are not editable
+        expect(ids).to include v6.id
+
+        # Removes existing variants that are not in an incoming exchange,
+        # regardless of whether they are not editable
+        expect(ids).not_to include v7.id, v8.id
+
+        # Does not add variants that are not in an incoming exchange
+        expect(ids).not_to include v9.id
+      end
+    end
+
+    describe "updating the list of variants for a given incoming exchange" do
+      let!(:v1) { create(:variant) } # Not Existing + Request Add + Editable
+      let!(:v2) { create(:variant) } # Not Existing + Request Add + Not Editable
+      let!(:v3) { create(:variant) } # Existing + Request Add + Editable
+      let!(:v4) { create(:variant) } # Existing + Request Remove + Not Editable
+      let!(:v5) { create(:variant) } # Existing + Request Remove + Editable
+      let!(:v6) { create(:variant) } # Existing + Request Remove + Not Editable
+      let!(:v7) { create(:variant) } # Existing + Not mentioned + Editable
+      let!(:exchange) {
+        create(:exchange, incoming: true, variant_ids: [v3.id, v4.id, v5.id, v6.id, v7.id])
+      }
+      let!(:oc) { exchange.order_cycle }
+      let!(:enterprise) { exchange.sender }
+      let!(:coordinator) { oc.coordinator }
+      let!(:applicator) { described_class.new(oc, user) }
+      let(:ids) do
+        applicator.__send__(:incoming_exchange_variant_ids,
+                            enterprise_id: enterprise.id,
+                            variants: {
+                              v1.id.to_s => true,
+                              v2.id.to_s => true,
+                              v3.id.to_s => true,
+                              v4.id.to_s => false,
+                              v5.id.to_s => false,
+                              v6.id.to_s => false
+                            })
       end
 
-      describe "updating exchanges" do
-        let!(:sender) { create(:enterprise) }
-        let!(:receiver) { create(:enterprise) }
-        let!(:oc) { create(:simple_order_cycle) }
-        let!(:applicator) { OrderCycleFormApplicator.new(oc, user) }
-        let!(:incoming) { true }
-        let!(:variant1) { create(:variant) }
-        let!(:variant2) { create(:variant) }
-        let!(:variant3) { create(:variant) }
-        let!(:enterprise_fee1) { create(:enterprise_fee) }
-        let!(:enterprise_fee2) { create(:enterprise_fee) }
-        let!(:enterprise_fee3) { create(:enterprise_fee) }
-
-        let!(:exchange) {
-          create(:exchange, order_cycle: oc, sender:, receiver:, incoming:,
-                            variant_ids: [variant1.id, variant2.id],
-                            enterprise_fee_ids: [enterprise_fee1.id, enterprise_fee2.id])
-        }
-
-        context "as a manager of the coorindator" do
-          before do
-            allow(applicator).to receive(:manages_coordinator?) { true }
-            allow(applicator).to receive(:manager_for) { false }
-            allow(applicator).to receive(:permission_for) { true }
-            applicator.__send__(:touched_exchanges=, [])
-            applicator.__send__(:update_exchange, sender.id, receiver.id, incoming,
-                                variant_ids: [variant1.id, variant3.id],
-                                enterprise_fee_ids: [enterprise_fee2.id, enterprise_fee3.id],
-                                pickup_time: 'New Pickup Time',
-                                pickup_instructions: 'New Pickup Instructions',
-                                tag_list: 'wholesale')
-          end
-
-          it "updates the variants, enterprise fees tags, and pickup information of the exchange" do
-            exchange.reload
-            expect(exchange.variants).to match_array [variant1, variant3]
-            expect(exchange.enterprise_fees).to match_array [enterprise_fee2, enterprise_fee3]
-            expect(exchange.pickup_time).to eq 'New Pickup Time'
-            expect(exchange.pickup_instructions).to eq 'New Pickup Instructions'
-            expect(exchange.tag_list).to eq ['wholesale']
-            expect(applicator.__send__(:touched_exchanges)).to eq [exchange]
-          end
-        end
-
-        context "as a manager of the participating enterprise" do
-          before do
-            allow(applicator).to receive(:manages_coordinator?) { false }
-            allow(applicator).to receive(:manager_for) { true }
-            allow(applicator).to receive(:permission_for) { true }
-            applicator.__send__(:touched_exchanges=, [])
-            applicator.__send__(:update_exchange, sender.id, receiver.id, incoming,
-                                variant_ids: [variant1.id, variant3.id],
-                                enterprise_fee_ids: [enterprise_fee2.id, enterprise_fee3.id],
-                                pickup_time: 'New Pickup Time',
-                                pickup_instructions: 'New Pickup Instructions',
-                                tag_list: 'wholesale')
-          end
-
-          it "updates the variants, enterprise fees, tags and pickup information of the exchange" do
-            exchange.reload
-            expect(exchange.variants).to match_array [variant1, variant3]
-            expect(exchange.enterprise_fees).to match_array [enterprise_fee2, enterprise_fee3]
-            expect(exchange.pickup_time).to eq 'New Pickup Time'
-            expect(exchange.pickup_instructions).to eq 'New Pickup Instructions'
-            expect(exchange.tag_list).to eq ['wholesale']
-            expect(applicator.__send__(:touched_exchanges)).to eq [exchange]
-          end
-        end
-
-        context "where the participating enterprise is permitted for the user" do
-          before do
-            allow(applicator).to receive(:manages_coordinator?) { false }
-            allow(applicator).to receive(:manager_for) { false }
-            allow(applicator).to receive(:permission_for) { true }
-            applicator.__send__(:touched_exchanges=, [])
-            applicator.__send__(:update_exchange, sender.id, receiver.id, incoming,
-                                variant_ids: [variant1.id, variant3.id],
-                                enterprise_fee_ids: [enterprise_fee2.id, enterprise_fee3.id],
-                                pickup_time: 'New Pickup Time',
-                                pickup_instructions: 'New Pickup Instructions',
-                                tag_list: 'wholesale')
-          end
-
-          it "updates the variants in the exchange, but not the fees, tags or pickup information" do
-            exchange.reload
-            expect(exchange.variants).to match_array [variant1, variant3]
-            expect(exchange.enterprise_fees).to match_array [enterprise_fee1, enterprise_fee2]
-            expect(exchange.pickup_time).not_to eq 'New Pickup Time'
-            expect(exchange.pickup_instructions).not_to eq 'New Pickup Instructions'
-            expect(exchange.tag_list).to eq []
-            expect(applicator.__send__(:touched_exchanges)).to eq [exchange]
-          end
-        end
+      before do
+        allow(applicator).to receive(:editable_variant_ids_for_incoming_exchange_between) {
+                               [v1.id, v3.id, v5.id, v7.id]
+                             }
       end
 
-      it "does not add exchanges it is not permitted to touch" do
-        sender = FactoryBot.create(:enterprise)
-        receiver = FactoryBot.create(:enterprise)
-        oc = FactoryBot.create(:simple_order_cycle)
-        applicator = OrderCycleFormApplicator.new(oc, user)
-        incoming = true
+      it "updates the list of variants for the exchange" do
+        # Adds variants that are editable
+        expect(ids).to include v1.id
 
-        expect do
+        # Does not add variants that are not editable
+        expect(ids).not_to include v2.id
+
+        # Keeps existing variants, if they are editable and requested
+        expect(ids).to include v3.id
+
+        # Keeps existing variants if they are non-editable, regardless of request
+        expect(ids).to include v4.id
+
+        # Removes existing variants that are editable, when the request explicitly removes them
+        expect(ids).not_to include v5.id
+
+        # Keeps existing variants that are not editable
+        expect(ids).to include v6.id
+
+        # Removes existing variants that are editable, when they are not mentioned in the request
+        expect(ids).not_to include v7.id
+      end
+    end
+
+    describe "filtering exchanges for permission" do
+      describe "checking permission on a single exchange" do
+        it "returns true when it has permission" do
+          e = double(:enterprise)
+          ex = double(:exchange, participant: e)
+
+          applicator = described_class.new(nil, user)
+          allow(applicator).to receive(:permitted_enterprises) { [e] }
+
+          expect(applicator.__send__(:permission_for, ex)).to be true
+        end
+
+        it "returns false otherwise" do
+          e = double(:enterprise)
+          ex = double(:exchange, participant: e)
+
+          applicator = described_class.new(nil, user)
+          allow(applicator).to receive(:permitted_enterprises) { [] }
+
+          expect(applicator.__send__(:permission_for, ex)).to be false
+        end
+      end
+    end
+  end
+
+  context "integration specs" do
+    before(:all) do
+      require 'spec_helper'
+    end
+
+    it "checks whether exchanges exist" do
+      oc = FactoryBot.create(:simple_order_cycle)
+      exchange = FactoryBot.create(:exchange, order_cycle: oc)
+      applicator = described_class.new(oc, user)
+
+      expect(applicator.__send__(:exchange_exists?, exchange.sender_id, exchange.receiver_id,
+                                 exchange.incoming)).to be true
+      expect(applicator.__send__(:exchange_exists?, exchange.sender_id, exchange.receiver_id,
+                                 !exchange.incoming)).to be false
+      expect(applicator.__send__(:exchange_exists?, exchange.receiver_id, exchange.sender_id,
+                                 exchange.incoming)).to be false
+      expect(applicator.__send__(:exchange_exists?, exchange.sender_id, 999_999,
+                                 exchange.incoming)).to be false
+      expect(applicator.__send__(:exchange_exists?, 999_999, exchange.receiver_id,
+                                 exchange.incoming)).to be false
+      expect(applicator.__send__(:exchange_exists?, 999_999, 888_888,
+                                 exchange.incoming)).to be false
+    end
+
+    describe "adding exchanges" do
+      let!(:sender) { create(:enterprise) }
+      let!(:receiver) { create(:enterprise) }
+      let!(:oc) { create(:simple_order_cycle) }
+      let!(:applicator) { described_class.new(oc, user) }
+      let!(:incoming) { true }
+      let!(:variant1) { create(:variant) }
+      let!(:variant2) { create(:variant) }
+      let!(:enterprise_fee1) { create(:enterprise_fee) }
+      let!(:enterprise_fee2) { create(:enterprise_fee) }
+
+      context "as a manager of the coorindator" do
+        before do
+          allow(applicator).to receive(:manages_coordinator?) { true }
           applicator.__send__(:touched_exchanges=, [])
-          applicator.__send__(:add_exchange, sender.id, receiver.id, incoming)
-        end.to change { Exchange.count }.by(0)
+          applicator.__send__(:add_exchange, sender.id, receiver.id, incoming,
+                              variant_ids: [variant1.id, variant2.id],
+                              enterprise_fee_ids: [enterprise_fee1.id, enterprise_fee2.id])
+        end
+
+        it "adds new exchanges" do
+          exchange = Exchange.last
+          expect(exchange.sender).to eq sender
+          expect(exchange.receiver).to eq receiver
+          expect(exchange.incoming).to eq incoming
+          expect(exchange.variants).to match_array [variant1, variant2]
+          expect(exchange.enterprise_fees).to match_array [enterprise_fee1, enterprise_fee2]
+
+          expect(applicator.__send__(:touched_exchanges)).to eq([exchange])
+        end
       end
 
-      it "does not update exchanges it is not permitted to touch" do
-        sender = FactoryBot.create(:enterprise)
-        receiver = FactoryBot.create(:enterprise)
-        oc = FactoryBot.create(:simple_order_cycle)
-        applicator = OrderCycleFormApplicator.new(oc, user)
-        incoming = true
-        exchange = FactoryBot.create(:exchange, order_cycle: oc, sender:,
-                                                receiver:, incoming:)
-        variant1 = FactoryBot.create(:variant)
+      context "as a user which does not manage the coorindator" do
+        before do
+          allow(applicator).to receive(:manages_coordinator?) { false }
+          applicator.__send__(:add_exchange, sender.id, receiver.id, incoming,
+                              variant_ids: [variant1.id, variant2.id],
+                              enterprise_fee_ids: [enterprise_fee1.id, enterprise_fee2.id])
+        end
 
+        it "does not add new exchanges" do
+          expect(Exchange.last).to be_nil
+        end
+      end
+    end
+
+    describe "updating exchanges" do
+      let!(:sender) { create(:enterprise) }
+      let!(:receiver) { create(:enterprise) }
+      let!(:oc) { create(:simple_order_cycle) }
+      let!(:applicator) { described_class.new(oc, user) }
+      let!(:incoming) { true }
+      let!(:variant1) { create(:variant) }
+      let!(:variant2) { create(:variant) }
+      let!(:variant3) { create(:variant) }
+      let!(:enterprise_fee1) { create(:enterprise_fee) }
+      let!(:enterprise_fee2) { create(:enterprise_fee) }
+      let!(:enterprise_fee3) { create(:enterprise_fee) }
+
+      let!(:exchange) {
+        create(:exchange, order_cycle: oc, sender:, receiver:, incoming:,
+                          variant_ids: [variant1.id, variant2.id],
+                          enterprise_fee_ids: [enterprise_fee1.id, enterprise_fee2.id])
+      }
+
+      context "as a manager of the coorindator" do
+        before do
+          allow(applicator).to receive(:manages_coordinator?) { true }
+          allow(applicator).to receive(:manager_for) { false }
+          allow(applicator).to receive(:permission_for) { true }
+          applicator.__send__(:touched_exchanges=, [])
+          applicator.__send__(:update_exchange, sender.id, receiver.id, incoming,
+                              variant_ids: [variant1.id, variant3.id],
+                              enterprise_fee_ids: [enterprise_fee2.id, enterprise_fee3.id],
+                              pickup_time: 'New Pickup Time',
+                              pickup_instructions: 'New Pickup Instructions',
+                              tag_list: 'wholesale')
+        end
+
+        it "updates the variants, enterprise fees tags, and pickup information of the exchange" do
+          exchange.reload
+          expect(exchange.variants).to match_array [variant1, variant3]
+          expect(exchange.enterprise_fees).to match_array [enterprise_fee2, enterprise_fee3]
+          expect(exchange.pickup_time).to eq 'New Pickup Time'
+          expect(exchange.pickup_instructions).to eq 'New Pickup Instructions'
+          expect(exchange.tag_list).to eq ['wholesale']
+          expect(applicator.__send__(:touched_exchanges)).to eq [exchange]
+        end
+      end
+
+      context "as a manager of the participating enterprise" do
+        before do
+          allow(applicator).to receive(:manages_coordinator?) { false }
+          allow(applicator).to receive(:manager_for) { true }
+          allow(applicator).to receive(:permission_for) { true }
+          applicator.__send__(:touched_exchanges=, [])
+          applicator.__send__(:update_exchange, sender.id, receiver.id, incoming,
+                              variant_ids: [variant1.id, variant3.id],
+                              enterprise_fee_ids: [enterprise_fee2.id, enterprise_fee3.id],
+                              pickup_time: 'New Pickup Time',
+                              pickup_instructions: 'New Pickup Instructions',
+                              tag_list: 'wholesale')
+        end
+
+        it "updates the variants, enterprise fees, tags and pickup information of the exchange" do
+          exchange.reload
+          expect(exchange.variants).to match_array [variant1, variant3]
+          expect(exchange.enterprise_fees).to match_array [enterprise_fee2, enterprise_fee3]
+          expect(exchange.pickup_time).to eq 'New Pickup Time'
+          expect(exchange.pickup_instructions).to eq 'New Pickup Instructions'
+          expect(exchange.tag_list).to eq ['wholesale']
+          expect(applicator.__send__(:touched_exchanges)).to eq [exchange]
+        end
+      end
+
+      context "where the participating enterprise is permitted for the user" do
+        before do
+          allow(applicator).to receive(:manages_coordinator?) { false }
+          allow(applicator).to receive(:manager_for) { false }
+          allow(applicator).to receive(:permission_for) { true }
+          applicator.__send__(:touched_exchanges=, [])
+          applicator.__send__(:update_exchange, sender.id, receiver.id, incoming,
+                              variant_ids: [variant1.id, variant3.id],
+                              enterprise_fee_ids: [enterprise_fee2.id, enterprise_fee3.id],
+                              pickup_time: 'New Pickup Time',
+                              pickup_instructions: 'New Pickup Instructions',
+                              tag_list: 'wholesale')
+        end
+
+        it "updates the variants in the exchange, but not the fees, tags or pickup information" do
+          exchange.reload
+          expect(exchange.variants).to match_array [variant1, variant3]
+          expect(exchange.enterprise_fees).to match_array [enterprise_fee1, enterprise_fee2]
+          expect(exchange.pickup_time).not_to eq 'New Pickup Time'
+          expect(exchange.pickup_instructions).not_to eq 'New Pickup Instructions'
+          expect(exchange.tag_list).to eq []
+          expect(applicator.__send__(:touched_exchanges)).to eq [exchange]
+        end
+      end
+    end
+
+    it "does not add exchanges it is not permitted to touch" do
+      sender = FactoryBot.create(:enterprise)
+      receiver = FactoryBot.create(:enterprise)
+      oc = FactoryBot.create(:simple_order_cycle)
+      applicator = described_class.new(oc, user)
+      incoming = true
+
+      expect do
         applicator.__send__(:touched_exchanges=, [])
-        applicator.__send__(:update_exchange, sender.id, receiver.id, incoming,
-                            variant_ids: [variant1.id])
+        applicator.__send__(:add_exchange, sender.id, receiver.id, incoming)
+      end.to change { Exchange.count }.by(0)
+    end
 
-        expect(exchange.variants).not_to eq([variant1])
-      end
+    it "does not update exchanges it is not permitted to touch" do
+      sender = FactoryBot.create(:enterprise)
+      receiver = FactoryBot.create(:enterprise)
+      oc = FactoryBot.create(:simple_order_cycle)
+      applicator = described_class.new(oc, user)
+      incoming = true
+      exchange = FactoryBot.create(:exchange, order_cycle: oc, sender:,
+                                              receiver:, incoming:)
+      variant1 = FactoryBot.create(:variant)
+
+      applicator.__send__(:touched_exchanges=, [])
+      applicator.__send__(:update_exchange, sender.id, receiver.id, incoming,
+                          variant_ids: [variant1.id])
+
+      expect(exchange.variants).not_to eq([variant1])
     end
   end
 end

--- a/spec/lib/open_food_network/order_cycle_permissions_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_permissions_spec.rb
@@ -3,52 +3,78 @@
 require 'spec_helper'
 require 'open_food_network/order_cycle_permissions'
 
-module OpenFoodNetwork
-  RSpec.describe OrderCyclePermissions do
-    let(:coordinator) { create(:distributor_enterprise) }
-    let(:hub) { create(:distributor_enterprise) }
-    let(:producer) { create(:supplier_enterprise) }
-    let(:user) { double(:user) }
-    let(:oc) { create(:simple_order_cycle, coordinator:) }
-    let(:permissions) { OrderCyclePermissions.new(user, oc) }
+RSpec.describe OpenFoodNetwork::OrderCyclePermissions do
+  let(:coordinator) { create(:distributor_enterprise) }
+  let(:hub) { create(:distributor_enterprise) }
+  let(:producer) { create(:supplier_enterprise) }
+  let(:user) { double(:user) }
+  let(:oc) { create(:simple_order_cycle, coordinator:) }
+  let(:permissions) { described_class.new(user, oc) }
 
-    describe "finding enterprises that can be viewed in the order cycle interface" do
-      context "when permissions are initialized without an order_cycle" do
-        let(:permissions) { OrderCyclePermissions.new(user, nil) }
+  describe "finding enterprises that can be viewed in the order cycle interface" do
+    context "when permissions are initialized without an order_cycle" do
+      let(:permissions) { described_class.new(user, nil) }
 
+      before do
+        allow(permissions).to receive(:managed_enterprises) {
+                                Enterprise.where(id: [coordinator])
+                              }
+      end
+
+      it "returns an empty scope" do
+        expect(permissions.visible_enterprises).to be_empty
+      end
+    end
+
+    context "as a manager of the coordinator" do
+      before do
+        allow(permissions).to receive(:managed_enterprises) {
+                                Enterprise.where(id: [coordinator])
+                              }
+      end
+
+      it "returns the coordinator itself" do
+        expect(permissions.visible_enterprises).to include coordinator
+      end
+
+      context "where P-OC has been granted to the coordinator by other enterprises" do
         before do
-          allow(permissions).to receive(:managed_enterprises) {
-                                  Enterprise.where(id: [coordinator])
-                                }
+          create(:enterprise_relationship, parent: hub, child: coordinator,
+                                           permissions_list: [:add_to_order_cycle])
         end
 
-        it "returns an empty scope" do
-          expect(permissions.visible_enterprises).to be_empty
+        context "where the coordinator sells any" do
+          it "returns enterprises which have granted P-OC to the coordinator" do
+            enterprises = permissions.visible_enterprises
+            expect(enterprises).to include hub
+            expect(enterprises).not_to include producer
+          end
+        end
+
+        context "where the coordinator sells 'own'" do
+          before { allow(coordinator).to receive(:sells) { 'own' } }
+          it "returns just the coordinator" do
+            enterprises = permissions.visible_enterprises
+            expect(enterprises).not_to include hub, producer
+          end
         end
       end
 
-      context "as a manager of the coordinator" do
-        before do
-          allow(permissions).to receive(:managed_enterprises) {
-                                  Enterprise.where(id: [coordinator])
-                                }
-        end
-
-        it "returns the coordinator itself" do
-          expect(permissions.visible_enterprises).to include coordinator
-        end
-
-        context "where P-OC has been granted to the coordinator by other enterprises" do
-          before do
-            create(:enterprise_relationship, parent: hub, child: coordinator,
-                                             permissions_list: [:add_to_order_cycle])
-          end
+      context "where P-OC has not been granted to the coordinator by other enterprises" do
+        context "where the other enterprise are already in the order cycle" do
+          let!(:ex_incoming) {
+            create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
+                              incoming: true)
+          }
+          let!(:ex_outgoing) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                              incoming: false)
+          }
 
           context "where the coordinator sells any" do
             it "returns enterprises which have granted P-OC to the coordinator" do
               enterprises = permissions.visible_enterprises
-              expect(enterprises).to include hub
-              expect(enterprises).not_to include producer
+              expect(enterprises).to include hub, producer
             end
           end
 
@@ -61,858 +87,821 @@ module OpenFoodNetwork
           end
         end
 
-        context "where P-OC has not been granted to the coordinator by other enterprises" do
-          context "where the other enterprise are already in the order cycle" do
-            let!(:ex_incoming) {
-              create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
-                                incoming: true)
-            }
-            let!(:ex_outgoing) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                incoming: false)
-            }
-
-            context "where the coordinator sells any" do
-              it "returns enterprises which have granted P-OC to the coordinator" do
-                enterprises = permissions.visible_enterprises
-                expect(enterprises).to include hub, producer
-              end
-            end
-
-            context "where the coordinator sells 'own'" do
-              before { allow(coordinator).to receive(:sells) { 'own' } }
-              it "returns just the coordinator" do
-                enterprises = permissions.visible_enterprises
-                expect(enterprises).not_to include hub, producer
-              end
-            end
-          end
-
-          context "where the other enterprises are not in the order cycle" do
-            it "returns just the coordinator" do
-              enterprises = permissions.visible_enterprises
-              expect(enterprises).not_to include hub, producer
-            end
+        context "where the other enterprises are not in the order cycle" do
+          it "returns just the coordinator" do
+            enterprises = permissions.visible_enterprises
+            expect(enterprises).not_to include hub, producer
           end
         end
       end
+    end
 
-      context "as a manager of a hub" do
+    context "as a manager of a hub" do
+      before do
+        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
+      end
+
+      context "that has granted P-OC to the coordinator" do
         before do
-          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
+          create(:enterprise_relationship, parent: hub, child: coordinator,
+                                           permissions_list: [:add_to_order_cycle])
         end
 
-        context "that has granted P-OC to the coordinator" do
-          before do
-            create(:enterprise_relationship, parent: hub, child: coordinator,
-                                             permissions_list: [:add_to_order_cycle])
+        context "where my hub is in the order cycle" do
+          let!(:ex_outgoing) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                              incoming: false)
+          }
+
+          it "returns my hub" do
+            enterprises = permissions.visible_enterprises
+            expect(enterprises).to include hub
+            expect(enterprises).not_to include producer, coordinator
           end
 
-          context "where my hub is in the order cycle" do
-            let!(:ex_outgoing) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                incoming: false)
-            }
-
-            it "returns my hub" do
-              enterprises = permissions.visible_enterprises
-              expect(enterprises).to include hub
-              expect(enterprises).not_to include producer, coordinator
+          context "and has been granted P-OC by a producer" do
+            before do
+              create(:enterprise_relationship, parent: producer, child: hub,
+                                               permissions_list: [:add_to_order_cycle])
             end
 
-            context "and has been granted P-OC by a producer" do
-              before do
-                create(:enterprise_relationship, parent: producer, child: hub,
-                                                 permissions_list: [:add_to_order_cycle])
-              end
+            context "where the producer is in the order cycle" do
+              let!(:ex_incoming) {
+                create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
+                                  incoming: true)
+              }
 
-              context "where the producer is in the order cycle" do
-                let!(:ex_incoming) {
-                  create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
-                                    incoming: true)
-                }
-
-                it "returns the producer" do
-                  enterprises = permissions.visible_enterprises
-                  expect(enterprises).to include producer, hub
-                end
-              end
-
-              context "where the producer is not in the order cycle" do
-                # No incoming exchange
-
-                it "does not return the producer" do
-                  enterprises = permissions.visible_enterprises
-                  expect(enterprises).not_to include producer
-                end
+              it "returns the producer" do
+                enterprises = permissions.visible_enterprises
+                expect(enterprises).to include producer, hub
               end
             end
 
-            context "and has granted P-OC to a producer" do
-              before do
-                create(:enterprise_relationship, parent: hub, child: producer,
-                                                 permissions_list: [:add_to_order_cycle])
-              end
+            context "where the producer is not in the order cycle" do
+              # No incoming exchange
 
-              context "where the producer is in the order cycle" do
-                let!(:ex_incoming) {
-                  create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
-                                    incoming: true)
-                }
-
-                it "returns the producer" do
-                  enterprises = permissions.visible_enterprises
-                  expect(enterprises).to include producer, hub
-                end
-              end
-
-              context "where the producer is not in the order cycle" do
-                # No incoming exchange
-
-                it "does not return the producer" do
-                  enterprises = permissions.visible_enterprises
-                  expect(enterprises).not_to include producer
-                end
+              it "does not return the producer" do
+                enterprises = permissions.visible_enterprises
+                expect(enterprises).not_to include producer
               end
             end
           end
 
-          context "where my hub is not in the order cycle" do
-            # No outgoing exchange for my hub
+          context "and has granted P-OC to a producer" do
+            before do
+              create(:enterprise_relationship, parent: hub, child: producer,
+                                               permissions_list: [:add_to_order_cycle])
+            end
 
-            it "does not return my hub" do
-              enterprises = permissions.visible_enterprises
-              expect(enterprises).not_to include hub, producer, coordinator
+            context "where the producer is in the order cycle" do
+              let!(:ex_incoming) {
+                create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
+                                  incoming: true)
+              }
+
+              it "returns the producer" do
+                enterprises = permissions.visible_enterprises
+                expect(enterprises).to include producer, hub
+              end
+            end
+
+            context "where the producer is not in the order cycle" do
+              # No incoming exchange
+
+              it "does not return the producer" do
+                enterprises = permissions.visible_enterprises
+                expect(enterprises).not_to include producer
+              end
             end
           end
         end
 
-        context "that has not granted P-OC to the coordinator" do
+        context "where my hub is not in the order cycle" do
+          # No outgoing exchange for my hub
+
           it "does not return my hub" do
             enterprises = permissions.visible_enterprises
             expect(enterprises).not_to include hub, producer, coordinator
           end
-
-          context "but is already in the order cycle" do
-            let!(:ex) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                incoming: false)
-            }
-
-            it "returns my hub" do
-              enterprises = permissions.visible_enterprises
-              expect(enterprises).to include hub
-              expect(enterprises).not_to include producer, coordinator
-            end
-
-            context "and distributes variants distributed by an unmanaged & unpermitted producer" do
-              before {
-                ex.variants << create(:variant, supplier: producer)
-              }
-
-              # TODO: update this when we are confident about P-OCs
-              it "returns that producer as well" do
-                enterprises = permissions.visible_enterprises
-                expect(enterprises).to include producer, hub
-                expect(enterprises).not_to include coordinator
-              end
-            end
-          end
         end
       end
 
-      context "as a manager of a producer" do
-        before do
-          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer]) }
+      context "that has not granted P-OC to the coordinator" do
+        it "does not return my hub" do
+          enterprises = permissions.visible_enterprises
+          expect(enterprises).not_to include hub, producer, coordinator
         end
 
-        context "which has granted P-OC to the coordinator" do
-          before do
-            create(:enterprise_relationship, parent: producer, child: coordinator,
-                                             permissions_list: [:add_to_order_cycle])
-          end
+        context "but is already in the order cycle" do
+          let!(:ex) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                              incoming: false)
+          }
 
-          context "where my producer is in the order cycle" do
-            let!(:ex_incoming) {
-              create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
-                                incoming: true)
-            }
-
-            it "returns my producer" do
-              enterprises = permissions.visible_enterprises
-              expect(enterprises).to include producer
-              expect(enterprises).not_to include hub, coordinator
-            end
-
-            context "and has been granted P-OC by a hub" do
-              before do
-                create(:enterprise_relationship, parent: hub, child: producer,
-                                                 permissions_list: [:add_to_order_cycle])
-              end
-
-              context "where the hub is also in the order cycle" do
-                let!(:ex_outgoing) {
-                  create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                    incoming: false)
-                }
-
-                it "returns the hub as well" do
-                  enterprises = permissions.visible_enterprises
-                  expect(enterprises).to include producer, hub
-                  expect(enterprises).not_to include coordinator
-                end
-              end
-
-              context "where the hub is not in the order cycle" do
-                # No outgoing exchange
-
-                it "does not return the hub" do
-                  enterprises = permissions.visible_enterprises
-                  expect(enterprises).not_to include hub
-                end
-              end
-            end
-
-            context "and has granted P-OC to a hub" do
-              before do
-                create(:enterprise_relationship, parent: producer, child: hub,
-                                                 permissions_list: [:add_to_order_cycle])
-              end
-
-              context "where the hub is also in the order cycle" do
-                let!(:ex_outgoing) {
-                  create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                    incoming: false)
-                }
-
-                it "returns the hub as well" do
-                  enterprises = permissions.visible_enterprises
-                  expect(enterprises).to include producer, hub
-                  expect(enterprises).not_to include coordinator
-                end
-              end
-
-              context "where the hub is not in the order cycle" do
-                # No outgoing exchange
-
-                it "does not return the hub" do
-                  enterprises = permissions.visible_enterprises
-                  expect(enterprises).not_to include hub
-                end
-              end
-            end
-          end
-
-          context "where my producer is not in the order cycle" do
-            # No incoming exchange for producer
-
-            it "does not return my producer" do
-              enterprises = permissions.visible_enterprises
-              expect(enterprises).not_to include hub, producer, coordinator
-            end
-          end
-        end
-
-        context "which has not granted P-OC to the coordinator" do
-          it "does not return my producer" do
+          it "returns my hub" do
             enterprises = permissions.visible_enterprises
-            expect(enterprises).not_to include producer
+            expect(enterprises).to include hub
+            expect(enterprises).not_to include producer, coordinator
           end
 
-          context "but is already in the order cycle" do
-            let!(:ex_incoming) {
-              create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
-                                incoming: true)
+          context "and distributes variants distributed by an unmanaged & unpermitted producer" do
+            before {
+              ex.variants << create(:variant, supplier: producer)
             }
 
             # TODO: update this when we are confident about P-OCs
-            it "returns my producer" do
+            it "returns that producer as well" do
               enterprises = permissions.visible_enterprises
-              expect(enterprises).to include producer
-              expect(enterprises).not_to include hub, coordinator
-            end
-
-            context "and has variants distributed by an outgoing hub" do
-              let!(:ex_outgoing) {
-                create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                  incoming: false)
-              }
-              before {
-                ex_outgoing.variants << create(:variant, supplier: producer)
-              }
-
-              # TODO: update this when we are confident about P-OCs
-              it "returns that hub as well" do
-                enterprises = permissions.visible_enterprises
-                expect(enterprises).to include producer, hub
-                expect(enterprises).not_to include coordinator
-              end
+              expect(enterprises).to include producer, hub
+              expect(enterprises).not_to include coordinator
             end
           end
         end
       end
     end
 
-    describe "finding exchanges of an order cycle that an admin can manage" do
-      describe "as the manager of the coordinator" do
-        let!(:ex_in) {
-          create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
-                            incoming: true)
-        }
+    context "as a manager of a producer" do
+      before do
+        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer]) }
+      end
+
+      context "which has granted P-OC to the coordinator" do
+        before do
+          create(:enterprise_relationship, parent: producer, child: coordinator,
+                                           permissions_list: [:add_to_order_cycle])
+        end
+
+        context "where my producer is in the order cycle" do
+          let!(:ex_incoming) {
+            create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
+                              incoming: true)
+          }
+
+          it "returns my producer" do
+            enterprises = permissions.visible_enterprises
+            expect(enterprises).to include producer
+            expect(enterprises).not_to include hub, coordinator
+          end
+
+          context "and has been granted P-OC by a hub" do
+            before do
+              create(:enterprise_relationship, parent: hub, child: producer,
+                                               permissions_list: [:add_to_order_cycle])
+            end
+
+            context "where the hub is also in the order cycle" do
+              let!(:ex_outgoing) {
+                create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                                  incoming: false)
+              }
+
+              it "returns the hub as well" do
+                enterprises = permissions.visible_enterprises
+                expect(enterprises).to include producer, hub
+                expect(enterprises).not_to include coordinator
+              end
+            end
+
+            context "where the hub is not in the order cycle" do
+              # No outgoing exchange
+
+              it "does not return the hub" do
+                enterprises = permissions.visible_enterprises
+                expect(enterprises).not_to include hub
+              end
+            end
+          end
+
+          context "and has granted P-OC to a hub" do
+            before do
+              create(:enterprise_relationship, parent: producer, child: hub,
+                                               permissions_list: [:add_to_order_cycle])
+            end
+
+            context "where the hub is also in the order cycle" do
+              let!(:ex_outgoing) {
+                create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                                  incoming: false)
+              }
+
+              it "returns the hub as well" do
+                enterprises = permissions.visible_enterprises
+                expect(enterprises).to include producer, hub
+                expect(enterprises).not_to include coordinator
+              end
+            end
+
+            context "where the hub is not in the order cycle" do
+              # No outgoing exchange
+
+              it "does not return the hub" do
+                enterprises = permissions.visible_enterprises
+                expect(enterprises).not_to include hub
+              end
+            end
+          end
+        end
+
+        context "where my producer is not in the order cycle" do
+          # No incoming exchange for producer
+
+          it "does not return my producer" do
+            enterprises = permissions.visible_enterprises
+            expect(enterprises).not_to include hub, producer, coordinator
+          end
+        end
+      end
+
+      context "which has not granted P-OC to the coordinator" do
+        it "does not return my producer" do
+          enterprises = permissions.visible_enterprises
+          expect(enterprises).not_to include producer
+        end
+
+        context "but is already in the order cycle" do
+          let!(:ex_incoming) {
+            create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
+                              incoming: true)
+          }
+
+          # TODO: update this when we are confident about P-OCs
+          it "returns my producer" do
+            enterprises = permissions.visible_enterprises
+            expect(enterprises).to include producer
+            expect(enterprises).not_to include hub, coordinator
+          end
+
+          context "and has variants distributed by an outgoing hub" do
+            let!(:ex_outgoing) {
+              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                                incoming: false)
+            }
+            before {
+              ex_outgoing.variants << create(:variant, supplier: producer)
+            }
+
+            # TODO: update this when we are confident about P-OCs
+            it "returns that hub as well" do
+              enterprises = permissions.visible_enterprises
+              expect(enterprises).to include producer, hub
+              expect(enterprises).not_to include coordinator
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "finding exchanges of an order cycle that an admin can manage" do
+    describe "as the manager of the coordinator" do
+      let!(:ex_in) {
+        create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
+                          incoming: true)
+      }
+      let!(:ex_out) {
+        create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub, incoming: false)
+      }
+
+      before do
+        allow(permissions).to receive(:managed_enterprises) {
+                                Enterprise.where(id: [coordinator])
+                              }
+      end
+
+      it "returns all exchanges in the order cycle, regardless of hubE permissions" do
+        expect(permissions.visible_exchanges).to include ex_in, ex_out
+      end
+    end
+
+    describe "as the manager of a hub" do
+      let!(:ex_in) {
+        create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
+                          incoming: true)
+      }
+
+      before do
+        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
+      end
+
+      context "where my hub is in the order cycle" do
         let!(:ex_out) {
           create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub, incoming: false)
         }
 
+        it "returns my hub's outgoing exchange" do
+          expect(permissions.visible_exchanges).to eq([ex_out])
+        end
+
+        context "where my hub has been granted P-OC by an incoming producer" do
+          before do
+            create(:enterprise_relationship, parent: producer, child: hub,
+                                             permissions_list: [:add_to_order_cycle])
+          end
+
+          it "returns the producer's incoming exchange" do
+            expect(permissions.visible_exchanges).to include ex_in
+          end
+        end
+
+        context "where my hub has not been granted P-OC by an incoming producer" do
+          it "returns the producers's incoming exchange, and my own outhoing exchange" do
+            expect(permissions.visible_exchanges).not_to include ex_in
+          end
+        end
+      end
+
+      context "where my hub isn't in the order cycle" do
+        it "does not return the producer's incoming exchanges" do
+          expect(permissions.visible_exchanges).to eq([])
+        end
+      end
+
+      # TODO: this is testing legacy behaviour for backwards compatability,
+      # remove when behaviour no longer required
+      describe "legacy compatability" do
+        context "where my hub's outgoing exchange contains variants of a producer " \
+                "I don't manage and has not given my hub P-OC" do
+          let!(:variant) { create(:variant, supplier: producer) }
+          let!(:ex_out) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub, incoming: true)
+          }
+          before { ex_out.variants << variant }
+
+          it "returns incoming exchanges supplying the variants in my outgoing exchange" do
+            expect(permissions.visible_exchanges).to include ex_out
+          end
+        end
+      end
+    end
+
+    describe "as the manager of a producer" do
+      let!(:ex_out) {
+        create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub, incoming: false)
+      }
+
+      before do
+        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer]) }
+      end
+
+      context "where my producer supplies to the order cycle" do
+        let!(:ex_in) {
+          create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
+                            incoming: true)
+        }
+
+        it "returns my producer's incoming exchange" do
+          expect(permissions.visible_exchanges).to eq([ex_in])
+        end
+
+        context "my producer has granted P-OC to an outgoing hub" do
+          before do
+            create(:enterprise_relationship, parent: producer, child: hub,
+                                             permissions_list: [:add_to_order_cycle])
+          end
+
+          it "returns the hub's outgoing exchange" do
+            expect(permissions.visible_exchanges).to include ex_out
+          end
+        end
+
+        context "my producer has not granted P-OC to an outgoing hub" do
+          it "does not return the hub's outgoing exchange" do
+            expect(permissions.visible_exchanges).not_to include ex_out
+          end
+        end
+      end
+
+      context "where my producer doesn't supply the order cycle" do
+        it "does not return the hub's outgoing exchanges" do
+          expect(permissions.visible_exchanges).to eq([])
+        end
+      end
+
+      # TODO: this is testing legacy behaviour for backwards compatability,
+      # remove when behaviour no longer required
+      describe "legacy compatability" do
+        context "where an outgoing exchange contains variants of a producer I manage" do
+          let!(:variant) { create(:variant, supplier: producer) }
+
+          before { ex_out.variants << variant }
+
+          context "where my producer supplies to the order cycle" do
+            let!(:ex_in) {
+              create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
+                                incoming: true)
+            }
+
+            it "returns the outgoing exchange" do
+              expect(permissions.visible_exchanges).to include ex_out
+            end
+          end
+
+          context "where my producer doesn't supply to the order cycle" do
+            it "does not return the outgoing exchange" do
+              expect(permissions.visible_exchanges).not_to include ex_out
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "finding the variants within a hypothetical exchange " \
+           "between two enterprises which are visible to a user" do
+    let!(:producer1) { create(:supplier_enterprise) }
+    let!(:producer2) { create(:supplier_enterprise) }
+    let!(:v1) { create(:variant, supplier: producer1) }
+    let!(:v2) { create(:variant, supplier: producer2) }
+
+    describe "incoming exchanges" do
+      context "as a manager of the coordinator" do
         before do
           allow(permissions).to receive(:managed_enterprises) {
                                   Enterprise.where(id: [coordinator])
                                 }
         end
 
-        it "returns all exchanges in the order cycle, regardless of hubE permissions" do
-          expect(permissions.visible_exchanges).to include ex_in, ex_out
+        it "returns all variants belonging to the sending producer" do
+          visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
+          expect(visible).to include v1
+          expect(visible).not_to include v2
         end
       end
 
-      describe "as the manager of a hub" do
-        let!(:ex_in) {
-          create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
-                            incoming: true)
-        }
+      context "as a manager of the producer" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) {
+                                  Enterprise.where(id: [producer1])
+                                }
+        end
 
+        it "returns all variants belonging to the sending producer" do
+          visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
+          expect(visible).to include v1
+          expect(visible).not_to include v2
+        end
+      end
+
+      context "as a manager of a hub which has been granted P-OC by the producer" do
         before do
           allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
+          create(:enterprise_relationship, parent: producer1, child: hub,
+                                           permissions_list: [:add_to_order_cycle])
         end
 
-        context "where my hub is in the order cycle" do
-          let!(:ex_out) {
-            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub, incoming: false)
+        context "where the hub is in the order cycle" do
+          let!(:ex) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                              incoming: false)
           }
 
-          it "returns my hub's outgoing exchange" do
-            expect(permissions.visible_exchanges).to eq([ex_out])
-          end
-
-          context "where my hub has been granted P-OC by an incoming producer" do
-            before do
-              create(:enterprise_relationship, parent: producer, child: hub,
-                                               permissions_list: [:add_to_order_cycle])
-            end
-
-            it "returns the producer's incoming exchange" do
-              expect(permissions.visible_exchanges).to include ex_in
-            end
-          end
-
-          context "where my hub has not been granted P-OC by an incoming producer" do
-            it "returns the producers's incoming exchange, and my own outhoing exchange" do
-              expect(permissions.visible_exchanges).not_to include ex_in
-            end
+          it "returns variants produced by that producer only" do
+            visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
+            expect(visible).to include v1
+            expect(visible).not_to include v2
           end
         end
 
-        context "where my hub isn't in the order cycle" do
-          it "does not return the producer's incoming exchanges" do
-            expect(permissions.visible_exchanges).to eq([])
+        context "where the hub is not in the order cycle" do
+          # No outgoing exchange
+
+          it "does not return variants produced by that producer" do
+            visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
+            expect(visible).not_to include v1, v2
+          end
+        end
+      end
+    end
+
+    describe "outgoing exchanges" do
+      context "as a manager of the coordinator" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) {
+                                  Enterprise.where(id: [coordinator])
+                                }
+          create(:enterprise_relationship, parent: producer1, child: hub,
+                                           permissions_list: [:add_to_order_cycle])
+        end
+
+        it "returns all variants of any producer which has granted the outgoing hub P-OC" do
+          visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
+          expect(visible).to include v1
+          expect(visible).not_to include v2
+        end
+
+        context "where the coordinator produces products" do
+          let!(:v3) { create(:variant, supplier: coordinator) }
+
+          it "returns any variants produced by the coordinator itself for exchanges w/ 'self'" do
+            visible = permissions.visible_variants_for_outgoing_exchanges_to(coordinator)
+            expect(visible).to include v3
+            expect(visible).not_to include v1, v2
+          end
+
+          it "does not return coordinator's variants for exchanges with other hubs, " \
+             "when permission has not been granted" do
+            visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
+            expect(visible).to include v1
+            expect(visible).not_to include v2, v3
           end
         end
 
-        # TODO: this is testing legacy behaviour for backwards compatability,
-        # remove when behaviour no longer required
-        describe "legacy compatability" do
-          context "where my hub's outgoing exchange contains variants of a producer " \
-                  "I don't manage and has not given my hub P-OC" do
-            let!(:variant) { create(:variant, supplier: producer) }
-            let!(:ex_out) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub, incoming: true)
-            }
-            before { ex_out.variants << variant }
+        # TODO: for backwards compatability, remove later
+        context "when an exchange exists between the coordinator " \
+                "and the hub within this order cycle" do
+          let!(:ex) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                              incoming: false)
+          }
 
-            it "returns incoming exchanges supplying the variants in my outgoing exchange" do
-              expect(permissions.visible_exchanges).to include ex_out
-            end
+          # producer2 produces v2 and has not granted P-OC to hub (or coordinator for that matter)
+          before { ex.variants << v2 }
+
+          it "returns those variants that are in the exchange" do
+            visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
+            expect(visible).to include v1, v2
           end
         end
       end
 
-      describe "as the manager of a producer" do
-        let!(:ex_out) {
-          create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub, incoming: false)
-        }
-
+      context "as manager of an outgoing hub" do
         before do
-          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer]) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
+          create(:enterprise_relationship, parent: producer1, child: hub,
+                                           permissions_list: [:add_to_order_cycle])
         end
 
-        context "where my producer supplies to the order cycle" do
-          let!(:ex_in) {
-            create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
+        it "returns all variants of any producer which has granted the outgoing hub P-OC" do
+          visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
+          expect(visible).to include v1
+          expect(visible).not_to include v2
+        end
+
+        context "where the hub produces products" do
+          # NOTE: No relationship to self required
+          let!(:v3) { create(:variant, supplier: hub) }
+
+          it "returns any variants produced by the hub" do
+            visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
+            expect(visible).to include v3
+          end
+        end
+
+        # TODO: for backwards compatability, remove later
+        context "when an exchange exists between the coordinator " \
+                "and the hub within this order cycle" do
+          let!(:ex) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                              incoming: false)
+          }
+
+          # producer2 produces v2 and has not granted P-OC to hub
+          before { ex.variants << v2 }
+
+          it "returns those variants that are in the exchange" do
+            visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
+            expect(visible).to include v1, v2
+          end
+        end
+      end
+
+      context "as the manager of a producer which has granted P-OC to an outgoing hub" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) {
+                                  Enterprise.where(id: [producer1])
+                                }
+          create(:enterprise_relationship, parent: producer1, child: hub,
+                                           permissions_list: [:add_to_order_cycle])
+        end
+
+        context "where my producer is in the order cycle" do
+          let!(:ex) {
+            create(:exchange, order_cycle: oc, sender: producer1, receiver: coordinator,
                               incoming: true)
           }
 
-          it "returns my producer's incoming exchange" do
-            expect(permissions.visible_exchanges).to eq([ex_in])
-          end
-
-          context "my producer has granted P-OC to an outgoing hub" do
-            before do
-              create(:enterprise_relationship, parent: producer, child: hub,
-                                               permissions_list: [:add_to_order_cycle])
-            end
-
-            it "returns the hub's outgoing exchange" do
-              expect(permissions.visible_exchanges).to include ex_out
-            end
-          end
-
-          context "my producer has not granted P-OC to an outgoing hub" do
-            it "does not return the hub's outgoing exchange" do
-              expect(permissions.visible_exchanges).not_to include ex_out
-            end
-          end
-        end
-
-        context "where my producer doesn't supply the order cycle" do
-          it "does not return the hub's outgoing exchanges" do
-            expect(permissions.visible_exchanges).to eq([])
-          end
-        end
-
-        # TODO: this is testing legacy behaviour for backwards compatability,
-        # remove when behaviour no longer required
-        describe "legacy compatability" do
-          context "where an outgoing exchange contains variants of a producer I manage" do
-            let!(:variant) { create(:variant, supplier: producer) }
-
-            before { ex_out.variants << variant }
-
-            context "where my producer supplies to the order cycle" do
-              let!(:ex_in) {
-                create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator,
-                                  incoming: true)
-              }
-
-              it "returns the outgoing exchange" do
-                expect(permissions.visible_exchanges).to include ex_out
-              end
-            end
-
-            context "where my producer doesn't supply to the order cycle" do
-              it "does not return the outgoing exchange" do
-                expect(permissions.visible_exchanges).not_to include ex_out
-              end
-            end
-          end
-        end
-      end
-    end
-
-    describe "finding the variants within a hypothetical exchange " \
-             "between two enterprises which are visible to a user" do
-      let!(:producer1) { create(:supplier_enterprise) }
-      let!(:producer2) { create(:supplier_enterprise) }
-      let!(:v1) { create(:variant, supplier: producer1) }
-      let!(:v2) { create(:variant, supplier: producer2) }
-
-      describe "incoming exchanges" do
-        context "as a manager of the coordinator" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) {
-                                    Enterprise.where(id: [coordinator])
-                                  }
-          end
-
-          it "returns all variants belonging to the sending producer" do
-            visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
-            expect(visible).to include v1
-            expect(visible).not_to include v2
-          end
-        end
-
-        context "as a manager of the producer" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) {
-                                    Enterprise.where(id: [producer1])
-                                  }
-          end
-
-          it "returns all variants belonging to the sending producer" do
-            visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
-            expect(visible).to include v1
-            expect(visible).not_to include v2
-          end
-        end
-
-        context "as a manager of a hub which has been granted P-OC by the producer" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
-            create(:enterprise_relationship, parent: producer1, child: hub,
-                                             permissions_list: [:add_to_order_cycle])
-          end
-
-          context "where the hub is in the order cycle" do
-            let!(:ex) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                incoming: false)
-            }
-
-            it "returns variants produced by that producer only" do
-              visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
-              expect(visible).to include v1
-              expect(visible).not_to include v2
-            end
-          end
-
-          context "where the hub is not in the order cycle" do
-            # No outgoing exchange
-
-            it "does not return variants produced by that producer" do
-              visible = permissions.visible_variants_for_incoming_exchanges_from(producer1)
-              expect(visible).not_to include v1, v2
-            end
-          end
-        end
-      end
-
-      describe "outgoing exchanges" do
-        context "as a manager of the coordinator" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) {
-                                    Enterprise.where(id: [coordinator])
-                                  }
-            create(:enterprise_relationship, parent: producer1, child: hub,
-                                             permissions_list: [:add_to_order_cycle])
-          end
-
-          it "returns all variants of any producer which has granted the outgoing hub P-OC" do
+          it "returns all of my produced variants" do
             visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
             expect(visible).to include v1
             expect(visible).not_to include v2
           end
-
-          context "where the coordinator produces products" do
-            let!(:v3) { create(:variant, supplier: coordinator) }
-
-            it "returns any variants produced by the coordinator itself for exchanges w/ 'self'" do
-              visible = permissions.visible_variants_for_outgoing_exchanges_to(coordinator)
-              expect(visible).to include v3
-              expect(visible).not_to include v1, v2
-            end
-
-            it "does not return coordinator's variants for exchanges with other hubs, " \
-               "when permission has not been granted" do
-              visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to include v1
-              expect(visible).not_to include v2, v3
-            end
-          end
-
-          # TODO: for backwards compatability, remove later
-          context "when an exchange exists between the coordinator " \
-                  "and the hub within this order cycle" do
-            let!(:ex) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                incoming: false)
-            }
-
-            # producer2 produces v2 and has not granted P-OC to hub (or coordinator for that matter)
-            before { ex.variants << v2 }
-
-            it "returns those variants that are in the exchange" do
-              visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to include v1, v2
-            end
-          end
         end
 
-        context "as manager of an outgoing hub" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
-            create(:enterprise_relationship, parent: producer1, child: hub,
-                                             permissions_list: [:add_to_order_cycle])
-          end
+        context "where my producer isn't in the order cycle" do
+          # No incoming exchange
 
-          it "returns all variants of any producer which has granted the outgoing hub P-OC" do
+          it "does not return my variants" do
             visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-            expect(visible).to include v1
-            expect(visible).not_to include v2
-          end
-
-          context "where the hub produces products" do
-            # NOTE: No relationship to self required
-            let!(:v3) { create(:variant, supplier: hub) }
-
-            it "returns any variants produced by the hub" do
-              visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to include v3
-            end
-          end
-
-          # TODO: for backwards compatability, remove later
-          context "when an exchange exists between the coordinator " \
-                  "and the hub within this order cycle" do
-            let!(:ex) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                incoming: false)
-            }
-
-            # producer2 produces v2 and has not granted P-OC to hub
-            before { ex.variants << v2 }
-
-            it "returns those variants that are in the exchange" do
-              visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to include v1, v2
-            end
-          end
-        end
-
-        context "as the manager of a producer which has granted P-OC to an outgoing hub" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) {
-                                    Enterprise.where(id: [producer1])
-                                  }
-            create(:enterprise_relationship, parent: producer1, child: hub,
-                                             permissions_list: [:add_to_order_cycle])
-          end
-
-          context "where my producer is in the order cycle" do
-            let!(:ex) {
-              create(:exchange, order_cycle: oc, sender: producer1, receiver: coordinator,
-                                incoming: true)
-            }
-
-            it "returns all of my produced variants" do
-              visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to include v1
-              expect(visible).not_to include v2
-            end
-          end
-
-          context "where my producer isn't in the order cycle" do
-            # No incoming exchange
-
-            it "does not return my variants" do
-              visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).not_to include v1, v2
-            end
-          end
-        end
-
-        context "as the manager of a producer which has not granted P-OC to an outgoing hub" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) {
-                                    Enterprise.where(id: [producer2])
-                                  }
-            create(:enterprise_relationship, parent: producer1, child: hub,
-                                             permissions_list: [:add_to_order_cycle])
-          end
-
-          it "returns an empty array" do
-            expect(permissions.visible_variants_for_outgoing_exchanges_to(hub)).to eq []
-          end
-
-          # TODO: for backwards compatability, remove later
-          context "but which has variants already in the exchange" do
-            let!(:ex) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                incoming: false)
-            }
-            # This one won't be in the exchange, and so shouldn't be visible
-            let!(:v3) { create(:variant, supplier: producer2) }
-
-            before { ex.variants << v2 }
-
-            it "returns those variants that are in the exchange" do
-              visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).not_to include v1, v3
-              expect(visible).to include v2
-            end
-          end
-        end
-      end
-    end
-
-    describe "finding the variants within a hypothetical exchange " \
-             "between two enterprises which are editable by a user" do
-      let!(:producer1) { create(:supplier_enterprise) }
-      let!(:producer2) { create(:supplier_enterprise) }
-      let!(:v1) { create(:variant, supplier: producer1) }
-      let!(:v2) { create(:variant, supplier: producer2) }
-
-      describe "incoming exchanges" do
-        context "as a manager of the coordinator" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) {
-                                    Enterprise.where(id: [coordinator])
-                                  }
-          end
-
-          it "returns all variants belonging to the sending producer" do
-            visible = permissions.editable_variants_for_incoming_exchanges_from(producer1)
-            expect(visible).to include v1
-            expect(visible).not_to include v2
-          end
-        end
-
-        context "as a manager of the producer" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) {
-                                    Enterprise.where(id: [producer1])
-                                  }
-          end
-
-          it "returns all variants belonging to the sending producer" do
-            visible = permissions.editable_variants_for_incoming_exchanges_from(producer1)
-            expect(visible).to include v1
-            expect(visible).not_to include v2
-          end
-        end
-
-        context "as a manager of a hub which has been granted P-OC by the producer" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
-            create(:enterprise_relationship, parent: producer1, child: hub,
-                                             permissions_list: [:add_to_order_cycle])
-          end
-
-          it "does not return variants produced by that producer" do
-            visible = permissions.editable_variants_for_incoming_exchanges_from(producer1)
             expect(visible).not_to include v1, v2
           end
         end
       end
 
-      describe "outgoing exchanges" do
-        context "as a manager of the coordinator" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) {
-                                    Enterprise.where(id: [coordinator])
-                                  }
-            create(:enterprise_relationship, parent: producer1, child: hub,
-                                             permissions_list: [:add_to_order_cycle])
+      context "as the manager of a producer which has not granted P-OC to an outgoing hub" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) {
+                                  Enterprise.where(id: [producer2])
+                                }
+          create(:enterprise_relationship, parent: producer1, child: hub,
+                                           permissions_list: [:add_to_order_cycle])
+        end
+
+        it "returns an empty array" do
+          expect(permissions.visible_variants_for_outgoing_exchanges_to(hub)).to eq []
+        end
+
+        # TODO: for backwards compatability, remove later
+        context "but which has variants already in the exchange" do
+          let!(:ex) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                              incoming: false)
+          }
+          # This one won't be in the exchange, and so shouldn't be visible
+          let!(:v3) { create(:variant, supplier: producer2) }
+
+          before { ex.variants << v2 }
+
+          it "returns those variants that are in the exchange" do
+            visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
+            expect(visible).not_to include v1, v3
+            expect(visible).to include v2
+          end
+        end
+      end
+    end
+  end
+
+  describe "finding the variants within a hypothetical exchange " \
+           "between two enterprises which are editable by a user" do
+    let!(:producer1) { create(:supplier_enterprise) }
+    let!(:producer2) { create(:supplier_enterprise) }
+    let!(:v1) { create(:variant, supplier: producer1) }
+    let!(:v2) { create(:variant, supplier: producer2) }
+
+    describe "incoming exchanges" do
+      context "as a manager of the coordinator" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) {
+                                  Enterprise.where(id: [coordinator])
+                                }
+        end
+
+        it "returns all variants belonging to the sending producer" do
+          visible = permissions.editable_variants_for_incoming_exchanges_from(producer1)
+          expect(visible).to include v1
+          expect(visible).not_to include v2
+        end
+      end
+
+      context "as a manager of the producer" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) {
+                                  Enterprise.where(id: [producer1])
+                                }
+        end
+
+        it "returns all variants belonging to the sending producer" do
+          visible = permissions.editable_variants_for_incoming_exchanges_from(producer1)
+          expect(visible).to include v1
+          expect(visible).not_to include v2
+        end
+      end
+
+      context "as a manager of a hub which has been granted P-OC by the producer" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
+          create(:enterprise_relationship, parent: producer1, child: hub,
+                                           permissions_list: [:add_to_order_cycle])
+        end
+
+        it "does not return variants produced by that producer" do
+          visible = permissions.editable_variants_for_incoming_exchanges_from(producer1)
+          expect(visible).not_to include v1, v2
+        end
+      end
+    end
+
+    describe "outgoing exchanges" do
+      context "as a manager of the coordinator" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) {
+                                  Enterprise.where(id: [coordinator])
+                                }
+          create(:enterprise_relationship, parent: producer1, child: hub,
+                                           permissions_list: [:add_to_order_cycle])
+        end
+
+        it "returns all variants of any producer which has granted the outgoing hub P-OC" do
+          visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
+          expect(visible).to include v1
+          expect(visible).not_to include v2
+        end
+
+        context "where the coordinator produces products" do
+          let!(:v3) { create(:variant, supplier: coordinator) }
+
+          it "returns any variants produced by the coordinator itself for exchanges w/ 'self'" do
+            visible = permissions.editable_variants_for_outgoing_exchanges_to(coordinator)
+            expect(visible).to include v3
+            expect(visible).not_to include v1, v2
           end
 
-          it "returns all variants of any producer which has granted the outgoing hub P-OC" do
+          it "does not return coordinator's variants for exchanges with other hubs, " \
+             "when permission has not been granted" do
             visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
             expect(visible).to include v1
-            expect(visible).not_to include v2
+            expect(visible).not_to include v2, v3
           end
+        end
 
-          context "where the coordinator produces products" do
-            let!(:v3) { create(:variant, supplier: coordinator) }
+        # TODO: for backwards compatability, remove later
+        context "when an exchange exists between the coordinator and the hub within this OC" do
+          let!(:ex) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                              incoming: false)
+          }
 
-            it "returns any variants produced by the coordinator itself for exchanges w/ 'self'" do
-              visible = permissions.editable_variants_for_outgoing_exchanges_to(coordinator)
-              expect(visible).to include v3
-              expect(visible).not_to include v1, v2
+          # producer2 produces v2 and has not granted P-OC to hub (or coordinator for that matter)
+          before { ex.variants << v2 }
+
+          it "returns those variants that are in the exchange" do
+            visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
+            expect(visible).to include v1, v2
+          end
+        end
+      end
+
+      context "as manager of an outgoing hub" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
+          create(:enterprise_relationship, parent: producer1, child: hub,
+                                           permissions_list: [:add_to_order_cycle])
+        end
+
+        it "returns all variants of any producer which has granted the outgoing hub P-OC" do
+          visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
+          expect(visible).to include v1
+          expect(visible).not_to include v2
+        end
+
+        context "where the hub produces products" do
+          # NOTE: No relationship to self required
+          let!(:v3) { create(:variant, supplier: hub) }
+
+          it "returns any variants produced by the hub" do
+            visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
+            expect(visible).to include v3
+          end
+        end
+
+        # TODO: for backwards compatability, remove later
+        context "when an exchange exists between the coordinator " \
+                "and the hub within this order cycle" do
+          let!(:ex) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                              incoming: false)
+          }
+
+          # producer2 produces v2 and has not granted P-OC to hub
+          before { ex.variants << v2 }
+
+          it "returns those variants that are in the exchange" do
+            visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
+            expect(visible).to include v1, v2
+          end
+        end
+      end
+
+      context "as the manager of a producer which has granted P-OC to an outgoing hub" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) {
+                                  Enterprise.where(id: [producer1])
+                                }
+          create(:enterprise_relationship, parent: producer1, child: hub,
+                                           permissions_list: [:add_to_order_cycle])
+        end
+
+        context "where my producer is in the order cycle" do
+          let!(:ex) {
+            create(:exchange, order_cycle: oc, sender: producer1, receiver: coordinator,
+                              incoming: true)
+          }
+
+          context "where the outgoing hub has granted P-OC to my producer" do
+            before do
+              create(:enterprise_relationship, parent: hub, child: producer1,
+                                               permissions_list: [:add_to_order_cycle])
             end
 
-            it "does not return coordinator's variants for exchanges with other hubs, " \
-               "when permission has not been granted" do
+            it "returns all of my produced variants" do
               visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
               expect(visible).to include v1
-              expect(visible).not_to include v2, v3
+              expect(visible).not_to include v2
             end
           end
 
-          # TODO: for backwards compatability, remove later
-          context "when an exchange exists between the coordinator and the hub within this OC" do
-            let!(:ex) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                incoming: false)
-            }
-
-            # producer2 produces v2 and has not granted P-OC to hub (or coordinator for that matter)
-            before { ex.variants << v2 }
-
-            it "returns those variants that are in the exchange" do
-              visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to include v1, v2
-            end
-          end
-        end
-
-        context "as manager of an outgoing hub" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
-            create(:enterprise_relationship, parent: producer1, child: hub,
-                                             permissions_list: [:add_to_order_cycle])
-          end
-
-          it "returns all variants of any producer which has granted the outgoing hub P-OC" do
-            visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
-            expect(visible).to include v1
-            expect(visible).not_to include v2
-          end
-
-          context "where the hub produces products" do
-            # NOTE: No relationship to self required
-            let!(:v3) { create(:variant, supplier: hub) }
-
-            it "returns any variants produced by the hub" do
-              visible = permissions.visible_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to include v3
-            end
-          end
-
-          # TODO: for backwards compatability, remove later
-          context "when an exchange exists between the coordinator " \
-                  "and the hub within this order cycle" do
-            let!(:ex) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                incoming: false)
-            }
-
-            # producer2 produces v2 and has not granted P-OC to hub
-            before { ex.variants << v2 }
-
-            it "returns those variants that are in the exchange" do
-              visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).to include v1, v2
-            end
-          end
-        end
-
-        context "as the manager of a producer which has granted P-OC to an outgoing hub" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) {
-                                    Enterprise.where(id: [producer1])
-                                  }
-            create(:enterprise_relationship, parent: producer1, child: hub,
-                                             permissions_list: [:add_to_order_cycle])
-          end
-
-          context "where my producer is in the order cycle" do
-            let!(:ex) {
-              create(:exchange, order_cycle: oc, sender: producer1, receiver: coordinator,
-                                incoming: true)
-            }
-
-            context "where the outgoing hub has granted P-OC to my producer" do
-              before do
-                create(:enterprise_relationship, parent: hub, child: producer1,
-                                                 permissions_list: [:add_to_order_cycle])
-              end
-
-              it "returns all of my produced variants" do
-                visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
-                expect(visible).to include v1
-                expect(visible).not_to include v2
-              end
-            end
-
-            context "where the outgoing hub has not granted P-OC to my producer" do
-              # No permission granted
-
-              it "does not return my variants" do
-                visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
-                expect(visible).not_to include v1, v2
-              end
-            end
-          end
-
-          context "where my producer isn't in the order cycle" do
-            # No incoming exchange
+          context "where the outgoing hub has not granted P-OC to my producer" do
+            # No permission granted
 
             it "does not return my variants" do
               visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
@@ -921,34 +910,43 @@ module OpenFoodNetwork
           end
         end
 
-        context "as the manager of a producer which has not granted P-OC to an outgoing hub" do
-          before do
-            allow(permissions).to receive(:managed_enterprises) {
-                                    Enterprise.where(id: [producer2])
-                                  }
-            create(:enterprise_relationship, parent: producer1, child: hub,
-                                             permissions_list: [:add_to_order_cycle])
+        context "where my producer isn't in the order cycle" do
+          # No incoming exchange
+
+          it "does not return my variants" do
+            visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
+            expect(visible).not_to include v1, v2
           end
+        end
+      end
 
-          it "returns an empty array" do
-            expect(permissions.editable_variants_for_outgoing_exchanges_to(hub)).to eq []
-          end
+      context "as the manager of a producer which has not granted P-OC to an outgoing hub" do
+        before do
+          allow(permissions).to receive(:managed_enterprises) {
+                                  Enterprise.where(id: [producer2])
+                                }
+          create(:enterprise_relationship, parent: producer1, child: hub,
+                                           permissions_list: [:add_to_order_cycle])
+        end
 
-          # TODO: for backwards compatability, remove later
-          context "but which has variants already in the exchange" do
-            let!(:ex) {
-              create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
-                                incoming: false)
-            }
-            # This one won't be in the exchange, and so shouldn't be visible
-            let!(:v3) { create(:variant, supplier: producer2) }
+        it "returns an empty array" do
+          expect(permissions.editable_variants_for_outgoing_exchanges_to(hub)).to eq []
+        end
 
-            before { ex.variants << v2 }
+        # TODO: for backwards compatability, remove later
+        context "but which has variants already in the exchange" do
+          let!(:ex) {
+            create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub,
+                              incoming: false)
+          }
+          # This one won't be in the exchange, and so shouldn't be visible
+          let!(:v3) { create(:variant, supplier: producer2) }
 
-            it "does not return my variants" do
-              visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
-              expect(visible).not_to include v1, v2, v3
-            end
+          before { ex.variants << v2 }
+
+          it "does not return my variants" do
+            visible = permissions.editable_variants_for_outgoing_exchanges_to(hub)
+            expect(visible).not_to include v1, v2, v3
           end
         end
       end

--- a/spec/lib/open_food_network/permissions_spec.rb
+++ b/spec/lib/open_food_network/permissions_spec.rb
@@ -3,340 +3,338 @@
 require 'spec_helper'
 require 'open_food_network/permissions'
 
-module OpenFoodNetwork
-  RSpec.describe Permissions do
-    let(:user) { double(:user) }
-    let(:permissions) { Permissions.new(user) }
-    let(:permission) { 'one' }
-    let(:e1) { create(:enterprise) }
-    let(:e2) { create(:enterprise) }
+RSpec.describe OpenFoodNetwork::Permissions do
+  let(:user) { double(:user) }
+  let(:permissions) { described_class.new(user) }
+  let(:permission) { 'one' }
+  let(:e1) { create(:enterprise) }
+  let(:e2) { create(:enterprise) }
 
-    describe "finding managed and related enterprises granting a particular permission" do
-      describe "as super admin" do
-        before { allow(user).to receive(:admin?) { true } }
+  describe "finding managed and related enterprises granting a particular permission" do
+    describe "as super admin" do
+      before { allow(user).to receive(:admin?) { true } }
 
-        it "returns all enterprises" do
-          expect(permissions.__send__(:managed_and_related_enterprises_granting,
-                                      :some_permission)).to match_array [e1, e2]
-        end
-      end
-
-      describe "as an enterprise user" do
-        let(:e3) { create(:enterprise) }
-        before { allow(user).to receive(:admin?) { false } }
-
-        it "returns only my managed enterprises any that have granting them P-OC" do
-          expect(permissions).to receive(:managed_enterprises) { Enterprise.where(id: e1) }
-          expect(permissions).to receive(:related_enterprises_granting).with(:some_permission) {
-                                   Enterprise.where(id: e3).select(:id)
-                                 }
-          expect(permissions.__send__(:managed_and_related_enterprises_granting,
-                                      :some_permission)).to match_array [e1, e3]
-        end
+      it "returns all enterprises" do
+        expect(permissions.__send__(:managed_and_related_enterprises_granting,
+                                    :some_permission)).to match_array [e1, e2]
       end
     end
 
-    describe "finding managed & related enterprises granting or granted a particular permission" do
-      describe "as super admin" do
-        before { allow(user).to receive(:admin?) { true } }
+    describe "as an enterprise user" do
+      let(:e3) { create(:enterprise) }
+      before { allow(user).to receive(:admin?) { false } }
 
-        it "returns all enterprises" do
-          expect(permissions.__send__(:managed_and_related_enterprises_granting,
-                                      :some_permission)).to match_array [e1, e2]
-        end
-      end
-
-      describe "as an enterprise user" do
-        let(:e3) { create(:enterprise) }
-        let(:e4) { create(:enterprise) }
-        before { allow(user).to receive(:admin?) { false } }
-
-        it "returns only my managed enterprises any that have granting them P-OC" do
-          expect(permissions).to receive(:managed_enterprises) { Enterprise.where(id: e1) }
-          expect(permissions).to receive(:related_enterprises_granting).with(:some_permission) {
-                                   Enterprise.where(id: e3).select(:id)
-                                 }
-          expect(permissions).to receive(:related_enterprises_granted).with(:some_permission) {
-                                   Enterprise.where(id: e4).select(:id)
-                                 }
-          expect(permissions.__send__(:managed_and_related_enterprises_with,
-                                      :some_permission)).to match_array [e1, e3, e4]
-        end
-      end
-    end
-
-    describe "finding enterprises that can be selected in order report filters" do
-      let(:e) { double(:enterprise) }
-
-      it "returns managed and related enterprises with add_to_order_cycle permission" do
-        expect(permissions).to receive(:managed_and_related_enterprises_with).
-          with(:add_to_order_cycle).
-          and_return([e])
-
-        expect(permissions.visible_enterprises_for_order_reports).to eq [e]
-      end
-    end
-
-    describe "finding visible enterprises" do
-      let(:e) { double(:enterprise) }
-
-      it "returns managed and related enterprises with add_to_order_cycle permission" do
-        expect(permissions).to receive(:managed_and_related_enterprises_granting).
-          with(:add_to_order_cycle).
-          and_return([e])
-
-        expect(permissions.visible_enterprises).to eq [e]
-      end
-    end
-
-    describe "finding enterprises whose profiles can be edited" do
-      let(:e) { double(:enterprise) }
-
-      it "returns managed and related enterprises with edit_profile permission" do
-        expect(permissions).
-          to receive(:managed_and_related_enterprises_granting).
-          with(:edit_profile).
-          and_return([e])
-
-        expect(permissions.editable_enterprises).to eq([e])
-      end
-    end
-
-    describe "finding all producers for which we can create variant overrides" do
-      let(:e1) { create(:supplier_enterprise) }
-      let(:e2) { create(:supplier_enterprise) }
-
-      it "compiles the list from variant_override_enterprises_per_hub" do
-        allow(permissions).to receive(:variant_override_enterprises_per_hub) do
-          { 1 => [e1.id], 2 => [e1.id, e2.id] }
-        end
-
-        expect(permissions.variant_override_producers).to match_array [e1, e2]
-      end
-    end
-
-    describe "finding enterprises for which variant overrides can be created, for each hub" do
-      let!(:hub) { create(:distributor_enterprise) }
-      let!(:producer) { create(:supplier_enterprise) }
-      let!(:er) {
-        create(:enterprise_relationship, parent: producer, child: hub,
-                                         permissions_list: [:create_variant_overrides])
-      }
-
-      before do
-        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: hub.id) }
-        allow(permissions).to receive(:admin?) { false }
-      end
-
-      it "returns enterprises as hub_id => [producer, ...]" do
-        expect(permissions.variant_override_enterprises_per_hub).to eq(
-          hub.id => [producer.id]
-        )
-      end
-
-      it "returns only permissions relating to managed hubs" do
-        create(:enterprise_relationship, parent: e1, child: e2,
-                                         permissions_list: [:create_variant_overrides])
-
-        expect(permissions.variant_override_enterprises_per_hub).to eq(
-          hub.id => [producer.id]
-        )
-      end
-
-      it "returns only create_variant_overrides permissions" do
-        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub, e2]) }
-        create(:enterprise_relationship, parent: e1, child: e2,
-                                         permissions_list: [:manage_products])
-
-        expect(permissions.variant_override_enterprises_per_hub).to eq(
-          hub.id => [producer.id]
-        )
-      end
-
-      describe "hubs connected to the user by relationships only" do
-        let!(:producer_managed) { create(:supplier_enterprise) }
-        let!(:er_oc) {
-          create(:enterprise_relationship, parent: hub, child: producer_managed,
-                                           permissions_list: [:add_to_order_cycle,
-                                                              :create_variant_overrides])
-        }
-
-        before do
-          allow(permissions).to receive(:managed_enterprises) {
-                                  Enterprise.where(id: producer_managed.id)
-                                }
-        end
-
-        it "does not allow the user to create variant overrides for the hub" do
-          expect(permissions.variant_override_enterprises_per_hub).to eq({})
-        end
-      end
-
-      it "does not return managed producers (ie. only uses explicitly granted VO permissions)" do
-        producer2 = create(:supplier_enterprise)
-        allow(permissions).to receive(:managed_enterprises) {
-                                Enterprise.where(id: [hub, producer2])
-                              }
-
-        expect(permissions.variant_override_enterprises_per_hub[hub.id]).not_to include producer2.id
-      end
-
-      it "returns itself if self is also a primary producer " \
-         "(even when no explicit permission exists)" do
-        hub.update_attribute(:is_primary_producer, true)
-
-        expect(permissions.variant_override_enterprises_per_hub[hub.id]).to include hub.id
-      end
-    end
-
-    describe "#editable_products" do
-      let!(:p1) { create(:simple_product, supplier_id: create(:supplier_enterprise).id ) }
-      let!(:p2) { create(:simple_product, supplier_id: create(:supplier_enterprise).id ) }
-
-      before do
-        allow(permissions).to receive(:managed_enterprise_products) { Spree::Product.where('1=0') }
-        allow(permissions).to receive(:related_enterprises_granting).with(:manage_products) {
-                                Enterprise.where("1=0").select(:id)
-                              }
-      end
-
-      it "returns products produced by managed enterprises" do
-        allow(user).to receive(:admin?) { false }
-        allow(user).to receive(:enterprises) { [p1.variants.first.supplier] }
-
-        expect(permissions.editable_products).to eq([p1])
-      end
-
-      it "returns products produced by permitted enterprises" do
-        allow(user).to receive(:admin?) { false }
-        allow(user).to receive(:enterprises) { [] }
-        allow(permissions).to receive(:related_enterprises_granting).
-          with(:manage_products) { Enterprise.where(id: p2.variants.first.supplier) }
-
-        expect(permissions.editable_products).to eq([p2])
-      end
-
-      context "as superadmin" do
-        it "returns all products" do
-          allow(user).to receive(:admin?) { true }
-
-          expect(permissions.editable_products).to include p1, p2
-        end
-      end
-    end
-
-    describe "finding visible products" do
-      let!(:p1) { create(:simple_product, supplier_id: create(:supplier_enterprise).id ) }
-      let!(:p2) { create(:simple_product, supplier_id: create(:supplier_enterprise).id ) }
-      let!(:p3) { create(:simple_product, supplier_id: create(:supplier_enterprise).id ) }
-
-      before do
-        allow(permissions).to receive(:managed_enterprise_products) { Spree::Product.where("1=0") }
-        allow(permissions).to receive(:related_enterprises_granting).with(:manage_products) {
-                                Enterprise.where("1=0").select(:id)
-                              }
-        allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle) {
-                                Enterprise.where("1=0").select(:id)
-                              }
-      end
-
-      it "returns products produced by managed enterprises" do
-        allow(user).to receive(:admin?) { false }
-        allow(user).to receive(:enterprises) { Enterprise.where(id: p1.variants.first.supplier_id) }
-
-        expect(permissions.visible_products).to eq([p1])
-      end
-
-      it "returns products produced by enterprises that have granted manage products" do
-        allow(user).to receive(:admin?) { false }
-        allow(user).to receive(:enterprises) { [] }
-        allow(permissions).to receive(:related_enterprises_granting).
-          with(:manage_products) { Enterprise.where(id: p2.variants.first.supplier) }
-
-        expect(permissions.visible_products).to eq([p2])
-      end
-
-      it "returns products produced by enterprises that have granted P-OC" do
-        allow(user).to receive(:admin?) { false }
-        allow(user).to receive(:enterprises) { [] }
-        allow(permissions).to receive(:related_enterprises_granting).
-          with(:add_to_order_cycle) { Enterprise.where(id: p3.variants.first.supplier).select(:id) }
-
-        expect(permissions.visible_products).to eq([p3])
-      end
-
-      context "as superadmin" do
-        it "returns all products" do
-          allow(user).to receive(:admin?) { true }
-
-          expect(permissions.visible_products.to_a).to include p1, p2, p3
-        end
-      end
-    end
-
-    describe "finding enterprises that we manage products for" do
-      let(:e) { double(:enterprise) }
-
-      it "returns managed and related enterprises with manage_products permission" do
-        expect(permissions).
-          to receive(:managed_and_related_enterprises_granting).
-          with(:manage_products).
-          and_return([e])
-
-        expect(permissions.managed_product_enterprises).to eq([e])
-      end
-    end
-
-    ########################################
-
-    describe "finding related enterprises with a particular permission" do
-      let!(:er) {
-        create(:enterprise_relationship, parent: e1, child: e2, permissions_list: [permission])
-      }
-
-      it "returns the enterprises" do
-        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: e2) }
-        expect(permissions.__send__(:related_enterprises_granting, permission)).to eq([e1])
-      end
-
-      it "returns an empty array when there are none" do
-        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: e1) }
-        expect(permissions.__send__(:related_enterprises_granting, permission)).to eq([])
-      end
-    end
-
-    describe "finding enterprises that are managed or with a particular permission" do
-      before do
-        allow(permissions).to receive(:managed_enterprises) { Enterprise.where('1=0') }
-        allow(permissions).to receive(:related_enterprises_granting) {
-                                Enterprise.where('1=0').select(:id)
-                              }
-        allow(permissions).to receive(:admin?) { false }
-      end
-
-      it "returns managed enterprises" do
+      it "returns only my managed enterprises any that have granting them P-OC" do
         expect(permissions).to receive(:managed_enterprises) { Enterprise.where(id: e1) }
+        expect(permissions).to receive(:related_enterprises_granting).with(:some_permission) {
+                                 Enterprise.where(id: e3).select(:id)
+                               }
         expect(permissions.__send__(:managed_and_related_enterprises_granting,
-                                    permission)).to eq([e1])
+                                    :some_permission)).to match_array [e1, e3]
       end
+    end
+  end
 
-      it "returns permitted enterprises" do
-        expect(permissions).to receive(:related_enterprises_granting).with(permission).
-          and_return(Enterprise.where(id: e2).select(:id))
+  describe "finding managed & related enterprises granting or granted a particular permission" do
+    describe "as super admin" do
+      before { allow(user).to receive(:admin?) { true } }
+
+      it "returns all enterprises" do
         expect(permissions.__send__(:managed_and_related_enterprises_granting,
-                                    permission)).to eq([e2])
+                                    :some_permission)).to match_array [e1, e2]
       end
     end
 
-    describe "finding visible subscriptions" do
-      let!(:so1) { create(:subscription) }
-      let!(:so2) { create(:subscription) }
+    describe "as an enterprise user" do
+      let(:e3) { create(:enterprise) }
+      let(:e4) { create(:enterprise) }
+      before { allow(user).to receive(:admin?) { false } }
 
-      it "returns subscriptions placed with managed shops" do
-        expect(permissions).to receive(:managed_enterprises) { [so1.shop] }
-
-        expect(permissions.visible_subscriptions).to eq [so1]
+      it "returns only my managed enterprises any that have granting them P-OC" do
+        expect(permissions).to receive(:managed_enterprises) { Enterprise.where(id: e1) }
+        expect(permissions).to receive(:related_enterprises_granting).with(:some_permission) {
+                                 Enterprise.where(id: e3).select(:id)
+                               }
+        expect(permissions).to receive(:related_enterprises_granted).with(:some_permission) {
+                                 Enterprise.where(id: e4).select(:id)
+                               }
+        expect(permissions.__send__(:managed_and_related_enterprises_with,
+                                    :some_permission)).to match_array [e1, e3, e4]
       end
+    end
+  end
+
+  describe "finding enterprises that can be selected in order report filters" do
+    let(:e) { double(:enterprise) }
+
+    it "returns managed and related enterprises with add_to_order_cycle permission" do
+      expect(permissions).to receive(:managed_and_related_enterprises_with).
+        with(:add_to_order_cycle).
+        and_return([e])
+
+      expect(permissions.visible_enterprises_for_order_reports).to eq [e]
+    end
+  end
+
+  describe "finding visible enterprises" do
+    let(:e) { double(:enterprise) }
+
+    it "returns managed and related enterprises with add_to_order_cycle permission" do
+      expect(permissions).to receive(:managed_and_related_enterprises_granting).
+        with(:add_to_order_cycle).
+        and_return([e])
+
+      expect(permissions.visible_enterprises).to eq [e]
+    end
+  end
+
+  describe "finding enterprises whose profiles can be edited" do
+    let(:e) { double(:enterprise) }
+
+    it "returns managed and related enterprises with edit_profile permission" do
+      expect(permissions).
+        to receive(:managed_and_related_enterprises_granting).
+        with(:edit_profile).
+        and_return([e])
+
+      expect(permissions.editable_enterprises).to eq([e])
+    end
+  end
+
+  describe "finding all producers for which we can create variant overrides" do
+    let(:e1) { create(:supplier_enterprise) }
+    let(:e2) { create(:supplier_enterprise) }
+
+    it "compiles the list from variant_override_enterprises_per_hub" do
+      allow(permissions).to receive(:variant_override_enterprises_per_hub) do
+        { 1 => [e1.id], 2 => [e1.id, e2.id] }
+      end
+
+      expect(permissions.variant_override_producers).to match_array [e1, e2]
+    end
+  end
+
+  describe "finding enterprises for which variant overrides can be created, for each hub" do
+    let!(:hub) { create(:distributor_enterprise) }
+    let!(:producer) { create(:supplier_enterprise) }
+    let!(:er) {
+      create(:enterprise_relationship, parent: producer, child: hub,
+                                       permissions_list: [:create_variant_overrides])
+    }
+
+    before do
+      allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: hub.id) }
+      allow(permissions).to receive(:admin?) { false }
+    end
+
+    it "returns enterprises as hub_id => [producer, ...]" do
+      expect(permissions.variant_override_enterprises_per_hub).to eq(
+        hub.id => [producer.id]
+      )
+    end
+
+    it "returns only permissions relating to managed hubs" do
+      create(:enterprise_relationship, parent: e1, child: e2,
+                                       permissions_list: [:create_variant_overrides])
+
+      expect(permissions.variant_override_enterprises_per_hub).to eq(
+        hub.id => [producer.id]
+      )
+    end
+
+    it "returns only create_variant_overrides permissions" do
+      allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub, e2]) }
+      create(:enterprise_relationship, parent: e1, child: e2,
+                                       permissions_list: [:manage_products])
+
+      expect(permissions.variant_override_enterprises_per_hub).to eq(
+        hub.id => [producer.id]
+      )
+    end
+
+    describe "hubs connected to the user by relationships only" do
+      let!(:producer_managed) { create(:supplier_enterprise) }
+      let!(:er_oc) {
+        create(:enterprise_relationship, parent: hub, child: producer_managed,
+                                         permissions_list: [:add_to_order_cycle,
+                                                            :create_variant_overrides])
+      }
+
+      before do
+        allow(permissions).to receive(:managed_enterprises) {
+                                Enterprise.where(id: producer_managed.id)
+                              }
+      end
+
+      it "does not allow the user to create variant overrides for the hub" do
+        expect(permissions.variant_override_enterprises_per_hub).to eq({})
+      end
+    end
+
+    it "does not return managed producers (ie. only uses explicitly granted VO permissions)" do
+      producer2 = create(:supplier_enterprise)
+      allow(permissions).to receive(:managed_enterprises) {
+                              Enterprise.where(id: [hub, producer2])
+                            }
+
+      expect(permissions.variant_override_enterprises_per_hub[hub.id]).not_to include producer2.id
+    end
+
+    it "returns itself if self is also a primary producer " \
+       "(even when no explicit permission exists)" do
+      hub.update_attribute(:is_primary_producer, true)
+
+      expect(permissions.variant_override_enterprises_per_hub[hub.id]).to include hub.id
+    end
+  end
+
+  describe "#editable_products" do
+    let!(:p1) { create(:simple_product, supplier_id: create(:supplier_enterprise).id ) }
+    let!(:p2) { create(:simple_product, supplier_id: create(:supplier_enterprise).id ) }
+
+    before do
+      allow(permissions).to receive(:managed_enterprise_products) { Spree::Product.where('1=0') }
+      allow(permissions).to receive(:related_enterprises_granting).with(:manage_products) {
+                              Enterprise.where("1=0").select(:id)
+                            }
+    end
+
+    it "returns products produced by managed enterprises" do
+      allow(user).to receive(:admin?) { false }
+      allow(user).to receive(:enterprises) { [p1.variants.first.supplier] }
+
+      expect(permissions.editable_products).to eq([p1])
+    end
+
+    it "returns products produced by permitted enterprises" do
+      allow(user).to receive(:admin?) { false }
+      allow(user).to receive(:enterprises) { [] }
+      allow(permissions).to receive(:related_enterprises_granting).
+        with(:manage_products) { Enterprise.where(id: p2.variants.first.supplier) }
+
+      expect(permissions.editable_products).to eq([p2])
+    end
+
+    context "as superadmin" do
+      it "returns all products" do
+        allow(user).to receive(:admin?) { true }
+
+        expect(permissions.editable_products).to include p1, p2
+      end
+    end
+  end
+
+  describe "finding visible products" do
+    let!(:p1) { create(:simple_product, supplier_id: create(:supplier_enterprise).id ) }
+    let!(:p2) { create(:simple_product, supplier_id: create(:supplier_enterprise).id ) }
+    let!(:p3) { create(:simple_product, supplier_id: create(:supplier_enterprise).id ) }
+
+    before do
+      allow(permissions).to receive(:managed_enterprise_products) { Spree::Product.where("1=0") }
+      allow(permissions).to receive(:related_enterprises_granting).with(:manage_products) {
+                              Enterprise.where("1=0").select(:id)
+                            }
+      allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle) {
+                              Enterprise.where("1=0").select(:id)
+                            }
+    end
+
+    it "returns products produced by managed enterprises" do
+      allow(user).to receive(:admin?) { false }
+      allow(user).to receive(:enterprises) { Enterprise.where(id: p1.variants.first.supplier_id) }
+
+      expect(permissions.visible_products).to eq([p1])
+    end
+
+    it "returns products produced by enterprises that have granted manage products" do
+      allow(user).to receive(:admin?) { false }
+      allow(user).to receive(:enterprises) { [] }
+      allow(permissions).to receive(:related_enterprises_granting).
+        with(:manage_products) { Enterprise.where(id: p2.variants.first.supplier) }
+
+      expect(permissions.visible_products).to eq([p2])
+    end
+
+    it "returns products produced by enterprises that have granted P-OC" do
+      allow(user).to receive(:admin?) { false }
+      allow(user).to receive(:enterprises) { [] }
+      allow(permissions).to receive(:related_enterprises_granting).
+        with(:add_to_order_cycle) { Enterprise.where(id: p3.variants.first.supplier).select(:id) }
+
+      expect(permissions.visible_products).to eq([p3])
+    end
+
+    context "as superadmin" do
+      it "returns all products" do
+        allow(user).to receive(:admin?) { true }
+
+        expect(permissions.visible_products.to_a).to include p1, p2, p3
+      end
+    end
+  end
+
+  describe "finding enterprises that we manage products for" do
+    let(:e) { double(:enterprise) }
+
+    it "returns managed and related enterprises with manage_products permission" do
+      expect(permissions).
+        to receive(:managed_and_related_enterprises_granting).
+        with(:manage_products).
+        and_return([e])
+
+      expect(permissions.managed_product_enterprises).to eq([e])
+    end
+  end
+
+  ########################################
+
+  describe "finding related enterprises with a particular permission" do
+    let!(:er) {
+      create(:enterprise_relationship, parent: e1, child: e2, permissions_list: [permission])
+    }
+
+    it "returns the enterprises" do
+      allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: e2) }
+      expect(permissions.__send__(:related_enterprises_granting, permission)).to eq([e1])
+    end
+
+    it "returns an empty array when there are none" do
+      allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: e1) }
+      expect(permissions.__send__(:related_enterprises_granting, permission)).to eq([])
+    end
+  end
+
+  describe "finding enterprises that are managed or with a particular permission" do
+    before do
+      allow(permissions).to receive(:managed_enterprises) { Enterprise.where('1=0') }
+      allow(permissions).to receive(:related_enterprises_granting) {
+                              Enterprise.where('1=0').select(:id)
+                            }
+      allow(permissions).to receive(:admin?) { false }
+    end
+
+    it "returns managed enterprises" do
+      expect(permissions).to receive(:managed_enterprises) { Enterprise.where(id: e1) }
+      expect(permissions.__send__(:managed_and_related_enterprises_granting,
+                                  permission)).to eq([e1])
+    end
+
+    it "returns permitted enterprises" do
+      expect(permissions).to receive(:related_enterprises_granting).with(permission).
+        and_return(Enterprise.where(id: e2).select(:id))
+      expect(permissions.__send__(:managed_and_related_enterprises_granting,
+                                  permission)).to eq([e2])
+    end
+  end
+
+  describe "finding visible subscriptions" do
+    let!(:so1) { create(:subscription) }
+    let!(:so2) { create(:subscription) }
+
+    it "returns subscriptions placed with managed shops" do
+      expect(permissions).to receive(:managed_enterprises) { [so1.shop] }
+
+      expect(permissions.visible_subscriptions).to eq [so1]
     end
   end
 end

--- a/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
+++ b/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
@@ -3,235 +3,233 @@
 require 'spec_helper'
 require 'open_food_network/scope_variant_to_hub'
 
-module OpenFoodNetwork
-  RSpec.describe ScopeVariantToHub do
-    let(:hub) { create(:distributor_enterprise) }
-    let(:v)   { create(:variant, price: 11.11, on_hand: 1, on_demand: true, sku: "VARIANTSKU") }
-    let(:v2)  { create(:variant, price: 22.22, on_hand: 5) }
-    let(:v3)  { create(:variant, price: 33.33, on_hand: 6) }
-    let(:vo)  {
-      create(:variant_override, hub:, variant: v, price: 22.22, count_on_hand: 2,
-                                on_demand: false, sku: "VOSKU")
-    }
-    let(:vo2) {
-      create(:variant_override, hub:, variant: v2, price: 33.33, count_on_hand: nil,
-                                on_demand: true)
-    }
-    let(:vo3) { create(:variant_override, hub:, variant: v3, price: 44.44, count_on_hand: 16) }
-    let(:vo_price_only) {
-      create(:variant_override, :use_producer_stock_settings, hub:, variant: v, price: 22.22)
-    }
-    let(:scoper) { ScopeVariantToHub.new(hub) }
+RSpec.describe OpenFoodNetwork::ScopeVariantToHub do
+  let(:hub) { create(:distributor_enterprise) }
+  let(:v)   { create(:variant, price: 11.11, on_hand: 1, on_demand: true, sku: "VARIANTSKU") }
+  let(:v2)  { create(:variant, price: 22.22, on_hand: 5) }
+  let(:v3)  { create(:variant, price: 33.33, on_hand: 6) }
+  let(:vo)  {
+    create(:variant_override, hub:, variant: v, price: 22.22, count_on_hand: 2,
+                              on_demand: false, sku: "VOSKU")
+  }
+  let(:vo2) {
+    create(:variant_override, hub:, variant: v2, price: 33.33, count_on_hand: nil,
+                              on_demand: true)
+  }
+  let(:vo3) { create(:variant_override, hub:, variant: v3, price: 44.44, count_on_hand: 16) }
+  let(:vo_price_only) {
+    create(:variant_override, :use_producer_stock_settings, hub:, variant: v, price: 22.22)
+  }
+  let(:scoper) { described_class.new(hub) }
 
-    describe "overriding price" do
-      it "returns the overridden price when one is present" do
+  describe "overriding price" do
+    it "returns the overridden price when one is present" do
+      vo
+      scoper.scope v
+      expect(v.price).to eq(22.22)
+    end
+
+    it "returns the variant's price otherwise" do
+      scoper.scope v
+      expect(v.price).to eq(11.11)
+    end
+  end
+
+  describe "overriding price_in" do
+    it "returns the overridden price when one is present" do
+      vo
+      scoper.scope v
+      expect(v.price_in('AUD').amount).to eq(22.22)
+    end
+
+    it "returns the variant's price otherwise" do
+      scoper.scope v
+      expect(v.price_in('AUD').amount).to eq(11.11)
+    end
+  end
+
+  describe "overriding stock levels" do
+    it "returns the overridden stock level when one is present" do
+      vo
+      scoper.scope v
+      expect(v.on_hand).to eq(2)
+    end
+
+    it "returns the variant's stock level otherwise" do
+      scoper.scope v
+      expect(v.on_hand).to eq(1)
+    end
+
+    describe "overriding stock on an on_demand variant" do
+      let(:v) { create(:variant, price: 11.11, on_demand: true) }
+
+      it "clears on_demand when the stock is overridden" do
         vo
         scoper.scope v
-        expect(v.price).to eq(22.22)
+        expect(v.on_demand).to be false
       end
 
-      it "returns the variant's price otherwise" do
+      it "does not clear on_demand when only the price is overridden" do
+        vo_price_only
         scoper.scope v
-        expect(v.price).to eq(11.11)
+        expect(v.on_demand).to be true
+      end
+
+      it "does not clear on_demand when there is no override" do
+        scoper.scope v
+        expect(v.on_demand).to be true
       end
     end
 
-    describe "overriding price_in" do
-      it "returns the overridden price when one is present" do
-        vo
-        scoper.scope v
-        expect(v.price_in('AUD').amount).to eq(22.22)
-      end
+    describe "overriding on_demand" do
+      context "when an override exists" do
+        before { vo }
 
-      it "returns the variant's price otherwise" do
-        scoper.scope v
-        expect(v.price_in('AUD').amount).to eq(11.11)
-      end
-    end
-
-    describe "overriding stock levels" do
-      it "returns the overridden stock level when one is present" do
-        vo
-        scoper.scope v
-        expect(v.on_hand).to eq(2)
-      end
-
-      it "returns the variant's stock level otherwise" do
-        scoper.scope v
-        expect(v.on_hand).to eq(1)
-      end
-
-      describe "overriding stock on an on_demand variant" do
-        let(:v) { create(:variant, price: 11.11, on_demand: true) }
-
-        it "clears on_demand when the stock is overridden" do
-          vo
-          scoper.scope v
-          expect(v.on_demand).to be false
-        end
-
-        it "does not clear on_demand when only the price is overridden" do
-          vo_price_only
-          scoper.scope v
-          expect(v.on_demand).to be true
-        end
-
-        it "does not clear on_demand when there is no override" do
-          scoper.scope v
-          expect(v.on_demand).to be true
-        end
-      end
-
-      describe "overriding on_demand" do
-        context "when an override exists" do
-          before { vo }
-
-          context "with an on_demand set" do
-            it "returns the overridden on_demand" do
-              scoper.scope v
-              expect(v.on_demand).to be false
-            end
-          end
-
-          context "without an on_demand set" do
-            before { vo.update_column(:on_demand, nil) }
-
-            context "when count_on_hand is not set" do
-              before { vo.update_column(:count_on_hand, nil) }
-
-              it "returns the variant's on_demand" do
-                scoper.scope v
-                expect(v.on_demand).to be true
-              end
-            end
-
-            context "when count_on_hand is set" do
-              it "should return validation error on save" do
-                scoper.scope v
-                expect{ vo.save! }.to raise_error ActiveRecord::RecordInvalid
-              end
-            end
-          end
-        end
-
-        context "when no override exists" do
-          it "returns the variant's on_demand" do
+        context "with an on_demand set" do
+          it "returns the overridden on_demand" do
             scoper.scope v
-            expect(v.on_demand).to be true
+            expect(v.on_demand).to be false
+          end
+        end
+
+        context "without an on_demand set" do
+          before { vo.update_column(:on_demand, nil) }
+
+          context "when count_on_hand is not set" do
+            before { vo.update_column(:count_on_hand, nil) }
+
+            it "returns the variant's on_demand" do
+              scoper.scope v
+              expect(v.on_demand).to be true
+            end
+          end
+
+          context "when count_on_hand is set" do
+            it "should return validation error on save" do
+              scoper.scope v
+              expect{ vo.save! }.to raise_error ActiveRecord::RecordInvalid
+            end
           end
         end
       end
 
-      # in_stock? is indirectly overridden through can_supply?
-      #   can_supply? is indirectly overridden by on_demand and total_on_hand
-      #   these tests validate this chain is working correctly
-      describe "overriding in_stock?" do
-        before { v.on_demand = false }
-
-        context "when an override exists" do
-          before { vo }
-
-          context "when variant in stock" do
-            it "returns true if VO in stock" do
-              scoper.scope v
-              expect(v.in_stock?).to eq(true)
-            end
-
-            it "returns false if VO out of stock" do
-              vo.update_attribute :count_on_hand, 0
-              scoper.scope v
-              expect(v.in_stock?).to eq(false)
-            end
-          end
-
-          context "when variant out of stock" do
-            before { v.on_hand = 0 }
-
-            it "returns true if VO in stock" do
-              scoper.scope v
-              expect(v.in_stock?).to eq(true)
-            end
-
-            it "returns false if VO out of stock" do
-              vo.update_attribute :count_on_hand, 0
-              scoper.scope v
-              expect(v.in_stock?).to eq(false)
-            end
-          end
+      context "when no override exists" do
+        it "returns the variant's on_demand" do
+          scoper.scope v
+          expect(v.on_demand).to be true
         end
+      end
+    end
 
-        context "when there's no override" do
-          it "returns true if variant in stock" do
+    # in_stock? is indirectly overridden through can_supply?
+    #   can_supply? is indirectly overridden by on_demand and total_on_hand
+    #   these tests validate this chain is working correctly
+    describe "overriding in_stock?" do
+      before { v.on_demand = false }
+
+      context "when an override exists" do
+        before { vo }
+
+        context "when variant in stock" do
+          it "returns true if VO in stock" do
             scoper.scope v
             expect(v.in_stock?).to eq(true)
           end
 
-          it "returns false if variant out of stock" do
-            v.on_hand = 0
+          it "returns false if VO out of stock" do
+            vo.update_attribute :count_on_hand, 0
+            scoper.scope v
+            expect(v.in_stock?).to eq(false)
+          end
+        end
+
+        context "when variant out of stock" do
+          before { v.on_hand = 0 }
+
+          it "returns true if VO in stock" do
+            scoper.scope v
+            expect(v.in_stock?).to eq(true)
+          end
+
+          it "returns false if VO out of stock" do
+            vo.update_attribute :count_on_hand, 0
             scoper.scope v
             expect(v.in_stock?).to eq(false)
           end
         end
       end
 
-      describe "overriding #move" do
-        context "when override is on_demand" do
-          before do
-            vo2
-            scoper.scope v2
-          end
-
-          it "reduces override stock, not variant's stock" do
-            v2.move(-2)
-            expect(Spree::Variant.find(v2.id).on_hand).to eq 5
-            expect(v2.on_hand).to eq(-2)
-          end
+      context "when there's no override" do
+        it "returns true if variant in stock" do
+          scoper.scope v
+          expect(v.in_stock?).to eq(true)
         end
 
-        context "when stock is overridden" do
-          before do
-            vo3
-            scoper.scope v3
-          end
+        it "returns false if variant out of stock" do
+          v.on_hand = 0
+          scoper.scope v
+          expect(v.in_stock?).to eq(false)
+        end
+      end
+    end
 
-          it "reduces the override's stock" do
-            v3.move(-2)
-            expect(vo3.reload.count_on_hand).to eq 14
-          end
+    describe "overriding #move" do
+      context "when override is on_demand" do
+        before do
+          vo2
+          scoper.scope v2
+        end
 
-          it "doesn't reduce the variant's stock" do
-            v3.move(-2)
-            expect(Spree::Variant.find(v3.id).on_hand).to eq 6
-          end
+        it "reduces override stock, not variant's stock" do
+          v2.move(-2)
+          expect(Spree::Variant.find(v2.id).on_hand).to eq 5
+          expect(v2.on_hand).to eq(-2)
         end
       end
 
-      describe "overriding sku" do
-        context "when an override exists" do
-          before { vo }
+      context "when stock is overridden" do
+        before do
+          vo3
+          scoper.scope v3
+        end
 
-          context "with an sku set" do
-            it "returns the overridden sku" do
-              scoper.scope v
-              expect(v.sku).to eq "VOSKU"
-            end
-          end
+        it "reduces the override's stock" do
+          v3.move(-2)
+          expect(vo3.reload.count_on_hand).to eq 14
+        end
 
-          context "without an sku set" do
-            before { vo.update_column(:sku, nil) }
+        it "doesn't reduce the variant's stock" do
+          v3.move(-2)
+          expect(Spree::Variant.find(v3.id).on_hand).to eq 6
+        end
+      end
+    end
 
-            it "returns the variant's sku" do
-              scoper.scope v
-              expect(v.sku).to eq "VARIANTSKU"
-            end
+    describe "overriding sku" do
+      context "when an override exists" do
+        before { vo }
+
+        context "with an sku set" do
+          it "returns the overridden sku" do
+            scoper.scope v
+            expect(v.sku).to eq "VOSKU"
           end
         end
 
-        context "when no override exists" do
+        context "without an sku set" do
+          before { vo.update_column(:sku, nil) }
+
           it "returns the variant's sku" do
             scoper.scope v
             expect(v.sku).to eq "VARIANTSKU"
           end
+        end
+      end
+
+      context "when no override exists" do
+        it "returns the variant's sku" do
+          scoper.scope v
+          expect(v.sku).to eq "VARIANTSKU"
         end
       end
     end

--- a/spec/lib/open_food_network/tag_rule_applicator_spec.rb
+++ b/spec/lib/open_food_network/tag_rule_applicator_spec.rb
@@ -3,296 +3,294 @@
 require 'open_food_network/tag_rule_applicator'
 require 'spec_helper'
 
-module OpenFoodNetwork
-  RSpec.describe TagRuleApplicator do
-    let!(:enterprise) { create(:distributor_enterprise) }
-    let!(:oc_tag_rule) {
-      create(:filter_order_cycles_tag_rule, enterprise:, priority: 6,
-                                            preferred_customer_tags: "tag1",
-                                            preferred_exchange_tags: "tag1",
-                                            preferred_matched_order_cycles_visibility: "visible" )
-    }
-    let!(:product_tag_rule1) {
-      create(:filter_products_tag_rule, enterprise:, priority: 5,
-                                        preferred_customer_tags: "tag1",
-                                        preferred_variant_tags: "tag1",
-                                        preferred_matched_variants_visibility: "visible" )
-    }
-    let!(:product_tag_rule2) {
-      create(:filter_products_tag_rule, enterprise:, priority: 4,
-                                        preferred_customer_tags: "tag1",
-                                        preferred_variant_tags: "tag3",
-                                        preferred_matched_variants_visibility: "hidden" )
-    }
-    let!(:product_tag_rule3) {
-      create(:filter_products_tag_rule, enterprise:, priority: 3,
-                                        preferred_customer_tags: "tag2",
-                                        preferred_variant_tags: "tag1",
-                                        preferred_matched_variants_visibility: "visible" )
-    }
-    let!(:default_product_tag_rule) {
-      create(:filter_products_tag_rule, enterprise:, priority: 2, is_default: true,
-                                        preferred_variant_tags: "tag1",
-                                        preferred_matched_variants_visibility: "hidden" )
-    }
-    let!(:sm_tag_rule) {
-      create(
-        :filter_shipping_methods_tag_rule, enterprise:, priority: 1,
-                                           preferred_customer_tags: "tag1",
-                                           preferred_shipping_method_tags: "tag1",
-                                           preferred_matched_shipping_methods_visibility: "visible"
-      )
-    }
+RSpec.describe OpenFoodNetwork::TagRuleApplicator do
+  let!(:enterprise) { create(:distributor_enterprise) }
+  let!(:oc_tag_rule) {
+    create(:filter_order_cycles_tag_rule, enterprise:, priority: 6,
+                                          preferred_customer_tags: "tag1",
+                                          preferred_exchange_tags: "tag1",
+                                          preferred_matched_order_cycles_visibility: "visible" )
+  }
+  let!(:product_tag_rule1) {
+    create(:filter_products_tag_rule, enterprise:, priority: 5,
+                                      preferred_customer_tags: "tag1",
+                                      preferred_variant_tags: "tag1",
+                                      preferred_matched_variants_visibility: "visible" )
+  }
+  let!(:product_tag_rule2) {
+    create(:filter_products_tag_rule, enterprise:, priority: 4,
+                                      preferred_customer_tags: "tag1",
+                                      preferred_variant_tags: "tag3",
+                                      preferred_matched_variants_visibility: "hidden" )
+  }
+  let!(:product_tag_rule3) {
+    create(:filter_products_tag_rule, enterprise:, priority: 3,
+                                      preferred_customer_tags: "tag2",
+                                      preferred_variant_tags: "tag1",
+                                      preferred_matched_variants_visibility: "visible" )
+  }
+  let!(:default_product_tag_rule) {
+    create(:filter_products_tag_rule, enterprise:, priority: 2, is_default: true,
+                                      preferred_variant_tags: "tag1",
+                                      preferred_matched_variants_visibility: "hidden" )
+  }
+  let!(:sm_tag_rule) {
+    create(
+      :filter_shipping_methods_tag_rule, enterprise:, priority: 1,
+                                         preferred_customer_tags: "tag1",
+                                         preferred_shipping_method_tags: "tag1",
+                                         preferred_matched_shipping_methods_visibility: "visible"
+    )
+  }
 
-    describe "initialisation" do
-      context "when enterprise is nil" do
-        let(:applicator) { OpenFoodNetwork::TagRuleApplicator.new(nil, "FilterProducts", ["tag1"]) }
-        it { expect{ applicator }.to raise_error "Enterprise cannot be nil" }
-      end
-
-      context "when rule_type is nil" do
-        let(:applicator) { OpenFoodNetwork::TagRuleApplicator.new(enterprise, nil, ["tag1"]) }
-        it { expect{ applicator }.to raise_error "Rule Type cannot be nil" }
-      end
-
-      context "when rule_type does not match an existing rule type" do
-        let(:applicator) {
-          OpenFoodNetwork::TagRuleApplicator.new(enterprise, "FilterSomething", ["tag1"])
-        }
-        it { expect{ applicator }.to raise_error NameError }
-      end
-
-      context "when enterprise and rule_type are present" do
-        let(:applicator) {
-          OpenFoodNetwork::TagRuleApplicator.new(enterprise, "FilterProducts", customer_tags)
-        }
-
-        context "when the customer tags are nil" do
-          let!(:customer_tags) { nil }
-
-          it "sets customer tags to an empty array" do
-            expect(applicator.customer_tags).to eq []
-          end
-
-          it "does not match rules without customer tags" do
-            rule = double(:rule, preferred_customer_tags: "")
-            expect(applicator.__send__(:customer_tags_match?, rule)).to be false
-          end
-        end
-
-        context "when customer tags are empty" do
-          let!(:customer_tags) { [] }
-
-          it "sets customer tags to an empty array" do
-            expect(applicator.customer_tags).to eq []
-          end
-
-          it "does not match rules without customer tags" do
-            rule = double(:rule, preferred_customer_tags: "")
-            expect(applicator.__send__(:customer_tags_match?, rule)).to be false
-          end
-        end
-
-        context "when customer_tags are present" do
-          let!(:customer_tags) { ["tag1"] }
-
-          let(:rules) { applicator.__send__(:rules) }
-          let(:customer_rules) { applicator.__send__(:customer_rules) }
-          let(:default_rules) { applicator.__send__(:default_rules) }
-
-          it "stores enterprise, rule_class and customer_tags as instance variables" do
-            expect(applicator.enterprise).to eq enterprise
-            expect(applicator.rule_class).to eq TagRule::FilterProducts
-            expect(applicator.customer_tags).to eq ["tag1"]
-          end
-
-          it "selects only rules of the specified type, in order of priority" do
-            expect(rules).to eq [default_product_tag_rule, product_tag_rule3, product_tag_rule2,
-                                 product_tag_rule1]
-          end
-
-          it "splits rules into those which match customer tags " \
-             "and those which don't, in order of priority" do
-            expect(customer_rules).to eq [product_tag_rule2, product_tag_rule1]
-          end
-
-          it "splits out default rules" do
-            expect(default_rules).to eq [default_product_tag_rule]
-          end
-        end
-      end
+  describe "initialisation" do
+    context "when enterprise is nil" do
+      let(:applicator) { described_class.new(nil, "FilterProducts", ["tag1"]) }
+      it { expect{ applicator }.to raise_error "Enterprise cannot be nil" }
     end
 
-    describe "filter" do
-      let(:applicator) { OpenFoodNetwork::TagRuleApplicator.new(enterprise, "FilterProducts", []) }
-
-      it "handles nil" do
-        applicator.filter(nil)
-      end
-
-      it "handles an empty collection" do
-        applicator.filter(OrderCycle.none)
-      end
-
-      context "when filtering an array" do
-        let(:element) { double(:element, ) }
-        let(:list) { [element] }
-
-        context "when rule_class reponds to tagged_children_for" do
-          let(:child1) { double(:child) }
-          let(:child2) { double(:child) }
-          let(:children) { [child1, child2] }
-          let(:rule_class) { double(:rule_class, tagged_children_for: children) }
-
-          before{ allow(applicator).to receive(:rule_class) { rule_class } }
-
-          context "when reject? returns true only for some children" do
-            before do
-              allow(applicator).to receive(:reject?).with(child1) { true }
-              allow(applicator).to receive(:reject?).with(child2) { false }
-            end
-
-            it "rejects the specified children from the array" do
-              applicator.filter(list)
-              expect(children).to eq [child2]
-            end
-
-            it "does not remove the element from the result" do
-              result = applicator.filter(list)
-              expect(result).to eq [element]
-            end
-          end
-
-          context "when reject? returns true for all children" do
-            before do
-              allow(applicator).to receive(:reject?).with(child1) { true }
-              allow(applicator).to receive(:reject?).with(child2) { true }
-            end
-
-            it "removes all children from the array" do
-              applicator.filter(list)
-              expect(children).to eq []
-            end
-
-            it "removes the element from the result" do
-              result = applicator.filter(list)
-              expect(result).to eq []
-            end
-          end
-        end
-
-        context "when rule_class doesn't respond to tagged_children_for" do
-          let(:rule_class) { double(:rule_class) }
-
-          before{ allow(applicator).to receive(:rule_class) { rule_class } }
-
-          context "when reject? returns false for the element" do
-            before do
-              allow(applicator).to receive(:reject?).with(element) { false }
-            end
-
-            it "does not remove the element from the result" do
-              result = applicator.filter(list)
-              expect(result).to eq [element]
-            end
-          end
-
-          context "when reject? returns true for the element" do
-            before do
-              allow(applicator).to receive(:reject?).with(element) { true }
-            end
-
-            it "removes the element from the result" do
-              result = applicator.filter(list)
-              expect(result).to eq []
-            end
-          end
-        end
-      end
+    context "when rule_type is nil" do
+      let(:applicator) { described_class.new(enterprise, nil, ["tag1"]) }
+      it { expect{ applicator }.to raise_error "Rule Type cannot be nil" }
     end
 
-    describe "reject?" do
+    context "when rule_type does not match an existing rule type" do
       let(:applicator) {
-        OpenFoodNetwork::TagRuleApplicator.new(enterprise, "FilterProducts", ["tag1"])
+        described_class.new(enterprise, "FilterSomething", ["tag1"])
       }
-      let(:customer_rule) {
-        double(:customer_rule, reject_matched?: "customer_rule.reject_matched?" )
+      it { expect{ applicator }.to raise_error NameError }
+    end
+
+    context "when enterprise and rule_type are present" do
+      let(:applicator) {
+        described_class.new(enterprise, "FilterProducts", customer_tags)
       }
-      let(:default_rule) {
-        double(:customer_rule, reject_matched?: "default_rule.reject_matched?" )
-      }
-      let(:dummy) { double(:dummy) }
 
-      before{ allow(applicator).to receive(:customer_rules) { [customer_rule] } }
-      before{ allow(applicator).to receive(:default_rules) { [default_rule] } }
+      context "when the customer tags are nil" do
+        let!(:customer_tags) { nil }
 
-      context "when a customer rule matches the tags of the element" do
-        before{ allow(customer_rule).to receive(:tags_match?).with(dummy) { true } }
+        it "sets customer tags to an empty array" do
+          expect(applicator.customer_tags).to eq []
+        end
 
-        it "returns the value of customer_rule.reject_matched?" do
-          expect(applicator.__send__(:reject?, dummy)).to eq "customer_rule.reject_matched?"
+        it "does not match rules without customer tags" do
+          rule = double(:rule, preferred_customer_tags: "")
+          expect(applicator.__send__(:customer_tags_match?, rule)).to be false
         end
       end
 
-      context "when no customer rules match the tags of the element" do
-        before{ allow(customer_rule).to receive(:tags_match?) { false } }
+      context "when customer tags are empty" do
+        let!(:customer_tags) { [] }
 
-        context "when a default rule matches the tags of the element" do
-          before{ allow(default_rule).to receive(:tags_match?) { true } }
+        it "sets customer tags to an empty array" do
+          expect(applicator.customer_tags).to eq []
+        end
 
-          it "returns the value of the default_rule.reject_matched?" do
-            expect(applicator.__send__(:reject?, dummy)).to eq "default_rule.reject_matched?"
+        it "does not match rules without customer tags" do
+          rule = double(:rule, preferred_customer_tags: "")
+          expect(applicator.__send__(:customer_tags_match?, rule)).to be false
+        end
+      end
+
+      context "when customer_tags are present" do
+        let!(:customer_tags) { ["tag1"] }
+
+        let(:rules) { applicator.__send__(:rules) }
+        let(:customer_rules) { applicator.__send__(:customer_rules) }
+        let(:default_rules) { applicator.__send__(:default_rules) }
+
+        it "stores enterprise, rule_class and customer_tags as instance variables" do
+          expect(applicator.enterprise).to eq enterprise
+          expect(applicator.rule_class).to eq TagRule::FilterProducts
+          expect(applicator.customer_tags).to eq ["tag1"]
+        end
+
+        it "selects only rules of the specified type, in order of priority" do
+          expect(rules).to eq [default_product_tag_rule, product_tag_rule3, product_tag_rule2,
+                               product_tag_rule1]
+        end
+
+        it "splits rules into those which match customer tags " \
+           "and those which don't, in order of priority" do
+          expect(customer_rules).to eq [product_tag_rule2, product_tag_rule1]
+        end
+
+        it "splits out default rules" do
+          expect(default_rules).to eq [default_product_tag_rule]
+        end
+      end
+    end
+  end
+
+  describe "filter" do
+    let(:applicator) { described_class.new(enterprise, "FilterProducts", []) }
+
+    it "handles nil" do
+      applicator.filter(nil)
+    end
+
+    it "handles an empty collection" do
+      applicator.filter(OrderCycle.none)
+    end
+
+    context "when filtering an array" do
+      let(:element) { double(:element, ) }
+      let(:list) { [element] }
+
+      context "when rule_class reponds to tagged_children_for" do
+        let(:child1) { double(:child) }
+        let(:child2) { double(:child) }
+        let(:children) { [child1, child2] }
+        let(:rule_class) { double(:rule_class, tagged_children_for: children) }
+
+        before{ allow(applicator).to receive(:rule_class) { rule_class } }
+
+        context "when reject? returns true only for some children" do
+          before do
+            allow(applicator).to receive(:reject?).with(child1) { true }
+            allow(applicator).to receive(:reject?).with(child2) { false }
+          end
+
+          it "rejects the specified children from the array" do
+            applicator.filter(list)
+            expect(children).to eq [child2]
+          end
+
+          it "does not remove the element from the result" do
+            result = applicator.filter(list)
+            expect(result).to eq [element]
           end
         end
 
-        context "when a default rule matches the tags of the element" do
-          before{ allow(default_rule).to receive(:tags_match?) { false } }
+        context "when reject? returns true for all children" do
+          before do
+            allow(applicator).to receive(:reject?).with(child1) { true }
+            allow(applicator).to receive(:reject?).with(child2) { true }
+          end
 
-          it "returns false" do
-            expect(applicator.__send__(:reject?, dummy)).to be false
+          it "removes all children from the array" do
+            applicator.filter(list)
+            expect(children).to eq []
+          end
+
+          it "removes the element from the result" do
+            result = applicator.filter(list)
+            expect(result).to eq []
+          end
+        end
+      end
+
+      context "when rule_class doesn't respond to tagged_children_for" do
+        let(:rule_class) { double(:rule_class) }
+
+        before{ allow(applicator).to receive(:rule_class) { rule_class } }
+
+        context "when reject? returns false for the element" do
+          before do
+            allow(applicator).to receive(:reject?).with(element) { false }
+          end
+
+          it "does not remove the element from the result" do
+            result = applicator.filter(list)
+            expect(result).to eq [element]
+          end
+        end
+
+        context "when reject? returns true for the element" do
+          before do
+            allow(applicator).to receive(:reject?).with(element) { true }
+          end
+
+          it "removes the element from the result" do
+            result = applicator.filter(list)
+            expect(result).to eq []
           end
         end
       end
     end
+  end
 
-    describe "smoke test for products" do
-      let(:product1) {
-        { :id => 1, :name => 'product 1', "variants" => [{ :id => 4, "tag_list" => ["tag1"] }] }
-      }
-      let(:product2) {
-        { :id => 2, :name => 'product 2',
-          "variants" => [{ :id => 5, "tag_list" => ["tag1"] },
-                         { :id => 9, "tag_list" => ["tag2"] }] }
-      }
-      let(:product3) {
-        { :id => 3, :name => 'product 3', "variants" => [{ :id => 6, "tag_list" => ["tag3"] }] }
-      }
-      let!(:products_array) { [product1, product2, product3] }
+  describe "reject?" do
+    let(:applicator) {
+      described_class.new(enterprise, "FilterProducts", ["tag1"])
+    }
+    let(:customer_rule) {
+      double(:customer_rule, reject_matched?: "customer_rule.reject_matched?" )
+    }
+    let(:default_rule) {
+      double(:customer_rule, reject_matched?: "default_rule.reject_matched?" )
+    }
+    let(:dummy) { double(:dummy) }
 
-      context "when customer tags don't match any rules" do
-        let(:applicator) {
-          OpenFoodNetwork::TagRuleApplicator.new(enterprise, "FilterProducts", ["lalalala"])
-        }
+    before{ allow(applicator).to receive(:customer_rules) { [customer_rule] } }
+    before{ allow(applicator).to receive(:default_rules) { [default_rule] } }
 
-        it "applies the default rule" do
-          result = applicator.filter(products_array)
-          expect(result).to eq [
-            { :id => 2, :name => 'product 2',
-              "variants" => [{ :id => 9, "tag_list" => ["tag2"] }] }, product3
-          ]
+    context "when a customer rule matches the tags of the element" do
+      before{ allow(customer_rule).to receive(:tags_match?).with(dummy) { true } }
+
+      it "returns the value of customer_rule.reject_matched?" do
+        expect(applicator.__send__(:reject?, dummy)).to eq "customer_rule.reject_matched?"
+      end
+    end
+
+    context "when no customer rules match the tags of the element" do
+      before{ allow(customer_rule).to receive(:tags_match?) { false } }
+
+      context "when a default rule matches the tags of the element" do
+        before{ allow(default_rule).to receive(:tags_match?) { true } }
+
+        it "returns the value of the default_rule.reject_matched?" do
+          expect(applicator.__send__(:reject?, dummy)).to eq "default_rule.reject_matched?"
         end
       end
 
-      context "when customer tags match one or more rules" do
-        let(:applicator) {
-          OpenFoodNetwork::TagRuleApplicator.new(enterprise, "FilterProducts", ["tag1"])
-        }
+      context "when a default rule matches the tags of the element" do
+        before{ allow(default_rule).to receive(:tags_match?) { false } }
 
-        it "applies those rules" do
-          # product_tag_rule1 and product_tag_rule2 are being applied
-          result = applicator.filter(products_array)
-          expect(result).to eq [product1, product2]
+        it "returns false" do
+          expect(applicator.__send__(:reject?, dummy)).to be false
         end
+      end
+    end
+  end
+
+  describe "smoke test for products" do
+    let(:product1) {
+      { :id => 1, :name => 'product 1', "variants" => [{ :id => 4, "tag_list" => ["tag1"] }] }
+    }
+    let(:product2) {
+      { :id => 2, :name => 'product 2',
+        "variants" => [{ :id => 5, "tag_list" => ["tag1"] },
+                       { :id => 9, "tag_list" => ["tag2"] }] }
+    }
+    let(:product3) {
+      { :id => 3, :name => 'product 3', "variants" => [{ :id => 6, "tag_list" => ["tag3"] }] }
+    }
+    let!(:products_array) { [product1, product2, product3] }
+
+    context "when customer tags don't match any rules" do
+      let(:applicator) {
+        described_class.new(enterprise, "FilterProducts", ["lalalala"])
+      }
+
+      it "applies the default rule" do
+        result = applicator.filter(products_array)
+        expect(result).to eq [
+          { :id => 2, :name => 'product 2',
+            "variants" => [{ :id => 9, "tag_list" => ["tag2"] }] }, product3
+        ]
+      end
+    end
+
+    context "when customer tags match one or more rules" do
+      let(:applicator) {
+        described_class.new(enterprise, "FilterProducts", ["tag1"])
+      }
+
+      it "applies those rules" do
+        # product_tag_rule1 and product_tag_rule2 are being applied
+        result = applicator.filter(products_array)
+        expect(result).to eq [product1, product2]
       end
     end
   end

--- a/spec/lib/reports/all_products_spec.rb
+++ b/spec/lib/reports/all_products_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Reporting::Reports::ProductsAndInventory::AllProducts do
+  let(:user) { create(:admin_user) }
+  let(:report) do
+    described_class.new user, { fields_to_hide: [] }
+  end
+  let(:variant) { create(:variant, supplier:) }
+  let(:supplier) { create(:supplier_enterprise) }
+
+  it "returns headers" do
+    expect(report.table_headers).to eq([
+                                         "Supplier",
+                                         "Producer Suburb",
+                                         "Product",
+                                         "Product Properties",
+                                         "Taxons",
+                                         "Variant Value",
+                                         "Price",
+                                         "Group Buy Unit Quantity",
+                                         "Amount",
+                                         "SKU",
+                                         "On Demand?",
+                                         "On Hand",
+                                         "Tax Category"
+                                       ])
+  end
+
+  it "renders 'On demand' when the product is available on demand" do
+    variant.on_demand = true
+    variant.on_hand = 15
+    variant.save!
+
+    last_row = report.table_rows.last
+    on_demand_column = last_row[-3]
+    on_hand_column = last_row[-2]
+
+    expect(on_demand_column).to eq("Yes")
+    expect(on_hand_column).to eq("On demand")
+  end
+
+  it "renders the on hand count when the product is not available on demand" do
+    variant.on_demand = false
+    variant.on_hand = 22
+    variant.save!
+
+    last_row = report.table_rows.last
+    on_demand_column = last_row[-3]
+    on_hand_column = last_row[-2]
+
+    expect(on_demand_column).to eq("No")
+    expect(on_hand_column).to eq(22)
+  end
+
+  it "renders tax category if present, otherwise none" do
+    variant.update!(tax_category: create(:tax_category, name: 'Test Category'))
+
+    table_rows = report.table_rows
+    first_row = table_rows.first # row for default variant, as result of product creation
+    last_row = table_rows.last # row for the variant created/updated above
+
+    expect(first_row.last).to eq('none')
+    expect(last_row.last).to eq('Test Category')
+  end
+end

--- a/spec/lib/reports/customers_report_spec.rb
+++ b/spec/lib/reports/customers_report_spec.rb
@@ -2,296 +2,290 @@
 
 require 'spec_helper'
 
-module Reporting
-  module Reports
-    module Customers
-      RSpec.describe Base do
-        context "as a site admin" do
-          let(:user) { create(:admin_user) }
-          subject { Base.new user, {} }
+RSpec.describe Reporting::Reports::Customers::Base do
+  context "as a site admin" do
+    let(:user) { create(:admin_user) }
+    subject { described_class.new user, {} }
 
-          describe "addresses report" do
-            it "returns headers for addresses" do
-              expect(subject.table_headers).to eq(["First Name", "Last Name", "Billing Address",
-                                                   "Email", "Phone", "Hub", "Hub Address",
-                                                   "Shipping Method", "Total Number of Orders",
-                                                   "Total incl. tax ($)",
-                                                   "Last completed order date"])
-            end
+    describe "addresses report" do
+      it "returns headers for addresses" do
+        expect(subject.table_headers).to eq(["First Name", "Last Name", "Billing Address",
+                                             "Email", "Phone", "Hub", "Hub Address",
+                                             "Shipping Method", "Total Number of Orders",
+                                             "Total incl. tax ($)",
+                                             "Last completed order date"])
+      end
 
-            it "builds a table from a list of variants" do
-              a = create(:address)
-              d = create(:distributor_enterprise)
-              o = create(:order, distributor: d, bill_address: a)
-              o.shipments << create(:shipment)
+      it "builds a table from a list of variants" do
+        a = create(:address)
+        d = create(:distributor_enterprise)
+        o = create(:order, distributor: d, bill_address: a)
+        o.shipments << create(:shipment)
 
-              allow(subject).to receive(:query_result).and_return [[o]]
-              expect(subject.table_rows).to eq([[
-                                                 a.firstname, a.lastname,
-                                                 [a.address1, a.address2, a.city].join(" "),
-                                                 o.email, a.phone, d.name,
-                                                 [d.address.address1, d.address.address2,
-                                                  d.address.city].join(" "),
-                                                 o.shipping_method.name, 1, o.total, "none"
-                                               ]])
-            end
+        allow(subject).to receive(:query_result).and_return [[o]]
+        expect(subject.table_rows).to eq([[
+                                           a.firstname, a.lastname,
+                                           [a.address1, a.address2, a.city].join(" "),
+                                           o.email, a.phone, d.name,
+                                           [d.address.address1, d.address.address2,
+                                            d.address.city].join(" "),
+                                           o.shipping_method.name, 1, o.total, "none"
+                                         ]])
+      end
 
-            context "when there are multiple orders for the same customer" do
-              let!(:a) { create(:bill_address) }
-              let!(:d){ create(:distributor_enterprise) }
-              let!(:sm) { create(:shipping_method, distributors: [d]) }
-              let!(:customer) { create(:customer) }
-              let!(:o1) {
-                create(:order_with_totals_and_distribution, :completed, distributor: d,
-                                                                        bill_address: a,
-                                                                        shipping_method: sm,
-                                                                        customer:)
-              }
-              let!(:o2) {
-                create(:order_with_totals_and_distribution, :completed, distributor: d,
-                                                                        bill_address: a,
-                                                                        shipping_method: sm,
-                                                                        customer:)
-              }
-              before do
-                o1.update(completed_at: "2023-01-01")
-                o2.update(completed_at: "2023-01-02")
-                [o1, o2].each do |order|
-                  order.update!(email: "test@test.com")
-                end
-              end
-
-              it "returns only one row per customer with the right data" do
-                expect(subject.query_result).to match_array [[o1, o2]]
-                expect(subject.table_rows.size).to eq(1)
-                expect(subject.table_rows)
-                  .to eq([[
-                           a.firstname, a.lastname,
-                           [a.address1, a.address2, a.city].join(" "),
-                           o1.email, a.phone, d.name,
-                           [d.address.address1, d.address.address2, d.address.city].join(" "),
-                           o1.shipping_method.name, 2, o1.total + o2.total, "2023-01-02"
-                         ]])
-              end
-
-              context "orders from different hubs" do
-                let!(:d2) { create(:distributor_enterprise) }
-                let!(:sm2) { create(:shipping_method, distributors: [d2]) }
-                let!(:o2) {
-                  create(:order_with_totals_and_distribution, :completed, distributor: d2,
-                                                                          bill_address: a,
-                                                                          shipping_method: sm2)
-                }
-
-                it "returns one row per customer per hub" do
-                  expect(subject.query_result.size).to eq(2)
-                  expect(subject.table_rows.size).to eq(2)
-                  expect(subject.table_rows)
-                    .to eq([[
-                             a.firstname, a.lastname,
-                             [a.address1, a.address2, a.city].join(" "),
-                             o1.email, a.phone, d.name,
-                             [d.address.address1, d.address.address2, d.address.city].join(" "),
-                             o1.shipping_method.name, 1, o1.total, "2023-01-01"
-                           ], [
-                             a.firstname, a.lastname,
-                             [a.address1, a.address2, a.city].join(" "),
-                             o2.email, a.phone, d2.name,
-                             [d2.address.address1, d2.address.address2, d2.address.city].join(" "),
-                             o2.shipping_method.name, 1, o2.total, "2023-01-02"
-                           ]])
-                end
-              end
-
-              context "orders with different shipping methods" do
-                let!(:sm2) { create(:shipping_method, distributors: [d], name: "Bike") }
-                let!(:o2) {
-                  create(:order_with_totals_and_distribution, :completed, distributor: d,
-                                                                          bill_address: a,
-                                                                          shipping_method: sm2)
-                }
-                before do
-                  o2.select_shipping_method(sm2.id)
-                end
-
-                context "when the shipping method column is being included" do
-                  let(:fields_to_show) do
-                    [:first_name, :last_name, :billing_address, :email, :phone, :hub, :hub_address,
-                     :shipping_method, :total_orders, :total_incl_tax, :last_completed_order_date]
-                  end
-                  subject { Base.new(user, { fields_to_show: }) }
-
-                  it "returns one row per customer per shipping method" do
-                    expect(subject.query_result.size).to eq(2)
-                    expect(subject.table_rows.size).to eq(2)
-                    expect(subject.table_rows).to eq(
-                      [
-                        [
-                          a.firstname,
-                          a.lastname,
-                          [a.address1, a.address2, a.city].join(" "),
-                          o1.email,
-                          a.phone,
-                          d.name,
-                          [d.address.address1, d.address.address2, d.address.city].join(" "),
-                          o1.shipping_method.name, 1, o1.total, o1.completed_at.strftime("%Y-%m-%d")
-                        ],
-                        [
-                          a.firstname,
-                          a.lastname,
-                          [a.address1, a.address2, a.city].join(" "),
-                          o2.email,
-                          a.phone,
-                          d.name,
-                          [d.address.address1, d.address.address2, d.address.city].join(" "),
-                          sm2.name, 1, o2.total, o2.completed_at.strftime("%Y-%m-%d")
-                        ]
-                      ]
-                    )
-                  end
-                end
-
-                context "when the shipping method column is not included in the report" do
-                  let(:fields_to_show) do
-                    [:first_name, :last_name, :billing_address, :email, :phone, :hub, :hub_address]
-                  end
-                  subject { Base.new(user, { fields_to_show: }) }
-
-                  it "returns a single row for the customer, otherwise it would return two identical
-                      rows" do
-                    expect(subject.query_result.size).to eq(2)
-                    expect(subject.table_rows.size).to eq(1)
-                    expect(subject.table_rows).to eq(
-                      [[
-                        a.firstname,
-                        a.lastname,
-                        [a.address1, a.address2, a.city].join(" "),
-                        o1.email,
-                        a.phone,
-                        d.name,
-                        [d.address.address1, d.address.address2, d.address.city].join(" ")
-                      ]]
-                    )
-                  end
-                end
-              end
-            end
-          end
-
-          describe "fetching orders" do
-            it "fetches completed orders" do
-              o1 = create(:order)
-              o2 = create(:order, completed_at: 1.day.ago)
-              expect(subject.query_result).to eq([[o2]])
-            end
-
-            it "does not show cancelled orders" do
-              o1 = create(:order, state: "canceled", completed_at: 1.day.ago)
-              o2 = create(:order, completed_at: 1.day.ago)
-              expect(subject.query_result).to eq([[o2]])
-            end
+      context "when there are multiple orders for the same customer" do
+        let!(:a) { create(:bill_address) }
+        let!(:d){ create(:distributor_enterprise) }
+        let!(:sm) { create(:shipping_method, distributors: [d]) }
+        let!(:customer) { create(:customer) }
+        let!(:o1) {
+          create(:order_with_totals_and_distribution, :completed, distributor: d,
+                                                                  bill_address: a,
+                                                                  shipping_method: sm,
+                                                                  customer:)
+        }
+        let!(:o2) {
+          create(:order_with_totals_and_distribution, :completed, distributor: d,
+                                                                  bill_address: a,
+                                                                  shipping_method: sm,
+                                                                  customer:)
+        }
+        before do
+          o1.update(completed_at: "2023-01-01")
+          o2.update(completed_at: "2023-01-02")
+          [o1, o2].each do |order|
+            order.update!(email: "test@test.com")
           end
         end
 
-        context "as an enterprise user" do
-          let(:user) { create(:user) }
+        it "returns only one row per customer with the right data" do
+          expect(subject.query_result).to match_array [[o1, o2]]
+          expect(subject.table_rows.size).to eq(1)
+          expect(subject.table_rows)
+            .to eq([[
+                     a.firstname, a.lastname,
+                     [a.address1, a.address2, a.city].join(" "),
+                     o1.email, a.phone, d.name,
+                     [d.address.address1, d.address.address2, d.address.city].join(" "),
+                     o1.shipping_method.name, 2, o1.total + o2.total, "2023-01-02"
+                   ]])
+        end
 
-          subject { Base.new user, {} }
+        context "orders from different hubs" do
+          let!(:d2) { create(:distributor_enterprise) }
+          let!(:sm2) { create(:shipping_method, distributors: [d2]) }
+          let!(:o2) {
+            create(:order_with_totals_and_distribution, :completed, distributor: d2,
+                                                                    bill_address: a,
+                                                                    shipping_method: sm2)
+          }
 
-          describe "fetching orders" do
-            let(:supplier) { create(:supplier_enterprise) }
-            let(:product) { create(:simple_product, supplier_id: supplier.id) }
-            let(:order) { create(:order, completed_at: 1.day.ago) }
+          it "returns one row per customer per hub" do
+            expect(subject.query_result.size).to eq(2)
+            expect(subject.table_rows.size).to eq(2)
+            expect(subject.table_rows)
+              .to eq([[
+                       a.firstname, a.lastname,
+                       [a.address1, a.address2, a.city].join(" "),
+                       o1.email, a.phone, d.name,
+                       [d.address.address1, d.address.address2, d.address.city].join(" "),
+                       o1.shipping_method.name, 1, o1.total, "2023-01-01"
+                     ], [
+                       a.firstname, a.lastname,
+                       [a.address1, a.address2, a.city].join(" "),
+                       o2.email, a.phone, d2.name,
+                       [d2.address.address1, d2.address.address2, d2.address.city].join(" "),
+                       o2.shipping_method.name, 1, o2.total, "2023-01-02"
+                     ]])
+          end
+        end
 
-            it "only shows orders managed by the current user" do
-              d1 = create(:distributor_enterprise)
-              d1.enterprise_roles.build(user:).save
-              d2 = create(:distributor_enterprise)
-              d2.enterprise_roles.build(user: create(:user)).save
+        context "orders with different shipping methods" do
+          let!(:sm2) { create(:shipping_method, distributors: [d], name: "Bike") }
+          let!(:o2) {
+            create(:order_with_totals_and_distribution, :completed, distributor: d,
+                                                                    bill_address: a,
+                                                                    shipping_method: sm2)
+          }
+          before do
+            o2.select_shipping_method(sm2.id)
+          end
 
-              o1 = create(:order, distributor: d1, completed_at: 1.day.ago)
-              o2 = create(:order, distributor: d2, completed_at: 1.day.ago)
-
-              expect(subject).to receive(:filter).with([o1]).and_return([o1])
-              expect(subject.query_result).to eq([[o1]])
+          context "when the shipping method column is being included" do
+            let(:fields_to_show) do
+              [:first_name, :last_name, :billing_address, :email, :phone, :hub, :hub_address,
+               :shipping_method, :total_orders, :total_incl_tax, :last_completed_order_date]
             end
+            subject { described_class.new(user, { fields_to_show: }) }
 
-            it "does not show orders through a hub that the current user does not manage" do
-              # Given a supplier enterprise with an order for one of its products
-              supplier.enterprise_roles.build(user:).save
-              order.line_items << create(:line_item_with_shipment, product:)
-
-              # When I fetch orders, I should see no orders
-              expect(subject).to receive(:filter).with([]).and_return([])
-              expect(subject.query_result).to eq([])
+            it "returns one row per customer per shipping method" do
+              expect(subject.query_result.size).to eq(2)
+              expect(subject.table_rows.size).to eq(2)
+              expect(subject.table_rows).to eq(
+                [
+                  [
+                    a.firstname,
+                    a.lastname,
+                    [a.address1, a.address2, a.city].join(" "),
+                    o1.email,
+                    a.phone,
+                    d.name,
+                    [d.address.address1, d.address.address2, d.address.city].join(" "),
+                    o1.shipping_method.name, 1, o1.total, o1.completed_at.strftime("%Y-%m-%d")
+                  ],
+                  [
+                    a.firstname,
+                    a.lastname,
+                    [a.address1, a.address2, a.city].join(" "),
+                    o2.email,
+                    a.phone,
+                    d.name,
+                    [d.address.address1, d.address.address2, d.address.city].join(" "),
+                    sm2.name, 1, o2.total, o2.completed_at.strftime("%Y-%m-%d")
+                  ]
+                ]
+              )
             end
           end
 
-          describe "filtering orders" do
-            let(:orders) { Spree::Order.where(nil) }
-            let(:supplier) { create(:supplier_enterprise) }
-
-            it "returns all orders sans-params" do
-              expect(subject.filter(orders)).to eq(orders)
+          context "when the shipping method column is not included in the report" do
+            let(:fields_to_show) do
+              [:first_name, :last_name, :billing_address, :email, :phone, :hub, :hub_address]
             end
+            subject { described_class.new(user, { fields_to_show: }) }
 
-            describe "filters to a specific completed_at date range" do
-              let!(:o1) { create(:order, completed_at: 1.day.ago) }
-              let!(:o2) { create(:order, completed_at: 3.days.ago) }
-              let!(:o3) { create(:order, completed_at: 5.days.ago) }
-
-              it do
-                allow(subject).to receive(:params).and_return(
-                  q: {
-                    completed_at_gt: 1.day.before(o2.completed_at),
-                    completed_at_lt: 1.day.after(o2.completed_at)
-                  }
-                )
-                expect(subject.filter(orders)).to eq([o2])
-              end
-
-              it "when completed_at_gt param is missing" do
-                allow(subject).to receive(:params).and_return(
-                  q: {
-                    completed_at_gt: "",
-                    completed_at_lt: 1.day.after(o2.completed_at)
-                  }
-                )
-                expect(subject.filter(orders)).to match_array [o2, o3]
-              end
-
-              it "when completed_at_lt param is missing" do
-                allow(subject).to receive(:params).and_return(
-                  q: {
-                    completed_at_gt: 1.day.before(o2.completed_at),
-                    completed_at_lt: ""
-                  }
-                )
-                expect(subject.filter(orders)).to match_array [o1, o2]
-              end
-            end
-
-            it "filters to a specific distributor" do
-              d1 = create(:distributor_enterprise)
-              d2 = create(:distributor_enterprise)
-              order1 = create(:order, distributor: d1)
-              order2 = create(:order, distributor: d2)
-
-              allow(subject).to receive(:params).and_return(distributor_id: d1.id)
-              expect(subject.filter(orders)).to eq([order1])
-            end
-
-            it "filters to a specific cycle" do
-              oc1 = create(:simple_order_cycle)
-              oc2 = create(:simple_order_cycle)
-              order1 = create(:order, order_cycle: oc1)
-              order2 = create(:order, order_cycle: oc2)
-
-              allow(subject).to receive(:params).and_return(order_cycle_id: oc1.id)
-              expect(subject.filter(orders)).to eq([order1])
+            it "returns a single row for the customer, otherwise it would return two identical
+                rows" do
+              expect(subject.query_result.size).to eq(2)
+              expect(subject.table_rows.size).to eq(1)
+              expect(subject.table_rows).to eq(
+                [[
+                  a.firstname,
+                  a.lastname,
+                  [a.address1, a.address2, a.city].join(" "),
+                  o1.email,
+                  a.phone,
+                  d.name,
+                  [d.address.address1, d.address.address2, d.address.city].join(" ")
+                ]]
+              )
             end
           end
         end
+      end
+    end
+
+    describe "fetching orders" do
+      it "fetches completed orders" do
+        o1 = create(:order)
+        o2 = create(:order, completed_at: 1.day.ago)
+        expect(subject.query_result).to eq([[o2]])
+      end
+
+      it "does not show cancelled orders" do
+        o1 = create(:order, state: "canceled", completed_at: 1.day.ago)
+        o2 = create(:order, completed_at: 1.day.ago)
+        expect(subject.query_result).to eq([[o2]])
+      end
+    end
+  end
+
+  context "as an enterprise user" do
+    let(:user) { create(:user) }
+
+    subject { described_class.new user, {} }
+
+    describe "fetching orders" do
+      let(:supplier) { create(:supplier_enterprise) }
+      let(:product) { create(:simple_product, supplier_id: supplier.id) }
+      let(:order) { create(:order, completed_at: 1.day.ago) }
+
+      it "only shows orders managed by the current user" do
+        d1 = create(:distributor_enterprise)
+        d1.enterprise_roles.build(user:).save
+        d2 = create(:distributor_enterprise)
+        d2.enterprise_roles.build(user: create(:user)).save
+
+        o1 = create(:order, distributor: d1, completed_at: 1.day.ago)
+        o2 = create(:order, distributor: d2, completed_at: 1.day.ago)
+
+        expect(subject).to receive(:filter).with([o1]).and_return([o1])
+        expect(subject.query_result).to eq([[o1]])
+      end
+
+      it "does not show orders through a hub that the current user does not manage" do
+        # Given a supplier enterprise with an order for one of its products
+        supplier.enterprise_roles.build(user:).save
+        order.line_items << create(:line_item_with_shipment, product:)
+
+        # When I fetch orders, I should see no orders
+        expect(subject).to receive(:filter).with([]).and_return([])
+        expect(subject.query_result).to eq([])
+      end
+    end
+
+    describe "filtering orders" do
+      let(:orders) { Spree::Order.where(nil) }
+      let(:supplier) { create(:supplier_enterprise) }
+
+      it "returns all orders sans-params" do
+        expect(subject.filter(orders)).to eq(orders)
+      end
+
+      describe "filters to a specific completed_at date range" do
+        let!(:o1) { create(:order, completed_at: 1.day.ago) }
+        let!(:o2) { create(:order, completed_at: 3.days.ago) }
+        let!(:o3) { create(:order, completed_at: 5.days.ago) }
+
+        it do
+          allow(subject).to receive(:params).and_return(
+            q: {
+              completed_at_gt: 1.day.before(o2.completed_at),
+              completed_at_lt: 1.day.after(o2.completed_at)
+            }
+          )
+          expect(subject.filter(orders)).to eq([o2])
+        end
+
+        it "when completed_at_gt param is missing" do
+          allow(subject).to receive(:params).and_return(
+            q: {
+              completed_at_gt: "",
+              completed_at_lt: 1.day.after(o2.completed_at)
+            }
+          )
+          expect(subject.filter(orders)).to match_array [o2, o3]
+        end
+
+        it "when completed_at_lt param is missing" do
+          allow(subject).to receive(:params).and_return(
+            q: {
+              completed_at_gt: 1.day.before(o2.completed_at),
+              completed_at_lt: ""
+            }
+          )
+          expect(subject.filter(orders)).to match_array [o1, o2]
+        end
+      end
+
+      it "filters to a specific distributor" do
+        d1 = create(:distributor_enterprise)
+        d2 = create(:distributor_enterprise)
+        order1 = create(:order, distributor: d1)
+        order2 = create(:order, distributor: d2)
+
+        allow(subject).to receive(:params).and_return(distributor_id: d1.id)
+        expect(subject.filter(orders)).to eq([order1])
+      end
+
+      it "filters to a specific cycle" do
+        oc1 = create(:simple_order_cycle)
+        oc2 = create(:simple_order_cycle)
+        order1 = create(:order, order_cycle: oc1)
+        order2 = create(:order, order_cycle: oc2)
+
+        allow(subject).to receive(:params).and_return(order_cycle_id: oc1.id)
+        expect(subject.filter(orders)).to eq([order1])
       end
     end
   end

--- a/spec/lib/reports/enterprise_fee_summary/authorizer_spec.rb
+++ b/spec/lib/reports/enterprise_fee_summary/authorizer_spec.rb
@@ -2,178 +2,175 @@
 
 require "spec_helper"
 
-module Reporting
-  module Reports
-    module EnterpriseFeeSummary
-      RSpec.describe Authorizer do
-        let(:user) { create(:user) }
+RSpec.describe Reporting::Reports::EnterpriseFeeSummary::Authorizer do
+  let(:user) { create(:user) }
 
-        let(:parameters) { Parameters.new(params) }
-        let(:permissions) { Permissions.new(user) }
-        let(:authorizer) { Authorizer.new(parameters, permissions) }
+  let(:parameters) { Reporting::Reports::EnterpriseFeeSummary::Parameters.new(params) }
+  let(:permissions) { Reporting::Reports::EnterpriseFeeSummary::Permissions.new(user) }
+  let(:authorizer) { described_class.new(parameters, permissions) }
+  let!(:parameter_not_allowed_error) do
+    Reporting::Reports::EnterpriseFeeSummary::ParameterNotAllowedError
+  end
 
-        context "for distributors" do
-          before do
-            allow(permissions).to receive(:allowed_distributors) do
-              stub_model_collection(Enterprise, :id, ["1", "2", "3"])
-            end
-          end
-
-          context "when distributors are allowed" do
-            let(:params) { { distributor_ids: ["1", "3"] } }
-
-            it "does not raise error" do
-              expect { authorizer.authorize! }.not_to raise_error
-            end
-          end
-
-          context "when a distributor is not allowed" do
-            let(:params) { { distributor_ids: ["1", "4"] } }
-
-            it "raises ParameterNotAllowedError" do
-              expect { authorizer.authorize! }
-                .to raise_error(ParameterNotAllowedError)
-            end
-          end
-        end
-
-        context "for producers" do
-          before do
-            allow(permissions).to receive(:allowed_producers) do
-              stub_model_collection(Enterprise, :id, ["1", "2", "3"])
-            end
-          end
-
-          context "when producers are allowed" do
-            let(:params) { { producer_ids: ["1", "3"] } }
-
-            it "does not raise error" do
-              expect { authorizer.authorize! }.not_to raise_error
-            end
-          end
-
-          context "when a producer is not allowed" do
-            let(:params) { { producer_ids: ["1", "4"] } }
-
-            it "raises ParameterNotAllowedError" do
-              expect { authorizer.authorize! }
-                .to raise_error(ParameterNotAllowedError)
-            end
-          end
-        end
-
-        context "for order cycles" do
-          before do
-            allow(permissions).to receive(:allowed_order_cycles) do
-              stub_model_collection(OrderCycle, :id, ["1", "2", "3"])
-            end
-          end
-
-          context "when order cycles are allowed" do
-            let(:params) { { order_cycle_ids: ["1", "3"] } }
-
-            it "does not raise error" do
-              expect { authorizer.authorize! }.not_to raise_error
-            end
-          end
-
-          context "when an order cycle is not allowed" do
-            let(:params) { { order_cycle_ids: ["1", "4"] } }
-
-            it "raises ParameterNotAllowedError" do
-              expect { authorizer.authorize! }
-                .to raise_error(ParameterNotAllowedError)
-            end
-          end
-        end
-
-        context "for enterprise fees" do
-          before do
-            allow(permissions).to receive(:allowed_enterprise_fees) do
-              stub_model_collection(EnterpriseFee, :id, ["1", "2", "3"])
-            end
-          end
-
-          context "when enterprise fees are allowed" do
-            let(:params) { { enterprise_fee_ids: ["1", "3"] } }
-
-            it "does not raise error" do
-              expect { authorizer.authorize! }.not_to raise_error
-            end
-          end
-
-          context "when an enterprise fee is not allowed" do
-            let(:params) { { enterprise_fee_ids: ["1", "4"] } }
-
-            it "raises ParameterNotAllowedError" do
-              expect { authorizer.authorize! }
-                .to raise_error(ParameterNotAllowedError)
-            end
-          end
-        end
-
-        context "for shipping methods" do
-          before do
-            allow(permissions).to receive(:allowed_shipping_methods) do
-              stub_model_collection(Spree::ShippingMethod, :id, ["1", "2", "3"])
-            end
-          end
-
-          context "when shipping methods are allowed" do
-            let(:params) { { shipping_method_ids: ["1", "3"] } }
-
-            it "does not raise error" do
-              expect { authorizer.authorize! }.not_to raise_error
-            end
-          end
-
-          context "when a shipping method is not allowed" do
-            let(:params) { { shipping_method_ids: ["1", "4"] } }
-
-            it "raises ParameterNotAllowedError" do
-              expect { authorizer.authorize! }
-                .to raise_error(ParameterNotAllowedError)
-            end
-          end
-        end
-
-        context "for payment methods" do
-          before do
-            allow(permissions).to receive(:allowed_payment_methods) do
-              stub_model_collection(Spree::PaymentMethod, :id, ["1", "2", "3"])
-            end
-          end
-
-          context "when payment methods are allowed" do
-            let(:params) { { payment_method_ids: ["1", "3"] } }
-
-            it "does not raise error" do
-              expect { authorizer.authorize! }.not_to raise_error
-            end
-          end
-
-          context "when a payment method is not allowed" do
-            let(:params) { { payment_method_ids: ["1", "4"] } }
-
-            it "raises ParameterNotAllowedError" do
-              expect { authorizer.authorize! }
-                .to raise_error(ParameterNotAllowedError)
-            end
-          end
-        end
-
-        def stub_model_collection(model, attribute_name, attribute_list)
-          attribute_list.map do |attribute_value|
-            stub_model(model, attribute_name => attribute_value)
-          end
-        end
-
-        def stub_model(model, params)
-          model.new.tap do |instance|
-            allow(instance).to receive_messages(params)
-          end
-        end
+  context "for distributors" do
+    before do
+      allow(permissions).to receive(:allowed_distributors) do
+        stub_model_collection(Enterprise, :id, ["1", "2", "3"])
       end
+    end
+
+    context "when distributors are allowed" do
+      let(:params) { { distributor_ids: ["1", "3"] } }
+
+      it "does not raise error" do
+        expect { authorizer.authorize! }.not_to raise_error
+      end
+    end
+
+    context "when a distributor is not allowed" do
+      let(:params) { { distributor_ids: ["1", "4"] } }
+
+      it "raises ParameterNotAllowedError" do
+        expect { authorizer.authorize! }
+          .to raise_error(parameter_not_allowed_error)
+      end
+    end
+  end
+
+  context "for producers" do
+    before do
+      allow(permissions).to receive(:allowed_producers) do
+        stub_model_collection(Enterprise, :id, ["1", "2", "3"])
+      end
+    end
+
+    context "when producers are allowed" do
+      let(:params) { { producer_ids: ["1", "3"] } }
+
+      it "does not raise error" do
+        expect { authorizer.authorize! }.not_to raise_error
+      end
+    end
+
+    context "when a producer is not allowed" do
+      let(:params) { { producer_ids: ["1", "4"] } }
+
+      it "raises parameter_not_allowed_error" do
+        expect { authorizer.authorize! }
+          .to raise_error(parameter_not_allowed_error)
+      end
+    end
+  end
+
+  context "for order cycles" do
+    before do
+      allow(permissions).to receive(:allowed_order_cycles) do
+        stub_model_collection(OrderCycle, :id, ["1", "2", "3"])
+      end
+    end
+
+    context "when order cycles are allowed" do
+      let(:params) { { order_cycle_ids: ["1", "3"] } }
+
+      it "does not raise error" do
+        expect { authorizer.authorize! }.not_to raise_error
+      end
+    end
+
+    context "when an order cycle is not allowed" do
+      let(:params) { { order_cycle_ids: ["1", "4"] } }
+
+      it "raises parameter_not_allowed_error" do
+        expect { authorizer.authorize! }
+          .to raise_error(parameter_not_allowed_error)
+      end
+    end
+  end
+
+  context "for enterprise fees" do
+    before do
+      allow(permissions).to receive(:allowed_enterprise_fees) do
+        stub_model_collection(EnterpriseFee, :id, ["1", "2", "3"])
+      end
+    end
+
+    context "when enterprise fees are allowed" do
+      let(:params) { { enterprise_fee_ids: ["1", "3"] } }
+
+      it "does not raise error" do
+        expect { authorizer.authorize! }.not_to raise_error
+      end
+    end
+
+    context "when an enterprise fee is not allowed" do
+      let(:params) { { enterprise_fee_ids: ["1", "4"] } }
+
+      it "raises parameter_not_allowed_error" do
+        expect { authorizer.authorize! }
+          .to raise_error(parameter_not_allowed_error)
+      end
+    end
+  end
+
+  context "for shipping methods" do
+    before do
+      allow(permissions).to receive(:allowed_shipping_methods) do
+        stub_model_collection(Spree::ShippingMethod, :id, ["1", "2", "3"])
+      end
+    end
+
+    context "when shipping methods are allowed" do
+      let(:params) { { shipping_method_ids: ["1", "3"] } }
+
+      it "does not raise error" do
+        expect { authorizer.authorize! }.not_to raise_error
+      end
+    end
+
+    context "when a shipping method is not allowed" do
+      let(:params) { { shipping_method_ids: ["1", "4"] } }
+
+      it "raises parameter_not_allowed_error" do
+        expect { authorizer.authorize! }
+          .to raise_error(parameter_not_allowed_error)
+      end
+    end
+  end
+
+  context "for payment methods" do
+    before do
+      allow(permissions).to receive(:allowed_payment_methods) do
+        stub_model_collection(Spree::PaymentMethod, :id, ["1", "2", "3"])
+      end
+    end
+
+    context "when payment methods are allowed" do
+      let(:params) { { payment_method_ids: ["1", "3"] } }
+
+      it "does not raise error" do
+        expect { authorizer.authorize! }.not_to raise_error
+      end
+    end
+
+    context "when a payment method is not allowed" do
+      let(:params) { { payment_method_ids: ["1", "4"] } }
+
+      it "raises parameter_not_allowed_error" do
+        expect { authorizer.authorize! }
+          .to raise_error(parameter_not_allowed_error)
+      end
+    end
+  end
+
+  def stub_model_collection(model, attribute_name, attribute_list)
+    attribute_list.map do |attribute_value|
+      stub_model(model, attribute_name => attribute_value)
+    end
+  end
+
+  def stub_model(model, params)
+    model.new.tap do |instance|
+      allow(instance).to receive_messages(params)
     end
   end
 end

--- a/spec/lib/reports/order_cycle_management_report_spec.rb
+++ b/spec/lib/reports/order_cycle_management_report_spec.rb
@@ -2,212 +2,206 @@
 
 require 'spec_helper'
 
-module Reporting
-  module Reports
-    module OrderCycleManagement
-      RSpec.describe Base do
-        context "as a site admin" do
-          subject { Base.new(user, params) }
-          let(:params) { {} }
+RSpec.describe Reporting::Reports::OrderCycleManagement::Base do
+  context "as a site admin" do
+    subject { described_class.new(user, params) }
+    let(:params) { {} }
 
-          let(:user) { create(:admin_user) }
+    let(:user) { create(:admin_user) }
 
-          describe "fetching orders" do
-            it 'calls the OutstandingBalanceQuery query object' do
-              outstanding_balance = instance_double(OutstandingBalanceQuery,
-                                                    call: Spree::Order.none)
-              expect(OutstandingBalanceQuery).to receive(:new).and_return(outstanding_balance)
+    describe "fetching orders" do
+      it 'calls the OutstandingBalanceQuery query object' do
+        outstanding_balance = instance_double(OutstandingBalanceQuery,
+                                              call: Spree::Order.none)
+        expect(OutstandingBalanceQuery).to receive(:new).and_return(outstanding_balance)
 
-              subject.orders
-            end
+        subject.orders
+      end
 
-            it "fetches completed orders" do
-              o1 = create(:order)
-              o2 = create(:order, completed_at: 1.day.ago, state: 'complete')
-              expect(subject.orders).to eq([o2])
-            end
+      it "fetches completed orders" do
+        o1 = create(:order)
+        o2 = create(:order, completed_at: 1.day.ago, state: 'complete')
+        expect(subject.orders).to eq([o2])
+      end
 
-            it 'fetches resumed orders' do
-              order = create(:order, state: 'resumed', completed_at: 1.day.ago)
-              expect(subject.orders).to eq([order])
-            end
+      it 'fetches resumed orders' do
+        order = create(:order, state: 'resumed', completed_at: 1.day.ago)
+        expect(subject.orders).to eq([order])
+      end
 
-            it 'orders them by id' do
-              order1 = create(:order, completed_at: 1.day.ago, state: 'complete')
-              order2 = create(:order, completed_at: 2.days.ago, state: 'complete')
+      it 'orders them by id' do
+        order1 = create(:order, completed_at: 1.day.ago, state: 'complete')
+        order2 = create(:order, completed_at: 2.days.ago, state: 'complete')
 
-              expect(subject.orders.pluck(:id)).to eq([order2.id, order1.id])
-            end
+        expect(subject.orders.pluck(:id)).to eq([order2.id, order1.id])
+      end
 
-            it "does not show cancelled orders" do
-              o1 = create(:order, state: 'canceled', completed_at: 1.day.ago)
-              o2 = create(:order, state: 'complete', completed_at: 1.day.ago)
-              expect(subject.orders).to eq([o2])
-            end
+      it "does not show cancelled orders" do
+        o1 = create(:order, state: 'canceled', completed_at: 1.day.ago)
+        o2 = create(:order, state: 'complete', completed_at: 1.day.ago)
+        expect(subject.orders).to eq([o2])
+      end
 
-            context "default date range" do
-              it "fetches orders completed in the past month" do
-                o1 = create(:order, state: 'complete', completed_at: 1.month.ago - 1.day)
-                o2 = create(:order, state: 'complete', completed_at: 1.month.ago + 1.day)
-                expect(subject.orders).to eq([o2])
-              end
-            end
-          end
+      context "default date range" do
+        it "fetches orders completed in the past month" do
+          o1 = create(:order, state: 'complete', completed_at: 1.month.ago - 1.day)
+          o2 = create(:order, state: 'complete', completed_at: 1.month.ago + 1.day)
+          expect(subject.orders).to eq([o2])
+        end
+      end
+    end
+  end
+
+  context "as an enterprise user" do
+    let!(:user) { create(:user) }
+
+    subject { described_class.new user, {} }
+
+    describe "fetching orders" do
+      let(:supplier) { create(:supplier_enterprise) }
+      let(:product) { create(:simple_product, supplier_id: supplier.id) }
+      let(:order) { create(:order, completed_at: 1.day.ago) }
+
+      it "only shows orders managed by the current user" do
+        d1 = create(:distributor_enterprise)
+        d1.enterprise_roles.create!(user:)
+        d2 = create(:distributor_enterprise)
+        d2.enterprise_roles.create!(user: create(:user))
+
+        o1 = create(:order, distributor: d1, state: 'complete', completed_at: 1.day.ago)
+        o2 = create(:order, distributor: d2, state: 'complete', completed_at: 1.day.ago)
+
+        expect(subject).to receive(:filter).with([o1]).and_return([o1])
+        expect(subject.orders).to eq([o1])
+      end
+
+      it "does not show orders through a hub that the current user does not manage" do
+        # Given a supplier enterprise with an order for one of its products
+        supplier.enterprise_roles.create!(user:)
+        order.line_items << create(:line_item_with_shipment, product:)
+
+        # When I fetch orders, I should see no orders
+        expect(subject).to receive(:filter).with([]).and_return([])
+        expect(subject.orders).to eq([])
+      end
+    end
+
+    describe "filtering orders" do
+      let!(:orders) { Spree::Order.where(nil) }
+      let!(:supplier) { create(:supplier_enterprise) }
+
+      let!(:oc1) { create(:simple_order_cycle) }
+      let!(:pm1) { create(:payment_method, name: "PM1") }
+      let!(:sm1) { create(:shipping_method, name: "ship1") }
+      let!(:s1) { create(:shipment_with, :shipping_method, shipping_method: sm1) }
+      let!(:order1) { create(:order, shipments: [s1], order_cycle: oc1) }
+      let!(:payment1) { create(:payment, order: order1, payment_method: pm1) }
+
+      it "returns all orders sans-params" do
+        expect(subject.filter(orders)).to eq(orders)
+      end
+
+      it "filters to a specific order cycle" do
+        oc2 = create(:simple_order_cycle)
+        order2 = create(:order, order_cycle: oc2)
+
+        allow(subject).to receive(:params).and_return(order_cycle_id: oc1.id)
+        expect(subject.filter(orders)).to eq([order1])
+      end
+
+      it "filters to a payment method" do
+        pm2 = create(:payment_method, name: "PM2")
+        pm3 = create(:payment_method, name: "PM3")
+        order2 = create(:order, payments: [create(:payment, payment_method: pm2)])
+        order3 = create(:order, payments: [create(:payment, payment_method: pm3)])
+
+        allow(subject).to receive(:params).and_return(payment_method_in: [pm1.id, pm3.id] )
+        expect(subject.filter(orders)).to match_array [order1, order3]
+      end
+
+      it "filters to a shipping method" do
+        sm2 = create(:shipping_method, name: "ship2")
+        sm3 = create(:shipping_method, name: "ship3")
+        s2 = create(:shipment_with, :shipping_method, shipping_method: sm2)
+        s3 = create(:shipment_with, :shipping_method, shipping_method: sm3)
+        order2 = create(:order, shipments: [s2])
+        order3 = create(:order, shipments: [s3])
+
+        allow(subject).to receive(:params).and_return(shipping_method_in: [sm1.id, sm3.id])
+        expect(subject.filter(orders)).to match_array [order1, order3]
+      end
+
+      it "should do all the filters at once" do
+        allow(subject).to receive(:params).and_return(order_cycle_id: oc1.id,
+                                                      shipping_method_name: sm1.name,
+                                                      payment_method_name: pm1.name)
+        expect(subject.filter(orders)).to eq([order1])
+      end
+    end
+
+    describe '#table_rows' do
+      subject { described_class.new(user, params) }
+
+      let(:distributor) { create(:distributor_enterprise) }
+      before { distributor.enterprise_roles.create!(user:) }
+
+      context 'when the report type is payment_methods' do
+        subject { Reporting::Reports::OrderCycleManagement::PaymentMethods.new(user) }
+
+        let!(:order) do
+          create(
+            :completed_order_with_totals,
+            distributor:,
+            completed_at: 1.day.ago
+          )
         end
 
-        context "as an enterprise user" do
-          let!(:user) { create(:user) }
+        it 'returns rows with payment information' do
+          allow(subject).to receive(:unformatted_render?).and_return(true)
+          expect(subject.table_rows).to eq([[
+                                             order.billing_address.firstname,
+                                             order.billing_address.lastname,
+                                             order.distributor.name,
+                                             '',
+                                             order.email,
+                                             order.billing_address.phone,
+                                             order.shipment.shipping_method.name,
+                                             nil,
+                                             order.total,
+                                             -order.total
+                                           ]])
+        end
+      end
 
-          subject { Base.new user, {} }
+      context 'when the report type is delivery' do
+        subject { Reporting::Reports::OrderCycleManagement::Delivery.new(user) }
+        let!(:order) do
+          create(
+            :completed_order_with_totals,
+            distributor:,
+            completed_at: 1.day.ago
+          )
+        end
 
-          describe "fetching orders" do
-            let(:supplier) { create(:supplier_enterprise) }
-            let(:product) { create(:simple_product, supplier_id: supplier.id) }
-            let(:order) { create(:order, completed_at: 1.day.ago) }
-
-            it "only shows orders managed by the current user" do
-              d1 = create(:distributor_enterprise)
-              d1.enterprise_roles.create!(user:)
-              d2 = create(:distributor_enterprise)
-              d2.enterprise_roles.create!(user: create(:user))
-
-              o1 = create(:order, distributor: d1, state: 'complete', completed_at: 1.day.ago)
-              o2 = create(:order, distributor: d2, state: 'complete', completed_at: 1.day.ago)
-
-              expect(subject).to receive(:filter).with([o1]).and_return([o1])
-              expect(subject.orders).to eq([o1])
-            end
-
-            it "does not show orders through a hub that the current user does not manage" do
-              # Given a supplier enterprise with an order for one of its products
-              supplier.enterprise_roles.create!(user:)
-              order.line_items << create(:line_item_with_shipment, product:)
-
-              # When I fetch orders, I should see no orders
-              expect(subject).to receive(:filter).with([]).and_return([])
-              expect(subject.orders).to eq([])
-            end
-          end
-
-          describe "filtering orders" do
-            let!(:orders) { Spree::Order.where(nil) }
-            let!(:supplier) { create(:supplier_enterprise) }
-
-            let!(:oc1) { create(:simple_order_cycle) }
-            let!(:pm1) { create(:payment_method, name: "PM1") }
-            let!(:sm1) { create(:shipping_method, name: "ship1") }
-            let!(:s1) { create(:shipment_with, :shipping_method, shipping_method: sm1) }
-            let!(:order1) { create(:order, shipments: [s1], order_cycle: oc1) }
-            let!(:payment1) { create(:payment, order: order1, payment_method: pm1) }
-
-            it "returns all orders sans-params" do
-              expect(subject.filter(orders)).to eq(orders)
-            end
-
-            it "filters to a specific order cycle" do
-              oc2 = create(:simple_order_cycle)
-              order2 = create(:order, order_cycle: oc2)
-
-              allow(subject).to receive(:params).and_return(order_cycle_id: oc1.id)
-              expect(subject.filter(orders)).to eq([order1])
-            end
-
-            it "filters to a payment method" do
-              pm2 = create(:payment_method, name: "PM2")
-              pm3 = create(:payment_method, name: "PM3")
-              order2 = create(:order, payments: [create(:payment, payment_method: pm2)])
-              order3 = create(:order, payments: [create(:payment, payment_method: pm3)])
-
-              allow(subject).to receive(:params).and_return(payment_method_in: [pm1.id, pm3.id] )
-              expect(subject.filter(orders)).to match_array [order1, order3]
-            end
-
-            it "filters to a shipping method" do
-              sm2 = create(:shipping_method, name: "ship2")
-              sm3 = create(:shipping_method, name: "ship3")
-              s2 = create(:shipment_with, :shipping_method, shipping_method: sm2)
-              s3 = create(:shipment_with, :shipping_method, shipping_method: sm3)
-              order2 = create(:order, shipments: [s2])
-              order3 = create(:order, shipments: [s3])
-
-              allow(subject).to receive(:params).and_return(shipping_method_in: [sm1.id, sm3.id])
-              expect(subject.filter(orders)).to match_array [order1, order3]
-            end
-
-            it "should do all the filters at once" do
-              allow(subject).to receive(:params).and_return(order_cycle_id: oc1.id,
-                                                            shipping_method_name: sm1.name,
-                                                            payment_method_name: pm1.name)
-              expect(subject.filter(orders)).to eq([order1])
-            end
-          end
-
-          describe '#table_rows' do
-            subject { Base.new(user, params) }
-
-            let(:distributor) { create(:distributor_enterprise) }
-            before { distributor.enterprise_roles.create!(user:) }
-
-            context 'when the report type is payment_methods' do
-              subject { PaymentMethods.new(user) }
-
-              let!(:order) do
-                create(
-                  :completed_order_with_totals,
-                  distributor:,
-                  completed_at: 1.day.ago
-                )
-              end
-
-              it 'returns rows with payment information' do
-                allow(subject).to receive(:unformatted_render?).and_return(true)
-                expect(subject.table_rows).to eq([[
-                                                   order.billing_address.firstname,
-                                                   order.billing_address.lastname,
-                                                   order.distributor.name,
-                                                   '',
-                                                   order.email,
-                                                   order.billing_address.phone,
-                                                   order.shipment.shipping_method.name,
-                                                   nil,
-                                                   order.total,
-                                                   -order.total
-                                                 ]])
-              end
-            end
-
-            context 'when the report type is delivery' do
-              subject { Delivery.new(user) }
-              let!(:order) do
-                create(
-                  :completed_order_with_totals,
-                  distributor:,
-                  completed_at: 1.day.ago
-                )
-              end
-
-              it 'returns rows with delivery information' do
-                allow(subject).to receive(:unformatted_render?).and_return(true)
-                expect(subject.table_rows)
-                  .to eq([[
-                           order.ship_address.firstname,
-                           order.ship_address.lastname,
-                           order.distributor.name,
-                           "",
-                           "#{order.ship_address.address1} #{order.ship_address.address2} " \
-                           "#{order.ship_address.city}",
-                           order.ship_address.zipcode,
-                           order.ship_address.phone,
-                           order.shipment.shipping_method.name,
-                           nil,
-                           order.total,
-                           -order.total,
-                           false,
-                           order.special_instructions
-                         ]])
-              end
-            end
-          end
+        it 'returns rows with delivery information' do
+          allow(subject).to receive(:unformatted_render?).and_return(true)
+          expect(subject.table_rows)
+            .to eq([[
+                     order.ship_address.firstname,
+                     order.ship_address.lastname,
+                     order.distributor.name,
+                     "",
+                     "#{order.ship_address.address1} #{order.ship_address.address2} " \
+                     "#{order.ship_address.city}",
+                     order.ship_address.zipcode,
+                     order.ship_address.phone,
+                     order.shipment.shipping_method.name,
+                     nil,
+                     order.total,
+                     -order.total,
+                     false,
+                     order.special_instructions
+                   ]])
         end
       end
     end

--- a/spec/lib/reports/products_and_inventory_report_spec.rb
+++ b/spec/lib/reports/products_and_inventory_report_spec.rb
@@ -2,318 +2,248 @@
 
 require 'spec_helper'
 
-module Reporting
-  module Reports
-    module ProductsAndInventory
-      RSpec.describe Base do
-        context "As a site admin" do
-          let(:user) { create(:admin_user) }
-          subject do
-            Base.new user, {}
-          end
+RSpec.describe Reporting::Reports::ProductsAndInventory::Base do
+  context "As a site admin" do
+    let(:user) { create(:admin_user) }
+    subject do
+      described_class.new user, {}
+    end
 
-          it "Should return headers" do
-            expect(subject.table_headers).to eq([
-                                                  "Supplier",
-                                                  "Producer Suburb",
-                                                  "Product",
-                                                  "Product Properties",
-                                                  "Taxons",
-                                                  "Variant Value",
-                                                  "Price",
-                                                  "Group Buy Unit Quantity",
-                                                  "Amount",
-                                                  "SKU"
-                                                ])
-          end
+    it "Should return headers" do
+      expect(subject.table_headers).to eq([
+                                            "Supplier",
+                                            "Producer Suburb",
+                                            "Product",
+                                            "Product Properties",
+                                            "Taxons",
+                                            "Variant Value",
+                                            "Price",
+                                            "Group Buy Unit Quantity",
+                                            "Amount",
+                                            "SKU"
+                                          ])
+    end
 
-          it "should build a table from a list of variants" do
-            variant = double(:variant, sku: "sku",
-                                       full_name: "Variant Name",
-                                       count_on_hand: 10,
-                                       price: 100)
-            allow(variant).to receive_message_chain(:supplier, :name).and_return("Supplier")
-            allow(variant).to receive_message_chain(:supplier, :address, :city).and_return("A city")
-            allow(variant).to receive_message_chain(:product, :name).and_return("Product Name")
-            allow(variant).to receive_message_chain(:product, :properties)
-              .and_return [double(name: "property1"), double(name: "property2")]
-            allow(variant).to receive_message_chain(:primary_taxon).
-              and_return double(name: "taxon1")
-            allow(variant).to receive_message_chain(:product, :group_buy_unit_size).and_return(21)
-            allow(subject).to receive(:query_result).and_return [variant]
+    it "should build a table from a list of variants" do
+      variant = double(:variant, sku: "sku",
+                                 full_name: "Variant Name",
+                                 count_on_hand: 10,
+                                 price: 100)
+      allow(variant).to receive_message_chain(:supplier, :name).and_return("Supplier")
+      allow(variant).to receive_message_chain(:supplier, :address, :city).and_return("A city")
+      allow(variant).to receive_message_chain(:product, :name).and_return("Product Name")
+      allow(variant).to receive_message_chain(:product, :properties)
+        .and_return [double(name: "property1"), double(name: "property2")]
+      allow(variant).to receive_message_chain(:primary_taxon).
+        and_return double(name: "taxon1")
+      allow(variant).to receive_message_chain(:product, :group_buy_unit_size).and_return(21)
+      allow(subject).to receive(:query_result).and_return [variant]
 
-            expect(subject.table_rows).to eq([[
-                                               "Supplier",
-                                               "A city",
-                                               "Product Name",
-                                               "property1, property2",
-                                               "taxon1",
-                                               "Variant Name",
-                                               100,
-                                               21,
-                                               "",
-                                               "sku"
-                                             ]])
-          end
+      expect(subject.table_rows).to eq([[
+                                         "Supplier",
+                                         "A city",
+                                         "Product Name",
+                                         "property1, property2",
+                                         "taxon1",
+                                         "Variant Name",
+                                         100,
+                                         21,
+                                         "",
+                                         "sku"
+                                       ]])
+    end
 
-          it "fetches variants for some params" do
-            expect(subject).to receive(:child_variants).and_return ["children"]
-            expect(subject).to receive(:filter).with(['children']).and_return ["filter_children"]
-            expect(subject.query_result).to eq(["filter_children"])
-          end
-        end
+    it "fetches variants for some params" do
+      expect(subject).to receive(:child_variants).and_return ["children"]
+      expect(subject).to receive(:filter).with(['children']).and_return ["filter_children"]
+      expect(subject.query_result).to eq(["filter_children"])
+    end
+  end
 
-        context "As an enterprise user" do
-          let(:supplier) { create(:supplier_enterprise) }
-          let(:enterprise_user) do
-            user = create(:user)
-            user.enterprise_roles.create(enterprise: supplier)
-            user.save!
-            user
-          end
+  context "As an enterprise user" do
+    let(:supplier) { create(:supplier_enterprise) }
+    let(:enterprise_user) do
+      user = create(:user)
+      user.enterprise_roles.create(enterprise: supplier)
+      user.save!
+      user
+    end
 
-          subject do
-            Base.new enterprise_user, {}
-          end
+    subject do
+      described_class.new enterprise_user, {}
+    end
 
-          describe "fetching child variants" do
-            it "returns some variants" do
-              product1 = create(:simple_product)
-              variant1 = create(:variant, product: product1, supplier:)
-              variant2 = create(:variant, product: product1, supplier:)
+    describe "fetching child variants" do
+      it "returns some variants" do
+        product1 = create(:simple_product)
+        variant1 = create(:variant, product: product1, supplier:)
+        variant2 = create(:variant, product: product1, supplier:)
 
-              expect(subject.child_variants).to match_array [variant1, variant2]
-            end
+        expect(subject.child_variants).to match_array [variant1, variant2]
+      end
 
-            it "should only return variants managed by the user" do
-              variant1 = create(:variant, supplier: create(:supplier_enterprise))
-              variant2 = create(:variant, supplier:)
+      it "should only return variants managed by the user" do
+        variant1 = create(:variant, supplier: create(:supplier_enterprise))
+        variant2 = create(:variant, supplier:)
 
-              expect(subject.child_variants).to match_array([variant2])
-            end
-          end
+        expect(subject.child_variants).to match_array([variant2])
+      end
+    end
 
-          describe "Filtering variants" do
-            let(:variants) { Spree::Variant.joins(:product) }
+    describe "Filtering variants" do
+      let(:variants) { Spree::Variant.joins(:product) }
 
-            describe "based on report type" do
-              it "returns only variants on hand" do
-                product1 = create(:simple_product, supplier_id: supplier.id, on_hand: 99)
-                product2 = create(:simple_product, supplier_id: supplier.id, on_hand: 0)
+      describe "based on report type" do
+        it "returns only variants on hand" do
+          product1 = create(:simple_product, supplier_id: supplier.id, on_hand: 99)
+          product2 = create(:simple_product, supplier_id: supplier.id, on_hand: 0)
 
-                subject = Inventory.new enterprise_user
-                expect(subject.filter(variants)).to eq([product1.variants.first])
-              end
-            end
-
-            it "filters to a specific supplier" do
-              supplier2 = create(:supplier_enterprise)
-              variant1 = create(:variant, supplier: )
-              variant2 = create(:variant, supplier: supplier2)
-
-              allow(subject).to receive(:params).and_return(supplier_id: supplier.id)
-              expect(subject.filter(variants)).to eq([variant1])
-            end
-
-            it "filters to a specific distributor" do
-              distributor = create(:distributor_enterprise)
-              variant1 = create(:variant, supplier:)
-              variant2 = create(:variant, supplier:)
-              order_cycle = create(:simple_order_cycle, suppliers: [supplier],
-                                                        distributors: [distributor],
-                                                        variants: [variant2])
-
-              allow(subject).to receive(:params).and_return(distributor_id: distributor.id)
-              expect(subject.filter(variants)).to eq([variant2])
-            end
-
-            it "ignores variant overrides without filter" do
-              distributor = create(:distributor_enterprise)
-              product = create(:simple_product, supplier_id: supplier.id, price: 5)
-              variant = product.variants.first
-              order_cycle = create(:simple_order_cycle, suppliers: [supplier],
-                                                        distributors: [distributor],
-                                                        variants: [variant])
-              create(:variant_override, hub: distributor, variant:, price: 2)
-
-              result = subject.filter(variants)
-
-              expect(result.first.price).to eq 5
-            end
-
-            it "considers variant overrides with distributor" do
-              distributor = create(:distributor_enterprise)
-              product = create(:simple_product, supplier_id: supplier.id, price: 5)
-              variant = product.variants.first
-              order_cycle = create(:simple_order_cycle, suppliers: [supplier],
-                                                        distributors: [distributor],
-                                                        variants: [variant])
-              create(:variant_override, hub: distributor, variant:, price: 2)
-
-              allow(subject).to receive(:params).and_return(distributor_id: distributor.id)
-              result = subject.filter(variants)
-
-              expect(result.first.price).to eq 2
-            end
-
-            it "filters to a specific order cycle" do
-              distributor = create(:distributor_enterprise)
-              variant1 = create(:variant, supplier:)
-              variant2 = create(:variant, supplier:)
-              order_cycle = create(:simple_order_cycle, suppliers: [supplier],
-                                                        distributors: [distributor],
-                                                        variants: [variant1])
-
-              allow(subject).to receive(:params).and_return(order_cycle_id: order_cycle.id)
-              expect(subject.filter(variants)).to eq([variant1])
-            end
-
-            it "should do all the filters at once" do
-              # The following data ensures that this spec fails if any of the
-              # filters fail. It's testing the filters are not impacting each other.
-              distributor = create(:distributor_enterprise)
-              other_distributor = create(:distributor_enterprise)
-              other_supplier = create(:supplier_enterprise)
-              not_filtered_variant = create(:variant, supplier:)
-              variant_filtered_by_order_cycle = create(:variant, supplier:)
-              variant_filtered_by_distributor = create(:variant, supplier:)
-              variant_filtered_by_supplier = create(:variant, supplier: other_supplier)
-              variant_filtered_by_stock = create(:variant, supplier:, on_hand: 0)
-
-              # This OC contains all products except the one that should be filtered
-              # by order cycle. We create a separate OC further down to proof that
-              # the product is passing all other filters.
-              order_cycle = create(
-                :simple_order_cycle,
-                suppliers: [supplier, other_supplier],
-                distributors: [distributor, other_distributor],
-                variants: [
-                  not_filtered_variant,
-                  variant_filtered_by_distributor,
-                  variant_filtered_by_supplier,
-                  variant_filtered_by_stock
-                ]
-              )
-
-              # Remove the distribution of one product for one distributor but still
-              # sell it through the other distributor.
-              order_cycle.exchanges.outgoing.find_by(receiver_id: distributor.id).
-                exchange_variants.
-                find_by(variant_id: variant_filtered_by_distributor).
-                destroy
-
-              # Make product available to be filtered later. See OC comment above.
-              create(
-                :simple_order_cycle,
-                suppliers: [supplier],
-                distributors: [distributor, other_distributor],
-                variants: [
-                  variant_filtered_by_order_cycle
-                ]
-              )
-
-              subject = Inventory.new enterprise_user
-              allow(subject).to receive(:params).and_return(
-                order_cycle_id: order_cycle.id,
-                supplier_id: supplier.id,
-                distributor_id: distributor.id
-              )
-
-              expect(subject.filter(variants)).to match_array [not_filtered_variant]
-
-              # And it integrates with the ordering of the `variants` method.
-              expect(subject.query_result).to match_array [not_filtered_variant]
-            end
-          end
-
-          describe "fetching SKU for a variant" do
-            let(:variant) { create(:variant) }
-            let(:product) { variant.product }
-
-            before {
-              product.update_attribute(:sku, "Product SKU")
-              allow(subject).to receive(:query_result).and_return([variant])
-            }
-
-            context "when the variant has an SKU set" do
-              before { variant.update_attribute(:sku, "Variant SKU") }
-              it "returns it" do
-                expect(subject.rows.first.sku).to eq "Variant SKU"
-              end
-            end
-
-            context "when the variant has bo SKU set" do
-              before { variant.update_attribute(:sku, "") }
-
-              it "returns the product's SKU" do
-                expect(subject.rows.first.sku).to eq "Product SKU"
-              end
-            end
-          end
+          subject = Reporting::Reports::ProductsAndInventory::Inventory.new enterprise_user
+          expect(subject.filter(variants)).to eq([product1.variants.first])
         end
       end
 
-      RSpec.describe AllProducts do
-        let(:user) { create(:admin_user) }
-        let(:report) do
-          AllProducts.new user, { fields_to_hide: [] }
+      it "filters to a specific supplier" do
+        supplier2 = create(:supplier_enterprise)
+        variant1 = create(:variant, supplier: )
+        variant2 = create(:variant, supplier: supplier2)
+
+        allow(subject).to receive(:params).and_return(supplier_id: supplier.id)
+        expect(subject.filter(variants)).to eq([variant1])
+      end
+
+      it "filters to a specific distributor" do
+        distributor = create(:distributor_enterprise)
+        variant1 = create(:variant, supplier:)
+        variant2 = create(:variant, supplier:)
+        order_cycle = create(:simple_order_cycle, suppliers: [supplier],
+                                                  distributors: [distributor],
+                                                  variants: [variant2])
+
+        allow(subject).to receive(:params).and_return(distributor_id: distributor.id)
+        expect(subject.filter(variants)).to eq([variant2])
+      end
+
+      it "ignores variant overrides without filter" do
+        distributor = create(:distributor_enterprise)
+        product = create(:simple_product, supplier_id: supplier.id, price: 5)
+        variant = product.variants.first
+        order_cycle = create(:simple_order_cycle, suppliers: [supplier],
+                                                  distributors: [distributor],
+                                                  variants: [variant])
+        create(:variant_override, hub: distributor, variant:, price: 2)
+
+        result = subject.filter(variants)
+
+        expect(result.first.price).to eq 5
+      end
+
+      it "considers variant overrides with distributor" do
+        distributor = create(:distributor_enterprise)
+        product = create(:simple_product, supplier_id: supplier.id, price: 5)
+        variant = product.variants.first
+        order_cycle = create(:simple_order_cycle, suppliers: [supplier],
+                                                  distributors: [distributor],
+                                                  variants: [variant])
+        create(:variant_override, hub: distributor, variant:, price: 2)
+
+        allow(subject).to receive(:params).and_return(distributor_id: distributor.id)
+        result = subject.filter(variants)
+
+        expect(result.first.price).to eq 2
+      end
+
+      it "filters to a specific order cycle" do
+        distributor = create(:distributor_enterprise)
+        variant1 = create(:variant, supplier:)
+        variant2 = create(:variant, supplier:)
+        order_cycle = create(:simple_order_cycle, suppliers: [supplier],
+                                                  distributors: [distributor],
+                                                  variants: [variant1])
+
+        allow(subject).to receive(:params).and_return(order_cycle_id: order_cycle.id)
+        expect(subject.filter(variants)).to eq([variant1])
+      end
+
+      it "should do all the filters at once" do
+        # The following data ensures that this spec fails if any of the
+        # filters fail. It's testing the filters are not impacting each other.
+        distributor = create(:distributor_enterprise)
+        other_distributor = create(:distributor_enterprise)
+        other_supplier = create(:supplier_enterprise)
+        not_filtered_variant = create(:variant, supplier:)
+        variant_filtered_by_order_cycle = create(:variant, supplier:)
+        variant_filtered_by_distributor = create(:variant, supplier:)
+        variant_filtered_by_supplier = create(:variant, supplier: other_supplier)
+        variant_filtered_by_stock = create(:variant, supplier:, on_hand: 0)
+
+        # This OC contains all products except the one that should be filtered
+        # by order cycle. We create a separate OC further down to proof that
+        # the product is passing all other filters.
+        order_cycle = create(
+          :simple_order_cycle,
+          suppliers: [supplier, other_supplier],
+          distributors: [distributor, other_distributor],
+          variants: [
+            not_filtered_variant,
+            variant_filtered_by_distributor,
+            variant_filtered_by_supplier,
+            variant_filtered_by_stock
+          ]
+        )
+
+        # Remove the distribution of one product for one distributor but still
+        # sell it through the other distributor.
+        order_cycle.exchanges.outgoing.find_by(receiver_id: distributor.id).
+          exchange_variants.
+          find_by(variant_id: variant_filtered_by_distributor).
+          destroy
+
+        # Make product available to be filtered later. See OC comment above.
+        create(
+          :simple_order_cycle,
+          suppliers: [supplier],
+          distributors: [distributor, other_distributor],
+          variants: [
+            variant_filtered_by_order_cycle
+          ]
+        )
+
+        subject = Reporting::Reports::ProductsAndInventory::Inventory.new enterprise_user
+        allow(subject).to receive(:params).and_return(
+          order_cycle_id: order_cycle.id,
+          supplier_id: supplier.id,
+          distributor_id: distributor.id
+        )
+
+        expect(subject.filter(variants)).to match_array [not_filtered_variant]
+
+        # And it integrates with the ordering of the `variants` method.
+        expect(subject.query_result).to match_array [not_filtered_variant]
+      end
+    end
+
+    describe "fetching SKU for a variant" do
+      let(:variant) { create(:variant) }
+      let(:product) { variant.product }
+
+      before {
+        product.update_attribute(:sku, "Product SKU")
+        allow(subject).to receive(:query_result).and_return([variant])
+      }
+
+      context "when the variant has an SKU set" do
+        before { variant.update_attribute(:sku, "Variant SKU") }
+        it "returns it" do
+          expect(subject.rows.first.sku).to eq "Variant SKU"
         end
-        let(:variant) { create(:variant, supplier:) }
-        let(:supplier) { create(:supplier_enterprise) }
+      end
 
-        it "returns headers" do
-          expect(report.table_headers).to eq([
-                                               "Supplier",
-                                               "Producer Suburb",
-                                               "Product",
-                                               "Product Properties",
-                                               "Taxons",
-                                               "Variant Value",
-                                               "Price",
-                                               "Group Buy Unit Quantity",
-                                               "Amount",
-                                               "SKU",
-                                               "On Demand?",
-                                               "On Hand",
-                                               "Tax Category"
-                                             ])
-        end
+      context "when the variant has bo SKU set" do
+        before { variant.update_attribute(:sku, "") }
 
-        it "renders 'On demand' when the product is available on demand" do
-          variant.on_demand = true
-          variant.on_hand = 15
-          variant.save!
-
-          last_row = report.table_rows.last
-          on_demand_column = last_row[-3]
-          on_hand_column = last_row[-2]
-
-          expect(on_demand_column).to eq("Yes")
-          expect(on_hand_column).to eq("On demand")
-        end
-
-        it "renders the on hand count when the product is not available on demand" do
-          variant.on_demand = false
-          variant.on_hand = 22
-          variant.save!
-
-          last_row = report.table_rows.last
-          on_demand_column = last_row[-3]
-          on_hand_column = last_row[-2]
-
-          expect(on_demand_column).to eq("No")
-          expect(on_hand_column).to eq(22)
-        end
-
-        it "renders tax category if present, otherwise none" do
-          variant.update!(tax_category: create(:tax_category, name: 'Test Category'))
-
-          table_rows = report.table_rows
-          first_row = table_rows.first # row for default variant, as result of product creation
-          last_row = table_rows.last # row for the variant created/updated above
-
-          expect(first_row.last).to eq('none')
-          expect(last_row.last).to eq('Test Category')
+        it "returns the product's SKU" do
+          expect(subject.rows.first.sku).to eq "Product SKU"
         end
       end
     end

--- a/spec/lib/reports/users_and_enterprises_report_spec.rb
+++ b/spec/lib/reports/users_and_enterprises_report_spec.rb
@@ -2,134 +2,128 @@
 
 require 'spec_helper'
 
-module Reporting
-  module Reports
-    module UsersAndEnterprises
-      RSpec.describe Base do
-        describe "query_result" do
-          let!(:owners_and_enterprises) { double(:owners_and_enterprises) }
-          let!(:managers_and_enterprises) { double(:managers_and_enterprises) }
-          let!(:subject) { Base.new(nil, {}) }
+RSpec.describe Reporting::Reports::UsersAndEnterprises::Base do
+  describe "query_result" do
+    let!(:owners_and_enterprises) { double(:owners_and_enterprises) }
+    let!(:managers_and_enterprises) { double(:managers_and_enterprises) }
+    let!(:subject) { described_class.new(nil, {}) }
 
-          before do
-            allow(subject).to receive(:owners_and_enterprises) { owners_and_enterprises }
-            allow(subject).to receive(:managers_and_enterprises) { managers_and_enterprises }
-          end
+    before do
+      allow(subject).to receive(:owners_and_enterprises) { owners_and_enterprises }
+      allow(subject).to receive(:managers_and_enterprises) { managers_and_enterprises }
+    end
 
-          it "should concatenate owner and manager queries" do
-            expect(subject).to receive(:owners_and_enterprises).once
-            expect(subject).to receive(:managers_and_enterprises).once
-            expect(owners_and_enterprises).to receive(:concat)
-              .with(managers_and_enterprises).and_return []
-            expect(subject).to receive(:sort).with []
-            subject.query_result
-          end
+    it "should concatenate owner and manager queries" do
+      expect(subject).to receive(:owners_and_enterprises).once
+      expect(subject).to receive(:managers_and_enterprises).once
+      expect(owners_and_enterprises).to receive(:concat)
+        .with(managers_and_enterprises).and_return []
+      expect(subject).to receive(:sort).with []
+      subject.query_result
+    end
+  end
+
+  describe "sorting results" do
+    let!(:subject) { described_class.new(nil, {}) }
+
+    it "sorts by creation date" do
+      uae_mock = [
+        OpenStruct.new({ created_at: Date.new(2015, 1, 1), name: "aaa" }),
+        OpenStruct.new({ created_at: Date.new(2015, 1, 2), name: "bbb" })
+      ]
+      expect(subject.sort(uae_mock)).to eq [uae_mock[1], uae_mock[0]]
+    end
+
+    it "sorts by creation date when nil date" do
+      uae_mock = [
+        OpenStruct.new({ created_at: nil, name: "aaa" }),
+        OpenStruct.new({ created_at: Date.new(2015, 1, 2), name: "bbb" })
+      ]
+      expect(subject.sort(uae_mock)).to eq [uae_mock[1], uae_mock[0]]
+    end
+
+    it "then sorts by name" do
+      uae_mock = [
+        OpenStruct.new({ name: "aaa", relationship_type: "bbb", user_email: "bbb" }),
+        OpenStruct.new({ name: "bbb", relationship_type: "aaa", user_email: "aaa" })
+      ]
+      expect(subject.sort(uae_mock)).to eq [uae_mock[0], uae_mock[1]]
+    end
+
+    it "then sorts by relationship type (reveresed)" do
+      uae_mock = [
+        OpenStruct.new({ name: "aaa", relationship_type: "bbb", user_email: "bbb" }),
+        OpenStruct.new({ name: "aaa", relationship_type: "aaa", user_email: "aaa" }),
+        OpenStruct.new({ name: "aaa", relationship_type: "bbb", user_email: "aaa" })
+      ]
+      expect(subject.sort(uae_mock)).to eq [uae_mock[2], uae_mock[0], uae_mock[1]]
+    end
+
+    it "then sorts by user_email" do
+      uae_mock = [
+        OpenStruct.new({ name: "aaa", relationship_type: "bbb", user_email: "aaa" }),
+        OpenStruct.new({ name: "aaa", relationship_type: "aaa", user_email: "aaa" }),
+        OpenStruct.new({ name: "aaa", relationship_type: "aaa", user_email: "bbb" })
+      ]
+      expect(subject.sort(uae_mock)).to eq [uae_mock[0], uae_mock[1], uae_mock[2]]
+    end
+  end
+
+  describe "filtering results" do
+    let!(:enterprise1) { create(:enterprise, owner: create(:user) ) }
+    let!(:enterprise2) { create(:enterprise, owner: create(:user) ) }
+
+    describe "for owners and enterprises" do
+      describe "by enterprise id" do
+        let!(:params) { { enterprise_id_in: [enterprise1.id.to_s] } }
+        let!(:subject) { described_class.new nil, params }
+
+        it "excludes enterprises that are not explicitly requested" do
+          results = subject.owners_and_enterprises.to_a.pluck(:name)
+          expect(results).to include enterprise1.name
+          expect(results).not_to include enterprise2.name
+        end
+      end
+
+      describe "by user id" do
+        let!(:params) { { user_id_in: [enterprise1.owner.id.to_s] } }
+        let!(:subject) { described_class.new nil, params }
+
+        it "excludes enterprises that are not explicitly requested" do
+          results = subject.owners_and_enterprises.to_a.pluck(:name)
+          expect(results).to include enterprise1.name
+          expect(results).not_to include enterprise2.name
+        end
+      end
+    end
+
+    describe "for managers and enterprises" do
+      describe "by enterprise id" do
+        let!(:params) { { enterprise_id_in: [enterprise1.id.to_s] } }
+        let!(:subject) { described_class.new nil, params }
+
+        it "excludes enterprises that are not explicitly requested" do
+          results = subject.managers_and_enterprises.to_a.pluck(:name)
+          expect(results).to include enterprise1.name
+          expect(results).not_to include enterprise2.name
+        end
+      end
+
+      describe "by user id" do
+        let!(:manager1) { create(:user) }
+        let!(:manager2) { create(:user) }
+        let!(:params) { { user_id_in: [manager1.id.to_s] } }
+        let!(:subject) { described_class.new nil, params }
+
+        before do
+          enterprise1.enterprise_roles.build(user: manager1).save
+          enterprise2.enterprise_roles.build(user: manager2).save
         end
 
-        describe "sorting results" do
-          let!(:subject) { Base.new(nil, {}) }
-
-          it "sorts by creation date" do
-            uae_mock = [
-              OpenStruct.new({ created_at: Date.new(2015, 1, 1), name: "aaa" }),
-              OpenStruct.new({ created_at: Date.new(2015, 1, 2), name: "bbb" })
-            ]
-            expect(subject.sort(uae_mock)).to eq [uae_mock[1], uae_mock[0]]
-          end
-
-          it "sorts by creation date when nil date" do
-            uae_mock = [
-              OpenStruct.new({ created_at: nil, name: "aaa" }),
-              OpenStruct.new({ created_at: Date.new(2015, 1, 2), name: "bbb" })
-            ]
-            expect(subject.sort(uae_mock)).to eq [uae_mock[1], uae_mock[0]]
-          end
-
-          it "then sorts by name" do
-            uae_mock = [
-              OpenStruct.new({ name: "aaa", relationship_type: "bbb", user_email: "bbb" }),
-              OpenStruct.new({ name: "bbb", relationship_type: "aaa", user_email: "aaa" })
-            ]
-            expect(subject.sort(uae_mock)).to eq [uae_mock[0], uae_mock[1]]
-          end
-
-          it "then sorts by relationship type (reveresed)" do
-            uae_mock = [
-              OpenStruct.new({ name: "aaa", relationship_type: "bbb", user_email: "bbb" }),
-              OpenStruct.new({ name: "aaa", relationship_type: "aaa", user_email: "aaa" }),
-              OpenStruct.new({ name: "aaa", relationship_type: "bbb", user_email: "aaa" })
-            ]
-            expect(subject.sort(uae_mock)).to eq [uae_mock[2], uae_mock[0], uae_mock[1]]
-          end
-
-          it "then sorts by user_email" do
-            uae_mock = [
-              OpenStruct.new({ name: "aaa", relationship_type: "bbb", user_email: "aaa" }),
-              OpenStruct.new({ name: "aaa", relationship_type: "aaa", user_email: "aaa" }),
-              OpenStruct.new({ name: "aaa", relationship_type: "aaa", user_email: "bbb" })
-            ]
-            expect(subject.sort(uae_mock)).to eq [uae_mock[0], uae_mock[1], uae_mock[2]]
-          end
-        end
-
-        describe "filtering results" do
-          let!(:enterprise1) { create(:enterprise, owner: create(:user) ) }
-          let!(:enterprise2) { create(:enterprise, owner: create(:user) ) }
-
-          describe "for owners and enterprises" do
-            describe "by enterprise id" do
-              let!(:params) { { enterprise_id_in: [enterprise1.id.to_s] } }
-              let!(:subject) { Base.new nil, params }
-
-              it "excludes enterprises that are not explicitly requested" do
-                results = subject.owners_and_enterprises.to_a.pluck(:name)
-                expect(results).to include enterprise1.name
-                expect(results).not_to include enterprise2.name
-              end
-            end
-
-            describe "by user id" do
-              let!(:params) { { user_id_in: [enterprise1.owner.id.to_s] } }
-              let!(:subject) { Base.new nil, params }
-
-              it "excludes enterprises that are not explicitly requested" do
-                results = subject.owners_and_enterprises.to_a.pluck(:name)
-                expect(results).to include enterprise1.name
-                expect(results).not_to include enterprise2.name
-              end
-            end
-          end
-
-          describe "for managers and enterprises" do
-            describe "by enterprise id" do
-              let!(:params) { { enterprise_id_in: [enterprise1.id.to_s] } }
-              let!(:subject) { Base.new nil, params }
-
-              it "excludes enterprises that are not explicitly requested" do
-                results = subject.managers_and_enterprises.to_a.pluck(:name)
-                expect(results).to include enterprise1.name
-                expect(results).not_to include enterprise2.name
-              end
-            end
-
-            describe "by user id" do
-              let!(:manager1) { create(:user) }
-              let!(:manager2) { create(:user) }
-              let!(:params) { { user_id_in: [manager1.id.to_s] } }
-              let!(:subject) { Base.new nil, params }
-
-              before do
-                enterprise1.enterprise_roles.build(user: manager1).save
-                enterprise2.enterprise_roles.build(user: manager2).save
-              end
-
-              it "excludes enterprises whose managers are not explicitly requested" do
-                results = subject.managers_and_enterprises.to_a.pluck(:name)
-                expect(results).to include enterprise1.name
-                expect(results).not_to include enterprise2.name
-              end
-            end
-          end
+        it "excludes enterprises whose managers are not explicitly requested" do
+          results = subject.managers_and_enterprises.to_a.pluck(:name)
+          expect(results).to include enterprise1.name
+          expect(results).not_to include enterprise2.name
         end
       end
     end

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -2,599 +2,597 @@
 
 require 'spec_helper'
 
-module Spree
-  RSpec.describe Adjustment do
-    let(:order) { build(:order) }
-    let(:adjustment) { Spree::Adjustment.create(label: "Adjustment", amount: 5) }
+RSpec.describe Spree::Adjustment do
+  let(:order) { build(:order) }
+  let(:adjustment) { described_class.create(label: "Adjustment", amount: 5) }
 
-    describe "associations" do
-      it { is_expected.to have_one(:metadata) }
-      it { is_expected.to have_many(:adjustments) }
+  describe "associations" do
+    it { is_expected.to have_one(:metadata) }
+    it { is_expected.to have_many(:adjustments) }
 
-      it { is_expected.to belong_to(:adjustable).optional }
-      it { is_expected.to belong_to(:originator).optional }
-      it { is_expected.to belong_to(:order).optional }
-      it { is_expected.to belong_to(:tax_category).optional }
+    it { is_expected.to belong_to(:adjustable).optional }
+    it { is_expected.to belong_to(:originator).optional }
+    it { is_expected.to belong_to(:order).optional }
+    it { is_expected.to belong_to(:tax_category).optional }
+  end
+
+  describe "scopes" do
+    let!(:arbitrary_adjustment) { create(:adjustment, label: "Arbitrary") }
+    let!(:return_authorization_adjustment) {
+      create(:adjustment, originator: create(:return_authorization))
+    }
+
+    it "returns return_authorization adjustments" do
+      expect(described_class.return_authorization.to_a).to eq [return_authorization_adjustment]
     end
+  end
 
-    describe "scopes" do
-      let!(:arbitrary_adjustment) { create(:adjustment, label: "Arbitrary") }
-      let!(:return_authorization_adjustment) {
-        create(:adjustment, originator: create(:return_authorization))
-      }
+  context "#update_adjustment!" do
+    context "when originator present" do
+      let(:originator) { instance_double(EnterpriseFee, compute_amount: 10.0) }
+      let(:adjustable) { instance_double(Spree::LineItem) }
 
-      it "returns return_authorization adjustments" do
-        expect(Spree::Adjustment.return_authorization.to_a).to eq [return_authorization_adjustment]
-      end
-    end
-
-    context "#update_adjustment!" do
-      context "when originator present" do
-        let(:originator) { instance_double(EnterpriseFee, compute_amount: 10.0) }
-        let(:adjustable) { instance_double(LineItem) }
-
-        before do
-          allow(adjustment).to receive_messages originator:, label: 'adjustment',
-                                                adjustable:, amount: 0
-        end
-
-        it "should do nothing when closed" do
-          adjustment.close
-          expect(originator).not_to receive(:compute_amount)
-          adjustment.update_adjustment!
-        end
-
-        it "should do nothing when finalized" do
-          adjustment.finalize
-          expect(originator).not_to receive(:compute_amount)
-          adjustment.update_adjustment!
-        end
-
-        it "should ask the originator to recalculate the amount" do
-          expect(originator).to receive(:compute_amount)
-          adjustment.update_adjustment!
-        end
-
-        context "using the :force argument" do
-          it "should update adjustments without changing their state" do
-            expect(originator).to receive(:compute_amount)
-            adjustment.update_adjustment!(force: true)
-            expect(adjustment.state).to eq "open"
-          end
-
-          it "should update closed adjustments" do
-            adjustment.close
-            expect(originator).to receive(:compute_amount)
-            adjustment.update_adjustment!(force: true)
-          end
-        end
+      before do
+        allow(adjustment).to receive_messages originator:, label: 'adjustment',
+                                              adjustable:, amount: 0
       end
 
-      it "should do nothing when originator is nil" do
-        allow(adjustment).to receive_messages originator: nil
-        expect(adjustment).not_to receive(:update_columns)
+      it "should do nothing when closed" do
+        adjustment.close
+        expect(originator).not_to receive(:compute_amount)
         adjustment.update_adjustment!
       end
 
-      context "where the adjustable has been deleted" do
-        let(:line_item) { create(:line_item, price: 10) }
-        let!(:adjustment) { create(:adjustment, adjustable: line_item) }
+      it "should do nothing when finalized" do
+        adjustment.finalize
+        expect(originator).not_to receive(:compute_amount)
+        adjustment.update_adjustment!
+      end
 
-        it "returns zero" do
+      it "should ask the originator to recalculate the amount" do
+        expect(originator).to receive(:compute_amount)
+        adjustment.update_adjustment!
+      end
+
+      context "using the :force argument" do
+        it "should update adjustments without changing their state" do
+          expect(originator).to receive(:compute_amount)
+          adjustment.update_adjustment!(force: true)
+          expect(adjustment.state).to eq "open"
+        end
+
+        it "should update closed adjustments" do
+          adjustment.close
+          expect(originator).to receive(:compute_amount)
+          adjustment.update_adjustment!(force: true)
+        end
+      end
+    end
+
+    it "should do nothing when originator is nil" do
+      allow(adjustment).to receive_messages originator: nil
+      expect(adjustment).not_to receive(:update_columns)
+      adjustment.update_adjustment!
+    end
+
+    context "where the adjustable has been deleted" do
+      let(:line_item) { create(:line_item, price: 10) }
+      let!(:adjustment) { create(:adjustment, adjustable: line_item) }
+
+      it "returns zero" do
+        line_item.delete
+        expect(adjustment.reload.update_adjustment!).to eq 0.0
+      end
+
+      it "removes orphaned adjustments" do
+        expect {
           line_item.delete
-          expect(adjustment.reload.update_adjustment!).to eq 0.0
-        end
+          adjustment.reload.update_adjustment!
+        }.to change{ described_class.count }.by(-1)
+      end
+    end
+  end
 
-        it "removes orphaned adjustments" do
-          expect {
-            line_item.delete
-            adjustment.reload.update_adjustment!
-          }.to change{ Spree::Adjustment.count }.by(-1)
-        end
+  context "adjustment state" do
+    let(:adjustment) { create(:adjustment, state: 'open') }
+
+    context "#immutable?" do
+      it "is true when adjustment state isn't open" do
+        adjustment.state = "closed"
+        expect(adjustment).to be_immutable
+        adjustment.state = "finalized"
+        expect(adjustment).to be_immutable
+      end
+
+      it "is false when adjustment state is open" do
+        adjustment.state = "open"
+        expect(adjustment).not_to be_immutable
       end
     end
 
-    context "adjustment state" do
-      let(:adjustment) { create(:adjustment, state: 'open') }
-
-      context "#immutable?" do
-        it "is true when adjustment state isn't open" do
-          adjustment.state = "closed"
-          expect(adjustment).to be_immutable
-          adjustment.state = "finalized"
-          expect(adjustment).to be_immutable
-        end
-
-        it "is false when adjustment state is open" do
-          adjustment.state = "open"
-          expect(adjustment).not_to be_immutable
-        end
+    context "#finalized?" do
+      it "is true when adjustment state is finalized" do
+        adjustment.state = "finalized"
+        expect(adjustment).to be_finalized
       end
 
-      context "#finalized?" do
-        it "is true when adjustment state is finalized" do
-          adjustment.state = "finalized"
-          expect(adjustment).to be_finalized
-        end
+      it "is false when adjustment state isn't finalized" do
+        adjustment.state = "closed"
+        expect(adjustment).not_to be_finalized
+        adjustment.state = "open"
+        expect(adjustment).not_to be_finalized
+      end
+    end
+  end
 
-        it "is false when adjustment state isn't finalized" do
-          adjustment.state = "closed"
-          expect(adjustment).not_to be_finalized
-          adjustment.state = "open"
-          expect(adjustment).not_to be_finalized
-        end
+  context "#display_amount" do
+    before { adjustment.amount = 10.55 }
+
+    context "with display_currency set to true" do
+      before { Spree::Config[:display_currency] = true }
+
+      it "shows the currency" do
+        expect(adjustment.display_amount.to_s).to eq "$10.55 AUD"
       end
     end
 
-    context "#display_amount" do
-      before { adjustment.amount = 10.55 }
+    context "with display_currency set to false" do
+      before { Spree::Config[:display_currency] = false }
 
-      context "with display_currency set to true" do
-        before { Spree::Config[:display_currency] = true }
+      it "does not include the currency" do
+        expect(adjustment.display_amount.to_s).to eq "$10.55"
+      end
+    end
 
-        it "shows the currency" do
-          expect(adjustment.display_amount.to_s).to eq "$10.55 AUD"
+    context "with currency set to JPY" do
+      context "when adjustable is set to an order" do
+        before do
+          allow(order).to receive(:currency) { 'JPY' }
+          adjustment.adjustable = order
+        end
+
+        it "displays in JPY" do
+          expect(adjustment.display_amount.to_s).to eq "¥11"
         end
       end
 
-      context "with display_currency set to false" do
-        before { Spree::Config[:display_currency] = false }
-
-        it "does not include the currency" do
+      context "when adjustable is nil" do
+        it "displays in the default currency" do
           expect(adjustment.display_amount.to_s).to eq "$10.55"
         end
       end
+    end
+  end
 
-      context "with currency set to JPY" do
-        context "when adjustable is set to an order" do
-          before do
-            allow(order).to receive(:currency) { 'JPY' }
-            adjustment.adjustable = order
-          end
+  context '#currency' do
+    it 'returns the globally configured currency' do
+      expect(adjustment.currency).to eq "AUD"
+    end
+  end
 
-          it "displays in JPY" do
-            expect(adjustment.display_amount.to_s).to eq "¥11"
-          end
+  it "has metadata" do
+    adjustment = create(:adjustment, metadata: create(:adjustment_metadata))
+    expect(adjustment.metadata).to be
+  end
+
+  describe "recording included tax" do
+    describe "TaxRate adjustments" do
+      let!(:zone)        { create(:zone_with_member) }
+      let!(:order)       { create(:order, bill_address: create(:address)) }
+      let!(:line_item)   { create(:line_item, order:) }
+      let(:tax_category) { create(:tax_category, tax_rates: [tax_rate]) }
+      let(:tax_rate)     { create(:tax_rate, included_in_price: true, amount: 0.10) }
+      let(:adjustment)   { line_item.adjustments.reload.first }
+
+      before do
+        order.reload
+        tax_rate.adjust(order, line_item)
+      end
+
+      context "when the tax rate is inclusive" do
+        it "has 10% inclusive tax correctly recorded" do
+          amount = line_item.amount - (line_item.amount / (1 + tax_rate.amount))
+          rounded_amount = tax_rate.calculator.__send__(:round_to_two_places, amount)
+          expect(adjustment.amount).to eq rounded_amount
+          expect(adjustment.amount).to eq 0.91
+          expect(adjustment.included).to be true
         end
 
-        context "when adjustable is nil" do
-          it "displays in the default currency" do
-            expect(adjustment.display_amount.to_s).to eq "$10.55"
-          end
-        end
-      end
-    end
-
-    context '#currency' do
-      it 'returns the globally configured currency' do
-        expect(adjustment.currency).to eq "AUD"
-      end
-    end
-
-    it "has metadata" do
-      adjustment = create(:adjustment, metadata: create(:adjustment_metadata))
-      expect(adjustment.metadata).to be
-    end
-
-    describe "recording included tax" do
-      describe "TaxRate adjustments" do
-        let!(:zone)        { create(:zone_with_member) }
-        let!(:order)       { create(:order, bill_address: create(:address)) }
-        let!(:line_item)   { create(:line_item, order:) }
-        let(:tax_category) { create(:tax_category, tax_rates: [tax_rate]) }
-        let(:tax_rate)     { create(:tax_rate, included_in_price: true, amount: 0.10) }
-        let(:adjustment)   { line_item.adjustments.reload.first }
-
-        before do
-          order.reload
+        it "does not crash when order data has been updated previously" do
+          order.line_item_adjustments.first.destroy
           tax_rate.adjust(order, line_item)
         end
+      end
 
-        context "when the tax rate is inclusive" do
-          it "has 10% inclusive tax correctly recorded" do
-            amount = line_item.amount - (line_item.amount / (1 + tax_rate.amount))
-            rounded_amount = tax_rate.calculator.__send__(:round_to_two_places, amount)
-            expect(adjustment.amount).to eq rounded_amount
-            expect(adjustment.amount).to eq 0.91
-            expect(adjustment.included).to be true
-          end
+      context "when the tax rate is additional" do
+        let(:tax_rate) { create(:tax_rate, included_in_price: false, amount: 0.10) }
 
-          it "does not crash when order data has been updated previously" do
-            order.line_item_adjustments.first.destroy
-            tax_rate.adjust(order, line_item)
-          end
+        it "has 10% added tax correctly recorded" do
+          expect(adjustment.amount).to eq line_item.amount * tax_rate.amount
+          expect(adjustment.amount).to eq 1.0
+          expect(adjustment.included).to be false
         end
+      end
+    end
 
-        context "when the tax rate is additional" do
-          let(:tax_rate) { create(:tax_rate, included_in_price: false, amount: 0.10) }
+    describe "Shipment adjustments" do
+      let(:zone) { create(:zone_with_member) }
+      let(:inclusive_tax) { true }
+      let(:tax_rate) {
+        create(:tax_rate, included_in_price: inclusive_tax, zone:, amount: 0.25)
+      }
+      let(:tax_category)    { create(:tax_category, name: "Shipping", tax_rates: [tax_rate] ) }
+      let(:hub)             { create(:distributor_enterprise, charges_sales_tax: true) }
+      let(:order)           { create(:order, distributor: hub, state: 'payment') }
+      let(:line_item)       { create(:line_item, order:) }
 
-          it "has 10% added tax correctly recorded" do
-            expect(adjustment.amount).to eq line_item.amount * tax_rate.amount
-            expect(adjustment.amount).to eq 1.0
-            expect(adjustment.included).to be false
-          end
+      let(:shipping_method) {
+        create(:shipping_method_with, :flat_rate, tax_category:)
+      }
+      let(:shipment) {
+        create(:shipment_with, :shipping_method, shipping_method:, order:)
+      }
+
+      describe "the shipping charge" do
+        it "is the adjustment amount" do
+          order.shipments = [shipment]
+          expect(order.shipment_adjustments.first.amount).to eq(50)
+          expect(shipment.cost).to eq(50)
         end
       end
 
-      describe "Shipment adjustments" do
-        let(:zone) { create(:zone_with_member) }
-        let(:inclusive_tax) { true }
-        let(:tax_rate) {
-          create(:tax_rate, included_in_price: inclusive_tax, zone:, amount: 0.25)
-        }
-        let(:tax_category)    { create(:tax_category, name: "Shipping", tax_rates: [tax_rate] ) }
-        let(:hub)             { create(:distributor_enterprise, charges_sales_tax: true) }
-        let(:order)           { create(:order, distributor: hub, state: 'payment') }
-        let(:line_item)       { create(:line_item, order:) }
+      context "with tax" do
+        before do
+          allow(order).to receive(:tax_zone) { zone }
+        end
 
-        let(:shipping_method) {
-          create(:shipping_method_with, :flat_rate, tax_category:)
-        }
-        let(:shipment) {
-          create(:shipment_with, :shipping_method, shipping_method:, order:)
-        }
-
-        describe "the shipping charge" do
-          it "is the adjustment amount" do
+        context "when the shipment has an inclusive tax rate" do
+          it "calculates the shipment tax from the tax rate" do
             order.shipments = [shipment]
-            expect(order.shipment_adjustments.first.amount).to eq(50)
-            expect(shipment.cost).to eq(50)
+            order.state = "payment"
+            order.create_tax_charge!
+            order.update_totals
+
+            # Finding the tax included in an amount that's already inclusive of tax:
+            # total - ( total / (1 + rate) )
+            # 50    - ( 50    / (1 + 0.25) )
+            # = 10
+            expect(order.shipment_adjustments.tax.first.amount).to eq(10)
+            expect(order.shipment_adjustments.tax.first.included).to eq true
+
+            expect(shipment.reload.cost).to eq(50)
+            expect(shipment.included_tax_total).to eq(10)
+            expect(shipment.additional_tax_total).to eq(0)
+
+            expect(order.included_tax_total).to eq(10)
+            expect(order.additional_tax_total).to eq(0)
           end
         end
 
-        context "with tax" do
-          before do
-            allow(order).to receive(:tax_zone) { zone }
+        context "when the shipment has an added tax rate" do
+          let(:inclusive_tax) { false }
+
+          it "records the tax on the shipment's adjustments" do
+            order.shipments = [shipment]
+            order.state = "payment"
+            order.create_tax_charge!
+            order.update_totals
+
+            # Finding the added tax for an amount:
+            # total * rate
+            # 50    * 0.25
+            # = 12.5
+            expect(order.shipment_adjustments.tax.first.amount).to eq(12.50)
+            expect(order.shipment_adjustments.tax.first.included).to eq false
+
+            expect(shipment.reload.cost).to eq(50)
+            expect(shipment.included_tax_total).to eq(0)
+            expect(shipment.additional_tax_total).to eq(12.50)
+
+            expect(order.included_tax_total).to eq(0)
+            expect(order.additional_tax_total).to eq(12.50)
           end
+        end
 
-          context "when the shipment has an inclusive tax rate" do
-            it "calculates the shipment tax from the tax rate" do
-              order.shipments = [shipment]
-              order.state = "payment"
-              order.create_tax_charge!
-              order.update_totals
+        context "when the distributor does not charge sales tax" do
+          it "records 0% tax on shipments" do
+            order.distributor.update! charges_sales_tax: false
+            order.shipments = [shipment]
+            order.create_tax_charge!
+            order.update_totals
 
-              # Finding the tax included in an amount that's already inclusive of tax:
-              # total - ( total / (1 + rate) )
-              # 50    - ( 50    / (1 + 0.25) )
-              # = 10
-              expect(order.shipment_adjustments.tax.first.amount).to eq(10)
-              expect(order.shipment_adjustments.tax.first.included).to eq true
+            expect(order.shipment_adjustments.tax.count).to be_zero
 
-              expect(shipment.reload.cost).to eq(50)
-              expect(shipment.included_tax_total).to eq(10)
-              expect(shipment.additional_tax_total).to eq(0)
+            expect(shipment.reload.cost).to eq(50)
+            expect(shipment.included_tax_total).to eq(0)
+            expect(shipment.additional_tax_total).to eq(0)
 
-              expect(order.included_tax_total).to eq(10)
-              expect(order.additional_tax_total).to eq(0)
+            expect(order.included_tax_total).to eq(0)
+            expect(order.additional_tax_total).to eq(0)
+          end
+        end
+
+        context "when the shipment has no applicable tax rate" do
+          it "records 0% tax on shipments" do
+            allow(shipment).to receive(:tax_category) { nil }
+            order.shipments = [shipment]
+            order.create_tax_charge!
+            order.update_totals
+
+            expect(order.shipment_adjustments.tax.count).to be_zero
+
+            expect(shipment.reload.cost).to eq(50)
+            expect(shipment.included_tax_total).to eq(0)
+            expect(shipment.additional_tax_total).to eq(0)
+
+            expect(order.included_tax_total).to eq(0)
+            expect(order.additional_tax_total).to eq(0)
+          end
+        end
+      end
+    end
+
+    describe "EnterpriseFee adjustments" do
+      let(:zone)             { create(:zone_with_member) }
+      let(:fee_tax_rate)     {
+        create(:tax_rate, included_in_price: true, calculator: Calculator::DefaultTax.new,
+                          zone:, amount: 0.1)
+      }
+      let(:fee_tax_category) { create(:tax_category, tax_rates: [fee_tax_rate]) }
+
+      let(:coordinator) { create(:distributor_enterprise, charges_sales_tax: true) }
+      let(:variant)     { create(:variant, product: create(:product, tax_category: nil)) }
+      let(:order_cycle) {
+        create(:simple_order_cycle, coordinator:, coordinator_fees: [enterprise_fee],
+                                    distributors: [coordinator], variants: [variant])
+      }
+      let(:line_item)   { create(:line_item, variant:) }
+      let(:order)       {
+        create(:order, line_items: [line_item], order_cycle:,
+                       distributor: coordinator, state: 'payment')
+      }
+      let(:fee)         { order.all_adjustments.reload.enterprise_fee.first }
+      let(:fee_tax)     { fee.adjustments.tax.first }
+
+      context "when enterprise fees have a fixed tax_category" do
+        before do
+          order.update(state: "payment")
+          order.recreate_all_fees!
+        end
+
+        context "when enterprise fees are taxed per-order" do
+          let(:enterprise_fee) {
+            create(:enterprise_fee, enterprise: coordinator, tax_category: fee_tax_category,
+                                    calculator: Calculator::FlatRate.new(
+                                      preferred_amount: 50.0
+                                    ))
+          }
+
+          describe "when the tax rate includes the tax in the price" do
+            it "records the correct amount in a tax adjustment" do
+              # The fee is $50, tax is 10%, and the fee is inclusive of tax
+              # Therefore, the included tax should be 0.1/1.1 * 50 = $4.55
+
+              expect(fee_tax.amount).to eq(4.55)
             end
           end
 
-          context "when the shipment has an added tax rate" do
-            let(:inclusive_tax) { false }
+          describe "when the tax rate does not include the tax in the price" do
+            before do
+              fee_tax_rate.update_attribute :included_in_price, false
+              order.recreate_all_fees!
+            end
 
-            it "records the tax on the shipment's adjustments" do
-              order.shipments = [shipment]
-              order.state = "payment"
-              order.create_tax_charge!
-              order.update_totals
-
-              # Finding the added tax for an amount:
-              # total * rate
-              # 50    * 0.25
-              # = 12.5
-              expect(order.shipment_adjustments.tax.first.amount).to eq(12.50)
-              expect(order.shipment_adjustments.tax.first.included).to eq false
-
-              expect(shipment.reload.cost).to eq(50)
-              expect(shipment.included_tax_total).to eq(0)
-              expect(shipment.additional_tax_total).to eq(12.50)
-
-              expect(order.included_tax_total).to eq(0)
-              expect(order.additional_tax_total).to eq(12.50)
+            it "records the correct amount in a tax adjustment" do
+              expect(fee_tax.amount).to eq(5.0)
             end
           end
 
-          context "when the distributor does not charge sales tax" do
-            it "records 0% tax on shipments" do
-              order.distributor.update! charges_sales_tax: false
-              order.shipments = [shipment]
-              order.create_tax_charge!
-              order.update_totals
+          describe "when enterprise fees have no tax" do
+            before do
+              enterprise_fee.tax_category = nil
+              enterprise_fee.save!
+              order.recreate_all_fees!
+            end
 
-              expect(order.shipment_adjustments.tax.count).to be_zero
+            it "records no tax as charged" do
+              expect(fee_tax).to be_nil
+            end
+          end
+        end
 
-              expect(shipment.reload.cost).to eq(50)
-              expect(shipment.included_tax_total).to eq(0)
-              expect(shipment.additional_tax_total).to eq(0)
+        context "when enterprise fees are taxed per-item" do
+          let(:enterprise_fee) {
+            create(:enterprise_fee, enterprise: coordinator, tax_category: fee_tax_category,
+                                    calculator: Calculator::PerItem.new(preferred_amount: 50.0))
+          }
 
-              expect(order.included_tax_total).to eq(0)
-              expect(order.additional_tax_total).to eq(0)
+          describe "when the tax rate includes the tax in the price" do
+            it "records the correct amount in a tax adjustment" do
+              expect(fee_tax.amount).to eq(4.55)
             end
           end
 
-          context "when the shipment has no applicable tax rate" do
-            it "records 0% tax on shipments" do
-              allow(shipment).to receive(:tax_category) { nil }
-              order.shipments = [shipment]
-              order.create_tax_charge!
-              order.update_totals
+          describe "when the tax rate does not include the tax in the price" do
+            before do
+              fee_tax_rate.update_attribute :included_in_price, false
+              order.recreate_all_fees!
+            end
 
-              expect(order.shipment_adjustments.tax.count).to be_zero
-
-              expect(shipment.reload.cost).to eq(50)
-              expect(shipment.included_tax_total).to eq(0)
-              expect(shipment.additional_tax_total).to eq(0)
-
-              expect(order.included_tax_total).to eq(0)
-              expect(order.additional_tax_total).to eq(0)
+            it "records the correct amount in a tax adjustment" do
+              expect(fee_tax.amount).to eq(5.0)
             end
           end
         end
       end
 
-      describe "EnterpriseFee adjustments" do
-        let(:zone)             { create(:zone_with_member) }
-        let(:fee_tax_rate)     {
-          create(:tax_rate, included_in_price: true, calculator: ::Calculator::DefaultTax.new,
-                            zone:, amount: 0.1)
+      context "when enterprise fees inherit tax_category from the product they are applied to" do
+        let(:product_tax_rate) {
+          create(:tax_rate, included_in_price: true, calculator: Calculator::DefaultTax.new,
+                            zone:, amount: 0.2)
         }
-        let(:fee_tax_category) { create(:tax_category, tax_rates: [fee_tax_rate]) }
+        let(:product_tax_category) { create(:tax_category, tax_rates: [product_tax_rate]) }
 
-        let(:coordinator) { create(:distributor_enterprise, charges_sales_tax: true) }
-        let(:variant)     { create(:variant, product: create(:product, tax_category: nil)) }
-        let(:order_cycle) {
-          create(:simple_order_cycle, coordinator:, coordinator_fees: [enterprise_fee],
-                                      distributors: [coordinator], variants: [variant])
-        }
-        let(:line_item)   { create(:line_item, variant:) }
-        let(:order)       {
-          create(:order, line_items: [line_item], order_cycle:,
-                         distributor: coordinator, state: 'payment')
-        }
-        let(:fee)         { order.all_adjustments.reload.enterprise_fee.first }
-        let(:fee_tax)     { fee.adjustments.tax.first }
+        before do
+          variant.update_attribute(:tax_category_id, product_tax_category.id)
+          order.recreate_all_fees!
+        end
 
-        context "when enterprise fees have a fixed tax_category" do
+        context "when enterprise fees are taxed per-order" do
+          let(:enterprise_fee) {
+            create(:enterprise_fee, enterprise: coordinator, inherits_tax_category: false,
+                                    calculator: Calculator::FlatRate.new(
+                                      preferred_amount: 50.0
+                                    ))
+          }
+
           before do
             order.update(state: "payment")
-            order.recreate_all_fees!
+            order.create_tax_charge!
           end
 
-          context "when enterprise fees are taxed per-order" do
-            let(:enterprise_fee) {
-              create(:enterprise_fee, enterprise: coordinator, tax_category: fee_tax_category,
-                                      calculator: ::Calculator::FlatRate.new(
-                                        preferred_amount: 50.0
-                                      ))
-            }
-
-            describe "when the tax rate includes the tax in the price" do
-              it "records the correct amount in a tax adjustment" do
-                # The fee is $50, tax is 10%, and the fee is inclusive of tax
-                # Therefore, the included tax should be 0.1/1.1 * 50 = $4.55
-
-                expect(fee_tax.amount).to eq(4.55)
-              end
-            end
-
-            describe "when the tax rate does not include the tax in the price" do
-              before do
-                fee_tax_rate.update_attribute :included_in_price, false
-                order.recreate_all_fees!
-              end
-
-              it "records the correct amount in a tax adjustment" do
-                expect(fee_tax.amount).to eq(5.0)
-              end
-            end
-
-            describe "when enterprise fees have no tax" do
-              before do
-                enterprise_fee.tax_category = nil
-                enterprise_fee.save!
-                order.recreate_all_fees!
-              end
-
-              it "records no tax as charged" do
-                expect(fee_tax).to be_nil
-              end
+          describe "when the tax rate includes the tax in the price" do
+            it "records no tax on the enterprise fee adjustments" do
+              # EnterpriseFee tax category is nil and inheritance only applies to per item fees
+              # so tax on the enterprise_fee adjustment will be 0
+              # Tax on line item is: 0.2/1.2 x $10 = $1.67
+              expect(fee_tax).to be_nil
+              expect(line_item.adjustments.tax.first.amount).to eq(1.67)
             end
           end
 
-          context "when enterprise fees are taxed per-item" do
-            let(:enterprise_fee) {
-              create(:enterprise_fee, enterprise: coordinator, tax_category: fee_tax_category,
-                                      calculator: ::Calculator::PerItem.new(preferred_amount: 50.0))
-            }
-
-            describe "when the tax rate includes the tax in the price" do
-              it "records the correct amount in a tax adjustment" do
-                expect(fee_tax.amount).to eq(4.55)
-              end
+          describe "when the tax rate does not include the tax in the price" do
+            before do
+              product_tax_rate.update_attribute :included_in_price, false
+              order.reload.recreate_all_fees!
             end
 
-            describe "when the tax rate does not include the tax in the price" do
-              before do
-                fee_tax_rate.update_attribute :included_in_price, false
-                order.recreate_all_fees!
-              end
-
-              it "records the correct amount in a tax adjustment" do
-                expect(fee_tax.amount).to eq(5.0)
-              end
+            it "records the no tax on TaxRate adjustment on the order" do
+              # EnterpriseFee tax category is nil and inheritance only applies to per item fees
+              # so total tax on the order is only that which applies to the line_item itself
+              # ie. $10 x 0.2 = $2.0
+              expect(fee_tax).to be_nil
             end
           end
         end
 
-        context "when enterprise fees inherit tax_category from the product they are applied to" do
-          let(:product_tax_rate) {
-            create(:tax_rate, included_in_price: true, calculator: ::Calculator::DefaultTax.new,
-                              zone:, amount: 0.2)
+        context "when enterprise fees are taxed per-item" do
+          let(:enterprise_fee) {
+            create(:enterprise_fee, enterprise: coordinator, inherits_tax_category: true,
+                                    calculator: Calculator::PerItem.new(preferred_amount: 50.0))
           }
-          let(:product_tax_category) { create(:tax_category, tax_rates: [product_tax_rate]) }
 
           before do
-            variant.update_attribute(:tax_category_id, product_tax_category.id)
-            order.recreate_all_fees!
+            order.update(state: "payment")
+            order.create_tax_charge!
           end
 
-          context "when enterprise fees are taxed per-order" do
-            let(:enterprise_fee) {
-              create(:enterprise_fee, enterprise: coordinator, inherits_tax_category: false,
-                                      calculator: ::Calculator::FlatRate.new(
-                                        preferred_amount: 50.0
-                                      ))
-            }
+          describe "when the tax rate includes the tax in the price" do
+            it "records the correct amount in a tax adjustment" do
+              # Applying product tax rate of 0.2 to enterprise fee of $50
+              # gives tax on fee of 0.2/1.2 x $50 = $8.33
+              # Tax on line item is: 0.2/1.2 x $10 = $1.67
+              expect(fee_tax.amount).to eq(8.33)
+              expect(line_item.adjustments.tax.first.amount).to eq(1.67)
+            end
+          end
 
+          describe "when the tax rate does not include the tax in the price" do
             before do
-              order.update(state: "payment")
-              order.create_tax_charge!
+              product_tax_rate.update_attribute :included_in_price, false
+              order.recreate_all_fees!
             end
 
-            describe "when the tax rate includes the tax in the price" do
-              it "records no tax on the enterprise fee adjustments" do
-                # EnterpriseFee tax category is nil and inheritance only applies to per item fees
-                # so tax on the enterprise_fee adjustment will be 0
-                # Tax on line item is: 0.2/1.2 x $10 = $1.67
-                expect(fee_tax).to be_nil
-                expect(line_item.adjustments.tax.first.amount).to eq(1.67)
-              end
-            end
-
-            describe "when the tax rate does not include the tax in the price" do
-              before do
-                product_tax_rate.update_attribute :included_in_price, false
-                order.reload.recreate_all_fees!
-              end
-
-              it "records the no tax on TaxRate adjustment on the order" do
-                # EnterpriseFee tax category is nil and inheritance only applies to per item fees
-                # so total tax on the order is only that which applies to the line_item itself
-                # ie. $10 x 0.2 = $2.0
-                expect(fee_tax).to be_nil
-              end
-            end
-          end
-
-          context "when enterprise fees are taxed per-item" do
-            let(:enterprise_fee) {
-              create(:enterprise_fee, enterprise: coordinator, inherits_tax_category: true,
-                                      calculator: ::Calculator::PerItem.new(preferred_amount: 50.0))
-            }
-
-            before do
-              order.update(state: "payment")
-              order.create_tax_charge!
-            end
-
-            describe "when the tax rate includes the tax in the price" do
-              it "records the correct amount in a tax adjustment" do
-                # Applying product tax rate of 0.2 to enterprise fee of $50
-                # gives tax on fee of 0.2/1.2 x $50 = $8.33
-                # Tax on line item is: 0.2/1.2 x $10 = $1.67
-                expect(fee_tax.amount).to eq(8.33)
-                expect(line_item.adjustments.tax.first.amount).to eq(1.67)
-              end
-            end
-
-            describe "when the tax rate does not include the tax in the price" do
-              before do
-                product_tax_rate.update_attribute :included_in_price, false
-                order.recreate_all_fees!
-              end
-
-              it "records the correct amount in a tax adjustment" do
-                # EnterpriseFee inherits tax_category from product so total tax on
-                # the order is that which applies to the line item itself, plus the
-                # same rate applied to the fee of $50. ie. ($10 + $50) x 0.2 = $12.0
-                expect(fee_tax.amount).to eq(10.0)
-                expect(order.all_adjustments.tax.sum(:amount)).to eq(12.0)
-              end
+            it "records the correct amount in a tax adjustment" do
+              # EnterpriseFee inherits tax_category from product so total tax on
+              # the order is that which applies to the line item itself, plus the
+              # same rate applied to the fee of $50. ie. ($10 + $50) x 0.2 = $12.0
+              expect(fee_tax.amount).to eq(10.0)
+              expect(order.all_adjustments.tax.sum(:amount)).to eq(12.0)
             end
           end
         end
       end
     end
+  end
 
-    context "extends LocalizedNumber" do
-      it_behaves_like "a model using the LocalizedNumber module", [:amount]
-    end
+  context "extends LocalizedNumber" do
+    it_behaves_like "a model using the LocalizedNumber module", [:amount]
+  end
 
-    describe "inclusive and additional taxes" do
-      let!(:zone) { create(:zone_with_member) }
-      let!(:tax_category) { create(:tax_category, name: "Tax Test") }
-      let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true) }
-      let(:order) { create(:order, distributor:, state: "payment") }
-      let(:included_in_price) { true }
-      let(:tax_rate) {
-        create(:tax_rate, included_in_price:, zone:,
-                          calculator: ::Calculator::FlatRate.new(preferred_amount: 0.1))
-      }
-      let(:variant) { create(:variant, tax_category:) }
-      let(:product) { variant.product }
+  describe "inclusive and additional taxes" do
+    let!(:zone) { create(:zone_with_member) }
+    let!(:tax_category) { create(:tax_category, name: "Tax Test") }
+    let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true) }
+    let(:order) { create(:order, distributor:, state: "payment") }
+    let(:included_in_price) { true }
+    let(:tax_rate) {
+      create(:tax_rate, included_in_price:, zone:,
+                        calculator: Calculator::FlatRate.new(preferred_amount: 0.1))
+    }
+    let(:variant) { create(:variant, tax_category:) }
+    let(:product) { variant.product }
 
-      describe "tax adjustment creation" do
-        before do
-          tax_category.tax_rates << tax_rate
-          allow(order).to receive(:tax_zone) { zone }
-          order.line_items << create(:line_item, variant:, quantity: 5)
-          order.update(state: "payment")
-          order.create_tax_charge!
-        end
+    describe "tax adjustment creation" do
+      before do
+        tax_category.tax_rates << tax_rate
+        allow(order).to receive(:tax_zone) { zone }
+        order.line_items << create(:line_item, variant:, quantity: 5)
+        order.update(state: "payment")
+        order.create_tax_charge!
+      end
 
-        context "with included taxes" do
-          it "records the tax as included" do
-            expect(order.all_adjustments.tax.count).to eq 1
-            expect(order.all_adjustments.tax.first.included).to be true
-          end
-        end
-
-        context "with additional taxes" do
-          let(:included_in_price) { false }
-
-          it "records the tax as additional" do
-            expect(order.all_adjustments.tax.count).to eq 1
-            expect(order.all_adjustments.tax.first.included).to be false
-          end
+      context "with included taxes" do
+        it "records the tax as included" do
+          expect(order.all_adjustments.tax.count).to eq 1
+          expect(order.all_adjustments.tax.first.included).to be true
         end
       end
 
-      describe "inclusive and additional scopes" do
-        let(:included) { true }
-        let(:adjustment) {
-          create(:adjustment, adjustable: order, originator: tax_rate, included:)
-        }
+      context "with additional taxes" do
+        let(:included_in_price) { false }
 
-        context "when tax is included in price" do
-          it "is returned by the #included scope" do
-            expect(Spree::Adjustment.inclusive).to eq [adjustment]
-          end
-        end
-
-        context "when tax is additional to the price" do
-          let(:included) { false }
-
-          it "is returned by the #additional scope" do
-            expect(Spree::Adjustment.additional).to eq [adjustment]
-          end
+        it "records the tax as additional" do
+          expect(order.all_adjustments.tax.count).to eq 1
+          expect(order.all_adjustments.tax.first.included).to be false
         end
       end
     end
 
-    context "return authorization adjustments" do
-      let!(:return_authorization) { create(:return_authorization, amount: 123) }
-      let(:order) { return_authorization.order }
-      let!(:return_adjustment) {
-        create(:adjustment, originator: return_authorization, order:,
-                            adjustable: order, amount: 456)
+    describe "inclusive and additional scopes" do
+      let(:included) { true }
+      let(:adjustment) {
+        create(:adjustment, adjustable: order, originator: tax_rate, included:)
       }
 
-      describe "#update_adjustment!" do
-        it "sets a negative value equal to the return authorization amount" do
-          expect { return_adjustment.update_adjustment! }.
-            to change { return_adjustment.reload.amount }.to(-123)
+      context "when tax is included in price" do
+        it "is returned by the #included scope" do
+          expect(described_class.inclusive).to eq [adjustment]
         end
+      end
+
+      context "when tax is additional to the price" do
+        let(:included) { false }
+
+        it "is returned by the #additional scope" do
+          expect(described_class.additional).to eq [adjustment]
+        end
+      end
+    end
+  end
+
+  context "return authorization adjustments" do
+    let!(:return_authorization) { create(:return_authorization, amount: 123) }
+    let(:order) { return_authorization.order }
+    let!(:return_adjustment) {
+      create(:adjustment, originator: return_authorization, order:,
+                          adjustable: order, amount: 456)
+    }
+
+    describe "#update_adjustment!" do
+      it "sets a negative value equal to the return authorization amount" do
+        expect { return_adjustment.update_adjustment! }.
+          to change { return_adjustment.reload.amount }.to(-123)
       end
     end
   end

--- a/spec/models/spree/credit_card_spec.rb
+++ b/spec/models/spree/credit_card_spec.rb
@@ -2,321 +2,319 @@
 
 require 'spec_helper'
 
-module Spree
-  RSpec.describe CreditCard do
-    let(:valid_credit_card_attributes) {
-      {
-        number: '4111111111111111',
-        verification_value: '123',
-        month: 12,
-        year: Time.zone.now.year + 1
-      }
+RSpec.describe Spree::CreditCard do
+  let(:valid_credit_card_attributes) {
+    {
+      number: '4111111111111111',
+      verification_value: '123',
+      month: 12,
+      year: Time.zone.now.year + 1
     }
+  }
 
-    describe "original specs from Spree" do
-      def self.payment_states
-        Spree::Payment.state_machine.states.keys
+  describe "original specs from Spree" do
+    def self.payment_states
+      Spree::Payment.state_machine.states.keys
+    end
+
+    def stub_rails_env(environment)
+      allow(Rails).to receive_messages(env: ActiveSupport::StringInquirer.new(environment))
+    end
+
+    let(:credit_card) { described_class.new }
+
+    context "#can_capture?" do
+      it "should be true if payment is pending" do
+        payment = build_stubbed(:payment, created_at: Time.zone.now)
+        allow(payment).to receive(:pending?) { true }
+        expect(credit_card.can_capture_and_complete_order?(payment)).to be_truthy
       end
 
-      def stub_rails_env(environment)
-        allow(Rails).to receive_messages(env: ActiveSupport::StringInquirer.new(environment))
-      end
-
-      let(:credit_card) { Spree::CreditCard.new }
-
-      context "#can_capture?" do
-        it "should be true if payment is pending" do
-          payment = build_stubbed(:payment, created_at: Time.zone.now)
-          allow(payment).to receive(:pending?) { true }
-          expect(credit_card.can_capture_and_complete_order?(payment)).to be_truthy
-        end
-
-        it "should be true if payment is checkout" do
-          payment = build_stubbed(:payment, created_at: Time.zone.now)
-          allow(payment).to receive_messages pending?: false,
-                                             checkout?: true
-          expect(credit_card.can_capture_and_complete_order?(payment)).to be_truthy
-        end
-      end
-
-      context "#can_void?" do
-        it "should be true if payment is not void" do
-          payment = build_stubbed(:payment)
-          allow(payment).to receive(:void?) { false }
-          expect(credit_card.can_void?(payment)).to be_truthy
-        end
-      end
-
-      context "#can_credit?" do
-        it "should be false if payment is not completed" do
-          payment = build_stubbed(:payment)
-          allow(payment).to receive(:completed?) { false }
-          expect(credit_card.can_credit?(payment)).to be_falsy
-        end
-
-        it "should be false when order payment_state is not 'credit_owed'" do
-          payment = build_stubbed(:payment,
-                                  order: create(:order, payment_state: 'paid'))
-          allow(payment).to receive(:completed?) { true }
-          expect(credit_card.can_credit?(payment)).to be_falsy
-        end
-
-        it "should be false when credit_allowed is zero" do
-          payment = build_stubbed(:payment,
-                                  order: create(:order, payment_state: 'credit_owed'))
-          allow(payment).to receive_messages completed?: true,
-                                             credit_allowed: 0
-
-          expect(credit_card.can_credit?(payment)).to be_falsy
-        end
-      end
-
-      context "#valid?" do
-        it "should validate presence of number" do
-          credit_card.attributes = valid_credit_card_attributes.except(:number)
-          expect(credit_card).not_to be_valid
-          expect(credit_card.errors[:number]).to eq ["can't be blank"]
-        end
-
-        it "should validate presence of security code" do
-          credit_card.attributes = valid_credit_card_attributes.except(:verification_value)
-          expect(credit_card).not_to be_valid
-          expect(credit_card.errors[:verification_value]).to eq ["can't be blank"]
-        end
-
-        it "should validate expiration is not in the past" do
-          credit_card.month = 1.month.ago.month
-          credit_card.year = 1.month.ago.year
-          expect(credit_card).not_to be_valid
-          expect(credit_card.errors[:base]).to eq ["has expired"]
-        end
-
-        it "does not run expiration in the past validation if month is not set" do
-          credit_card.month = nil
-          credit_card.year = Time.zone.now.year
-          expect(credit_card).not_to be_valid
-          expect(credit_card.errors[:base]).to be_blank
-        end
-
-        it "does not run expiration in the past validation if year is not set" do
-          credit_card.month = Time.zone.now.month
-          credit_card.year = nil
-          expect(credit_card).not_to be_valid
-          expect(credit_card.errors[:base]).to be_blank
-        end
-
-        it "does not run expiration in the past validation if year and month are empty" do
-          credit_card.year = ""
-          credit_card.month = ""
-          expect(credit_card).not_to be_valid
-          expect(credit_card.errors[:card]).to be_blank
-        end
-
-        it "should only validate on create" do
-          credit_card.attributes = valid_credit_card_attributes
-          credit_card.save
-          expect(credit_card).to be_valid
-        end
-      end
-
-      context "#save" do
-        before do
-          credit_card.attributes = valid_credit_card_attributes
-          credit_card.save!
-        end
-
-        let!(:persisted_card) { Spree::CreditCard.find(credit_card.id) }
-
-        it "should not actually store the number" do
-          expect(persisted_card.number).to be_blank
-        end
-
-        it "should not actually store the security code" do
-          expect(persisted_card.verification_value).to be_blank
-        end
-      end
-
-      context "#number=" do
-        it "should strip non-numeric characters from card input" do
-          credit_card.number = "6011000990139424"
-          expect(credit_card.number).to eq "6011000990139424"
-
-          credit_card.number = "  6011-0009-9013-9424  "
-          expect(credit_card.number).to eq "6011000990139424"
-        end
-
-        it "should not raise an exception on non-string input" do
-          credit_card.number = ({})
-          expect(credit_card.number).to be_nil
-        end
-      end
-
-      context "#associations" do
-        it "should be able to access its payments" do
-          expect { credit_card.payments.to_a }.not_to raise_error
-        end
-      end
-
-      context "#to_active_merchant" do
-        before do
-          credit_card.number = "4111111111111111"
-          credit_card.year = Time.zone.now.year
-          credit_card.month = Time.zone.now.month
-          credit_card.first_name = "Bob"
-          credit_card.last_name = "Boblaw"
-          credit_card.verification_value = 123
-        end
-
-        it "converts to an ActiveMerchant::Billing::CreditCard object" do
-          am_card = credit_card.to_active_merchant
-          expect(am_card.number).to eq "4111111111111111"
-          expect(am_card.year).to eq Time.zone.now.year
-          expect(am_card.month).to eq Time.zone.now.month
-          expect(am_card.first_name).to eq "Bob"
-          am_card.last_name = "Boblaw"
-          expect(am_card.verification_value).to eq 123
-        end
+      it "should be true if payment is checkout" do
+        payment = build_stubbed(:payment, created_at: Time.zone.now)
+        allow(payment).to receive_messages pending?: false,
+                                           checkout?: true
+        expect(credit_card.can_capture_and_complete_order?(payment)).to be_truthy
       end
     end
 
-    describe "formatting the card type for ActiveMerchant" do
-      context "#cc_type=" do
-        let(:credit_card) { build(:credit_card) }
-
-        it "converts the card type format" do
-          credit_card.cc_type = 'mastercard'
-          expect(credit_card.cc_type).to eq 'master'
-
-          credit_card.cc_type = 'maestro'
-          expect(credit_card.cc_type).to eq 'master'
-
-          credit_card.cc_type = 'amex'
-          expect(credit_card.cc_type).to eq 'american_express'
-
-          credit_card.cc_type = 'dinersclub'
-          expect(credit_card.cc_type).to eq 'diners_club'
-
-          credit_card.cc_type = 'some_outlandish_cc_type'
-          expect(credit_card.cc_type).to eq 'some_outlandish_cc_type'
-        end
-      end
-
-      context "on save" do
-        it "converts the card type format" do
-          expect_any_instance_of(Spree::CreditCard).to receive(:reformat_card_type!).
-            at_least(:once).and_call_original
-
-          credit_card = Spree::CreditCard.create(
-            valid_credit_card_attributes.merge(cc_type: "Master Card")
-          )
-
-          expect(credit_card.cc_type).to eq "master"
-        end
+    context "#can_void?" do
+      it "should be true if payment is not void" do
+        payment = build_stubbed(:payment)
+        allow(payment).to receive(:void?) { false }
+        expect(credit_card.can_void?(payment)).to be_truthy
       end
     end
 
-    describe "setting default credit card for a user" do
-      let(:user) { create(:user) }
-      let(:onetime_card_attrs) do
-        { user:, gateway_payment_profile_id: "tok_1EY..." }
-      end
-      let(:stored_card_attrs) do
-        {
-          user:,
-          gateway_customer_profile_id: "cus_F2T...",
-          gateway_payment_profile_id: "card_1EY..."
-        }
-      end
-      let(:stored_default_card_attrs) do
-        stored_card_attrs.merge(is_default: true)
+    context "#can_credit?" do
+      it "should be false if payment is not completed" do
+        payment = build_stubbed(:payment)
+        allow(payment).to receive(:completed?) { false }
+        expect(credit_card.can_credit?(payment)).to be_falsy
       end
 
-      context "when a card is already set as the default" do
-        let!(:card1) { create(:credit_card, stored_default_card_attrs) }
+      it "should be false when order payment_state is not 'credit_owed'" do
+        payment = build_stubbed(:payment,
+                                order: create(:order, payment_state: 'paid'))
+        allow(payment).to receive(:completed?) { true }
+        expect(credit_card.can_credit?(payment)).to be_falsy
+      end
 
-        context "and I create a new card" do
-          context "without specifying it as the default" do
-            let!(:card2) { create(:credit_card, stored_card_attrs) }
+      it "should be false when credit_allowed is zero" do
+        payment = build_stubbed(:payment,
+                                order: create(:order, payment_state: 'credit_owed'))
+        allow(payment).to receive_messages completed?: true,
+                                           credit_allowed: 0
 
-            it "keeps the existing default" do
-              expect(card1.reload.is_default).to be true
-              expect(card2.reload.is_default).to be false
-            end
-          end
+        expect(credit_card.can_credit?(payment)).to be_falsy
+      end
+    end
 
-          context "and I specify it as the default" do
-            let!(:card2) { create(:credit_card, stored_default_card_attrs) }
+    context "#valid?" do
+      it "should validate presence of number" do
+        credit_card.attributes = valid_credit_card_attributes.except(:number)
+        expect(credit_card).not_to be_valid
+        expect(credit_card.errors[:number]).to eq ["can't be blank"]
+      end
 
-            it "switches the default to the new card" do
-              expect(card1.reload.is_default).to be false
-              expect(card2.reload.is_default).to be true
-            end
+      it "should validate presence of security code" do
+        credit_card.attributes = valid_credit_card_attributes.except(:verification_value)
+        expect(credit_card).not_to be_valid
+        expect(credit_card.errors[:verification_value]).to eq ["can't be blank"]
+      end
+
+      it "should validate expiration is not in the past" do
+        credit_card.month = 1.month.ago.month
+        credit_card.year = 1.month.ago.year
+        expect(credit_card).not_to be_valid
+        expect(credit_card.errors[:base]).to eq ["has expired"]
+      end
+
+      it "does not run expiration in the past validation if month is not set" do
+        credit_card.month = nil
+        credit_card.year = Time.zone.now.year
+        expect(credit_card).not_to be_valid
+        expect(credit_card.errors[:base]).to be_blank
+      end
+
+      it "does not run expiration in the past validation if year is not set" do
+        credit_card.month = Time.zone.now.month
+        credit_card.year = nil
+        expect(credit_card).not_to be_valid
+        expect(credit_card.errors[:base]).to be_blank
+      end
+
+      it "does not run expiration in the past validation if year and month are empty" do
+        credit_card.year = ""
+        credit_card.month = ""
+        expect(credit_card).not_to be_valid
+        expect(credit_card.errors[:card]).to be_blank
+      end
+
+      it "should only validate on create" do
+        credit_card.attributes = valid_credit_card_attributes
+        credit_card.save
+        expect(credit_card).to be_valid
+      end
+    end
+
+    context "#save" do
+      before do
+        credit_card.attributes = valid_credit_card_attributes
+        credit_card.save!
+      end
+
+      let!(:persisted_card) { described_class.find(credit_card.id) }
+
+      it "should not actually store the number" do
+        expect(persisted_card.number).to be_blank
+      end
+
+      it "should not actually store the security code" do
+        expect(persisted_card.verification_value).to be_blank
+      end
+    end
+
+    context "#number=" do
+      it "should strip non-numeric characters from card input" do
+        credit_card.number = "6011000990139424"
+        expect(credit_card.number).to eq "6011000990139424"
+
+        credit_card.number = "  6011-0009-9013-9424  "
+        expect(credit_card.number).to eq "6011000990139424"
+      end
+
+      it "should not raise an exception on non-string input" do
+        credit_card.number = ({})
+        expect(credit_card.number).to be_nil
+      end
+    end
+
+    context "#associations" do
+      it "should be able to access its payments" do
+        expect { credit_card.payments.to_a }.not_to raise_error
+      end
+    end
+
+    context "#to_active_merchant" do
+      before do
+        credit_card.number = "4111111111111111"
+        credit_card.year = Time.zone.now.year
+        credit_card.month = Time.zone.now.month
+        credit_card.first_name = "Bob"
+        credit_card.last_name = "Boblaw"
+        credit_card.verification_value = 123
+      end
+
+      it "converts to an ActiveMerchant::Billing::CreditCard object" do
+        am_card = credit_card.to_active_merchant
+        expect(am_card.number).to eq "4111111111111111"
+        expect(am_card.year).to eq Time.zone.now.year
+        expect(am_card.month).to eq Time.zone.now.month
+        expect(am_card.first_name).to eq "Bob"
+        am_card.last_name = "Boblaw"
+        expect(am_card.verification_value).to eq 123
+      end
+    end
+  end
+
+  describe "formatting the card type for ActiveMerchant" do
+    context "#cc_type=" do
+      let(:credit_card) { build(:credit_card) }
+
+      it "converts the card type format" do
+        credit_card.cc_type = 'mastercard'
+        expect(credit_card.cc_type).to eq 'master'
+
+        credit_card.cc_type = 'maestro'
+        expect(credit_card.cc_type).to eq 'master'
+
+        credit_card.cc_type = 'amex'
+        expect(credit_card.cc_type).to eq 'american_express'
+
+        credit_card.cc_type = 'dinersclub'
+        expect(credit_card.cc_type).to eq 'diners_club'
+
+        credit_card.cc_type = 'some_outlandish_cc_type'
+        expect(credit_card.cc_type).to eq 'some_outlandish_cc_type'
+      end
+    end
+
+    context "on save" do
+      it "converts the card type format" do
+        expect_any_instance_of(described_class).to receive(:reformat_card_type!).
+          at_least(:once).and_call_original
+
+        credit_card = described_class.create(
+          valid_credit_card_attributes.merge(cc_type: "Master Card")
+        )
+
+        expect(credit_card.cc_type).to eq "master"
+      end
+    end
+  end
+
+  describe "setting default credit card for a user" do
+    let(:user) { create(:user) }
+    let(:onetime_card_attrs) do
+      { user:, gateway_payment_profile_id: "tok_1EY..." }
+    end
+    let(:stored_card_attrs) do
+      {
+        user:,
+        gateway_customer_profile_id: "cus_F2T...",
+        gateway_payment_profile_id: "card_1EY..."
+      }
+    end
+    let(:stored_default_card_attrs) do
+      stored_card_attrs.merge(is_default: true)
+    end
+
+    context "when a card is already set as the default" do
+      let!(:card1) { create(:credit_card, stored_default_card_attrs) }
+
+      context "and I create a new card" do
+        context "without specifying it as the default" do
+          let!(:card2) { create(:credit_card, stored_card_attrs) }
+
+          it "keeps the existing default" do
+            expect(card1.reload.is_default).to be true
+            expect(card2.reload.is_default).to be false
           end
         end
 
-        context "and I update another card" do
-          let!(:card2) { create(:credit_card, user:) }
+        context "and I specify it as the default" do
+          let!(:card2) { create(:credit_card, stored_default_card_attrs) }
 
-          context "without specifying it as the default" do
-            it "keeps the existing default" do
-              card2.update!(stored_card_attrs)
-
-              expect(card1.reload.is_default).to be true
-              expect(card2.reload.is_default).to be false
-            end
-          end
-
-          context "and I specify it as the default" do
-            it "switches the default to the updated card" do
-              card2.update!(stored_default_card_attrs)
-
-              expect(card1.reload.is_default).to be false
-              expect(card2.reload.is_default).to be true
-            end
-          end
-        end
-      end
-
-      context "when no card is currently set as the default for a user" do
-        context "and I create a new card" do
-          context "without specifying it as the default" do
-            let!(:card1) { create(:credit_card, stored_card_attrs) }
-
-            it "sets it as the default anyway" do
-              expect(card1.reload.is_default).to be true
-            end
-          end
-
-          context "and I specify it as the default" do
-            let!(:card1) { create(:credit_card, stored_default_card_attrs) }
-
-            it "sets it as the default" do
-              expect(card1.reload.is_default).to be true
-            end
-          end
-        end
-
-        context "and the checkout creates a card" do
-          let!(:card1) { create(:credit_card, onetime_card_attrs) }
-          let(:store_card_profile_attrs) {
-            {
-              cc_type: "visa",
-              gateway_customer_profile_id: "cus_FH9HflKAJw6Kxy",
-              gateway_payment_profile_id: "card_1EmayNBZvgSKc1B2wctIzzoh"
-            }
-          }
-
-          it "doesn't set a one-time card as the default" do
+          it "switches the default to the new card" do
             expect(card1.reload.is_default).to be false
+            expect(card2.reload.is_default).to be true
           end
+        end
+      end
 
-          it "sets a re-usable card as the default" do
-            # The checkout first creates a one-time card and then converts it
-            # to a re-usable card.
-            # This imitates Stripe::ProfileStorer.
-            card1.update!(store_card_profile_attrs)
+      context "and I update another card" do
+        let!(:card2) { create(:credit_card, user:) }
+
+        context "without specifying it as the default" do
+          it "keeps the existing default" do
+            card2.update!(stored_card_attrs)
+
+            expect(card1.reload.is_default).to be true
+            expect(card2.reload.is_default).to be false
+          end
+        end
+
+        context "and I specify it as the default" do
+          it "switches the default to the updated card" do
+            card2.update!(stored_default_card_attrs)
+
+            expect(card1.reload.is_default).to be false
+            expect(card2.reload.is_default).to be true
+          end
+        end
+      end
+    end
+
+    context "when no card is currently set as the default for a user" do
+      context "and I create a new card" do
+        context "without specifying it as the default" do
+          let!(:card1) { create(:credit_card, stored_card_attrs) }
+
+          it "sets it as the default anyway" do
             expect(card1.reload.is_default).to be true
           end
+        end
+
+        context "and I specify it as the default" do
+          let!(:card1) { create(:credit_card, stored_default_card_attrs) }
+
+          it "sets it as the default" do
+            expect(card1.reload.is_default).to be true
+          end
+        end
+      end
+
+      context "and the checkout creates a card" do
+        let!(:card1) { create(:credit_card, onetime_card_attrs) }
+        let(:store_card_profile_attrs) {
+          {
+            cc_type: "visa",
+            gateway_customer_profile_id: "cus_FH9HflKAJw6Kxy",
+            gateway_payment_profile_id: "card_1EmayNBZvgSKc1B2wctIzzoh"
+          }
+        }
+
+        it "doesn't set a one-time card as the default" do
+          expect(card1.reload.is_default).to be false
+        end
+
+        it "sets a re-usable card as the default" do
+          # The checkout first creates a one-time card and then converts it
+          # to a re-usable card.
+          # This imitates Stripe::ProfileStorer.
+          card1.update!(store_card_profile_attrs)
+          expect(card1.reload.is_default).to be true
         end
       end
     end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -2,854 +2,852 @@
 
 require 'spec_helper'
 
-module Spree
-  RSpec.describe LineItem do
-    let(:order) { create :order_with_line_items, line_items_count: 1 }
-    let(:line_item) { order.line_items.first }
+RSpec.describe Spree::LineItem do
+  let(:order) { create :order_with_line_items, line_items_count: 1 }
+  let(:line_item) { order.line_items.first }
 
-    describe "associations" do
-      it { is_expected.to belong_to(:order).required }
-      it { is_expected.to have_one(:order_cycle).through(:order) }
-      it { is_expected.to belong_to(:variant).required }
-      it { is_expected.to have_one(:product).through(:variant) }
-      it { is_expected.to have_one(:supplier).through(:variant) }
-      it { is_expected.to belong_to(:tax_category).optional }
-      it { is_expected.to have_many(:adjustments) }
+  describe "associations" do
+    it { is_expected.to belong_to(:order).required }
+    it { is_expected.to have_one(:order_cycle).through(:order) }
+    it { is_expected.to belong_to(:variant).required }
+    it { is_expected.to have_one(:product).through(:variant) }
+    it { is_expected.to have_one(:supplier).through(:variant) }
+    it { is_expected.to belong_to(:tax_category).optional }
+    it { is_expected.to have_many(:adjustments) }
+  end
+
+  context '#save' do
+    it 'should update inventory, totals, and tax' do
+      # Regression check for Spree #1481
+      expect(line_item.order).to receive(:create_tax_charge!)
+      line_item.quantity = 2
+      line_item.save
+    end
+  end
+
+  context '#destroy' do
+    # Regression test for Spree #1481
+    it "applies tax adjustments" do
+      expect(line_item.order).to receive(:create_tax_charge!)
+      line_item.destroy
     end
 
-    context '#save' do
-      it 'should update inventory, totals, and tax' do
-        # Regression check for Spree #1481
-        expect(line_item.order).to receive(:create_tax_charge!)
-        line_item.quantity = 2
+    it "fetches deleted products" do
+      line_item.product.destroy
+      expect(line_item.reload.product).to be_a Spree::Product
+    end
+
+    it "fetches deleted variants" do
+      line_item.variant.destroy
+      expect(line_item.reload.variant).to be_a Spree::Variant
+    end
+  end
+
+  # Test for Spree #3391
+  context '#copy_price' do
+    it "copies over a variant's prices" do
+      line_item.price = nil
+      line_item.currency = nil
+      line_item.copy_price
+      variant = line_item.variant
+      expect(line_item.price).to eq variant.price
+      expect(line_item.currency).to eq variant.currency
+    end
+  end
+
+  # Test for Spree #3481
+  context '#copy_tax_category' do
+    it "copies over a variant's tax category" do
+      line_item.tax_category = nil
+      line_item.copy_tax_category
+      expect(line_item.tax_category).to eq line_item.variant.tax_category
+    end
+  end
+
+  describe '.currency' do
+    it 'returns the globally configured currency' do
+      line_item.currency == 'USD'
+    end
+  end
+
+  describe ".money" do
+    before do
+      line_item.price = 3.50
+      line_item.quantity = 2
+    end
+
+    it "returns a Spree::Money representing the total for this line item" do
+      expect(line_item.money.to_s).to eq "$7.00"
+    end
+  end
+
+  describe '.single_money' do
+    before { line_item.price = 3.50 }
+    it "returns a Spree::Money representing the price for one variant" do
+      expect(line_item.single_money.to_s).to eq "$3.50"
+    end
+  end
+
+  context "has inventory (completed order so items were already unstocked)" do
+    let(:order) { Spree::Order.create }
+    let(:variant) { create(:variant) }
+
+    context "nothing left on stock" do
+      before do
+        variant.stock_items.update_all count_on_hand: 5, backorderable: false
+        order.contents.add(variant, 5)
+        order.create_proposed_shipments
+        order.finalize!
+      end
+
+      it "allows to decrease item quantity" do
+        line_item = order.line_items.first
+        line_item.quantity -= 1
+        line_item.target_shipment = order.shipments.first
+
         line_item.save
+        expect(line_item.errors[:quantity]).to be_empty
+      end
+
+      it "doesnt allow to increase item quantity" do
+        line_item = order.line_items.first
+        line_item.quantity += 2
+        line_item.target_shipment = order.shipments.first
+
+        line_item.save
+        expect(line_item.errors[:quantity].first).to include "is out of stock"
       end
     end
 
-    context '#destroy' do
-      # Regression test for Spree #1481
-      it "applies tax adjustments" do
-        expect(line_item.order).to receive(:create_tax_charge!)
-        line_item.destroy
-      end
-
-      it "fetches deleted products" do
-        line_item.product.destroy
-        expect(line_item.reload.product).to be_a Spree::Product
-      end
-
-      it "fetches deleted variants" do
-        line_item.variant.destroy
-        expect(line_item.reload.variant).to be_a Spree::Variant
-      end
-    end
-
-    # Test for Spree #3391
-    context '#copy_price' do
-      it "copies over a variant's prices" do
-        line_item.price = nil
-        line_item.currency = nil
-        line_item.copy_price
-        variant = line_item.variant
-        expect(line_item.price).to eq variant.price
-        expect(line_item.currency).to eq variant.currency
-      end
-    end
-
-    # Test for Spree #3481
-    context '#copy_tax_category' do
-      it "copies over a variant's tax category" do
-        line_item.tax_category = nil
-        line_item.copy_tax_category
-        expect(line_item.tax_category).to eq line_item.variant.tax_category
-      end
-    end
-
-    describe '.currency' do
-      it 'returns the globally configured currency' do
-        line_item.currency == 'USD'
-      end
-    end
-
-    describe ".money" do
+    context "2 items left on stock" do
       before do
-        line_item.price = 3.50
-        line_item.quantity = 2
+        variant.stock_items.update_all count_on_hand: 7, backorderable: false
+        order.contents.add(variant, 5)
+        order.create_proposed_shipments
+        order.finalize!
       end
 
-      it "returns a Spree::Money representing the total for this line item" do
-        expect(line_item.money.to_s).to eq "$7.00"
-      end
-    end
+      it "allows to increase quantity up to stock availability" do
+        line_item = order.line_items.first
+        line_item.quantity += 2
+        line_item.target_shipment = order.shipments.first
 
-    describe '.single_money' do
-      before { line_item.price = 3.50 }
-      it "returns a Spree::Money representing the price for one variant" do
-        expect(line_item.single_money.to_s).to eq "$3.50"
-      end
-    end
-
-    context "has inventory (completed order so items were already unstocked)" do
-      let(:order) { Spree::Order.create }
-      let(:variant) { create(:variant) }
-
-      context "nothing left on stock" do
-        before do
-          variant.stock_items.update_all count_on_hand: 5, backorderable: false
-          order.contents.add(variant, 5)
-          order.create_proposed_shipments
-          order.finalize!
-        end
-
-        it "allows to decrease item quantity" do
-          line_item = order.line_items.first
-          line_item.quantity -= 1
-          line_item.target_shipment = order.shipments.first
-
-          line_item.save
-          expect(line_item.errors[:quantity]).to be_empty
-        end
-
-        it "doesnt allow to increase item quantity" do
-          line_item = order.line_items.first
-          line_item.quantity += 2
-          line_item.target_shipment = order.shipments.first
-
-          line_item.save
-          expect(line_item.errors[:quantity].first).to include "is out of stock"
-        end
+        line_item.save
+        expect(line_item.errors[:quantity]).to be_empty
       end
 
-      context "2 items left on stock" do
-        before do
-          variant.stock_items.update_all count_on_hand: 7, backorderable: false
-          order.contents.add(variant, 5)
-          order.create_proposed_shipments
-          order.finalize!
-        end
+      it "doesnt allow to increase quantity over stock availability" do
+        line_item = order.line_items.first
+        line_item.quantity += 3
+        line_item.target_shipment = order.shipments.first
 
-        it "allows to increase quantity up to stock availability" do
-          line_item = order.line_items.first
-          line_item.quantity += 2
-          line_item.target_shipment = order.shipments.first
-
-          line_item.save
-          expect(line_item.errors[:quantity]).to be_empty
-        end
-
-        it "doesnt allow to increase quantity over stock availability" do
-          line_item = order.line_items.first
-          line_item.quantity += 3
-          line_item.target_shipment = order.shipments.first
-
-          line_item.save
-          expect(line_item.errors[:quantity].first).to include "is out of stock"
-        end
+        line_item.save
+        expect(line_item.errors[:quantity].first).to include "is out of stock"
       end
     end
+  end
 
-    describe "scopes" do
-      let(:o) { create(:order) }
+  describe "scopes" do
+    let(:o) { create(:order) }
 
-      let(:s1) { create(:supplier_enterprise) }
-      let(:s2) { create(:supplier_enterprise) }
+    let(:s1) { create(:supplier_enterprise) }
+    let(:s2) { create(:supplier_enterprise) }
 
-      let(:variant1) { create(:variant, supplier: s1) }
-      let(:variant2) { create(:variant, supplier: s2) }
+    let(:variant1) { create(:variant, supplier: s1) }
+    let(:variant2) { create(:variant, supplier: s2) }
 
-      let(:li1) { create(:line_item, order: o, variant: variant1) }
-      let(:li2) { create(:line_item, order: o, variant: variant2) }
+    let(:li1) { create(:line_item, order: o, variant: variant1) }
+    let(:li2) { create(:line_item, order: o, variant: variant2) }
 
-      let(:p3) { create(:product, name: 'Clear Honey') }
-      let(:p4) { create(:product, name: 'Apricots') }
-      let(:v1) { create(:variant, product: p3, unit_value: 500) }
-      let(:v2) { create(:variant, product: p3, unit_value: 250) }
-      let(:v3) { create(:variant, product: p4, unit_value: 500, display_name: "ZZ") }
-      let(:v4) { create(:variant, product: p4, unit_value: 500, display_name: "aa") }
-      let(:li3) { create(:line_item, order: o, product: p3, variant: v1) }
-      let(:li4) { create(:line_item, order: o, product: p3, variant: v2) }
-      let(:li5) { create(:line_item, order: o, product: p4, variant: v3) }
-      let(:li6) { create(:line_item, order: o, product: p4, variant: v4) }
+    let(:p3) { create(:product, name: 'Clear Honey') }
+    let(:p4) { create(:product, name: 'Apricots') }
+    let(:v1) { create(:variant, product: p3, unit_value: 500) }
+    let(:v2) { create(:variant, product: p3, unit_value: 250) }
+    let(:v3) { create(:variant, product: p4, unit_value: 500, display_name: "ZZ") }
+    let(:v4) { create(:variant, product: p4, unit_value: 500, display_name: "aa") }
+    let(:li3) { create(:line_item, order: o, product: p3, variant: v1) }
+    let(:li4) { create(:line_item, order: o, product: p3, variant: v2) }
+    let(:li5) { create(:line_item, order: o, product: p4, variant: v3) }
+    let(:li6) { create(:line_item, order: o, product: p4, variant: v4) }
 
-      let(:oc_order) { create :order_with_totals_and_distribution }
+    let(:oc_order) { create :order_with_totals_and_distribution }
 
-      it "finds line items for products supplied by one of a number of enterprises" do
-        li1; li2
-        expect(LineItem.supplied_by_any([s1])).to eq([li1])
-        expect(LineItem.supplied_by_any([s2])).to eq([li2])
-        expect(LineItem.supplied_by_any([s1, s2])).to match_array [li1, li2]
-      end
-
-      describe "finding line items with and without tax" do
-        let(:tax_rate) { create(:tax_rate, calculator: ::Calculator::DefaultTax.new) }
-        let!(:adjustment1) {
-          create(:adjustment, originator: tax_rate, label: "TR", amount: 123, included_tax: 10.00)
-        }
-
-        before do
-          li1
-          li2.reload
-          li1.adjustments << adjustment1
-        end
-
-        it "finds line items with tax" do
-          expect(LineItem.with_tax.to_a).to eq([li1])
-        end
-
-        it "finds line items without tax" do
-          expect(LineItem.without_tax).to eq([li2])
-        end
-      end
-
-      describe "#sorted_by_name_and_unit_value" do
-        it "finds line items sorted by name and unit_value" do
-          expect(o.line_items.sorted_by_name_and_unit_value).to eq([li6, li5, li4, li3])
-        end
-
-        it "includes soft-deleted products/variants" do
-          li3.variant.product.destroy
-
-          expect(o.line_items.reload.sorted_by_name_and_unit_value).to eq([li6, li5, li4, li3])
-          expect(o.line_items.sorted_by_name_and_unit_value.to_sql).not_to match "deleted_at"
-        end
-      end
-
-      it "finds line items from a given order cycle" do
-        expect(LineItem.from_order_cycle(oc_order.order_cycle).first.id)
-          .to eq oc_order.line_items.first.id
-      end
+    it "finds line items for products supplied by one of a number of enterprises" do
+      li1; li2
+      expect(described_class.supplied_by_any([s1])).to eq([li1])
+      expect(described_class.supplied_by_any([s2])).to eq([li2])
+      expect(described_class.supplied_by_any([s1, s2])).to match_array [li1, li2]
     end
 
-    describe "capping quantity at stock level" do
-      let!(:v) { create(:variant, on_demand: false, on_hand: 10) }
-      let!(:li) { create(:line_item, variant: v, quantity: 10, max_quantity: 10) }
+    describe "finding line items with and without tax" do
+      let(:tax_rate) { create(:tax_rate, calculator: Calculator::DefaultTax.new) }
+      let!(:adjustment1) {
+        create(:adjustment, originator: tax_rate, label: "TR", amount: 123, included_tax: 10.00)
+      }
 
       before do
-        v.update! on_hand: 5
+        li1
+        li2.reload
+        li1.adjustments << adjustment1
       end
 
-      it "caps quantity" do
-        li.cap_quantity_at_stock!
-        expect(li.reload.quantity).to eq 5
+      it "finds line items with tax" do
+        expect(described_class.with_tax.to_a).to eq([li1])
       end
 
-      it "does not cap max_quantity" do
-        li.cap_quantity_at_stock!
-        expect(li.reload.max_quantity).to eq 10
+      it "finds line items without tax" do
+        expect(described_class.without_tax).to eq([li2])
+      end
+    end
+
+    describe "#sorted_by_name_and_unit_value" do
+      it "finds line items sorted by name and unit_value" do
+        expect(o.line_items.sorted_by_name_and_unit_value).to eq([li6, li5, li4, li3])
       end
 
-      it "works for products without max_quantity" do
-        li.update_column :max_quantity, nil
-        li.cap_quantity_at_stock!
-        li.reload
-        expect(li.quantity).to eq 5
-        expect(li.max_quantity).to be nil
+      it "includes soft-deleted products/variants" do
+        li3.variant.product.destroy
+
+        expect(o.line_items.reload.sorted_by_name_and_unit_value).to eq([li6, li5, li4, li3])
+        expect(o.line_items.sorted_by_name_and_unit_value.to_sql).not_to match "deleted_at"
+      end
+    end
+
+    it "finds line items from a given order cycle" do
+      expect(described_class.from_order_cycle(oc_order.order_cycle).first.id)
+        .to eq oc_order.line_items.first.id
+    end
+  end
+
+  describe "capping quantity at stock level" do
+    let!(:v) { create(:variant, on_demand: false, on_hand: 10) }
+    let!(:li) { create(:line_item, variant: v, quantity: 10, max_quantity: 10) }
+
+    before do
+      v.update! on_hand: 5
+    end
+
+    it "caps quantity" do
+      li.cap_quantity_at_stock!
+      expect(li.reload.quantity).to eq 5
+    end
+
+    it "does not cap max_quantity" do
+      li.cap_quantity_at_stock!
+      expect(li.reload.max_quantity).to eq 10
+    end
+
+    it "works for products without max_quantity" do
+      li.update_column :max_quantity, nil
+      li.cap_quantity_at_stock!
+      li.reload
+      expect(li.quantity).to eq 5
+      expect(li.max_quantity).to be nil
+    end
+
+    it "does nothing for on_demand items" do
+      v.update! on_demand: true
+      li.cap_quantity_at_stock!
+      li.reload
+      expect(li.quantity).to eq 10
+      expect(li.max_quantity).to eq 10
+    end
+
+    it "caps at zero when stock is negative" do
+      v.__send__(:stock_item).update_column(:count_on_hand, -2)
+      li.cap_quantity_at_stock!
+      expect(li.reload.quantity).to eq 0
+    end
+
+    context "when a variant override is in place" do
+      let!(:hub) { create(:distributor_enterprise) }
+      let!(:vo) { create(:variant_override, hub:, variant: v, count_on_hand: 2) }
+
+      before do
+        li.order.update(distributor_id: hub.id)
+
+        # li#scoper is memoised, and this makes it difficult to update test conditions
+        # so we reset it after the line_item is created for each spec
+        li.remove_instance_variable(:@scoper)
       end
 
-      it "does nothing for on_demand items" do
-        v.update! on_demand: true
+      it "caps quantity to override stock level" do
         li.cap_quantity_at_stock!
-        li.reload
-        expect(li.quantity).to eq 10
-        expect(li.max_quantity).to eq 10
+        expect(li.quantity).to eq 2
+      end
+    end
+  end
+
+  describe "reducing stock levels on order completion" do
+    context "when the item is on_demand" do
+      let!(:hub) { create(:distributor_enterprise) }
+      let(:bill_address) { create(:address) }
+      let!(:variant_on_demand) { create(:variant, on_demand: true, on_hand: 1) }
+      let!(:order) {
+        create(:order,
+               distributor: hub,
+               order_cycle: create(:simple_order_cycle),
+               bill_address:,
+               ship_address: bill_address)
+      }
+      let!(:shipping_method) { create(:shipping_method, distributors: [hub]) }
+      let!(:line_item) {
+        create(:line_item, variant: variant_on_demand, quantity: 10, order:)
+      }
+
+      before do
+        order.reload
+        order.update_totals
+        order.payments << create(:payment, amount: order.total)
+        Orders::WorkflowService.new(order).complete!
+        order.payment_state = 'paid'
+        order.select_shipping_method(shipping_method.id)
+        order.shipment.update!(order)
       end
 
-      it "caps at zero when stock is negative" do
-        v.__send__(:stock_item).update_column(:count_on_hand, -2)
-        li.cap_quantity_at_stock!
-        expect(li.reload.quantity).to eq 0
+      it "creates a shipment without backordered items" do
+        expect(order.shipment.manifest.count).to eq 1
+        expect(order.shipment.manifest.first.quantity).to eq 10
+        expect(order.shipment.manifest.first.states).to eq 'on_hand' => 10
+        expect(order.shipment.manifest.first.variant).to eq line_item.variant
+      end
+
+      it "reduces the variant's stock level" do
+        expect(variant_on_demand.reload.on_hand).to eq(-9)
+      end
+
+      it "does not mark inventory units as backorderd" do
+        backordered_units = order.shipments.first.inventory_units.any?(&:backordered?)
+        expect(backordered_units).to be false
+      end
+
+      it "does not mark the shipment as backorderd" do
+        expect(order.shipments.first.backordered?).to be false
+      end
+
+      it "allows the order to be shipped" do
+        expect(order.ready_to_ship?).to be true
+      end
+
+      it "does not change stock levels when cancelled" do
+        order.cancel!
+        expect(variant_on_demand.reload.on_hand).to eq 1
+      end
+    end
+  end
+
+  describe "tracking stock when quantity is changed" do
+    context "when the order is already complete" do
+      let(:shop) { create(:distributor_enterprise) }
+      let(:order) { create(:completed_order_with_totals, distributor: shop) }
+      let!(:line_item) { order.reload.line_items.first }
+      let!(:variant) { line_item.variant }
+
+      context "when a variant override applies" do
+        let!(:vo) { create(:variant_override, hub: shop, variant:, count_on_hand: 3 ) }
+
+        it "draws stock from the variant override" do
+          expect(vo.reload.count_on_hand).to eq 3
+          expect{ line_item.update!(quantity: line_item.quantity + 1) }
+            .not_to change{ Spree::Variant.find(variant.id).on_hand }
+          expect(vo.reload.count_on_hand).to eq 2
+        end
+      end
+
+      context "when a variant override does not apply" do
+        it "draws stock from the variant" do
+          expect{ line_item.update!(quantity: line_item.quantity + 1) }.to change{
+            Spree::Variant.find(variant.id).on_hand
+          }.by(-1)
+        end
+      end
+    end
+  end
+
+  describe "tracking stock when a line item is destroyed" do
+    context "when the order is already complete" do
+      let(:shop) { create(:distributor_enterprise) }
+      let(:order) { create(:completed_order_with_totals, distributor: shop) }
+      let!(:line_item) { order.reload.line_items.first }
+      let!(:variant) { line_item.variant }
+
+      context "when a variant override applies" do
+        let!(:vo) { create(:variant_override, hub: shop, variant:, count_on_hand: 3 ) }
+
+        it "restores stock to the variant override" do
+          expect(vo.reload.count_on_hand).to eq 3
+          expect{ line_item.destroy }.not_to change{ Spree::Variant.find(variant.id).on_hand }
+          expect(vo.reload.count_on_hand).to eq 4
+        end
+      end
+
+      context "when a variant override does not apply" do
+        it "restores stock to the variant" do
+          expect{ line_item.destroy }.to change{ Spree::Variant.find(variant.id).on_hand }.by(1)
+        end
+      end
+    end
+  end
+
+  describe "determining if sufficient stock is present" do
+    let!(:hub) { create(:distributor_enterprise) }
+    let!(:o) { create(:order, distributor: hub) }
+    let!(:v) { create(:variant, on_demand: false, on_hand: 10) }
+    let!(:v_on_demand) { create(:variant, on_demand: true, on_hand: 1) }
+    let(:li) { build_stubbed(:line_item, variant: v, order: o, quantity: 5, max_quantity: 5) }
+    let(:li_on_demand) {
+      build_stubbed(:line_item, variant: v_on_demand, order: o, quantity: 99, max_quantity: 99)
+    }
+
+    context "when the variant is on_demand" do
+      it { expect(li_on_demand.sufficient_stock?).to be true }
+    end
+
+    context "when stock on the variant is sufficient" do
+      it { expect(li.sufficient_stock?).to be true }
+    end
+
+    context "when the stock on the variant is not sufficient" do
+      before { v.update(on_hand: 4) }
+
+      context "when no variant override is in place" do
+        it { expect(li.sufficient_stock?).to be false }
       end
 
       context "when a variant override is in place" do
-        let!(:hub) { create(:distributor_enterprise) }
-        let!(:vo) { create(:variant_override, hub:, variant: v, count_on_hand: 2) }
+        let!(:vo) { create(:variant_override, hub:, variant: v, count_on_hand: 5) }
 
-        before do
-          li.order.update(distributor_id: hub.id)
-
-          # li#scoper is memoised, and this makes it difficult to update test conditions
-          # so we reset it after the line_item is created for each spec
-          li.remove_instance_variable(:@scoper)
+        context "and stock on the variant override is sufficient" do
+          it { expect(li.sufficient_stock?).to be true }
         end
 
-        it "caps quantity to override stock level" do
-          li.cap_quantity_at_stock!
-          expect(li.quantity).to eq 2
-        end
-      end
-    end
+        context "and stock on the variant override is not sufficient" do
+          before { vo.update(count_on_hand: 4) }
 
-    describe "reducing stock levels on order completion" do
-      context "when the item is on_demand" do
-        let!(:hub) { create(:distributor_enterprise) }
-        let(:bill_address) { create(:address) }
-        let!(:variant_on_demand) { create(:variant, on_demand: true, on_hand: 1) }
-        let!(:order) {
-          create(:order,
-                 distributor: hub,
-                 order_cycle: create(:simple_order_cycle),
-                 bill_address:,
-                 ship_address: bill_address)
-        }
-        let!(:shipping_method) { create(:shipping_method, distributors: [hub]) }
-        let!(:line_item) {
-          create(:line_item, variant: variant_on_demand, quantity: 10, order:)
-        }
-
-        before do
-          order.reload
-          order.update_totals
-          order.payments << create(:payment, amount: order.total)
-          Orders::WorkflowService.new(order).complete!
-          order.payment_state = 'paid'
-          order.select_shipping_method(shipping_method.id)
-          order.shipment.update!(order)
-        end
-
-        it "creates a shipment without backordered items" do
-          expect(order.shipment.manifest.count).to eq 1
-          expect(order.shipment.manifest.first.quantity).to eq 10
-          expect(order.shipment.manifest.first.states).to eq 'on_hand' => 10
-          expect(order.shipment.manifest.first.variant).to eq line_item.variant
-        end
-
-        it "reduces the variant's stock level" do
-          expect(variant_on_demand.reload.on_hand).to eq(-9)
-        end
-
-        it "does not mark inventory units as backorderd" do
-          backordered_units = order.shipments.first.inventory_units.any?(&:backordered?)
-          expect(backordered_units).to be false
-        end
-
-        it "does not mark the shipment as backorderd" do
-          expect(order.shipments.first.backordered?).to be false
-        end
-
-        it "allows the order to be shipped" do
-          expect(order.ready_to_ship?).to be true
-        end
-
-        it "does not change stock levels when cancelled" do
-          order.cancel!
-          expect(variant_on_demand.reload.on_hand).to eq 1
-        end
-      end
-    end
-
-    describe "tracking stock when quantity is changed" do
-      context "when the order is already complete" do
-        let(:shop) { create(:distributor_enterprise) }
-        let(:order) { create(:completed_order_with_totals, distributor: shop) }
-        let!(:line_item) { order.reload.line_items.first }
-        let!(:variant) { line_item.variant }
-
-        context "when a variant override applies" do
-          let!(:vo) { create(:variant_override, hub: shop, variant:, count_on_hand: 3 ) }
-
-          it "draws stock from the variant override" do
-            expect(vo.reload.count_on_hand).to eq 3
-            expect{ line_item.update!(quantity: line_item.quantity + 1) }
-              .not_to change{ Spree::Variant.find(variant.id).on_hand }
-            expect(vo.reload.count_on_hand).to eq 2
-          end
-        end
-
-        context "when a variant override does not apply" do
-          it "draws stock from the variant" do
-            expect{ line_item.update!(quantity: line_item.quantity + 1) }.to change{
-              Spree::Variant.find(variant.id).on_hand
-            }.by(-1)
-          end
-        end
-      end
-    end
-
-    describe "tracking stock when a line item is destroyed" do
-      context "when the order is already complete" do
-        let(:shop) { create(:distributor_enterprise) }
-        let(:order) { create(:completed_order_with_totals, distributor: shop) }
-        let!(:line_item) { order.reload.line_items.first }
-        let!(:variant) { line_item.variant }
-
-        context "when a variant override applies" do
-          let!(:vo) { create(:variant_override, hub: shop, variant:, count_on_hand: 3 ) }
-
-          it "restores stock to the variant override" do
-            expect(vo.reload.count_on_hand).to eq 3
-            expect{ line_item.destroy }.not_to change{ Spree::Variant.find(variant.id).on_hand }
-            expect(vo.reload.count_on_hand).to eq 4
-          end
-        end
-
-        context "when a variant override does not apply" do
-          it "restores stock to the variant" do
-            expect{ line_item.destroy }.to change{ Spree::Variant.find(variant.id).on_hand }.by(1)
-          end
-        end
-      end
-    end
-
-    describe "determining if sufficient stock is present" do
-      let!(:hub) { create(:distributor_enterprise) }
-      let!(:o) { create(:order, distributor: hub) }
-      let!(:v) { create(:variant, on_demand: false, on_hand: 10) }
-      let!(:v_on_demand) { create(:variant, on_demand: true, on_hand: 1) }
-      let(:li) { build_stubbed(:line_item, variant: v, order: o, quantity: 5, max_quantity: 5) }
-      let(:li_on_demand) {
-        build_stubbed(:line_item, variant: v_on_demand, order: o, quantity: 99, max_quantity: 99)
-      }
-
-      context "when the variant is on_demand" do
-        it { expect(li_on_demand.sufficient_stock?).to be true }
-      end
-
-      context "when stock on the variant is sufficient" do
-        it { expect(li.sufficient_stock?).to be true }
-      end
-
-      context "when the stock on the variant is not sufficient" do
-        before { v.update(on_hand: 4) }
-
-        context "when no variant override is in place" do
           it { expect(li.sufficient_stock?).to be false }
         end
+      end
+    end
+  end
 
-        context "when a variant override is in place" do
-          let!(:vo) { create(:variant_override, hub:, variant: v, count_on_hand: 5) }
+  describe "calculating price with adjustments" do
+    it "does not return fractional cents" do
+      li = described_class.new
 
-          context "and stock on the variant override is sufficient" do
-            it { expect(li.sufficient_stock?).to be true }
-          end
+      allow(li).to receive(:price) { 55.55 }
+      allow(li).to receive_message_chain(:adjustments, :enterprise_fee, :sum) { 11.11 }
+      allow(li).to receive(:quantity) { 2 }
+      expect(li.price_with_adjustments).to eq(61.11)
+    end
+  end
 
-          context "and stock on the variant override is not sufficient" do
-            before { vo.update(count_on_hand: 4) }
+  describe "calculating amount with adjustments" do
+    it "returns a value consistent with price_with_adjustments" do
+      li = described_class.new
 
-            it { expect(li.sufficient_stock?).to be false }
-          end
-        end
+      allow(li).to receive(:price) { 55.55 }
+      allow(li).to receive_message_chain(:adjustments, :enterprise_fee, :sum) { 11.11 }
+      allow(li).to receive(:quantity) { 2 }
+      expect(li.amount_with_adjustments).to eq(122.22)
+    end
+  end
+
+  describe "tax" do
+    let(:li_no_tax)   { create(:line_item) }
+    let(:li_tax)      { create(:line_item) }
+    let(:tax_rate)    { create(:tax_rate, calculator: Calculator::DefaultTax.new) }
+    let!(:adjustment) {
+      create(:adjustment, adjustable: li_tax, originator: tax_rate, label: "TR",
+                          amount: 10.00, included: true)
+    }
+
+    context "checking if a line item has tax included" do
+      it "returns true when it does" do
+        expect(li_tax).to have_tax
+      end
+
+      it "returns false otherwise" do
+        expect(li_no_tax).not_to have_tax
       end
     end
 
-    describe "calculating price with adjustments" do
-      it "does not return fractional cents" do
-        li = LineItem.new
+    context "calculating the amount of included tax" do
+      it "returns the included tax when present" do
+        expect(li_tax.included_tax).to eq 10.00
+      end
 
-        allow(li).to receive(:price) { 55.55 }
-        allow(li).to receive_message_chain(:adjustments, :enterprise_fee, :sum) { 11.11 }
-        allow(li).to receive(:quantity) { 2 }
-        expect(li.price_with_adjustments).to eq(61.11)
+      it "returns 0.00 otherwise" do
+        expect(li_no_tax.included_tax).to eq 0.00
       end
     end
+  end
 
-    describe "calculating amount with adjustments" do
-      it "returns a value consistent with price_with_adjustments" do
-        li = LineItem.new
-
-        allow(li).to receive(:price) { 55.55 }
-        allow(li).to receive_message_chain(:adjustments, :enterprise_fee, :sum) { 11.11 }
-        allow(li).to receive(:quantity) { 2 }
-        expect(li.amount_with_adjustments).to eq(122.22)
-      end
-    end
-
-    describe "tax" do
-      let(:li_no_tax)   { create(:line_item) }
-      let(:li_tax)      { create(:line_item) }
-      let(:tax_rate)    { create(:tax_rate, calculator: ::Calculator::DefaultTax.new) }
-      let!(:adjustment) {
-        create(:adjustment, adjustable: li_tax, originator: tax_rate, label: "TR",
-                            amount: 10.00, included: true)
+  describe "unit value/description" do
+    describe "inheriting units" do
+      let!(:p) {
+        create(:product, variant_unit: "weight", variant_unit_scale: 1,
+                         unit_value: 1000 )
       }
+      let!(:v) { p.variants.first }
+      let!(:o) { create(:order) }
 
-      context "checking if a line item has tax included" do
-        it "returns true when it does" do
-          expect(li_tax).to have_tax
+      context "on create" do
+        context "when no final_weight_volume is set" do
+          let(:li) { build(:line_item, order: o, variant: v, quantity: 3) }
+
+          it "initializes final_weight_volume from the variant's unit_value" do
+            expect(li.final_weight_volume).to be nil
+            li.save
+            expect(li.final_weight_volume).to eq 3000
+          end
         end
 
-        it "returns false otherwise" do
-          expect(li_no_tax).not_to have_tax
+        context "when a final_weight_volume has been set" do
+          let(:li) {
+            build(:line_item, order: o, variant: v, quantity: 3, final_weight_volume: 2000)
+          }
+
+          it "uses the changed value" do
+            expect(li.final_weight_volume).to eq 2000
+            li.save
+            expect(li.final_weight_volume).to eq 2000
+          end
         end
       end
 
-      context "calculating the amount of included tax" do
-        it "returns the included tax when present" do
-          expect(li_tax.included_tax).to eq 10.00
+      context "on save" do
+        let!(:li) { create(:line_item, order: o, variant: v, quantity: 3) }
+
+        before do
+          expect(li.final_weight_volume).to eq 3000
         end
 
-        it "returns 0.00 otherwise" do
-          expect(li_no_tax.included_tax).to eq 0.00
+        context "when final_weight_volume is changed" do
+          let(:attrs) { { final_weight_volume: 2000 } }
+
+          context "and quantity is not changed" do
+            before do
+              li.update(attrs)
+            end
+
+            it "uses the value given" do
+              expect(li.final_weight_volume).to eq 2000
+            end
+          end
+
+          context "and quantity is changed" do
+            before do
+              attrs[:quantity] = 4
+              li.update(attrs)
+            end
+
+            it "uses the value given" do
+              expect(li.final_weight_volume).to eq 2000
+            end
+          end
         end
-      end
-    end
 
-    describe "unit value/description" do
-      describe "inheriting units" do
-        let!(:p) {
-          create(:product, variant_unit: "weight", variant_unit_scale: 1,
-                           unit_value: 1000 )
-        }
-        let!(:v) { p.variants.first }
-        let!(:o) { create(:order) }
+        context "when final_weight_volume is not changed" do
+          let(:attrs) { { price: 3.00 } }
 
-        context "on create" do
-          context "when no final_weight_volume is set" do
-            let(:li) { build(:line_item, order: o, variant: v, quantity: 3) }
+          context "and quantity is not changed" do
+            before do
+              li.update(attrs)
+            end
 
-            it "initializes final_weight_volume from the variant's unit_value" do
-              expect(li.final_weight_volume).to be nil
-              li.save
+            it "does not change final_weight_volume" do
               expect(li.final_weight_volume).to eq 3000
             end
           end
 
-          context "when a final_weight_volume has been set" do
-            let(:li) {
-              build(:line_item, order: o, variant: v, quantity: 3, final_weight_volume: 2000)
-            }
-
-            it "uses the changed value" do
-              expect(li.final_weight_volume).to eq 2000
-              li.save
-              expect(li.final_weight_volume).to eq 2000
-            end
-          end
-        end
-
-        context "on save" do
-          let!(:li) { create(:line_item, order: o, variant: v, quantity: 3) }
-
-          before do
-            expect(li.final_weight_volume).to eq 3000
-          end
-
-          context "when final_weight_volume is changed" do
-            let(:attrs) { { final_weight_volume: 2000 } }
-
-            context "and quantity is not changed" do
-              before do
-                li.update(attrs)
-              end
-
-              it "uses the value given" do
-                expect(li.final_weight_volume).to eq 2000
-              end
-            end
-
-            context "and quantity is changed" do
-              before do
-                attrs[:quantity] = 4
-                li.update(attrs)
-              end
-
-              it "uses the value given" do
-                expect(li.final_weight_volume).to eq 2000
-              end
-            end
-          end
-
-          context "when final_weight_volume is not changed" do
-            let(:attrs) { { price: 3.00 } }
-
-            context "and quantity is not changed" do
-              before do
-                li.update(attrs)
-              end
-
-              it "does not change final_weight_volume" do
-                expect(li.final_weight_volume).to eq 3000
-              end
-            end
-
-            context "and quantity is changed" do
-              context "from > 0" do
-                context "and a final_weight_volume has been set" do
-                  before do
-                    expect(li.final_weight_volume).to eq 3000
-                    attrs[:quantity] = 4
-                    li.update(attrs)
-                  end
-
-                  it "scales the final_weight_volume based on the change in quantity" do
-                    expect(li.final_weight_volume).to eq 4000
-                  end
+          context "and quantity is changed" do
+            context "from > 0" do
+              context "and a final_weight_volume has been set" do
+                before do
+                  expect(li.final_weight_volume).to eq 3000
+                  attrs[:quantity] = 4
+                  li.update(attrs)
                 end
 
-                context "and a final_weight_volume has not been set" do
-                  before do
-                    li.update(final_weight_volume: nil)
-                    attrs[:quantity] = 1
-                    li.update(attrs)
-                  end
-
-                  it "calculates a final_weight_volume from the variants unit_value" do
-                    expect(li.final_weight_volume).to eq 1000
-                  end
+                it "scales the final_weight_volume based on the change in quantity" do
+                  expect(li.final_weight_volume).to eq 4000
                 end
               end
 
-              context "from 0" do
-                before { li.update(quantity: 0) }
-
-                context "and a final_weight_volume has been set" do
-                  before do
-                    expect(li.final_weight_volume).to eq 0
-                    attrs[:quantity] = 4
-                    li.update(attrs)
-                  end
-
-                  it "recalculates a final_weight_volume from the variants unit_value" do
-                    expect(li.final_weight_volume).to eq 4000
-                  end
+              context "and a final_weight_volume has not been set" do
+                before do
+                  li.update(final_weight_volume: nil)
+                  attrs[:quantity] = 1
+                  li.update(attrs)
                 end
 
-                context "and a final_weight_volume has not been set" do
-                  before do
-                    li.update(final_weight_volume: nil)
-                    attrs[:quantity] = 1
-                    li.update(attrs)
-                  end
+                it "calculates a final_weight_volume from the variants unit_value" do
+                  expect(li.final_weight_volume).to eq 1000
+                end
+              end
+            end
 
-                  it "calculates a final_weight_volume from the variants unit_value" do
-                    expect(li.final_weight_volume).to eq 1000
-                  end
+            context "from 0" do
+              before { li.update(quantity: 0) }
+
+              context "and a final_weight_volume has been set" do
+                before do
+                  expect(li.final_weight_volume).to eq 0
+                  attrs[:quantity] = 4
+                  li.update(attrs)
+                end
+
+                it "recalculates a final_weight_volume from the variants unit_value" do
+                  expect(li.final_weight_volume).to eq 4000
+                end
+              end
+
+              context "and a final_weight_volume has not been set" do
+                before do
+                  li.update(final_weight_volume: nil)
+                  attrs[:quantity] = 1
+                  li.update(attrs)
+                end
+
+                it "calculates a final_weight_volume from the variants unit_value" do
+                  expect(li.final_weight_volume).to eq 1000
                 end
               end
             end
           end
         end
       end
+    end
 
-      describe "generating the full name" do
-        let(:li) { LineItem.new }
+    describe "generating the full name" do
+      let(:li) { described_class.new }
 
-        context "when display_name is blank" do
-          before do
-            allow(li).to receive(:unit_to_display) { 'unit_to_display' }
-            allow(li).to receive(:display_name) { '' }
-          end
-
-          it "returns unit_to_display" do
-            expect(li.full_name).to eq('unit_to_display')
-          end
-        end
-
-        context "when unit_to_display contains display_name" do
-          before do
-            allow(li).to receive(:unit_to_display) { '1kg Jar' }
-            allow(li).to receive(:display_name) { '1kg' }
-          end
-
-          it "returns unit_to_display" do
-            expect(li.full_name).to eq('1kg Jar')
-          end
-        end
-
-        context "when display_name contains unit_to_display" do
-          before do
-            allow(li).to receive(:unit_to_display) { '10kg' }
-            allow(li).to receive(:display_name) { '10kg Box' }
-          end
-
-          it "returns display_name" do
-            expect(li.full_name).to eq('10kg Box')
-          end
-        end
-
-        context "otherwise" do
-          before do
-            allow(li).to receive(:unit_to_display) { '1 Loaf' }
-            allow(li).to receive(:display_name) { 'Spelt Sourdough' }
-          end
-
-          it "returns unit_to_display" do
-            expect(li.full_name).to eq('Spelt Sourdough (1 Loaf)')
-          end
-        end
-      end
-
-      describe "generating the product and variant name" do
-        let(:li) { LineItem.new }
-        let(:p) { double(:product, name: 'product') }
-        before { allow(li).to receive(:product) { p } }
-
-        context "when full_name starts with the product name" do
-          before { allow(li).to receive(:full_name) { "#{p.name} - something" } }
-
-          it "does not show the product name twice" do
-            expect(li.product_and_full_name).to eq('product - something')
-          end
-        end
-
-        context "when full_name does not start with the product name" do
-          before { allow(li).to receive(:full_name) { "display_name (unit)" } }
-
-          it "prepends the product name to the full name" do
-            expect(li.product_and_full_name).to eq('product - display_name (unit)')
-          end
-        end
-      end
-
-      describe "getting name for display" do
-        it "returns product name" do
-          li = build_stubbed(:line_item)
-          expect(li.name_to_display).to eq(li.product.name)
-        end
-      end
-
-      describe "getting unit for display" do
-        let(:o) { create(:order) }
-        let(:p1) { create(:product, name: 'Clear Honey') }
-        let(:v1) { create(:variant, product: p1, variant_unit_scale: 1, unit_value: 500) }
-        let(:li1) { create(:line_item, order: o, product: p1, variant: v1) }
-        let(:p2) { create(:product, name: 'Clear United States Honey') }
-        let(:v2) { create(:variant, product: p2, variant_unit_scale: 453.6, unit_value: 453.6) }
-        let(:li2) { create(:line_item, order: o, product: p2, variant: v2) }
-
+      context "when display_name is blank" do
         before do
-          allow(Spree::Config).to receive(:available_units).and_return("g,lb,oz,kg,T,mL,L,kL")
+          allow(li).to receive(:unit_to_display) { 'unit_to_display' }
+          allow(li).to receive(:display_name) { '' }
         end
 
-        it "returns options_text" do
-          li = build_stubbed(:line_item)
-          allow(li).to receive(:options_text).and_return "ponies"
-          expect(li.unit_to_display).to eq("ponies")
-        end
-
-        it "returns options_text based on configured units" do
-          expect(li1.options_text).to eq("500g")
-          expect(li2.options_text).to eq("1lb")
+        it "returns unit_to_display" do
+          expect(li.full_name).to eq('unit_to_display')
         end
       end
 
-      context "when the line_item has a final_weight_volume set" do
-        let!(:p0) { create(:simple_product) }
-        let!(:v) {
-          create(:variant, product: p0, variant_unit: 'weight', variant_unit_scale: 1,
-                           unit_value: 10, unit_description: 'bar')
-        }
+      context "when unit_to_display contains display_name" do
+        before do
+          allow(li).to receive(:unit_to_display) { '1kg Jar' }
+          allow(li).to receive(:display_name) { '1kg' }
+        end
 
-        let!(:p) { create(:simple_product, variant_unit: 'weight', variant_unit_scale: 1) }
-        let!(:li) { create(:line_item, product: p, final_weight_volume: 5) }
-
-        it "assigns the new value" do
-          expect(li.unit_presentation).to eq "5g"
-          expect(v.unit_presentation).to eq "10g bar"
-
-          allow(li).to receive(:unit_description) { 'foo' }
-
-          li.update_attribute(:final_weight_volume, 10)
-
-          expect(li.unit_presentation).to eq "10g foo"
+        it "returns unit_to_display" do
+          expect(li.full_name).to eq('1kg Jar')
         end
       end
 
-      context "when the variant already has a value set" do
-        let!(:p0) { create(:simple_product) }
-        let!(:v) {
-          create(:variant, product: p0, variant_unit: 'weight', variant_unit_scale: 1,
-                           unit_value: 10, unit_description: 'bar')
-        }
+      context "when display_name contains unit_to_display" do
+        before do
+          allow(li).to receive(:unit_to_display) { '10kg' }
+          allow(li).to receive(:display_name) { '10kg Box' }
+        end
 
-        let!(:p) { create(:simple_product, variant_unit: 'weight', variant_unit_scale: 1) }
-        let!(:li) { create(:line_item, product: p, final_weight_volume: 5) }
-
-        it "assigns the new value" do
-          expect(li.unit_presentation).to eq "5g"
-          expect(v.unit_presentation).to eq "10g bar"
-
-          allow(li).to receive(:unit_description) { 'bar' }
-
-          li.update_attribute(:final_weight_volume, 10)
-
-          expect(li.unit_presentation).to eq "10g bar"
+        it "returns display_name" do
+          expect(li.full_name).to eq('10kg Box')
         end
       end
 
-      describe "calculating unit_value" do
-        let(:v) { build_stubbed(:variant, unit_value: 10) }
-        let(:li) { build_stubbed(:line_item, variant: v, quantity: 5) }
+      context "otherwise" do
+        before do
+          allow(li).to receive(:unit_to_display) { '1 Loaf' }
+          allow(li).to receive(:display_name) { 'Spelt Sourdough' }
+        end
 
-        context "when the quantity is greater than zero" do
-          context "and final_weight_volume has not been changed" do
-            it "returns the unit_value of the variant" do
-              # Though note that this has been calculated
-              # backwards from the final_weight_volume
-              expect(li.unit_value).to eq 10
-            end
-          end
+        it "returns unit_to_display" do
+          expect(li.full_name).to eq('Spelt Sourdough (1 Loaf)')
+        end
+      end
+    end
 
-          context "and final_weight_volume has been changed" do
-            before { li.final_weight_volume = 35 }
+    describe "generating the product and variant name" do
+      let(:li) { described_class.new }
+      let(:p) { double(:product, name: 'product') }
+      before { allow(li).to receive(:product) { p } }
 
-            it "returns the unit_value of the variant" do
-              expect(li.unit_value).to eq 7
-            end
-          end
+      context "when full_name starts with the product name" do
+        before { allow(li).to receive(:full_name) { "#{p.name} - something" } }
 
-          context "and final_weight_volume is nil" do
-            before { li.final_weight_volume = nil }
+        it "does not show the product name twice" do
+          expect(li.product_and_full_name).to eq('product - something')
+        end
+      end
 
-            it "returns the unit_value of the variant" do
-              expect(li.unit_value).to eq 10
-            end
+      context "when full_name does not start with the product name" do
+        before { allow(li).to receive(:full_name) { "display_name (unit)" } }
+
+        it "prepends the product name to the full name" do
+          expect(li.product_and_full_name).to eq('product - display_name (unit)')
+        end
+      end
+    end
+
+    describe "getting name for display" do
+      it "returns product name" do
+        li = build_stubbed(:line_item)
+        expect(li.name_to_display).to eq(li.product.name)
+      end
+    end
+
+    describe "getting unit for display" do
+      let(:o) { create(:order) }
+      let(:p1) { create(:product, name: 'Clear Honey') }
+      let(:v1) { create(:variant, product: p1, variant_unit_scale: 1, unit_value: 500) }
+      let(:li1) { create(:line_item, order: o, product: p1, variant: v1) }
+      let(:p2) { create(:product, name: 'Clear United States Honey') }
+      let(:v2) { create(:variant, product: p2, variant_unit_scale: 453.6, unit_value: 453.6) }
+      let(:li2) { create(:line_item, order: o, product: p2, variant: v2) }
+
+      before do
+        allow(Spree::Config).to receive(:available_units).and_return("g,lb,oz,kg,T,mL,L,kL")
+      end
+
+      it "returns options_text" do
+        li = build_stubbed(:line_item)
+        allow(li).to receive(:options_text).and_return "ponies"
+        expect(li.unit_to_display).to eq("ponies")
+      end
+
+      it "returns options_text based on configured units" do
+        expect(li1.options_text).to eq("500g")
+        expect(li2.options_text).to eq("1lb")
+      end
+    end
+
+    context "when the line_item has a final_weight_volume set" do
+      let!(:p0) { create(:simple_product) }
+      let!(:v) {
+        create(:variant, product: p0, variant_unit: 'weight', variant_unit_scale: 1,
+                         unit_value: 10, unit_description: 'bar')
+      }
+
+      let!(:p) { create(:simple_product, variant_unit: 'weight', variant_unit_scale: 1) }
+      let!(:li) { create(:line_item, product: p, final_weight_volume: 5) }
+
+      it "assigns the new value" do
+        expect(li.unit_presentation).to eq "5g"
+        expect(v.unit_presentation).to eq "10g bar"
+
+        allow(li).to receive(:unit_description) { 'foo' }
+
+        li.update_attribute(:final_weight_volume, 10)
+
+        expect(li.unit_presentation).to eq "10g foo"
+      end
+    end
+
+    context "when the variant already has a value set" do
+      let!(:p0) { create(:simple_product) }
+      let!(:v) {
+        create(:variant, product: p0, variant_unit: 'weight', variant_unit_scale: 1,
+                         unit_value: 10, unit_description: 'bar')
+      }
+
+      let!(:p) { create(:simple_product, variant_unit: 'weight', variant_unit_scale: 1) }
+      let!(:li) { create(:line_item, product: p, final_weight_volume: 5) }
+
+      it "assigns the new value" do
+        expect(li.unit_presentation).to eq "5g"
+        expect(v.unit_presentation).to eq "10g bar"
+
+        allow(li).to receive(:unit_description) { 'bar' }
+
+        li.update_attribute(:final_weight_volume, 10)
+
+        expect(li.unit_presentation).to eq "10g bar"
+      end
+    end
+
+    describe "calculating unit_value" do
+      let(:v) { build_stubbed(:variant, unit_value: 10) }
+      let(:li) { build_stubbed(:line_item, variant: v, quantity: 5) }
+
+      context "when the quantity is greater than zero" do
+        context "and final_weight_volume has not been changed" do
+          it "returns the unit_value of the variant" do
+            # Though note that this has been calculated
+            # backwards from the final_weight_volume
+            expect(li.unit_value).to eq 10
           end
         end
 
-        context "when the quantity is zero" do
-          before { li.quantity = 0 }
+        context "and final_weight_volume has been changed" do
+          before { li.final_weight_volume = 35 }
+
+          it "returns the unit_value of the variant" do
+            expect(li.unit_value).to eq 7
+          end
+        end
+
+        context "and final_weight_volume is nil" do
+          before { li.final_weight_volume = nil }
 
           it "returns the unit_value of the variant" do
             expect(li.unit_value).to eq 10
           end
         end
       end
-    end
 
-    describe "when the associated variant is soft-deleted" do
-      let!(:variant) { create(:variant) }
-      let!(:line_item) { create(:line_item, variant:) }
+      context "when the quantity is zero" do
+        before { li.quantity = 0 }
 
-      it "returns the associated variant or product" do
-        line_item.variant.delete
-
-        expect(line_item.variant).to eq variant
-        expect(line_item.product).to eq variant.product
+        it "returns the unit_value of the variant" do
+          expect(li.unit_value).to eq 10
+        end
       end
     end
   end
 
-  RSpec.describe "searching with ransack" do
-    let(:order_cycle1) { create(:order_cycle) }
-    let(:order_cycle2) { create(:order_cycle) }
-    let(:variant1) { create(:variant, supplier: supplier1) }
-    let(:variant2) { create(:variant, supplier: supplier2) }
-    let(:supplier1) { create(:supplier_enterprise) }
-    let(:supplier2) { create(:supplier_enterprise) }
-    let!(:line_item1) { create(:line_item, variant: variant1) }
-    let!(:line_item2) { create(:line_item, variant: variant2) }
+  describe "when the associated variant is soft-deleted" do
+    let!(:variant) { create(:variant) }
+    let!(:line_item) { create(:line_item, variant:) }
 
-    let(:search_result) { Spree::LineItem.ransack(query).result }
+    it "returns the associated variant or product" do
+      line_item.variant.delete
 
-    before do
-      line_item1.order.update_attribute :order_cycle, order_cycle1
-      line_item2.order.update_attribute :order_cycle, order_cycle2
+      expect(line_item.variant).to eq variant
+      expect(line_item.product).to eq variant.product
     end
+  end
+end
 
-    context "searching by supplier" do
-      let(:query) { { supplier_id_eq: line_item1.variant.supplier_id } }
+RSpec.describe "searching with ransack" do
+  let(:order_cycle1) { create(:order_cycle) }
+  let(:order_cycle2) { create(:order_cycle) }
+  let(:variant1) { create(:variant, supplier: supplier1) }
+  let(:variant2) { create(:variant, supplier: supplier2) }
+  let(:supplier1) { create(:supplier_enterprise) }
+  let(:supplier2) { create(:supplier_enterprise) }
+  let!(:line_item1) { create(:line_item, variant: variant1) }
+  let!(:line_item2) { create(:line_item, variant: variant2) }
 
-      it "filters results" do
-        expect(search_result.to_a).to eq [line_item1]
-      end
+  let(:search_result) { Spree::LineItem.ransack(query).result }
+
+  before do
+    line_item1.order.update_attribute :order_cycle, order_cycle1
+    line_item2.order.update_attribute :order_cycle, order_cycle2
+  end
+
+  context "searching by supplier" do
+    let(:query) { { supplier_id_eq: line_item1.variant.supplier_id } }
+
+    it "filters results" do
+      expect(search_result.to_a).to eq [line_item1]
     end
+  end
 
-    context "searching by order_cycle" do
-      let(:query) { { order_cycle_id_eq: order_cycle1.id } }
+  context "searching by order_cycle" do
+    let(:query) { { order_cycle_id_eq: order_cycle1.id } }
 
-      it "filters results" do
-        expect(search_result.to_a).to eq [line_item1]
-      end
+    it "filters results" do
+      expect(search_result.to_a).to eq [line_item1]
     end
   end
 end

--- a/spec/models/spree/order/tax_spec.rb
+++ b/spec/models/spree/order/tax_spec.rb
@@ -2,173 +2,171 @@
 
 require 'spec_helper'
 
-module Spree
-  RSpec.describe Spree::Order do
-    let(:order) { build(:order) }
+RSpec.describe Spree::Order do
+  let(:order) { build(:order) }
 
-    context "#tax_zone" do
-      let(:bill_address) { create :address }
-      let(:ship_address) { create :address }
-      let(:order) { Spree::Order.create(ship_address:, bill_address:) }
-      let(:zone) { create :zone }
+  context "#tax_zone" do
+    let(:bill_address) { create :address }
+    let(:ship_address) { create :address }
+    let(:order) { Spree::Order.create(ship_address:, bill_address:) }
+    let(:zone) { create :zone }
 
-      context "when no zones exist" do
-        before { Spree::Zone.destroy_all }
+    context "when no zones exist" do
+      before { Spree::Zone.destroy_all }
+
+      it "should return nil" do
+        expect(order.tax_zone).to be_nil
+      end
+    end
+
+    context "when :tax_using_ship_address => true" do
+      before { Spree::Config.set(tax_using_ship_address: true) }
+
+      it "should calculate using ship_address" do
+        expect(Spree::Zone).to receive(:match).at_least(:once).with(ship_address)
+        expect(Spree::Zone).not_to receive(:match).with(bill_address)
+        order.tax_zone
+      end
+    end
+
+    context "when :tax_using_ship_address => false" do
+      before { Spree::Config.set(tax_using_ship_address: false) }
+
+      it "should calculate using bill_address" do
+        expect(Spree::Zone).to receive(:match).at_least(:once).with(bill_address)
+        expect(Spree::Zone).not_to receive(:match).with(ship_address)
+        order.tax_zone
+      end
+    end
+
+    context "when there is a default tax zone" do
+      before do
+        @default_zone = create(:zone, name: "foo_zone")
+        allow(Spree::Zone).to receive_messages default_tax: @default_zone
+      end
+
+      context "when there is a matching zone" do
+        before { allow(Spree::Zone).to receive_messages(match: zone) }
+
+        it "should return the matching zone" do
+          expect(order.tax_zone).to eq zone
+        end
+      end
+
+      context "when there is no matching zone" do
+        before { allow(Spree::Zone).to receive_messages(match: nil) }
+
+        it "should return the default tax zone" do
+          expect(order.tax_zone).to eq @default_zone
+        end
+      end
+    end
+
+    context "when no default tax zone" do
+      before { allow(Spree::Zone).to receive_messages default_tax: nil }
+
+      context "when there is a matching zone" do
+        before { allow(Spree::Zone).to receive_messages(match: zone) }
+
+        it "should return the matching zone" do
+          expect(order.tax_zone).to eq zone
+        end
+      end
+
+      context "when there is no matching zone" do
+        before { allow(Spree::Zone).to receive_messages(match: nil) }
 
         it "should return nil" do
           expect(order.tax_zone).to be_nil
         end
       end
+    end
+  end
 
-      context "when :tax_using_ship_address => true" do
-        before { Spree::Config.set(tax_using_ship_address: true) }
+  context "#exclude_tax?" do
+    before do
+      @order = create(:order)
+      @default_zone = create(:zone)
+      allow(Spree::Zone).to receive_messages default_tax: @default_zone
+    end
 
-        it "should calculate using ship_address" do
-          expect(Spree::Zone).to receive(:match).at_least(:once).with(ship_address)
-          expect(Spree::Zone).not_to receive(:match).with(bill_address)
-          order.tax_zone
-        end
+    context "when prices include tax" do
+      before { Spree::Config.set(prices_inc_tax: true) }
+
+      it "should be true when tax_zone is not the same as the default" do
+        allow(@order).to receive_messages tax_zone: create(:zone, name: "other_zone")
+        expect(@order.exclude_tax?).to be_truthy
       end
 
-      context "when :tax_using_ship_address => false" do
-        before { Spree::Config.set(tax_using_ship_address: false) }
-
-        it "should calculate using bill_address" do
-          expect(Spree::Zone).to receive(:match).at_least(:once).with(bill_address)
-          expect(Spree::Zone).not_to receive(:match).with(ship_address)
-          order.tax_zone
-        end
-      end
-
-      context "when there is a default tax zone" do
-        before do
-          @default_zone = create(:zone, name: "foo_zone")
-          allow(Spree::Zone).to receive_messages default_tax: @default_zone
-        end
-
-        context "when there is a matching zone" do
-          before { allow(Spree::Zone).to receive_messages(match: zone) }
-
-          it "should return the matching zone" do
-            expect(order.tax_zone).to eq zone
-          end
-        end
-
-        context "when there is no matching zone" do
-          before { allow(Spree::Zone).to receive_messages(match: nil) }
-
-          it "should return the default tax zone" do
-            expect(order.tax_zone).to eq @default_zone
-          end
-        end
-      end
-
-      context "when no default tax zone" do
-        before { allow(Spree::Zone).to receive_messages default_tax: nil }
-
-        context "when there is a matching zone" do
-          before { allow(Spree::Zone).to receive_messages(match: zone) }
-
-          it "should return the matching zone" do
-            expect(order.tax_zone).to eq zone
-          end
-        end
-
-        context "when there is no matching zone" do
-          before { allow(Spree::Zone).to receive_messages(match: nil) }
-
-          it "should return nil" do
-            expect(order.tax_zone).to be_nil
-          end
-        end
+      it "should be false when tax_zone is the same as the default" do
+        allow(@order).to receive_messages tax_zone: @default_zone
+        expect(@order.exclude_tax?).to be_falsy
       end
     end
 
-    context "#exclude_tax?" do
+    context "when prices do not include tax" do
+      before { Spree::Config.set(prices_inc_tax: false) }
+
+      it "should be false" do
+        expect(@order.exclude_tax?).to be_falsy
+      end
+    end
+  end
+
+  describe "#create_tax_charge!" do
+    context "handling legacy taxes" do
+      let(:order) { create(:order) }
+      let(:zone) { create(:zone_with_member) }
+      let(:tax_rate20) {
+        create(:tax_rate, amount: 0.20, included_in_price: false, zone:)
+      }
+      let(:tax_rate30) {
+        create(:tax_rate, amount: 0.30, included_in_price: false, zone:)
+      }
+      let!(:variant) {
+        create(:variant, tax_category: tax_rate20.tax_category, price: 10)
+      }
+      let!(:line_item) {
+        create(:line_item, variant:, order:, quantity: 2)
+      }
+      let!(:shipping_method) {
+        create(:shipping_method, tax_category: tax_rate30.tax_category)
+      }
+      let!(:shipment) {
+        create(:shipment_with, :shipping_method, order:, cost: 50,
+                                                 shipping_method:)
+      }
+
       before do
-        @order = create(:order)
-        @default_zone = create(:zone)
-        allow(Spree::Zone).to receive_messages default_tax: @default_zone
+        shipment.update_columns(cost: 20.0)
+        order.reload
+
+        allow(order).to receive(:completed_at) { Time.zone.now }
+        allow(order).to receive(:tax_zone) { zone }
       end
 
-      context "when prices include tax" do
-        before { Spree::Config.set(prices_inc_tax: true) }
-
-        it "should be true when tax_zone is not the same as the default" do
-          allow(@order).to receive_messages tax_zone: create(:zone, name: "other_zone")
-          expect(@order.exclude_tax?).to be_truthy
-        end
-
-        it "should be false when tax_zone is the same as the default" do
-          allow(@order).to receive_messages tax_zone: @default_zone
-          expect(@order.exclude_tax?).to be_falsy
-        end
-      end
-
-      context "when prices do not include tax" do
-        before { Spree::Config.set(prices_inc_tax: false) }
-
-        it "should be false" do
-          expect(@order.exclude_tax?).to be_falsy
-        end
-      end
-    end
-
-    describe "#create_tax_charge!" do
-      context "handling legacy taxes" do
-        let(:order) { create(:order) }
-        let(:zone) { create(:zone_with_member) }
-        let(:tax_rate20) {
-          create(:tax_rate, amount: 0.20, included_in_price: false, zone:)
-        }
-        let(:tax_rate30) {
-          create(:tax_rate, amount: 0.30, included_in_price: false, zone:)
-        }
-        let!(:variant) {
-          create(:variant, tax_category: tax_rate20.tax_category, price: 10)
-        }
-        let!(:line_item) {
-          create(:line_item, variant:, order:, quantity: 2)
-        }
-        let!(:shipping_method) {
-          create(:shipping_method, tax_category: tax_rate30.tax_category)
-        }
-        let!(:shipment) {
-          create(:shipment_with, :shipping_method, order:, cost: 50,
-                                                   shipping_method:)
+      context "when the order has legacy taxes" do
+        let!(:legacy_tax_adjustment) {
+          create(:adjustment, order:, adjustable: order, included: false,
+                              label: "legacy", originator_type: "Spree::TaxRate")
         }
 
         before do
-          shipment.update_columns(cost: 20.0)
-          order.reload
-
-          allow(order).to receive(:completed_at) { Time.zone.now }
-          allow(order).to receive(:tax_zone) { zone }
+          order.update(state: "payment")
         end
 
-        context "when the order has legacy taxes" do
-          let!(:legacy_tax_adjustment) {
-            create(:adjustment, order:, adjustable: order, included: false,
-                                label: "legacy", originator_type: "Spree::TaxRate")
-          }
+        it "removes any legacy tax adjustments on order" do
+          order.create_tax_charge!
 
-          before do
-            order.update(state: "payment")
-          end
+          expect(order.reload.adjustments).not_to include legacy_tax_adjustment
+        end
 
-          it "removes any legacy tax adjustments on order" do
-            order.create_tax_charge!
+        it "re-applies taxes on individual items" do
+          order.create_tax_charge!
 
-            expect(order.reload.adjustments).not_to include legacy_tax_adjustment
-          end
-
-          it "re-applies taxes on individual items" do
-            order.create_tax_charge!
-
-            expect(order.all_adjustments.tax.count).to eq 2
-            expect(line_item.adjustments.tax.first.amount).to eq 4
-            expect(shipment.adjustments.tax.first.amount).to eq 6
-          end
+          expect(order.all_adjustments.tax.count).to eq 2
+          expect(line_item.adjustments.tax.first.amount).to eq 4
+          expect(shipment.adjustments.tax.first.amount).to eq 6
         end
       end
     end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -3,171 +3,206 @@
 require 'spec_helper'
 require 'spree/core/product_duplicator'
 
-module Spree
-  RSpec.describe Product do
-    context 'product instance' do
-      let(:product) { create(:product) }
+RSpec.describe Spree::Product do
+  context 'product instance' do
+    let(:product) { create(:product) }
 
-      context '#duplicate' do
-        it 'duplicates product' do
-          clone = product.duplicate
+    context '#duplicate' do
+      it 'duplicates product' do
+        clone = product.duplicate
 
-          expect(clone).to be_persisted
-          expect(clone.name).to eq "COPY OF #{product.name}"
-          expect(clone.sku).to eq ""
-          expect(clone.image).to eq product.image
-        end
-
-        it 'fails to duplicate invalid product' do
-          # cloned product will be invalid
-          product.update_columns(name: "l" * 254)
-
-          expect{ product.duplicate }.to raise_error(ActiveRecord::ActiveRecordError)
-        end
+        expect(clone).to be_persisted
+        expect(clone.name).to eq "COPY OF #{product.name}"
+        expect(clone.sku).to eq ""
+        expect(clone.image).to eq product.image
       end
 
-      context "product has variants" do
-        before do
-          product.reload.variants << create(:variant, product:)
-        end
+      it 'fails to duplicate invalid product' do
+        # cloned product will be invalid
+        product.update_columns(name: "l" * 254)
 
-        context "#destroy" do
-          it "should set deleted_at value" do
-            product.destroy
-            expect(product.deleted_at).not_to be_nil
-            expect(product.variants.all? { |v| !v.deleted_at.nil? }).to be_truthy
-          end
-        end
+        expect{ product.duplicate }.to raise_error(ActiveRecord::ActiveRecordError)
+      end
+    end
+
+    context "product has variants" do
+      before do
+        product.reload.variants << create(:variant, product:)
       end
 
-      describe 'Variants sorting' do
-        it 'sorts variants by id' do
-          expect(product.variants.to_sql).to match(/ORDER BY spree_variants.id ASC/)
+      context "#destroy" do
+        it "should set deleted_at value" do
+          product.destroy
+          expect(product.deleted_at).not_to be_nil
+          expect(product.variants.all? { |v| !v.deleted_at.nil? }).to be_truthy
         end
       end
     end
 
-    context "properties" do
-      let(:product) { create(:product) }
-
-      it "should properly assign properties" do
-        expect {
-          product.set_property('the_prop', 'value1')
-          product.save
-          product.reload
-        }.to change { product.properties.length }.by(1)
-        expect(product.property('the_prop')).to eq 'value1'
-
-        product.set_property('the_prop', 'value2')
-        expect(product.property('the_prop')).to eq 'value2'
+    describe 'Variants sorting' do
+      it 'sorts variants by id' do
+        expect(product.variants.to_sql).to match(/ORDER BY spree_variants.id ASC/)
       end
+    end
+  end
 
-      it "should not create duplicate properties when set_property is called" do
+  context "properties" do
+    let(:product) { create(:product) }
+
+    it "should properly assign properties" do
+      expect {
+        product.set_property('the_prop', 'value1')
+        product.save
+        product.reload
+      }.to change { product.properties.length }.by(1)
+      expect(product.property('the_prop')).to eq 'value1'
+
+      product.set_property('the_prop', 'value2')
+      expect(product.property('the_prop')).to eq 'value2'
+    end
+
+    it "should not create duplicate properties when set_property is called" do
+      product.set_property('the_prop', 'value2')
+      product.save
+
+      expect {
         product.set_property('the_prop', 'value2')
         product.save
-
-        expect {
-          product.set_property('the_prop', 'value2')
-          product.save
-          product.reload
-        }.not_to change { product.properties.length }
-      end
-
-      # Regression test for #2455
-      it "should not overwrite properties' presentation names" do
-        Spree::Property.where(name: 'foo').first_or_create!(presentation: "Foo's Presentation Name")
-        product.set_property('foo', 'value1')
-        product.set_property('bar', 'value2')
-        expect(Spree::Property.where(name: 'foo').first.presentation)
-          .to eq "Foo's Presentation Name"
-        expect(Spree::Property.where(name: 'bar').first.presentation).to eq "bar"
-      end
+        product.reload
+      }.not_to change { product.properties.length }
     end
 
-    describe "associations" do
-      it { is_expected.to have_one(:image) }
+    # Regression test for #2455
+    it "should not overwrite properties' presentation names" do
+      Spree::Property.where(name: 'foo').first_or_create!(presentation: "Foo's Presentation Name")
+      product.set_property('foo', 'value1')
+      product.set_property('bar', 'value2')
+      expect(Spree::Property.where(name: 'foo').first.presentation)
+        .to eq "Foo's Presentation Name"
+      expect(Spree::Property.where(name: 'bar').first.presentation).to eq "bar"
+    end
+  end
 
-      it { is_expected.to have_many(:product_properties) }
-      it { is_expected.to have_many(:properties).through(:product_properties) }
-      it { is_expected.to have_many(:variants) }
-      it { is_expected.to have_many(:prices).through(:variants) }
-      it { is_expected.to have_many(:stock_items).through(:variants) }
-      it { is_expected.to have_many(:variant_images).through(:variants) }
+  describe "associations" do
+    it { is_expected.to have_one(:image) }
+
+    it { is_expected.to have_many(:product_properties) }
+    it { is_expected.to have_many(:properties).through(:product_properties) }
+    it { is_expected.to have_many(:variants) }
+    it { is_expected.to have_many(:prices).through(:variants) }
+    it { is_expected.to have_many(:stock_items).through(:variants) }
+    it { is_expected.to have_many(:variant_images).through(:variants) }
+  end
+
+  describe "validations and defaults" do
+    it "is valid when built from factory" do
+      expect(build(:product)).to be_valid
     end
 
-    describe "validations and defaults" do
-      it "is valid when built from factory" do
-        expect(build(:product)).to be_valid
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_length_of(:name).is_at_most(255) }
+    it { is_expected.to validate_length_of(:sku).is_at_most(255) }
+
+    context "when the product has variants" do
+      let(:product) do
+        product = create(:simple_product)
+        create(:variant, product:)
+        product.reload
       end
 
-      it { is_expected.to validate_presence_of :name }
-      it { is_expected.to validate_length_of(:name).is_at_most(255) }
-      it { is_expected.to validate_length_of(:sku).is_at_most(255) }
+      it { is_expected.to validate_numericality_of(:price).is_greater_than_or_equal_to(0) }
 
-      context "when the product has variants" do
-        let(:product) do
-          product = create(:simple_product)
-          create(:variant, product:)
-          product.reload
+      context "saving a new product" do
+        let!(:product){ described_class.new }
+        let!(:shipping_category){ create(:shipping_category) }
+        let!(:taxon){ create(:taxon) }
+        let(:supplier){ create(:enterprise) }
+
+        it "copies properties to the first standard variant" do
+          product.primary_taxon_id = taxon.id
+          product.name = "Product1"
+          product.variant_unit = "weight"
+          product.variant_unit_scale = 1000
+          product.unit_value = 1
+          product.unit_description = "some product"
+          product.price = 4.27
+          product.shipping_category_id = shipping_category.id
+          product.supplier_id = supplier.id
+          product.save(context: :create_and_create_standard_variant)
+
+          expect(product.variants.reload.length).to eq 1
+          standard_variant = product.variants.reload.first
+
+          expect(standard_variant).to be_valid
+          expect(standard_variant.variant_unit).to eq("weight")
+          expect(standard_variant.variant_unit_scale).to eq(1000)
+          expect(standard_variant.unit_value).to eq(1)
+          expect(standard_variant.unit_description).to eq("some product")
+          expect(standard_variant.price).to eq 4.27
+          expect(standard_variant.shipping_category).to eq shipping_category
+          expect(standard_variant.primary_taxon).to eq taxon
+          expect(standard_variant.supplier).to eq supplier
         end
 
-        it { is_expected.to validate_numericality_of(:price).is_greater_than_or_equal_to(0) }
+        context "with variant attributes" do
+          it {
+            is_expected.to validate_presence_of(:variant_unit)
+              .on(:create_and_create_standard_variant)
+          }
+          it {
+            is_expected.to validate_presence_of(:supplier_id)
+              .on(:create_and_create_standard_variant)
+          }
+          it {
+            is_expected.to validate_presence_of(:primary_taxon_id)
+              .on(:create_and_create_standard_variant)
+          }
 
-        context "saving a new product" do
-          let!(:product){ Spree::Product.new }
-          let!(:shipping_category){ create(:shipping_category) }
-          let!(:taxon){ create(:taxon) }
-          let(:supplier){ create(:enterprise) }
+          describe "unit_value" do
+            subject { build(:simple_product, variant_unit: "items") }
 
-          it "copies properties to the first standard variant" do
-            product.primary_taxon_id = taxon.id
-            product.name = "Product1"
-            product.variant_unit = "weight"
-            product.variant_unit_scale = 1000
-            product.unit_value = 1
-            product.unit_description = "some product"
-            product.price = 4.27
-            product.shipping_category_id = shipping_category.id
-            product.supplier_id = supplier.id
-            product.save(context: :create_and_create_standard_variant)
-
-            expect(product.variants.reload.length).to eq 1
-            standard_variant = product.variants.reload.first
-
-            expect(standard_variant).to be_valid
-            expect(standard_variant.variant_unit).to eq("weight")
-            expect(standard_variant.variant_unit_scale).to eq(1000)
-            expect(standard_variant.unit_value).to eq(1)
-            expect(standard_variant.unit_description).to eq("some product")
-            expect(standard_variant.price).to eq 4.27
-            expect(standard_variant.shipping_category).to eq shipping_category
-            expect(standard_variant.primary_taxon).to eq taxon
-            expect(standard_variant.supplier).to eq supplier
-          end
-
-          context "with variant attributes" do
             it {
-              is_expected.to validate_presence_of(:variant_unit)
+              is_expected.to validate_numericality_of(:unit_value).is_greater_than(0)
                 .on(:create_and_create_standard_variant)
             }
             it {
-              is_expected.to validate_presence_of(:supplier_id)
-                .on(:create_and_create_standard_variant)
-            }
-            it {
-              is_expected.to validate_presence_of(:primary_taxon_id)
+              is_expected.not_to validate_presence_of(:unit_value)
                 .on(:create_and_create_standard_variant)
             }
 
-            describe "unit_value" do
-              subject { build(:simple_product, variant_unit: "items") }
+            ["weight", "volume"].each do |variant_unit|
+              context "when variant_unit is #{variant_unit}" do
+                subject { build(:simple_product, variant_unit:) }
 
+                it {
+                  is_expected.to validate_presence_of(:unit_value)
+                    .on(:create_and_create_standard_variant)
+                }
+              end
+            end
+
+            describe "unit_description" do
               it {
-                is_expected.to validate_numericality_of(:unit_value).is_greater_than(0)
+                is_expected.not_to validate_presence_of(:unit_description)
                   .on(:create_and_create_standard_variant)
               }
+
+              context "when variant_unit is et and unit_value is nil" do
+                subject {
+                  build(:simple_product, variant_unit: "items", unit_value: nil,
+                                         unit_description: "box")
+                }
+
+                it {
+                  is_expected.to validate_presence_of(:unit_description)
+                    .on(:create_and_create_standard_variant)
+                }
+              end
+            end
+
+            describe "variant_unit_scale" do
               it {
-                is_expected.not_to validate_presence_of(:unit_value)
+                is_expected.not_to validate_presence_of(:variant_unit_scale)
                   .on(:create_and_create_standard_variant)
               }
 
@@ -176,563 +211,528 @@ module Spree
                   subject { build(:simple_product, variant_unit:) }
 
                   it {
-                    is_expected.to validate_presence_of(:unit_value)
-                      .on(:create_and_create_standard_variant)
-                  }
-                end
-              end
-
-              describe "unit_description" do
-                it {
-                  is_expected.not_to validate_presence_of(:unit_description)
-                    .on(:create_and_create_standard_variant)
-                }
-
-                context "when variant_unit is et and unit_value is nil" do
-                  subject {
-                    build(:simple_product, variant_unit: "items", unit_value: nil,
-                                           unit_description: "box")
-                  }
-
-                  it {
-                    is_expected.to validate_presence_of(:unit_description)
-                      .on(:create_and_create_standard_variant)
-                  }
-                end
-              end
-
-              describe "variant_unit_scale" do
-                it {
-                  is_expected.not_to validate_presence_of(:variant_unit_scale)
-                    .on(:create_and_create_standard_variant)
-                }
-
-                ["weight", "volume"].each do |variant_unit|
-                  context "when variant_unit is #{variant_unit}" do
-                    subject { build(:simple_product, variant_unit:) }
-
-                    it {
-                      is_expected.to validate_presence_of(:variant_unit_scale)
-                        .on(:create_and_create_standard_variant)
-                    }
-                  end
-                end
-              end
-
-              describe "variant_unit_name" do
-                subject { build(:simple_product, variant_unit: "volume") }
-
-                it {
-                  is_expected.not_to validate_presence_of(:variant_unit_name)
-                    .on(:create_and_create_standard_variant)
-                }
-
-                context "when variant_unit is items" do
-                  subject { build(:simple_product, variant_unit: "items") }
-
-                  it {
-                    is_expected.to validate_presence_of(:variant_unit_name)
+                    is_expected.to validate_presence_of(:variant_unit_scale)
                       .on(:create_and_create_standard_variant)
                   }
                 end
               end
             end
-          end
-        end
-      end
 
-      describe "#validate_image" do
-        subject(:product) { create(:product_with_image) }
+            describe "variant_unit_name" do
+              subject { build(:simple_product, variant_unit: "volume") }
 
-        context "when the image is invalid" do
-          before { allow(product.image).to receive(:valid?).and_return(false) }
+              it {
+                is_expected.not_to validate_presence_of(:variant_unit_name)
+                  .on(:create_and_create_standard_variant)
+              }
 
-          context "and has been changed" do
-            before { expect(product.image).to receive(:changed?).and_return(true) }
+              context "when variant_unit is items" do
+                subject { build(:simple_product, variant_unit: "items") }
 
-            it "adds an error message to the base object" do
-              expect(product).not_to be_valid
-              expect(product.errors[:base]).to include('Image attachment is not a valid image.')
+                it {
+                  is_expected.to validate_presence_of(:variant_unit_name)
+                    .on(:create_and_create_standard_variant)
+                }
+              end
             end
           end
-
-          it "ignores if unchanged" do
-            expect(product).to be_valid
-          end
-        end
-
-        context "when image is valid" do
-          it { is_expected.to be_valid }
-        end
-
-        context "when image is blank" do
-          subject { create(:product) }
-
-          it { is_expected.to be_valid }
         end
       end
     end
 
-    describe "callbacks" do
-      let(:product) { create(:simple_product) }
+    describe "#validate_image" do
+      subject(:product) { create(:product_with_image) }
 
-      describe "destroy product" do
-        let(:product) { create(:simple_product, supplier_id: distributor.id) }
-        let(:distributor) { create(:distributor_enterprise) }
-        let!(:oc) {
-          create(:simple_order_cycle, distributors: [distributor],
-                                      variants: [product.variants.first])
-        }
+      context "when the image is invalid" do
+        before { allow(product.image).to receive(:valid?).and_return(false) }
 
-        it "removes variants from order cycles" do
-          expect { product.destroy }.to change { ExchangeVariant.count }
+        context "and has been changed" do
+          before { expect(product.image).to receive(:changed?).and_return(true) }
+
+          it "adds an error message to the base object" do
+            expect(product).not_to be_valid
+            expect(product.errors[:base]).to include('Image attachment is not a valid image.')
+          end
+        end
+
+        it "ignores if unchanged" do
+          expect(product).to be_valid
         end
       end
 
-      describe "after updating primary taxon" do
-        let(:product) { create(:simple_product, supplier_id: supplier.id) }
-        let(:supplier) { create(:supplier_enterprise) }
-        let(:new_taxon) { create(:taxon) }
-
-        it "touches the supplier" do
-          expect { product.update(primary_taxon_id: new_taxon.id) }
-            .to change { supplier.reload.updated_at }
-        end
-
-        context "when product has no variant" do
-          it "doesn't blow up" do
-            product.variants = []
-            product.save!
-
-            expect { product.update(primary_taxon_id: new_taxon.id) }.not_to raise_error
-          end
-        end
+      context "when image is valid" do
+        it { is_expected.to be_valid }
       end
 
-      describe "after touching the product" do
-        let(:product) { create(:simple_product, supplier_id: supplier.id) }
-        let(:supplier) { create(:supplier_enterprise) }
+      context "when image is blank" do
+        subject { create(:product) }
 
-        it "touches the supplier" do
-          expect { product.touch }
-            .to change { supplier.reload.updated_at }
-        end
+        it { is_expected.to be_valid }
+      end
+    end
+  end
 
-        context "when the first variant is missing supplier" do
-          it "doesn't blow up" do
-            product.variants.first.update_attribute(:supplier_id, nil)
+  describe "callbacks" do
+    let(:product) { create(:simple_product) }
 
-            expect { product.touch }.not_to raise_error
-          end
+    describe "destroy product" do
+      let(:product) { create(:simple_product, supplier_id: distributor.id) }
+      let(:distributor) { create(:distributor_enterprise) }
+      let!(:oc) {
+        create(:simple_order_cycle, distributors: [distributor],
+                                    variants: [product.variants.first])
+      }
+
+      it "removes variants from order cycles" do
+        expect { product.destroy }.to change { ExchangeVariant.count }
+      end
+    end
+
+    describe "after updating primary taxon" do
+      let(:product) { create(:simple_product, supplier_id: supplier.id) }
+      let(:supplier) { create(:supplier_enterprise) }
+      let(:new_taxon) { create(:taxon) }
+
+      it "touches the supplier" do
+        expect { product.update(primary_taxon_id: new_taxon.id) }
+          .to change { supplier.reload.updated_at }
+      end
+
+      context "when product has no variant" do
+        it "doesn't blow up" do
+          product.variants = []
+          product.save!
+
+          expect { product.update(primary_taxon_id: new_taxon.id) }.not_to raise_error
         end
       end
     end
 
-    describe "scopes" do
-      describe ".with_properties" do
-        let!(:product_with_wanted_property) { create(:product, properties: [wanted_property]) }
-        let!(:product_without_wanted_property_property) {
-          create(:product, properties: [unwanted_property])
-        }
-        let!(:product_ignoring_property) {
-          create(:product, inherits_properties: false)
-        }
-        let(:wanted_property) { create(:property, presentation: 'Certified Organic') }
-        let(:unwanted_property) { create(:property, presentation: 'Latest Hype') }
-
-        it "returns no products without a property id" do
-          expect(Spree::Product.with_properties([])).to eq []
-        end
-
-        it "returns only products with the wanted property set both on supplier & product itself" do
-          expect(
-            Spree::Product.with_properties([wanted_property.id, 99_999])
-          ).to match_array [product_with_wanted_property]
-        end
-      end
-
-      describe "in_supplier" do
-        it "shows products in supplier" do
-          s1 = create(:supplier_enterprise)
-          p1 = create(:product, supplier_id: s1.id)
-          # We create two variants to let us test we don't get duplicated product
-          create(:variant, product: p1, supplier: s1)
-          create(:variant, product: p1, supplier: s1)
-          s2 = create(:supplier_enterprise)
-          p2 = create(:product, supplier_id: s2.id)
-          create(:variant, product: p2, supplier: s2)
-
-          expect(Product.in_supplier(s1)).to eq([p1])
-        end
-      end
-
-      describe "in_distributor" do
-        it "shows products in order cycle distribution" do
-          s = create(:supplier_enterprise)
-          d1 = create(:distributor_enterprise)
-          d2 = create(:distributor_enterprise)
-          p1 = create(:product)
-          p2 = create(:product)
-          create(:simple_order_cycle, suppliers: [s], distributors: [d1],
-                                      variants: [p1.variants.first])
-          create(:simple_order_cycle, suppliers: [s], distributors: [d2],
-                                      variants: [p2.variants.first])
-          expect(Product.in_distributor(d1)).to eq([p1])
-        end
-
-        it "shows products in order cycle distribution by variant" do
-          s = create(:supplier_enterprise)
-          d1 = create(:distributor_enterprise)
-          d2 = create(:distributor_enterprise)
-          p1 = create(:product)
-          v1 = create(:variant, product: p1)
-          p2 = create(:product)
-          v2 = create(:variant, product: p2)
-          create(:simple_order_cycle, suppliers: [s], distributors: [d1], variants: [v1])
-          create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [v2])
-          expect(Product.in_distributor(d1)).to eq([p1])
-        end
-
-        it "doesn't show products listed in the incoming exchange only" do
-          s = create(:supplier_enterprise)
-          c = create(:distributor_enterprise)
-          d = create(:distributor_enterprise)
-          p = create(:product)
-          oc = create(:simple_order_cycle, coordinator: c, suppliers: [s], distributors: [d])
-          ex = oc.exchanges.incoming.first
-          ex.variants << p.variants.first
-
-          expect(Product.in_distributor(d)).to be_empty
-        end
-      end
-
-      describe "in_distributors" do
-        let!(:distributor1) { create(:distributor_enterprise) }
-        let!(:distributor2) { create(:distributor_enterprise) }
-        let!(:product1) { create(:product) }
-        let!(:product2) { create(:product) }
-        let!(:product3) { create(:product) }
-        let!(:product4) { create(:product) }
-        let!(:order_cycle1) {
-          create(:order_cycle, distributors: [distributor1],
-                               variants: [product1.variants.first, product2.variants.first])
-        }
-        let!(:order_cycle2) {
-          create(:order_cycle, distributors: [distributor2],
-                               variants: [product3.variants.first])
-        }
-
-        it "returns distributed products for a given Enterprise AR relation" do
-          distributors = Enterprise.where(id: [distributor1.id, distributor2.id]).to_a
-
-          expect(Product.in_distributors(distributors)).to include product1, product2, product3
-          expect(Product.in_distributors(distributors)).not_to include product4
-        end
-
-        it "returns distributed products for a given array of enterprise ids" do
-          distributors_ids = [distributor1.id, distributor2.id]
-
-          expect(Product.in_distributors(distributors_ids)).to include product1, product2, product3
-          expect(Product.in_distributors(distributors_ids)).not_to include product4
-        end
-      end
-
-      describe "in_order_cycle" do
-        it "shows products in order cycle distribution" do
-          s = create(:supplier_enterprise)
-          d1 = create(:distributor_enterprise)
-          d2 = create(:distributor_enterprise)
-          p1 = create(:product)
-          p2 = create(:product)
-          oc1 = create(:simple_order_cycle, suppliers: [s], distributors: [d1],
-                                            variants: [p1.variants.first])
-          oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d2],
-                                            variants: [p2.variants.first])
-          expect(Product.in_order_cycle(oc1)).to eq([p1])
-        end
-      end
-
-      describe "in_an_active_order_cycle" do
-        it "shows products in order cycle distribution" do
-          s = create(:supplier_enterprise)
-          d2 = create(:distributor_enterprise)
-          d3 = create(:distributor_enterprise)
-          p1 = create(:product)
-          p2 = create(:product)
-          p3 = create(:product)
-          oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d2],
-                                            variants: [p2.variants.first],
-                                            orders_open_at: 8.days.ago, orders_close_at: 1.day.ago)
-          oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d3],
-                                            variants: [p3.variants.first],
-                                            orders_close_at: Date.tomorrow)
-          expect(Product.in_an_active_order_cycle).to eq([p3])
-        end
-      end
-
-      describe "by_producer" do
-        it "orders by producer name" do
-          producer_z = create(:enterprise, name: "z_cooperative")
-          producer_a = create(:enterprise, name: "a_cooperative")
-          producer_g = create(:enterprise, name: "g_cooperative")
-
-          product1 = create(:product, supplier_id: producer_z.id)
-          product2 = create(:product, supplier_id: producer_a.id)
-          product3 = create(:product, supplier_id: producer_g.id)
-
-          expect(Product.by_producer).to eq([product2, product3, product1])
-        end
-      end
-
-      describe "managed_by" do
-        let!(:e1) { create(:enterprise) }
-        let!(:e2) { create(:enterprise) }
-        let!(:p1) { create(:product) }
-        let!(:p2) { create(:product) }
-
-        before(:each) do
-          create(:variant, product: p1, supplier: e1)
-          create(:variant, product: p1, supplier: e2)
-        end
-
-        it "shows only products for given user" do
-          user = create(:user)
-          e1.enterprise_roles.build(user:).save
-
-          product = Product.managed_by user
-
-          expect(product.count).to eq(1)
-          expect(product).to include p1
-        end
-
-        it "shows all products for admin user" do
-          user = create(:admin_user)
-
-          product = Product.managed_by user
-
-          expect(product.count).to eq(2)
-          expect(product).to include p1
-          expect(product).to include p2
-        end
-      end
-
-      describe "visible_for" do
-        let(:enterprise) { create(:distributor_enterprise) }
-        let!(:new_variant) { create(:variant) }
-        let!(:hidden_variant) { create(:variant) }
-
-        let!(:product) { create(:product) }
-        let!(:visible_variant1) { create(:variant, product:) }
-        let!(:visible_variant2) { create(:variant, product:) }
-
-        let!(:hidden_inventory_item) {
-          create(:inventory_item, enterprise:, variant: hidden_variant, visible: false )
-        }
-        let!(:visible_inventory_item1) {
-          create(:inventory_item, enterprise:, variant: visible_variant1, visible: true )
-        }
-        let!(:visible_inventory_item2) {
-          create(:inventory_item, enterprise:, variant: visible_variant2, visible: true )
-        }
-
-        let!(:products) { Spree::Product.visible_for(enterprise) }
-
-        it "lists any products with variants that are listed as visible=true" do
-          expect(products.length).to eq(1)
-          expect(products).to include product
-          expect(products).not_to include new_variant.product, hidden_variant.product
-        end
-      end
-
-      describe "imported_on" do
-        let!(:v1) { create(:variant, import_date: 1.day.ago) }
-        let!(:v2) { create(:variant, import_date: 2.days.ago) }
-        let!(:v3) { create(:variant, import_date: 1.day.ago) }
-
-        it "returns products imported on given day" do
-          imported_products = Spree::Product.imported_on(1.day.ago.to_date)
-          expect(imported_products).to include v1.product, v3.product
-        end
-      end
-    end
-
-    describe "#properties_including_inherited" do
-      let(:product) { create(:simple_product) }
+    describe "after touching the product" do
+      let(:product) { create(:simple_product, supplier_id: supplier.id) }
       let(:supplier) { create(:supplier_enterprise) }
 
-      before do
-        product.variants = []
-        product.variants << create(:variant, product:, supplier:)
+      it "touches the supplier" do
+        expect { product.touch }
+          .to change { supplier.reload.updated_at }
       end
 
-      it "returns product properties as a hash" do
-        product.set_property 'Organic Certified', 'NASAA 12345'
-        property = product.properties.last
+      context "when the first variant is missing supplier" do
+        it "doesn't blow up" do
+          product.variants.first.update_attribute(:supplier_id, nil)
 
-        expect(product.properties_including_inherited)
-          .to eq([{ id: property.id, name: "Organic Certified", value: 'NASAA 12345' }])
+          expect { product.touch }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  describe "scopes" do
+    describe ".with_properties" do
+      let!(:product_with_wanted_property) { create(:product, properties: [wanted_property]) }
+      let!(:product_without_wanted_property_property) {
+        create(:product, properties: [unwanted_property])
+      }
+      let!(:product_ignoring_property) {
+        create(:product, inherits_properties: false)
+      }
+      let(:wanted_property) { create(:property, presentation: 'Certified Organic') }
+      let(:unwanted_property) { create(:property, presentation: 'Latest Hype') }
+
+      it "returns no products without a property id" do
+        expect(described_class.with_properties([])).to eq []
       end
 
-      it "returns producer properties as a hash" do
+      it "returns only products with the wanted property set both on supplier & product itself" do
+        expect(
+          described_class.with_properties([wanted_property.id, 99_999])
+        ).to match_array [product_with_wanted_property]
+      end
+    end
+
+    describe "in_supplier" do
+      it "shows products in supplier" do
+        s1 = create(:supplier_enterprise)
+        p1 = create(:product, supplier_id: s1.id)
+        # We create two variants to let us test we don't get duplicated product
+        create(:variant, product: p1, supplier: s1)
+        create(:variant, product: p1, supplier: s1)
+        s2 = create(:supplier_enterprise)
+        p2 = create(:product, supplier_id: s2.id)
+        create(:variant, product: p2, supplier: s2)
+
+        expect(described_class.in_supplier(s1)).to eq([p1])
+      end
+    end
+
+    describe "in_distributor" do
+      it "shows products in order cycle distribution" do
+        s = create(:supplier_enterprise)
+        d1 = create(:distributor_enterprise)
+        d2 = create(:distributor_enterprise)
+        p1 = create(:product)
+        p2 = create(:product)
+        create(:simple_order_cycle, suppliers: [s], distributors: [d1],
+                                    variants: [p1.variants.first])
+        create(:simple_order_cycle, suppliers: [s], distributors: [d2],
+                                    variants: [p2.variants.first])
+        expect(described_class.in_distributor(d1)).to eq([p1])
+      end
+
+      it "shows products in order cycle distribution by variant" do
+        s = create(:supplier_enterprise)
+        d1 = create(:distributor_enterprise)
+        d2 = create(:distributor_enterprise)
+        p1 = create(:product)
+        v1 = create(:variant, product: p1)
+        p2 = create(:product)
+        v2 = create(:variant, product: p2)
+        create(:simple_order_cycle, suppliers: [s], distributors: [d1], variants: [v1])
+        create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [v2])
+        expect(described_class.in_distributor(d1)).to eq([p1])
+      end
+
+      it "doesn't show products listed in the incoming exchange only" do
+        s = create(:supplier_enterprise)
+        c = create(:distributor_enterprise)
+        d = create(:distributor_enterprise)
+        p = create(:product)
+        oc = create(:simple_order_cycle, coordinator: c, suppliers: [s], distributors: [d])
+        ex = oc.exchanges.incoming.first
+        ex.variants << p.variants.first
+
+        expect(described_class.in_distributor(d)).to be_empty
+      end
+    end
+
+    describe "in_distributors" do
+      let!(:distributor1) { create(:distributor_enterprise) }
+      let!(:distributor2) { create(:distributor_enterprise) }
+      let!(:product1) { create(:product) }
+      let!(:product2) { create(:product) }
+      let!(:product3) { create(:product) }
+      let!(:product4) { create(:product) }
+      let!(:order_cycle1) {
+        create(:order_cycle, distributors: [distributor1],
+                             variants: [product1.variants.first, product2.variants.first])
+      }
+      let!(:order_cycle2) {
+        create(:order_cycle, distributors: [distributor2],
+                             variants: [product3.variants.first])
+      }
+
+      it "returns distributed products for a given Enterprise AR relation" do
+        distributors = Enterprise.where(id: [distributor1.id, distributor2.id]).to_a
+
+        expect(described_class.in_distributors(distributors)).
+          to include product1, product2, product3
+        expect(described_class.in_distributors(distributors)).not_to include product4
+      end
+
+      it "returns distributed products for a given array of enterprise ids" do
+        distributors_ids = [distributor1.id, distributor2.id]
+
+        expect(described_class.in_distributors(distributors_ids)).
+          to include product1, product2, product3
+        expect(described_class.in_distributors(distributors_ids)).not_to include product4
+      end
+    end
+
+    describe "in_order_cycle" do
+      it "shows products in order cycle distribution" do
+        s = create(:supplier_enterprise)
+        d1 = create(:distributor_enterprise)
+        d2 = create(:distributor_enterprise)
+        p1 = create(:product)
+        p2 = create(:product)
+        oc1 = create(:simple_order_cycle, suppliers: [s], distributors: [d1],
+                                          variants: [p1.variants.first])
+        oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d2],
+                                          variants: [p2.variants.first])
+        expect(described_class.in_order_cycle(oc1)).to eq([p1])
+      end
+    end
+
+    describe "in_an_active_order_cycle" do
+      it "shows products in order cycle distribution" do
+        s = create(:supplier_enterprise)
+        d2 = create(:distributor_enterprise)
+        d3 = create(:distributor_enterprise)
+        p1 = create(:product)
+        p2 = create(:product)
+        p3 = create(:product)
+        oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d2],
+                                          variants: [p2.variants.first],
+                                          orders_open_at: 8.days.ago, orders_close_at: 1.day.ago)
+        oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d3],
+                                          variants: [p3.variants.first],
+                                          orders_close_at: Date.tomorrow)
+        expect(described_class.in_an_active_order_cycle).to eq([p3])
+      end
+    end
+
+    describe "by_producer" do
+      it "orders by producer name" do
+        producer_z = create(:enterprise, name: "z_cooperative")
+        producer_a = create(:enterprise, name: "a_cooperative")
+        producer_g = create(:enterprise, name: "g_cooperative")
+
+        product1 = create(:product, supplier_id: producer_z.id)
+        product2 = create(:product, supplier_id: producer_a.id)
+        product3 = create(:product, supplier_id: producer_g.id)
+
+        expect(described_class.by_producer).to eq([product2, product3, product1])
+      end
+    end
+
+    describe "managed_by" do
+      let!(:e1) { create(:enterprise) }
+      let!(:e2) { create(:enterprise) }
+      let!(:p1) { create(:product) }
+      let!(:p2) { create(:product) }
+
+      before(:each) do
+        create(:variant, product: p1, supplier: e1)
+        create(:variant, product: p1, supplier: e2)
+      end
+
+      it "shows only products for given user" do
+        user = create(:user)
+        e1.enterprise_roles.build(user:).save
+
+        product = described_class.managed_by user
+
+        expect(product.count).to eq(1)
+        expect(product).to include p1
+      end
+
+      it "shows all products for admin user" do
+        user = create(:admin_user)
+
+        product = described_class.managed_by user
+
+        expect(product.count).to eq(2)
+        expect(product).to include p1
+        expect(product).to include p2
+      end
+    end
+
+    describe "visible_for" do
+      let(:enterprise) { create(:distributor_enterprise) }
+      let!(:new_variant) { create(:variant) }
+      let!(:hidden_variant) { create(:variant) }
+
+      let!(:product) { create(:product) }
+      let!(:visible_variant1) { create(:variant, product:) }
+      let!(:visible_variant2) { create(:variant, product:) }
+
+      let!(:hidden_inventory_item) {
+        create(:inventory_item, enterprise:, variant: hidden_variant, visible: false )
+      }
+      let!(:visible_inventory_item1) {
+        create(:inventory_item, enterprise:, variant: visible_variant1, visible: true )
+      }
+      let!(:visible_inventory_item2) {
+        create(:inventory_item, enterprise:, variant: visible_variant2, visible: true )
+      }
+
+      let!(:products) { described_class.visible_for(enterprise) }
+
+      it "lists any products with variants that are listed as visible=true" do
+        expect(products.length).to eq(1)
+        expect(products).to include product
+        expect(products).not_to include new_variant.product, hidden_variant.product
+      end
+    end
+
+    describe "imported_on" do
+      let!(:v1) { create(:variant, import_date: 1.day.ago) }
+      let!(:v2) { create(:variant, import_date: 2.days.ago) }
+      let!(:v3) { create(:variant, import_date: 1.day.ago) }
+
+      it "returns products imported on given day" do
+        imported_products = described_class.imported_on(1.day.ago.to_date)
+        expect(imported_products).to include v1.product, v3.product
+      end
+    end
+  end
+
+  describe "#properties_including_inherited" do
+    let(:product) { create(:simple_product) }
+    let(:supplier) { create(:supplier_enterprise) }
+
+    before do
+      product.variants = []
+      product.variants << create(:variant, product:, supplier:)
+    end
+
+    it "returns product properties as a hash" do
+      product.set_property 'Organic Certified', 'NASAA 12345'
+      property = product.properties.last
+
+      expect(product.properties_including_inherited)
+        .to eq([{ id: property.id, name: "Organic Certified", value: 'NASAA 12345' }])
+    end
+
+    it "returns producer properties as a hash" do
+      supplier.set_producer_property 'Organic Certified', 'NASAA 54321'
+      property = supplier.properties.last
+
+      expect(product.properties_including_inherited)
+        .to eq([{ id: property.id, name: "Organic Certified", value: 'NASAA 54321' }])
+    end
+
+    it "overrides producer properties with product properties" do
+      product.set_property 'Organic Certified', 'NASAA 12345'
+      supplier.set_producer_property 'Organic Certified', 'NASAA 54321'
+      property = product.properties.last
+
+      expect(product.properties_including_inherited)
+        .to eq([{ id: property.id, name: "Organic Certified", value: 'NASAA 12345' }])
+    end
+
+    context "when product has an inherit_properties value set to true" do
+      let(:product) { create(:simple_product, inherits_properties: true) }
+
+      it "inherits producer properties" do
         supplier.set_producer_property 'Organic Certified', 'NASAA 54321'
         property = supplier.properties.last
 
         expect(product.properties_including_inherited)
           .to eq([{ id: property.id, name: "Organic Certified", value: 'NASAA 54321' }])
       end
+    end
 
-      it "overrides producer properties with product properties" do
-        product.set_property 'Organic Certified', 'NASAA 12345'
+    context "when product has an inherit_properties value set to false" do
+      let(:product) { create(:simple_product, inherits_properties: false) }
+
+      it "does not inherit producer properties" do
         supplier.set_producer_property 'Organic Certified', 'NASAA 54321'
-        property = product.properties.last
 
-        expect(product.properties_including_inherited)
-          .to eq([{ id: property.id, name: "Organic Certified", value: 'NASAA 12345' }])
-      end
-
-      context "when product has an inherit_properties value set to true" do
-        let(:product) { create(:simple_product, inherits_properties: true) }
-
-        it "inherits producer properties" do
-          supplier.set_producer_property 'Organic Certified', 'NASAA 54321'
-          property = supplier.properties.last
-
-          expect(product.properties_including_inherited)
-            .to eq([{ id: property.id, name: "Organic Certified", value: 'NASAA 54321' }])
-        end
-      end
-
-      context "when product has an inherit_properties value set to false" do
-        let(:product) { create(:simple_product, inherits_properties: false) }
-
-        it "does not inherit producer properties" do
-          supplier.set_producer_property 'Organic Certified', 'NASAA 54321'
-
-          expect(product.properties_including_inherited).to eq([])
-        end
-      end
-
-      it "sorts by position" do
-        pa = Spree::Property.create! name: 'A', presentation: 'A'
-        pb = Spree::Property.create! name: 'B', presentation: 'B'
-        pc = Spree::Property.create! name: 'C', presentation: 'C'
-
-        product.product_properties.create!({ property_id: pa.id, value: '1', position: 1 })
-        product.product_properties.create!({ property_id: pc.id, value: '3', position: 3 })
-        supplier.producer_properties.create!({ property_id: pb.id, value: '2', position: 2 })
-
-        expect(product.properties_including_inherited).to eq(
-          [{ id: pa.id, name: "A", value: '1' },
-           { id: pb.id, name: "B", value: '2' },
-           { id: pc.id, name: "C", value: '3' }]
-        )
+        expect(product.properties_including_inherited).to eq([])
       end
     end
 
-    describe "membership" do
-      it "queries its membership of a particular order cycle distribution" do
-        d1 = create(:distributor_enterprise)
-        d2 = create(:distributor_enterprise)
-        p1 = create(:product)
-        p2 = create(:product)
-        oc1 = create(:simple_order_cycle, distributors: [d1], variants: [p1.variants.first])
-        oc2 = create(:simple_order_cycle, distributors: [d2], variants: [p2.variants.first])
+    it "sorts by position" do
+      pa = Spree::Property.create! name: 'A', presentation: 'A'
+      pb = Spree::Property.create! name: 'B', presentation: 'B'
+      pc = Spree::Property.create! name: 'C', presentation: 'C'
 
-        expect(p1).to be_in_distributor d1
-        expect(p1).not_to be_in_distributor d2
-      end
+      product.product_properties.create!({ property_id: pa.id, value: '1', position: 1 })
+      product.product_properties.create!({ property_id: pc.id, value: '3', position: 3 })
+      supplier.producer_properties.create!({ property_id: pb.id, value: '2', position: 2 })
 
-      it "queries its membership of a particular order cycle" do
-        d1 = create(:distributor_enterprise)
-        d2 = create(:distributor_enterprise)
-        p1 = create(:product)
-        p2 = create(:product)
-        oc1 = create(:simple_order_cycle, distributors: [d1], variants: [p1.variants.first])
-        oc2 = create(:simple_order_cycle, distributors: [d2], variants: [p2.variants.first])
-
-        expect(p1).to be_in_order_cycle oc1
-        expect(p1).not_to be_in_order_cycle oc2
-      end
-    end
-
-    describe "deletion" do
-      let(:product) { create(:simple_product) }
-      let(:variant) { create(:variant, product:) }
-      let(:order_cycle) { create(:simple_order_cycle) }
-      let(:supplier) { create(:supplier_enterprise) }
-      let(:exchange) {
-        create(
-          :exchange,
-          order_cycle:,
-          incoming: true,
-          sender: supplier,
-          receiver: order_cycle.coordinator
-        )
-      }
-
-      it "removes all variants from order cycles" do
-        exchange.variants << variant
-
-        product.destroy
-        expect(exchange.variants.reload).to be_empty
-      end
-    end
-
-    describe "serialisation" do
-      it "sanitises HTML in description" do
-        subject.description = "Hello <script>alert</script> dearest <b>monster</b>."
-        expect(subject.description).to eq "Hello alert dearest <b>monster</b>."
-      end
+      expect(product.properties_including_inherited).to eq(
+        [{ id: pa.id, name: "A", value: '1' },
+         { id: pb.id, name: "B", value: '2' },
+         { id: pc.id, name: "C", value: '3' }]
+      )
     end
   end
 
-  RSpec.describe "product import" do
-    describe "finding the most recent import date of the variants" do
-      let!(:product) { create(:product) }
+  describe "membership" do
+    it "queries its membership of a particular order cycle distribution" do
+      d1 = create(:distributor_enterprise)
+      d2 = create(:distributor_enterprise)
+      p1 = create(:product)
+      p2 = create(:product)
+      oc1 = create(:simple_order_cycle, distributors: [d1], variants: [p1.variants.first])
+      oc2 = create(:simple_order_cycle, distributors: [d2], variants: [p2.variants.first])
 
-      let(:reference_time) { Time.zone.now.beginning_of_day }
+      expect(p1).to be_in_distributor d1
+      expect(p1).not_to be_in_distributor d2
+    end
 
-      before do
-        product.reload
+    it "queries its membership of a particular order cycle" do
+      d1 = create(:distributor_enterprise)
+      d2 = create(:distributor_enterprise)
+      p1 = create(:product)
+      p2 = create(:product)
+      oc1 = create(:simple_order_cycle, distributors: [d1], variants: [p1.variants.first])
+      oc2 = create(:simple_order_cycle, distributors: [d2], variants: [p2.variants.first])
+
+      expect(p1).to be_in_order_cycle oc1
+      expect(p1).not_to be_in_order_cycle oc2
+    end
+  end
+
+  describe "deletion" do
+    let(:product) { create(:simple_product) }
+    let(:variant) { create(:variant, product:) }
+    let(:order_cycle) { create(:simple_order_cycle) }
+    let(:supplier) { create(:supplier_enterprise) }
+    let(:exchange) {
+      create(
+        :exchange,
+        order_cycle:,
+        incoming: true,
+        sender: supplier,
+        receiver: order_cycle.coordinator
+      )
+    }
+
+    it "removes all variants from order cycles" do
+      exchange.variants << variant
+
+      product.destroy
+      expect(exchange.variants.reload).to be_empty
+    end
+  end
+
+  describe "serialisation" do
+    it "sanitises HTML in description" do
+      subject.description = "Hello <script>alert</script> dearest <b>monster</b>."
+      expect(subject.description).to eq "Hello alert dearest <b>monster</b>."
+    end
+  end
+end
+
+RSpec.describe "product import" do
+  describe "finding the most recent import date of the variants" do
+    let!(:product) { create(:product) }
+
+    let(:reference_time) { Time.zone.now.beginning_of_day }
+
+    before do
+      product.reload
+    end
+
+    context "when the variants do not have an import date" do
+      let!(:variant_a) { create(:variant, product:, import_date: nil) }
+      let!(:variant_b) { create(:variant, product:, import_date: nil) }
+
+      it "returns nil" do
+        expect(product.import_date).to be_nil
       end
+    end
 
-      context "when the variants do not have an import date" do
-        let!(:variant_a) { create(:variant, product:, import_date: nil) }
-        let!(:variant_b) { create(:variant, product:, import_date: nil) }
+    context "when some variants have import date and some do not" do
+      let!(:variant_a) { create(:variant, product:, import_date: nil) }
+      let!(:variant_b) {
+        create(:variant, product:, import_date: reference_time - 1.hour)
+      }
+      let!(:variant_c) {
+        create(:variant, product:, import_date: reference_time - 2.hours)
+      }
 
-        it "returns nil" do
-          expect(product.import_date).to be_nil
-        end
+      it "returns the most recent import date" do
+        expect(product.import_date).to eq(variant_b.import_date)
       end
+    end
 
-      context "when some variants have import date and some do not" do
-        let!(:variant_a) { create(:variant, product:, import_date: nil) }
-        let!(:variant_b) {
-          create(:variant, product:, import_date: reference_time - 1.hour)
-        }
-        let!(:variant_c) {
-          create(:variant, product:, import_date: reference_time - 2.hours)
-        }
+    context "when all variants have import date" do
+      let!(:variant_a) {
+        create(:variant, product:, import_date: reference_time - 2.hours)
+      }
+      let!(:variant_b) {
+        create(:variant, product:, import_date: reference_time - 1.hour)
+      }
+      let!(:variant_c) {
+        create(:variant, product:, import_date: reference_time - 3.hours)
+      }
 
-        it "returns the most recent import date" do
-          expect(product.import_date).to eq(variant_b.import_date)
-        end
-      end
-
-      context "when all variants have import date" do
-        let!(:variant_a) {
-          create(:variant, product:, import_date: reference_time - 2.hours)
-        }
-        let!(:variant_b) {
-          create(:variant, product:, import_date: reference_time - 1.hour)
-        }
-        let!(:variant_c) {
-          create(:variant, product:, import_date: reference_time - 3.hours)
-        }
-
-        it "returns the most recent import date" do
-          expect(product.import_date).to eq(variant_b.import_date)
-        end
+      it "returns the most recent import date" do
+        expect(product.import_date).to eq(variant_b.import_date)
       end
     end
   end

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -2,219 +2,217 @@
 
 require 'spec_helper'
 
-module Spree
-  RSpec.describe ShippingMethod do
-    it "is valid when built from factory" do
-      expect(
-        build(
+RSpec.describe Spree::ShippingMethod do
+  it "is valid when built from factory" do
+    expect(
+      build(
+        :shipping_method,
+        shipping_categories: [Spree::ShippingCategory.new(name: 'Test')]
+      )
+    ).to be_valid
+  end
+
+  it "can have distributors" do
+    d1 = create(:distributor_enterprise)
+    d2 = create(:distributor_enterprise)
+    sm = create(:shipping_method)
+
+    sm.distributors.clear
+    sm.distributors << d1
+    sm.distributors << d2
+
+    expect(sm.reload.distributors).to match_array [d1, d2]
+  end
+
+  describe "scope" do
+    describe "filtering to specified distributors" do
+      let!(:distributor_a) { create(:distributor_enterprise) }
+      let!(:distributor_b) { create(:distributor_enterprise) }
+      let!(:distributor_c) { create(:distributor_enterprise) }
+
+      let!(:shipping_method_a) {
+        create(:shipping_method, distributors: [distributor_a, distributor_b])
+      }
+      let!(:shipping_method_b) { create(:shipping_method, distributors: [distributor_b]) }
+      let!(:shipping_method_c) { create(:shipping_method, distributors: [distributor_c]) }
+
+      it "includes only unique records under specified distributors" do
+        result = described_class.for_distributors([distributor_a, distributor_b])
+        expect(result.length).to eq(2)
+        expect(result).to include(shipping_method_a)
+        expect(result).to include(shipping_method_b)
+      end
+    end
+
+    it "finds shipping methods for a particular distributor" do
+      d1 = create(:distributor_enterprise)
+      d2 = create(:distributor_enterprise)
+      sm1 = create(:shipping_method, distributors: [d1])
+      sm2 = create(:shipping_method, distributors: [d2])
+
+      expect(described_class.for_distributor(d1)).to eq([sm1])
+    end
+  end
+
+  it "orders shipping methods by name" do
+    sm1 = create(:shipping_method, name: 'ZZ')
+    sm2 = create(:shipping_method, name: 'AA')
+    sm3 = create(:shipping_method, name: 'BB')
+
+    expect(described_class.by_name).to eq([sm2, sm3, sm1])
+  end
+
+  describe "finding services offered by all distributors" do
+    let!(:d1) { create(:distributor_enterprise) }
+    let!(:d2) { create(:distributor_enterprise) }
+    let!(:d3) { create(:distributor_enterprise) }
+    let!(:d4) { create(:distributor_enterprise) }
+    let!(:d1_pickup) { create(:shipping_method, require_ship_address: false, distributors: [d1]) }
+    let!(:d1_delivery) {
+      create(:shipping_method, require_ship_address: true, distributors: [d1])
+    }
+    let!(:d2_pickup) { create(:shipping_method, require_ship_address: false, distributors: [d2]) }
+    let!(:d3_delivery) {
+      create(:shipping_method, require_ship_address: true, distributors: [d3])
+    }
+
+    it "reports when the services are available" do
+      expect(described_class.services[d1.id]).to eq(pickup: true, delivery: true)
+    end
+
+    it "reports when only pickup is available" do
+      expect(described_class.services[d2.id]).to eq(pickup: true, delivery: false)
+    end
+
+    it "reports when only delivery is available" do
+      expect(described_class.services[d3.id]).to eq(pickup: false, delivery: true)
+    end
+
+    it "returns no entry when no service is available" do
+      expect(described_class.services[d4.id]).to be_nil
+    end
+  end
+
+  describe '#delivery?' do
+    context 'when the shipping method requires an address' do
+      let(:shipping_method) { build(:shipping_method, require_ship_address: true) }
+      it { expect(shipping_method.delivery?).to be true }
+    end
+
+    context 'when the shipping method does not require address' do
+      let(:shipping_method) { build(:shipping_method, require_ship_address: false) }
+      it { expect(shipping_method.delivery?).to be false }
+    end
+  end
+
+  describe "#delivers_to?" do
+    let(:shipping_method) { build_stubbed(:shipping_method) }
+
+    it "does not deliver to a nil address" do
+      expect(shipping_method.delivers_to?(nil)).to be false
+    end
+
+    it "includes an address that is not included in the zones of the shipping method" do
+      address = create(:address)
+      zone_mock = instance_double(Spree::Zone)
+      allow(zone_mock).to receive(:contains?).with(address).and_return(false)
+      allow(shipping_method).to receive(:zones) { [zone_mock] }
+
+      expect(shipping_method.delivers_to?(address)).to be true
+    end
+  end
+
+  describe "touches" do
+    let!(:distributor) { create(:distributor_enterprise) }
+    let!(:shipping_method) { create(:shipping_method) }
+    let(:add_distributor) { shipping_method.distributors << distributor }
+
+    it "is touched when applied to a distributor" do
+      expect{ add_distributor }.to change { shipping_method.reload.updated_at }
+    end
+  end
+
+  context "validations" do
+    it "validates presence of name" do
+      shipping_method = build_stubbed(
+        :shipping_method,
+        name: ''
+      )
+      expect(shipping_method).not_to be_valid
+      expect(shipping_method.errors[:name].first).to eq "can't be blank"
+    end
+
+    describe "#display_on" do
+      it "is valid when it's set to nil, an empty string or 'back_end'" do
+        shipping_method = build_stubbed(
           :shipping_method,
           shipping_categories: [Spree::ShippingCategory.new(name: 'Test')]
         )
-      ).to be_valid
-    end
-
-    it "can have distributors" do
-      d1 = create(:distributor_enterprise)
-      d2 = create(:distributor_enterprise)
-      sm = create(:shipping_method)
-
-      sm.distributors.clear
-      sm.distributors << d1
-      sm.distributors << d2
-
-      expect(sm.reload.distributors).to match_array [d1, d2]
-    end
-
-    describe "scope" do
-      describe "filtering to specified distributors" do
-        let!(:distributor_a) { create(:distributor_enterprise) }
-        let!(:distributor_b) { create(:distributor_enterprise) }
-        let!(:distributor_c) { create(:distributor_enterprise) }
-
-        let!(:shipping_method_a) {
-          create(:shipping_method, distributors: [distributor_a, distributor_b])
-        }
-        let!(:shipping_method_b) { create(:shipping_method, distributors: [distributor_b]) }
-        let!(:shipping_method_c) { create(:shipping_method, distributors: [distributor_c]) }
-
-        it "includes only unique records under specified distributors" do
-          result = described_class.for_distributors([distributor_a, distributor_b])
-          expect(result.length).to eq(2)
-          expect(result).to include(shipping_method_a)
-          expect(result).to include(shipping_method_b)
+        [nil, "", "back_end"].each do |display_on_option|
+          shipping_method.display_on = display_on_option
+          expect(shipping_method).to be_valid
         end
       end
 
-      it "finds shipping methods for a particular distributor" do
-        d1 = create(:distributor_enterprise)
-        d2 = create(:distributor_enterprise)
-        sm1 = create(:shipping_method, distributors: [d1])
-        sm2 = create(:shipping_method, distributors: [d2])
-
-        expect(ShippingMethod.for_distributor(d1)).to eq([sm1])
+      it "is not valid when it's set to an unknown value" do
+        shipping_method = build_stubbed(:shipping_method, display_on: "front_end")
+        expect(shipping_method).not_to be_valid
+        expect(shipping_method.errors[:display_on]).to eq ["is not included in the list"]
       end
     end
 
-    it "orders shipping methods by name" do
-      sm1 = create(:shipping_method, name: 'ZZ')
-      sm2 = create(:shipping_method, name: 'AA')
-      sm3 = create(:shipping_method, name: 'BB')
-
-      expect(ShippingMethod.by_name).to eq([sm2, sm3, sm1])
-    end
-
-    describe "finding services offered by all distributors" do
-      let!(:d1) { create(:distributor_enterprise) }
-      let!(:d2) { create(:distributor_enterprise) }
-      let!(:d3) { create(:distributor_enterprise) }
-      let!(:d4) { create(:distributor_enterprise) }
-      let!(:d1_pickup) { create(:shipping_method, require_ship_address: false, distributors: [d1]) }
-      let!(:d1_delivery) {
-        create(:shipping_method, require_ship_address: true, distributors: [d1])
-      }
-      let!(:d2_pickup) { create(:shipping_method, require_ship_address: false, distributors: [d2]) }
-      let!(:d3_delivery) {
-        create(:shipping_method, require_ship_address: true, distributors: [d3])
-      }
-
-      it "reports when the services are available" do
-        expect(ShippingMethod.services[d1.id]).to eq(pickup: true, delivery: true)
-      end
-
-      it "reports when only pickup is available" do
-        expect(ShippingMethod.services[d2.id]).to eq(pickup: true, delivery: false)
-      end
-
-      it "reports when only delivery is available" do
-        expect(ShippingMethod.services[d3.id]).to eq(pickup: false, delivery: true)
-      end
-
-      it "returns no entry when no service is available" do
-        expect(ShippingMethod.services[d4.id]).to be_nil
-      end
-    end
-
-    describe '#delivery?' do
-      context 'when the shipping method requires an address' do
-        let(:shipping_method) { build(:shipping_method, require_ship_address: true) }
-        it { expect(shipping_method.delivery?).to be true }
-      end
-
-      context 'when the shipping method does not require address' do
-        let(:shipping_method) { build(:shipping_method, require_ship_address: false) }
-        it { expect(shipping_method.delivery?).to be false }
-      end
-    end
-
-    describe "#delivers_to?" do
-      let(:shipping_method) { build_stubbed(:shipping_method) }
-
-      it "does not deliver to a nil address" do
-        expect(shipping_method.delivers_to?(nil)).to be false
-      end
-
-      it "includes an address that is not included in the zones of the shipping method" do
-        address = create(:address)
-        zone_mock = instance_double(Spree::Zone)
-        allow(zone_mock).to receive(:contains?).with(address).and_return(false)
-        allow(shipping_method).to receive(:zones) { [zone_mock] }
-
-        expect(shipping_method.delivers_to?(address)).to be true
-      end
-    end
-
-    describe "touches" do
-      let!(:distributor) { create(:distributor_enterprise) }
-      let!(:shipping_method) { create(:shipping_method) }
-      let(:add_distributor) { shipping_method.distributors << distributor }
-
-      it "is touched when applied to a distributor" do
-        expect{ add_distributor }.to change { shipping_method.reload.updated_at }
-      end
-    end
-
-    context "validations" do
-      it "validates presence of name" do
+    context "shipping category" do
+      it "validates presence of at least one" do
         shipping_method = build_stubbed(
           :shipping_method,
-          name: ''
+          shipping_categories: []
         )
         expect(shipping_method).not_to be_valid
-        expect(shipping_method.errors[:name].first).to eq "can't be blank"
+        expect(shipping_method.errors[:base].first)
+          .to eq "You need to select at least one shipping category"
       end
 
-      describe "#display_on" do
-        it "is valid when it's set to nil, an empty string or 'back_end'" do
-          shipping_method = build_stubbed(
+      context "one associated" do
+        let(:shipping_method) do
+          build_stubbed(
             :shipping_method,
             shipping_categories: [Spree::ShippingCategory.new(name: 'Test')]
           )
-          [nil, "", "back_end"].each do |display_on_option|
-            shipping_method.display_on = display_on_option
-            expect(shipping_method).to be_valid
-          end
         end
-
-        it "is not valid when it's set to an unknown value" do
-          shipping_method = build_stubbed(:shipping_method, display_on: "front_end")
-          expect(shipping_method).not_to be_valid
-          expect(shipping_method.errors[:display_on]).to eq ["is not included in the list"]
-        end
-      end
-
-      context "shipping category" do
-        it "validates presence of at least one" do
-          shipping_method = build_stubbed(
-            :shipping_method,
-            shipping_categories: []
-          )
-          expect(shipping_method).not_to be_valid
-          expect(shipping_method.errors[:base].first)
-            .to eq "You need to select at least one shipping category"
-        end
-
-        context "one associated" do
-          let(:shipping_method) do
-            build_stubbed(
-              :shipping_method,
-              shipping_categories: [Spree::ShippingCategory.new(name: 'Test')]
-            )
-          end
-          it { expect(shipping_method).to be_valid }
-        end
+        it { expect(shipping_method).to be_valid }
       end
     end
+  end
 
-    # Regression test for Spree #4320
-    context "soft deletion" do
-      let(:shipping_method) { create(:shipping_method) }
+  # Regression test for Spree #4320
+  context "soft deletion" do
+    let(:shipping_method) { create(:shipping_method) }
 
-      it "soft-deletes when destroy is called" do
-        shipping_method.destroy
-        expect(shipping_method.deleted_at).not_to be_blank
-      end
+    it "soft-deletes when destroy is called" do
+      shipping_method.destroy
+      expect(shipping_method.deleted_at).not_to be_blank
+    end
+  end
+
+  context 'factory' do
+    let(:shipping_method){ create :shipping_method }
+
+    it "should set calculable correctly" do
+      expect(shipping_method.calculator.calculable).to eq(shipping_method)
+    end
+  end
+
+  # Regression test for Spree #4492
+  context "#shipments" do
+    let!(:shipping_method) { create(:shipping_method) }
+    let!(:shipment) do
+      shipment = create(:shipment)
+      shipment.shipping_rates.create!(shipping_method:)
+      shipment
     end
 
-    context 'factory' do
-      let(:shipping_method){ create :shipping_method }
-
-      it "should set calculable correctly" do
-        expect(shipping_method.calculator.calculable).to eq(shipping_method)
-      end
-    end
-
-    # Regression test for Spree #4492
-    context "#shipments" do
-      let!(:shipping_method) { create(:shipping_method) }
-      let!(:shipment) do
-        shipment = create(:shipment)
-        shipment.shipping_rates.create!(shipping_method:)
-        shipment
-      end
-
-      it "can gather all the related shipments" do
-        expect(shipping_method.shipments).to include(shipment)
-      end
+    it "can gather all the related shipments" do
+      expect(shipping_method.shipments).to include(shipment)
     end
   end
 end

--- a/spec/models/spree/tax_rate_spec.rb
+++ b/spec/models/spree/tax_rate_spec.rb
@@ -2,404 +2,402 @@
 
 require 'spec_helper'
 
-module Spree
-  RSpec.describe TaxRate do
-    describe ".match" do
-      let!(:zone) { create(:zone_with_member) }
-      let!(:order) { create(:order, distributor: hub, bill_address: create(:address)) }
-      let!(:tax_rate) {
-        create(:tax_rate, included_in_price: true,
-                          calculator: ::Calculator::FlatRate.new(preferred_amount: 0.1), zone:)
-      }
+RSpec.describe Spree::TaxRate do
+  describe ".match" do
+    let!(:zone) { create(:zone_with_member) }
+    let!(:order) { create(:order, distributor: hub, bill_address: create(:address)) }
+    let!(:tax_rate) {
+      create(:tax_rate, included_in_price: true,
+                        calculator: Calculator::FlatRate.new(preferred_amount: 0.1), zone:)
+    }
 
-      describe "when the order's hub charges sales tax" do
-        let(:hub) { create(:distributor_enterprise, charges_sales_tax: true) }
+    describe "when the order's hub charges sales tax" do
+      let(:hub) { create(:distributor_enterprise, charges_sales_tax: true) }
 
-        it "selects all tax rates" do
-          expect(TaxRate.match(order)).to eq([tax_rate])
-        end
+      it "selects all tax rates" do
+        expect(described_class.match(order)).to eq([tax_rate])
+      end
+    end
+
+    describe "when the order's hub does not charge sales tax" do
+      let(:hub) { create(:distributor_enterprise, charges_sales_tax: false) }
+
+      it "selects no tax rates" do
+        expect(described_class.match(order)).to be_empty
+      end
+    end
+
+    describe "when the order does not have a hub" do
+      let!(:order) { create(:order, distributor: nil, bill_address: create(:address)) }
+
+      it "selects all tax rates" do
+        expect(described_class.match(order)).to eq([tax_rate])
+      end
+    end
+  end
+
+  context "original Spree::TaxRate specs" do
+    context "match" do
+      let(:order) { create(:order) }
+      let(:country) { create(:country) }
+      let(:tax_category) { create(:tax_category) }
+      let(:calculator) { Calculator::FlatRate.new }
+
+      it "returns an empty array when tax_zone is nil" do
+        allow(order).to receive(:tax_zone) { nil }
+        expect(described_class.match(order)).to eq []
       end
 
-      describe "when the order's hub does not charge sales tax" do
-        let(:hub) { create(:distributor_enterprise, charges_sales_tax: false) }
-
-        it "selects no tax rates" do
-          expect(TaxRate.match(order)).to be_empty
+      context "when no rate zones match the tax zone" do
+        before do
+          described_class.create(amount: 1, zone: create(:zone))
         end
-      end
 
-      describe "when the order does not have a hub" do
-        let!(:order) { create(:order, distributor: nil, bill_address: create(:address)) }
+        context "when there is no default tax zone" do
+          let(:zone) { create( :zone, name: "Country Zone", default_tax: false, member: country) }
 
-        it "selects all tax rates" do
-          expect(TaxRate.match(order)).to eq([tax_rate])
+          it "returns an empty array" do
+            allow(order).to receive(:tax_zone).and_return(zone)
+            expect(described_class.match(order)).to eq []
+          end
+
+          it "returns the rate that matches the rate zone" do
+            rate = described_class.create(
+              amount: 1,
+              zone:,
+              tax_category:,
+              calculator:
+            )
+
+            allow(order).to receive(:tax_zone).and_return(zone)
+
+            expect(described_class.match(order)).to eq [rate]
+          end
+
+          it "returns all rates that match the rate zone" do
+            rate1 = described_class.create(
+              amount: 1,
+              zone:,
+              tax_category:,
+              calculator:
+            )
+
+            rate2 = described_class.create(
+              amount: 2,
+              zone:,
+              tax_category:,
+              calculator: Calculator::FlatRate.new
+            )
+
+            allow(order).to receive(:tax_zone).and_return(zone)
+
+            expect(described_class.match(order)).to eq [rate1, rate2]
+          end
+
+          context "when the tax_zone is contained within a rate zone" do
+            let(:sub_zone) { create(:zone, name: "State Zone", member: create(:state, country:)) }
+
+            it "returns the rate zone" do
+              allow(order).to receive(:tax_zone).and_return(sub_zone)
+
+              rate = described_class.create(
+                amount: 1,
+                zone:,
+                tax_category:,
+                calculator:
+              )
+
+              expect(described_class.match(order)).to eq [rate]
+            end
+          end
+        end
+
+        context "when there is a default tax zone" do
+          let(:zone) { create(:zone, name: "Country Zone", default_tax: true, member: country) }
+          let(:included_in_price) { false }
+          let!(:rate) do
+            described_class.create(amount: 1,
+                                   zone:,
+                                   tax_category:,
+                                   calculator:,
+                                   included_in_price:)
+          end
+
+          subject { described_class.match(order) }
+
+          context "when the order has the same tax zone" do
+            before do
+              allow(order).to receive(:tax_zone) { zone }
+              allow(order).to receive(:billing_address) { tax_address }
+            end
+
+            let(:tax_address) { build_stubbed(:address) }
+
+            context "when the tax is not a VAT" do
+              it { is_expected.to eq [rate] }
+            end
+
+            context "when the tax is a VAT" do
+              let(:included_in_price) { true }
+
+              it { is_expected.to eq [rate] }
+            end
+          end
+
+          context "when the order has a different tax zone" do
+            let(:other_zone) { create(:zone, name: "Other Zone", default_tax: false) }
+
+            before do
+              allow(order).to receive(:tax_zone) { other_zone }
+              allow(order).to receive(:billing_address) { tax_address }
+            end
+
+            context "when the order has a tax_address" do
+              let(:tax_address) { build_stubbed(:address) }
+
+              context "when the tax is a VAT" do
+                let(:included_in_price) { true }
+                # The rate should match in this instance because:
+                # 1) It's the default rate (and as such, a negative adjustment should apply)
+                it { is_expected.to eq [rate] }
+              end
+
+              context "when the tax is not VAT" do
+                it "returns no tax rate" do
+                  expect(subject).to be_empty
+                end
+              end
+            end
+
+            context "when the order does not have a tax_address" do
+              let(:tax_address) { nil }
+
+              context "when the tax is a VAT" do
+                let(:included_in_price) { true }
+                # The rate should match in this instance because:
+                # 1) The order has no tax address by this stage
+                # 2) With no tax address, it has no tax zone
+                # 3) Therefore, we assume the default tax zone
+                # 4) This default zone has a default tax rate.
+                it { is_expected.to eq [rate] }
+              end
+
+              context "when the tax is not a VAT" do
+                it { is_expected.to be_empty }
+              end
+            end
+          end
         end
       end
     end
 
-    context "original Spree::TaxRate specs" do
-      context "match" do
-        let(:order) { create(:order) }
-        let(:country) { create(:country) }
-        let(:tax_category) { create(:tax_category) }
-        let(:calculator) { ::Calculator::FlatRate.new }
+    describe ".default" do
+      let(:tax_category) { create(:tax_category) }
+      let(:country) { create(:country) }
+      let(:calculator) { Calculator::FlatRate.new }
 
-        it "returns an empty array when tax_zone is nil" do
-          allow(order).to receive(:tax_zone) { nil }
-          expect(Spree::TaxRate.match(order)).to eq []
-        end
+      context "when there is no default tax_category" do
+        before { tax_category.is_default = false }
 
-        context "when no rate zones match the tax zone" do
-          before do
-            Spree::TaxRate.create(amount: 1, zone: create(:zone))
-          end
-
-          context "when there is no default tax zone" do
-            let(:zone) { create( :zone, name: "Country Zone", default_tax: false, member: country) }
-
-            it "returns an empty array" do
-              allow(order).to receive(:tax_zone).and_return(zone)
-              expect(Spree::TaxRate.match(order)).to eq []
-            end
-
-            it "returns the rate that matches the rate zone" do
-              rate = Spree::TaxRate.create(
-                amount: 1,
-                zone:,
-                tax_category:,
-                calculator:
-              )
-
-              allow(order).to receive(:tax_zone).and_return(zone)
-
-              expect(Spree::TaxRate.match(order)).to eq [rate]
-            end
-
-            it "returns all rates that match the rate zone" do
-              rate1 = Spree::TaxRate.create(
-                amount: 1,
-                zone:,
-                tax_category:,
-                calculator:
-              )
-
-              rate2 = Spree::TaxRate.create(
-                amount: 2,
-                zone:,
-                tax_category:,
-                calculator: ::Calculator::FlatRate.new
-              )
-
-              allow(order).to receive(:tax_zone).and_return(zone)
-
-              expect(Spree::TaxRate.match(order)).to eq [rate1, rate2]
-            end
-
-            context "when the tax_zone is contained within a rate zone" do
-              let(:sub_zone) { create(:zone, name: "State Zone", member: create(:state, country:)) }
-
-              it "returns the rate zone" do
-                allow(order).to receive(:tax_zone).and_return(sub_zone)
-
-                rate = Spree::TaxRate.create(
-                  amount: 1,
-                  zone:,
-                  tax_category:,
-                  calculator:
-                )
-
-                expect(Spree::TaxRate.match(order)).to eq [rate]
-              end
-            end
-          end
-
-          context "when there is a default tax zone" do
-            let(:zone) { create(:zone, name: "Country Zone", default_tax: true, member: country) }
-            let(:included_in_price) { false }
-            let!(:rate) do
-              Spree::TaxRate.create(amount: 1,
-                                    zone:,
-                                    tax_category:,
-                                    calculator:,
-                                    included_in_price:)
-            end
-
-            subject { Spree::TaxRate.match(order) }
-
-            context "when the order has the same tax zone" do
-              before do
-                allow(order).to receive(:tax_zone) { zone }
-                allow(order).to receive(:billing_address) { tax_address }
-              end
-
-              let(:tax_address) { build_stubbed(:address) }
-
-              context "when the tax is not a VAT" do
-                it { is_expected.to eq [rate] }
-              end
-
-              context "when the tax is a VAT" do
-                let(:included_in_price) { true }
-
-                it { is_expected.to eq [rate] }
-              end
-            end
-
-            context "when the order has a different tax zone" do
-              let(:other_zone) { create(:zone, name: "Other Zone", default_tax: false) }
-
-              before do
-                allow(order).to receive(:tax_zone) { other_zone }
-                allow(order).to receive(:billing_address) { tax_address }
-              end
-
-              context "when the order has a tax_address" do
-                let(:tax_address) { build_stubbed(:address) }
-
-                context "when the tax is a VAT" do
-                  let(:included_in_price) { true }
-                  # The rate should match in this instance because:
-                  # 1) It's the default rate (and as such, a negative adjustment should apply)
-                  it { is_expected.to eq [rate] }
-                end
-
-                context "when the tax is not VAT" do
-                  it "returns no tax rate" do
-                    expect(subject).to be_empty
-                  end
-                end
-              end
-
-              context "when the order does not have a tax_address" do
-                let(:tax_address) { nil }
-
-                context "when the tax is a VAT" do
-                  let(:included_in_price) { true }
-                  # The rate should match in this instance because:
-                  # 1) The order has no tax address by this stage
-                  # 2) With no tax address, it has no tax zone
-                  # 3) Therefore, we assume the default tax zone
-                  # 4) This default zone has a default tax rate.
-                  it { is_expected.to eq [rate] }
-                end
-
-                context "when the tax is not a VAT" do
-                  it { is_expected.to be_empty }
-                end
-              end
-            end
-          end
+        it "returns 0" do
+          expect(described_class.default).to eq 0
         end
       end
 
-      describe ".default" do
-        let(:tax_category) { create(:tax_category) }
-        let(:country) { create(:country) }
-        let(:calculator) { ::Calculator::FlatRate.new }
+      context "when there is a default tax_category" do
+        before { tax_category.update_column :is_default, true }
 
-        context "when there is no default tax_category" do
-          before { tax_category.is_default = false }
+        context "when the default category has tax rates in the default tax zone" do
+          before(:each) do
+            allow(DefaultCountry).to receive(:id) { country.id }
+            zone = create(:zone, name: "Country Zone", default_tax: true, member: country)
+            rate = described_class.create(
+              amount: 1,
+              zone:,
+              tax_category:,
+              calculator:
+            )
+          end
 
+          it "returns the correct tax_rate" do
+            expect(described_class.default.to_f).to eq 1.0
+          end
+        end
+
+        context "when the default category has no tax rates in the default tax zone" do
           it "returns 0" do
-            expect(Spree::TaxRate.default).to eq 0
-          end
-        end
-
-        context "when there is a default tax_category" do
-          before { tax_category.update_column :is_default, true }
-
-          context "when the default category has tax rates in the default tax zone" do
-            before(:each) do
-              allow(DefaultCountry).to receive(:id) { country.id }
-              zone = create(:zone, name: "Country Zone", default_tax: true, member: country)
-              rate = Spree::TaxRate.create(
-                amount: 1,
-                zone:,
-                tax_category:,
-                calculator:
-              )
-            end
-
-            it "returns the correct tax_rate" do
-              expect(Spree::TaxRate.default.to_f).to eq 1.0
-            end
-          end
-
-          context "when the default category has no tax rates in the default tax zone" do
-            it "returns 0" do
-              expect(Spree::TaxRate.default).to eq 0
-            end
+            expect(described_class.default).to eq 0
           end
         end
       end
+    end
 
-      describe ".adjust" do
-        let!(:country) { create(:country, name: "Default Country") }
-        let!(:state) { create(:state, name: "Default State", country:) }
-        let!(:zone) { create(:zone_with_member, default_tax: true, member: country ) }
-        let!(:category) { create(:tax_category, name: "Taxable Foo") }
-        let!(:category2) { create(:tax_category, name: "Non Taxable") }
-        let!(:rate1) {
-          create(:tax_rate, amount: 0.10, zone:, tax_category: category)
-        }
-        let!(:rate2) {
-          create(:tax_rate, amount: 0.05, zone:, tax_category: category)
-        }
-        let(:hub) { create(:distributor_enterprise, charges_sales_tax: true) }
-        let(:address) { create(:address, state: country.states.first, country:) }
-        let!(:order) {
-          create(:order_with_line_items, line_items_count: 2, distributor: hub,
-                                         ship_address: address)
-        }
-        let!(:taxable) { order.line_items.first.variant }
-        let!(:nontaxable) { order.line_items.last.variant }
+    describe ".adjust" do
+      let!(:country) { create(:country, name: "Default Country") }
+      let!(:state) { create(:state, name: "Default State", country:) }
+      let!(:zone) { create(:zone_with_member, default_tax: true, member: country ) }
+      let!(:category) { create(:tax_category, name: "Taxable Foo") }
+      let!(:category2) { create(:tax_category, name: "Non Taxable") }
+      let!(:rate1) {
+        create(:tax_rate, amount: 0.10, zone:, tax_category: category)
+      }
+      let!(:rate2) {
+        create(:tax_rate, amount: 0.05, zone:, tax_category: category)
+      }
+      let(:hub) { create(:distributor_enterprise, charges_sales_tax: true) }
+      let(:address) { create(:address, state: country.states.first, country:) }
+      let!(:order) {
+        create(:order_with_line_items, line_items_count: 2, distributor: hub,
+                                       ship_address: address)
+      }
+      let!(:taxable) { order.line_items.first.variant }
+      let!(:nontaxable) { order.line_items.last.variant }
+
+      before do
+        taxable.update(tax_category: category)
+        nontaxable.update(tax_category: category2)
+        order.line_items.delete_all
+      end
+
+      context "not taxable line item " do
+        let!(:line_item) { order.contents.add(nontaxable, 1) }
+
+        it "does not create a tax adjustment" do
+          described_class.adjust(order, order.line_items)
+          expect(line_item.adjustments.tax.charge.count).to eq 0
+        end
+
+        it "does not create a refund" do
+          described_class.adjust(order, order.line_items)
+          expect(line_item.adjustments.credit.count).to eq 0
+        end
+      end
+
+      context "taxable line item" do
+        let!(:line_item) { order.contents.add(taxable, 1) }
 
         before do
-          taxable.update(tax_category: category)
-          nontaxable.update(tax_category: category2)
-          order.line_items.delete_all
+          rate1.update_column(:included_in_price, true)
+          rate2.update_column(:included_in_price, true)
         end
 
-        context "not taxable line item " do
-          let!(:line_item) { order.contents.add(nontaxable, 1) }
+        it "applies adjustments for the matching tax rates to the order" do
+          line_item = build_stubbed(:line_item, tax_category: category)
+          rate3 = create(:tax_rate, amount: 0.05, zone:)
 
-          it "does not create a tax adjustment" do
-            Spree::TaxRate.adjust(order, order.line_items)
-            expect(line_item.adjustments.tax.charge.count).to eq 0
-          end
+          allow(described_class).to receive(:match) { [rate1, rate3] }
 
-          it "does not create a refund" do
-            Spree::TaxRate.adjust(order, order.line_items)
-            expect(line_item.adjustments.credit.count).to eq 0
-          end
+          expect(rate1).to receive(:adjust)
+          expect(rate3).not_to receive(:adjust)
+
+          described_class.adjust(order, [line_item])
         end
 
-        context "taxable line item" do
-          let!(:line_item) { order.contents.add(taxable, 1) }
-
-          before do
-            rate1.update_column(:included_in_price, true)
-            rate2.update_column(:included_in_price, true)
-          end
-
-          it "applies adjustments for the matching tax rates to the order" do
-            line_item = build_stubbed(:line_item, tax_category: category)
-            rate3 = create(:tax_rate, amount: 0.05, zone:)
-
-            allow(Spree::TaxRate).to receive(:match) { [rate1, rate3] }
-
-            expect(rate1).to receive(:adjust)
-            expect(rate3).not_to receive(:adjust)
-
-            Spree::TaxRate.adjust(order, [line_item])
-          end
-
-          context "when price includes tax" do
-            context "when zone is contained by default tax zone" do
-              it "creates two adjustments, one for each tax rate" do
-                Spree::TaxRate.adjust(order, order.line_items)
-                expect(line_item.adjustments.count).to eq 2
-              end
-
-              it "does not create a tax refund" do
-                Spree::TaxRate.adjust(order, order.line_items)
-                expect(line_item.adjustments.credit.count).to eq 0
-              end
-            end
-
-            context "when order's zone is neither the default zone, or included " \
-                    "in the default zone, but matches the rate's zone" do
-              before do
-                # Create a new default zone, so the order's zone won't match this new one
-                create(:zone_with_member, default_tax: true)
-              end
-
-              it "creates an adjustment" do
-                Spree::TaxRate.adjust(order, order.line_items)
-
-                expect(line_item.adjustments.charge.count).to eq 2
-              end
-
-              it "does not create a tax refund for each tax rate" do
-                Spree::TaxRate.adjust(order, order.line_items)
-                expect(line_item.adjustments.credit.count).to eq 0
-              end
-            end
-
-            context "when order's zone does not match default zone, is not included in the " \
-                    "default zone, AND does not match the rate's zone" do
-              let!(:other_country) { create(:country, name: "Other Country") }
-              let!(:other_state) { create(:state, name: "Other State", country: other_country) }
-              let!(:other_address) { create(:address, state: other_state, country: other_country) }
-              let!(:other_zone) {
-                create(:zone_with_member, name: "Other Zone", default_tax: false,
-                                          member: other_country)
-              }
-
-              before do
-                order.update(ship_address: other_address)
-                order.all_adjustments.delete_all
-              end
-
-              it "does not create positive adjustments" do
-                Spree::TaxRate.adjust(order, order.line_items)
-                expect(line_item.adjustments.charge.count).to eq 0
-              end
-
-              it "creates a tax refund for each tax rate" do
-                Spree::TaxRate.adjust(order, order.line_items)
-                expect(line_item.adjustments.credit.count).to eq 2
-              end
-            end
-          end
-
-          context "when price does not include tax" do
-            before do
-              allow(order).to receive(:tax_zone) { zone }
-              [rate1, rate2].each do |rate|
-                rate.update(included_in_price: false, zone:)
-              end
-
-              Spree::TaxRate.adjust(order, order.line_items)
-            end
-
-            it "does not delete adjustments for complete order when taxrate is deleted" do
-              rate1.destroy!
-              rate2.destroy!
-              expect(line_item.adjustments.count).to eq 2
-            end
-
-            it "creates adjustments" do
+        context "when price includes tax" do
+          context "when zone is contained by default tax zone" do
+            it "creates two adjustments, one for each tax rate" do
+              described_class.adjust(order, order.line_items)
               expect(line_item.adjustments.count).to eq 2
             end
 
             it "does not create a tax refund" do
+              described_class.adjust(order, order.line_items)
               expect(line_item.adjustments.credit.count).to eq 0
             end
+          end
 
-            it "removes adjustments when tax_zone is removed" do
-              expect(line_item.adjustments.count).to eq 2
-              allow(order).to receive(:tax_zone) { nil }
-              Spree::TaxRate.adjust(order, order.line_items)
-              expect(line_item.adjustments.count).to eq 0
+          context "when order's zone is neither the default zone, or included " \
+                  "in the default zone, but matches the rate's zone" do
+            before do
+              # Create a new default zone, so the order's zone won't match this new one
+              create(:zone_with_member, default_tax: true)
+            end
+
+            it "creates an adjustment" do
+              described_class.adjust(order, order.line_items)
+
+              expect(line_item.adjustments.charge.count).to eq 2
+            end
+
+            it "does not create a tax refund for each tax rate" do
+              described_class.adjust(order, order.line_items)
+              expect(line_item.adjustments.credit.count).to eq 0
+            end
+          end
+
+          context "when order's zone does not match default zone, is not included in the " \
+                  "default zone, AND does not match the rate's zone" do
+            let!(:other_country) { create(:country, name: "Other Country") }
+            let!(:other_state) { create(:state, name: "Other State", country: other_country) }
+            let!(:other_address) { create(:address, state: other_state, country: other_country) }
+            let!(:other_zone) {
+              create(:zone_with_member, name: "Other Zone", default_tax: false,
+                                        member: other_country)
+            }
+
+            before do
+              order.update(ship_address: other_address)
+              order.all_adjustments.delete_all
+            end
+
+            it "does not create positive adjustments" do
+              described_class.adjust(order, order.line_items)
+              expect(line_item.adjustments.charge.count).to eq 0
+            end
+
+            it "creates a tax refund for each tax rate" do
+              described_class.adjust(order, order.line_items)
+              expect(line_item.adjustments.credit.count).to eq 2
             end
           end
         end
 
-        context "with shipments" do
-          let(:shipment) { build_stubbed(:shipment, order:) }
+        context "when price does not include tax" do
+          before do
+            allow(order).to receive(:tax_zone) { zone }
+            [rate1, rate2].each do |rate|
+              rate.update(included_in_price: false, zone:)
+            end
 
-          it "applies adjustments for two tax rates to the order" do
-            rate3 = create(:tax_rate, amount: 0.05, zone:)
-
-            allow(shipment).to receive(:tax_category) { category }
-            allow(Spree::TaxRate).to receive(:match) { [rate1, rate3] }
-
-            expect(rate1).to receive(:adjust)
-            expect(rate3).not_to receive(:adjust)
-
-            Spree::TaxRate.adjust(order, [shipment])
+            described_class.adjust(order, order.line_items)
           end
+
+          it "does not delete adjustments for complete order when taxrate is deleted" do
+            rate1.destroy!
+            rate2.destroy!
+            expect(line_item.adjustments.count).to eq 2
+          end
+
+          it "creates adjustments" do
+            expect(line_item.adjustments.count).to eq 2
+          end
+
+          it "does not create a tax refund" do
+            expect(line_item.adjustments.credit.count).to eq 0
+          end
+
+          it "removes adjustments when tax_zone is removed" do
+            expect(line_item.adjustments.count).to eq 2
+            allow(order).to receive(:tax_zone) { nil }
+            described_class.adjust(order, order.line_items)
+            expect(line_item.adjustments.count).to eq 0
+          end
+        end
+      end
+
+      context "with shipments" do
+        let(:shipment) { build_stubbed(:shipment, order:) }
+
+        it "applies adjustments for two tax rates to the order" do
+          rate3 = create(:tax_rate, amount: 0.05, zone:)
+
+          allow(shipment).to receive(:tax_category) { category }
+          allow(described_class).to receive(:match) { [rate1, rate3] }
+
+          expect(rate1).to receive(:adjust)
+          expect(rate3).not_to receive(:adjust)
+
+          described_class.adjust(order, [shipment])
         end
       end
     end

--- a/spec/services/permissions/order_spec.rb
+++ b/spec/services/permissions/order_spec.rb
@@ -2,49 +2,97 @@
 
 require 'spec_helper'
 
-module Permissions
-  RSpec.describe Order do
-    let(:permissions) { Permissions::Order.new(user) }
-    let!(:basic_permissions) { OpenFoodNetwork::Permissions.new(user) }
-    let(:distributor) { create(:distributor_enterprise) }
-    let(:coordinator) { create(:distributor_enterprise) }
-    let(:order_cycle) {
-      create(:simple_order_cycle, coordinator:, distributors: [distributor])
-    }
-    let(:order_completed) {
-      create(:completed_order_with_totals, order_cycle:, distributor: )
-    }
-    let(:order_cancelled) {
-      create(:order, order_cycle:, distributor:, state: 'canceled' )
-    }
-    let(:order_cart) {
-      create(:order, order_cycle:, distributor:, state: 'cart' )
-    }
-    let(:order_from_last_year) {
-      create(:completed_order_with_totals, order_cycle:, distributor:,
-                                           completed_at: 1.year.ago)
-    }
+RSpec.describe Permissions::Order do
+  let(:permissions) { described_class.new(user) }
+  let!(:basic_permissions) { OpenFoodNetwork::Permissions.new(user) }
+  let(:distributor) { create(:distributor_enterprise) }
+  let(:coordinator) { create(:distributor_enterprise) }
+  let(:order_cycle) {
+    create(:simple_order_cycle, coordinator:, distributors: [distributor])
+  }
+  let(:order_completed) {
+    create(:completed_order_with_totals, order_cycle:, distributor: )
+  }
+  let(:order_cancelled) {
+    create(:order, order_cycle:, distributor:, state: 'canceled' )
+  }
+  let(:order_cart) {
+    create(:order, order_cycle:, distributor:, state: 'cart' )
+  }
+  let(:order_from_last_year) {
+    create(:completed_order_with_totals, order_cycle:, distributor:,
+                                         completed_at: 1.year.ago)
+  }
 
-    before { allow(OpenFoodNetwork::Permissions).to receive(:new) { basic_permissions } }
+  before { allow(OpenFoodNetwork::Permissions).to receive(:new) { basic_permissions } }
 
-    context "with user cannot only manage line_items in orders" do
-      let(:user) { instance_double('Spree::User', can_manage_line_items_in_orders_only?: false) }
+  context "with user cannot only manage line_items in orders" do
+    let(:user) { instance_double('Spree::User', can_manage_line_items_in_orders_only?: false) }
 
-      describe "finding orders that are visible in reports" do
-        let(:random_enterprise) { create(:distributor_enterprise) }
-        let(:order) { create(:order, order_cycle:, distributor: ) }
-        let!(:line_item) { create(:line_item, order:) }
-        let!(:producer) { create(:supplier_enterprise) }
+    describe "finding orders that are visible in reports" do
+      let(:random_enterprise) { create(:distributor_enterprise) }
+      let(:order) { create(:order, order_cycle:, distributor: ) }
+      let!(:line_item) { create(:line_item, order:) }
+      let!(:producer) { create(:supplier_enterprise) }
 
+      before do
+        allow(basic_permissions).to receive(:coordinated_order_cycles) { Enterprise.where("1=0") }
+      end
+
+      context "as the hub through which the order was placed" do
         before do
-          allow(basic_permissions).to receive(:coordinated_order_cycles) { Enterprise.where("1=0") }
+          allow(basic_permissions).to receive(:managed_enterprises) {
+                                        Enterprise.where(id: distributor)
+                                      }
         end
 
-        context "as the hub through which the order was placed" do
+        it "should let me see the order" do
+          expect(permissions.visible_orders).to include order
+        end
+      end
+
+      context "as the coordinator of the order cycle through which the order was placed" do
+        before do
+          allow(basic_permissions).to receive(:managed_enterprises) {
+                                        Enterprise.where(id: coordinator)
+                                      }
+          allow(basic_permissions).to receive(:coordinated_order_cycles) {
+                                        OrderCycle.where(id: order_cycle)
+                                      }
+        end
+
+        it "should let me see the order" do
+          expect(permissions.visible_orders).to include order
+        end
+
+        context "with search params" do
+          let(:search_params) {
+            { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') }
+          }
+          let(:permissions) { Permissions::Order.new(user, search_params) }
+
+          it "only returns completed, non-cancelled orders within search filter range" do
+            expect(permissions.visible_orders).to include order_completed
+            expect(permissions.visible_orders).not_to include order_cancelled
+            expect(permissions.visible_orders).not_to include order_cart
+            expect(permissions.visible_orders).not_to include order_from_last_year
+          end
+        end
+      end
+
+      context "as a producer which has granted P-OC to the distributor of an order" do
+        before do
+          allow(basic_permissions).to receive(:managed_enterprises) {
+                                        Enterprise.where(id: producer)
+                                      }
+          create(:enterprise_relationship, parent: producer, child: distributor,
+                                           permissions_list: [:add_to_order_cycle])
+        end
+
+        context "which contains my products" do
           before do
-            allow(basic_permissions).to receive(:managed_enterprises) {
-                                          Enterprise.where(id: distributor)
-                                        }
+            line_item.variant.supplier = producer
+            line_item.variant.save
           end
 
           it "should let me see the order" do
@@ -52,209 +100,159 @@ module Permissions
           end
         end
 
-        context "as the coordinator of the order cycle through which the order was placed" do
-          before do
-            allow(basic_permissions).to receive(:managed_enterprises) {
-                                          Enterprise.where(id: coordinator)
-                                        }
-            allow(basic_permissions).to receive(:coordinated_order_cycles) {
-                                          OrderCycle.where(id: order_cycle)
-                                        }
-          end
-
-          it "should let me see the order" do
-            expect(permissions.visible_orders).to include order
-          end
-
-          context "with search params" do
-            let(:search_params) {
-              { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') }
-            }
-            let(:permissions) { Permissions::Order.new(user, search_params) }
-
-            it "only returns completed, non-cancelled orders within search filter range" do
-              expect(permissions.visible_orders).to include order_completed
-              expect(permissions.visible_orders).not_to include order_cancelled
-              expect(permissions.visible_orders).not_to include order_cart
-              expect(permissions.visible_orders).not_to include order_from_last_year
-            end
-          end
-        end
-
-        context "as a producer which has granted P-OC to the distributor of an order" do
-          before do
-            allow(basic_permissions).to receive(:managed_enterprises) {
-                                          Enterprise.where(id: producer)
-                                        }
-            create(:enterprise_relationship, parent: producer, child: distributor,
-                                             permissions_list: [:add_to_order_cycle])
-          end
-
-          context "which contains my products" do
-            before do
-              line_item.variant.supplier = producer
-              line_item.variant.save
-            end
-
-            it "should let me see the order" do
-              expect(permissions.visible_orders).to include order
-            end
-          end
-
-          context "which does not contain my products" do
-            it "should not let me see the order" do
-              expect(permissions.visible_orders).not_to include order
-            end
-          end
-        end
-
-        context "as an enterprise that is a distributor in the order cycle, " \
-                "but not the distributor of the order" do
-          before do
-            allow(basic_permissions).to receive(:managed_enterprises) {
-                                          Enterprise.where(id: random_enterprise)
-                                        }
-          end
-
+        context "which does not contain my products" do
           it "should not let me see the order" do
             expect(permissions.visible_orders).not_to include order
           end
         end
       end
 
-      describe "finding line items that are visible in reports" do
-        let(:random_enterprise) { create(:distributor_enterprise) }
-        let(:order) { create(:order, order_cycle:, distributor: ) }
-        let!(:line_item1) { create(:line_item, order:) }
-        let!(:line_item2) { create(:line_item, order:) }
-        let!(:producer) { create(:supplier_enterprise) }
-
+      context "as an enterprise that is a distributor in the order cycle, " \
+              "but not the distributor of the order" do
         before do
-          allow(basic_permissions).to receive(:coordinated_order_cycles) { Enterprise.where("1=0") }
+          allow(basic_permissions).to receive(:managed_enterprises) {
+                                        Enterprise.where(id: random_enterprise)
+                                      }
         end
 
-        context "as the hub through which the parent order was placed" do
-          before do
-            allow(basic_permissions).to receive(:managed_enterprises) {
-                                          Enterprise.where(id: distributor)
-                                        }
-          end
-
-          it "should let me see the line_items" do
-            expect(permissions.visible_line_items).to include line_item1, line_item2
-          end
-        end
-
-        context "as the coordinator of the order cycle through which the parent order was placed" do
-          before do
-            allow(basic_permissions).to receive(:managed_enterprises) {
-                                          Enterprise.where(id: coordinator)
-                                        }
-            allow(basic_permissions).to receive(:coordinated_order_cycles) {
-                                          OrderCycle.where(id: order_cycle)
-                                        }
-          end
-
-          it "should let me see the line_items" do
-            expect(permissions.visible_line_items).to include line_item1, line_item2
-          end
-        end
-
-        context "as the manager producer which has granted P-OC to the distributor " \
-                "of the parent order" do
-          before do
-            allow(basic_permissions).to receive(:managed_enterprises) {
-                                          Enterprise.where(id: producer)
-                                        }
-            create(:enterprise_relationship, parent: producer, child: distributor,
-                                             permissions_list: [:add_to_order_cycle])
-
-            line_item1.variant.supplier = producer
-            line_item1.variant.save
-          end
-
-          it "should let me see the line_items pertaining to variants I produce" do
-            ps = permissions.visible_line_items
-            expect(ps).to include line_item1
-            expect(ps).not_to include line_item2
-          end
-        end
-
-        context "as an enterprise that is a distributor in the order cycle, " \
-                "but not the distributor of the parent order" do
-          before do
-            allow(basic_permissions).to receive(:managed_enterprises) {
-                                          Enterprise.where(id: random_enterprise)
-                                        }
-          end
-
-          it "should not let me see the line_items" do
-            expect(permissions.visible_line_items).not_to include line_item1, line_item2
-          end
-        end
-
-        context "with search params" do
-          let!(:line_item3) { create(:line_item, order: order_completed) }
-          let!(:line_item4) { create(:line_item, order: order_cancelled) }
-          let!(:line_item5) { create(:line_item, order: order_cart) }
-          let!(:line_item6) { create(:line_item, order: order_from_last_year) }
-
-          let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
-          let(:permissions) { Permissions::Order.new(user, search_params) }
-
-          before do
-            allow(user).to receive(:admin?) { "admin" }
-          end
-
-          it "only returns line items from completed, " \
-             "non-cancelled orders within search filter range" do
-            expect(permissions.visible_line_items).to include order_completed.line_items.first
-            expect(permissions.visible_line_items).not_to include order_cancelled.line_items.first
-            expect(permissions.visible_line_items).not_to include order_cart.line_items.first
-            expect(permissions.visible_line_items)
-              .not_to include order_from_last_year.line_items.first
-          end
+        it "should not let me see the order" do
+          expect(permissions.visible_orders).not_to include order
         end
       end
     end
 
-    context "with user can only manage line_items in orders" do
-      let(:producer) { create(:supplier_enterprise) }
-      let(:user) do
-        create(:user, enterprises: [producer])
-      end
-      let!(:order_by_distributor_allow_edits) do
-        order = create(
-          :order_with_line_items,
-          distributor: create(
-            :distributor_enterprise,
-            enable_producers_to_edit_orders: true
-          ),
-          line_items_count: 1
-        )
-        order.line_items.first.variant.update_attribute(:supplier_id, producer.id)
+    describe "finding line items that are visible in reports" do
+      let(:random_enterprise) { create(:distributor_enterprise) }
+      let(:order) { create(:order, order_cycle:, distributor: ) }
+      let!(:line_item1) { create(:line_item, order:) }
+      let!(:line_item2) { create(:line_item, order:) }
+      let!(:producer) { create(:supplier_enterprise) }
 
-        order
+      before do
+        allow(basic_permissions).to receive(:coordinated_order_cycles) { Enterprise.where("1=0") }
       end
-      let!(:order_by_distributor_disallow_edits) do
-        create(
-          :order_with_line_items,
-          distributor: create(:distributor_enterprise),
-          line_items_count: 1
-        )
-      end
-      describe "#editable_orders" do
-        it "returns orders where the distributor allows producers to edit" do
-          expect(permissions.editable_orders.count).to eq 1
-          expect(permissions.editable_orders).to include order_by_distributor_allow_edits
+
+      context "as the hub through which the parent order was placed" do
+        before do
+          allow(basic_permissions).to receive(:managed_enterprises) {
+                                        Enterprise.where(id: distributor)
+                                      }
+        end
+
+        it "should let me see the line_items" do
+          expect(permissions.visible_line_items).to include line_item1, line_item2
         end
       end
 
-      describe "#editable_line_items" do
-        it "returns line items from orders where the distributor allows producers to edit" do
-          expect(permissions.editable_line_items.count).to eq 1
-          expect(permissions.editable_line_items.first.order).to eq order_by_distributor_allow_edits
+      context "as the coordinator of the order cycle through which the parent order was placed" do
+        before do
+          allow(basic_permissions).to receive(:managed_enterprises) {
+                                        Enterprise.where(id: coordinator)
+                                      }
+          allow(basic_permissions).to receive(:coordinated_order_cycles) {
+                                        OrderCycle.where(id: order_cycle)
+                                      }
         end
+
+        it "should let me see the line_items" do
+          expect(permissions.visible_line_items).to include line_item1, line_item2
+        end
+      end
+
+      context "as the manager producer which has granted P-OC to the distributor " \
+              "of the parent order" do
+        before do
+          allow(basic_permissions).to receive(:managed_enterprises) {
+                                        Enterprise.where(id: producer)
+                                      }
+          create(:enterprise_relationship, parent: producer, child: distributor,
+                                           permissions_list: [:add_to_order_cycle])
+
+          line_item1.variant.supplier = producer
+          line_item1.variant.save
+        end
+
+        it "should let me see the line_items pertaining to variants I produce" do
+          ps = permissions.visible_line_items
+          expect(ps).to include line_item1
+          expect(ps).not_to include line_item2
+        end
+      end
+
+      context "as an enterprise that is a distributor in the order cycle, " \
+              "but not the distributor of the parent order" do
+        before do
+          allow(basic_permissions).to receive(:managed_enterprises) {
+                                        Enterprise.where(id: random_enterprise)
+                                      }
+        end
+
+        it "should not let me see the line_items" do
+          expect(permissions.visible_line_items).not_to include line_item1, line_item2
+        end
+      end
+
+      context "with search params" do
+        let!(:line_item3) { create(:line_item, order: order_completed) }
+        let!(:line_item4) { create(:line_item, order: order_cancelled) }
+        let!(:line_item5) { create(:line_item, order: order_cart) }
+        let!(:line_item6) { create(:line_item, order: order_from_last_year) }
+
+        let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
+        let(:permissions) { Permissions::Order.new(user, search_params) }
+
+        before do
+          allow(user).to receive(:admin?) { "admin" }
+        end
+
+        it "only returns line items from completed, " \
+           "non-cancelled orders within search filter range" do
+          expect(permissions.visible_line_items).to include order_completed.line_items.first
+          expect(permissions.visible_line_items).not_to include order_cancelled.line_items.first
+          expect(permissions.visible_line_items).not_to include order_cart.line_items.first
+          expect(permissions.visible_line_items)
+            .not_to include order_from_last_year.line_items.first
+        end
+      end
+    end
+  end
+
+  context "with user can only manage line_items in orders" do
+    let(:producer) { create(:supplier_enterprise) }
+    let(:user) do
+      create(:user, enterprises: [producer])
+    end
+    let!(:order_by_distributor_allow_edits) do
+      order = create(
+        :order_with_line_items,
+        distributor: create(
+          :distributor_enterprise,
+          enable_producers_to_edit_orders: true
+        ),
+        line_items_count: 1
+      )
+      order.line_items.first.variant.update_attribute(:supplier_id, producer.id)
+
+      order
+    end
+    let!(:order_by_distributor_disallow_edits) do
+      create(
+        :order_with_line_items,
+        distributor: create(:distributor_enterprise),
+        line_items_count: 1
+      )
+    end
+    describe "#editable_orders" do
+      it "returns orders where the distributor allows producers to edit" do
+        expect(permissions.editable_orders.count).to eq 1
+        expect(permissions.editable_orders).to include order_by_distributor_allow_edits
+      end
+    end
+
+    describe "#editable_line_items" do
+      it "returns line items from orders where the distributor allows producers to edit" do
+        expect(permissions.editable_line_items.count).to eq 1
+        expect(permissions.editable_line_items.first.order).to eq order_by_distributor_allow_edits
       end
     end
   end

--- a/spec/services/variant_units/option_value_namer_spec.rb
+++ b/spec/services/variant_units/option_value_namer_spec.rb
@@ -2,170 +2,168 @@
 
 require 'spec_helper'
 
-module VariantUnits
-  RSpec.describe OptionValueNamer do
-    describe "generating option value name" do
-      subject { OptionValueNamer.new(v) }
-      let(:v) { Spree::Variant.new }
+RSpec.describe VariantUnits::OptionValueNamer do
+  describe "generating option value name" do
+    subject { described_class.new(v) }
+    let(:v) { Spree::Variant.new }
 
-      it "when description is blank" do
-        allow(v).to receive(:unit_description) { nil }
-        allow(subject).to receive(:value_scaled?) { true }
-        allow(subject).to receive(:option_value_value_unit) { %w(value unit) }
-        expect(subject.name).to eq("valueunit")
-      end
+    it "when description is blank" do
+      allow(v).to receive(:unit_description) { nil }
+      allow(subject).to receive(:value_scaled?) { true }
+      allow(subject).to receive(:option_value_value_unit) { %w(value unit) }
+      expect(subject.name).to eq("valueunit")
+    end
 
-      it "when description is present" do
-        allow(v).to receive(:unit_description) { 'desc' }
-        allow(subject).to receive(:option_value_value_unit) { %w(value unit) }
-        allow(subject).to receive(:value_scaled?) { true }
-        expect(subject.name).to eq("valueunit desc")
-      end
+    it "when description is present" do
+      allow(v).to receive(:unit_description) { 'desc' }
+      allow(subject).to receive(:option_value_value_unit) { %w(value unit) }
+      allow(subject).to receive(:value_scaled?) { true }
+      expect(subject.name).to eq("valueunit desc")
+    end
 
-      it "when value is blank and description is present" do
-        allow(v).to receive(:unit_description) { 'desc' }
-        allow(subject).to receive(:option_value_value_unit) { [nil, nil] }
-        allow(subject).to receive(:value_scaled?) { true }
-        expect(subject.name).to eq("desc")
-      end
+    it "when value is blank and description is present" do
+      allow(v).to receive(:unit_description) { 'desc' }
+      allow(subject).to receive(:option_value_value_unit) { [nil, nil] }
+      allow(subject).to receive(:value_scaled?) { true }
+      expect(subject.name).to eq("desc")
+    end
 
-      it "spaces value and unit when value is unscaled" do
-        allow(v).to receive(:unit_description) { nil }
-        allow(subject).to receive(:option_value_value_unit) { %w(value unit) }
-        allow(subject).to receive(:value_scaled?) { false }
-        expect(subject.name).to eq("value unit")
+    it "spaces value and unit when value is unscaled" do
+      allow(v).to receive(:unit_description) { nil }
+      allow(subject).to receive(:option_value_value_unit) { %w(value unit) }
+      allow(subject).to receive(:value_scaled?) { false }
+      expect(subject.name).to eq("value unit")
+    end
+  end
+
+  describe "determining if a variant's value is scaled" do
+    it "returns true when the product has a scale" do
+      v = Spree::Variant.new variant_unit_scale: 1000
+      subject = described_class.new v
+
+      expect(subject.__send__(:value_scaled?)).to be true
+    end
+
+    it "returns false otherwise" do
+      v = Spree::Variant.new
+      subject = described_class.new v
+
+      expect(subject.__send__(:value_scaled?)).to be false
+    end
+  end
+
+  describe "generating option value's value and unit" do
+    before do
+      allow(Spree::Config).to receive(:available_units).and_return("g,lb,oz,kg,T,mL,L,kL")
+    end
+
+    it "generates simple values" do
+      v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: 1.0,
+                                          unit_value: 100)
+
+      option_value_namer = described_class.new v
+      expect(option_value_namer.__send__(:option_value_value_unit)).to eq [100, 'g']
+    end
+
+    it "generates values when unit value is non-integer" do
+      v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: 1.0,
+                                          unit_value: 123.45)
+
+      option_value_namer = described_class.new v
+      expect(option_value_namer.__send__(:option_value_value_unit)).to eq [123.45, 'g']
+    end
+
+    it "returns a value of 1 when unit value equals the scale" do
+      v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: 1000.0,
+                                          unit_value: 1000.0)
+
+      option_value_namer = described_class.new v
+      expect(option_value_namer.__send__(:option_value_value_unit)).to eq [1, 'kg']
+    end
+
+    it "returns only values that are in the same measurement systems" do
+      v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: 1.0,
+                                          unit_value: 500)
+
+      # 500g would convert to > 1 pound, but we don't want the namer to use
+      # pounds since it's in a different measurement system.
+      option_value_namer = described_class.new v
+      expect(option_value_namer.__send__(:option_value_value_unit)).to eq [500, 'g']
+    end
+
+    it "generates values for all weight scales" do
+      [[1.0, 'g'], [28.35, 'oz'], [453.6, 'lb'], [1000.0, 'kg'],
+       [1_000_000.0, 'T']].each do |scale, unit|
+        v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: scale,
+                                            unit_value: 10.0 * scale)
+
+        option_value_namer = described_class.new v
+        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [10, unit]
       end
     end
 
-    describe "determining if a variant's value is scaled" do
-      it "returns true when the product has a scale" do
-        v = Spree::Variant.new variant_unit_scale: 1000
-        subject = OptionValueNamer.new v
+    it "generates values for all volume scales" do
+      [[0.001, 'mL'], [1.0, 'L'], [1000.0, 'kL']].each do |scale, unit|
+        v = instance_double(Spree::Variant, variant_unit: 'volume', variant_unit_scale: scale,
+                                            unit_value: 3 * scale)
 
-        expect(subject.__send__(:value_scaled?)).to be true
-      end
-
-      it "returns false otherwise" do
-        v = Spree::Variant.new
-        subject = OptionValueNamer.new v
-
-        expect(subject.__send__(:value_scaled?)).to be false
+        option_value_namer = described_class.new v
+        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [3, unit]
       end
     end
 
-    describe "generating option value's value and unit" do
-      before do
-        allow(Spree::Config).to receive(:available_units).and_return("g,lb,oz,kg,T,mL,L,kL")
-      end
+    it "chooses the correct scale when value is very small" do
+      v = instance_double(Spree::Variant, variant_unit: 'volume', variant_unit_scale: 0.001,
+                                          unit_value: 0.0001)
 
-      it "generates simple values" do
-        v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: 1.0,
-                                            unit_value: 100)
+      option_value_namer = described_class.new v
+      expect(option_value_namer.__send__(:option_value_value_unit)).to eq [0.1, 'mL']
+    end
 
-        option_value_namer = OptionValueNamer.new v
-        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [100, 'g']
-      end
-
-      it "generates values when unit value is non-integer" do
-        v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: 1.0,
-                                            unit_value: 123.45)
-
-        option_value_namer = OptionValueNamer.new v
-        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [123.45, 'g']
-      end
-
-      it "returns a value of 1 when unit value equals the scale" do
-        v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: 1000.0,
-                                            unit_value: 1000.0)
-
-        option_value_namer = OptionValueNamer.new v
-        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [1, 'kg']
-      end
-
-      it "returns only values that are in the same measurement systems" do
-        v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: 1.0,
-                                            unit_value: 500)
-
-        # 500g would convert to > 1 pound, but we don't want the namer to use
-        # pounds since it's in a different measurement system.
-        option_value_namer = OptionValueNamer.new v
-        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [500, 'g']
-      end
-
-      it "generates values for all weight scales" do
-        [[1.0, 'g'], [28.35, 'oz'], [453.6, 'lb'], [1000.0, 'kg'],
-         [1_000_000.0, 'T']].each do |scale, unit|
-          v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: scale,
-                                              unit_value: 10.0 * scale)
-
-          option_value_namer = OptionValueNamer.new v
-          expect(option_value_namer.__send__(:option_value_value_unit)).to eq [10, unit]
-        end
-      end
-
-      it "generates values for all volume scales" do
-        [[0.001, 'mL'], [1.0, 'L'], [1000.0, 'kL']].each do |scale, unit|
-          v = instance_double(Spree::Variant, variant_unit: 'volume', variant_unit_scale: scale,
-                                              unit_value: 3 * scale)
-
-          option_value_namer = OptionValueNamer.new v
-          expect(option_value_namer.__send__(:option_value_value_unit)).to eq [3, unit]
-        end
-      end
-
-      it "chooses the correct scale when value is very small" do
-        v = instance_double(Spree::Variant, variant_unit: 'volume', variant_unit_scale: 0.001,
-                                            unit_value: 0.0001)
-
-        option_value_namer = OptionValueNamer.new v
-        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [0.1, 'mL']
-      end
-
-      it "generates values for item units" do
-        %w(packet box).each do |unit|
-          v = instance_double(Spree::Variant, variant_unit: 'items', variant_unit_scale: nil,
-                                              variant_unit_name: unit, unit_value: 100)
-
-          option_value_namer = OptionValueNamer.new v
-          expect(option_value_namer.__send__(:option_value_value_unit)).to eq [100, unit.pluralize]
-        end
-      end
-
-      it "don't crash when variant_unit_name is nil" do
+    it "generates values for item units" do
+      %w(packet box).each do |unit|
         v = instance_double(Spree::Variant, variant_unit: 'items', variant_unit_scale: nil,
-                                            variant_unit_name: nil, unit_value: 100)
+                                            variant_unit_name: unit, unit_value: 100)
 
-        option_value_namer = OptionValueNamer.new v
-        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [100, nil]
+        option_value_namer = described_class.new v
+        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [100, unit.pluralize]
       end
+    end
 
-      it "generates singular values for item units when value is 1" do
-        v = instance_double(Spree::Variant, variant_unit: 'items', variant_unit_scale: nil,
-                                            variant_unit_name: 'packet', unit_value: 1)
+    it "don't crash when variant_unit_name is nil" do
+      v = instance_double(Spree::Variant, variant_unit: 'items', variant_unit_scale: nil,
+                                          variant_unit_name: nil, unit_value: 100)
 
-        option_value_namer = OptionValueNamer.new v
-        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [1, 'packet']
-      end
+      option_value_namer = described_class.new v
+      expect(option_value_namer.__send__(:option_value_value_unit)).to eq [100, nil]
+    end
 
-      it "returns [nil, nil] when unit value is not set" do
-        v = instance_double(Spree::Variant, variant_unit: 'items', variant_unit_scale: nil,
-                                            variant_unit_name: 'foo', unit_value: nil)
+    it "generates singular values for item units when value is 1" do
+      v = instance_double(Spree::Variant, variant_unit: 'items', variant_unit_scale: nil,
+                                          variant_unit_name: 'packet', unit_value: 1)
 
-        option_value_namer = OptionValueNamer.new v
-        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [nil, nil]
-      end
+      option_value_namer = described_class.new v
+      expect(option_value_namer.__send__(:option_value_value_unit)).to eq [1, 'packet']
+    end
 
-      it "truncates value to 2 decimals maximum" do
-        oz_scale = 28.35
-        v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: oz_scale,
-                                            unit_value: (12.5 * oz_scale).round(2))
+    it "returns [nil, nil] when unit value is not set" do
+      v = instance_double(Spree::Variant, variant_unit: 'items', variant_unit_scale: nil,
+                                          variant_unit_name: 'foo', unit_value: nil)
 
-        # The unit_value is stored rounded to 2 decimals
-        # allow(v).to receive(:unit_value) { (12.5 * oz_scale).round(2) }
-        option_value_namer = OptionValueNamer.new v
-        expect(option_value_namer.__send__(:option_value_value_unit)).to eq [BigDecimal(12.5, 6),
-                                                                             'oz']
-      end
+      option_value_namer = described_class.new v
+      expect(option_value_namer.__send__(:option_value_value_unit)).to eq [nil, nil]
+    end
+
+    it "truncates value to 2 decimals maximum" do
+      oz_scale = 28.35
+      v = instance_double(Spree::Variant, variant_unit: 'weight', variant_unit_scale: oz_scale,
+                                          unit_value: (12.5 * oz_scale).round(2))
+
+      # The unit_value is stored rounded to 2 decimals
+      # allow(v).to receive(:unit_value) { (12.5 * oz_scale).round(2) }
+      option_value_namer = described_class.new v
+      expect(option_value_namer.__send__(:option_value_value_unit)).to eq [BigDecimal(12.5, 6),
+                                                                           'oz']
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

- Contributes to #13346
Cop [Metrics/ModuleLength](https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmodulelength)
Files: engines specs, lib ofn specs, models specs

Also: replacement of hard coded names with variables (mostly `described_class` variable).
Small other offenses corrected.
I have split one file in two.

Follows discussion + examples here: #13377
In short : deletion of modules in spec, RSpec.describe with the complete name of the class + ensuing changes
regarding names and variables.

A lot of code seems to have changed, but it is only because indentation has been changed in files.

In order to avoid one gigantic commit, I treated each file in its own commit.

#### What should we test?
Nothing. All tests should pass.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled