### PR TITLE
Increase default timeout in system specs

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,14 @@
 # ENV vars for the test environment
 # Override locally with `.env.test.local`
 
+# Test env specific variables
+#
+# Adjust this to your computer. When you start test-driven development, you may
+# want to reduce this value to avoid waiting for a test that you expect to fail.
+CAPYBARA_MAX_WAIT_TIME="10"
+
+# General app specific variables
+
 # Locale for translation. Using a locale other than `en` tests the
 # successful fallback to `en`.
 LOCALE="en_TST"

--- a/spec/system/support/capybara_setup.rb
+++ b/spec/system/support/capybara_setup.rb
@@ -5,8 +5,9 @@
 Capybara.enable_aria_label = true
 
 # The default wait time is 2 seconds. Small is good for test-driven development
-# ensuring efficient code but CI can be a bit slow. We want to avoid flakiness.
-Capybara.default_max_wait_time = 10 if ENV["CI"]
+# ensuring efficient code but some machines can be a bit slow.
+# And we want to avoid flakiness.
+Capybara.default_max_wait_time = ENV.fetch("CAPYBARA_MAX_WAIT_TIME").to_i
 
 # Normalize whitespaces when using `has_text?` and similar matchers,
 # i.e., ignore newlines, trailing spaces, etc.


### PR DESCRIPTION
#### What? Why?

- Replaces and closes #13395 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

@filipefurtad0 found that our default timeout for system specs is too short for some computers. I'm taking up his suggestion to increase the default for `Capybara.default_max_wait_time`. And I'm adding the option to override the default value in your `env.test.local` file to ease test-driven development on faster machines. In many scenarios, you don't need to wait ten seconds to find out that a spec is failing as expected.

The ten seconds I'm proposing is simplifying our config by applying the same value to local machines and CI. Some new contributors may have very slow machines and we don't want to frustrate them with failing specs. But I hope that we can reduce this value over time as computers get faster.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

Let's announce this in the dev channel when merged.