### PR TITLE
Hide the delivery address for pickup on checkout summary

### DIFF
--- a/app/views/checkout/_delivery_details.html.haml
+++ b/app/views/checkout/_delivery_details.html.haml
@@ -1,0 +1,28 @@
+%div
+  .summary-subtitle
+    = t("checkout.step3.delivery_details.address")
+  %span
+    = @order.ship_address.firstname
+    = @order.ship_address.lastname
+  %div
+    = @order.ship_address.phone
+  %div
+    = @order.user.email if @order.user
+  %br
+  %div
+    = @order.ship_address.address1
+  - unless @order.ship_address.address2.blank?
+    %div
+      = @order.ship_address.address2
+  %div
+    = @order.ship_address.city
+  %div
+    = @order.ship_address.state
+  %div
+    = @order.ship_address.zipcode
+  %div
+    = @order.ship_address.country
+  - if @order.special_instructions.present?
+    %br
+    %em
+      = @order.special_instructions

--- a/app/views/checkout/_details.html.haml
+++ b/app/views/checkout/_details.html.haml
@@ -91,7 +91,7 @@
               "data-toggle-show": shipping_method.require_ship_address
             = shipping_method_form.label shipping_method.id, shipping_method.name, {for: "shipping_method_" + shipping_method.id.to_s }
             %em.fees= payment_or_shipping_price(shipping_method, @order)
-            - display_ship_address = display_ship_address || (ship_method_is_selected && shipping_method.require_ship_address)
+            - display_ship_address ||= ship_method_is_selected && shipping_method.require_ship_address
         .checkout-input{"data-shippingmethod-target": "shippingMethodDescription", "data-shippingmethodid": shipping_method.id , style: "display: #{ship_method_is_selected ? 'block' : 'none'}" }
           #distributor_address.panel
             - if shipping_method.description.present?

--- a/app/views/checkout/_summary.html.haml
+++ b/app/views/checkout/_summary.html.haml
@@ -11,34 +11,7 @@
         = @order.shipping_method.name
         %em.fees= payment_or_shipping_price(@order.shipping_method, @order)
       .two-columns
-        %div
-          .summary-subtitle
-            = t("checkout.step3.delivery_details.address")
-          %span
-            = @order.ship_address.firstname
-            = @order.ship_address.lastname
-          %div
-            = @order.ship_address.phone
-          %div
-            = @order.user.email if @order.user
-          %br
-          %div
-            = @order.ship_address.address1
-          - unless @order.ship_address.address2.blank?
-            %div
-              = @order.ship_address.address2
-          %div
-            = @order.ship_address.city
-          %div
-            = @order.ship_address.state
-          %div
-            = @order.ship_address.zipcode
-          %div
-            = @order.ship_address.country
-          - if @order.special_instructions.present?
-            %br
-            %em
-              = @order.special_instructions
+        = render "delivery_details"
         - if @order.shipping_method.description.present?
           %div
             .summary-subtitle

--- a/app/views/checkout/_summary.html.haml
+++ b/app/views/checkout/_summary.html.haml
@@ -11,7 +11,7 @@
         = @order.shipping_method.name
         %em.fees= payment_or_shipping_price(@order.shipping_method, @order)
       .two-columns
-        = render "delivery_details"
+        = render "delivery_details" if @order.shipping_method.delivery? || feature?(:hub_address)
         - if @order.shipping_method.description.present?
           %div
             .summary-subtitle

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -64,6 +64,9 @@ module OpenFoodNetwork
       "variant_tag" => <<~DESC,
         Variant Tag are available on the Bulk Edit Products page.
       DESC
+      "hub_address" => <<~DESC,
+        Show the hub's address as shipping address on pickup orders.
+      DESC
     }.merge(conditional_features).freeze;
 
     # Features you would like to be enabled to start with.


### PR DESCRIPTION
#### What? Why?

- Closes #13401 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

When the user selects pickup as delivery method then we don't ask for a delivery address. Instead we use the hub's address. The display of the hub's address during checkout has been confusing for many people though. Pickup instructions are usually in the delivery method's description field.

This change is active by default but I introduced the feature-toggle `hub_address` to get the old behaviour back in case any hubs complain about this.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
