### PR TITLE
Do not try to generate a URL for unpersisted blobs in development/test environment

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -20,6 +20,10 @@ class ApplicationRecord < ActiveRecord::Base
     if ENV["S3_BUCKET"].present? && variant.service.public?
       variant.processed.url
     else
+      unless variant.blob.persisted?
+        raise "ActiveStorage blob for variant is not persisted. Cannot generate URL."
+      end
+
       url_for(variant)
     end
   end


### PR DESCRIPTION
#### What? Why?
Do not try to generate a URL for unpersisted blobs in development/test environment [as suggested](https://github.com/openfoodfoundation/openfoodnetwork/pull/13232#discussion_r2071116581).

- Helps with #11673 

Explicitly raise an error in `image_variant_url_for` if an Active Storage variant's blob is not persisted.
    
This addresses `ArgumentError`/`URI::InvalidURIError` in Rails 7.1, which occurs when attempting to generate a URL for an unsaved Active Storage blob. By raising, we ensure existing error handling in calling methods (e.g., `Spree::Image#url`) can provide graceful fallbacks (default image URLs).
    
 This should only affect test and development environments (Really any env without `ENV["S3_BUCKET"]` set) where blobs may not be immediately persisted. Tests in `SuppliedProductImporter` have been updated to reflect this behavior.

https://github.com/openfoodfoundation/openfoodnetwork/blob/75b2119dd17194def7f025d68ffc824e16e7aefb/app/models/application_record.rb#L20


[Failing test](https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/14739687958/job/41374346184?pr=13232) in the rails 7.1 branch due to this issue. 


Update tests to make them more realistic. The product is persisted in `store_product` not in `import_product`. So it makes sense to validate the product image in `store_product` instead of `import_product`.

<details><summary>source</summary>

https://github.com/openfoodfoundation/openfoodnetwork/blob/75b2119dd17194def7f025d68ffc824e16e7aefb/engines/dfc_provider/app/services/supplied_product_importer.rb#L4-L14

</details>





#### What should we test?
Tests should cover the changes

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
