### PR TITLE
Fixes Save button does not enable when removing only tag in OC

### DIFF
--- a/app/assets/javascripts/templates/admin/panels/exchange_tags.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_tags.html.haml
@@ -3,4 +3,4 @@
     %span.text-normal
       {{ 'admin.tags' | t }}
     %br
-    %tags-with-translation.fullwidth{ object: 'object', form: 'order_cycle_form'}
+    %tags-with-translation.fullwidth{ object: 'object', form: 'order_cycle_form', id: 'tags_with_translation'}

--- a/app/assets/javascripts/templates/admin/panels/exchange_tags.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_tags.html.haml
@@ -3,4 +3,4 @@
     %span.text-normal
       {{ 'admin.tags' | t }}
     %br
-    %tags-with-translation.fullwidth{ object: 'object' }
+    %tags-with-translation.fullwidth{ object: 'object', form: 'order_cycle_form'}

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -36,5 +36,5 @@
 - if type == 'distributor'
   %tr.panel-row{ object: "exchange",
     panels: "{products: 'exchange_products_distributed', tags: 'exchange_tags'}",
-    locals: "$index,exchangeTotalVariants,order_cycle,exchange,enterprises,setExchangeVariants,incomingExchangeVariantsFor,variantSuppliedToOrderCycle,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading",
+    locals: "$index,exchangeTotalVariants,order_cycle,exchange,enterprises,setExchangeVariants,incomingExchangeVariantsFor,variantSuppliedToOrderCycle,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading,order_cycle_form",
     colspan: 5 }

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -7,7 +7,7 @@
     %td.receival-details
       = text_field_tag 'order_cycle_incoming_exchange_{{ $index }}_receival_instructions', '', 'id' => 'order_cycle_incoming_exchange_{{ $index }}_receival_instructions', 'placeholder' => t('.receival_instructions_placeholder'), 'ng-model' => 'exchange.receival_instructions'
   - if type == 'distributor'
-    %td.tags.panel-toggle.text-center{ name: "tags", "ng-if": 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' }
+    %td.tags.panel-toggle.text-center{ name: "tags", id: "tags", "ng-if": 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' }
       {{ exchange.tags.length }}
     %td.collection-details
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'ng-init' => 'setPickupTimeFieldDirty($index, exchange.pickup_time)', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'required' => 'required', 'placeholder' => t('.pickup_time_placeholder'), 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator', 'maxlength' => 35

--- a/spec/system/admin/order_cycles/tags_spec.rb
+++ b/spec/system/admin/order_cycles/tags_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+RSpec.describe '
+    As an administrator
+    I want to manage order cycle tags
+' do
+  include AdminHelper
+  include AuthenticationHelper
+  include WebHelper
+
+  it "adds and removes a tag under outgoing products" do
+    c = create(:distributor_enterprise, is_primary_producer: true)
+
+    # OC with a mono-enterprise outgoing exchange
+    oc_outgoing = create(:simple_order_cycle, coordinator: c, distributors: [c])
+
+    login_as_admin
+    visit admin_order_cycle_outgoing_path(oc_outgoing)
+    expect(page).to have_button "Save", disabled: true
+    find("#tags").click
+    # add one tag
+    find("#tags_with_translation").fill_in with: "Tag 1"
+
+    expect(page).to have_content('You have unsaved changes')
+    expect(page).to have_button "Save", disabled: false
+    click_on "Save"
+    expect(page).to have_content('Your order cycle has been updated')
+
+    page.refresh
+    find("#tags").click
+
+    within(".tags .tag-list") do
+      expect(page).to have_content 'tag-1'
+    end
+
+    # There is only one tag here so first and only tag is correct target
+    # Important to test use case with only one tag as there was a bug with
+    # this scenario. For future specs, add some other test cases but this
+    # one should not be removed/replaced
+    find('.remove-button').click
+    expect(page).to have_content('You have unsaved changes')
+    expect(page).to have_button "Save", disabled: false
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Closes #13351

Removing an only one tag in the '3. OUTGOING PRODUCTS' in editing Order Cycle did not enable the 'Save' button and also did not display the 'You have unsaved changes' like in other situations.


#### What should we test?
- Connect as an admin/shop owner
- click 'Administration' 
- click on 'Add & manage order cycles ' in the dahsboard
- choose if possible an OC with a single tag or one with none
- Go through the 'next' to the 3rd menu '3. Outgoing products'
- click on tags to show the submenu with tags
- delete the one tag OR delete as many tags to get only one, then refresh the page to get to the case 
  where there is only one
- The save button should be enabled and of a blue colour. The text 'You have unsaved changes" must be displayed.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.