### PR TITLE
CI - Do not run undercover CI step on the master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -412,3 +412,4 @@ jobs:
         run: |
           git fetch --no-tags origin master:master
           bundle exec undercover
+        if: ${{ github.ref != 'refs/heads/master' }} # Does not run on master, as we can't fetch master in the master branch


### PR DESCRIPTION
#### What? Why?

When adding the `undercover` gem in #13101, we added a CI step to compare code coverage against master. That steps fails when running on the master branch. This PR disable the undercover steps when running on the master branch, no need to compare code coverage in master against itself.
- Closes # <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

It's a tricky one to test, build should be green once we merge the PR. 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.