### PR TITLE
Align Cart Price column texts to the left

### DIFF
--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -11,7 +11,7 @@
       %thead
         %tr
           %th.cart-item-description-header= t(:item)
-          %th.cart-item-price-header.text-right= t(:price)
+          %th.cart-item-price-header= t(:price)
           %th.text-center.cart-item-quantity-header= t(:qty)
           %th.cart-item-total-header.text-right= t(:total)
           %th.cart-item-delete-header

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -18,7 +18,7 @@
           = t(".unavailable_item")
           %br/
 
-    %td.text-right.cart-item-price
+    %td.cart-item-price
       = line_item.single_display_amount_with_adjustments.to_html
       %br
       %span.unit-price


### PR DESCRIPTION
#### What? Why?

- Closes #13389


#### What should we test?
Cf. #13389:
- log in as a customer
- do some shopping
- click on `Cart` at the right in the upper menu
- click button `Edit cart`
- when having a closer look at the `Price` column:
  - Price label should be on the left
  - Price & unit price should be also on the left

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled