### PR TITLE
Disable inventory only for future enterprises

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -25,11 +25,11 @@ end
 Flipper.register(:new_2024_07_03) do |actor|
   actor.respond_to?(:created_at?) && actor.created_at >= "2024-07-03".to_time
 end
-Flipper.register(:enterprise_created_before_2025_08_04) do |actor|
+Flipper.register(:enterprise_created_before_2025_08_11) do |actor|
   # This group applies to enterprises only, so we return false if the actor is not an Enterprise
   next false unless actor.actor.instance_of? Enterprise
 
-  actor.respond_to?(:created_at?) && actor.created_at < "2025-08-04".to_time
+  actor.respond_to?(:created_at?) && actor.created_at < "2025-08-11".to_time
 end
 
 Flipper::UI.configure do |config|

--- a/db/migrate/20250709012346_enable_feature_inventory_for_existing_enterprises.rb
+++ b/db/migrate/20250709012346_enable_feature_inventory_for_existing_enterprises.rb
@@ -3,11 +3,11 @@
 class EnableFeatureInventoryForExistingEnterprises < ActiveRecord::Migration[7.0]
   # rubocop:disable Naming/VariableNumber
   def up
-    Flipper.enable_group(:inventory, :enterprise_created_before_2025_08_04)
+    Flipper.enable_group(:inventory, :enterprise_created_before_2025_08_11)
   end
 
   def down
-    Flipper.disable_group(:inventory, :enterprise_created_before_2025_08_04)
+    Flipper.disable_group(:inventory, :enterprise_created_before_2025_08_11)
   end
   # rubocop:enable Naming/VariableNumber
 end


### PR DESCRIPTION
#### What? Why?

- Addresses https://github.com/openfoodfoundation/openfoodnetwork/pull/13381#issuecomment-3109217779
- Part of https://github.com/openfoodfoundation/openfoodnetwork/issues/13373

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Code review and testing of the above pull request took so long that the chosen date to disable the inventory from is now in the past. I adjusted the date so that the deactivation only becomes active the Monday of the next deployment. That should give us some time to respond if we realise that something isn't right. We can experiment with some enterprises in production before it applies to all new enterprises.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test needed.
- But if you insist, you need to update the `created_at` field in the database for an enterprise. Example: `Enterprise.last.update!(created_at: 2.weeks.from_now)`


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
