### PR TITLE
Add gem puffing-billy to record browser requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -171,6 +171,7 @@ end
 
 group :test do
   gem 'pdf-reader'
+  gem 'puffing-billy'
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
   gem 'simplecov-lcov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
       ruby-rc4 (>= 0.1.5)
     concurrent-ruby (1.3.1)
     connection_pool (2.4.1)
+    cookiejar (0.3.4)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -269,11 +270,24 @@ GEM
     digest (3.1.1)
     docile (1.4.0)
     dotenv (3.1.2)
+    em-http-request (1.1.7)
+      addressable (>= 2.3.4)
+      cookiejar (!= 0.3.1)
+      em-socksify (>= 0.3)
+      eventmachine (>= 1.0.3)
+      http_parser.rb (>= 0.6.0)
+    em-socksify (0.3.3)
+      base64
+      eventmachine (>= 1.0.0.beta.4)
+    em-synchrony (1.0.6)
+      eventmachine (>= 1.0.0.beta.1)
     email_validator (2.2.4)
       activemodel
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
+    eventmachine (1.2.7)
+    eventmachine_httpserver (0.2.1)
     excon (0.81.0)
     execjs (2.7.0)
     factory_bot (6.2.0)
@@ -347,6 +361,7 @@ GEM
     hashie (5.0.0)
     highline (2.0.3)
     htmlentities (4.3.4)
+    http_parser.rb (0.8.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     i18n-js (3.9.2)
@@ -527,6 +542,14 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (5.0.5)
+    puffing-billy (4.0.2)
+      addressable (~> 2.5)
+      em-http-request (~> 1.1, >= 1.1.0)
+      em-synchrony
+      eventmachine (~> 1.2)
+      eventmachine_httpserver
+      http_parser.rb (~> 0.8.0)
+      multi_json
     puma (6.5.0)
       nio4r (~> 2.0)
     query_count (1.1.1)
@@ -961,6 +984,7 @@ DEPENDENCIES
   pg (~> 1.2.3)
   private_address_check
   pry (~> 0.13.0)
+  puffing-billy
   puma
   query_count
   rack-mini-profiler (< 3.0.0)

--- a/spec/fixtures/vcr_cassettes/Testing_external_scripts_loaded_in_the_browser/handles_HTTPS.yml
+++ b/spec/fixtures/vcr_cassettes/Testing_external_scripts_loaded_in_the_browser/handles_HTTPS.yml
@@ -2,20 +2,18 @@
 http_interactions:
 - request:
     method: get
-    uri: http://www.gstatic.com/generate_204
+    uri: http://deb.debian.org/favicon.ico
     body:
       encoding: UTF-8
       string: ''
     headers:
       Proxy-Connection:
       - keep-alive
-      Pragma:
-      - no-cache
-      Cache-Control:
-      - no-cache
       User-Agent:
       - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
         Safari/537.36
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
       Accept-Encoding:
       - ''
       Accept-Language:
@@ -24,19 +22,646 @@ http_interactions:
       - close
   response:
     status:
-      code: 204
-      message: No Content
+      code: 404
+      message: Not Found
     headers:
-      Content-Length:
-      - '0'
-      Cross-Origin-Resource-Policy:
-      - cross-origin
-      Date:
-      - Fri, 11 Jul 2025 05:04:02 GMT
       Connection:
       - close
+      Content-Length:
+      - '260'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Content-Type:
+      - text/html; charset=iso-8859-1
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Wed, 30 Jul 2025 02:22:26 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-syd10162-SYD
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1753842146.721877,VS0,VE615
+      X-Req-Url:
+      - recv="/favicon.ico",deliver="/favicon.ico"
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>404 Not Found</title>
+        </head><body>
+        <h1>Not Found</h1>
+        <p>The requested URL was not found on this server.</p>
+        <hr>
+        <address>Apache Server at deb.debian.org Port 80</address>
+        </body></html>
+  recorded_at: Wed, 30 Jul 2025 02:22:27 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/compressed.gif
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Fri, 11 Jul 2025 05:04:02 GMT
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1038'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"40e-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 30 Jul 2025 02:22:27 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '2'
+      X-Served-By:
+      - cache-syd10139-SYD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1753842148.531974,VS0,VE1
+      X-Req-Url:
+      - recv="/icons/compressed.gif",deliver="/icons/compressed.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAOcAAP//////zP//mf//Zv//M///AP/M///MzP/Mmf/MZv/MM//MAP+Z//+ZzP+Zmf+ZZv+ZM/+ZAP9m//9mzP9mmf9mZv9mM/9mAP8z//8zzP8zmf8zZv8zM/8zAP8A//8AzP8Amf8AZv8AM/8AAMz//8z/zMz/mcz/Zsz/M8z/AMzM/8zMzMzMmczMZszMM8zMAMyZ/8yZzMyZmcyZZsyZM8yZAMxm/8xmzMxmmcxmZsxmM8xmAMwz/8wzzMwzmcwzZswzM8wzAMwA/8wAzMwAmcwAZswAM8wAAJn//5n/zJn/mZn/Zpn/M5n/AJnM/5nMzJnMmZnMZpnMM5nMAJmZ/5mZzJmZmZmZZpmZM5mZAJlm/5lmzJlmmZlmZplmM5lmAJkz/5kzzJkzmZkzZpkzM5kzAJkA/5kAzJkAmZkAZpkAM5kAAGb//2b/zGb/mWb/Zmb/M2b/AGbM/2bMzGbMmWbMZmbMM2bMAGaZ/2aZzGaZmWaZZmaZM2aZAGZm/2ZmzGZmmWZmZmZmM2ZmAGYz/2YzzGYzmWYzZmYzM2YzAGYA/2YAzGYAmWYAZmYAM2YAADP//zP/zDP/mTP/ZjP/MzP/ADPM/zPMzDPMmTPMZjPMMzPMADOZ/zOZzDOZmTOZZjOZMzOZADNm/zNmzDNmmTNmZjNmMzNmADMz/zMzzDMzmTMzZjMzMzMzADMA/zMAzDMAmTMAZjMAMzMAAAD//wD/zAD/mQD/ZgD/MwD/AADM/wDMzADMmQDMZgDMMwDMAACZ/wCZzACZmQCZZgCZMwCZAABm/wBmzABmmQBmZgBmMwBmAAAz/wAzzAAzmQAzZgAzMwAzAAAA/wAAzAAAmQAAZgAAM+4AAN0AALsAAKoAAIgAAHcAAFUAAEQAACIAABEAAADuAADdAAC7AACqAACIAAB3AABVAABEAAAiAAARAAAA7gAA3QAAuwAAqgAAiAAAdwAAVQAARAAAIgAAEe7u7t3d3bu7u6qqqoiIiHd3d1VVVURERCIiIhEREQAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAAkACwAAAAAFAAWAAAImQBJCCTBqmDBgQgTDmQFAABDVgojEmzI0KHEhBUrWrwoMGNDihwnAvjHiqRJjhX/qVz5D+VHAFZiWmmZ8BGHji9hxqTJ4ZFAmzc1vpxJgkPPn0Y5CP04M6lPEkCN5mxoJelRqFY5TM36NGrPqV67Op0KM6rYnkup/gMq1mdamC1tdn36lijUpwjr0pSoFyUrmTJLhiTBkqXCgAA7
+  recorded_at: Wed, 30 Jul 2025 02:22:27 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/blank.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"94-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 30 Jul 2025 02:22:27 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '3'
+      X-Served-By:
+      - cache-syd10176-SYD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1753842148.541864,VS0,VE1
+      X-Req-Url:
+      - recv="/icons/blank.gif",deliver="/icons/blank.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAKEAAP///8z//wAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAACE4yPqcvtD6OctNqLs968+w+GSQEAOw==
+  recorded_at: Wed, 30 Jul 2025 02:22:27 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/back.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '216'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"d8-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 30 Jul 2025 02:22:27 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '3'
+      X-Served-By:
+      - cache-syd10161-SYD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1753842148.542278,VS0,VE1
+      X-Req-Url:
+      - recv="/icons/back.gif",deliver="/icons/back.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP///8z//5mZmWZmZjMzMwAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADSxi63P4jEPJqEDNTu6LO3PVpnDdOFnaCkHQGBTcqRRxuWG0v+5LrNUZQ8QPqeMakkaZsFihOpyDajMCoOoJAGNVWkt7QVfzokc+LBAA7
+  recorded_at: Wed, 30 Jul 2025 02:22:27 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/hand.right.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '217'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"d9-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 30 Jul 2025 02:22:27 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '3'
+      X-Served-By:
+      - cache-syd10121-SYD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1753842148.542101,VS0,VE1
+      X-Req-Url:
+      - recv="/icons/hand.right.gif",deliver="/icons/hand.right.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP/////Mmcz//5lmMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAACACwAAAAAFAAWAAADTCi63P4wykkdubiSwDuRVydi5CWEYjBsKbe2rDjMdMwRw1iaaZx7jcDm8nOpVsFjsSh0CFuq46fxko0eKOtsiu0UuRHfVlOqmM9oSgIAOw==
+  recorded_at: Wed, 30 Jul 2025 02:22:27 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/unknown.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '245'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"f5-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 30 Jul 2025 02:22:27 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '3'
+      X-Served-By:
+      - cache-syd10172-SYD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1753842148.542293,VS0,VE1
+      X-Req-Url:
+      - recv="/icons/unknown.gif",deliver="/icons/unknown.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP///8z//5mZmTMzMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADaDi6vPEwDECrnSO+aTvPEQcIAmGaIrhR5XmKgMq1LkoMN7ECrjDWp52r0iPpJJ0KjUAq7SxLE+sI+9V8vycFiM0iLb2O80s8JcfVJJTaGYrZYPNby5Ov6WolPD+XDJqAgSQ4EUCGQQEJADs=
+  recorded_at: Wed, 30 Jul 2025 02:22:27 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/text.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '229'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"e5-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 30 Jul 2025 02:22:27 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '3'
+      X-Served-By:
+      - cache-syd10120-SYD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1753842148.541994,VS0,VE1
+      X-Req-Url:
+      - recv="/icons/text.gif",deliver="/icons/text.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP///8z//5mZmTMzMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADWDi6vPEwDECrnSO+aTvPEddVIriN1wVxROtSxBDPJwq7bo23luALhJqt8gtKbrsXBSgcEo2spBLAPDp7UKT02bxWRdrp94rtbpdZMrrr/A5+8LhPFpHajQkAOw==
+  recorded_at: Wed, 30 Jul 2025 02:22:27 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/folder.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '225'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"e1-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 30 Jul 2025 02:22:27 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '3'
+      X-Served-By:
+      - cache-syd10165-SYD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1753842148.992546,VS0,VE1
+      X-Req-Url:
+      - recv="/icons/folder.gif",deliver="/icons/folder.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP/////Mmcz//5lmMzMzMwAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAACACwAAAAAFAAWAAADVCi63P4wyklZufjOErrvRcR9ZKYpxUB6aokGQyzHKxyO9RoTV54PPJyPBewNSUXhcWc8soJOIjTaSVJhVphWxd3CeILUbDwmgMPmtHrNIyxM8Iw7AQA7
+  recorded_at: Wed, 30 Jul 2025 02:22:28 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Testing_external_scripts_loaded_in_the_browser/handles_HTTPS.yml
+++ b/spec/fixtures/vcr_cassettes/Testing_external_scripts_loaded_in_the_browser/handles_HTTPS.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.gstatic.com/generate_204
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Proxy-Connection:
+      - keep-alive
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+      Connection:
+      - close
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 11 Jul 2025 05:04:02 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 11 Jul 2025 05:04:02 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Testing_external_scripts_loaded_in_the_browser/loads_a_website.yml
+++ b/spec/fixtures/vcr_cassettes/Testing_external_scripts_loaded_in_the_browser/loads_a_website.yml
@@ -1,0 +1,948 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://clients2.google.com/time/1/current?cup2hreq=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855&cup2key=9:s5jDVMfcuUIhrqbHhePH_nBoAC1CjxTn99-PT031EBI
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Proxy-Connection:
+      - keep-alive
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Accept-Encoding:
+      - ''
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Content-Type-Options:
+      - nosniff
+      X-Cup-Server-Proof:
+      - 304402203592554ffcc4bc9ea59f39b1ac3f09be988e1987742afef742d1b40a6fe1cc56022057ef8ace9edc80e72939c136e2b29069e75cc3886817ddbae3b7a9a1fb025c98:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 11 Jul 2025 04:56:31 GMT
+      Content-Disposition:
+      - attachment; filename="json.txt"; filename*=UTF-8''json.txt
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Server:
+      - ESF
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Accept-Ranges:
+      - none
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site,Accept-Encoding
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        )]}'
+        {"current_time_millis":1752209791246,"server_nonce":3.589026436260661E-105}
+  recorded_at: Fri, 11 Jul 2025 04:56:31 GMT
+- request:
+    method: post
+    uri: https://accounts.google.com/ListAccounts?gpsia=1&json=standard&source=ChromiumBrowser
+    body:
+      encoding: UTF-8
+      string: " "
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Origin:
+      - https://www.google.com
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Sec-Fetch-Site:
+      - none
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - empty
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Access-Control-Allow-Origin:
+      - https://www.google.com
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 11 Jul 2025 04:56:32 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Accept-Ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Content-Security-Policy:
+      - require-trusted-types-for 'script';report-uri /_/IdentityListAccountsHttp/cspreport
+      - script-src 'report-sample' 'nonce-DAr6J4mndfAlMG1hXXiENw' 'unsafe-inline';object-src
+        'none';base-uri 'self';report-uri /_/IdentityListAccountsHttp/cspreport;worker-src
+        'self'
+      - 'script-src ''unsafe-inline'' ''unsafe-eval'' blob: data: ''self'' https://apis.google.com
+        https://ssl.gstatic.com https://www.google.com https://www.googletagmanager.com
+        https://www.gstatic.com https://www.google-analytics.com;report-uri /_/IdentityListAccountsHttp/cspreport/allowlist'
+      - 'script-src ''unsafe-inline'' ''unsafe-eval'' blob: data:;report-uri /_/IdentityListAccountsHttp/cspreport/fine-allowlist'
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Reporting-Endpoints:
+      - default="/_/IdentityListAccountsHttp/web-reports?context=eJzjEtHikmII0pBiOHxtB5Meyy0mIyAW4uFo2HzoMJvAjlX_JzMp6SblF8ZnpqTmlWSWVOZkFpckJifnl-aVFBenFpWlFsUbGRiZGpgbmOkZmMcXGAAAaV4b9A"
+      Server:
+      - ESF
+      X-Xss-Protection:
+      - '0'
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Accept-Ranges:
+      - none
+      Vary:
+      - Origin,Accept-Encoding
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '["gaia.l.a.r",[]]'
+  recorded_at: Fri, 11 Jul 2025 04:56:32 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/debian/
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Upgrade-Insecure-Requests:
+      - '1'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      Sec-Fetch-Site:
+      - none
+      Sec-Fetch-Mode:
+      - navigate
+      Sec-Fetch-User:
+      - "?1"
+      Sec-Fetch-Dest:
+      - document
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '6121'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - text/html;charset=UTF-8
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_skroutz_debian_backend_mirrors_debian_org
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Fri, 11 Jul 2025 04:56:32 GMT
+      X-Served-By:
+      - cache-ams21082-AMS, cache-mel11231-MEL
+      X-Cache:
+      - HIT, MISS
+      X-Cache-Hits:
+      - 2, 0
+      X-Timer:
+      - S1752209792.452248,VS0,VE236
+      Vary:
+      - Accept-Encoding
+      X-Req-Url:
+      - recv="/debian/",deliver="/debian/"
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+        <html>
+         <head>
+          <title>Index of /debian</title>
+         </head>
+         <body>
+        <h1>Index of /debian</h1>
+          <table>
+           <tr><th valign="top"><img src="/icons/blank.gif" alt="[ICO]"></th><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th></tr>
+           <tr><th colspan="4"><hr></th></tr>
+        <tr><td valign="top"><img src="/icons/back.gif" alt="[PARENTDIR]"></td><td><a href="/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/hand.right.gif" alt="[   ]"></td><td><a href="README">README</a></td><td align="right">2025-05-17 08:29  </td><td align="right">1.2K</td></tr>
+        <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="README.CD-manufacture">README.CD-manufacture</a></td><td align="right">2010-06-26 09:52  </td><td align="right">1.3K</td></tr>
+        <tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="README.html">README.html</a></td><td align="right">2025-05-17 08:29  </td><td align="right">2.8K</td></tr>
+        <tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="README.mirrors.html">README.mirrors.html</a></td><td align="right">2017-03-04 20:08  </td><td align="right">291 </td></tr>
+        <tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="README.mirrors.txt">README.mirrors.txt</a></td><td align="right">2017-03-04 20:08  </td><td align="right"> 86 </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="dists/">dists/</a></td><td align="right">2025-05-17 08:29  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="doc/">doc/</a></td><td align="right">2025-07-11 01:52  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="extrafiles">extrafiles</a></td><td align="right">2025-07-11 02:21  </td><td align="right">193K</td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="indices/">indices/</a></td><td align="right">2025-07-11 02:20  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/compressed.gif" alt="[   ]"></td><td><a href="ls-lR.gz">ls-lR.gz</a></td><td align="right">2025-07-11 02:14  </td><td align="right"> 15M</td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="pool/">pool/</a></td><td align="right">2022-10-05 17:09  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="project/">project/</a></td><td align="right">2008-11-17 23:05  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="tools/">tools/</a></td><td align="right">2012-10-10 16:29  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="zzz-dists/">zzz-dists/</a></td><td align="right">2023-10-07 11:07  </td><td align="right">  - </td></tr>
+           <tr><th colspan="4"><hr></th></tr>
+        </table>
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+        <html>
+        <head>
+          <title>Debian Archive</title>
+          <meta name="Modified" content="2025-05-17">
+        </head>
+        <body>
+
+        <h1>Debian Archive</h1>
+
+        <p>See <a href="https://www.debian.org/">https://www.debian.org/</a>
+        for information about Debian GNU/Linux.</p>
+
+        <h2>Current Releases</h2>
+
+        <p>Four Debian releases are available on the main site:</p>
+
+        <blockquote>
+        <dl>
+
+        <dt><a href="dists/buster/">Debian 10.13, or buster</a></dt>
+        <dd>Debian 10.13 was released Saturday, 10th September 2022.
+        <a href="https://www.debian.org/releases/buster/amd64/">Installation
+        and upgrading instructions</a>,
+        <a href="https://www.debian.org/releases/buster/">More information</a>
+        </dd>
+
+        <dt><a href="dists/bullseye/">Debian 11.11, or bullseye</a></dt>
+        <dd>Debian 11.11 was released Saturday, 31st August 2024.
+        <a href="https://www.debian.org/releases/bullseye/amd64/">Installation
+        and upgrading instructions</a>,
+        <a href="https://www.debian.org/releases/bullseye/">More information</a>
+        </dd>
+
+        <dt><a href="dists/bookworm/">Debian 12.11, or bookworm</a></dt>
+        <dd>Debian 12.11 was released Saturday, 17th May 2025.
+        <a href="https://www.debian.org/releases/bookworm/amd64/">Installation
+        and upgrading instructions</a>,
+        <a href="https://www.debian.org/releases/bookworm/">More information</a>
+        </dd>
+
+        <dt><a href="dists/testing/">Testing, or trixie</a></dt>
+        <dd>The current tested development snapshot is named trixie.<br>
+        Packages which have been tested in unstable and passed automated
+        tests propagate to this release.<br>
+        <a href="https://www.debian.org/releases/testing/">More information</a>
+        </dd>
+
+        <dt><a href="dists/unstable/">Unstable, or sid</a></dt>
+        <dd>The current development snapshot is named sid.<br>
+        Untested candidate packages for future releases.<br>
+        <a href="https://www.debian.org/releases/unstable/">More information</a>
+        </dd>
+        </dl>
+        </blockquote>
+
+        <h2>Old Releases</h2>
+
+        <p>Older releases of Debian are at
+        <a href="http://archive.debian.org/debian-archive/">http://archive.debian.org/debian-archive</a>
+        <br>
+        <a href="https://www.debian.org/distrib/archive">More information</a>
+        </p>
+
+        <h2>CDs</h2>
+
+        <p>For more information about Debian CDs, please see
+        <a href="README.CD-manufacture">README.CD-manufacture</a>.
+        <br>
+        <a href="https://www.debian.org/CD/">Further information</a>
+        </p>
+
+        <h2>Mirrors</h2>
+
+        <p>For more information about Debian mirrors, please see
+        <a href="README.mirrors.html">README.mirrors.html</a>.
+        <br>
+        <a href="https://www.debian.org/mirror/">Further information</a>
+        </p>
+
+        <h2>Other directories</h2>
+
+        <table border="0" summary="Other directories">
+        <tr><td><a href="doc/">doc</a></td>          <td>Debian documentation.</td></tr>
+        <tr><td><a href="indices/">indices</a></td>  <td>Various indices of the site.</td></tr>
+        <tr><td><a href="project/">project</a></td>  <td>Experimental packages and other miscellaneous files.</td></tr>
+        </table>
+
+        </body>
+        </html>
+        </body></html>
+  recorded_at: Fri, 11 Jul 2025 04:56:32 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/compressed.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1038'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"40e-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Fri, 11 Jul 2025 04:56:34 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-mel11275-MEL
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1752209794.092857,VS0,VE544
+      X-Req-Url:
+      - recv="/icons/compressed.gif",deliver="/icons/compressed.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAOcAAP//////zP//mf//Zv//M///AP/M///MzP/Mmf/MZv/MM//MAP+Z//+ZzP+Zmf+ZZv+ZM/+ZAP9m//9mzP9mmf9mZv9mM/9mAP8z//8zzP8zmf8zZv8zM/8zAP8A//8AzP8Amf8AZv8AM/8AAMz//8z/zMz/mcz/Zsz/M8z/AMzM/8zMzMzMmczMZszMM8zMAMyZ/8yZzMyZmcyZZsyZM8yZAMxm/8xmzMxmmcxmZsxmM8xmAMwz/8wzzMwzmcwzZswzM8wzAMwA/8wAzMwAmcwAZswAM8wAAJn//5n/zJn/mZn/Zpn/M5n/AJnM/5nMzJnMmZnMZpnMM5nMAJmZ/5mZzJmZmZmZZpmZM5mZAJlm/5lmzJlmmZlmZplmM5lmAJkz/5kzzJkzmZkzZpkzM5kzAJkA/5kAzJkAmZkAZpkAM5kAAGb//2b/zGb/mWb/Zmb/M2b/AGbM/2bMzGbMmWbMZmbMM2bMAGaZ/2aZzGaZmWaZZmaZM2aZAGZm/2ZmzGZmmWZmZmZmM2ZmAGYz/2YzzGYzmWYzZmYzM2YzAGYA/2YAzGYAmWYAZmYAM2YAADP//zP/zDP/mTP/ZjP/MzP/ADPM/zPMzDPMmTPMZjPMMzPMADOZ/zOZzDOZmTOZZjOZMzOZADNm/zNmzDNmmTNmZjNmMzNmADMz/zMzzDMzmTMzZjMzMzMzADMA/zMAzDMAmTMAZjMAMzMAAAD//wD/zAD/mQD/ZgD/MwD/AADM/wDMzADMmQDMZgDMMwDMAACZ/wCZzACZmQCZZgCZMwCZAABm/wBmzABmmQBmZgBmMwBmAAAz/wAzzAAzmQAzZgAzMwAzAAAA/wAAzAAAmQAAZgAAM+4AAN0AALsAAKoAAIgAAHcAAFUAAEQAACIAABEAAADuAADdAAC7AACqAACIAAB3AABVAABEAAAiAAARAAAA7gAA3QAAuwAAqgAAiAAAdwAAVQAARAAAIgAAEe7u7t3d3bu7u6qqqoiIiHd3d1VVVURERCIiIhEREQAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAAkACwAAAAAFAAWAAAImQBJCCTBqmDBgQgTDmQFAABDVgojEmzI0KHEhBUrWrwoMGNDihwnAvjHiqRJjhX/qVz5D+VHAFZiWmmZ8BGHji9hxqTJ4ZFAmzc1vpxJgkPPn0Y5CP04M6lPEkCN5mxoJelRqFY5TM36NGrPqV67Op0KM6rYnkup/gMq1mdamC1tdn36lijUpwjr0pSoFyUrmTJLhiTBkqXCgAA7
+  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/blank.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"94-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Fri, 11 Jul 2025 04:56:34 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-mel11256-MEL
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1752209794.092746,VS0,VE559
+      X-Req-Url:
+      - recv="/icons/blank.gif",deliver="/icons/blank.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAKEAAP///8z//wAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAACE4yPqcvtD6OctNqLs968+w+GSQEAOw==
+  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/back.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '216'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"d8-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Fri, 11 Jul 2025 04:56:34 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-mel11253-MEL
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1752209794.092777,VS0,VE544
+      X-Req-Url:
+      - recv="/icons/back.gif",deliver="/icons/back.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP///8z//5mZmWZmZjMzMwAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADSxi63P4jEPJqEDNTu6LO3PVpnDdOFnaCkHQGBTcqRRxuWG0v+5LrNUZQ8QPqeMakkaZsFihOpyDajMCoOoJAGNVWkt7QVfzokc+LBAA7
+  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/hand.right.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '217'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"d9-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Fri, 11 Jul 2025 04:56:34 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-mel11263-MEL
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1752209794.137505,VS0,VE543
+      X-Req-Url:
+      - recv="/icons/hand.right.gif",deliver="/icons/hand.right.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP/////Mmcz//5lmMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAACACwAAAAAFAAWAAADTCi63P4wykkdubiSwDuRVydi5CWEYjBsKbe2rDjMdMwRw1iaaZx7jcDm8nOpVsFjsSh0CFuq46fxko0eKOtsiu0UuRHfVlOqmM9oSgIAOw==
+  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/text.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '229'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"e5-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Fri, 11 Jul 2025 04:56:34 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-mel11266-MEL
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1752209794.137616,VS0,VE546
+      X-Req-Url:
+      - recv="/icons/text.gif",deliver="/icons/text.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP///8z//5mZmTMzMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADWDi6vPEwDECrnSO+aTvPEddVIriN1wVxROtSxBDPJwq7bo23luALhJqt8gtKbrsXBSgcEo2spBLAPDp7UKT02bxWRdrp94rtbpdZMrrr/A5+8LhPFpHajQkAOw==
+  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/unknown.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '245'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"f5-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Fri, 11 Jul 2025 04:56:34 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-mel11261-MEL
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1752209794.137743,VS0,VE554
+      X-Req-Url:
+      - recv="/icons/unknown.gif",deliver="/icons/unknown.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP///8z//5mZmTMzMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADaDi6vPEwDECrnSO+aTvPEQcIAmGaIrhR5XmKgMq1LkoMN7ECrjDWp52r0iPpJJ0KjUAq7SxLE+sI+9V8vycFiM0iLb2O80s8JcfVJJTaGYrZYPNby5Ov6WolPD+XDJqAgSQ4EUCGQQEJADs=
+  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+- request:
+    method: get
+    uri: https://deb.debian.org/icons/folder.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Sec-Ch-Ua-Platform:
+      - '"Linux"'
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Sec-Ch-Ua:
+      - '"Not)A;Brand";v="8", "Chromium";v="138"'
+      Sec-Ch-Ua-Mobile:
+      - "?0"
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Sec-Fetch-Site:
+      - same-origin
+      Sec-Fetch-Mode:
+      - no-cors
+      Sec-Fetch-Dest:
+      - image
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '225'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"e1-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Fri, 11 Jul 2025 04:56:35 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-mel11253-MEL
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1752209795.922267,VS0,VE545
+      X-Req-Url:
+      - recv="/icons/folder.gif",deliver="/icons/folder.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP/////Mmcz//5lmMzMzMwAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAACACwAAAAAFAAWAAADVCi63P4wyklZufjOErrvRcR9ZKYpxUB6aokGQyzHKxyO9RoTV54PPJyPBewNSUXhcWc8soJOIjTaSVJhVphWxd3CeILUbDwmgMPmtHrNIyxM8Iw7AQA7
+  recorded_at: Fri, 11 Jul 2025 04:56:35 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Testing_external_scripts_loaded_in_the_browser/loads_a_website.yml
+++ b/spec/fixtures/vcr_cassettes/Testing_external_scripts_loaded_in_the_browser/loads_a_website.yml
@@ -2,160 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: http://clients2.google.com/time/1/current?cup2hreq=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855&cup2key=9:s5jDVMfcuUIhrqbHhePH_nBoAC1CjxTn99-PT031EBI
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Proxy-Connection:
-      - keep-alive
-      Pragma:
-      - no-cache
-      Cache-Control:
-      - no-cache
-      User-Agent:
-      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
-        Safari/537.36
-      Accept-Encoding:
-      - ''
-      Connection:
-      - close
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Cup-Server-Proof:
-      - 304402203592554ffcc4bc9ea59f39b1ac3f09be988e1987742afef742d1b40a6fe1cc56022057ef8ace9edc80e72939c136e2b29069e75cc3886817ddbae3b7a9a1fb025c98:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Fri, 11 Jul 2025 04:56:31 GMT
-      Content-Disposition:
-      - attachment; filename="json.txt"; filename*=UTF-8''json.txt
-      Cross-Origin-Resource-Policy:
-      - same-site
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Server:
-      - ESF
-      X-Xss-Protection:
-      - '0'
-      X-Frame-Options:
-      - SAMEORIGIN
-      Accept-Ranges:
-      - none
-      Vary:
-      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site,Accept-Encoding
-      Connection:
-      - close
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |-
-        )]}'
-        {"current_time_millis":1752209791246,"server_nonce":3.589026436260661E-105}
-  recorded_at: Fri, 11 Jul 2025 04:56:31 GMT
-- request:
-    method: post
-    uri: https://accounts.google.com/ListAccounts?gpsia=1&json=standard&source=ChromiumBrowser
-    body:
-      encoding: UTF-8
-      string: " "
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Origin:
-      - https://www.google.com
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Sec-Fetch-Site:
-      - none
-      Sec-Fetch-Mode:
-      - no-cors
-      Sec-Fetch-Dest:
-      - empty
-      User-Agent:
-      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
-        Safari/537.36
-      Accept-Encoding:
-      - ''
-      Accept-Language:
-      - en-US,en;q=0.9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Access-Control-Allow-Origin:
-      - https://www.google.com
-      Access-Control-Allow-Credentials:
-      - 'true'
-      X-Content-Type-Options:
-      - nosniff
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Fri, 11 Jul 2025 04:56:32 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Accept-Ch:
-      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
-        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
-        Sec-CH-UA-Platform-Version
-      Content-Security-Policy:
-      - require-trusted-types-for 'script';report-uri /_/IdentityListAccountsHttp/cspreport
-      - script-src 'report-sample' 'nonce-DAr6J4mndfAlMG1hXXiENw' 'unsafe-inline';object-src
-        'none';base-uri 'self';report-uri /_/IdentityListAccountsHttp/cspreport;worker-src
-        'self'
-      - 'script-src ''unsafe-inline'' ''unsafe-eval'' blob: data: ''self'' https://apis.google.com
-        https://ssl.gstatic.com https://www.google.com https://www.googletagmanager.com
-        https://www.gstatic.com https://www.google-analytics.com;report-uri /_/IdentityListAccountsHttp/cspreport/allowlist'
-      - 'script-src ''unsafe-inline'' ''unsafe-eval'' blob: data:;report-uri /_/IdentityListAccountsHttp/cspreport/fine-allowlist'
-      Permissions-Policy:
-      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
-        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
-      Reporting-Endpoints:
-      - default="/_/IdentityListAccountsHttp/web-reports?context=eJzjEtHikmII0pBiOHxtB5Meyy0mIyAW4uFo2HzoMJvAjlX_JzMp6SblF8ZnpqTmlWSWVOZkFpckJifnl-aVFBenFpWlFsUbGRiZGpgbmOkZmMcXGAAAaV4b9A"
-      Server:
-      - ESF
-      X-Xss-Protection:
-      - '0'
-      Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Accept-Ranges:
-      - none
-      Vary:
-      - Origin,Accept-Encoding
-      Connection:
-      - close
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: '["gaia.l.a.r",[]]'
-  recorded_at: Fri, 11 Jul 2025 04:56:32 GMT
-- request:
-    method: get
     uri: https://deb.debian.org/debian/
     body:
       encoding: UTF-8
@@ -196,7 +42,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '6121'
+      - '5820'
       Server:
       - Apache
       X-Content-Type-Options:
@@ -214,23 +60,23 @@ http_interactions:
       Content-Type:
       - text/html;charset=UTF-8
       Backend:
-      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_skroutz_debian_backend_mirrors_debian_org
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_accumu_debian_backend_mirrors_debian_org
       Via:
       - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
+      Date:
+      - Wed, 30 Jul 2025 02:22:24 GMT
       Age:
       - '0'
-      Date:
-      - Fri, 11 Jul 2025 04:56:32 GMT
       X-Served-By:
-      - cache-ams21082-AMS, cache-mel11231-MEL
+      - cache-ams21082-AMS, cache-syd10146-SYD
       X-Cache:
-      - HIT, MISS
+      - HIT, HIT
       X-Cache-Hits:
-      - 2, 0
+      - 4, 1
       X-Timer:
-      - S1752209792.452248,VS0,VE236
+      - S1753842144.042689,VS0,VE198
       Vary:
       - Accept-Encoding
       X-Req-Url:
@@ -251,25 +97,25 @@ http_interactions:
         <tr><td valign="top"><img src="/icons/back.gif" alt="[PARENTDIR]"></td><td><a href="/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td></tr>
         <tr><td valign="top"><img src="/icons/hand.right.gif" alt="[   ]"></td><td><a href="README">README</a></td><td align="right">2025-05-17 08:29  </td><td align="right">1.2K</td></tr>
         <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="README.CD-manufacture">README.CD-manufacture</a></td><td align="right">2010-06-26 09:52  </td><td align="right">1.3K</td></tr>
-        <tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="README.html">README.html</a></td><td align="right">2025-05-17 08:29  </td><td align="right">2.8K</td></tr>
+        <tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="README.html">README.html</a></td><td align="right">2025-07-12 22:19  </td><td align="right">2.6K</td></tr>
         <tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="README.mirrors.html">README.mirrors.html</a></td><td align="right">2017-03-04 20:08  </td><td align="right">291 </td></tr>
         <tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="README.mirrors.txt">README.mirrors.txt</a></td><td align="right">2017-03-04 20:08  </td><td align="right"> 86 </td></tr>
-        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="dists/">dists/</a></td><td align="right">2025-05-17 08:29  </td><td align="right">  - </td></tr>
-        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="doc/">doc/</a></td><td align="right">2025-07-11 01:52  </td><td align="right">  - </td></tr>
-        <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="extrafiles">extrafiles</a></td><td align="right">2025-07-11 02:21  </td><td align="right">193K</td></tr>
-        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="indices/">indices/</a></td><td align="right">2025-07-11 02:20  </td><td align="right">  - </td></tr>
-        <tr><td valign="top"><img src="/icons/compressed.gif" alt="[   ]"></td><td><a href="ls-lR.gz">ls-lR.gz</a></td><td align="right">2025-07-11 02:14  </td><td align="right"> 15M</td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="dists/">dists/</a></td><td align="right">2025-07-22 17:15  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="doc/">doc/</a></td><td align="right">2025-07-29 19:54  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="extrafiles">extrafiles</a></td><td align="right">2025-07-29 20:27  </td><td align="right">168K</td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="indices/">indices/</a></td><td align="right">2025-07-29 20:26  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/compressed.gif" alt="[   ]"></td><td><a href="ls-lR.gz">ls-lR.gz</a></td><td align="right">2025-07-29 20:23  </td><td align="right"> 12M</td></tr>
         <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="pool/">pool/</a></td><td align="right">2022-10-05 17:09  </td><td align="right">  - </td></tr>
         <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="project/">project/</a></td><td align="right">2008-11-17 23:05  </td><td align="right">  - </td></tr>
         <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="tools/">tools/</a></td><td align="right">2012-10-10 16:29  </td><td align="right">  - </td></tr>
-        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="zzz-dists/">zzz-dists/</a></td><td align="right">2023-10-07 11:07  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="zzz-dists/">zzz-dists/</a></td><td align="right">2025-07-12 22:20  </td><td align="right">  - </td></tr>
            <tr><th colspan="4"><hr></th></tr>
         </table>
         <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
         <html>
         <head>
           <title>Debian Archive</title>
-          <meta name="Modified" content="2025-05-17">
+          <meta name="Modified" content="2025-07-13">
         </head>
         <body>
 
@@ -284,13 +130,6 @@ http_interactions:
 
         <blockquote>
         <dl>
-
-        <dt><a href="dists/buster/">Debian 10.13, or buster</a></dt>
-        <dd>Debian 10.13 was released Saturday, 10th September 2022.
-        <a href="https://www.debian.org/releases/buster/amd64/">Installation
-        and upgrading instructions</a>,
-        <a href="https://www.debian.org/releases/buster/">More information</a>
-        </dd>
 
         <dt><a href="dists/bullseye/">Debian 11.11, or bullseye</a></dt>
         <dd>Debian 11.11 was released Saturday, 31st August 2024.
@@ -356,37 +195,29 @@ http_interactions:
         </body>
         </html>
         </body></html>
-  recorded_at: Fri, 11 Jul 2025 04:56:32 GMT
+  recorded_at: Wed, 30 Jul 2025 02:22:24 GMT
 - request:
     method: get
-    uri: https://deb.debian.org/icons/compressed.gif
+    uri: http://deb.debian.org/debian/
     body:
       encoding: UTF-8
       string: ''
     headers:
-      Connection:
-      - close
-      Sec-Ch-Ua-Platform:
-      - '"Linux"'
+      Proxy-Connection:
+      - keep-alive
+      Upgrade-Insecure-Requests:
+      - '1'
       User-Agent:
       - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
         Safari/537.36
-      Sec-Ch-Ua:
-      - '"Not)A;Brand";v="8", "Chromium";v="138"'
-      Sec-Ch-Ua-Mobile:
-      - "?0"
       Accept:
-      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
-      Sec-Fetch-Site:
-      - same-origin
-      Sec-Fetch-Mode:
-      - no-cors
-      Sec-Fetch-Dest:
-      - image
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
       Accept-Encoding:
       - ''
       Accept-Language:
       - en-US,en;q=0.9
+      Connection:
+      - close
   response:
     status:
       code: 200
@@ -395,7 +226,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1038'
+      - '5820'
       Server:
       - Apache
       X-Content-Type-Options:
@@ -408,69 +239,167 @@ http_interactions:
       - '1'
       Permissions-Policy:
       - interest-cohort=()
-      Last-Modified:
-      - Sat, 20 Nov 2004 20:16:24 GMT
-      Etag:
-      - '"40e-3e9564c23b600"'
       X-Clacks-Overhead:
       - GNU Terry Pratchett
       Content-Type:
-      - image/gif
+      - text/html;charset=UTF-8
       Backend:
-      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_accumu_debian_backend_mirrors_debian_org
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Age:
       - '0'
       Date:
-      - Fri, 11 Jul 2025 04:56:34 GMT
-      Via:
-      - 1.1 varnish
+      - Wed, 30 Jul 2025 02:22:24 GMT
       X-Served-By:
-      - cache-mel11275-MEL
+      - cache-ams21082-AMS, cache-syd10179-SYD
       X-Cache:
-      - HIT
+      - HIT, MISS
       X-Cache-Hits:
-      - '0'
+      - 4, 0
       X-Timer:
-      - S1752209794.092857,VS0,VE544
+      - S1753842144.982706,VS0,VE258
+      Vary:
+      - Accept-Encoding
       X-Req-Url:
-      - recv="/icons/compressed.gif",deliver="/icons/compressed.gif"
+      - recv="/debian/",deliver="/debian/"
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        R0lGODlhFAAWAOcAAP//////zP//mf//Zv//M///AP/M///MzP/Mmf/MZv/MM//MAP+Z//+ZzP+Zmf+ZZv+ZM/+ZAP9m//9mzP9mmf9mZv9mM/9mAP8z//8zzP8zmf8zZv8zM/8zAP8A//8AzP8Amf8AZv8AM/8AAMz//8z/zMz/mcz/Zsz/M8z/AMzM/8zMzMzMmczMZszMM8zMAMyZ/8yZzMyZmcyZZsyZM8yZAMxm/8xmzMxmmcxmZsxmM8xmAMwz/8wzzMwzmcwzZswzM8wzAMwA/8wAzMwAmcwAZswAM8wAAJn//5n/zJn/mZn/Zpn/M5n/AJnM/5nMzJnMmZnMZpnMM5nMAJmZ/5mZzJmZmZmZZpmZM5mZAJlm/5lmzJlmmZlmZplmM5lmAJkz/5kzzJkzmZkzZpkzM5kzAJkA/5kAzJkAmZkAZpkAM5kAAGb//2b/zGb/mWb/Zmb/M2b/AGbM/2bMzGbMmWbMZmbMM2bMAGaZ/2aZzGaZmWaZZmaZM2aZAGZm/2ZmzGZmmWZmZmZmM2ZmAGYz/2YzzGYzmWYzZmYzM2YzAGYA/2YAzGYAmWYAZmYAM2YAADP//zP/zDP/mTP/ZjP/MzP/ADPM/zPMzDPMmTPMZjPMMzPMADOZ/zOZzDOZmTOZZjOZMzOZADNm/zNmzDNmmTNmZjNmMzNmADMz/zMzzDMzmTMzZjMzMzMzADMA/zMAzDMAmTMAZjMAMzMAAAD//wD/zAD/mQD/ZgD/MwD/AADM/wDMzADMmQDMZgDMMwDMAACZ/wCZzACZmQCZZgCZMwCZAABm/wBmzABmmQBmZgBmMwBmAAAz/wAzzAAzmQAzZgAzMwAzAAAA/wAAzAAAmQAAZgAAM+4AAN0AALsAAKoAAIgAAHcAAFUAAEQAACIAABEAAADuAADdAAC7AACqAACIAAB3AABVAABEAAAiAAARAAAA7gAA3QAAuwAAqgAAiAAAdwAAVQAARAAAIgAAEe7u7t3d3bu7u6qqqoiIiHd3d1VVVURERCIiIhEREQAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAAkACwAAAAAFAAWAAAImQBJCCTBqmDBgQgTDmQFAABDVgojEmzI0KHEhBUrWrwoMGNDihwnAvjHiqRJjhX/qVz5D+VHAFZiWmmZ8BGHji9hxqTJ4ZFAmzc1vpxJgkPPn0Y5CP04M6lPEkCN5mxoJelRqFY5TM36NGrPqV67Op0KM6rYnkup/gMq1mdamC1tdn36lijUpwjr0pSoFyUrmTJLhiTBkqXCgAA7
-  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+        <html>
+         <head>
+          <title>Index of /debian</title>
+         </head>
+         <body>
+        <h1>Index of /debian</h1>
+          <table>
+           <tr><th valign="top"><img src="/icons/blank.gif" alt="[ICO]"></th><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th></tr>
+           <tr><th colspan="4"><hr></th></tr>
+        <tr><td valign="top"><img src="/icons/back.gif" alt="[PARENTDIR]"></td><td><a href="/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/hand.right.gif" alt="[   ]"></td><td><a href="README">README</a></td><td align="right">2025-05-17 08:29  </td><td align="right">1.2K</td></tr>
+        <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="README.CD-manufacture">README.CD-manufacture</a></td><td align="right">2010-06-26 09:52  </td><td align="right">1.3K</td></tr>
+        <tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="README.html">README.html</a></td><td align="right">2025-07-12 22:19  </td><td align="right">2.6K</td></tr>
+        <tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="README.mirrors.html">README.mirrors.html</a></td><td align="right">2017-03-04 20:08  </td><td align="right">291 </td></tr>
+        <tr><td valign="top"><img src="/icons/text.gif" alt="[TXT]"></td><td><a href="README.mirrors.txt">README.mirrors.txt</a></td><td align="right">2017-03-04 20:08  </td><td align="right"> 86 </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="dists/">dists/</a></td><td align="right">2025-07-22 17:15  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="doc/">doc/</a></td><td align="right">2025-07-29 19:54  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="extrafiles">extrafiles</a></td><td align="right">2025-07-29 20:27  </td><td align="right">168K</td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="indices/">indices/</a></td><td align="right">2025-07-29 20:26  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/compressed.gif" alt="[   ]"></td><td><a href="ls-lR.gz">ls-lR.gz</a></td><td align="right">2025-07-29 20:23  </td><td align="right"> 12M</td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="pool/">pool/</a></td><td align="right">2022-10-05 17:09  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="project/">project/</a></td><td align="right">2008-11-17 23:05  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="tools/">tools/</a></td><td align="right">2012-10-10 16:29  </td><td align="right">  - </td></tr>
+        <tr><td valign="top"><img src="/icons/folder.gif" alt="[DIR]"></td><td><a href="zzz-dists/">zzz-dists/</a></td><td align="right">2025-07-12 22:20  </td><td align="right">  - </td></tr>
+           <tr><th colspan="4"><hr></th></tr>
+        </table>
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+        <html>
+        <head>
+          <title>Debian Archive</title>
+          <meta name="Modified" content="2025-07-13">
+        </head>
+        <body>
+
+        <h1>Debian Archive</h1>
+
+        <p>See <a href="https://www.debian.org/">https://www.debian.org/</a>
+        for information about Debian GNU/Linux.</p>
+
+        <h2>Current Releases</h2>
+
+        <p>Four Debian releases are available on the main site:</p>
+
+        <blockquote>
+        <dl>
+
+        <dt><a href="dists/bullseye/">Debian 11.11, or bullseye</a></dt>
+        <dd>Debian 11.11 was released Saturday, 31st August 2024.
+        <a href="https://www.debian.org/releases/bullseye/amd64/">Installation
+        and upgrading instructions</a>,
+        <a href="https://www.debian.org/releases/bullseye/">More information</a>
+        </dd>
+
+        <dt><a href="dists/bookworm/">Debian 12.11, or bookworm</a></dt>
+        <dd>Debian 12.11 was released Saturday, 17th May 2025.
+        <a href="https://www.debian.org/releases/bookworm/amd64/">Installation
+        and upgrading instructions</a>,
+        <a href="https://www.debian.org/releases/bookworm/">More information</a>
+        </dd>
+
+        <dt><a href="dists/testing/">Testing, or trixie</a></dt>
+        <dd>The current tested development snapshot is named trixie.<br>
+        Packages which have been tested in unstable and passed automated
+        tests propagate to this release.<br>
+        <a href="https://www.debian.org/releases/testing/">More information</a>
+        </dd>
+
+        <dt><a href="dists/unstable/">Unstable, or sid</a></dt>
+        <dd>The current development snapshot is named sid.<br>
+        Untested candidate packages for future releases.<br>
+        <a href="https://www.debian.org/releases/unstable/">More information</a>
+        </dd>
+        </dl>
+        </blockquote>
+
+        <h2>Old Releases</h2>
+
+        <p>Older releases of Debian are at
+        <a href="http://archive.debian.org/debian-archive/">http://archive.debian.org/debian-archive</a>
+        <br>
+        <a href="https://www.debian.org/distrib/archive">More information</a>
+        </p>
+
+        <h2>CDs</h2>
+
+        <p>For more information about Debian CDs, please see
+        <a href="README.CD-manufacture">README.CD-manufacture</a>.
+        <br>
+        <a href="https://www.debian.org/CD/">Further information</a>
+        </p>
+
+        <h2>Mirrors</h2>
+
+        <p>For more information about Debian mirrors, please see
+        <a href="README.mirrors.html">README.mirrors.html</a>.
+        <br>
+        <a href="https://www.debian.org/mirror/">Further information</a>
+        </p>
+
+        <h2>Other directories</h2>
+
+        <table border="0" summary="Other directories">
+        <tr><td><a href="doc/">doc</a></td>          <td>Debian documentation.</td></tr>
+        <tr><td><a href="indices/">indices</a></td>  <td>Various indices of the site.</td></tr>
+        <tr><td><a href="project/">project</a></td>  <td>Experimental packages and other miscellaneous files.</td></tr>
+        </table>
+
+        </body>
+        </html>
+        </body></html>
+  recorded_at: Wed, 30 Jul 2025 02:22:24 GMT
 - request:
     method: get
-    uri: https://deb.debian.org/icons/blank.gif
+    uri: http://deb.debian.org/icons/blank.gif
     body:
       encoding: UTF-8
       string: ''
     headers:
-      Connection:
-      - close
-      Sec-Ch-Ua-Platform:
-      - '"Linux"'
+      Proxy-Connection:
+      - keep-alive
       User-Agent:
       - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
         Safari/537.36
-      Sec-Ch-Ua:
-      - '"Not)A;Brand";v="8", "Chromium";v="138"'
-      Sec-Ch-Ua-Mobile:
-      - "?0"
       Accept:
       - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
-      Sec-Fetch-Site:
-      - same-origin
-      Sec-Fetch-Mode:
-      - no-cors
-      Sec-Fetch-Dest:
-      - image
       Accept-Encoding:
       - ''
       Accept-Language:
       - en-US,en;q=0.9
+      Connection:
+      - close
   response:
     status:
       code: 200
@@ -507,54 +436,44 @@ http_interactions:
       Age:
       - '0'
       Date:
-      - Fri, 11 Jul 2025 04:56:34 GMT
+      - Wed, 30 Jul 2025 02:22:24 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-mel11256-MEL
+      - cache-syd10125-SYD
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1752209794.092746,VS0,VE559
+      - S1753842144.402396,VS0,VE414
       X-Req-Url:
       - recv="/icons/blank.gif",deliver="/icons/blank.gif"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         R0lGODlhFAAWAKEAAP///8z//wAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAACE4yPqcvtD6OctNqLs968+w+GSQEAOw==
-  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+  recorded_at: Wed, 30 Jul 2025 02:22:24 GMT
 - request:
     method: get
-    uri: https://deb.debian.org/icons/back.gif
+    uri: http://deb.debian.org/icons/back.gif
     body:
       encoding: UTF-8
       string: ''
     headers:
-      Connection:
-      - close
-      Sec-Ch-Ua-Platform:
-      - '"Linux"'
+      Proxy-Connection:
+      - keep-alive
       User-Agent:
       - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
         Safari/537.36
-      Sec-Ch-Ua:
-      - '"Not)A;Brand";v="8", "Chromium";v="138"'
-      Sec-Ch-Ua-Mobile:
-      - "?0"
       Accept:
       - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
-      Sec-Fetch-Site:
-      - same-origin
-      Sec-Fetch-Mode:
-      - no-cors
-      Sec-Fetch-Dest:
-      - image
       Accept-Encoding:
       - ''
       Accept-Language:
       - en-US,en;q=0.9
+      Connection:
+      - close
   response:
     status:
       code: 200
@@ -591,54 +510,44 @@ http_interactions:
       Age:
       - '0'
       Date:
-      - Fri, 11 Jul 2025 04:56:34 GMT
+      - Wed, 30 Jul 2025 02:22:24 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-mel11253-MEL
+      - cache-syd10140-SYD
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1752209794.092777,VS0,VE544
+      - S1753842144.402014,VS0,VE418
       X-Req-Url:
       - recv="/icons/back.gif",deliver="/icons/back.gif"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         R0lGODlhFAAWAMIAAP///8z//5mZmWZmZjMzMwAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADSxi63P4jEPJqEDNTu6LO3PVpnDdOFnaCkHQGBTcqRRxuWG0v+5LrNUZQ8QPqeMakkaZsFihOpyDajMCoOoJAGNVWkt7QVfzokc+LBAA7
-  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+  recorded_at: Wed, 30 Jul 2025 02:22:24 GMT
 - request:
     method: get
-    uri: https://deb.debian.org/icons/hand.right.gif
+    uri: http://deb.debian.org/icons/hand.right.gif
     body:
       encoding: UTF-8
       string: ''
     headers:
-      Connection:
-      - close
-      Sec-Ch-Ua-Platform:
-      - '"Linux"'
+      Proxy-Connection:
+      - keep-alive
       User-Agent:
       - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
         Safari/537.36
-      Sec-Ch-Ua:
-      - '"Not)A;Brand";v="8", "Chromium";v="138"'
-      Sec-Ch-Ua-Mobile:
-      - "?0"
       Accept:
       - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
-      Sec-Fetch-Site:
-      - same-origin
-      Sec-Fetch-Mode:
-      - no-cors
-      Sec-Fetch-Dest:
-      - image
       Accept-Encoding:
       - ''
       Accept-Language:
       - en-US,en;q=0.9
+      Connection:
+      - close
   response:
     status:
       code: 200
@@ -675,54 +584,44 @@ http_interactions:
       Age:
       - '0'
       Date:
-      - Fri, 11 Jul 2025 04:56:34 GMT
+      - Wed, 30 Jul 2025 02:22:24 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-mel11263-MEL
+      - cache-syd10160-SYD
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1752209794.137505,VS0,VE543
+      - S1753842144.402195,VS0,VE417
       X-Req-Url:
       - recv="/icons/hand.right.gif",deliver="/icons/hand.right.gif"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         R0lGODlhFAAWAMIAAP/////Mmcz//5lmMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAACACwAAAAAFAAWAAADTCi63P4wykkdubiSwDuRVydi5CWEYjBsKbe2rDjMdMwRw1iaaZx7jcDm8nOpVsFjsSh0CFuq46fxko0eKOtsiu0UuRHfVlOqmM9oSgIAOw==
-  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+  recorded_at: Wed, 30 Jul 2025 02:22:24 GMT
 - request:
     method: get
-    uri: https://deb.debian.org/icons/text.gif
+    uri: http://deb.debian.org/icons/text.gif
     body:
       encoding: UTF-8
       string: ''
     headers:
-      Connection:
-      - close
-      Sec-Ch-Ua-Platform:
-      - '"Linux"'
+      Proxy-Connection:
+      - keep-alive
       User-Agent:
       - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
         Safari/537.36
-      Sec-Ch-Ua:
-      - '"Not)A;Brand";v="8", "Chromium";v="138"'
-      Sec-Ch-Ua-Mobile:
-      - "?0"
       Accept:
       - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
-      Sec-Fetch-Site:
-      - same-origin
-      Sec-Fetch-Mode:
-      - no-cors
-      Sec-Fetch-Dest:
-      - image
       Accept-Encoding:
       - ''
       Accept-Language:
       - en-US,en;q=0.9
+      Connection:
+      - close
   response:
     status:
       code: 200
@@ -759,138 +658,44 @@ http_interactions:
       Age:
       - '0'
       Date:
-      - Fri, 11 Jul 2025 04:56:34 GMT
+      - Wed, 30 Jul 2025 02:22:25 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-mel11266-MEL
+      - cache-syd10179-SYD
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1752209794.137616,VS0,VE546
+      - S1753842144.431907,VS0,VE589
       X-Req-Url:
       - recv="/icons/text.gif",deliver="/icons/text.gif"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         R0lGODlhFAAWAMIAAP///8z//5mZmTMzMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADWDi6vPEwDECrnSO+aTvPEddVIriN1wVxROtSxBDPJwq7bo23luALhJqt8gtKbrsXBSgcEo2spBLAPDp7UKT02bxWRdrp94rtbpdZMrrr/A5+8LhPFpHajQkAOw==
-  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
+  recorded_at: Wed, 30 Jul 2025 02:22:25 GMT
 - request:
     method: get
-    uri: https://deb.debian.org/icons/unknown.gif
+    uri: http://deb.debian.org/icons/folder.gif
     body:
       encoding: UTF-8
       string: ''
     headers:
-      Connection:
-      - close
-      Sec-Ch-Ua-Platform:
-      - '"Linux"'
+      Proxy-Connection:
+      - keep-alive
       User-Agent:
       - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
         Safari/537.36
-      Sec-Ch-Ua:
-      - '"Not)A;Brand";v="8", "Chromium";v="138"'
-      Sec-Ch-Ua-Mobile:
-      - "?0"
       Accept:
       - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
-      Sec-Fetch-Site:
-      - same-origin
-      Sec-Fetch-Mode:
-      - no-cors
-      Sec-Fetch-Dest:
-      - image
       Accept-Encoding:
       - ''
       Accept-Language:
       - en-US,en;q=0.9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
       Connection:
       - close
-      Content-Length:
-      - '245'
-      Server:
-      - Apache
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - sameorigin
-      Referrer-Policy:
-      - no-referrer
-      X-Xss-Protection:
-      - '1'
-      Permissions-Policy:
-      - interest-cohort=()
-      Last-Modified:
-      - Sat, 20 Nov 2004 20:16:24 GMT
-      Etag:
-      - '"f5-3e9564c23b600"'
-      X-Clacks-Overhead:
-      - GNU Terry Pratchett
-      Content-Type:
-      - image/gif
-      Backend:
-      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
-      Accept-Ranges:
-      - bytes
-      Age:
-      - '0'
-      Date:
-      - Fri, 11 Jul 2025 04:56:34 GMT
-      Via:
-      - 1.1 varnish
-      X-Served-By:
-      - cache-mel11261-MEL
-      X-Cache:
-      - HIT
-      X-Cache-Hits:
-      - '0'
-      X-Timer:
-      - S1752209794.137743,VS0,VE554
-      X-Req-Url:
-      - recv="/icons/unknown.gif",deliver="/icons/unknown.gif"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        R0lGODlhFAAWAMIAAP///8z//5mZmTMzMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADaDi6vPEwDECrnSO+aTvPEQcIAmGaIrhR5XmKgMq1LkoMN7ECrjDWp52r0iPpJJ0KjUAq7SxLE+sI+9V8vycFiM0iLb2O80s8JcfVJJTaGYrZYPNby5Ov6WolPD+XDJqAgSQ4EUCGQQEJADs=
-  recorded_at: Fri, 11 Jul 2025 04:56:34 GMT
-- request:
-    method: get
-    uri: https://deb.debian.org/icons/folder.gif
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Connection:
-      - close
-      Sec-Ch-Ua-Platform:
-      - '"Linux"'
-      User-Agent:
-      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
-        Safari/537.36
-      Sec-Ch-Ua:
-      - '"Not)A;Brand";v="8", "Chromium";v="138"'
-      Sec-Ch-Ua-Mobile:
-      - "?0"
-      Accept:
-      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
-      Sec-Fetch-Site:
-      - same-origin
-      Sec-Fetch-Mode:
-      - no-cors
-      Sec-Fetch-Dest:
-      - image
-      Accept-Encoding:
-      - ''
-      Accept-Language:
-      - en-US,en;q=0.9
   response:
     status:
       code: 200
@@ -927,22 +732,170 @@ http_interactions:
       Age:
       - '0'
       Date:
-      - Fri, 11 Jul 2025 04:56:35 GMT
+      - Wed, 30 Jul 2025 02:22:25 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-mel11253-MEL
+      - cache-syd10182-SYD
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1752209795.922267,VS0,VE545
+      - S1753842144.432033,VS0,VE589
       X-Req-Url:
       - recv="/icons/folder.gif",deliver="/icons/folder.gif"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         R0lGODlhFAAWAMIAAP/////Mmcz//5lmMzMzMwAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAACACwAAAAAFAAWAAADVCi63P4wyklZufjOErrvRcR9ZKYpxUB6aokGQyzHKxyO9RoTV54PPJyPBewNSUXhcWc8soJOIjTaSVJhVphWxd3CeILUbDwmgMPmtHrNIyxM8Iw7AQA7
-  recorded_at: Fri, 11 Jul 2025 04:56:35 GMT
+  recorded_at: Wed, 30 Jul 2025 02:22:25 GMT
+- request:
+    method: get
+    uri: http://deb.debian.org/icons/unknown.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Proxy-Connection:
+      - keep-alive
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '245'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"f5-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Wed, 30 Jul 2025 02:22:25 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-syd10136-SYD
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1753842144.402202,VS0,VE623
+      X-Req-Url:
+      - recv="/icons/unknown.gif",deliver="/icons/unknown.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAMIAAP///8z//5mZmTMzMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADaDi6vPEwDECrnSO+aTvPEQcIAmGaIrhR5XmKgMq1LkoMN7ECrjDWp52r0iPpJJ0KjUAq7SxLE+sI+9V8vycFiM0iLb2O80s8JcfVJJTaGYrZYPNby5Ov6WolPD+XDJqAgSQ4EUCGQQEJADs=
+  recorded_at: Wed, 30 Jul 2025 02:22:25 GMT
+- request:
+    method: get
+    uri: http://deb.debian.org/icons/compressed.gif
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Proxy-Connection:
+      - keep-alive
+      User-Agent:
+      - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/138.0.0.0
+        Safari/537.36
+      Accept:
+      - image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+      Accept-Encoding:
+      - ''
+      Accept-Language:
+      - en-US,en;q=0.9
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1038'
+      Server:
+      - Apache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '1'
+      Permissions-Policy:
+      - interest-cohort=()
+      Last-Modified:
+      - Sat, 20 Nov 2004 20:16:24 GMT
+      Etag:
+      - '"40e-3e9564c23b600"'
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      Content-Type:
+      - image/gif
+      Backend:
+      - 4qpvL1tJyeV1P6Tmf0Lj8g--F_static_backend
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Wed, 30 Jul 2025 02:22:25 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-syd10169-SYD
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1753842145.932677,VS0,VE585
+      X-Req-Url:
+      - recv="/icons/compressed.gif",deliver="/icons/compressed.gif"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhFAAWAOcAAP//////zP//mf//Zv//M///AP/M///MzP/Mmf/MZv/MM//MAP+Z//+ZzP+Zmf+ZZv+ZM/+ZAP9m//9mzP9mmf9mZv9mM/9mAP8z//8zzP8zmf8zZv8zM/8zAP8A//8AzP8Amf8AZv8AM/8AAMz//8z/zMz/mcz/Zsz/M8z/AMzM/8zMzMzMmczMZszMM8zMAMyZ/8yZzMyZmcyZZsyZM8yZAMxm/8xmzMxmmcxmZsxmM8xmAMwz/8wzzMwzmcwzZswzM8wzAMwA/8wAzMwAmcwAZswAM8wAAJn//5n/zJn/mZn/Zpn/M5n/AJnM/5nMzJnMmZnMZpnMM5nMAJmZ/5mZzJmZmZmZZpmZM5mZAJlm/5lmzJlmmZlmZplmM5lmAJkz/5kzzJkzmZkzZpkzM5kzAJkA/5kAzJkAmZkAZpkAM5kAAGb//2b/zGb/mWb/Zmb/M2b/AGbM/2bMzGbMmWbMZmbMM2bMAGaZ/2aZzGaZmWaZZmaZM2aZAGZm/2ZmzGZmmWZmZmZmM2ZmAGYz/2YzzGYzmWYzZmYzM2YzAGYA/2YAzGYAmWYAZmYAM2YAADP//zP/zDP/mTP/ZjP/MzP/ADPM/zPMzDPMmTPMZjPMMzPMADOZ/zOZzDOZmTOZZjOZMzOZADNm/zNmzDNmmTNmZjNmMzNmADMz/zMzzDMzmTMzZjMzMzMzADMA/zMAzDMAmTMAZjMAMzMAAAD//wD/zAD/mQD/ZgD/MwD/AADM/wDMzADMmQDMZgDMMwDMAACZ/wCZzACZmQCZZgCZMwCZAABm/wBmzABmmQBmZgBmMwBmAAAz/wAzzAAzmQAzZgAzMwAzAAAA/wAAzAAAmQAAZgAAM+4AAN0AALsAAKoAAIgAAHcAAFUAAEQAACIAABEAAADuAADdAAC7AACqAACIAAB3AABVAABEAAAiAAARAAAA7gAA3QAAuwAAqgAAiAAAdwAAVQAARAAAIgAAEe7u7t3d3bu7u6qqqoiIiHd3d1VVVURERCIiIhEREQAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAAkACwAAAAAFAAWAAAImQBJCCTBqmDBgQgTDmQFAABDVgojEmzI0KHEhBUrWrwoMGNDihwnAvjHiqRJjhX/qVz5D+VHAFZiWmmZ8BGHji9hxqTJ4ZFAmzc1vpxJgkPPn0Y5CP04M6lPEkCN5mxoJelRqFY5TM36NGrPqV67Op0KM6rYnkup/gMq1mdamC1tdn36lijUpwjr0pSoFyUrmTJLhiTBkqXCgAA7
+  recorded_at: Wed, 30 Jul 2025 02:22:25 GMT
 recorded_with: VCR 6.2.0

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -5,9 +5,17 @@ require 'vcr'
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
   config.hook_into :webmock
-  config.ignore_localhost = true
   config.configure_rspec_metadata!
-  config.ignore_localhost = true
+
+  # Chrome calls a lot of services and they trip us up.
+  config.ignore_hosts(
+    "localhost", "127.0.0.1", "0.0.0.0",
+    "accounts.google.com",
+    "android.clients.google.com",
+    "clients2.google.com",
+    "content-autofill.googleapis.com",
+    "optimizationguide-pa.googleapis.com",
+  )
 
   # Filter sensitive environment variables
   %w[

--- a/spec/system/billy_spec.rb
+++ b/spec/system/billy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+RSpec.describe "Testing external scripts loaded in the browser" do
+  it "loads a website", :vcr do
+    visit "http://deb.debian.org:80/debian/"
+    expect(page).to have_content "Debian Archive"
+  end
+
+  it "handles HTTPS", :vcr do
+    visit "https://deb.debian.org:443/debian/"
+    expect(page).to have_content "Debian Archive"
+  end
+
+  it "stubs content" do
+    stub_request(:get, "https://deb.debian.org:443").to_return(body: "stubbed")
+    visit "https://deb.debian.org:443"
+    expect(page).to have_content "stubbed"
+  end
+end

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -4,7 +4,9 @@ require "capybara/cuprite"
 
 headless = ActiveModel::Type::Boolean.new.cast(ENV.fetch("HEADLESS", true))
 
-browser_options = {}
+browser_options = {
+  "ignore-certificate-errors" => nil,
+}
 browser_options["no-sandbox"] = nil if ENV['CI'] || ENV['DOCKER']
 
 Capybara.register_driver(:cuprite_ofn) do |app|
@@ -15,10 +17,16 @@ Capybara.register_driver(:cuprite_ofn) do |app|
     process_timeout: 60,
     timeout: 60,
     # Don't load scripts from external sources, like google maps or stripe
-    url_whitelist: [%r{http://localhost}i, %r{http://0.0.0.0}i, %r{http://127.0.0.1}],
+    url_whitelist: [
+      %r{^http://localhost}, %r{^http://0.0.0.0}, %r{http://127.0.0.1},
+
+      # Just for testing external connections: spec/system/billy_spec.rb
+      %r{^https?://deb.debian.org},
+    ],
     inspector: true,
     headless:,
-    js_errors: true
+    js_errors: true,
+    proxy: { host: Billy.proxy.host, port: Billy.proxy.port },
   )
 end
 


### PR DESCRIPTION
**:information_source: Please track all associated work under project `#77 CoopCircuits - NGI`.**

#### What? Why?

I finally got puffing-billy working. It's needed to properly test the DFC Permissions module which is a web component loading several resources from the web.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
