### PR TITLE
Losen engine gemspec requirement for Dependabot

### DIFF
--- a/engines/catalog/catalog.gemspec
+++ b/engines/catalog/catalog.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ["developers@ofn"]
   s.summary     = "Catalog domain of the OFN solution."
 
-  s.required_ruby_version = File.read(File.expand_path("../../.ruby-version", __dir__)).chomp
+  s.required_ruby_version = ">= 1.0.0" # rubocop:disable Gemspec/RequiredRubyVersion
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE.txt", "Rakefile", "README.rdoc"]
   s.metadata['rubygems_mfa_required'] = 'true'

--- a/engines/dfc_provider/dfc_provider.gemspec
+++ b/engines/dfc_provider/dfc_provider.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary     = 'Provides an API stack implementing DFC semantic ' \
                      'specifications'
 
-  spec.required_ruby_version = File.read(File.expand_path("../../.ruby-version", __dir__)).chomp
+  spec.required_ruby_version = ">= 1.0.0" # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.files = Dir["{app,config,lib}/**/*"] + ['README.md']
 

--- a/engines/order_management/order_management.gemspec
+++ b/engines/order_management/order_management.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ["developers@ofn"]
   s.summary     = "Order Management domain of the OFN solution."
 
-  s.required_ruby_version = File.read(File.expand_path("../../.ruby-version", __dir__)).chomp
+  s.required_ruby_version = ">= 1.0.0" # rubocop:disable Gemspec/RequiredRubyVersion
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE.txt", "Rakefile", "README.rdoc"]
   s.metadata['rubygems_mfa_required'] = 'true'

--- a/engines/web/web.gemspec
+++ b/engines/web/web.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ["developers@ofn"]
   s.summary     = "Web domain of the OFN solution."
 
-  s.required_ruby_version = File.read(File.expand_path("../../.ruby-version", __dir__)).chomp
+  s.required_ruby_version = ">= 1.0.0" # rubocop:disable Gemspec/RequiredRubyVersion
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE.txt", "Rakefile", "README.rdoc"]
   s.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION

#### What? Why?

- Workaround for https://github.com/dependabot/dependabot-core/issues/12795

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Dependabot doesn't seem to be able to resolve the ruby version requirement correctly. We got this message:

```
Could not find compatible versions

Because every version of web depends on Ruby = 0.0.1
  and Gemfile depends on web >= 0,
  Ruby = 0.0.1 is required.
So, because current Ruby version is = 3.1.4,
  version solving has failed.
```

We introduced the version declaration only because of Rubocop. The engines are only used in our app and are not used independently. Now I hope that a dummy declaration unblocks Dependabot.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- After this has been merged, we'll see if Dependabot opens PRs again.
- I could activate Dependabot on my fork to test but last time I found it very difficult to deactivate again. I would like to avoid all those PRs there.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
