### PR TITLE
Allow only existing deprecations in Rails 7.1

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,5 +54,33 @@ Openfoodnetwork::Application.configure do
   # Print deprecation notices to the stderr
   # config.active_support.deprecation = :stderr
 
+  # Fail tests on deprecated code unless it's a known case to solve.
+  Rails.application.deprecators.behavior = ->(message, callstack, deprecator) do
+    allowed_warnings = [
+      # List strings here to allow matching deprecations.
+      #
+      # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
+      "config.active_support.cache_format_version",
+
+      # `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2
+      "Rails.application.secrets",
+
+      "Passing the class as positional argument",
+
+      # Spree::Order model aliases `bill_address`, but `bill_address` is not an attribute. Starting in Rails 7.2, alias_attribute with non-attribute targets will raise. Use `alias_method :billing_address, :bill_address` or define the method manually. (called from initialize at app/models/spree/order.rb:188)
+      "alias_attribute with non-attribute targets will raise",
+
+      # Spree::CreditCard model aliases `cc_type` and has a method called `cc_type=` defined. Starting in Rails 7.2 `brand=` will not be calling `cc_type=` anymore. You may want to additionally define `brand=` to preserve the current behavior.
+      "model aliases",
+
+      # Setting action_dispatch.show_exceptions to true is deprecated. Set to :all instead.
+      # spec/requests/errors_spec.rb
+      "action_dispatch.show_exceptions",
+    ]
+    unless allowed_warnings.any? { |pattern| message.match(pattern) }
+      ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:raise].call(message, callstack, deprecator)
+    end
+  end
+
   config.active_job.queue_adapter = :test
 end

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -68,9 +68,6 @@ InvisibleCaptcha.timestamp_enabled = false
 InvisibleCaptcha.spinner_enabled = false
 
 RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec/fixtures').to_s
-
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
#### What? Why?

We just merged our upgrade to Rails 7.1 but the code is still emitting some deprecation warnings. This PR is fixing one warning and listing the rest. Now we know what we need to work on and the tests won't allow the introduction of any new deprecation warnings.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
