### PR TITLE
Optimise loading of language-specific date pickers

### DIFF
--- a/app/webpacker/controllers/flatpickr_controller.js
+++ b/app/webpacker/controllers/flatpickr_controller.js
@@ -1,20 +1,5 @@
 // import Flatpickr
 import Flatpickr from "stimulus-flatpickr";
-import { ar } from "flatpickr/dist/l10n/ar";
-import { cat } from "flatpickr/dist/l10n/cat";
-import { cy } from "flatpickr/dist/l10n/cy";
-import { de } from "flatpickr/dist/l10n/de";
-import { fi } from "flatpickr/dist/l10n/fi";
-import { fr } from "flatpickr/dist/l10n/fr";
-import { it } from "flatpickr/dist/l10n/it";
-import { nl } from "flatpickr/dist/l10n/nl";
-import { pl } from "flatpickr/dist/l10n/pl";
-import { pt } from "flatpickr/dist/l10n/pt";
-import { ru } from "flatpickr/dist/l10n/ru";
-import { sv } from "flatpickr/dist/l10n/sv";
-import { tr } from "flatpickr/dist/l10n/tr";
-import { en } from "flatpickr/dist/l10n/default.js";
-import { hu } from "flatpickr/dist/l10n/hu";
 import ShortcutButtonsPlugin from "shortcut-buttons-flatpickr";
 import labelPlugin from "flatpickr/dist/plugins/labelPlugin/labelPlugin";
 
@@ -24,28 +9,11 @@ export default class extends Flatpickr {
    */
   static values = { enableTime: Boolean, mode: String, defaultDate: String };
   static targets = ["start", "end"];
-  locales = {
-    ar: ar,
-    cat: cat,
-    cy: cy,
-    de: de,
-    fi: fi,
-    fr: fr,
-    it: it,
-    nl: nl,
-    pl: pl,
-    pt: pt,
-    ru: ru,
-    sv: sv,
-    tr: tr,
-    en: en,
-    hu: hu,
-  };
 
   initialize() {
     const datetimepicker = this.enableTimeValue === true;
     const mode = this.modeValue === "range" ? "range" : "single";
-    // sets your language (you can also set some global setting for all time pickers)
+    // configure flatpickr options (locale set dynamically in connect())
     this.config = {
       altInput: true,
       altFormat: datetimepicker
@@ -54,13 +22,18 @@ export default class extends Flatpickr {
       dateFormat: datetimepicker ? "Y-m-d H:i" : "Y-m-d",
       enableTime: datetimepicker,
       time_24hr: datetimepicker,
-      locale: I18n.base_locale,
       plugins: this.plugins(mode, datetimepicker),
       mode,
     };
   }
 
-  connect() {
+  async connect() {
+    const locale = await this.getFlatpickrLocale(I18n.base_locale);
+    this.config = {
+      ...this.config,
+      locale,
+    };
+
     super.connect();
     window.addEventListener("flatpickr:change", this.onChangeEvent);
     window.addEventListener("flatpickr:clear", this.clear);
@@ -162,6 +135,18 @@ export default class extends Flatpickr {
        * the records between [23:59:00 ~ 23:59:59] of today
        */
       this.fp.setDate(moment().add(1, "days").startOf("day").format());
+    }
+  }
+
+  async getFlatpickrLocale(localeCode) {
+    // null tells flatpickr to fall back to its built-in english locale
+    if (!localeCode || localeCode === "en") return null;
+
+    try {
+      const localeModule = await import(`flatpickr/dist/l10n/${localeCode}.js`);
+      return localeModule.default?.[localeCode] ?? null;
+    } catch {
+      return null;
     }
   }
 }

--- a/spec/javascripts/stimulus/flatpickr_controller_test.js
+++ b/spec/javascripts/stimulus/flatpickr_controller_test.js
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { Application } from "stimulus";
+import FlatpickrController from "../../../app/webpacker/controllers/flatpickr_controller.js";
+
+describe("FlatpickrController", () => {
+  beforeAll(() => {
+    const application = Application.start();
+    application.register("flatpickr", FlatpickrController);
+  });
+
+  describe("#getFlatpickrLocale", () => {
+    describe("returns null to trigger flatpickr fallback to english", () => {
+      test.each([
+        ["when no base_locale is set", {}],
+        ["when base_locale doesn't match a Flatpickr locale", { base_locale: "invalid-locale" }],
+        ["when base_locale is 'en'", { base_locale: "en" }],
+      ])("%s", async (_description, i18nData) => {
+        const I18n = i18nData;
+        const controller = new FlatpickrController();
+        const locale = await controller.getFlatpickrLocale(I18n.base_locale);
+        expect(locale).toBeNull();
+      });
+    });
+
+    it("returns locale object for a supported locale (fr)", async () => {
+      const controller = new FlatpickrController();
+      const locale = await controller.getFlatpickrLocale("fr");
+      expect(locale).toBeInstanceOf(Object);
+      expect(locale).toHaveProperty("weekAbbreviation");
+    });
+
+    it("caches the locale object for repeated calls", async () => {
+      const controller = new FlatpickrController();
+      const locale1 = await controller.getFlatpickrLocale("fr");
+      const locale2 = await controller.getFlatpickrLocale("fr");
+      expect(locale1).toBe(locale2);
+    });
+  });
+});


### PR DESCRIPTION
#### What? Why?

- Closes #13366

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Currently, the `flatpickr` configuration imports all of the project defined locales, regardless of the user selected language. This increases the bundle unnecessarily and will become increasingly inefficient as more translations are added.

The solution uses dynamic imports to load only the selected locale (thanks to @dacook for the suggestion in the issue). English locale is not dynamically imported, as it is already bundled by default. If no base locale is set, the locale is 'en', or a matching `flatpickr` import isn't available, `null` is passed to the locale config which triggers `flatpickr` to default to english.

##### Why move locale config from initialize to connect?
Dynamic imports for locale are async and `connect()` runs before a Promise is returned in `initialize()`, causing no pickers to load. The async logic in `connect()` instead ensures it loads locale before `super.connect()` is executed.

##### Why send null to the flatpickr locale config?
Passing null to the locale config makes `flatpickr` fall back to English, which is bundled by default, so no explicit English import is needed. Comments are in the code for clarity as it might be unclear what returning null achieves.
###### Alternative solutions considered:
- Return "en" string: locale accepts either an object or string like "en". Valid but mixing types felt confusing without clear typing.
- Import English statically: Could import English locale upfront for clarity, but it’s redundant since English is already the default. Also mixes static and dynamic imports, which may confuse.
- Import English dynamically: More complex because English locale uses a different filename and export. Also redundant and adds complexity.
- Return undefined instead of null: Can conditionally omit locale or return `undefined` to trigger default English, but adds conditional logic and complexity.

##### Potentially controversial tests
_Caches locale object_: More documentation than strict testing to show expected caching behaviour that we get for free.
_Returns locale for supported locale_: Don't want to test library internals but want to test `flatpickr` export hasn’t changed. Also means it calls the library instead of mocking.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit an admin page where date picker is used (e.g. `admin/order_cycles`)
- Switch to different locales via user language preference and confirm:
  - the picker still functions as expected across different languages
  - the correct locale is applied (e.g. language for month)
  - english fallback works correctly

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->