### PR TITLE
Fix url sanitization for Stripe authorisation URL

### DIFF
--- a/lib/stripe/authorize_response_patcher.rb
+++ b/lib/stripe/authorize_response_patcher.rb
@@ -28,7 +28,8 @@ module Stripe
       return unless %w(authorize_with_url redirect_to_url).include?(next_action_type)
 
       url = next_action[next_action_type]["url"]
-      url if url.match(%r{https?://\S+}) && url.include?("stripe.com")
+      host = URI(url).host
+      url if url.match(%r{https?://\S+}) && host.match?(/\S?stripe.com\Z/)
     end
 
     # This field is used because the Spree code recognizes and stores it

--- a/lib/stripe/authorize_response_patcher.rb
+++ b/lib/stripe/authorize_response_patcher.rb
@@ -27,9 +27,9 @@ module Stripe
       next_action_type = next_action["type"]
       return unless %w(authorize_with_url redirect_to_url).include?(next_action_type)
 
-      url = next_action[next_action_type]["url"]
-      host = URI(url).host
-      url if url.match(%r{https?://\S+}) && host.match?(/\S?stripe.com\Z/)
+      url = URI(next_action[next_action_type]["url"])
+      # Check the URL is from a stripe subdomain
+      url.to_s if url.is_a?(URI::HTTPS) && url.host.match?(/\.stripe.com\Z/)
     end
 
     # This field is used because the Spree code recognizes and stores it

--- a/spec/lib/stripe/authorize_response_patcher_spec.rb
+++ b/spec/lib/stripe/authorize_response_patcher_spec.rb
@@ -17,14 +17,35 @@ RSpec.describe Stripe::AuthorizeResponsePatcher do
 
     context "when url is found in response" do
       let(:params) {
-        { "status" => "requires_source_action",
-          "next_source_action" => { "type" => "authorize_with_url",
-                                    "authorize_with_url" => { "url" => "https://test.stripe.com/authorize" } } }
+        {
+          "status" => "requires_source_action",
+          "next_source_action" => {
+            "type" => "authorize_with_url",
+            "authorize_with_url" => { "url" => "https://www.stripe.com/authorize" }
+          }
+        }
       }
 
       it "patches response.cvv_result.message with the url in the response" do
         new_response = patcher.call!
         expect(new_response.cvv_result['message']).to eq "https://www.stripe.com/authorize"
+      end
+
+      context "with invalid url containing 'stripe.com'" do
+        let(:params) {
+          {
+            "status" => "requires_source_action",
+            "next_source_action" => {
+              "type" => "authorize_with_url",
+              "authorize_with_url" => { "url" => "https://www.stripe.com.malicious.org/authorize" }
+            }
+          }
+        }
+
+        it "patches response.cvv_result.message with nil" do
+          new_response = patcher.call!
+          expect(new_response.cvv_result['message']).to be_nil
+        end
       end
     end
   end

--- a/spec/lib/stripe/authorize_response_patcher_spec.rb
+++ b/spec/lib/stripe/authorize_response_patcher_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Stripe::AuthorizeResponsePatcher do
             "status" => "requires_source_action",
             "next_source_action" => {
               "type" => "authorize_with_url",
-              "authorize_with_url" => { "url" => "https://www.stripe.com.malicious.org/authorize" }
+              "authorize_with_url" => { "url" => "https://www.evil-stripe.com.malicious.org/authorize" }
             }
           }
         }

--- a/spec/lib/stripe/authorize_response_patcher_spec.rb
+++ b/spec/lib/stripe/authorize_response_patcher_spec.rb
@@ -2,31 +2,29 @@
 
 require 'spec_helper'
 
-module Stripe
-  RSpec.describe AuthorizeResponsePatcher do
-    describe "#call!" do
-      let(:patcher) { Stripe::AuthorizeResponsePatcher.new(response) }
-      let(:params) { {} }
-      let(:response) { ActiveMerchant::Billing::Response.new(true, "Transaction approved", params) }
+RSpec.describe Stripe::AuthorizeResponsePatcher do
+  describe "#call!" do
+    subject(:patcher) { Stripe::AuthorizeResponsePatcher.new(response) }
+    let(:params) { {} }
+    let(:response) { ActiveMerchant::Billing::Response.new(true, "Transaction approved", params) }
 
-      context "when url not found in response" do
-        it "does nothing" do
-          new_response = patcher.call!
-          expect(new_response).to eq response
-        end
+    context "when url not found in response" do
+      it "does nothing" do
+        new_response = patcher.call!
+        expect(new_response).to eq response
       end
+    end
 
-      context "when url is found in response" do
-        let(:params) {
-          { "status" => "requires_source_action",
-            "next_source_action" => { "type" => "authorize_with_url",
-                                      "authorize_with_url" => { "url" => "https://www.stripe.com/authorize" } } }
-        }
+    context "when url is found in response" do
+      let(:params) {
+        { "status" => "requires_source_action",
+          "next_source_action" => { "type" => "authorize_with_url",
+                                    "authorize_with_url" => { "url" => "https://test.stripe.com/authorize" } } }
+      }
 
-        it "patches response.cvv_result.message with the url in the response" do
-          new_response = patcher.call!
-          expect(new_response.cvv_result['message']).to eq "https://www.stripe.com/authorize"
-        end
+      it "patches response.cvv_result.message with the url in the response" do
+        new_response = patcher.call!
+        expect(new_response.cvv_result['message']).to eq "https://www.stripe.com/authorize"
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/security/code-scanning/241

Tighten url validation for the Stripe authorisation URL, as suggested in the security ticket. 
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
Place an order with a stripe payment method :
-  Start checkout 
- Choose stripe as payment method
- Proceed to confirmation page and confirm order 
  --> Order is placed successfully 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
