### PR TITLE
Revert "Redeem VINE voucher before redirecting to payment url"

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -80,6 +80,8 @@ class CheckoutController < BaseController
 
     @order.customer.touch :terms_and_conditions_accepted_at
 
+    return true if redirect_to_payment_gateway
+
     # Redeem VINE voucher
     vine_voucher_redeemer = Vine::VoucherRedeemerService.new(order: @order)
     unless vine_voucher_redeemer.redeem
@@ -92,9 +94,6 @@ class CheckoutController < BaseController
       return false
       # rubocop:enable Rails/DeprecatedActiveModelErrorsMethods
     end
-
-    return true if redirect_to_payment_gateway
-
     @order.process_payments!
     @order.confirm!
     BackorderJob.check_stock(@order)

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -625,30 +625,14 @@ RSpec.describe CheckoutController do
             expect(flash[:error]).to match "There was an error while trying to redeem your voucher"
           end
         end
-
-        context "when an external payment gateway is used" do
-          before do
-            expect(payment_method).to receive(:external_gateway?) { true }
-            expect(payment_method).to receive(:external_payment_url) { "https://example.com/pay" }
-            mock_payment_method_fetcher(payment_method)
-          end
-
-          it "redeems the voucher and redirect to the payment gateway's URL" do
-            expect(vine_voucher_redeemer).to receive(:redeem).and_return(true)
-
-            put(:update, params:)
-
-            expect(response.body).to match("https://example.com/pay").and match("redirect")
-            expect(order.reload.state).to eq "confirmation"
-          end
-        end
       end
 
       context "when an external payment gateway is used" do
         before do
+          expect(Checkout::PaymentMethodFetcher).
+            to receive_message_chain(:new, :call) { payment_method }
           expect(payment_method).to receive(:external_gateway?) { true }
           expect(payment_method).to receive(:external_payment_url) { "https://example.com/pay" }
-          mock_payment_method_fetcher(payment_method)
         end
 
         describe "confirming the order" do
@@ -708,10 +692,5 @@ RSpec.describe CheckoutController do
     expect(response.parsed_body).to eq(
       [{ "url" => "/checkout/details", "operation" => "redirectTo" }].to_json
     )
-  end
-
-  def mock_payment_method_fetcher(payment_method)
-    payment_method_fetcher = instance_double(Checkout::PaymentMethodFetcher, call: payment_method)
-    expect(Checkout::PaymentMethodFetcher).to receive(:new).and_return(payment_method_fetcher)
   end
 end


### PR DESCRIPTION

#### What? Why?

- Closes #13488 

This revert changes from #13459, this is the only PR affecting payment which should hopefully fix or mitigate the issue with Stripe payment

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
