### PR TITLE
Bump stripe v13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'state_machines-activerecord'
 gem 'stringex', '~> 2.8.5', require: false
 
 gem 'paypal-sdk-merchant', '1.117.2'
-gem 'stripe', '~> 12'
+gem 'stripe'
 
 gem 'devise'
 gem 'devise-encryptable'

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'state_machines-activerecord'
 gem 'stringex', '~> 2.8.5', require: false
 
 gem 'paypal-sdk-merchant', '1.117.2'
-gem 'stripe'
+gem 'stripe', '~> 12'
 
 gem 'devise'
 gem 'devise-encryptable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -828,7 +828,7 @@ GEM
       redis (>= 4.0, < 6.0)
     stringex (2.8.6)
     stringio (3.1.0)
-    stripe (12.6.0)
+    stripe (13.5.1)
     swd (2.0.3)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -1046,7 +1046,7 @@ DEPENDENCIES
   stimulus_reflex
   stimulus_reflex_testing!
   stringex (~> 2.8.5)
-  stripe (~> 12)
+  stripe
   timecop
   turbo-rails
   turbo_power

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -828,7 +828,7 @@ GEM
       redis (>= 4.0, < 6.0)
     stringex (2.8.6)
     stringio (3.1.0)
-    stripe (11.1.0)
+    stripe (12.6.0)
     swd (2.0.3)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -1046,7 +1046,7 @@ DEPENDENCIES
   stimulus_reflex
   stimulus_reflex_testing!
   stringex (~> 2.8.5)
-  stripe
+  stripe (~> 12)
   timecop
   turbo-rails
   turbo_power


### PR DESCRIPTION
#### What? Why?

* v13 Please refer to our [migration guide for v13](https://github.com/stripe/stripe-ruby/wiki/Migration-guide-for-v13) for more information about the backwards incompatible changes.
  * Move `StripeClient` and requestor logic to `APIRequestor`
  * Repurpose and introduce StripeClient as the the entry-point to the service-based pattern
  * Other breaking changes
*  v12 This release changes the pinned API version to 2024-06-20. Please read the [API Changelog](https://docs.stripe.com/changelog/2024-06-20) and carefully review the API changes before upgrading.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
