### PR TITLE
Fix link to enterprise payment methods tab

### DIFF
--- a/app/assets/javascripts/admin/payment_methods/controllers/stripe_controller.js.coffee
+++ b/app/assets/javascripts/admin/payment_methods/controllers/stripe_controller.js.coffee
@@ -15,4 +15,4 @@ angular.module("admin.paymentMethods").controller "StripeController", ($scope, $
     permalink = shops.filter((shop) ->
       shop.id == $scope.paymentMethod.preferred_enterprise_id
     )[0].permalink
-    "/admin/enterprises/#{permalink}/edit#/payment_methods"
+    "/admin/enterprises/#{permalink}/edit#/payment_methods_panel"

--- a/spec/system/admin/payment_method_spec.rb
+++ b/spec/system/admin/payment_method_spec.rb
@@ -73,10 +73,24 @@ RSpec.describe '
         select2_select "Missing", from: "payment_method_preferred_enterprise_id"
         expect(page).to have_selector "#stripe-account-status .alert-box.error",
                                       text: 'No Stripe account exists for this enterprise.'
-        connect_one = 'Connect One'
-        expect(page).to have_link connect_one,
-                                  href: edit_admin_enterprise_path(missing_account_enterprise,
-                                                                   anchor: "/payment_methods_panel")
+        click_link 'Connect One' # opens in new tab
+
+        new_window = windows.last
+        page.within_window new_window do
+          expect(page).to have_content "Settings: Missing"
+          # we should be on the Payment Methods tab already
+          expect(page).to have_content "Use the button to the right to get started."
+          page.find("a", text: "Connect with Stripe").click # it's not a proper link without href
+
+          expect(page).to have_content "connect your Stripe account to the OFN."
+          href = connect_admin_stripe_accounts_path(enterprise_id: missing_account_enterprise)
+          expect(page).to have_link "I Agree", href:
+
+          # Blocked by capybara. probably don't need to test this.
+          # click_link "I Agree"
+          # expect(page).to have_current_path("https://connect.stripe.com/", url: true)
+        end
+        new_window.close
 
         select2_select "Revoked", from: "payment_method_preferred_enterprise_id"
         expect(page).to have_selector "#stripe-account-status .alert-box.error",

--- a/spec/system/admin/payment_method_spec.rb
+++ b/spec/system/admin/payment_method_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe '
         connect_one = 'Connect One'
         expect(page).to have_link connect_one,
                                   href: edit_admin_enterprise_path(missing_account_enterprise,
-                                                                   anchor: "/payment_methods")
+                                                                   anchor: "/payment_methods_panel")
 
         select2_select "Revoked", from: "payment_method_preferred_enterprise_id"
         expect(page).to have_selector "#stripe-account-status .alert-box.error",


### PR DESCRIPTION
#### What? Why?
I clicked on a link and got confused! Hopefully this saves other people the confusion.

It looked hard to add a system spec to cover it, so I tried to avoid the temptation.. but gave in. So now it's covered by a system spec (mostly)



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit admin create new payment method page
- Select Stripe, then an enterprise that is not connected to stripe
<img width="564" height="260" alt="Screenshot 2025-08-20 at 1 08 40 pm" src="https://github.com/user-attachments/assets/94fee932-14db-4fdf-9606-d65a2b9919e2" />

- Click **Connect One**
- A new tab will open, showing the settings for the enterprise. **The Payment Methods** tab should be pre-selected, so you can see the Stripe button
<img width="544" height="138" alt="Screenshot 2025-08-20 at 1 09 22 pm" src="https://github.com/user-attachments/assets/9e30d7be-72a0-436c-8471-5ff24a347737" />



#### Release notes
<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
