### PR TITLE
Upgrade ActiveMerchant to v1.137.0 and rexml to 3.3.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ gem "active_storage_validations"
 gem "aws-sdk-s3", require: false
 gem "image_processing"
 
-gem 'activemerchant', '>= 1.137.0'
-gem 'angular-rails-templates', '>= 0.3.0'
+gem 'activemerchant'
+gem 'angular-rails-templates'
 gem 'ransack', '~> 4.1.0'
 gem 'responders'
 gem 'webpacker', '~> 5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -955,13 +955,13 @@ DEPENDENCIES
   actionpack-action_caching
   active_model_serializers (= 0.8.4)
   active_storage_validations
-  activemerchant (>= 1.137.0)
+  activemerchant
   activerecord-import
   activerecord-postgresql-adapter
   activerecord-session_store
   acts-as-taggable-on
   acts_as_list (= 1.0.4)
-  angular-rails-templates (>= 0.3.0)
+  angular-rails-templates
   angular_rails_csrf
   angularjs-file-upload-rails (~> 2.4.1)
   angularjs-rails (= 1.8.0)


### PR DESCRIPTION
#### What? Why?

- Closes #13497

Upgraded dependencies to ensure security and compatibility with the latest releases:

- **ActiveMerchant → v1.137.0**  
  - Includes updates for Stripe Payment Intents and other improvements.  
  - Helps maintain compatibility with modern payment flows.  

- **rexml → v3.3.2**  
  - Resolves **CVE-2024-39908** security vulnerability.  
  - Keeps XML parsing secure and up to date.  

This upgrade keeps the project current, reduces security risks, and ensures smoother payment processing with Stripe.

#### What should we test?

- Make sure that all the use cases related to stripe checkout should pass
- Plus need to make sure that the following issue doesn't happen https://github.com/openfoodfoundation/openfoodnetwork/issues/13488, we need to keep in mind [these steps as well](https://openfoodnetwork.slack.com/archives/C02TZ6X00/p1756107560274649?thread_ts=1755520985.856429&cid=C02TZ6X00).

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes  
- [ ] API changes (V0, V1, DFC or Webhook)  
- [x] Technical changes only  
- [ ] Feature toggled  

#### Dependencies

Following PR should be merged before this one:
- #13506 
- #13493 
