### PR TITLE
Fix missed I18n translations for enterprises sells options

### DIFF
--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -72,9 +72,8 @@ module Admin
     end
 
     def enterprise_sells_options
-      Enterprise::SELLS.map do |s|
-        [I18n.t("admin.enterprises.admin_index.sells_options.#{s}"), s]
-      end
+      scope = "admin.enterprises.admin_index.sells_options"
+      Enterprise::SELLS.map { |s| [I18n.t(s, scope:), s] }
     end
 
     private

--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -71,6 +71,12 @@ module Admin
       "#{enterprise_attachment_removal_panel}_panel"
     end
 
+    def enterprise_sells_options
+      Enterprise::SELLS.map do |s|
+        [I18n.t("admin.enterprises.admin_index.sells_options.#{s}"), s]
+      end
+    end
+
     private
 
     def build_enterprise_side_menu_items(is_shop:, show_options: ) # rubocop:disable Metrics/MethodLength

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -28,7 +28,7 @@
             = enterprise_form.check_box :is_primary_producer
             = t('.producer')
           - if spree_current_user.admin?
-            %td= enterprise_form.select :sells, Enterprise::SELLS, {}, class: 'select2 fullwidth'
+            %td= enterprise_form.select :sells, enterprise_sells_options, {}, class: 'select2 fullwidth'
           %td= enterprise_form.check_box :visible, {}, 'public', 'hidden'
           - if spree_current_user.admin?
             %td= enterprise_form.select :owner_id, enterprise.users.map{ |e| [ e.email, e.id ] }, {}, class: "select2 fullwidth"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1518,6 +1518,11 @@ en:
         visible: Visible?
         owner: Owner
         producer: Producer
+        sells_options:
+          unspecified: unspecified
+          none: none
+          own: own
+          any: any
       change_type_form:
         producer_profile: Producer Profile
         connect_ofn: Connect through OFN

--- a/spec/helpers/admin/enterprises_helper_spec.rb
+++ b/spec/helpers/admin/enterprises_helper_spec.rb
@@ -50,4 +50,10 @@ RSpec.describe Admin::EnterprisesHelper do
       expect(visible_items.pluck(:name)).to include "connected_apps"
     end
   end
+
+  describe '#enterprise_sells_options' do
+    it 'returns sells options with translations' do
+      expect(helper.enterprise_sells_options.map(&:first)).to eq %w[unspecified none own any]
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #13356 

Because of the sells options is an array inside Enterprises::SELLS, I thought it would be better to use the values as keys in our locales files. As I understood correctly other locales will be filled after Transifex find changes in en.yml file? So to test it locally you should temporarily add such translations in other locales files


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Go to Admin > Enterprises (as an admin user)
- The selectors under column "Sells" should show translated labels

#### Release notes


Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled



The title of the pull request will be included in the release notes.


#### Dependencies

#### Documentation updates

