### PR TITLE
Add missing timecop gem to fix master build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -174,6 +174,7 @@ group :test do
   gem 'puffing-billy'
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
+  gem 'timecop'
   gem 'undercover', require: false
   gem 'vcr', require: false
   gem 'webmock', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -842,6 +842,7 @@ GEM
     thor (1.4.0)
     thread-local (1.1.0)
     tilt (2.3.0)
+    timecop (0.9.10)
     timeout (0.4.3)
     ttfunk (1.8.0)
       bigdecimal (~> 3.1)
@@ -1048,6 +1049,7 @@ DEPENDENCIES
   stimulus_reflex_testing!
   stringex (~> 2.8.5)
   stripe
+  timecop
   turbo-rails
   turbo_power
   undercover


### PR DESCRIPTION
#### What? Why?

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
Right now, the master build is broken due to the missing timecop gem. This PR intends to fix that by adding that gem


#### What should we test?
- Build should be green

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled
