### PR TITLE
Add CQCM staging server to platforms to share data with

### DIFF
--- a/engines/dfc_provider/app/controllers/dfc_provider/platforms_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/platforms_controller.rb
@@ -6,6 +6,7 @@ module DfcProvider
     #   local ID => semantic ID
     PLATFORM_IDS = {
       'cqcm-dev' => "https://api.proxy-dev.cqcm.startinblox.com/profile",
+      'cqcm-stg' => "https://api.proxy-stg.cqcm.startinblox.com/profile",
     }.freeze
 
     prepend_before_action :move_authenticity_token

--- a/engines/dfc_provider/app/services/api_user.rb
+++ b/engines/dfc_provider/app/services/api_user.rb
@@ -4,6 +4,7 @@
 class ApiUser
   CLIENT_MAP = {
     "https://waterlooregionfood.ca/portal/profile" => "cqcm-dev",
+    "https://api.proxy-stg.cqcm.startinblox.com/profile" => "cqcm-stg",
   }.freeze
 
   def self.from_client_id(client_id)

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -65,7 +65,11 @@ module OpenFoodNetwork
         Show the hub's address as shipping address on pickup orders.
       DESC
       "cqcm-dev" => <<~DESC,
-        Show DFC Permissions interface to share data with CQCM dev platform.
+        Show DFC Permissions interface with development platform.
+      DESC
+      "cqcm-stg" => <<~DESC,
+        Show DFC Permissions interface to share data with CQCM staging platform.
+        After approval, enteprises should apppear on https://cqcm-map.startinblox.com/.
       DESC
     }.merge(conditional_features).freeze;
 

--- a/lib/tasks/reset.rake
+++ b/lib/tasks/reset.rake
@@ -3,16 +3,19 @@
 require 'sidekiq/api'
 
 namespace :ofn do
+  desc "Reset databases and load sample data"
   task reset_sample_data: :environment do
     Rake::Task["ofn:reset"].invoke
     Rake::Task["ofn:sample_data"].invoke
   end
 
+  desc "Reset database and jobs"
   task reset: :environment do
     Rake::Task["ofn:reset_sidekiq"].invoke
     Rake::Task["db:reset"].invoke
   end
 
+  desc "Clear all Sidekiq jobs"
   task reset_sidekiq: :environment do
     # Clear retry set
     Sidekiq::RetrySet.new.clear


### PR DESCRIPTION
#### What? Why?

You should now be able to share your enterprise with https://cqcm-map.startinblox.com/.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Enable feature `cqcm-stg`.
- Go to edit an enterprise.
- Click on the Connected Apps tab.
- Share your data with the staging platform.
- ??? Any other manual approvals???

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
