### PR TITLE
Lock sprockets dependency to major version 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,10 @@ gem 'ransack', '~> 4.1.0'
 gem 'responders'
 gem 'webpacker', '~> 5'
 
+# Indirect dependency but we access it directly in JS specs.
+# It turns out to be hard to upgrade but please do if you can.
+gem 'sprockets', '~> 3.7'
+
 gem 'i18n'
 gem 'i18n-js', '~> 3.9.0'
 gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -801,7 +801,8 @@ GEM
       spring (>= 0.9.1)
     spring-commands-rubocop (0.4.0)
       spring (>= 1.0)
-    sprockets (3.7.2)
+    sprockets (3.7.5)
+      base64
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1043,6 +1043,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-commands-rubocop
+  sprockets (~> 3.7)
   state_machines-activerecord
   stimulus_reflex
   stimulus_reflex_testing!


### PR DESCRIPTION
#### What? Why?

Many Dependabot updates bump sprockets with other gems but the bumping the major version breaks our app. I had a quick go at upgrading but got stuck. So for now I want to lock the dependency so that other gems can get updated more easily without causing trouble due to an unrelated gem update. Examples:

* #13490
* #13482
* #13473
* #13472
* #13471

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
