### PR TITLE
Remove retired hub_address feature

### DIFF
--- a/app/views/checkout/_summary.html.haml
+++ b/app/views/checkout/_summary.html.haml
@@ -11,7 +11,7 @@
         = @order.shipping_method.name
         %em.fees= payment_or_shipping_price(@order.shipping_method, @order)
       .two-columns
-        = render "delivery_details" if @order.shipping_method.delivery? || feature?(:hub_address)
+        = render "delivery_details" if @order.shipping_method.delivery?
         - if @order.shipping_method.description.present?
           %div
             .summary-subtitle

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -61,9 +61,6 @@ module OpenFoodNetwork
       "inventory" => <<~DESC,
         Enable the inventory.
       DESC
-      "hub_address" => <<~DESC,
-        Show the hub's address as shipping address on pickup orders.
-      DESC
       "cqcm-dev" => <<~DESC,
         Show DFC Permissions interface to share data with CQCM dev platform.
       DESC


### PR DESCRIPTION
#### What? Why?

- Follow-up from #13402 
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Go through checkout selecting different delivery methods.
- A normal delivery method should always show the delivery details on the summary page.
- A pickup method should never show the delivery details.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
