### PR TITLE
Remove project write permissions from Dependabot PR workflow

### DIFF
--- a/.github/workflows/move-dependency-pr-to-code-review.yml
+++ b/.github/workflows/move-dependency-pr-to-code-review.yml
@@ -2,7 +2,6 @@ name: Auto-move Dependabot PRs to Code Review
 permissions:
   contents: read
   pull-requests: read
-  project: write
 
 on:
   pull_request:


### PR DESCRIPTION
#### What? Why?

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- Fixes project value error in the workflow
- More context: https://github.com/openfoodfoundation/openfoodnetwork/pull/13546#issuecomment-3374578941

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Project value error should not occur on any PR merge

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
