### PR TITLE
Update sum calculation in order_cycle_customer_totals spec

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_customer_totals.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_customer_totals.rb
@@ -23,9 +23,11 @@ module Reporting
             product: product_name,
             variant: variant_name,
 
-            quantity: proc { |line_items| line_items.to_a.sum(&:quantity) },
-            item_price: proc { |line_items| line_items.sum(&:amount) },
-            item_fees_price: proc { |line_items| line_items.sum(&:amount_with_adjustments) },
+            quantity: proc { |line_items| line_items.to_a.map(&:quantity).sum(&:to_) },
+            item_price: proc { |line_items| line_items.map(&:amount).sum(&:to_f) },
+            item_fees_price: proc { |line_items|
+              line_items.map(&:amount_with_adjustments).sum(&:to_f)
+            },
             admin_handling_fees: proc { |_line_items| "" },
             ship_price: proc { |_line_items| "" },
             pay_fee_price: proc { |_line_items| "" },
@@ -66,7 +68,9 @@ module Reporting
 
             order_number: proc { |line_items| line_items.first.order.number },
             date: proc { |line_items| line_items.first.order.completed_at.strftime("%F %T") },
-            final_weight_volume: proc { |line_items| line_items.sum(&:final_weight_volume) },
+            final_weight_volume: proc { |line_items|
+              line_items.map(&:final_weight_volume).sum(&:to_f)
+            },
             shipment_state: proc { |line_items| line_items.first.order.shipment_state },
           }
         end


### PR DESCRIPTION
#### What? Why?

- Closes [#13270](https://github.com/openfoodfoundation/openfoodnetwork/issues/13270)

Initial objective was to fix a warning, but it was not possible to reproduce the issue.
Then, we decide to update the sum calculation to be consistent with [previous changes](https://github.com/openfoodfoundation/openfoodnetwork/commit/4962304a487e2bafd0d830475adc7870afcfa42f).


#### What should we test?
It is a refactoring, unit tests are already provided for this change.

#### Release notes
- Update sum calculation in reports

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled
