### PR TITLE
Deactivate Puffing Billy to avoid hanging specs

### DIFF
--- a/spec/system/admin/enterprises/dfc_permissions_spec.rb
+++ b/spec/system/admin/enterprises/dfc_permissions_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe "DFC Permissions", feature: "cqcm-dev", vcr: true do
   let(:enterprise) { create(:enterprise) }
 
   before do
+    skip "Puffing Billy seems to make our rspec processes hand at the end."
+  end
+
+  before do
     login_as enterprise.owner
   end
 

--- a/spec/system/admin/enterprises/dfc_permissions_spec.rb
+++ b/spec/system/admin/enterprises/dfc_permissions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "DFC Permissions", feature: "cqcm-dev", vcr: true do
   let(:enterprise) { create(:enterprise) }
 
   before do
-    skip "Puffing Billy seems to make our rspec processes hand at the end."
+    skip "Puffing Billy seems to make our rspec processes hang at the end."
   end
 
   before do

--- a/spec/system/admin/enterprises/images_spec.rb
+++ b/spec/system/admin/enterprises/images_spec.rb
@@ -71,7 +71,9 @@ RSpec.describe "Managing enterprise images" do
           click_button "Confirm"
         end
 
-        expect(flash_message).to match(/Logo removed/)
+        # There's a race condition.
+        # Either of these messages can be observed.
+        expect(flash_message).to match /(Logo removed)|(Enterprise .* updated)/
 
         within ".page-admin-enterprises-form__logo-field-group" do
           expect_no_preview_image

--- a/spec/system/billy_spec.rb
+++ b/spec/system/billy_spec.rb
@@ -3,6 +3,10 @@
 require 'system_helper'
 
 RSpec.describe "Testing external scripts loaded in the browser" do
+  before do
+    skip "Puffing Billy seems to make our rspec processes hand at the end."
+  end
+
   it "loads a website", :vcr do
     visit "http://deb.debian.org:80/debian/"
     expect(page).to have_content "Debian Archive"

--- a/spec/system/billy_spec.rb
+++ b/spec/system/billy_spec.rb
@@ -4,7 +4,7 @@ require 'system_helper'
 
 RSpec.describe "Testing external scripts loaded in the browser" do
   before do
-    skip "Puffing Billy seems to make our rspec processes hand at the end."
+    skip "Puffing Billy seems to make our rspec processes hang at the end."
   end
 
   it "loads a website", :vcr do

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -32,7 +32,10 @@ Capybara.register_driver(:cuprite_ofn) do |app|
     inspector: true,
     headless:,
     js_errors: true,
-    proxy: { host: Billy.proxy.host, port: Billy.proxy.port },
+    # Puffing Billy seems to make our rspec processes hand at the end.
+    # Deactivating for now.
+    #
+    # proxy: { host: Billy.proxy.host, port: Billy.proxy.port },
   )
 end
 

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -32,7 +32,7 @@ Capybara.register_driver(:cuprite_ofn) do |app|
     inspector: true,
     headless:,
     js_errors: true,
-    # Puffing Billy seems to make our rspec processes hand at the end.
+    # Puffing Billy seems to make our rspec processes hang at the end.
     # Deactivating for now.
     #
     # proxy: { host: Billy.proxy.host, port: Billy.proxy.port },


### PR DESCRIPTION
#### What? Why?

Deactivates Puffing Billy which seems to hand at exit of RSpec.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Run specs several times and observe any hanging processes.

Runs:

* https://github.com/mkllnk/openfoodnetwork/actions/runs/18331867727
* https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/18332133828?pr=13575
* https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/18332133828?pr=13575
* https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/18332661704/attempts/1?pr=13575
* https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/18332661704?pr=13575

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
