### PR TITLE
Add env var option for test log level

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -66,6 +66,9 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  # Change to reduce unecessary logging
+  config.log_level = ENV.fetch("RAILS_TEST_LOG_LEVEL", :debug)
+
   # Fail tests on deprecated code unless it's a known case to solve.
   Rails.application.deprecators.behavior = ->(message, callstack, deprecator) do
     allowed_warnings = [


### PR DESCRIPTION
Inspired by #13564. Open to discussion.

The test log level is already debug by default, but perhaps you don't want that because it results in a very large file over time, which isn't automatically cleaned up.


In that case, why not change the default, maybe to :info?

Or should i be using log rotation on my dev env? Or should I be running `rails log:clear` regularly?

#### What should a dev test?
Note that you need to stop spring for config changes to take effect. 
I tested this:

```sh
rails log:clear

ls -la log/test.log
# -rw-r--r--@ 1 dcook  staff  0  8 Oct 14:04 log/test.log

spring stop

RAILS_TEST_LOG_LEVEL=fatal rspec spec/services/sets/model_set_spec.rb

ls -la log/test.log
# -rw-r--r--@ 1 dcook  staff  0  8 Oct 14:04 log/test.log

spring stop
```

