### PR TITLE
use pull_request_target to run action in context of the base repo rather than forked dependabot repo

### DIFF
--- a/.github/workflows/move-dependency-pr-to-code-review.yml
+++ b/.github/workflows/move-dependency-pr-to-code-review.yml
@@ -4,7 +4,7 @@ permissions:
   pull-requests: read
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
This change updates the workflow trigger from pull_request to pull_request_target in the move-dependency-pr-to-code-review.yml file.
The motivation for this change is that workflows triggered by pull_request events run in the context of the forked repository, which means they don’t have access to repository secrets.
