### PR TITLE
Fix typo in getting started guide

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -73,7 +73,7 @@ To login as the default user, use:
     email: ofn@example.com
     password: ofn123
     
-Seee [Locale and sample data] about loading data.
+See [Locale and sample data] about loading data.
 
 ### Testing
 


### PR DESCRIPTION
#### What? Why?

I was reading the getting started guide and noticed this typo.

#### What should we test?

No testing needed, this is docs only.