### PR TITLE
Use supported RSpec syntax

### DIFF
--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -670,7 +670,7 @@ RSpec.describe Spree::Payment do
                 source: card,
                 payment_method:
               )
-            end.should raise_error(Spree::Core::GatewayError)
+            end.to raise_error(Spree::Core::GatewayError)
           end
         end
 


### PR DESCRIPTION
#### What? Why?

This spec was using a very old syntax no longer supported by RSpec. It's not currently influencing specs result because the spec running into the error is currently set as "pending". However, the spec is still run and the error is still visible.

Fixing the syntax does not fix the spec, but lets it get a bit further.

#### What should we test?

Observe in CI logs how the current error (screenshot attached) no longer shows up.

![Pending](https://github.com/user-attachments/assets/846e28db-686c-4b57-a2ce-3135224b5caf)
