### PR TITLE
Update caniuse-lite to fix `bin/webpack-dev-server` warnings

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2641,9 +2641,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001449:
-  version "1.0.30001696"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz"
-  integrity sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==
+  version "1.0.30001750"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz"
+  integrity sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
#### What? Why?

This is the result of running:

$  npx update-browserslist-db@latest

And fixes warnings like

> Browserslist: caniuse-lite is outdated. Please run:
>   npx update-browserslist-db@latest
>   Why you should do it regularly: https://github.com/browserslist/update-db#readme

when running `bin/webpack-dev-server`.

#### What should we test?

Like in https://github.com/openfoodfoundation/openfoodnetwork/pull/13120, I think passing tests is probably enough.