### PR TITLE
Fix RSpec warning when running `Reporting::ReportRenderer.render_as` unit spec

### DIFF
--- a/spec/lib/reports/report_renderer_spec.rb
+++ b/spec/lib/reports/report_renderer_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe Reporting::ReportRenderer do
 
   describe ".render_as" do
     it "raise an error if format is not supported" do
-      expect { subject.render_as("give_me_everything") }.to raise_error
+      expect {
+        subject.render_as("give_me_everything")
+      }.to raise_error(ActionController::BadRequest)
     end
   end
 


### PR DESCRIPTION
#### What? Why?

I'm trying to get a less distracting cleaner test output. And also get rid of future potential breaking changes by using better RSpec practices.


##### Before:

```
$ bundle exec rspec -e ".render_as"

(...)

Run options: include {:full_description=>/\.render_as/}
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ActionController::BadRequest: report_format should be in [:csv, :json, :html, :xlsx, :pdf]>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /path/to/spec/lib/reports/report_renderer_spec.rb:34:in `block (3 levels) in <main>'.
.

Finished in 0.02544 seconds (files took 4.08 seconds to load)
1 example, 0 failures
```

##### After this patch:

```
$ bundle exec rspec -e ".render_as"

(...)

Run options: include {:full_description=>/\.render_as/}
.

Finished in 0.02488 seconds (files took 4.09 seconds to load)
1 example, 0 failures
```

#### What should we test?

You can look for this warning in CI test output, and see it's gone now, or run the spec locally.

#### Release notes

- [x] Technical changes only

I'm not sure if this kind of PR is normally included in changelog since it's not relevant to end users, just OFN developers, but I tried to give it a good title