### PR TITLE
Fix duplicate keys warnings in some views

### DIFF
--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -65,7 +65,7 @@
                 .row
                   .small-12.columns
                     .active_table
-                      %producer.active_table_node.row.animate-repeat{id: "{{producer.path}}",
+                      %producer.active_table_node.row.animate-repeat{
                       "ng-repeat" => "producer in filteredEnterprises = (Enterprises.producers | searchEnterprises:query | taxons:activeTaxons | properties:activeProperties:'supplied_properties')",
                       "ng-controller" => "ProducerNodeCtrl",
                       "ng-class" => "{'closed' : !open(), 'open' : open(), 'inactive' : !producer.active}",

--- a/app/views/producers/index.html.haml
+++ b/app/views/producers/index.html.haml
@@ -24,7 +24,7 @@
   .row
     .small-12.columns
       .active_table
-        %producer.active_table_node.row.animate-repeat{id: "{{producer.path}}",
+        %producer.active_table_node.row.animate-repeat{
         "ng-repeat" => "producer in filteredEnterprises = (Enterprises.producers | searchEnterprises:query | taxons:activeTaxons | properties:activeProperties:'supplied_properties')",
         "ng-controller" => "ProducerNodeCtrl",
         "ng-class" => "{'closed' : !open(), 'open' : open(), 'inactive' : !producer.active}",


### PR DESCRIPTION
#### What? Why?

I'm aiming to have a cleaner less distracting spec output. And also less warnings in Rails logs.

We're passing the `id` key twice, and with different value, resulting in warnings like:

> /path/to/app/views/producers/index.html.haml:27: warning: key :id is duplicated and overwritten on line 31

Use only the latest value passed to remove the warning.

##### Before

```
$ bundle exec rspec -e "displays in an iframe" -e "logging in with a redirect set"

(...)

Run options: include {:full_description=>/(?-mix:displays\ in\ an\ iframe)|(?-mix:logging\ in\ with\ a\ redirect\ set)/}
Capybara starting Puma...
* Version 6.5.0, codename: Sky's Version
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:50292
/path/to/app/views/producers/index.html.haml:27: warning: key :id is duplicated and overwritten on line 31
./path/to/app/views/groups/show.html.haml:68: warning: key :id is duplicated and overwritten on line 72
Modal window with text `Unable to load map. Please check your browser settings and allow 3rd party cookies for this website.` has been opened, but you didn't wrap your code into (`accept_prompt` | `dismiss_prompt` | `accept_confirm` | `dismiss_confirm` | `accept_alert`), accepting by default
.

Finished in 4.54 seconds (files took 4.04 seconds to load)
2 examples, 0 failures
```

##### After

```
$ bundle exec rspec -e "displays in an iframe" -e "logging in with a redirect set"

(...)

Run options: include {:full_description=>/(?-mix:displays\ in\ an\ iframe)|(?-mix:logging\ in\ with\ a\ redirect\ set)/} Capybara starting Puma...
* Version 6.5.0, codename: Sky's Version
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:50256 .Modal window with text `Unable to load map. Please check your browser settings and allow 3rd party cookies for this website.` has been opened, but you didn't wrap your code into (`accept_prompt` | `dismiss_prompt` | `accept_confirm` | `dismiss_confirm` | `accept_alert`), accepting by default .

Finished in 4.17 seconds (files took 4.1 seconds to load) 2 examples, 0 failures
```


#### What should we test?

- Visit, for example, the producers index page, and make source page source does not change with or without this change.
- Run the specs above to verify the warning is gone

#### Release notes

- [x] Technical changes only