### PR TITLE
The PROFILE env variable should actually enable, not disable, caching

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp/caching-dev.txt").exist? || !ENV["PROFILE"] || !!ENV["DEV_CACHING"]
+  if Rails.root.join("tmp/caching-dev.txt").exist? || !!ENV["PROFILE"] || !!ENV["DEV_CACHING"]
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 


### PR DESCRIPTION
#### What? Why?

I noticed that caching is enabled in development, even if `DEV_CACHING` environment is unset and there's no `tmp/caching-dev.txt` file.

I think this may have been an unintentional change from 6d8ddd1edac17a431222c86482bceb83e8a7d32f?

#### What should we test?

Starting a development server with `DEV_CACHING` unset nor a `tmp/caching-dev.txt` file should actually disable caching, I think.

Also starting a development server with `PROFILE` set should always enable caching, in order to make profiling be more similar to production.

#### Release notes

- [x] Technical changes only