### PR TITLE
Update mini_magick to a version that plays nice with imagemagick v7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,7 +473,7 @@ GEM
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
-    mini_magick (4.11.0)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.6)
     minitest (5.25.5)


### PR DESCRIPTION
#### What? Why?

I trying to make test suite output cleaner and less distracting. Right now, a lot of messages show like the following:

```
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"
```

I don't think these warnings currently show up in CI because CI uses ubuntu 22.04, which has an older version of image magick. However, they do show up for me because I have v7 installed.

However, I still think this is a good change because it should be backwards compatible and it will make future OS upgrades easier (since new OS versions will likely ship v7, and things will just work).

#### What should we test?

- Install v7 locally and observe that the warnings are gone (for example when running `bin/rspec spec/system/admin/fees_on_orders_spec.rb`).
- Make sure image image variant creation, etc, still works fine.

I did make sure to not bump to the next major version of mini_magick (v5), since the latest v4 is enough to fix the warning, and 4.13.2 is already a year old and I see no related regressions in mini_magick repo, so I'd say passing tests is enough. And from reading changelogs of https://github.com/minimagick/minimagick/releases/tag/v4.13.2, https://github.com/minimagick/minimagick/releases/tag/v4.13.1, https://github.com/minimagick/minimagick/releases/tag/v4.13.0, and https://github.com/minimagick/minimagick/releases/tag/v4.12.0, they seem mostly related to smoothing the experience around these warnings. 

#### Release notes

- [x] Technical changes only