### PR TITLE
Silence capybara starting puma during system specs

### DIFF
--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -46,7 +46,7 @@ WebMock.disable_net_connect!(
 # in spec/support/ and its subdirectories.
 Rails.root.glob("spec/support/**/*.rb").sort.each { |f| require f }
 
-Capybara.server = :puma
+Capybara.server = :puma, { Silent: true }
 Capybara.disable_animation = true
 
 Capybara.configure do |config|


### PR DESCRIPTION
#### What? Why?

I'm trying to cleanup spec output, so that it's more meaningful and less distracting.

In this case, I'm silencing logs about capybara starting a puma server, which gets interleaved between test formatter and does not add much in my opinion

##### Before

```
$ bin/rspec spec/system/admin/order_cycles/simple_spec.rb:460
Running via Spring preloader in process 79308
Run options: include {:locations=>{"./spec/system/admin/order_cycles/simple_spec.rb"=>[460]}}

As an administrator
    I want to manage simple order cycles
  as an enterprise user
    that is a manager of the coordinator
      when variants are hidden via inventory settings
Capybara starting Puma...
* Version 6.5.0, codename: Sky's Version
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:51103
        shows a warning when going to 'outgoing products' tab

Finished in 3.95 seconds (files took 0.45949 seconds to load)
1 example, 0 failures
```

##### After

```
$ bin/rspec spec/system/admin/order_cycles/simple_spec.rb:460
Running via Spring preloader in process 79234
Run options: include {:locations=>{"./spec/system/admin/order_cycles/simple_spec.rb"=>[460]}}

As an administrator
    I want to manage simple order cycles
  as an enterprise user
    that is a manager of the coordinator
      when variants are hidden via inventory settings
        shows a warning when going to 'outgoing products' tab

Finished in 4.03 seconds (files took 0.49981 seconds to load)
1 example, 0 failures
```

#### What should we test?

Just checking the cleaner test output after this patch.

#### Release notes

- [x] Technical changes only