### PR TITLE
Upgrade cache format version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,7 @@ module Openfoodnetwork
     config.active_record.yaml_column_permitted_classes = [BigDecimal, Symbol, Time,
                                                           ActiveSupport::TimeWithZone,
                                                           ActiveSupport::TimeZone]
+    config.active_support.cache_format_version = 7.0
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -74,9 +74,6 @@ Rails.application.configure do
     allowed_warnings = [
       # List strings here to allow matching deprecations.
       #
-      # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
-      "config.active_support.cache_format_version",
-
       # `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2
       "Rails.application.secrets",
 

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -93,16 +93,6 @@
 # }
 
 
-# ** Please read carefully, this must be configured in config/application.rb **
-# Change the format of the cache entry.
-# Changing this default means that all new cache entries added to the cache
-# will have a different format that is not supported by Rails 6.1 applications.
-# Only change this value after your application is fully deployed to Rails 7.0
-# and you have no plans to rollback.
-# When you're ready to change format, add this to `config/application.rb` (NOT this file):
-#  config.active_support.cache_format_version = 7.0
-
-
 # Cookie serializer: 2 options
 #
 # If you're upgrading and haven't set `cookies_serializer` previously, your cookie serializer


### PR DESCRIPTION
#### What? Why?

It's supposed to be faster and more compact, and the previous format will become unsupported in Rails 7.2 as per Rails boot warnings:

> DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.
>
> Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
> for more information on how to upgrade.
>    (called from <main> at /path/to/config/environment.rb:5)


#### What should we test?

I think the explanation is quite clear and the change should be fully backwards compatible as long as you have already deployed the Rails 7.0 (which I assume every instance will have done before deploying the release in which this change will be included?).

#### Release notes

- [x] Technical changes only