### PR TITLE
Remove unnecessary explicit sleeps

### DIFF
--- a/spec/system/admin/order_cycles/simple_spec.rb
+++ b/spec/system/admin/order_cycles/simple_spec.rb
@@ -271,9 +271,8 @@ RSpec.describe '
         select 'Managed distributor fee', from: 'order_cycle_coordinator_fee_0_id'
 
         click_button 'Create'
-
-        # Wait for API requests to finish:
-        sleep 2
+        expect(page).to have_content 'Your order cycle has been created.'
+        click_button "Dismiss"
 
         expect(page).to have_select 'new_supplier_id', with_options: [
           "Managed supplier",

--- a/spec/system/admin/reports_spec.rb
+++ b/spec/system/admin/reports_spec.rb
@@ -142,12 +142,8 @@ RSpec.describe '
       # Now the controller response will show the loading spinner again and
       # the fallback mechanism will render the report later.
       expect(page).to have_selector ".loading"
-
-      # Wait for the fallback mechanism:
-      sleep 3
-
-      expect(page).not_to have_selector ".loading"
       expect(page).to have_content "First Name Last Name Billing Address Email"
+      expect(page).not_to have_selector ".loading"
     end
   end
 

--- a/spec/system/consumer/shops_spec.rb
+++ b/spec/system/consumer/shops_spec.rb
@@ -42,9 +42,8 @@ RSpec.describe 'Shops' do
       it "by URL" do
         pending("#9649")
         visit shops_path(anchor: "/?query=xyzzy")
-        sleep 1
-        expect(page).not_to have_content distributor.name
         expect(page).to have_content "Sorry, no results found for xyzzy. Try another search?"
+        expect(page).not_to have_content distributor.name
       end
 
       it "by typing in the search field" do


### PR DESCRIPTION
#### What? Why?

Capybara helpers already wait for the content to show up (and we already have a default of 10 seconds configured), so I don't think waiting more is actually the problem in these specs.

But if we wanted to wait more, I think it's better to pass the `:wait` option to capybara matchers, because that's a "maximum waiting value" but we'll still proceed earlier if the content shows up.

Using the same idea, I changed the positive assertions to happen first, because negative assertions do spend "max wait time" waiting, while positive assertions only wait until the content shows up.

#### What should we test?

That this PR does not make test flakiness worse.

#### Release notes

- [x] Technical changes only