### PR TITLE
[api/v0] Permit variant_unit_with_scale on variant

### DIFF
--- a/app/services/permitted_attributes/variant.rb
+++ b/app/services/permitted_attributes/variant.rb
@@ -6,9 +6,9 @@ module PermittedAttributes
       [
         :id, :sku, :on_hand, :on_hand_desired, :on_demand, :on_demand_desired,
         :shipping_category_id, :price, :unit_value,
-        :unit_description, :variant_unit, :variant_unit_name, :variant_unit_scale, :display_name,
-        :display_as, :tax_category_id, :weight, :height, :width, :depth, :taxon_ids,
-        :primary_taxon_id, :supplier_id, :tag_list
+        :unit_description, :variant_unit, :variant_unit_name, :variant_unit_scale,
+        :variant_unit_with_scale, :display_name, :display_as, :tax_category_id, :weight, :height,
+        :width, :depth, :taxon_ids, :primary_taxon_id, :supplier_id, :tag_list
       ]
     end
   end

--- a/spec/controllers/api/v0/variants_controller_spec.rb
+++ b/spec/controllers/api/v0/variants_controller_spec.rb
@@ -165,7 +165,6 @@ RSpec.describe Api::V0::VariantsController do
       expect(response).to have_http_status(:ok)
       variant.reload
       expect(variant.sku).to eq "12345"
-      pending
       expect(variant.variant_unit_with_scale).to eq "weight_1000"
     end
 


### PR DESCRIPTION
#### What? Why?
Volunteer contribution.
I was working on a integration and was confused why i couldn't update this value. Could probably work around it but gave into the temptation to look at the code. 


The attribute is still permitted on product, because it's required when creating a new product with default variant.

#### What should we test?
Hardly seems worth manually testing it.

#### Release notes
Not sure it's really worth announcing, but it adds an option to the existing v0 api.

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
