### PR TITLE
Don't run reviewdog on pushes

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,5 +1,5 @@
 name: Linters
-on: [push, pull_request]
+on: [pull_request]
 permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:


### PR DESCRIPTION
#### What? Why?

This is mainly to save CI resources.

As configured, reviewdog is meant to annotate PRs with linter errors (so you don't have to skim through logs). So it does not make sense for pushes.

In fact, on pushes rubocop action is doing nothing, and prettier action is failing with:

> reviewdog: this is not PullRequest build.
> sed: couldn't write 80 items to stdout: Broken pipe

#### What should we test?

You can check the actions tab and verify that this workflow did not run on push.

#### Release notes

- [x] Technical changes only