### PR TITLE
Follow up to old ofnEmptiesCart to ofnChangeHub rename

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/active_table_hub_link.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/active_table_hub_link.js.coffee
@@ -1,6 +1,6 @@
 angular.module('Darkswarm').directive "activeTableHubLink", (CurrentHub, CurrentOrder) ->
   # Change the text of the hub link based on CurrentHub
-  # To be used with ofnEmptiesCart
+  # To be used with ofnChangeHub
   # Takes "change" and "shop" as text string attributes
   restrict: "A"
   scope:

--- a/app/assets/javascripts/templates/partials/producer_details.html.haml
+++ b/app/assets/javascripts/templates/partials/producer_details.html.haml
@@ -12,7 +12,7 @@
     .row
       .columns.small-12
         %a.cta-hub{"ng-repeat" => "hub in enterprise.hubs | filter:{id: '!'+enterprise.id} | orderBy:'-active'",
-        "ng-href" => "{{::hub.path}}#/shop_panel", "ofn-empties-cart" => "hub",
+        "ng-href" => "{{::hub.path}}#/shop_panel",
         "ng-class" => "::{primary: hub.active, secondary: !hub.active}",
         "ng-click" => "$close()",
         "ofn-change-hub" => "hub"}


### PR DESCRIPTION

#### What? Why?

I was doing some git spelunking and noticed this.

A code rename happened back in 2015 through 9c9051498b0e9da2c5926d9300cd4fdebab6c36d, but two places were missed.

One was a code comment so did not affect anything (other than confused code readers I guess?). The other one did create a regression but was later fixed by 18d966f0de4715f89107dc28a085142a255b3d1a in 2021.

#### What should we test?

I'd say no testing is needed, this naming is no longer referenced anywhere in the code base, so nothing should break I think.

#### Release notes

- [x] Technical changes only