### PR TITLE
Error 500 checking out with Stripe, after navigating back to the Summary page

### DIFF
--- a/engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb
+++ b/engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb
@@ -18,6 +18,8 @@ module OrderManagement
       end
 
       def call!(return_url = off_session_return_url)
+        # if the payment requires_authorization (3D Secure), can't be authorized again
+        return payment if payment&.requires_authorization?
         return unless payment&.checkout?
 
         payment.authorize!(return_url)

--- a/engines/order_management/spec/services/order_management/order/stripe_sca_payment_authorize_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/stripe_sca_payment_authorize_spec.rb
@@ -19,6 +19,15 @@ module OrderManagement
           end
         end
 
+        context "when the payment already requires 3D Secure authorization" do
+          let(:payment) { create(:payment, amount: 10, state: 'requires_authorization') }
+          before { allow(order).to receive(:pending_payments).once { [payment] } }
+
+          it "returns the payment without authorizing because it has already been authorized" do
+            expect(payment_authorize.call!).to eq payment
+          end
+        end
+
         context "when a payment is present" do
           let(:payment) { create(:payment, amount: 10) }
 


### PR DESCRIPTION
#### What? Why?

- Closes #13556 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This PR fixes a 500 error that occurred when handling Stripe payments requiring 3D Secure authorization. 
Previously, the `StripeScaPaymentAuthorize` service would return `nil` for any payment not in the `checkout` state. When a payment was already in the `requires_authorization` state (after initial authorization but pending 3D Secure verification), the service returned `nil`, causing a 500 error when the code attempted to extract the `redirect_auth_url` from a nil payment object.
Now, the service checks if the payment is already in the `requires_authorization` state and returns the payment object (which contains the `redirect_auth_url`) instead of `nil`, allowing the redirect to proceed correctly.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As mentioned in the issue

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled