### PR TITLE
fix table format in edit order page

### DIFF
--- a/app/webpacker/css/darkswarm/cart-page.scss
+++ b/app/webpacker/css/darkswarm/cart-page.scss
@@ -11,8 +11,6 @@
 
 #cart-detail {
   width: 100%;
-  display: block;
-  overflow-x: auto;
 
   .cart-item-delete,
   .bought-item-delete {


### PR DESCRIPTION
#### What? Why?

- Closes #10261 

Fixes issue with table format on Desktop in order edit page.

#### What should we test?
- See issue #10261 for steps to reproduce
- Check that in large sceens, the empty space on the left of the table is no longer visible
- This issue was introduced when fixing issue #9976. I couldn't reproduce this issue, but I think its worth double checking. If it's still happening we can think of another way to prevent it, for example setting a maximum width to the table fields in mobile and making sure that the text doesn't overflow it.

#### Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

