### PR TITLE
Link to Stripe testing wiki page from the cassette regeneration script

### DIFF
--- a/script/test-stripe-live
+++ b/script/test-stripe-live
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 #
 # Test Stripe API integration and record new cassettes.
-# Requires account details in .env.test.local. You can copy from Bitwarden, or [set up a new Stripe account](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance)
+# Requires account details in .env.test.local. See [Stripe testing](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Stripe-testing) for details
 
 set -e # Exit if any command fails
 


### PR DESCRIPTION


#### What? Why?

I think this is the more relevant wiki page for someone looking into regenerating cassettes.

Also, no need to mention bitwarden explicitly, the wiki page already explains everything.

I also plan to introduce some improvements to this wiki page.

#### What should we test?

Nothing, this is just documentation.

#### Release notes

- [x] Technical changes only

#### Documentation updates

Not needed but it will be part of my effort to improve onboarding with respect to VCR testing, so I will be improving https://github.com/openfoodfoundation/openfoodnetwork/wiki/Stripe-testing, yes. 