### PR TITLE
Fix JS error when Stripe connect is disabled but Stripe API keys are setup

### DIFF
--- a/app/views/spree/users/show.html.haml
+++ b/app/views/spree/users/show.html.haml
@@ -3,7 +3,7 @@
   = inject_json_array("shops", @shops.all, Api::ShopForOrdersSerializer)
   = inject_saved_credit_cards
 
-  - if Stripe.publishable_key
+  - if Spree::Config.stripe_connect_enabled && Stripe.publishable_key
     :javascript
       angular.module('Darkswarm').value("stripeObject", Stripe("#{Stripe.publishable_key}"))
       angular.module('Darkswarm').value("stripePublishableKey", "#{Stripe.publishable_key}")

--- a/spec/system/consumer/account_spec.rb
+++ b/spec/system/consumer/account_spec.rb
@@ -112,6 +112,21 @@ RSpec.describe '
       end
     end
 
+    context "with Stripe setup" do
+      include StripeHelper
+
+      around do |example|
+        with_stripe_setup { example.call }
+      end
+
+      it "does not cause js errors even if Stripe connect is disabled" do
+        allow(Spree::Config).to receive(:stripe_connect_enabled).and_return(false)
+
+        visit "/account"
+        expect(page).to have_content "My account"
+      end
+    end
+
     context "as a disabled user" do
       before do
         user.disabled = '1'


### PR DESCRIPTION
#### What? Why?

This PR fixes an issue where the account page will run into JS errors provided that Stripe Connect checkbox is unchecked but Stripe is properly setup in the `/admin/stripe_connect_settings/edit` page.

Under that situation, visiting `/account` runs into the following JS error:

![JSError](https://github.com/user-attachments/assets/53985809-4dac-402d-992d-241cdb45e156)

This happens because the layout for the `/account` page is `darkswarm` which only includes stripe JS when `Spree::Config.stripe_connect_enabled` is set: https://github.com/openfoodfoundation/openfoodnetwork/blob/73688b954434ee50050c562b03aa6c2222d71c08/app/views/layouts/darkswarm.html.haml#L26-L28

Because of this, unless we also gate usages of `Stripe` JS to `Spree::Config.stripe_connect_enabled` as well, we'll get errors when trying to run code that has never been defined.

#### What should we test?

- Make sure Stripe Connect checkbox is unchecked but Stripe is properly setup in the `/admin/stripe_connect_settings/edit` page.
- Visit `/account` page.
- Open a JS inspector and see the error, and how this change makes it go away.

#### Release notes

I'm tagging this as "Technical changes only" because I'd say this does not affect end users, but let me know if I'm wrong and this is actually user facing.

- [x] Technical changes only