### PR TITLE
Fix reviewdog workflow failing to create checks

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,6 +2,7 @@ name: Linters
 on: [pull_request]
 permissions:
   contents: read # to fetch code (actions/checkout)
+  checks: write # to post check annotations
 jobs:
   lint:
     name: prettier and rubocop


### PR DESCRIPTION
#### What? Why?

Reviewdog (as configured by our linters workflow) is supposed to create checks for each linter and set them as failed is lint issues are found. See an example in my fork: https://github.com/deivid-rodriguez/openfoodnetwork/actions/runs/18717161451/job/53379580172.

I think this probably used to work until https://github.com/openfoodfoundation/openfoodnetwork/commit/bd6bf9315a770d73d7f9374fb600b4acdbab591d, because adding specific permissions to fetch the code automatically removed the rest of permissions.

#### What should we test?

I think, even if this is a PR from a fork, the new checks for rubocop and prettier should show up here. But we'll see.

#### Release notes

- [x] Technical changes only