### PR TITLE
Remove obsolete gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ gem 'sprockets', '~> 3.7'
 gem 'i18n'
 gem 'i18n-js', '~> 3.9.0'
 gem 'rails-i18n'
-gem 'rails_safe_tasks', '~> 1.0'
 
 gem "activerecord-import"
 gem "db2fog", github: "openfoodfoundation/db2fog", branch: "rails-7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,6 @@ GEM
     rails-i18n (7.0.10)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
-    rails_safe_tasks (1.0.0)
     railties (7.1.5.2)
       actionpack (= 7.1.5.2)
       activesupport (= 7.1.5.2)
@@ -1029,7 +1028,6 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd
   rails-i18n
-  rails_safe_tasks (~> 1.0)
   ransack (~> 4.1.0)
   redcarpet
   redis


### PR DESCRIPTION
#### What? Why?

Even without it, Rails seems to do this by default:

```console
$ RAILS_ENV=production SITE_URL=foo.bar SECRET_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx bin/rails db:drop
I, [2025-10-23T12:38:12.383244 #32647]  INFO -- : [dotenv] Loaded .env
I, [2025-10-23T12:38:12.383292 #32647]  INFO -- : [dotenv] Loaded .env
W, [2025-10-23T12:38:12.411675 #32647]  WARN -- [Bugsnag]: No valid API key has been set, notifications will not be sent
bin/rails aborted!
ActiveRecord::ProtectedEnvironmentError: You are attempting to run a destructive action against your 'production' database.
If you are sure you want to continue, run the same command with the environment variable:
DISABLE_DATABASE_ENVIRONMENT_CHECK=1

Tasks: TOP => db:drop => db:check_protected_environments
(See full trace by running task with --trace)
```

And the gem hasn't been updated in 10 years, so probably best to get rid of it.

#### What should we test?

Not sure, perhaps try in an staging enviroment which should have all production settings set, but still be fine to perform destructive actions on it.
  
#### Release notes

- [x] Technical changes only