### PR TITLE
Make the width of "Back to Store" and "Back to Website" buttons consistent with other buttons in order confirmation page

### DIFF
--- a/app/views/spree/orders/form/_update_buttons.html.haml
+++ b/app/views/spree/orders/form/_update_buttons.html.haml
@@ -1,21 +1,19 @@
 .row
-  .columns.small-12.medium-5
-    - if current_order.nil? || current_order.distributor.nil? || current_order.distributor == @order.distributor
-      - if current_order&.line_items.present?
-        = link_to main_app.cart_path, :class => "button expand" do
-          = t(:order_back_to_cart)
-      - else
-        .columns.small-12.medium-6
-          = link_to "#{main_app.enterprise_shop_path(@order.distributor)}#/shop_panel", class: "button expand" do
-            = t(:order_back_to_store)
-        .columns.small-12.medium-6
-          - if @order.distributor.website.present?
-            = link_to_service "https://", @order.distributor.website, class: "button expand" do
-              = t(:order_back_to_website)
+  - if current_order.nil? || current_order.distributor.nil? || current_order.distributor == @order.distributor
+    - if current_order&.line_items.present?
+      = link_to main_app.cart_path, :class => "button expand" do
+        = t(:order_back_to_cart)
     - else
-      &nbsp;
+      .columns.small-12.medium-3
+        = link_to "#{main_app.enterprise_shop_path(@order.distributor)}#/shop_panel", class: "button expand" do
+          = t(:order_back_to_store)
+      .columns.small-12.medium-3
+        - if @order.distributor.website.present?
+          = link_to_service "https://", @order.distributor.website, class: "button expand" do
+            = t(:order_back_to_website)
+  - else
+    &nbsp;
   - if order.changes_allowed?
-    .columns.show-for-medium-up.medium-1 &nbsp;
     .columns.small-12.medium-3
       = link_to main_app.cancel_order_path(@order), method: :put, class: "button secondary expand", "data-confirm": t('orders_confirm_cancel') do
         %i.ofn-i_009-close


### PR DESCRIPTION
#### What? Why?

- Closes #13651

The width of "Back to Store" and "Back to Website" buttons in order confirmation page are not consistent with the other buttons. This is fixed in this PR.

**Code changes:**
- Removed unwanted divs `.columns.small-12.medium-5` and `.columns.show-for-medium-up.medium-1 &nbsp;` which were causing this styling issue
- Changed `.columns.small-12.medium-6` to `.columns.small-12.medium-3` for "Back to Store" and "Back to Website" button divs to make it consistent with other buttons

**Before:**
<img width="399" height="860" alt="Screenshot 2025-10-25 220435" src="https://github.com/user-attachments/assets/c9becc05-4473-40d6-b1ed-d8d38fecb19e" />
<img width="1269" height="532" alt="Screenshot 2025-10-25 220421" src="https://github.com/user-attachments/assets/818345c8-4143-48e9-bc03-4f9ebf06c6b7" />

**After:**
<img width="394" height="851" alt="Screenshot 2025-10-25 214801" src="https://github.com/user-attachments/assets/45e8bfd6-0aa3-46bc-b518-15580c041424" />
<img width="1312" height="529" alt="Screenshot 2025-10-25 214818" src="https://github.com/user-attachments/assets/4a369071-b98c-437b-aaae-41c121d2c459" />

####
 What should we test?
- As a hub, on the Shop preferences tab, toggle the option "Customers can change / cancel orders while order cycle is open"
- As a hub, make sure you have the Address field filled in, in the Contacts tab
- As a customer place an order
- On the order confirmation page, verify the width of the buttons "Back to Store" and "Back to Website" are consistent with the other buttons. 
- Check the button size for both desktop view and mobile view

#### Release notes
`NA`

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

#### Dependencies
`NA`

#### Documentation updates
`NA`
