### PR TITLE
Fix tag rule visibility select box options hidden by save bar

### DIFF
--- a/app/webpacker/css/admin/components/save_bar.scss
+++ b/app/webpacker/css/admin/components/save_bar.scss
@@ -1,7 +1,7 @@
 #save-bar {
   position: fixed;
   width: 100%;
-  z-index: 100;
+  z-index: $save-bar-z-index;
   bottom: 0px;
   left: 0;
   padding: 8px 8px;

--- a/app/webpacker/css/admin_v3/components/tom_select.scss
+++ b/app/webpacker/css/admin_v3/components/tom_select.scss
@@ -99,6 +99,7 @@
   .ts-dropdown {
     // Cover up the control with the input
     top: 0;
+    z-index: $ts-dropdown-z-index;
   }
 
   .dropdown-input-wrap::after {

--- a/app/webpacker/css/admin_v3/globals/variables.scss
+++ b/app/webpacker/css/admin_v3/globals/variables.scss
@@ -187,3 +187,6 @@ $btn-condensed-height:           26px !default;
 $tos-banner-z-index: 1001;
 $flash-message-z-index: 1000;
 $tag-drop-down-z-index: 999;
+
+$ts-dropdown-z-index: 101;
+$save-bar-z-index: 100;


### PR DESCRIPTION
#### What? Why?

One flaky spec failure revealed that tag rule visibility select box options were getting hidden under the save bar.

It seems better that they are not overlapped and that should also fix the flaky spec.

To fix it, make sure they have a higher z-index than the save bar.

- Closes #13659.


#### Before

![Before](https://github.com/user-attachments/assets/2ffe6fff-c7a1-4e1a-b019-fb499166ef9b)

#### After

![After](https://github.com/user-attachments/assets/e16abb7b-16c6-447d-92cf-48dd24e7f8f9)

#### What should we test?

- Visit the tag rules page and try to create a tag rule with the save-bar close enough to potentially get hidden. Compare the result before and after this PR.
- Hope that the flaky does not come back, because the select box is no longer overlapped.

#### Release notes

- [x] User facing changes