### PR TITLE
Update turbo_power npm and rubygem packages together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,28 @@
 # Most of the configuration here is not used for security updates though.
 
 version: 2
+
+multi-ecosystem-groups:
+  turbo_power:
+    schedule:
+      interval: "daily"
+
 updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    patterns: ["turbo_power"]
+    multi-ecosystem-group: "turbo_power"
+
+    # Only specific requirements are specified in Gemfile, so don't touch it.
+    versioning-strategy: lockfile-only
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    patterns: ["turbo_power"]
+    multi-ecosystem-group: "turbo_power"
+
+    # All versions are specified in package.json, so please update them.
+    versioning-strategy: increase
 
   - package-ecosystem: "bundler"
     directory: "/"


### PR DESCRIPTION
#### What? Why?

The libraries seem very interrelated so probably best to upgrade them in lockstep.

If this PR is merged, I assume Dependabot would create a combined PR and (maybe) close https://github.com/openfoodfoundation/openfoodnetwork/pull/13041 and https://github.com/openfoodfoundation/openfoodnetwork/pull/13490.

#### What should we test?

I tested this against my fork and https://github.com/deivid-rodriguez/openfoodnetwork/pull/4 was created. Also no duplicated separate PRs for each library were created.

#### Release notes

- [x] Technical changes only