### PR TITLE
Change CreditCardRemover specs to not send raw credit card data

### DIFF
--- a/spec/fixtures/vcr_cassettes/Stripe-v13.5.1/Stripe_CreditCardRemover/_remove/Stripe_customer_does_not_exist/raises_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v13.5.1/Stripe_CreditCardRemover/_remove/Stripe_customer_does_not_exist/raises_an_error.yml
@@ -1,138 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://api.stripe.com/v1/payment_methods
-    body:
-      encoding: UTF-8
-      string: type=card&card[number]=4242424242424242&card[exp_month]=8&card[exp_year]=2026&card[cvc]=314
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/13.5.1
-      Authorization:
-      - "<HIDDEN-AUTHORIZATION-HEADER>"
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_uBOx7tLd7yOHUO","request_duration_ms":2373}}'
-      Idempotency-Key:
-      - 429656ee-1b44-4723-83e0-046e16c1af3e
-      Stripe-Version:
-      - 2025-02-24.acacia
-      X-Stripe-Client-User-Agent:
-      - "<HIDDEN-STRIPE-USER-AGENT>"
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Tue, 14 Oct 2025 03:06:25 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1054'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET, HEAD, PUT, PATCH, POST, DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
-      Idempotency-Key:
-      - 429656ee-1b44-4723-83e0-046e16c1af3e
-      Original-Request:
-      - req_YvqH7cALDO40gr
-      Request-Id:
-      - req_YvqH7cALDO40gr
-      Stripe-Should-Retry:
-      - 'false'
-      Stripe-Version:
-      - 2025-02-24.acacia
-      Vary:
-      - Origin
-      X-Stripe-Priority-Routing-Enabled:
-      - 'true'
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      X-Wc:
-      - ABGHIJ
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pm_1SHyZBKuuB1fWySnGL8WOmo5",
-          "object": "payment_method",
-          "allow_redisplay": "unspecified",
-          "billing_details": {
-            "address": {
-              "city": null,
-              "country": null,
-              "line1": null,
-              "line2": null,
-              "postal_code": null,
-              "state": null
-            },
-            "email": null,
-            "name": null,
-            "phone": null,
-            "tax_id": null
-          },
-          "card": {
-            "brand": "visa",
-            "checks": {
-              "address_line1_check": null,
-              "address_postal_code_check": null,
-              "cvc_check": "unchecked"
-            },
-            "country": "US",
-            "display_brand": "visa",
-            "exp_month": 8,
-            "exp_year": 2026,
-            "fingerprint": "6E6tgVjx6U65iHFV",
-            "funding": "credit",
-            "generated_from": null,
-            "last4": "4242",
-            "networks": {
-              "available": [
-                "visa"
-              ],
-              "preferred": null
-            },
-            "regulated_status": "unregulated",
-            "three_d_secure_usage": {
-              "supported": true
-            },
-            "wallet": null
-          },
-          "created": 1760411185,
-          "customer": null,
-          "livemode": false,
-          "metadata": {},
-          "type": "card"
-        }
-  recorded_at: Tue, 14 Oct 2025 03:06:25 GMT
-- request:
     method: get
     uri: https://api.stripe.com/v1/customers/non_existing_customer_id
     body:
@@ -144,7 +12,7 @@ http_interactions:
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_YvqH7cALDO40gr","request_duration_ms":368}}'
+      - '{"last_request_metrics":{"request_id":"req_1RsZjka6QFaNFz","request_duration_ms":2250}}'
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -161,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:25 GMT
+      - Thu, 06 Nov 2025 17:28:04 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -184,9 +52,9 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Request-Id:
-      - req_ZU5AnB5AztLBNx
+      - req_yB2LSIKpr5up0X
       Stripe-Version:
       - 2025-02-24.acacia
       Vary:
@@ -208,11 +76,11 @@ http_interactions:
             "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
             "message": "No such customer: 'non_existing_customer_id'",
             "param": "id",
-            "request_log_url": "https://dashboard.stripe.com/test/logs/req_ZU5AnB5AztLBNx?t=1760411185",
+            "request_log_url": "https://dashboard.stripe.com/test/logs/req_yB2LSIKpr5up0X?t=1762450084",
             "type": "invalid_request_error"
           }
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:25 GMT
+  recorded_at: Thu, 06 Nov 2025 17:28:04 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/accounts
@@ -225,7 +93,7 @@ http_interactions:
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       Idempotency-Key:
-      - a63d30a5-5c34-4583-9ca8-387cc8bd8ce5
+      - ba438468-262e-48b8-8df4-883e47bc9964
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -244,11 +112,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:28 GMT
+      - Thu, 06 Nov 2025 17:28:06 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3445'
+      - '3527'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -267,13 +135,13 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Idempotency-Key:
-      - a63d30a5-5c34-4583-9ca8-387cc8bd8ce5
+      - ba438468-262e-48b8-8df4-883e47bc9964
       Original-Request:
-      - req_glyz1wvyOkl5wB
+      - req_PsU9iKDhSY2G0b
       Request-Id:
-      - req_glyz1wvyOkl5wB
+      - req_PsU9iKDhSY2G0b
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -292,7 +160,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1SHyZC4B7uDcDX65",
+          "id": "acct_1SQWyeEJSKGySE54",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -301,6 +169,7 @@ http_interactions:
             "minority_owned_business_designation": null,
             "name": null,
             "product_description": null,
+            "specified_commercial_transactions_act_url": null,
             "support_address": null,
             "support_email": null,
             "support_phone": null,
@@ -325,7 +194,7 @@ http_interactions:
             "type": "application"
           },
           "country": "AU",
-          "created": 1760411187,
+          "created": 1762450085,
           "default_currency": "aud",
           "details_submitted": false,
           "email": "apple.producer@example.com",
@@ -334,7 +203,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1SHyZC4B7uDcDX65/external_accounts"
+            "url": "/v1/accounts/acct_1SQWyeEJSKGySE54/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -426,6 +295,7 @@ http_interactions:
               },
               "statement_descriptor": null
             },
+            "paypay_payments": {},
             "sepa_debit_payments": {}
           },
           "tos_acceptance": {
@@ -435,10 +305,10 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:28 GMT
+  recorded_at: Thu, 06 Nov 2025 17:28:06 GMT
 - request:
     method: delete
-    uri: https://api.stripe.com/v1/accounts/acct_1SHyZC4B7uDcDX65
+    uri: https://api.stripe.com/v1/accounts/acct_1SQWyeEJSKGySE54
     body:
       encoding: US-ASCII
       string: ''
@@ -448,9 +318,9 @@ http_interactions:
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_glyz1wvyOkl5wB","request_duration_ms":2190}}'
+      - '{"last_request_metrics":{"request_id":"req_PsU9iKDhSY2G0b","request_duration_ms":2253}}'
       Idempotency-Key:
-      - c9c12ec6-3ecb-4578-84ac-af7538ddbe16
+      - 365b5b53-ccab-41ae-8fb3-34e4af4e2abc
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -467,7 +337,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:30 GMT
+      - Thu, 06 Nov 2025 17:28:08 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -490,13 +360,13 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Idempotency-Key:
-      - c9c12ec6-3ecb-4578-84ac-af7538ddbe16
+      - 365b5b53-ccab-41ae-8fb3-34e4af4e2abc
       Request-Id:
-      - req_Q6XVUoPlIlD7vK
+      - req_d4CECr0bxi2axe
       Stripe-Account:
-      - acct_1SHyZC4B7uDcDX65
+      - acct_1SQWyeEJSKGySE54
       Stripe-Version:
       - 2025-02-24.acacia
       Vary:
@@ -513,9 +383,9 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1SHyZC4B7uDcDX65",
+          "id": "acct_1SQWyeEJSKGySE54",
           "object": "account",
           "deleted": true
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:30 GMT
+  recorded_at: Thu, 06 Nov 2025 17:28:08 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v13.5.1/Stripe_CreditCardRemover/_remove/Stripe_customer_exists/and_is_deleted/deletes_the_credit_card_clone.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v13.5.1/Stripe_CreditCardRemover/_remove/Stripe_customer_exists/and_is_deleted/deletes_the_credit_card_clone.yml
@@ -2,138 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_methods
-    body:
-      encoding: UTF-8
-      string: type=card&card[number]=4242424242424242&card[exp_month]=8&card[exp_year]=2026&card[cvc]=314
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/13.5.1
-      Authorization:
-      - "<HIDDEN-AUTHORIZATION-HEADER>"
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_da8QfGH4chIsAc","request_duration_ms":3207}}'
-      Idempotency-Key:
-      - 35ef7749-584f-4232-bca4-eeeeb39c934f
-      Stripe-Version:
-      - 2025-02-24.acacia
-      X-Stripe-Client-User-Agent:
-      - "<HIDDEN-STRIPE-USER-AGENT>"
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Tue, 14 Oct 2025 03:06:19 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1054'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET, HEAD, PUT, PATCH, POST, DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
-      Idempotency-Key:
-      - 35ef7749-584f-4232-bca4-eeeeb39c934f
-      Original-Request:
-      - req_vvyb0KmlV0J5AG
-      Request-Id:
-      - req_vvyb0KmlV0J5AG
-      Stripe-Should-Retry:
-      - 'false'
-      Stripe-Version:
-      - 2025-02-24.acacia
-      Vary:
-      - Origin
-      X-Stripe-Priority-Routing-Enabled:
-      - 'true'
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      X-Wc:
-      - ABGHIJ
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pm_1SHyZ5KuuB1fWySnwWRhRK17",
-          "object": "payment_method",
-          "allow_redisplay": "unspecified",
-          "billing_details": {
-            "address": {
-              "city": null,
-              "country": null,
-              "line1": null,
-              "line2": null,
-              "postal_code": null,
-              "state": null
-            },
-            "email": null,
-            "name": null,
-            "phone": null,
-            "tax_id": null
-          },
-          "card": {
-            "brand": "visa",
-            "checks": {
-              "address_line1_check": null,
-              "address_postal_code_check": null,
-              "cvc_check": "unchecked"
-            },
-            "country": "US",
-            "display_brand": "visa",
-            "exp_month": 8,
-            "exp_year": 2026,
-            "fingerprint": "6E6tgVjx6U65iHFV",
-            "funding": "credit",
-            "generated_from": null,
-            "last4": "4242",
-            "networks": {
-              "available": [
-                "visa"
-              ],
-              "preferred": null
-            },
-            "regulated_status": "unregulated",
-            "three_d_secure_usage": {
-              "supported": true
-            },
-            "wallet": null
-          },
-          "created": 1760411179,
-          "customer": null,
-          "livemode": false,
-          "metadata": {},
-          "type": "card"
-        }
-  recorded_at: Tue, 14 Oct 2025 03:06:19 GMT
-- request:
-    method: post
     uri: https://api.stripe.com/v1/customers
     body:
       encoding: UTF-8
@@ -144,9 +12,9 @@ http_interactions:
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_vvyb0KmlV0J5AG","request_duration_ms":391}}'
+      - '{"last_request_metrics":{"request_id":"req_x79fNj1mjyapXq","request_duration_ms":2249}}'
       Idempotency-Key:
-      - 0b5a6b0b-ebed-4eb9-a208-128569d68c35
+      - 0cc18233-4714-40a1-960f-61a7775a0497
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -165,7 +33,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:20 GMT
+      - Thu, 06 Nov 2025 17:27:59 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -188,13 +56,13 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Idempotency-Key:
-      - 0b5a6b0b-ebed-4eb9-a208-128569d68c35
+      - 0cc18233-4714-40a1-960f-61a7775a0497
       Original-Request:
-      - req_a5a9v5iPsIA5DR
+      - req_MXzmuPAJwohC3W
       Request-Id:
-      - req_a5a9v5iPsIA5DR
+      - req_MXzmuPAJwohC3W
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -213,18 +81,18 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_TERRQA58ZRl5NI",
+          "id": "cus_TNHXBO9AUnMDSh",
           "object": "customer",
           "address": null,
           "balance": 0,
-          "created": 1760411179,
+          "created": 1762450078,
           "currency": null,
           "default_source": null,
           "delinquent": false,
           "description": null,
           "discount": null,
           "email": "applecustomer@example.com",
-          "invoice_prefix": "0MKRYDJI",
+          "invoice_prefix": "6X4KQTLX",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -241,22 +109,22 @@ http_interactions:
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:20 GMT
+  recorded_at: Thu, 06 Nov 2025 17:27:59 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_methods/pm_1SHyZ5KuuB1fWySnwWRhRK17/attach
+    uri: https://api.stripe.com/v1/payment_methods/pm_card_visa/attach
     body:
       encoding: UTF-8
-      string: customer=cus_TERRQA58ZRl5NI
+      string: customer=cus_TNHXBO9AUnMDSh
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.5.1
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_a5a9v5iPsIA5DR","request_duration_ms":413}}'
+      - '{"last_request_metrics":{"request_id":"req_MXzmuPAJwohC3W","request_duration_ms":344}}'
       Idempotency-Key:
-      - 4347375a-3f65-4abe-98f6-7438500665dc
+      - ea114c2d-0c87-4667-b3c1-2fd83791ce21
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -275,11 +143,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:20 GMT
+      - Thu, 06 Nov 2025 17:27:59 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1065'
+      - '1066'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -298,13 +166,13 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Idempotency-Key:
-      - 4347375a-3f65-4abe-98f6-7438500665dc
+      - ea114c2d-0c87-4667-b3c1-2fd83791ce21
       Original-Request:
-      - req_VGjRe7cfQGo41m
+      - req_0igMtM7K5xj1yU
       Request-Id:
-      - req_VGjRe7cfQGo41m
+      - req_0igMtM7K5xj1yU
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -323,7 +191,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1SHyZ5KuuB1fWySnwWRhRK17",
+          "id": "pm_1SQWyZE2SHQy4eF793fMtmJT",
           "object": "payment_method",
           "allow_redisplay": "unspecified",
           "billing_details": {
@@ -349,9 +217,9 @@ http_interactions:
             },
             "country": "US",
             "display_brand": "visa",
-            "exp_month": 8,
+            "exp_month": 11,
             "exp_year": 2026,
-            "fingerprint": "6E6tgVjx6U65iHFV",
+            "fingerprint": "fYruUeN4kzOmlQx3",
             "funding": "credit",
             "generated_from": null,
             "last4": "4242",
@@ -367,13 +235,13 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1760411179,
-          "customer": "cus_TERRQA58ZRl5NI",
+          "created": 1762450079,
+          "customer": "cus_TNHXBO9AUnMDSh",
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:20 GMT
+  recorded_at: Thu, 06 Nov 2025 17:27:59 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/accounts
@@ -386,9 +254,9 @@ http_interactions:
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_VGjRe7cfQGo41m","request_duration_ms":565}}'
+      - '{"last_request_metrics":{"request_id":"req_0igMtM7K5xj1yU","request_duration_ms":612}}'
       Idempotency-Key:
-      - 60040b09-44da-4ca7-b7a8-aa07a6c0d88c
+      - f25ef097-51e3-461a-ad13-229f157931d9
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -407,11 +275,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:22 GMT
+      - Thu, 06 Nov 2025 17:28:01 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3445'
+      - '3527'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -430,13 +298,13 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Idempotency-Key:
-      - 60040b09-44da-4ca7-b7a8-aa07a6c0d88c
+      - f25ef097-51e3-461a-ad13-229f157931d9
       Original-Request:
-      - req_CBXYcKL6uoNkaa
+      - req_8058VIwZxRAszh
       Request-Id:
-      - req_CBXYcKL6uoNkaa
+      - req_8058VIwZxRAszh
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -455,7 +323,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1SHyZ63PgO0ldZjJ",
+          "id": "acct_1SQWyZCV4ih4cMbF",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -464,6 +332,7 @@ http_interactions:
             "minority_owned_business_designation": null,
             "name": null,
             "product_description": null,
+            "specified_commercial_transactions_act_url": null,
             "support_address": null,
             "support_email": null,
             "support_phone": null,
@@ -488,7 +357,7 @@ http_interactions:
             "type": "application"
           },
           "country": "AU",
-          "created": 1760411181,
+          "created": 1762450080,
           "default_currency": "aud",
           "details_submitted": false,
           "email": "apple.producer@example.com",
@@ -497,7 +366,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1SHyZ63PgO0ldZjJ/external_accounts"
+            "url": "/v1/accounts/acct_1SQWyZCV4ih4cMbF/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -589,6 +458,7 @@ http_interactions:
               },
               "statement_descriptor": null
             },
+            "paypay_payments": {},
             "sepa_debit_payments": {}
           },
           "tos_acceptance": {
@@ -598,10 +468,10 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:22 GMT
+  recorded_at: Thu, 06 Nov 2025 17:28:01 GMT
 - request:
     method: delete
-    uri: https://api.stripe.com/v1/accounts/acct_1SHyZ63PgO0ldZjJ
+    uri: https://api.stripe.com/v1/accounts/acct_1SQWyZCV4ih4cMbF
     body:
       encoding: US-ASCII
       string: ''
@@ -611,9 +481,9 @@ http_interactions:
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_CBXYcKL6uoNkaa","request_duration_ms":2103}}'
+      - '{"last_request_metrics":{"request_id":"req_8058VIwZxRAszh","request_duration_ms":2025}}'
       Idempotency-Key:
-      - 8c523488-ca43-43dd-9ecc-4eebfbe18699
+      - 5995d0d9-923a-4d0f-bf59-2343ac065654
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -630,7 +500,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:25 GMT
+      - Thu, 06 Nov 2025 17:28:03 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -653,13 +523,13 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Idempotency-Key:
-      - 8c523488-ca43-43dd-9ecc-4eebfbe18699
+      - 5995d0d9-923a-4d0f-bf59-2343ac065654
       Request-Id:
-      - req_uBOx7tLd7yOHUO
+      - req_1RsZjka6QFaNFz
       Stripe-Account:
-      - acct_1SHyZ63PgO0ldZjJ
+      - acct_1SQWyZCV4ih4cMbF
       Stripe-Version:
       - 2025-02-24.acacia
       Vary:
@@ -676,9 +546,9 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1SHyZ63PgO0ldZjJ",
+          "id": "acct_1SQWyZCV4ih4cMbF",
           "object": "account",
           "deleted": true
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:25 GMT
+  recorded_at: Thu, 06 Nov 2025 17:28:04 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Stripe-v13.5.1/Stripe_CreditCardRemover/_remove/Stripe_customer_exists/and_is_not_deleted/deletes_the_credit_card_clone_and_the_customer.yml
+++ b/spec/fixtures/vcr_cassettes/Stripe-v13.5.1/Stripe_CreditCardRemover/_remove/Stripe_customer_exists/and_is_not_deleted/deletes_the_credit_card_clone_and_the_customer.yml
@@ -2,138 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_methods
-    body:
-      encoding: UTF-8
-      string: type=card&card[number]=4242424242424242&card[exp_month]=8&card[exp_year]=2026&card[cvc]=314
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/13.5.1
-      Authorization:
-      - "<HIDDEN-AUTHORIZATION-HEADER>"
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_K5z4axV62uj291","request_duration_ms":3091}}'
-      Idempotency-Key:
-      - b36e5a8a-f980-4fb2-bdf6-27633a739e23
-      Stripe-Version:
-      - 2025-02-24.acacia
-      X-Stripe-Client-User-Agent:
-      - "<HIDDEN-STRIPE-USER-AGENT>"
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Tue, 14 Oct 2025 03:06:12 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1054'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET, HEAD, PUT, PATCH, POST, DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
-      Idempotency-Key:
-      - b36e5a8a-f980-4fb2-bdf6-27633a739e23
-      Original-Request:
-      - req_h0JkV1BE4AIRN9
-      Request-Id:
-      - req_h0JkV1BE4AIRN9
-      Stripe-Should-Retry:
-      - 'false'
-      Stripe-Version:
-      - 2025-02-24.acacia
-      Vary:
-      - Origin
-      X-Stripe-Priority-Routing-Enabled:
-      - 'true'
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      X-Wc:
-      - ABGHIJ
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "pm_1SHyYxKuuB1fWySnotVGEgLy",
-          "object": "payment_method",
-          "allow_redisplay": "unspecified",
-          "billing_details": {
-            "address": {
-              "city": null,
-              "country": null,
-              "line1": null,
-              "line2": null,
-              "postal_code": null,
-              "state": null
-            },
-            "email": null,
-            "name": null,
-            "phone": null,
-            "tax_id": null
-          },
-          "card": {
-            "brand": "visa",
-            "checks": {
-              "address_line1_check": null,
-              "address_postal_code_check": null,
-              "cvc_check": "unchecked"
-            },
-            "country": "US",
-            "display_brand": "visa",
-            "exp_month": 8,
-            "exp_year": 2026,
-            "fingerprint": "6E6tgVjx6U65iHFV",
-            "funding": "credit",
-            "generated_from": null,
-            "last4": "4242",
-            "networks": {
-              "available": [
-                "visa"
-              ],
-              "preferred": null
-            },
-            "regulated_status": "unregulated",
-            "three_d_secure_usage": {
-              "supported": true
-            },
-            "wallet": null
-          },
-          "created": 1760411171,
-          "customer": null,
-          "livemode": false,
-          "metadata": {},
-          "type": "card"
-        }
-  recorded_at: Tue, 14 Oct 2025 03:06:12 GMT
-- request:
-    method: post
     uri: https://api.stripe.com/v1/customers
     body:
       encoding: UTF-8
@@ -143,10 +11,8 @@ http_interactions:
       - Stripe/v1 RubyBindings/13.5.1
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_h0JkV1BE4AIRN9","request_duration_ms":376}}'
       Idempotency-Key:
-      - cd9ace7c-8163-4834-8b3c-2ee1eef8d491
+      - c51e52f5-fb69-45ad-88ca-cc6bfa4e5d54
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -165,7 +31,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:12 GMT
+      - Thu, 06 Nov 2025 17:27:52 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -188,13 +54,13 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2i6YrnQ4S32G_SrAn7bIM0UzyCO27KTnggJmEUuRVk0lPHv0Bu-CqUF6hmO2MylCqps6Ulmt2SjCFYDl
       Idempotency-Key:
-      - cd9ace7c-8163-4834-8b3c-2ee1eef8d491
+      - c51e52f5-fb69-45ad-88ca-cc6bfa4e5d54
       Original-Request:
-      - req_TZprtMSRrfXN7c
+      - req_ztT2pzL28yDGIU
       Request-Id:
-      - req_TZprtMSRrfXN7c
+      - req_ztT2pzL28yDGIU
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -213,18 +79,18 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_TERRMJ3Gr4erxc",
+          "id": "cus_TNHXSMHO6szSsv",
           "object": "customer",
           "address": null,
           "balance": 0,
-          "created": 1760411172,
+          "created": 1762450072,
           "currency": null,
           "default_source": null,
           "delinquent": false,
           "description": null,
           "discount": null,
           "email": "applecustomer@example.com",
-          "invoice_prefix": "AYEBEBL5",
+          "invoice_prefix": "AS3STE4P",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -241,22 +107,22 @@ http_interactions:
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:12 GMT
+  recorded_at: Thu, 06 Nov 2025 17:27:52 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/payment_methods/pm_1SHyYxKuuB1fWySnotVGEgLy/attach
+    uri: https://api.stripe.com/v1/payment_methods/pm_card_visa/attach
     body:
       encoding: UTF-8
-      string: customer=cus_TERRMJ3Gr4erxc
+      string: customer=cus_TNHXSMHO6szSsv
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.5.1
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_TZprtMSRrfXN7c","request_duration_ms":445}}'
+      - '{"last_request_metrics":{"request_id":"req_ztT2pzL28yDGIU","request_duration_ms":589}}'
       Idempotency-Key:
-      - a80a867d-29b7-474d-ab08-45bf30c33158
+      - dfe93423-26e8-44e7-b764-3c816cc11126
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -275,11 +141,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:13 GMT
+      - Thu, 06 Nov 2025 17:27:53 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1065'
+      - '1066'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -298,13 +164,13 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Idempotency-Key:
-      - a80a867d-29b7-474d-ab08-45bf30c33158
+      - dfe93423-26e8-44e7-b764-3c816cc11126
       Original-Request:
-      - req_MxIi7oXE3a1MH1
+      - req_zjfqqEJP08mDXX
       Request-Id:
-      - req_MxIi7oXE3a1MH1
+      - req_zjfqqEJP08mDXX
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -323,7 +189,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_1SHyYxKuuB1fWySnotVGEgLy",
+          "id": "pm_1SQWySE2SHQy4eF76oYTyPyk",
           "object": "payment_method",
           "allow_redisplay": "unspecified",
           "billing_details": {
@@ -349,9 +215,9 @@ http_interactions:
             },
             "country": "US",
             "display_brand": "visa",
-            "exp_month": 8,
+            "exp_month": 11,
             "exp_year": 2026,
-            "fingerprint": "6E6tgVjx6U65iHFV",
+            "fingerprint": "fYruUeN4kzOmlQx3",
             "funding": "credit",
             "generated_from": null,
             "last4": "4242",
@@ -367,16 +233,16 @@ http_interactions:
             },
             "wallet": null
           },
-          "created": 1760411171,
-          "customer": "cus_TERRMJ3Gr4erxc",
+          "created": 1762450072,
+          "customer": "cus_TNHXSMHO6szSsv",
           "livemode": false,
           "metadata": {},
           "type": "card"
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:13 GMT
+  recorded_at: Thu, 06 Nov 2025 17:27:53 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/customers/cus_TERRMJ3Gr4erxc
+    uri: https://api.stripe.com/v1/customers/cus_TNHXSMHO6szSsv
     body:
       encoding: US-ASCII
       string: ''
@@ -386,7 +252,7 @@ http_interactions:
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_MxIi7oXE3a1MH1","request_duration_ms":568}}'
+      - '{"last_request_metrics":{"request_id":"req_zjfqqEJP08mDXX","request_duration_ms":918}}'
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -403,7 +269,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:13 GMT
+      - Thu, 06 Nov 2025 17:27:53 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -426,9 +292,9 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Request-Id:
-      - req_jpMFL65NFa9L1J
+      - req_Y8Mbb6b97GR0mh
       Stripe-Version:
       - 2025-02-24.acacia
       Vary:
@@ -445,18 +311,18 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_TERRMJ3Gr4erxc",
+          "id": "cus_TNHXSMHO6szSsv",
           "object": "customer",
           "address": null,
           "balance": 0,
-          "created": 1760411172,
+          "created": 1762450072,
           "currency": null,
           "default_source": null,
           "delinquent": false,
           "description": null,
           "discount": null,
           "email": "applecustomer@example.com",
-          "invoice_prefix": "AYEBEBL5",
+          "invoice_prefix": "AS3STE4P",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -473,10 +339,10 @@ http_interactions:
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:13 GMT
+  recorded_at: Thu, 06 Nov 2025 17:27:53 GMT
 - request:
     method: delete
-    uri: https://api.stripe.com/v1/customers/cus_TERRMJ3Gr4erxc
+    uri: https://api.stripe.com/v1/customers/cus_TNHXSMHO6szSsv
     body:
       encoding: US-ASCII
       string: ''
@@ -486,9 +352,9 @@ http_interactions:
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jpMFL65NFa9L1J","request_duration_ms":285}}'
+      - '{"last_request_metrics":{"request_id":"req_Y8Mbb6b97GR0mh","request_duration_ms":235}}'
       Idempotency-Key:
-      - 4ebd7e86-94de-46d5-a93a-68547b114e65
+      - b8c01c9e-008d-434d-bb1c-0de71aae92b3
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -505,7 +371,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:13 GMT
+      - Thu, 06 Nov 2025 17:27:53 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -528,11 +394,11 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Idempotency-Key:
-      - 4ebd7e86-94de-46d5-a93a-68547b114e65
+      - b8c01c9e-008d-434d-bb1c-0de71aae92b3
       Request-Id:
-      - req_Mz7qdERO1fERRX
+      - req_QfT2abzMAEoV3K
       Stripe-Version:
       - 2025-02-24.acacia
       Vary:
@@ -549,11 +415,11 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_TERRMJ3Gr4erxc",
+          "id": "cus_TNHXSMHO6szSsv",
           "object": "customer",
           "deleted": true
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:13 GMT
+  recorded_at: Thu, 06 Nov 2025 17:27:53 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/accounts
@@ -566,9 +432,9 @@ http_interactions:
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_Mz7qdERO1fERRX","request_duration_ms":411}}'
+      - '{"last_request_metrics":{"request_id":"req_QfT2abzMAEoV3K","request_duration_ms":444}}'
       Idempotency-Key:
-      - 17193f30-bdbd-4196-986a-8ff49f552378
+      - d90af607-9626-45fc-94eb-bd82d631a918
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -587,11 +453,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:15 GMT
+      - Thu, 06 Nov 2025 17:27:56 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3445'
+      - '3527'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -610,13 +476,13 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Idempotency-Key:
-      - 17193f30-bdbd-4196-986a-8ff49f552378
+      - d90af607-9626-45fc-94eb-bd82d631a918
       Original-Request:
-      - req_u1JyUwgJpe0Grs
+      - req_kJNoCYsp4RJOiP
       Request-Id:
-      - req_u1JyUwgJpe0Grs
+      - req_kJNoCYsp4RJOiP
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -635,7 +501,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1SHyYz3nWeqw14wA",
+          "id": "acct_1SQWyUEOjFfBJoW2",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -644,6 +510,7 @@ http_interactions:
             "minority_owned_business_designation": null,
             "name": null,
             "product_description": null,
+            "specified_commercial_transactions_act_url": null,
             "support_address": null,
             "support_email": null,
             "support_phone": null,
@@ -668,7 +535,7 @@ http_interactions:
             "type": "application"
           },
           "country": "AU",
-          "created": 1760411175,
+          "created": 1762450075,
           "default_currency": "aud",
           "details_submitted": false,
           "email": "apple.producer@example.com",
@@ -677,7 +544,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1SHyYz3nWeqw14wA/external_accounts"
+            "url": "/v1/accounts/acct_1SQWyUEOjFfBJoW2/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -769,6 +636,7 @@ http_interactions:
               },
               "statement_descriptor": null
             },
+            "paypay_payments": {},
             "sepa_debit_payments": {}
           },
           "tos_acceptance": {
@@ -778,10 +646,10 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:15 GMT
+  recorded_at: Thu, 06 Nov 2025 17:27:56 GMT
 - request:
     method: delete
-    uri: https://api.stripe.com/v1/accounts/acct_1SHyYz3nWeqw14wA
+    uri: https://api.stripe.com/v1/accounts/acct_1SQWyUEOjFfBJoW2
     body:
       encoding: US-ASCII
       string: ''
@@ -791,9 +659,9 @@ http_interactions:
       Authorization:
       - "<HIDDEN-AUTHORIZATION-HEADER>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_u1JyUwgJpe0Grs","request_duration_ms":2194}}'
+      - '{"last_request_metrics":{"request_id":"req_kJNoCYsp4RJOiP","request_duration_ms":2449}}'
       Idempotency-Key:
-      - 3180e575-6470-405b-8080-0750284f46d1
+      - 9db82ee0-bee7-47ad-bc80-a91137fe29f4
       Stripe-Version:
       - 2025-02-24.acacia
       X-Stripe-Client-User-Agent:
@@ -810,7 +678,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 14 Oct 2025 03:06:19 GMT
+      - Thu, 06 Nov 2025 17:27:58 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -833,13 +701,13 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AhPRuPruhbL6j1zm7HfE8eBayqlqQ7OFvgbuwa79BHVAhrQtpVyhDNiXCNs_ifCCE2UHDBjMUCZ4kqXt
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xsu1z93yii5Y95tC8R6Z1HrnBYqlYAiexaLOSzelBoBfkGI_qYp84hq4D4rAFyZr5m_6yUH8auNG5IAv
       Idempotency-Key:
-      - 3180e575-6470-405b-8080-0750284f46d1
+      - 9db82ee0-bee7-47ad-bc80-a91137fe29f4
       Request-Id:
-      - req_da8QfGH4chIsAc
+      - req_x79fNj1mjyapXq
       Stripe-Account:
-      - acct_1SHyYz3nWeqw14wA
+      - acct_1SQWyUEOjFfBJoW2
       Stripe-Version:
       - 2025-02-24.acacia
       Vary:
@@ -856,9 +724,9 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1SHyYz3nWeqw14wA",
+          "id": "acct_1SQWyUEOjFfBJoW2",
           "object": "account",
           "deleted": true
         }
-  recorded_at: Tue, 14 Oct 2025 03:06:19 GMT
+  recorded_at: Thu, 06 Nov 2025 17:27:58 GMT
 recorded_with: VCR 6.2.0

--- a/spec/lib/stripe/credit_card_remover_spec.rb
+++ b/spec/lib/stripe/credit_card_remover_spec.rb
@@ -4,27 +4,13 @@ require 'spec_helper'
 require 'stripe/credit_card_remover'
 
 RSpec.describe Stripe::CreditCardRemover do
-  let(:credit_card) { create(:credit_card, gateway_payment_profile_id: pm_card.id, user:) }
+  let(:credit_card) { create(:credit_card, user:) }
 
   let!(:user) { create(:user, email: "apple.customer@example.com") }
   let!(:enterprise) { create(:enterprise) }
 
   describe "#remove", :vcr, :stripe_version do
-    let(:credit_card) { create(:credit_card, gateway_payment_profile_id: pm_card.id, user:) }
-
-    let(:pm_card) {
-      Stripe::PaymentMethod.create(
-        {
-          type: 'card',
-          card: {
-            number: '4242424242424242',
-            exp_month: 8,
-            exp_year: Time.zone.now.year.next,
-            cvc: '314',
-          },
-        },
-      )
-    }
+    let(:credit_card) { create(:credit_card, user:) }
 
     let(:connected_account) do
       Stripe::Account.create(
@@ -41,7 +27,7 @@ RSpec.describe Stripe::CreditCardRemover do
     end
 
     context 'Stripe customer exists' do
-      let(:payment_method_id) { pm_card.id }
+      let(:payment_method_id) { "pm_card_visa" }
       let(:customer_id) { customer.id }
 
       let(:customer) do


### PR DESCRIPTION
#### What? Why?

If I re-record cassettes for these specs using my test API key, I get the following errors:

```
1) Stripe::CreditCardRemover#remove Stripe customer exists and is not deleted deletes the credit card clone and the customer
   Failure/Error:
     Stripe::PaymentMethod.create(
       {
         type: 'card',
         card: {
           number: '4242424242424242',
           exp_month: 8,
           exp_year: Time.zone.now.year.next,
           cvc: '314',
         },
       },

   Stripe::CardError:
     Sending credit card numbers directly to the Stripe API is generally unsafe. We suggest you use test tokens that map to the test card you are using, see https://stripe.com/docs/testing. To enable testing raw card data APIs, see https://support.stripe.com/questions/enabling-access-to-raw-card-data-apis.
   # ./spec/lib/stripe/credit_card_remover_spec.rb:16:in `block (3 levels) in <main>'
   # ./spec/lib/stripe/credit_card_remover_spec.rb:44:in `block (4 levels) in <main>'
   # ./spec/lib/stripe/credit_card_remover_spec.rb:56:in `block (4 levels) in <main>'
   # ./spec/base_spec_helper.rb:208:in `block (2 levels) in <main>'
   # ./spec/base_spec_helper.rb:155:in `block (3 levels) in <main>'
   # ./spec/base_spec_helper.rb:155:in `block (2 levels) in <main>'
   # -e:1:in `<main>'
```

Use test payment methods instead as suggested by the error.

This is a follow up to https://github.com/openfoodfoundation/openfoodnetwork/pull/13644.

#### What should we test?

CI seems fine. Just check that the new specs still make sense and test what they are supposed to test.

#### Release notes

- [x] Technical changes only