### PR TITLE
Update button font to match with others

### DIFF
--- a/app/webpacker/css/darkswarm/ui.scss
+++ b/app/webpacker/css/darkswarm/ui.scss
@@ -65,7 +65,7 @@
 }
 
 .button.primary, button.primary {
-  font-family: $body-font;
+  font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
   background: $orange-450;
   color: white;
 }


### PR DESCRIPTION

## What

Replace the `$body-font` variable with an explicit font stack for `.button.primary`.

## Why

We are using different fonts on the buttons like it described in the [issue #13688 ](https://github.com/openfoodfoundation/openfoodnetwork/issues/13688#issuecomment-3507321439)

## Screenshots

Before: 
<img width="1311" height="292" alt="image" src="https://github.com/user-attachments/assets/755c2880-6df4-4e06-b133-0e78055c3f55" />

After:
<img width="1379" height="111" alt="Capture d’écran du 2025-11-09 21-04-43" src="https://github.com/user-attachments/assets/dbdc2db7-1fe8-400d-a0f0-67c72f14880a" />

The font is now the same for all four buttons

## Testing

1. As a hub, on the Shop preferences tab, toggle the option "Customers can change/cancel orders while order cycle is open".
2. As a hub, make sure you have the Website field filled in, in the Contacts tab.
3. As a customer place an order.
4. On the order confirmation page, verify the font of the four buttons "Back To Store", "Back To Website", "Cancel Order" and "Order saved"/"Save changes".

## Related issues

[issue #13688 ](https://github.com/openfoodfoundation/openfoodnetwork/issues/13688#issuecomment-3507321439)

## Impact

Low. This is a small cleanup that improves clarity without changing behavior.
