### PR TITLE
Update all webpack related dependencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,8 @@ updates:
 
     # All versions are specified in package.json, so please update them.
     versioning-strategy: increase
+
+    groups:
+      webpack:
+        patterns:
+          - "webpack*"


### PR DESCRIPTION
#### What? Why?

As per https://github.com/openfoodfoundation/openfoodnetwork/pull/12842#issuecomment-3524407065, these dependencies are very interrelated and should most likely be updated togher.

This PR configures Dependabot to do so.

I tried it on my fork and it correctly closed https://github.com/deivid-rodriguez/openfoodnetwork/pull/10, and opened https://github.com/deivid-rodriguez/openfoodnetwork/pull/15 to replace it.

Note that this update is complicated so the Dependabot group PR is not mergeable anyways and it's just a starting point for someone willing to work on the upgrade.

#### What should we test?

Nothing, I already tested this! :)

#### Release notes

- [x] Technical changes only