### PR TITLE
Let reviewdog use github-pr-annotation formatter

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,7 +2,6 @@ name: Linters
 on: [pull_request]
 permissions:
   contents: read # to fetch code (actions/checkout)
-  checks: write # to post check annotations
 jobs:
   lint:
     name: reviewdog

--- a/script/reviewdog.sh
+++ b/script/reviewdog.sh
@@ -17,7 +17,7 @@ echo "::group:: Running prettier with reviewdog 🐶 ..."
       -efm="%Z[error]%r" \
       -efm="%-G%r" \
       -name="prettier" \
-      -reporter="github-pr-check" \
+      -reporter="github-pr-annotations" \
       -filter-mode="nofilter" \
       -fail-level="any" \
       -level="error" \
@@ -31,7 +31,7 @@ bundle exec rubocop \
   --fail-level info \
   | reviewdog -f="rubocop" \
       -name="rubocop" \
-      -reporter="github-pr-check" \
+      -reporter="github-pr-annotations" \
       -filter-mode="nofilter" \
       -level="error" \
       -fail-level="any" \
@@ -45,7 +45,7 @@ bundle exec haml-lint \
   --fail-level warning \
   | reviewdog -f="haml-lint" \
       -name="haml-lint" \
-      -reporter="github-pr-check" \
+      -reporter="github-pr-annotations" \
       -filter-mode="nofilter" \
       -level="error" \
       -fail-level="any" \


### PR DESCRIPTION
#### What? Why?

This is already the default for forked PRs, and most (if not all) PRs to this repository come from forks anyways. So instead of relying on a fallback behavior when the GITHUB_TOKEN cannot write PR checks, explicitly ask for it.

Except for prettier, whose output does not provide line numbers, the other linters show [PR annotations](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-warning-message) exactly where the issues happen which is very handy and good enough.

#### What should we test?

This does not really change the current behavior, just makes it explicit, so no need for testing.

#### Release notes

- [x] Technical changes only