### PR TITLE
Replace rubygems.org with gem.coop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source 'https://gem.coop'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby File.read('.ruby-version').chomp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ PATH
     web (0.0.1)
 
 GEM
-  remote: https://rubygems.org/
+  remote: https://gem.coop/
   specs:
     Ascii85 (2.0.1)
     actioncable (7.1.6)


### PR DESCRIPTION

#### What? Why?

Several maintainers of RubyGems created gem.coop as a community-governed service after a takeover by RubyCentral, pushed by Shopify.

We are moving with the community that reflects our values best.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Nothing.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
