### PR TITLE
Always generate `<button>` tags, rather than `<input>` of type "button"

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -11,7 +11,7 @@
 
 # `button_to` view helper will render `<button>` element, regardless of whether
 # or not the content is passed as the first argument or as a block.
-# Rails.application.config.action_view.button_to_generates_button_tag = true
+Rails.application.config.action_view.button_to_generates_button_tag = true
 
 # `stylesheet_link_tag` view helper will not render the media attribute by default.
 # Rails.application.config.action_view.apply_stylesheet_media_default = false


### PR DESCRIPTION
#### What? Why?

I want to start migrating all defaults to match the ones in newer versions, in order to ease the migration to Rails 7.2.

#### What should we test?

That no behavior depends on buttons using an `<input>` tag under the hood. Simple grepping shows the affected helper is used 10 times in our code base.

Compatibility issues are explained here: https://stackoverflow.com/a/469084. Basically, they only affect very old IE versions, and only when you _don't_ want the button to submit the underlying form. Since none of our `button_to` usages override the generated `type` attribute to change the default from `submit` to `button` (so the form is not submitted when clicking in the button), I'd say there are no compatibility issues here, but good to manually test.

#### Release notes

- [x] Technical changes only
