### PR TITLE
Properly handle changes in `code` attribute when a customer is deleted

### DIFF
--- a/app/assets/javascripts/admin/index_utils/directives/obj_for_update.js.coffee
+++ b/app/assets/javascripts/admin/index_utils/directives/obj_for_update.js.coffee
@@ -38,16 +38,13 @@ angular.module("admin.indexUtils").directive "objForUpdate", (switchClass, pendi
     # To ensure the customer is still updated, we check on the $destroy event to see if
     # the attribute has changed, if so we queue up the change.
     scope.$on '$destroy', (value) ->
-      # No update
-      return if scope.object()[scope.attr] is scope.savedValue
+      currentValue = scope.object()[scope.attr] || ""
 
-      # For some reason the code attribute is removed from the object when cleared, so we add
-      # an emptyvalue so it gets updated properly
-      if scope.attr is "code" and scope.object()[scope.attr] is undefined
-        scope.object()["code"] = ""
+      # No update
+      return if currentValue is scope.savedValue
 
       # Queuing up change
-      addPendingChange(scope.attr, scope.object()[scope.attr])
+      addPendingChange(scope.attr, currentValue)
 
     # private
 

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe 'Customers' do
             end
           end
           expect(page).not_to have_selector "tr#c_#{customer2.id}"
+          expect(page).not_to have_content 'You have unsaved changes'
         }.to change{ Customer.count }.by(-1)
       end
 


### PR DESCRIPTION
#### What? Why?

Previously, `null` and empty value would be confused when a customer is removed, resulting in incorrect pending changes being added, and thus a "You have unsaved changes" message getting displayed and the save button not getting disabled.

- Closes #13753.

#### What should we test?

That removing a customer does not result in the "Save changes" button getting incorrectly enabled.

#### Release notes

- [x] User facing changes