### PR TITLE
Add a unique translatable string for the button that cancels an order

### DIFF
--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -120,7 +120,7 @@ module Spree
       end
 
       def cancel_event_link(order)
-        event_label = I18n.t("cancel", scope: "actions")
+        event_label = I18n.t("cancel_order", scope: "actions")
         button_link_to(event_label,
                        fire_admin_order_url(order, e: "cancel"),
                        method: :put, icon: "icon-cancel", form_id: "cancel_order_form")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -596,6 +596,7 @@ en:
     create_and_add_another: "Create and Add Another"
     create: "Create"
     cancel: "Cancel"
+    cancel_order: "Cancel"
     resume: "Resume"
     save: "Save"
     edit: "Edit"


### PR DESCRIPTION
#### What? Why?
In some languages there are different words for "cancelling an order" (EN: cancel; DE: stornieren) and "cancelling a process", e.g. leaving a page without saving changes (EN: cancel, DE: abbrechen).

On the edit order page, we have a button to cancel the order, but in German the label is misleading because we don't use "Abbrechen" in this case. Instead it should read "Stornieren". 

As there was no individual key for this yet, I have added it. So far it's only being use on that single button.

<img width="1095" height="298" alt="image" src="https://github.com/user-attachments/assets/24f890de-fbe5-44b3-b48c-89dbd725beb7" />

#### What should we test?
- Manipulate the yml file of a language on the staging server to include the newly added string for "cancel order". Note: This is required for testing because the translation will only be added automatically after Transifex has been triggered.
- Visit the edit order page for an order that has not been cancelled or shipped yet.
- In English the button label at the top of the page should still read "Cancel".
- In the other language the button should read what you types in the yml file.
- Verify that other buttons in the admin area are still reading "Cancel"/"Abbrechen".

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
