### PR TITLE
Show actions dropdown on edit order page only when there are actions available

### DIFF
--- a/app/views/spree/admin/shared/_order_links.html.haml
+++ b/app/views/spree/admin/shared/_order_links.html.haml
@@ -1,24 +1,26 @@
-%li.links-dropdown#links-dropdown
-  .ofn-drop-down
-    %details{"data-controller": "dropdown"}
-      %summary
-        %span
-          %i.icon-check
-          = I18n.t 'admin.actions'
-      .menu{"data-action": "click->dropdown#closeOnMenu"}
-        - order_links(@order).each do |link|
-          - if link[:name] == t(:ship_order)
-            %a.menu_item{ href: link[:url], target: link[:target] || "_self", data: { "modal-link-target-value": dom_id(@order, :ship), "action":  "click->modal-link#open", "controller": "modal-link" } }
-              %span
-                %i{ class: link[:icon] }
-              %span=link[:name]
-          - else
-            %a.menu_item{ href: link[:url], target: link[:target] || "_self", data: { method: link[:method], "ujs-navigate": link[:method] ? "false" : "undefined", confirm: link[:confirm] } }
-              %span
-                %i{ class: link[:icon] }
-              %span=link[:name]
+- links = order_links(@order)
+- if links.present?
+  %li.links-dropdown#links-dropdown
+    .ofn-drop-down
+      %details{"data-controller": "dropdown"}
+        %summary
+          %span
+            %i.icon-check
+            = I18n.t 'admin.actions'
+        .menu{"data-action": "click->dropdown#closeOnMenu"}
+          - links.each do |link|
+            - if link[:name] == t(:ship_order)
+              %a.menu_item{ href: link[:url], target: link[:target] || "_self", data: { "modal-link-target-value": dom_id(@order, :ship), "action":  "click->modal-link#open", "controller": "modal-link" } }
+                %span
+                  %i{ class: link[:icon] }
+                %span=link[:name]
+            - else
+              %a.menu_item{ href: link[:url], target: link[:target] || "_self", data: { method: link[:method], "ujs-navigate": link[:method] ? "false" : "undefined", confirm: link[:confirm] } }
+                %span
+                  %i{ class: link[:icon] }
+                %span=link[:name]
 
-= render 'spree/admin/shared/custom-confirm'
-- if order_shipment_ready?(@order)
-  %form
-    = render ShipOrderComponent.new(order: @order)
+  = render 'spree/admin/shared/custom-confirm'
+  - if order_shipment_ready?(@order)
+    %form
+      = render ShipOrderComponent.new(order: @order)

--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe "spree/admin/orders/edit.html.haml" do
       assign(:order_cycles, [])
     end
 
+    it "displays the order_links dropdown" do
+      render
+
+      expect(rendered).to have_content("Actions")
+    end
+
     describe "order values" do
       it "displays order shipping costs, transaction fee and order total" do
         render


### PR DESCRIPTION
#### What? Why?
On cancelled orders there are no actions that can be taken, like ship order, cancel order, send invoice, print invoice etc. So the actions dropdown is empty. Instead of showing the empty dropdown we should simply hide it.

This PR makes sure that the actions dropdown is only rendered when there are actions available.

#### Before
Dropdown open and no actions available:
<img width="1097" height="298" alt="image" src="https://github.com/user-attachments/assets/154e862a-2722-41b3-b662-2828c65a4abd" />

#### After
No dropdown:
<img width="1095" height="298" alt="image" src="https://github.com/user-attachments/assets/a089be98-d1b5-4e4a-a9c2-531159675a9f" />

#### Before and after (unchanged)
Dropdown is shown when actions are available:
<img width="1099" height="298" alt="image" src="https://github.com/user-attachments/assets/85e60eea-10ce-4c83-86cc-8834a3455770" />

#### What should we test?

- Visit the edit order page for orders in all different order states.
- Check that the actions dropdown is only shown when there are actions available.
- Check that the actions are working properly.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
