### PR TITLE
[Variant tags] Remove flipper groups that are not used anymore

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -27,18 +27,6 @@ end
 Flipper.register(:new_2024_07_03) do |actor|
   actor.respond_to?(:created_at?) && actor.created_at >= Time.zone.parse("2024-07-03")
 end
-Flipper.register(:enterprise_created_before_2025_08_11) do |actor|
-  # This group applies to enterprises only, so we return false if the actor is not an Enterprise
-  next false unless actor.actor.instance_of? Enterprise
-
-  actor.respond_to?(:created_at?) && actor.created_at < Time.zone.parse("2025-08-11")
-end
-Flipper.register(:enterprise_created_after_2025_08_11) do |actor|
-  # This group applies to enterprises only, so we return false if the actor is not an Enterprise
-  next false unless actor.actor.instance_of? Enterprise
-
-  actor.respond_to?(:created_at?) && actor.created_at >= Time.zone.parse("2025-08-11")
-end
 
 Flipper.register(:enterprise_with_no_inventory) do |actor|
   # This group applies to enterprises only, so we return false if the actor is not an Enterprise


### PR DESCRIPTION
#### What? Why?

- Follow up from #13642

Clean up flipper groups that are not relevant any more.
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

Green spec :green_circle: 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
- PR https://github.com/openfoodfoundation/openfoodnetwork/pull/13725 needs to be merged first

<!-- Does this PR depend on another one?
     Add the link or remove this section. -->
