### PR TITLE
Increase PR headings to level 2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-#### What? Why?
+## What? Why?
 
 - Closes # <!-- Insert issue number here. -->
 
@@ -7,7 +7,7 @@
 
 
 
-#### What should we test?
+## What should we test?
 <!-- List which features should be tested and how.
      This can be similar to the Steps to Reproduce in the issue.
      Also think of other parts of the app which could be affected
@@ -16,7 +16,7 @@
 - Visit ... page.
 - 
 
-#### Release notes
+## Release notes
 
 <!-- Please select one for your PR and delete the other. -->
 
@@ -33,12 +33,12 @@ Changelog Category (reviewers may add a label for the release notes):
 The title of the pull request will be included in the release notes.
 
 
-#### Dependencies
+## Dependencies
 <!-- Does this PR depend on another one?
      Add the link or remove this section. -->
 
 
 
-#### Documentation updates
+## Documentation updates
 <!-- Are there any wiki pages that need updating after merging this PR?
      List them here or remove this section. -->


### PR DESCRIPTION
## What? Why?

The current template uses heading level 4, which is rendered the same size as other content. When there are very large descriptions and screenshots, it's not easy to see where the sections are.

We use heading level 2 for issue templates, so let's use it here too. These also have a divider line which particularly helps when there are lots of images.
Then we can use level 3 and 4 for sub-sections.

I took some screenshots out of interest, here they are:

### _h4 (currently used)_
<img width="494" height="299" alt="Screenshot 2026-01-07 at 4 57 25 pm" src="https://github.com/user-attachments/assets/95941d36-9fa0-400a-84ed-c380ccf71ea4" />

-----

### _h3 (another option we could use)_
<img width="471" height="317" alt="Screenshot 2026-01-07 at 4 57 59 pm" src="https://github.com/user-attachments/assets/a07cfa4b-f213-4516-9192-6b0dc487432e" />

-----

### _h2 (the option I chose)_
<img width="512" height="350" alt="Screenshot 2026-01-07 at 4 59 01 pm" src="https://github.com/user-attachments/assets/8819ba6f-d6f3-47a5-a5f8-4bab0f43c9ba" />
