### PR TITLE
Add 7 day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
 
     # Only specific requirements are specified in Gemfile, so don't touch it.
     versioning-strategy: lockfile-only
@@ -39,6 +41,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
 
     # Only specific requirements are specified in package.json, so don't touch it.
     versioning-strategy: lockfile-only


### PR DESCRIPTION

## What? Why?

The gem.coop is testing out cooldowns which is an interesting approach. Dependabot supports this already.
It should make us less vulnerable to supply chain attacks. The idea being that there's a week between publishing a package and updating our dependencies which gives other agents time to discover malicious code. Security fixes are not included.

What do you think?

- https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Nothing.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
