### PR TITLE
13893-hiding too many columns in Admin product list, the table layout breaks

### DIFF
--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -9,7 +9,7 @@
 %td.col-sku.field.naked_inputs
   = f.text_field :sku, 'aria-label': t('admin.products_page.columns.sku')
   = error_message_on variant, :sku
-%td.col-unir_scale.field.naked_inputs{ 'data-controller': 'toggle-control', 'data-toggle-control-match-value': 'items' }
+%td.col-unit_scale.field.naked_inputs{ 'data-controller': 'toggle-control', 'data-toggle-control-match-value': 'items' }
   = f.hidden_field :variant_unit
   = f.hidden_field :variant_unit_scale
   = f.select :variant_unit_with_scale,


### PR DESCRIPTION
- Closes #13893 

## What should we test?
When too many columns are deselected in the product list, the product line of the table doesn't respond as the variant and displays a grey area on the right instead of stretching to the whole width of the table.
<img width="1512" height="982" alt="Screenshot 2026-02-02 at 10 49 38 AM" src="https://github.com/user-attachments/assets/4ba07d33-dcc3-4b02-a42b-09701bd4d040" />

- Visit page url ending with /admin/products
- 

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

<!-- When hiding too many columns in Admin product list, the table layout breaks. -->

The title of the pull request will be included in the release notes.
