### PR TITLE
Fix function call

### DIFF
--- a/app/webpacker/js/turbo.js
+++ b/app/webpacker/js/turbo.js
@@ -9,7 +9,7 @@ document.addEventListener("turbo:frame-missing", (event) => {
   event.preventDefault();
 
   // show error message instead
-  showError(event.detail.response?.status);
+  showHttpError(event.detail.response?.status);
 });
 
 document.addEventListener("turbo:submit-end", (event) => {


### PR DESCRIPTION
This function got renamed in 01d58304800a, but this call got missed.

I would like to add a spec to cover this, but am not sure exactly how to set it up right now. 

I also notice that one usage occurs after the `preventDefault`, and one before. I'm not sure if that matters. I have myself to blame for that inconsistency 🤦
