### PR TITLE
Allow S3-compatible provider for db2fog configuration

### DIFF
--- a/config/initializers/db2fog.rb
+++ b/config/initializers/db2fog.rb
@@ -2,16 +2,27 @@ require_relative 'spree'
 
 Rails.application.reloader.to_prepare do
   # See: https://github.com/openfoodfoundation/db2fog
-  DB2Fog.config = {
+  if ENV['S3_BACKUPS_HOST'].present?
+    DB2Fog.config = {
+      aws_access_key_id:     ENV['S3_BACKUPS_ACCESS_KEY'],
+      aws_secret_access_key: ENV['S3_BACKUPS_SECRET'],
+      directory:             ENV['S3_BACKUPS_BUCKET'],
+      provider:              'AWS',
+      scheme:                ENV['S3_BACKUPS_SCHEME'],
+      host:                  ENV['S3_BACKUPS_HOST']
+    }
+  else
+    DB2Fog.config = {
       :aws_access_key_id     => Spree::Config[:s3_access_key],
       :aws_secret_access_key => Spree::Config[:s3_secret],
       :directory             => ENV['S3_BACKUPS_BUCKET'],
       :provider              => 'AWS'
-  }
+    }
 
-  region = ENV['S3_BACKUPS_REGION'] || ENV['S3_REGION']
+    region = ENV['S3_BACKUPS_REGION'] || ENV['S3_REGION']
 
-  # If no region is defined we leave this config key undefined (instead of nil),
-  # so that db2fog correctly applies it's default
-  DB2Fog.config[:region] = region if region
+    # If no region is defined we leave this config key undefined (instead of nil),
+    # so that db2fog correctly applies it's default
+    DB2Fog.config[:region] = region if region
+  end
 end


### PR DESCRIPTION
## What? Why?
We were proposing alternatives to AWS S3 for files lately, I missed the backup case.
Let's then adjust the db2fog configuration to support S3-compatible providers.

I will also propose separated credentials for the backups bucket. And I will also update the [Backups wiki of ofn-install side](https://github.com/openfoodfoundation/ofn-install/wiki/Backups).

## What should we test?
With a S3-compatible bucket in hand, you can adjust the env vars managing the db2fog configuration.
- S3_BACKUPS_ACCESS_KEY
- S3_BACKUPS_SECRET
- S3_BACKUPS_BUCKET
- S3_BACKUPS_SCHEME
- S3_BACKUPS_HOST

Then you can test that db2fog backup command sends the backup into your new bucket:
```
bundle exec rake db2fog:backup RAILS_ENV=production
```

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
