### PR TITLE
Persist tag filters when updating a product

### DIFF
--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -28,7 +28,7 @@ module Admin
         flash[:success] = I18n.t('admin.products_v3.bulk_update.success')
         redirect_to [:index,
                      { page: @page, per_page: @per_page, search_term: @search_term,
-                       producer_id: @producer_id, category_id: @category_id }]
+                       producer_id: @producer_id, category_id: @category_id, tags_name_in: @tags }]
       elsif product_set.errors.present?
         @error_counts = { saved: product_set.saved_count, invalid: product_set.invalid.count }
 
@@ -120,7 +120,7 @@ module Admin
       @search_term = params[:search_term] || params[:_search_term]
       @producer_id = params[:producer_id] || params[:_producer_id]
       @category_id = params[:category_id] || params[:_category_id]
-      @tags = params[:tags_name_in] || params[:_tags_name_in]
+      @tags = params[:tags_name_in] || []
     end
 
     def init_pagination_params

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -13,6 +13,8 @@
   = hidden_field_tag :search_term, @search_term
   = hidden_field_tag :producer_id, @producer_id
   = hidden_field_tag :category_id, @category_id
+  - @tags.each do |tag|
+    = hidden_field_tag 'tags_name_in[]', tag
 
   %table.products{ 'data-column-preferences-target': "table", class: (hide_producer_column?(producer_options) ? 'hide-producer' : '') }
     %colgroup

--- a/spec/support/tom_select_helper.rb
+++ b/spec/support/tom_select_helper.rb
@@ -36,4 +36,21 @@ module TomSelectHelper
 
     find('.ts-dropdown .ts-dropdown-content .option', text: /#{Regexp.quote(value)}/i).click
   end
+
+  def expect_tomselect_selected_options(from, *options)
+    tomselect_control = page
+      .find("[name='#{from}']")
+      .sibling(".ts-wrapper")
+      .find('.ts-control')
+
+    within(tomselect_control) do
+      # options in case of we want to expect multiselect options
+      options.each do |option|
+        expect(page).to have_css(
+          "div[data-ts-item]",
+          text: option
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What? Why?

- Closes #13827

When using the **Tags filter** on the Products page, the selected filters were lost after updating a product. This forced users to reapply tag filters every time they edited and saved a product, interrupting workflows—especially when managing large product catalogs.

This PR ensures that selected tag filters are persisted after a product update. The controller now preserves the applied tag filter parameters when redirecting back to the Products page, so users remain in the same filtered context after saving changes.

This improves usability and reduces repetitive actions when performing bulk updates or sequential edits.


## What should we test?

- As mentioned in the issue


## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled