### PR TITLE
Bump faraday from 2.9.0 to 2.14.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,12 +326,14 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (2.9.0)
-      faraday-net_http (>= 2.0, < 3.2)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
     faraday-follow_redirects (0.4.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.1.1)
-      net-http
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ferrum (0.14)
       addressable (~> 2.5)
       concurrent-ruby (~> 1.1)
@@ -514,8 +516,8 @@ GEM
     multi_json (1.17.0)
     multi_xml (0.6.0)
     mutex_m (0.3.0)
-    net-http (0.7.0)
-      uri
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.5.12)
       date
       net-protocol


### PR DESCRIPTION
## What? Why?

Addressing a security vulnerability. We are not affected though.

- https://github.com/openfoodfoundation/openfoodnetwork/security/dependabot/286

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I don't know why Dependabot fails on updating gems with security issues. Maybe we should disable the cooldown period again so that we get the security patches that way?

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Nothing.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
