### PR TITLE
13864-Remove dead feature to re-arrange variants

### DIFF
--- a/app/views/spree/admin/variants/index.html.haml
+++ b/app/views/spree/admin/variants/index.html.haml
@@ -4,7 +4,7 @@
 
 #new_variant
 
-%table.index.sortable{"data-sortable-link" => update_positions_admin_product_variants_path(@product)}
+%table.index
   %colgroup
     %col{style: "width: 25%"}/
     %col{style: "width: 25%"}/

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -69,11 +69,7 @@ Spree::Core::Engine.routes.draw do
         end
       end
 
-      resources :variants do
-        collection do
-          post :update_positions
-        end
-      end
+      resources :variants
     end
 
     get '/variants/search', :to => "variants#search", :as => :search_variants


### PR DESCRIPTION
- Closes #13864 

## What should we test?
Removed the UX  which is still there but doesn't have any effect. 
<img width="1512" height="982" alt="Screenshot 2026-02-24 at 6 24 21 PM" src="https://github.com/user-attachments/assets/094d08cb-5d1d-4945-ad3c-a95362fe88fe" />

- Visit page url ending with /admin/products/:id/variants




## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

The title of the pull request will be included in the release notes.
