### PR TITLE
Update Finnish date and datetime formats in locale file

### DIFF
--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -4674,8 +4674,8 @@ fi:
           or_enter_new_card: "Tai anna uuden kortin tiedot:"
           remember_this_card: Muistatko tämän kortin?
     date_picker:
-      flatpickr_date_format: "Vuosi"
-      flatpickr_datetime_format: "Vuosi H:i"
+      flatpickr_date_format: "d.m.Y"
+      flatpickr_datetime_format: "d.m.Y H:i"
       today: "Tänään"
       now: "Nyt"
       close: "Sulje"


### PR DESCRIPTION
## What? Why?

- Closes #13776

Finnish date and datetime formats in the locale file were incorrectly set to display only the year (`Vuosi`). This caused date pickers using Flatpickr to render incomplete and confusing values for Finnish users.  
This change updates the formats to the correct Finnish convention (`d.m.Y` and `d.m.Y H:i`), ensuring dates and datetimes are displayed and selected properly across the application.

## What should we test?

- Visit any page that uses a date picker with the Finnish (`fi`) locale enabled.
- Verify that date fields display dates in `dd.mm.yyyy` format.
- Verify that datetime fields display dates and times in `dd.mm.yyyy HH:MM` format.
- Confirm that selecting dates/times works as expected and no regressions occur in other locales.
- Plus also test the case mentioned in the issue

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled