### PR TITLE
Improve accessibility of action button

### DIFF
--- a/app/components/vertical_ellipsis_menu_component.rb
+++ b/app/components/vertical_ellipsis_menu_component.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class VerticalEllipsisMenuComponent < ViewComponent::Base
+  attr_reader :id
+
+  def initialize(id: "blerh") #todo: add id for variant rows too
+    @id = id
+  end
 end

--- a/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_component.html.haml
+++ b/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_component.html.haml
@@ -1,4 +1,4 @@
 .vertical-ellipsis-menu{ "data-controller": "vertical-ellipsis-menu" }
-  %i.fa.fa-ellipsis-v{ "data-action": "click->vertical-ellipsis-menu#toggle" }
+  %button.vertical-ellipsis-menu-button.fa.fa-ellipsis-v{ "data-action": "click->vertical-ellipsis-menu#toggle", 'aria-label': t('admin.products_page.columns.actions') }
   .vertical-ellipsis-menu-content{ "data-vertical-ellipsis-menu-target": "content" }
     = content

--- a/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_component.html.haml
+++ b/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_component.html.haml
@@ -1,4 +1,4 @@
 .vertical-ellipsis-menu{ "data-controller": "vertical-ellipsis-menu" }
-  %button.vertical-ellipsis-menu-button.fa.fa-ellipsis-v{ "data-action": "click->vertical-ellipsis-menu#toggle", 'aria-label': t('admin.products_page.columns.actions') }
-  .vertical-ellipsis-menu-content{ "data-vertical-ellipsis-menu-target": "content" }
+  %button.vertical-ellipsis-menu-button.fa.fa-ellipsis-v{ popovertarget: id, "data-action": "vertical-ellipsis-menu#toggle", 'aria-label': t('admin.products_page.columns.actions') }
+  .vertical-ellipsis-menu-content{ id:, "data-vertical-ellipsis-menu-target": "content", popover: true }
     = content

--- a/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_component.scss
+++ b/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_component.scss
@@ -1,13 +1,16 @@
+// Currently styled for products_v3 table
 .vertical-ellipsis-menu {
   position: relative;
 
-  i.fa-ellipsis-v {
-    cursor: pointer;
-    display: block;
-    text-align: center;
-    border-radius: 3px;
-    background-color: white;
-    padding: 9px 14px;
+  // Increase specifity to override other button:not() styles :/
+  .vertical-ellipsis-menu-button.vertical-ellipsis-menu-button {
+    padding: 0 13px;
+
+    &, &:hover {
+      background-color: white;
+      border-color: white;
+      color: $near-black;
+    }
   }
 
   .vertical-ellipsis-menu-content {

--- a/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_component.scss
+++ b/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_component.scss
@@ -14,21 +14,26 @@
   }
 
   .vertical-ellipsis-menu-content {
-    position: absolute;
-    top: 0;
-    right: 0;
+    // position: absolute;
+    // top: 0;
+    // right: 0;
+    position: fixed;
+    position-anchor: auto;
+    position-area: self-end;
+    left: -80px;
+    top: -40px;
     padding-top: 5px;
     padding-bottom: 5px;
     background-color: white;
     box-shadow: $box-shadow;
     border-radius: 3px;
     min-width: 80px;
-    display: none;
+    // display: none;
     z-index: 100;
 
-    &.show {
-      display: block;
-    }
+    // &.show {
+    //   display: block;
+    // }
 
     & > a {
       display: block;

--- a/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_controller.js
+++ b/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_controller.js
@@ -12,7 +12,8 @@ export default class extends Controller {
     window.removeEventListener("click", this.#hideIfClickedOutside);
   }
 
-  toggle() {
+  toggle(event) {
+    event.preventDefault();
     this.contentTarget.classList.toggle("show");
   }
 

--- a/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_controller.js
+++ b/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_controller.js
@@ -3,28 +3,28 @@ import { Controller } from "stimulus";
 export default class extends Controller {
   static targets = ["content"];
 
-  connect() {
-    super.connect();
-    window.addEventListener("click", this.#hideIfClickedOutside);
-  }
+  // connect() {
+  //   super.connect();
+  //   window.addEventListener("click", this.#hideIfClickedOutside);
+  // }
 
-  disconnect() {
-    window.removeEventListener("click", this.#hideIfClickedOutside);
-  }
+  // disconnect() {
+  //   window.removeEventListener("click", this.#hideIfClickedOutside);
+  // }
 
   toggle(event) {
     event.preventDefault();
-    this.contentTarget.classList.toggle("show");
+    this.contentTarget.togglePopover({ source: event.target });
   }
 
-  #hideIfClickedOutside = (event) => {
-    if (this.element.contains(event.target)) {
-      return;
-    }
-    this.#hide();
-  };
+  // #hideIfClickedOutside = (event) => {
+  //   if (this.element.contains(event.target)) {
+  //     return;
+  //   }
+  //   this.#hide();
+  // };
 
-  #hide() {
-    this.contentTarget.classList.remove("show");
-  }
+  // #hide() {
+  //   this.contentTarget.classList.remove("show");
+  // }
 }

--- a/app/views/admin/products_v3/_product_row.html.haml
+++ b/app/views/admin/products_v3/_product_row.html.haml
@@ -24,7 +24,7 @@
 %td.col-inherits_properties.align-left
   .content= product.inherits_properties ? 'YES' : 'NO' #TODO: consider using https://github.com/RST-J/human_attribute_values, else use I18n.t (also below)
 %td.align-right
-  = render(VerticalEllipsisMenuComponent.new) do
+  = render(VerticalEllipsisMenuComponent.new(id: "product-actions-#{product_index}")) do
     = link_to t('admin.products_page.actions.edit'), edit_admin_product_path(product), 'data-turbo': false
     = link_to t('admin.products_page.actions.clone'), admin_clone_product_path(product), 'data-turbo-method': :post
     %a{ "data-controller": "modal-link", "data-action": "click->modal-link#setModalDataSetOnConfirm click->modal-link#open",

--- a/spec/support/products_helper.rb
+++ b/spec/support/products_helper.rb
@@ -99,11 +99,4 @@ module ProductsHelper
   def all_input_values
     page.find_all('input[type=text]').map(&:value).join
   end
-
-  def click_product_clone(product_name)
-    within row_containing_name(product_name) do
-      page.find(".vertical-ellipsis-menu").click
-      click_link('Clone')
-    end
-  end
 end

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe '
 
             products_page_url = current_url
             within row_containing_name('a product') do
-              page.find(".vertical-ellipsis-menu").click
+              click_button "Actions"
               click_link('Edit', href: spree.edit_admin_product_path(product))
             end
 

--- a/spec/system/admin/products_v3/actions_spec.rb
+++ b/spec/system/admin/products_v3/actions_spec.rb
@@ -201,13 +201,13 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
       it "shows an actions menu with an edit link for product and variant" do
         within row_containing_name("Apples") do
-          page.find(".vertical-ellipsis-menu").click
+          click_button "Actions"
           expect(page).to have_link "Edit", href: spree.edit_admin_product_path(product_a)
         end
         close_action_menu
 
         within row_containing_name("Medium box") do
-          page.find(".vertical-ellipsis-menu").click
+          click_button "Actions"
           expect(page).to have_link "Edit",
                                     href: spree.edit_admin_product_variant_path(product_a,
                                                                                 variant_a1)
@@ -232,13 +232,13 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
       describe "Actions columns (clone)" do
         it "shows an actions menu with a clone link when clicking on icon for product" do
           within row_containing_name("Apples") do
-            page.find(".vertical-ellipsis-menu").click
+            click_button "Actions"
             expect(page).to have_link "Clone", href: admin_clone_product_path(product_a)
           end
           close_action_menu
 
           within row_containing_name("Medium box") do
-            page.find(".vertical-ellipsis-menu").click
+            click_button "Actions"
             expect(page).not_to have_link "Clone", href: admin_clone_product_path(product_a)
           end
         end
@@ -246,7 +246,19 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
       describe "Cloning product" do
         it "shows the cloned product on page when clicked on the cloned option" do
-          click_product_clone "Apples"
+          # TODO, variant supplier missing, needs to be copied from variant and not product
+          within "table.products" do
+            # Gather input values, because page.content doesn't include them.
+            input_content = page.find_all('input[type=text]').map(&:value).join
+
+            # Products does not include the cloned product.
+            expect(input_content).not_to match /COPY OF Apples/
+          end
+
+          within row_containing_name("Apples") do
+            click_button "Actions"
+            click_link "Clone"
+          end
 
           expect(page).to have_content "Successfully cloned the product"
           within "table.products" do
@@ -273,7 +285,10 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
         product_a.update_columns(name: "L" * 254)
 
         # The page has not been reloaded so the product's name is still "Apples"
-        click_product_clone "Apples"
+        within row_containing_name("Apples") do
+          click_button "Actions"
+          click_link "Clone"
+        end
 
         expect(page).to have_content "Product Name is too long (maximum is 255 characters)"
 
@@ -383,14 +398,14 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
         it "shows an actions menu with a delete link when clicking on icon for product. " \
            "doesn't show delete link for the single variant" do
           within product_selector do
-            page.find(".vertical-ellipsis-menu").click
+            click_button "Actions"
             expect(page).to have_css(delete_option_selector)
           end
           page.find("div#content").click # to close the vertical actions menu
 
           # to select the default variant
           within default_variant_selector do
-            page.find(".vertical-ellipsis-menu").click
+            click_button "Actions"
             expect(page).not_to have_css(delete_option_selector)
           end
         end
@@ -406,13 +421,13 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
           # to select the default variant
           within default_variant_selector do
-            page.find(".vertical-ellipsis-menu").click
+            click_button "Actions"
             expect(page).to have_css(delete_option_selector)
           end
           page.find("div#content").click # to close the vertical actions menu
 
           within variant_selector do
-            page.find(".vertical-ellipsis-menu").click
+            click_button "Actions"
             expect(page).to have_css(delete_option_selector)
           end
         end
@@ -435,7 +450,7 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
             # Keep Product
             within product_selector do
-              page.find(".vertical-ellipsis-menu").click
+              click_button "Actions"
               page.find(delete_option_selector).click
             end
 
@@ -448,7 +463,7 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
             # Keep Variant
             within variant_selector do
-              page.find(".vertical-ellipsis-menu").click
+              click_button "Actions"
               page.find(delete_option_selector).click
             end
             within modal_selector do
@@ -467,7 +482,7 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
             visit admin_products_url
             # Delete Variant
             within variant_selector do
-              page.find(".vertical-ellipsis-menu").click
+              click_button "Actions"
               page.find(delete_option_selector).click
             end
 
@@ -484,7 +499,7 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
             # Delete product
             within product_selector do
-              page.find(".vertical-ellipsis-menu").click
+              click_button "Actions"
               page.find(delete_option_selector).click
             end
             within modal_selector do
@@ -504,7 +519,7 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
             # Delete Variant
             within variant_selector do
-              page.find(".vertical-ellipsis-menu").click
+              click_button "Actions"
               page.find(delete_option_selector).click
             end
 
@@ -519,7 +534,7 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
             # Delete product
             within product_selector do
-              page.find(".vertical-ellipsis-menu").click
+              click_button "Actions"
               page.find(delete_option_selector).click
             end
             within modal_selector do
@@ -542,7 +557,7 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
               # Delete Variant
               within variant_selector do
-                page.find(".vertical-ellipsis-menu").click
+                click_button "Actions"
                 page.find(delete_option_selector).click
               end
 
@@ -569,7 +584,7 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
         visit admin_products_url
 
         within row_containing_name("Apples") do
-          open_action_menu
+          click_button "Actions"
           click_link "Preview"
         end
 
@@ -593,10 +608,6 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
         expect(page).not_to have_content("Product preview")
       end
     end
-  end
-
-  def open_action_menu
-    page.find(".vertical-ellipsis-menu").click
   end
 
   def close_action_menu

--- a/spec/system/admin/products_v3/actions_spec.rb
+++ b/spec/system/admin/products_v3/actions_spec.rb
@@ -246,15 +246,6 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
       describe "Cloning product" do
         it "shows the cloned product on page when clicked on the cloned option" do
-          # TODO, variant supplier missing, needs to be copied from variant and not product
-          within "table.products" do
-            # Gather input values, because page.content doesn't include them.
-            input_content = page.find_all('input[type=text]').map(&:value).join
-
-            # Products does not include the cloned product.
-            expect(input_content).not_to match /COPY OF Apples/
-          end
-
           within row_containing_name("Apples") do
             click_button "Actions"
             click_link "Clone"

--- a/spec/system/admin/products_v3/update_spec.rb
+++ b/spec/system/admin/products_v3/update_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
         expect(page).to have_css('form.disabled-section#filters') # ie search/sort disabled
 
         within new_variant_row do
-          page.find(".vertical-ellipsis-menu").click
+          click_button "Actions"
           page.find('a', text: 'Remove').click
         end
 
@@ -424,14 +424,14 @@ RSpec.describe 'As an enterprise user, I can update my products' do
         expect(page).to have_css('form.disabled-section#filters')
 
         within first_new_variant_row do
-          page.find(".vertical-ellipsis-menu").click
+          click_button "Actions"
           page.find('a', text: 'Remove').click
         end
 
         expect(page).to have_text("1 product modified.")
 
         within second_new_variant_row do
-          page.find(".vertical-ellipsis-menu").click
+          click_button "Actions"
           page.find('a', text: 'Remove').click
         end
         # Only when all non persistent variants are gone that product is non modified
@@ -475,7 +475,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
           expect(page).to have_css('form.disabled-section#filters') # ie search/sort disabled
 
           within apples_new_variant_row do
-            page.find(".vertical-ellipsis-menu").click
+            click_button "Actions"
             page.find('a', text: 'Remove').click
           end
           # New variant for apples is no more, expect only 1 modified product
@@ -484,7 +484,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
           expect(page).to have_css('form.disabled-section#filters')
 
           within tomatoes_new_variant_row do
-            page.find(".vertical-ellipsis-menu").click
+            click_button "Actions"
             page.find('a', text: 'Remove').click
           end
           # Back to page without any alteration
@@ -618,7 +618,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
           expect(page).to have_text("1 product could not be saved.")
 
           within row_containing_name("N" * 256) do
-            page.find(".vertical-ellipsis-menu").click
+            click_button "Actions"
             page.find('a', text: 'Remove').click
           end
 

--- a/spec/system/admin/subscriptions/smoke_tests_spec.rb
+++ b/spec/system/admin/subscriptions/smoke_tests_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe 'Subscriptions' do
         modal_selector = "div[data-modal-target=modal]"
 
         within product_selector do
-          page.find(".vertical-ellipsis-menu").click
+          click_button "Actions"
           page.find(delete_option_selector).click
         end
         within modal_selector do


### PR DESCRIPTION
## What? Why?
Now it's keyboard accessible and can be labelled and accessed by assistive technology. And importantly, simplifies spec code.
I did this plus a little cleanup while working on Sourced Variants.



## What should we test?


- Visit admin > products page.
- Click the `⋮` button 
- Clone
   - The menu should close after cloning, but doesn't (existing issue)
   - clicking on different action buttons should close other action menus. ❌

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
