### PR TITLE
Update release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -27,7 +27,6 @@ assignees: ''
 - [ ] Move this issue to Test Ready.
 - [ ] Notify `@testers` in [#testing].
 - [ ] Test build: [Deploy to Staging] with release tag.
-- [ ] Check the following:
     - [ ] Map is displayed correctly. Address changes are reflected in the map.
     - [ ] Stripe with no authentication card: `4242424242424242` as shopper and as Admin. Order confirmation displays order as "Paid".
     - [ ] Stripe with Authentication required card: `4000002760003184` as shopper and as Admin. As admin, check authorization through customer account `/account#/transactions` and email.


### PR DESCRIPTION
## What? Why?

Currently testers are using google docs to store release tests. This is maybe overkill.

I've documented the steps here and the proposal is for testers to document their test in the release issue.

## What should we test?

No test needed

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled
