### PR TITLE
Add gem for spring to listen to filesystem changes efficiently

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -203,6 +203,7 @@ group :development do
   gem 'spring'
   gem 'spring-commands-rspec'
   gem 'spring-commands-rubocop'
+  gem 'spring-watcher-listen'
   gem 'web-console'
 
   gem 'rack-mini-profiler', '< 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -857,6 +857,9 @@ GEM
       spring (>= 0.9.1)
     spring-commands-rubocop (0.4.0)
       spring (>= 1.0)
+    spring-watcher-listen (2.1.0)
+      listen (>= 2.7, < 4.0)
+      spring (>= 4)
     sprockets (3.7.5)
       base64
       concurrent-ruby (~> 1.0)
@@ -1101,6 +1104,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-commands-rubocop
+  spring-watcher-listen
   sprockets (~> 3.7)
   state_machines-activerecord
   stimulus_reflex


### PR DESCRIPTION


## What? Why?

I found that each spring process was using around 3% CPU in the background just scanning for file changes. By default, spring polls the file system every 0.2 seconds.

With the added gem, I can't see any CPU use of spring in the background.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Nothing.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
