### PR TITLE
Add missing staging configuration for Shakapacker

### DIFF
--- a/config/shakapacker.yml
+++ b/config/shakapacker.yml
@@ -67,9 +67,6 @@ test:
   # Compile test packs to a separate directory
   public_output_path: packs-test
 
-staging:
-  <<: *production
-
 production: &production
   <<: *default
 
@@ -78,3 +75,6 @@ production: &production
 
   # Cache manifest.json for performance
   cache_manifest: true
+
+staging:
+  <<: *production


### PR DESCRIPTION
## What? Why?
We are facing issues while deployment on `FR_staging` server.
On [this deployment](https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/22675403564/job/65730512359#step:4:112), you can see that the `remove_transient_data` task is breaking because of the Shakapacker missing configuration.
```
openfoodnetwork@fr-staging:~/apps/openfoodnetwork/current$ bundle exec rake ofn:data:remove_transient_data RAILS_ENV=staging
RAILS_ENV=staging environment is not defined in /home/openfoodnetwork/apps/openfoodnetwork/releases-old/2026-02-27-070826/config/shakapacker.yml, falling back to production environment
```

## What should we test?
Just test the FR_staging deploymenet from Github

## Release notes
- Add missing staging configuration for Shakapacker

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [X] Technical changes only
- [ ] Feature toggled
