### PR TITLE
14004 link correct customer to order

### DIFF
--- a/app/services/orders/cart_reset_service.rb
+++ b/app/services/orders/cart_reset_service.rb
@@ -21,7 +21,7 @@ module Orders
     def reset_other!(current_user, current_customer)
       reset_user(current_user)
       reset_order_cycle(current_customer)
-      order.customer = current_customer if current_customer.present?
+      order.customer = current_customer
       order.save!
     end
 

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe EnterprisesController do
       expect(controller.current_order.order_cycle).to be_nil
     end
 
+    context "when the order is linked to a customer" do
+      it "removes the customer" do
+        # Make sure the order is linked to a customer
+        customer = create(:customer)
+        order.customer = customer
+        order.save!
+
+        expect do
+          get :shop, params: { id: distributor }
+        end.to change { controller.current_order.customer }.to(nil)
+      end
+    end
+
     context "when user is logged in" do
       before { allow(controller).to receive(:spree_current_user) { user } }
 

--- a/spec/services/orders/cart_reset_service_spec.rb
+++ b/spec/services/orders/cart_reset_service_spec.rb
@@ -70,10 +70,10 @@ RSpec.describe Orders::CartResetService do
       end
 
       context "when customer is missing" do
-        it "does not reset the customer" do
+        it "removes the customer" do
           expect do
             described_class.new(order, distributor.id.to_s).reset_other!(nil, nil)
-          end.not_to change { order.customer }
+          end.to change { order.customer }.to(nil)
         end
       end
 


### PR DESCRIPTION
## What? Why?

- Closes #14004 
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
After placing an order shop A, and starting a new order on  shop B, the order stayed linked to customer from shop A. This PR update the `CartResetService` logic to properly update the customer when switching shop.


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


- Have a user that is a customer in two different shop (Shop A and Shop B)
- In the backoffice, update the two customers billing address with a distinct name. ie set first name to Shop A and Shop B
- Start an order with Shop A, on the checkout details step, you should see "Shop A" as first name for the billing address
- Finish placing the order
- Navigate to Shop B
- Start an order with Shop B, on the checkout details step, 
 --> you should see "Shop B" as first name for the billing address.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
