### PR TITLE
Remove compatibility redirect for APIv0

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -95,8 +95,5 @@ Openfoodnetwork::Application.routes.draw do
 
       resources :customer_account_transaction, only: [:create]
     end
-
-    match '*path', to: redirect(path: "/api/v0/%{path}"), via: :all,
-                   constraints: { path: /(?!v[0-9]).+/ }
   end
 end

--- a/spec/requests/api/routes_spec.rb
+++ b/spec/requests/api/routes_spec.rb
@@ -6,17 +6,6 @@ RSpec.describe 'Orders Cycles endpoint' do
   let(:distributor) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:order_cycle, distributors: [distributor]) }
 
-  context "requesting the latest version" do
-    let(:path) { "/api/order_cycles/#{order_cycle.id}/products?distributor=#{distributor.id}" }
-
-    it "redirects to v0, preserving URL params" do
-      get path
-      expect(response).to redirect_to(
-        "/api/v0/order_cycles/#{order_cycle.id}/products?distributor=#{distributor.id}"
-      )
-    end
-  end
-
   context "requesting a specific API version" do
     let(:path) { "/api/v0/order_cycles/#{order_cycle.id}/products?distributor=#{distributor.id}" }
 


### PR DESCRIPTION
## What? Why?

We had that redirect for many years now and it's annoying when you got a typo and get redirected to a different path.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- specs only

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

:warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: 

*We need to announce this to the community before releasing.*

:warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: 
