### PR TITLE
Avoid conflicting login sessions between staging and production

### DIFF
--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -13,6 +13,7 @@ module Spree
     helper 'spree/base'
 
     prepend_before_action :handle_unconfirmed_email
+    before_action :tmp_delete_old_cookie, only: :create
     before_action :set_checkout_redirect, only: :create
     after_action :ensure_valid_locale_persisted, only: :create
     skip_before_action :check_disabled_user
@@ -43,6 +44,15 @@ module Spree
     private
 
     attr_reader :shopfront_redirect
+
+    def tmp_delete_old_cookie
+      # Delete old domain-based cookie, if any. We no longer specify domain in session_store.rb,
+      # meaning new session cookies are 'host-only'. But the old cookie will override the new one,
+      # so we need to delete the old one when logging in.
+      # This may be removed in the future, after all new browser sessions have ended
+      # (since pr #14055 deployed).
+      cookies.delete :_ofn_session_id, domain: ENV['SITE_URL'] if ENV['SITE_URL'].present?
+    end
 
     def accurate_title
       Spree.t(:login)

--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -13,9 +13,9 @@ module Spree
     helper 'spree/base'
 
     prepend_before_action :handle_unconfirmed_email
-    before_action :tmp_delete_old_cookie, only: :create
     before_action :set_checkout_redirect, only: :create
     after_action :ensure_valid_locale_persisted, only: :create
+    before_action :tmp_delete_old_cookie, only: :destroy
     skip_before_action :check_disabled_user
 
     def create

--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -15,7 +15,6 @@ module Spree
     prepend_before_action :handle_unconfirmed_email
     before_action :set_checkout_redirect, only: :create
     after_action :ensure_valid_locale_persisted, only: :create
-    before_action :tmp_delete_old_cookie, only: :destroy
     skip_before_action :check_disabled_user
 
     def create
@@ -44,15 +43,6 @@ module Spree
     private
 
     attr_reader :shopfront_redirect
-
-    def tmp_delete_old_cookie
-      # Delete old domain-based cookie, if any. We no longer specify domain in session_store.rb,
-      # meaning new session cookies are 'host-only'. But the old cookie will override the new one,
-      # so we need to delete the old one when logging in.
-      # This may be removed in the future, after all new browser sessions have ended
-      # (since pr #14055 deployed).
-      cookies.delete :_ofn_session_id, domain: ENV['SITE_URL'] if ENV['SITE_URL'].present?
-    end
 
     def accurate_title
       Spree.t(:login)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "boot"
 
 require "rails"
@@ -20,6 +22,7 @@ require_relative '../lib/spree/core/environment'
 require_relative '../lib/spree/core/mail_interceptor'
 require_relative "../lib/i18n_digests"
 require_relative "../lib/git_utils"
+require_relative "../lib/session_cookie_upgrader"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -47,6 +50,17 @@ module Openfoodnetwork
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
+
+    config.middleware.insert_before(
+      ActionDispatch::Cookies,
+      SessionCookieUpgrader, {
+        old_key: "_ofn_session_id",
+        new_key: "_h-ofn_session_id",
+        domain: ENV.fetch("SITE_URL", nil),
+        attrs: { http_only: true, secure: true },
+      }
+    ) if Rails.env.staging? || Rails.env.production?
+
     config.time_zone = ENV.fetch("TIMEZONE", nil)
     # config.eager_load_paths << Rails.root.join("extras")
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,14 +4,10 @@
 # which shouldn't be used to store highly confidential information
 # (create the session table with "rails generate session_migration")
 
-domain = if Rails.env.staging? || Rails.env.production?
-           ENV['SITE_URL']
-         else
-           :all
-         end
+# Cookie domain is not set, to ensure it is "host-only". This avoids conflicting cookies between the
+# root domain and subdomains (staging vs prod).
 
 Openfoodnetwork::Application.config.session_store(
   :active_record_store,
-  key: "_ofn_session_id",
-  domain: domain
+  key: "_ofn_session_id"
 )

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -9,5 +9,5 @@
 
 Openfoodnetwork::Application.config.session_store(
   :active_record_store,
-  key: "_ofn_session_id"
+  key: "_h-ofn_session_id"
 )

--- a/lib/session_cookie_upgrader.rb
+++ b/lib/session_cookie_upgrader.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Create a new cookie without a domain (dot prefix), making it 'host-only'
+# A new cookie name is required, because it seems you can't update the domain of an existing cookie.
+# Attributes must exactly match the current cookies.
+class SessionCookieUpgrader
+  def initialize(app, options = {})
+    @app = app
+    @options = options
+  end
+
+  def call(env)
+    request = ::Rack::Request.new(env)
+    cookies = request.cookies
+    old_key = @options[:old_key]
+    new_key = @options[:new_key]
+    attrs = @options[:attrs]
+
+    # Set the session id for this request from the old session cookie (if present)
+    # This must be done before @app.call(env) or a new session will be initialized
+    cookies[new_key] = cookies[old_key] if cookies[old_key]
+
+    status, headers, body = @app.call(env)
+
+    if cookies[old_key]
+      # Create new session cookie with pre-existing session id
+      Rack::Utils.set_cookie_header!(
+        headers,
+        new_key,
+        { value: cookies[old_key], path: "/", domain: nil, **attrs }
+      )
+
+      # Delete old session cookie.
+      Rack::Utils.delete_cookie_header!(headers, old_key, domain: ".#{@options[:domain]}", **attrs)
+    end
+
+    [status, headers, body]
+  end
+end


### PR DESCRIPTION
## What? Why?

- hopelly this one closes #13974



## What should we test?
* Try logging into both prod and staging on the same domain. 
* Try it in a different order.
* Try it in a browser where you've previously been logged in (the likely case for all existing users)

We need to make sure it doesn't mess up existing sessions. We can't expect all users to clear their browser cookies and try again.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
