### PR TITLE
Fix inline error style in Add Manager dialog

### DIFF
--- a/app/views/admin/user_invitations/new.turbo_stream.haml
+++ b/app/views/admin/user_invitations/new.turbo_stream.haml
@@ -6,7 +6,7 @@
       %p= t ".description"
 
       %fieldset.no-border-top.no-border-bottom
-        .row
+        .row.field
           = f.label :email, t(:email)
           = f.email_field :email, placeholder: t('.eg_email_address'), data: { controller: "select-user" }, inputmode: "email", autocomplete: "off"
           = f.error_message_on :email


### PR DESCRIPTION
## Summary

Fixes #13993

The "Add Manager" dialog in enterprise users shows inline validation errors with a different style than the product list. The product list wraps fields in a `.field` class, which activates the `.formError` styles in `forms.scss` (icon, color, font-size). The user invitation modal was missing this class.

This adds the `.field` class to the email field row in the user invitation modal so the error styling matches the product list:
- Error text color uses `$color-error`
- Font size uses 85%
- Error icon (icon-remove-sign) is shown before the message
- Label turns red and input border turns red on validation error

## Test plan

- [ ] Go to `/admin/enterprises/` and select an enterprise
- [ ] Go to Users tab
- [ ] Click "Invite manager" and submit with an invalid email
- [ ] Verify error message style matches the product list inline error style (red color, smaller font, icon)
- [ ] Try adding an already-existing user and verify error style is consistent

Developed with AI assistance (Claude Code)