### PR TITLE
Fix: unify font-family across all .button elements

### DIFF
--- a/app/webpacker/css/darkswarm/ui.scss
+++ b/app/webpacker/css/darkswarm/ui.scss
@@ -54,6 +54,7 @@
 .button, button {
   @include border-radius(0.5em);
 
+  font-family: inherit;
   outline: none;
 
   &.x-small {
@@ -65,7 +66,6 @@
 }
 
 .button.primary, button.primary {
-  font-family: $body-font;
   background: $orange-450;
   color: white;
 }


### PR DESCRIPTION
## What's the problem this is solving?

Closes #13688

On the order confirmation page, the **Save Changes** button (`<button>` rendered by `button_tag`) displayed in a slightly different font than the link-based buttons (Back To Store, Back To Website, Cancel Order — rendered as `<a>`). This caused a ~4px height difference and inconsistent visual appearance.

The root cause: browsers do **not** inherit `font-family` for form elements (`<button>`, `<input>`, etc.) by default. The existing `.button.primary` rule had an explicit `font-family: $body-font`, but no other button variants did.

## What's the fix?

Add `font-family: inherit` to the base `.button, button` rule in `ui.scss`, so all button elements (regardless of variant) inherit the page font (Roboto). Remove the now-redundant `font-family: $body-font` from the `.primary` rule.

```scss
// Before
.button, button {
  @include border-radius(0.5em);
  font-family: inherit; // was missing
  outline: none;
  ...
}

.button.primary, button.primary {
  font-family: $body-font; // redundant - now removed
  background: $orange-450;
  color: white;
}
```

## Test plan

- [ ] Navigate to an order confirmation page that has `changes_allowed?` returning true (enterprise has `allow_order_changes: true` and an open order cycle)
- [ ] Verify that the Back To Store, Back To Website, Cancel Order, and Save Changes buttons all render at the same height and in the same font (Roboto)
- [ ] Verify other button styles (success, neutral, transparent, etc.) are visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)