### PR TITLE
Make sure dialogs don't appear twice when deleting users and inviting existing users

### DIFF
--- a/app/controllers/admin/enterprise_roles_controller.rb
+++ b/app/controllers/admin/enterprise_roles_controller.rb
@@ -22,7 +22,10 @@ module Admin
     def destroy
       @enterprise_role = EnterpriseRole.find params[:id]
       @enterprise_role.destroy
-      render body: nil
+      respond_with do |format|
+        format.turbo_stream { render :destroy }
+        format.html { render body: nil }
+      end
     end
 
     private

--- a/app/forms/user_invitation.rb
+++ b/app/forms/user_invitation.rb
@@ -20,7 +20,7 @@ class UserInvitation
     user = find_or_create_user!
     enterprise.users << user
 
-    return unless user.previously_new_record?
+    return true unless user.previously_new_record?
 
     EnterpriseMailer.manager_invitation(enterprise, user).deliver_later
   end

--- a/app/helpers/spree/admin/navigation_helper.rb
+++ b/app/helpers/spree/admin/navigation_helper.rb
@@ -83,6 +83,14 @@ module Spree
       def link_to_delete(resource, options = {})
         url = options[:url] || object_url(resource)
         name = options[:name] || I18n.t(:delete)
+        options[:data] = { confirm: I18n.t(:are_you_sure), turbo: true, turbo_method: :delete }
+        link_to_with_icon 'icon-trash', name, url, options
+      end
+
+      # Old method using jQuery, deprecated in favour of :link_to_delete which uses turbo.
+      def deprecated_link_to_delete(resource, options = {})
+        url = options[:url] || object_url(resource)
+        name = options[:name] || I18n.t(:delete)
         options[:class] = "delete-resource"
         options[:data] = { confirm: I18n.t(:are_you_sure), action: 'remove' }
         link_to_with_icon 'icon-trash', name, url, options

--- a/app/helpers/spree/admin/navigation_helper.rb
+++ b/app/helpers/spree/admin/navigation_helper.rb
@@ -98,8 +98,11 @@ module Spree
 
       def link_to_with_icon(icon_name, text, url, options = {})
         options[:class] = (options[:class].to_s + " icon_link with-tip #{icon_name}").strip
-        options[:class] += ' no-text' if options[:no_text]
-        options[:title] = text if options[:no_text]
+        if options[:no_text]
+          options[:class] += ' no-text'
+          options[:title] = text
+          options['aria-label'] = text
+        end
         # rubocop:disable Rails/OutputSafety
         text = options[:no_text] ? '' : raw("<span class='text'>#{text}</span>")
         # rubocop:enable Rails/OutputSafety

--- a/app/views/admin/enterprise_groups/index.html.haml
+++ b/app/views/admin/enterprise_groups/index.html.haml
@@ -29,7 +29,7 @@
         %td= enterprise_group.enterprises.map(&:name).join ', '
         %td.actions
           = link_to '', main_app.edit_admin_enterprise_group_path(enterprise_group), class: 'edit-enterprise-group icon-edit no-text'
-          = link_to_delete enterprise_group, no_text: true
+          = deprecated_link_to_delete enterprise_group, no_text: true
 
           - if spree_current_user.admin?
             - if enterprise_group.last?

--- a/app/views/admin/enterprise_roles/destroy.turbo_stream.haml
+++ b/app/views/admin/enterprise_roles/destroy.turbo_stream.haml
@@ -1,0 +1,1 @@
+= turbo_stream.remove "manager-#{@enterprise_role.user_id}"

--- a/app/views/spree/admin/adjustments/_adjustments_table.html.haml
+++ b/app/views/spree/admin/adjustments/_adjustments_table.html.haml
@@ -32,4 +32,4 @@
           %td.actions
             - if adjustment.originator_type.nil?
               = link_to_edit adjustment, no_text: true
-              = link_to_delete adjustment, no_text: true
+              = deprecated_link_to_delete adjustment, no_text: true

--- a/app/views/spree/admin/images/index.html.haml
+++ b/app/views/spree/admin/images/index.html.haml
@@ -35,4 +35,4 @@
         %td= image.alt
         %td.actions
           = link_to_with_icon 'icon-edit', t('spree.edit'), edit_admin_product_image_url(@product, image, @url_filters), no_text: true, data: { action: 'edit'}
-          = link_to_delete image, { url: admin_product_image_url(@product, image, @url_filters), no_text: true }
+          = deprecated_link_to_delete image, { url: admin_product_image_url(@product, image, @url_filters), no_text: true }

--- a/app/views/spree/admin/orders/_insufficient_stock_lines.html.haml
+++ b/app/views/spree/admin/orders/_insufficient_stock_lines.html.haml
@@ -36,4 +36,4 @@
         %td.align-center
           = line_item.money.to_html
         %td.actions
-          = link_to_delete line_item, { url: main_app.admin_bulk_line_item_path(line_item), no_text: true }
+          = deprecated_link_to_delete line_item, { url: main_app.admin_bulk_line_item_path(line_item), no_text: true }

--- a/app/views/spree/admin/orders/_line_item.html.haml
+++ b/app/views/spree/admin/orders/_line_item.html.haml
@@ -9,4 +9,4 @@
   %td.total.align-center
     = f.object.display_amount
   %td.actions
-    = link_to_delete f.object, {url: admin_order_line_item_url(@order.number, f.object), no_text: true}
+    = deprecated_link_to_delete f.object, {url: admin_order_line_item_url(@order.number, f.object), no_text: true}

--- a/app/views/spree/admin/payment_methods/index.html.haml
+++ b/app/views/spree/admin/payment_methods/index.html.haml
@@ -44,6 +44,6 @@
           %td.align-center= method.active ? t('.active_yes') : t('.active_no')
           %td.actions
             = link_to_edit method, no_text: true
-            = link_to_delete method, no_text: true
+            = deprecated_link_to_delete method, no_text: true
 - else
   .alpha.twelve.columns.no-objects-found= t('.no_payment_methods_found')

--- a/app/views/spree/admin/product_properties/_product_property_fields.html.haml
+++ b/app/views/spree/admin/product_properties/_product_property_fields.html.haml
@@ -11,4 +11,4 @@
     = f.text_field :value, class: 'autocomplete'
   %td.actions
     - if f.object.persisted?
-      = link_to_delete f.object, { url: spree.admin_product_product_property_url(@product, f.object, @url_filters), no_text: true }
+      = deprecated_link_to_delete f.object, { url: spree.admin_product_product_property_url(@product, f.object, @url_filters), no_text: true }

--- a/app/views/spree/admin/properties/index.html.haml
+++ b/app/views/spree/admin/properties/index.html.haml
@@ -27,4 +27,4 @@
         %td= property.presentation
         %td.actions
           = link_to_edit(property, no_text: true)
-          = link_to_delete(property, no_text: true)
+          = deprecated_link_to_delete(property, no_text: true)

--- a/app/views/spree/admin/return_authorizations/index.html.haml
+++ b/app/views/spree/admin/return_authorizations/index.html.haml
@@ -34,7 +34,7 @@
             = link_to_edit return_authorization, no_text: true, class: 'edit'
             - unless return_authorization.received?
               &nbsp;
-              = link_to_delete return_authorization, no_text: true
+              = deprecated_link_to_delete return_authorization, no_text: true
 - else
   .no-objects-found
     = t('.cannot_create_returns')

--- a/app/views/spree/admin/shipping_categories/index.html.haml
+++ b/app/views/spree/admin/shipping_categories/index.html.haml
@@ -26,4 +26,4 @@
           %br/
         %td.actions
           = link_to_edit shipping_category, :no_text => true
-          = link_to_delete shipping_category, :no_text => true
+          = deprecated_link_to_delete shipping_category, :no_text => true

--- a/app/views/spree/admin/shipping_methods/index.html.haml
+++ b/app/views/spree/admin/shipping_methods/index.html.haml
@@ -35,6 +35,6 @@
           %td.align-center= shipping_method.display_on.blank? ? t('.both') : t(".#{shipping_method.display_on}")
           %td.actions
             = link_to_edit shipping_method, no_text: true
-            = link_to_delete shipping_method, no_text: true
+            = deprecated_link_to_delete shipping_method, no_text: true
 - else
   .alpha.twelve.columns.no-objects-found= t('.no_shipping_methods_found')

--- a/app/views/spree/admin/states/_state_list.html.haml
+++ b/app/views/spree/admin/states/_state_list.html.haml
@@ -18,7 +18,7 @@
         %td.align-center= state.abbr
         %td.actions
           = link_to_with_icon 'icon-edit', t("spree.edit"), edit_admin_country_state_url(@country, state), no_text: true
-          = link_to_delete state, no_text: true
+          = deprecated_link_to_delete state, no_text: true
     - if @states.empty?
       %tr
         %td{colspan: "3"}= t("spree.none")

--- a/app/views/spree/admin/tax_categories/index.html.haml
+++ b/app/views/spree/admin/tax_categories/index.html.haml
@@ -32,7 +32,7 @@
         %td.align-center= tax_category.is_default.to_s.titleize
         %td.actions
           = link_to_edit tax_category, no_text: true
-          = link_to_delete tax_category, no_text: true
+          = deprecated_link_to_delete tax_category, no_text: true
     - if @tax_categories.empty?
       %tr
         %td{colspan: "4"}= t("spree.none")

--- a/app/views/spree/admin/tax_rates/index.html.haml
+++ b/app/views/spree/admin/tax_rates/index.html.haml
@@ -45,4 +45,4 @@
           %td.align-center= tax_rate.calculator.to_s
           %td.actions
             = link_to_edit tax_rate, no_text: true
-            = link_to_delete tax_rate, no_text: true
+            = deprecated_link_to_delete tax_rate, no_text: true

--- a/app/views/spree/admin/taxons/_taxon_table.html.haml
+++ b/app/views/spree/admin/taxons/_taxon_table.html.haml
@@ -12,7 +12,7 @@
         %td= taxon.name
         %td= taxon_path taxon
         %td.actions
-          = link_to_delete taxon, url: remove_admin_product_taxon_url(@product, taxon), name: icon('delete') + ' ' + t("spree.remove")
+          = deprecated_link_to_delete taxon, url: remove_admin_product_taxon_url(@product, taxon), name: icon('delete') + ' ' + t("spree.remove")
     - if taxons.empty?
       %tr
         %td{colspan: "3"}

--- a/app/views/spree/admin/users/index.html.haml
+++ b/app/views/spree/admin/users/index.html.haml
@@ -25,7 +25,7 @@
         %td.user_email= link_to user.email, edit_object_url(user)
         %td.user_enterprise_limit= user.enterprise_limit
         %td.actions
-          = link_to_delete user, no_text: true
+          = deprecated_link_to_delete user, no_text: true
 
 - _with_routes Spree::Core::Engine.routes do
   = render partial: 'admin/shared/pagy_links', locals: { pagy: @pagy }

--- a/app/views/spree/admin/variants/index.html.haml
+++ b/app/views/spree/admin/variants/index.html.haml
@@ -24,7 +24,7 @@
         %td.align-center= variant.sku
         %td.actions
           = link_to_with_icon('icon-edit', Spree.t(:edit), edit_object_url(variant, @url_filters), no_text: true) unless variant.deleted?
-          = link_to_delete(variant, { url: object_url(variant, @url_filters), no_text: true }) unless variant.deleted?
+          = deprecated_link_to_delete(variant, { url: object_url(variant, @url_filters), no_text: true }) unless variant.deleted?
 
 - content_for :page_actions do
   %ul.inline-menu

--- a/app/views/spree/admin/zones/index.html.haml
+++ b/app/views/spree/admin/zones/index.html.haml
@@ -35,7 +35,7 @@
           %td.align-center= zone.default_tax
           %td.actions
             = link_to_edit zone, no_text: true
-            = link_to_delete zone, no_text: true
+            = deprecated_link_to_delete zone, no_text: true
 
 - _with_routes Spree::Core::Engine.routes do
   = render partial: 'admin/shared/pagy_links', locals: { pagy: @pagy }

--- a/spec/forms/user_invitation_spec.rb
+++ b/spec/forms/user_invitation_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe UserInvitation do
       existing_user = create(:user)
 
       user_invitation = UserInvitation.new(defaults.merge(email: existing_user.email))
-      user_invitation.save!
 
+      expect(user_invitation.save!).to eq true
       expect(enterprise.users).to include(existing_user)
     end
   end

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -623,7 +623,10 @@ RSpec.describe '
     end
 
     describe "check users tab" do
+      let(:existing_user) { create(:user, confirmed_at: Time.now.utc) }
+
       before do
+        distributor1.users << existing_user
         login_as_admin
         visit edit_admin_enterprise_path(distributor1)
         scroll_to(:bottom)
@@ -674,6 +677,20 @@ RSpec.describe '
             expect(page)
               .to have_content "email@email.com has been invited to manage this enterprise"
           end.to enqueue_job(ActionMailer::MailDeliveryJob).exactly(:twice)
+        end
+      end
+
+      context "removing a user" do
+        it do
+          expect(page).to have_content existing_user.email
+
+          within "#manager-#{existing_user.id}" do
+            handle_js_confirm do
+              page.find("a.icon-trash").click
+            end
+          end
+
+          expect(page).not_to have_content existing_user.email
         end
       end
     end

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe '
   include ShopWorkflow
   include UIComponentHelper
   include FileHelper
+  include TableHelper
 
   it "viewing an enterprise" do
     e = create(:enterprise)
@@ -684,7 +685,7 @@ RSpec.describe '
         it do
           expect(page).to have_content existing_user.email
 
-          within "#manager-#{existing_user.id}" do
+          within row_containing(existing_user.email) do
             handle_js_confirm do
               click_link "Delete"
             end

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -692,6 +692,7 @@ RSpec.describe '
           end
 
           expect(page).not_to have_content existing_user.email
+          expect(distributor1.reload.users).not_to include existing_user
         end
       end
     end

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -686,7 +686,7 @@ RSpec.describe '
 
           within "#manager-#{existing_user.id}" do
             handle_js_confirm do
-              page.find("a.icon-trash").click
+              click_link "Delete"
             end
           end
 


### PR DESCRIPTION
## What? Why?

1. Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/14068
2. Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/13992
- This also replaces the existing `link_to_delete` method with a turbo based method and renames the existing jQuery based method which could be replaced completely in a separate PR.
- This adds a test for deleting a user as a super admin. There is a separate bug https://github.com/openfoodfoundation/openfoodnetwork/issues/14081, not yet fixed, for deleting users when not logged in as a super admin.

## What should we test?

See _Steps to reproduce_ in https://github.com/openfoodfoundation/openfoodnetwork/issues/14068 and  #13992

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes