### PR TITLE
Fix authorization for removing enterprise managers for non-admins

### DIFF
--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -197,6 +197,10 @@ module Spree
       can [:admin, :index, :destroy], :oidc_setting
 
       can [:admin, :create], Voucher
+
+      can [:admin, :destroy], EnterpriseRole do |enterprise_role|
+        enterprise_role.enterprise.owner_id == user.id
+      end
     end
 
     def add_product_management_abilities(user)

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -885,6 +885,47 @@ RSpec.describe '
         end
       end
     end
+
+    describe "removing enterprise managers" do
+      let(:existing_user) { create(:user) }
+
+      before do
+        distributor1.users << existing_user
+        login_as logged_in_user
+        visit edit_admin_enterprise_path(distributor1)
+        scroll_to(:bottom)
+        within ".side_menu" do
+          find(:link, "Users").trigger("click")
+        end
+      end
+
+      context "as the enterprise owner" do
+        let(:logged_in_user) { distributor1.owner }
+
+        it 'removes the manager as enterprise owner' do
+          expect(page).to have_content existing_user.email
+
+          within "#manager-#{existing_user.id}" do
+            accept_confirm do
+              page.find("a.icon-trash").click
+            end
+          end
+
+          expect(page).not_to have_content existing_user.email
+        end
+      end
+
+      context "as the enterprise manager" do
+        let(:logged_in_user) { existing_user }
+
+        it "is unable delete any other manager" do
+          expect(page).to have_content existing_user.email
+          within('.edit_enterprise') do
+            expect(page).not_to have_selector('a.icon-trash')
+          end
+        end
+      end
+    end
   end
 
   context "changing package" do


### PR DESCRIPTION
## What? Why?

- Closes #14081

During the recent refactor of the enterprise users page, the deletion flow for enterprise managers was changed to directly call the `EnterpriseRole` destroy endpoint.

However, the authorization rules did not allow this action, causing deletion to fail for users who should have permission (specifically enterprise owners).

### Solution

- Added an authorization rule in `Spree::Ability` to allow:
  - Enterprise owners to destroy `EnterpriseRole` records belonging to their enterprise.
- Ensured that enterprise managers (non-owners) cannot delete other managers.
- Added system specs to cover both scenarios:
  - Owner can remove a manager
  - Manager cannot remove other managers

This restores expected behavior while keeping access control strict and correct.

---

## What should we test?

- Visit **Admin → Enterprises → Edit Enterprise → Users tab**
- As an **enterprise owner**:
  - Verify that managers are listed
  - Click the delete (trash) icon on a manager
  - Confirm deletion
  - Ensure the manager is removed from the list

- As an **enterprise user (non-owner)**:
  - Visit the same page
  - Verify that:
    - No delete (trash) icon is visible
    - No ability to remove other managers
    - Only able to view email addresses of the managers
---

## Release notes

Changelog Category:

- [x] User facing changes  
- [ ] API changes (V0, V1, DFC or Webhook)  
- [ ] Technical changes only  
- [ ] Feature toggled  

---