### PR TITLE
Fix Products search timing out when creating a new subscription

### DIFF
--- a/engines/order_management/app/services/order_management/subscriptions/variants_list.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/variants_list.rb
@@ -32,14 +32,14 @@ module OrderManagement
           .merge(Enterprise.is_primary_producer)
           .select(:parent_id)
 
-        # Append to the potentially gigantic array instead of using union, which creates a new array
-        # The db IN statement won't care if there's a duplicate.
         Enterprise.where(id: distributor.id)
           .select(:id)
           .or(Enterprise.where(id: other_permitted_producer_ids))
       end
 
       def self.outgoing_exchange_variant_ids(distributor)
+        # DISTINCT is not required here since this subquery is used within an IN clause,
+        # where duplicate values do not impact the result.
         ExchangeVariant.joins(:exchange)
           .where(exchanges: { incoming: false, receiver_id: distributor.id })
           .select(:variant_id)


### PR DESCRIPTION
## What? Why?

- Closes #14015

This PR fixes a performance issue caused by large `IN (...)` queries generated from `.pluck`-based implementations.

Previously, methods in `VariantsList` used `.pluck` to load IDs into Ruby arrays, which were then passed back into queries. For distributors with many permitted producers or variants, this resulted in very large `IN` clauses, leading to slow queries and increased memory usage.

### Key Changes:
- Replaced `.pluck` with `.select` to keep queries as ActiveRecord relations instead of materializing large arrays in memory.
- Refactored `permitted_producer_ids` to return a relation and leverage SQL composition (`OR`) instead of building large Ruby arrays.
- Updated `outgoing_exchange_variant_ids` to return a relation, avoiding large `IN` lists.

### Result:
- Avoids generating massive `IN` queries
- Reduces memory usage in Ruby
- Improves database performance by delegating work to SQL instead of Ruby
- Makes queries more scalable for large datasets

---

## What should we test?

- As mentioned in the issue and its comments
- Ideally, we should test it on the instance that has a huge number of variants in its outgoing exchange of all order cycles combined

---

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

---