### PR TITLE
Use real currency for Taler payments unless using demo backend

### DIFF
--- a/app/models/spree/payment_method/taler.rb
+++ b/app/models/spree/payment_method/taler.rb
@@ -18,6 +18,9 @@ module Spree
     # - backend_url: https://backend.demo.taler.net/instances/sandbox
     # - api_key: sandbox
     class Taler < PaymentMethod
+      # Demo backend instances will use the KUDOS currency.
+      DEMO_PREFIX = "https://backend.demo.taler.net/instances"
+
       preference :backend_url, :string
       preference :api_key, :password
 
@@ -96,7 +99,7 @@ module Spree
       def create_taler_order(payment)
         # We are ignoring currency for now so that we can test with the
         # current demo backend only working with the KUDOS currency.
-        taler_amount = "KUDOS:#{payment.amount}"
+        taler_amount = "#{currency(payment)}:#{payment.amount}"
         urls = Rails.application.routes.url_helpers
         fulfillment_url = urls.payment_gateways_confirm_taler_url(payment_id: payment.id)
         taler_order.create(
@@ -112,6 +115,12 @@ module Spree
           password: preferred_api_key,
           id:,
         )
+      end
+
+      def currency(payment)
+        return "KUDOS" if preferred_backend_url.starts_with?(DEMO_PREFIX)
+
+        payment.order.currency
       end
     end
   end

--- a/spec/models/spree/payment_method/taler_spec.rb
+++ b/spec/models/spree/payment_method/taler_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Spree::PaymentMethod::Taler do
   let(:backend_url) { "https://backend.demo.taler.net/instances/sandbox" }
   let(:token_url) { "#{backend_url}/private/token" }
 
-  describe "#external_payment_url", vcr: true do
-    it "creates an order reference and retrieves a URL to pay at" do
+  describe "#external_payment_url" do
+    it "creates an order reference and retrieves a URL to pay at", vcr: true do
       order = create(:order_ready_for_confirmation, payment_method: taler)
 
       url = subject.external_payment_url(order:)
@@ -22,6 +22,26 @@ RSpec.describe Spree::PaymentMethod::Taler do
 
       payment = order.payments.last.reload
       expect(payment.response_code).to match "20...[0-9A-Z-]{17}$"
+    end
+
+    it "creates the Taler order with the right currency" do
+      order = create(:order_ready_for_confirmation, payment_method: taler)
+
+      backend_url = "https://taler.example.com"
+      token_url = "https://taler.example.com/private/token"
+      order_url = "https://taler.example.com/private/orders"
+      taler = Spree::PaymentMethod::Taler.new(
+        preferred_backend_url: "https://taler.example.com",
+        preferred_api_key: "sandbox",
+      )
+
+      stub_request(:post, token_url).to_return(body: { token: "1234" }.to_json)
+      stub_request(:post, order_url)
+        .with(body: /"amount":"AUD:10.0"/)
+        .to_return(body: { order_id: "one" }.to_json)
+
+      url = taler.external_payment_url(order:)
+      expect(url).to eq "#{backend_url}/orders/one"
     end
   end
 

--- a/spec/system/consumer/checkout/payment_spec.rb
+++ b/spec/system/consumer/checkout/payment_spec.rb
@@ -370,6 +370,7 @@ RSpec.describe "As a consumer, I want to checkout my order" do
               Spree::PaymentMethod::Taler.create!(
                 name: "Taler",
                 environment: "test",
+                preferred_backend_url: "https://taler.example.com/",
                 distributors: [distributor]
               )
             end


### PR DESCRIPTION
⚠️ **Please use clockify code # 79 Taler when working on this**

## What? Why?

The current Taler payment method uses only the KUDOS currency used by the demo backend. Since we don't have a production setup yet, we have not been able to test with real currency. But with this change, we should be able to test with real currency once we have a compatible backend, possibly soon in Switzerland.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only. Test coverage is complete and we can't test real currency yet.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
