### PR TITLE
Prevent creating a linked variant from a linked variant

### DIFF
--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -92,7 +92,7 @@
     - if variant.persisted?
       = link_to t('admin.products_page.actions.edit'), edit_admin_product_variant_path(variant.product, variant)
 
-      - if allowed_source_producers.include?(variant.supplier)
+      - if variant.source_variants.empty? && allowed_source_producers.include?(variant.supplier)
         = link_to t('admin.products_page.actions.create_linked_variant'), admin_create_linked_variant_path(variant_id: variant.id, product_index:), 'data-turbo-method': :post
 
       - if variant.product.variants.size > 1

--- a/spec/system/admin/products_v3/actions_spec.rb
+++ b/spec/system/admin/products_v3/actions_spec.rb
@@ -285,8 +285,9 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
     end
 
     describe "Create linked variant" do
-      let!(:variant) {
-        create(:variant, display_name: "My box", supplier: producer)
+      let!(:variant) { create(:variant, display_name: "My box", supplier: producer) }
+      let!(:linked_variant) {
+        variant.create_linked_variant(user).tap{ |v| v.update! display_name: "My linked variant" }
       }
       let!(:other_producer) { create(:supplier_enterprise) }
       let!(:other_variant) {
@@ -312,6 +313,15 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
             expect(page).to have_link "Create linked variant"
           end
+          close_action_menu
+
+          # Check my own linked variant
+          within row_containing_name("My linked variant") do
+            page.find(".vertical-ellipsis-menu").click
+
+            expect(page).not_to have_link "Create linked variant"
+          end
+          close_action_menu
 
           # Create linked variant sourced from my friend
           within row_containing_name("My friends box") do


### PR DESCRIPTION
It's just too confusing.

## What? Why?

- Closes #14088

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
Note this affects the same menu as https://github.com/openfoodfoundation/openfoodnetwork/pull/14085, so it would be worth testing at the same time.

1. Log in as hub with ability to create linked variants from producer
2. Check it is still possible to create linked variants
3. Check the options to create linked variants on linked variants does not exist anymore
4. Only edit and delete actions are possible and are working

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
None
