### PR TITLE
Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,30 +13,26 @@ multi-ecosystem-groups:
       default-days: 7
 
 updates:
+  # turbo_power: ensure gem and package are updated together
   - package-ecosystem: "bundler"
     directory: "/"
     patterns: ["turbo_power"]
     multi-ecosystem-group: "turbo_power"
-
-    # Only specific requirements are specified in Gemfile, so don't touch it.
     versioning-strategy: lockfile-only
-
   - package-ecosystem: "npm"
     directory: "/"
     patterns: ["turbo_power"]
     multi-ecosystem-group: "turbo_power"
-
-    # Only specific requirements are specified in package.json, so don't touch it.
     versioning-strategy: lockfile-only
 
+  # All others
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
       default-days: 7
-
-    # Only specific requirements are specified in Gemfile, so don't touch it.
+    # Only specific requirements are specified in Gemfile, so don't let Dependabot touch it.
     versioning-strategy: lockfile-only
 
   - package-ecosystem: "npm"
@@ -45,6 +41,5 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
-
-    # Only specific requirements are specified in package.json, so don't touch it.
+    # Only specific requirements are specified in package.json, so don't let Dependabot touch it.
     versioning-strategy: lockfile-only


### PR DESCRIPTION
## What? Why?
Gaetan's [post](https://openfoodnetwork.slack.com/archives/C2GQ45KNU/p1774995747835339) prompted me to look at our Dependabot config, and I noticed that one gem and package don't seem to have the 'cooldown' feature applied. This means if a  compromised version was released and we merged the dependency update before finding out, we could get compromised on developer's computers or even servers.


## What should we test?
I think the only way to test is to merge it.