### PR TITLE
When a product name is changed, order edit page and customer view are still show original added name instead of new one

### DIFF
--- a/app/models/invoice/data_presenter/line_item.rb
+++ b/app/models/invoice/data_presenter/line_item.rb
@@ -12,6 +12,12 @@ class Invoice
 
       delegate :name_to_display, :options_text, to: :variant
 
+      def full_product_name
+        return data[:full_product_name] if data[:full_product_name].present?
+
+        variant&.product&.name.to_s
+      end
+
       def amount_with_adjustments_without_taxes
         fee_tax = enterprise_fee_included_tax || 0.0
         (price_with_adjustments * quantity) - included_tax - fee_tax

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -264,6 +264,13 @@ module Spree
       variant.product.name
     end
 
+    # added this function to override the shared one. reference the full product name added in previous bug fix
+    def name_to_display
+      return full_product_name if display_name.blank?
+
+      display_name
+    end
+
     private
 
     def computed_weight_from_variant

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -264,7 +264,8 @@ module Spree
       variant.product.name
     end
 
-    # added this function to override the shared one. reference the full product name added in previous bug fix
+    # added this function to override the shared one. 
+    # reference the full product name added in previous bug fix
     def name_to_display
       return full_product_name if display_name.blank?
 

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -264,7 +264,7 @@ module Spree
       variant.product.name
     end
 
-    # added this function to override the shared one. 
+    # added this function to override the shared one.
     # reference the full product name added in previous bug fix
     def name_to_display
       return full_product_name if display_name.blank?

--- a/app/views/spree/admin/orders/_insufficient_stock_lines.html.haml
+++ b/app/views/spree/admin/orders/_insufficient_stock_lines.html.haml
@@ -28,7 +28,7 @@
         %td
           = render 'spree/shared/variant_thumbnail', variant: line_item.variant
         %td
-          = line_item.variant.product_and_full_name
+          = line_item.full_product_name
         %td.align-center
           = line_item.single_money.to_html
         %td.align-center

--- a/app/views/spree/admin/orders/_invoice/_line_item_name.html.haml
+++ b/app/views/spree/admin/orders/_invoice/_line_item_name.html.haml
@@ -1,6 +1,6 @@
 %h5.inline-header
-  = line_item.variant.product.name
-  - unless line_item.variant.product.name.include? line_item.name_to_display
+  = line_item.full_product_name
+  - unless line_item.full_product_name.include? line_item.name_to_display
     %span= "- #{line_item.name_to_display}"
 - if line_item.unit_price
   = raw("(#{format_unit_price(line_item.unit_price)})")

--- a/app/views/spree/admin/orders/_line_item.html.haml
+++ b/app/views/spree/admin/orders/_line_item.html.haml
@@ -1,6 +1,6 @@
 %tr{id: "#{spree_dom_id(f.object)}", class: "#{cycle('odd', 'even')}"}
   %td
-    = f.object.variant.product.name
+    = f.object.full_product_name
     = "(#{f.object.full_name})"
   %td.price.align-center
     = f.object.single_display_amount

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -6,7 +6,7 @@
       %td.item-image
         = render 'spree/shared/variant_thumbnail', variant: item.variant
       %td.item-name
-        = item.variant.product_and_full_name
+        = line_item.full_product_name
       %td.item-price.align-center
         = line_item.single_money.to_html
       %td.item-qty-show.align-center

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -6,7 +6,7 @@
       %td.item-image
         = render 'spree/shared/variant_thumbnail', variant: item.variant
       %td.item-name
-        = line_item.full_product_name
+        = line_item.variant.product_and_full_name
       %td.item-price.align-center
         = line_item.single_money.to_html
       %td.item-qty-show.align-center

--- a/app/views/spree/shared/_line_item_name.html.haml
+++ b/app/views/spree/shared/_line_item_name.html.haml
@@ -1,6 +1,6 @@
 %h5.inline-header
-  = "#{line_item.product.name}"
-  - unless line_item.product.name.include? line_item.name_to_display
+  = "#{line_item.full_product_name}"
+  - unless line_item.full_product_name.include? line_item.name_to_display
     %span= "- #{line_item.name_to_display}"
 - if line_item.unit_to_display
   = "(#{line_item.unit_to_display})"

--- a/spec/models/invoice/data_presenter/line_item_spec.rb
+++ b/spec/models/invoice/data_presenter/line_item_spec.rb
@@ -139,4 +139,26 @@ RSpec.describe Invoice::DataPresenter::LineItem do
       end
     end
   end
+
+  describe "#full_product_name" do
+    let(:data) do
+      {
+        variant: {
+          id: 1,
+          display_name: '',
+          options_text: '',
+          product: { name: 'Pasta!' }
+        },
+        price_with_adjustments: 10.0,
+        quantity: 2,
+        included_tax: 0.0,
+        enterprise_fee_included_tax: nil,
+        currency: 'AUD'
+      }
+    end
+
+    it "returns the variant product name" do
+      expect(presenter.full_product_name).to eq('Pasta!')
+    end
+  end
 end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -721,29 +721,6 @@ RSpec.describe Spree::LineItem do
 
         expect(li.name_to_display).to eq(original_name)
       end
-
-      context "when display_name is blank" do
-        it "returns the full_product_name" do
-          li = create(:line_item)
-          allow(li.variant).to receive(:display_name).and_return(nil)
-          expect(li.name_to_display).to eq(li.full_product_name)
-        end
-
-        it "returns the full_product_name when display_name is empty string" do
-          li = create(:line_item)
-          allow(li.variant).to receive(:display_name).and_return('')
-          expect(li.name_to_display).to eq(li.full_product_name)
-        end
-      end
-
-      context "when display_name is present" do
-        it "returns the display_name from the variant" do
-          li = create(:line_item)
-          custom_display_name = "Custom Variant Display"
-          allow(li.variant).to receive(:display_name).and_return(custom_display_name)
-          expect(li.name_to_display).to eq(custom_display_name)
-        end
-      end
     end
 
     describe "getting unit for display" do

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -721,6 +721,29 @@ RSpec.describe Spree::LineItem do
 
         expect(li.name_to_display).to eq(original_name)
       end
+
+      context "when display_name is blank" do
+        it "returns the full_product_name" do
+          li = create(:line_item)
+          allow(li.variant).to receive(:display_name).and_return(nil)
+          expect(li.name_to_display).to eq(li.full_product_name)
+        end
+
+        it "returns the full_product_name when display_name is empty string" do
+          li = create(:line_item)
+          allow(li.variant).to receive(:display_name).and_return('')
+          expect(li.name_to_display).to eq(li.full_product_name)
+        end
+      end
+
+      context "when display_name is present" do
+        it "returns the display_name from the variant" do
+          li = create(:line_item)
+          custom_display_name = "Custom Variant Display"
+          allow(li.variant).to receive(:display_name).and_return(custom_display_name)
+          expect(li.name_to_display).to eq(custom_display_name)
+        end
+      end
     end
 
     describe "getting unit for display" do

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -714,6 +714,13 @@ RSpec.describe Spree::LineItem do
         li = build_stubbed(:line_item)
         expect(li.name_to_display).to eq(li.product.name)
       end
+      it "returns the original product name even after the product is renamed" do
+        li = create(:line_item)
+        original_name = li.product_name
+        li.variant.product.update!(name: "New Name")
+
+        expect(li.name_to_display).to eq(original_name)
+      end
     end
 
     describe "getting unit for display" do


### PR DESCRIPTION
## What? Why?

- Closes # <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

For bug 13969: https://github.com/openfoodfoundation/openfoodnetwork/issues/13969

- When a shop owner renamed a product after a customer had already placed an order, the order pages would show the new name instead of the original name the customer agreed to purchase.


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Manual Testing:
- Place an order for a product
- Edit the name of the product in  admin/products
- Check that the name now doesn't change in admin/orders/ORDERNUMBER/edit and /orders/ORDERNUMBER, when it did before

## Release notes

Changelog Category (reviewers may add a label for the release notes): User facing changes


<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies

Follow up from https://github.com/openfoodfoundation/openfoodnetwork/pull/13261. This provided a solution but missed certain parts of the code where views are updated.

## Documentation updates