### PR TITLE
Improve Truncate and Anonymize Rake tasks

### DIFF
--- a/lib/tasks/data/anonymize_data.rake
+++ b/lib/tasks/data/anonymize_data.rake
@@ -43,7 +43,9 @@ namespace :ofn do
     def anonymize_users_data
       Spree::User.update_all("email = concat(id, '_ofn_user@example.com'),
                               login = concat(id, '_ofn_user@example.com'),
-                              unconfirmed_email = concat(id, '_ofn_user@example.com')")
+                              unconfirmed_email = concat(id, '_ofn_user@example.com'),
+                              current_sign_in_ip = '0.0.0.0',
+                              last_sign_in_ip = '0.0.0.0'")
       Customer.where(user_id: nil)
         .update_all("email = concat(id, '_ofn_customer@example.com'),
                      name = concat('Customer Number ', id, ' (without connected User)'),
@@ -55,7 +57,8 @@ namespace :ofn do
                      first_name = concat('Customer Number ', id),
                      last_name = concat('User ', user_id)")
 
-      Spree::Order.update_all("email = concat(id, '_ofn_order@example.com')")
+      Spree::Order.update_all("email = concat(id, '_ofn_order@example.com'),
+                              last_ip_address = '0.0.0.0'")
     end
 
     def anonymize_payments_data

--- a/lib/tasks/data/anonymize_data.rake
+++ b/lib/tasks/data/anonymize_data.rake
@@ -50,7 +50,7 @@ namespace :ofn do
                      first_name = concat('Customer Number ', id),
                      last_name = '(without connected User)'")
       Customer.where.not(user_id: nil)
-        .update_all("email = concat(user_id, '_ofn_user@example.com'),
+        .update_all("email = concat(user_id, '_ofn_user+customer_', id, '@example.com'),
                      name = concat('Customer Number ', id, ' - User ', user_id),
                      first_name = concat('Customer Number ', id),
                      last_name = concat('User ', user_id)")

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -37,6 +37,7 @@ class TruncateData
     sql_delete_from "spree_payments #{where_order_id_in_orders_to_delete}"
     sql_delete_from "spree_shipments #{where_order_id_in_orders_to_delete}"
     sql_delete_from "spree_return_authorizations #{where_order_id_in_orders_to_delete}"
+    sql_delete_from "proxy_orders #{where_order_id_in_orders_to_delete}"
   end
 
   def truncate_subscriptions


### PR DESCRIPTION
## What? Why?
I detected 2 errors while importing data on FR staging:

Truncate:
```
PG::ForeignKeyViolation: ERROR:  update or delete on table "spree_orders" violates foreign key constraint "order_id_fk" on table "proxy_orders" (PG::ForeignKeyViolation)
DETAIL:  Key (id)=(1158662) is still referenced from table "proxy_orders".
```

Anonymize:
``` 
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_customers_on_email_and_enterprise_id" (ActiveRecord::RecordNotUnique)
DETAIL:  Key (email, enterprise_id)=(155_ofn_user@example.com, 56) already exists.
``` 

I also decided to clean the IP addresses during anonymization as it is a GDPR concern.

## What should we test?
You can test on test data, on stage server or locally.
```
bundle exec rake ofn:data:truncate
bundle exec rake ofn:data:anonymize
```

## Release notes

Improve Truncate and Anonymize Rake tasks

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled
