### PR TITLE
 Order page overflows on mobile #13972

### DIFF
--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -35,4 +35,4 @@
 
     %td.cart-item-delete.text-center
       %a.delete{href: "#", id: "delete_#{dom_id(line_item)}"}
-        %i.delete.ofn-i_026-trash
+        %i.delete.ofn-i_026-trash 

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -35,4 +35,4 @@
 
     %td.cart-item-delete.text-center
       %a.delete{href: "#", id: "delete_#{dom_id(line_item)}"}
-        %i.delete.ofn-i_026-trash 
+        %i.delete.ofn-i_026-trash

--- a/app/webpacker/css/darkswarm/cart-page.scss
+++ b/app/webpacker/css/darkswarm/cart-page.scss
@@ -11,8 +11,8 @@
 
 #cart-detail {
   width: 100%;
-  overflow-x: auto; //ADDED THIS
-  -webkit-overflow-scrolling: touch;  // add this for smooth scrolling on iOS
+  overflow-x: auto; 
+  -webkit-overflow-scrolling: touch;  
 
   .cart-item-delete,
   .bought-item-delete {

--- a/app/webpacker/css/darkswarm/cart-page.scss
+++ b/app/webpacker/css/darkswarm/cart-page.scss
@@ -11,6 +11,8 @@
 
 #cart-detail {
   width: 100%;
+  overflow-x: auto; //ADDED THIS
+  -webkit-overflow-scrolling: touch;  // add this for smooth scrolling on iOS
 
   .cart-item-delete,
   .bought-item-delete {

--- a/app/webpacker/css/darkswarm/tables.scss
+++ b/app/webpacker/css/darkswarm/tables.scss
@@ -11,7 +11,7 @@ table {
   }
 }
 
-#line-items { //added this 
+#line-items {
   width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;

--- a/app/webpacker/css/darkswarm/tables.scss
+++ b/app/webpacker/css/darkswarm/tables.scss
@@ -10,3 +10,9 @@ table {
     }
   }
 }
+
+#line-items { //added this 
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}


### PR DESCRIPTION
## What? Why?

- Closes #13972 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

After a successful order, the page that displays the order overflows on mobile, making it harder to read the content.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Manutal Testing: 

- Add products to cart
- Go through checkout flow selecting cash and pickup
- Complete order
- Load Confirmed Order page and change page width to 360px using inspect element (there shouldn't be any overflow/excess white areas)

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
