### PR TITLE
Avoid fallback to different language

### DIFF
--- a/lib/open_food_network/i18n_config.rb
+++ b/lib/open_food_network/i18n_config.rb
@@ -21,7 +21,7 @@ module OpenFoodNetwork
     end
 
     def self.fallbacks
-      [default_locale, source_locale].uniq
+      [source_locale]
     end
 
     # The default locale that is used when the user doesn't have a preference.


### PR DESCRIPTION


## What? Why?

In Switzerland, Swiss English was falling back to Swiss German instead of falling back to the source English. This was a recent, unrequested change. So I'm reverting it here.

This reverts part of:

- https://github.com/openfoodfoundation/openfoodnetwork/commit/bf22484addda5d8c1b5155adfa14155f834a7963

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Test on Swiss staging by Mikel.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
