### PR TITLE
Consolidate duplicate property tags in shopfront sidebar

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
@@ -29,13 +29,13 @@ angular.module('Darkswarm').controller "ProductsCtrl", ($scope, $sce, $filter, $
 
   $scope.update_filters = ->
     order_cycle_id = OrderCycle.order_cycle.order_cycle_id
-
     return unless order_cycle_id
 
     params = {
       id: order_cycle_id,
       distributor: currentHub.id
     }
+
     OrderCycleResource.taxons params, (data)=>
       $scope.supplied_taxons = {}
       data.map( (taxon) ->
@@ -48,11 +48,20 @@ angular.module('Darkswarm').controller "ProductsCtrl", ($scope, $sce, $filter, $
         $scope.supplied_properties[property.id] = Properties.properties_by_id[property.id]
       )
 
-    OrderCycleResource.producerProperties params, (data)=>
-      $scope.supplied_producer_properties = {}
-      data.map( (property) ->
-        $scope.supplied_producer_properties[property.id] = Properties.properties_by_id[property.id]
-      )
+      # Fetch Producer Properties ONLY after Product Properties have loaded
+      OrderCycleResource.producerProperties params, (producer_data)=>
+        $scope.supplied_producer_properties = {}
+        
+        # Extract an array of all names currently in the product properties bucket
+        existing_names = (p.name for k, p of $scope.supplied_properties)
+        
+        producer_data.map( (property) ->
+          prop_obj = Properties.properties_by_id[property.id]
+          
+          # Only add to the UI if the name isn't already in existing_names
+          if prop_obj.name not in existing_names
+            $scope.supplied_producer_properties[property.id] = prop_obj
+        )
 
   $scope.loadMore = ->
     if ($scope.page * $scope.per_page) <= Products.products.length


### PR DESCRIPTION
PR Title: Fix duplicate property tags in shopfront filters

### What? Why?

- Closes #13514

### The Problem:
The shopfront sidebar was displaying duplicate property tags (e.g., showing two "Organic" checkboxes) if a property was assigned directly to a product AND inherited from the enterprise/producer. This occurred because the frontend fetches properties and producer_properties in two separate AJAX calls and rendered them both directly into the filter lists.

### The Solution:
While backend consolidation was considered, doing so breaks the Ransack search engine, which requires distinct parameters (q[with_properties] vs q[with_variants_supplier_properties]) to search the different database tables.

Instead, this PR implements an optimized visual consolidation on the frontend in products_controller.js.coffee.

We load the Product Properties first and track their names.

When loading Producer Properties, we filter out any properties whose name already exists in the Product Properties list.

This ensures the user only sees one visually unique tag in the sidebar, while preserving the separate DOM elements and IDs required to pass the correct parameters back to the Ransack search engine.

### What should we test?
Visit a shopfront page that contains products with properties, where the producer also has the same property assigned.

Verify that the property (e.g., "Organic") only appears once in the "Filter by" sidebar.

Click the consolidated property filter and verify that the products list updates correctly.

Verify that the "X selected" count at the top of the filter sidebar displays the correct number.

Open the browser console and verify there are no AngularJS initialization errors.

### Release notes
Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

### Dependencies
None

### Documentation updates
None