### PR TITLE
Improvements to CI logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ env:
   TIMEZONE: UTC
   COVERAGE: true
   RAILS_ENV: test
-
 permissions:
   contents: read
 
@@ -82,6 +81,9 @@ jobs:
           # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it
           #KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/controllers/**/*_spec.rb,spec/models/**/*_spec.rb}"
+          # Enable debug logging if user checked "Enable debug logging" when re-running a workflow
+          RAILS_LOG_LEVEL: ${{ case(runner.debug == '1', 'debug', 'fatal') }}
+          SPEC_OPTS: ${{ case(runner.debug == '1', '--format documentation', '') }}
         run: |
           git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
           bin/rails assets:precompile knapsack_pro:rspec
@@ -94,6 +96,15 @@ jobs:
           retention-days: 2 # doesn't need to be long, because it's the combined results that matter
           if-no-files-found: ignore
           include-hidden-files: true
+
+      - name: Archive debug log files
+        if: runner.debug
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-system_${{ matrix.ci_node_index }}-tests-logs
+          path: log/*
+          retention-days: 7
+          if-no-files-found: ignore
 
   system:
     runs-on: ubuntu-22.04
@@ -160,6 +171,9 @@ jobs:
           # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it
           #KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/system/admin/**/*_spec.rb,spec/system/consumer/**/*_spec.rb}"
+          # Enable debug logging if user checked "Enable debug logging" when re-running a workflow
+          RAILS_LOG_LEVEL: ${{ case(runner.debug == '1', 'debug', 'fatal') }}
+          SPEC_OPTS: ${{ case(runner.debug == '1', '--format documentation', '') }}
 
         run: |
           bin/rails assets:precompile knapsack_pro:queue:rspec
@@ -179,6 +193,15 @@ jobs:
         with:
           name: failed-system_${{ matrix.ci_node_index }}-tests-screenshots
           path: tmp/capybara/screenshots/*.png
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Archive debug log files
+        if: runner.debug
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-system_${{ matrix.ci_node_index }}-tests-logs
+          path: log/*
           retention-days: 7
           if-no-files-found: ignore
 
@@ -248,6 +271,9 @@ jobs:
           # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it
           #KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_TEST_FILE_PATTERN: "{spec/lib/**/*_spec.rb,spec/migrations/**/*_spec.rb,spec/serializers/**/*_spec.rb,engines/**/*_spec.rb}"
+          # Enable debug logging if user checked "Enable debug logging" when re-running a workflow
+          RAILS_LOG_LEVEL: ${{ case(runner.debug == '1', 'debug', 'fatal') }}
+          SPEC_OPTS: ${{ case(runner.debug == '1', '--format documentation', '') }}
 
         run: |
           bin/rails assets:precompile knapsack_pro:rspec
@@ -260,6 +286,15 @@ jobs:
           retention-days: 2 # doesn't need to be long, because it's the combined results that matter
           if-no-files-found: ignore
           include-hidden-files: true
+
+      - name: Archive debug log files
+        if: runner.debug
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-system_${{ matrix.ci_node_index }}-tests-logs
+          path: log/*
+          retention-days: 7
+          if-no-files-found: ignore
 
   test_the_rest:
     runs-on: ubuntu-22.04
@@ -326,6 +361,10 @@ jobs:
           # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it
           #KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN: "{engines/**/*_spec.rb,spec/models/**/*_spec.rb,spec/controllers/**/*_spec.rb,spec/serializers/**/*_spec.rb,spec/lib/**/*_spec.rb,spec/migrations/**/*_spec.rb,spec/system/**/*_spec.rb}"
+          # Enable debug logging if user checked "Enable debug logging" when re-running a workflow
+          RAILS_LOG_LEVEL: ${{ case(runner.debug == '1', 'debug', 'fatal') }}
+          SPEC_OPTS: ${{ case(runner.debug == '1', '--format documentation', '') }}
+
         run: |
           bin/rails assets:precompile knapsack_pro:rspec
 
@@ -337,6 +376,15 @@ jobs:
           retention-days: 2 # doesn't need to be long, because it's the combined results that matter
           if-no-files-found: ignore
           include-hidden-files: true
+
+      - name: Archive debug log files
+        if: runner.debug
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-system_${{ matrix.ci_node_index }}-tests-logs
+          path: log/*
+          retention-days: 7
+          if-no-files-found: ignore
 
   non_knapsack_jest_karma:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
           SPEC_OPTS: ${{ case(runner.debug == '1', '--format documentation', '') }}
         run: |
           git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
-          bin/rails assets:precompile knapsack_pro:rspec
+          bin/rails assets:precompile knapsack_pro:rspec 2>&1 | sed '/INFO -- : Writing/d' # strip unnecessary output
 
       - name: Save SimpleCov file
         uses: actions/upload-artifact@v4
@@ -176,7 +176,7 @@ jobs:
           SPEC_OPTS: ${{ case(runner.debug == '1', '--format documentation', '') }}
 
         run: |
-          bin/rails assets:precompile knapsack_pro:queue:rspec
+          bin/rails assets:precompile knapsack_pro:queue:rspec 2>&1 | sed '/INFO -- : Writing/d' # strip unnecessary output
 
       - name: Save SimpleCov file
         uses: actions/upload-artifact@v4
@@ -276,7 +276,7 @@ jobs:
           SPEC_OPTS: ${{ case(runner.debug == '1', '--format documentation', '') }}
 
         run: |
-          bin/rails assets:precompile knapsack_pro:rspec
+          bin/rails assets:precompile knapsack_pro:rspec 2>&1 | sed '/INFO -- : Writing/d' # strip unnecessary output
 
       - name: Save SimpleCov file
         uses: actions/upload-artifact@v4
@@ -366,7 +366,7 @@ jobs:
           SPEC_OPTS: ${{ case(runner.debug == '1', '--format documentation', '') }}
 
         run: |
-          bin/rails assets:precompile knapsack_pro:rspec
+          bin/rails assets:precompile knapsack_pro:rspec 2>&1 | sed '/INFO -- : Writing/d' # strip unnecessary output
 
       - name: Save SimpleCov file
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,8 @@ jobs:
           SPEC_OPTS: ${{ case(runner.debug == '1', '--format documentation', '') }}
         run: |
           git show --no-patch # the commit being tested (which is often a merge due to actions/checkout@v3)
-          bin/rails assets:precompile knapsack_pro:rspec 2>&1 | sed '/INFO -- : Writing/d' # strip unnecessary output
+          bin/rails assets:precompile 2>&1 | sed '/INFO -- : Writing/d' # strip unnecessary output
+          bin/rails knapsack_pro:rspec
 
       - name: Save SimpleCov file
         uses: actions/upload-artifact@v4
@@ -176,7 +177,8 @@ jobs:
           SPEC_OPTS: ${{ case(runner.debug == '1', '--format documentation', '') }}
 
         run: |
-          bin/rails assets:precompile knapsack_pro:queue:rspec 2>&1 | sed '/INFO -- : Writing/d' # strip unnecessary output
+          bin/rails assets:precompile 2>&1 | sed '/INFO -- : Writing/d' # strip unnecessary output
+          bin/rails knapsack_pro:rspec
 
       - name: Save SimpleCov file
         uses: actions/upload-artifact@v4

--- a/config/shakapacker.yml
+++ b/config/shakapacker.yml
@@ -5,7 +5,7 @@ default: &default
   public_root_path: public
   public_output_path: packs
   cache_path: tmp/cache/webpacker
-  webpack_compile_output: true
+  webpack_compile_output: false
   additional_paths: &1
   - vendor
   - app/webpacker/css
@@ -20,6 +20,7 @@ default: &default
 development:
   <<: *default
   compile: true
+  webpack_compile_output: true
   dev_server:
     host: localhost
     port: 3035

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -248,6 +248,12 @@ RSpec.configure do |config|
     end
   end
 
+  # Add reference to help navigate debug logs
+  config.before(:each) do |example|
+    Rails.logger.debug(example.full_description)
+    Rails.logger.debug(example.location)
+  end
+
   config.infer_spec_type_from_file_location!
 
   # You can use `rspec -n` to run only failed specs.


### PR DESCRIPTION
While debugging some specs, I found some things to improve that would help navigate the logs. Happy to discuss each of these if you don't agree with anything.

## What's changed, and what should we check?
Green specs, and
   - check that a thousand compiled asset names aren't logged, ie: `INFO -- : Writing ...`
   - check that compilation messages aren't logged, ie: `Entrypoint admin [big] 1.25 MiB (4.04 MiB)` and `WARNING in ./app/webpacker/packs/admin-style.scss`


After merging, rerun a job in debug mode. 
   - Check that rails `debug` messages are logged
   
## On compiled assets logs
I don't know why precompile is showing `INFO -- : Writing ...` messages, because `RAILS_LOG_LEVEL` is already set to `fatal`. I did try to force it, but did didn't work (https://github.com/openfoodfoundation/openfoodnetwork/pull/14223/commits/2a407df976e84cd6ef426f9358b485490c9e598b).

## Other ideas
I just realised that if we're running the precompile separately to the tests, then we could just put it in a separate step (like pictured), which GH would collapse by default when it gets up to the spec execution. 
<img width="322" height="165" alt="Screenshot 2026-05-04 at 3 13 32 pm" src="https://github.com/user-attachments/assets/10363b1c-cdd9-4ed8-bcda-295a5cecd098" />
That way you could still easily find the compilation messages if you ever needed to.

I still think it's worth stripping out excessive logging in the first place, but would be ok with doing it this way if others agreed.