### PR TITLE
Fix form label associations for screen reader accessibility

### DIFF
--- a/app/views/admin/invoice_settings/edit.html.haml
+++ b/app/views/admin/invoice_settings/edit.html.haml
@@ -8,18 +8,18 @@
   .field.align-center
     = hidden_field_tag 'preferences[enable_invoices?]', '0'
     = check_box_tag 'preferences[enable_invoices?]', '1',  Spree::Config[:enable_invoices?]
-    = label_tag nil, t('.enable_invoices?')
+    = label_tag 'preferences_enable_invoices_', t('.enable_invoices?')
 
   - if ! OpenFoodNetwork::FeatureToggle.enabled?(:invoices, spree_current_user)
     .field.align-center
       = hidden_field_tag 'preferences[invoice_style2?]', '0'
       = check_box_tag 'preferences[invoice_style2?]', '1',  Spree::Config[:invoice_style2?]
-      = label_tag nil, t('.invoice_style2?')
+      = label_tag 'preferences_invoice_style2_', t('.invoice_style2?')
 
   .field.align-center
     = hidden_field_tag 'preferences[enterprise_number_required_on_invoices?]', '0'
     = check_box_tag 'preferences[enterprise_number_required_on_invoices?]', '1',  Spree::Config[:enterprise_number_required_on_invoices?]
-    = label_tag nil, t('.enterprise_number_required_on_invoices?')
+    = label_tag 'preferences_enterprise_number_required_on_invoices_', t('.enterprise_number_required_on_invoices?')
 
   .form-buttons
     = button t(:update), 'icon-refresh'

--- a/app/views/admin/reports/_date_range_form.html.haml
+++ b/app/views/admin/reports/_date_range_form.html.haml
@@ -8,10 +8,10 @@
 - end_date = datepicker_time(query[end_field].presence || Time.zone.tomorrow.beginning_of_day)
 
 .row.date-range-filter
-  .alpha.two.columns= label_tag nil, t(:date_range)
+  .alpha.two.columns= label_tag "report_date_range_#{field}", t(:date_range)
   .omega.fourteen.columns
     .field-block.omega.four.columns
       .date-range-fields{ data: { controller: "flatpickr", "flatpickr-mode-value": "range", "flatpickr-enable-time-value": true , "flatpickr-default-hour": 0, "flatpickr-default-date": [start_date, end_date] } }
-        = text_field_tag nil, nil, class: "datepicker fullwidth", data: { "flatpickr-target": "instance", action: "flatpickr_clear@window->flatpickr#clear" }
+        = text_field_tag nil, nil, id: "report_date_range_#{field}", class: "datepicker fullwidth", data: { "flatpickr-target": "instance", action: "flatpickr_clear@window->flatpickr#clear" }
         = text_field_tag "q[#{start_field}]", nil, data: { "flatpickr-target": "start" }, style: "display: none", value: start_date
         = text_field_tag "q[#{end_field}]", nil, data: { "flatpickr-target": "end" }, style: "display: none", value: end_date

--- a/app/views/admin/reports/_rendering_options.html.haml
+++ b/app/views/admin/reports/_rendering_options.html.haml
@@ -12,7 +12,8 @@
 
   - if @report.header_option? || @report.summary_row_option? || @report.metadata_option?
     .row
-      .alpha.two.columns= label_tag nil, t(".display")
+      .alpha.two.columns
+        %span.label-like= t(".display")
       .omega.fourteen.columns
         - if @report.metadata_option?
           %span.inline-checkbox{ style: "margin-right: 1rem;" }
@@ -29,6 +30,7 @@
 
 - if @report.available_headers.present?
   .row
-    .alpha.two.columns= label_tag nil, t(:report_columns)
+    .alpha.two.columns
+      %span.label-like= t(:report_columns)
     .omega.fourteen.columns
       = render MultipleCheckedSelectComponent.new(name: "fields_to_show", options: @report.available_headers, selected: @rendering_options.options[:fields_to_show])

--- a/app/views/admin/reports/filters/_bulk_coop.html.haml
+++ b/app/views/admin/reports/filters/_bulk_coop.html.haml
@@ -1,6 +1,6 @@
 = render 'admin/reports/date_range_form', f: f
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_hubs)
+  .alpha.two.columns= label_tag "q_distributor_id_in", t(:report_hubs)
   .omega.fourteen.columns
     = f.collection_select(:distributor_id_in, @data.distributors, :id, :name, {}, {class: "select2 fullwidth", multiple: true})

--- a/app/views/admin/reports/filters/_customers.html.haml
+++ b/app/views/admin/reports/filters/_customers.html.haml
@@ -1,13 +1,13 @@
 = render 'admin/reports/date_range_form', f: f
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_hub)
+  .alpha.two.columns= label_tag "distributor_id", t(:report_customers_hub)
   .omega.fourteen.columns
     = select_tag(:distributor_id,
       options_from_collection_for_select(@data.distributors, :id, :name, params[:distributor_id]),
       {:include_blank => true, :class => "select2 fullwidth light"})
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
+  .alpha.two.columns= label_tag "order_cycle_id", t(:report_customers_cycle)
   .omega.fourteen.columns
     = select_tag(:order_cycle_id,
       options_for_select(report_order_cycle_options(@data.order_cycles), params[:order_cycle_id]),

--- a/app/views/admin/reports/filters/_enterprise_fees_with_tax_report_by_order.html.haml
+++ b/app/views/admin/reports/filters/_enterprise_fees_with_tax_report_by_order.html.haml
@@ -1,6 +1,6 @@
 - search_url_query = {report_type: :enterprise_fee_summary, report_subtype: :enterprise_fees_with_tax_report_by_order}
 .row
-  .alpha.two.columns= label_tag nil, t(:report_hubs)
+  .alpha.two.columns= label_tag "q_distributor_id_in", t(:report_hubs)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(form: f,
       name: :distributor_id_in,
@@ -10,7 +10,7 @@
       remote_url: admin_reports_search_distributors_url))
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
+  .alpha.two.columns= label_tag "q_order_cycle_id_in", t(:report_customers_cycle)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(form: f,
       name: :order_cycle_id_in,
@@ -20,7 +20,7 @@
       remote_url: admin_reports_search_order_cycles_url))
 
 .row
-  .alpha.two.columns= label_tag nil, t(:fee_name)
+  .alpha.two.columns= label_tag "q_enterprise_fee_id_in", t(:fee_name)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(form: f,
       name: :enterprise_fee_id_in,
@@ -30,7 +30,7 @@
       remote_url: admin_reports_search_enterprise_fees_url(search_url_query)))
 
 .row
-  .alpha.two.columns= label_tag nil, t(:fee_owner)
+  .alpha.two.columns= label_tag "q_enterprise_fee_owner_id_in", t(:fee_owner)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(form: f,
       name: :enterprise_fee_owner_id_in,
@@ -40,7 +40,7 @@
       remote_url: admin_reports_search_enterprise_fee_owners_url(search_url_query)))
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers)
+  .alpha.two.columns= label_tag "q_customer_id_in", t(:report_customers)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(form: f,
       name: :customer_id_in,

--- a/app/views/admin/reports/filters/_enterprise_fees_with_tax_report_by_producer.html.haml
+++ b/app/views/admin/reports/filters/_enterprise_fees_with_tax_report_by_producer.html.haml
@@ -1,6 +1,6 @@
 - search_url_query = {report_type: :enterprise_fee_summary, report_subtype: :enterprise_fees_with_tax_report_by_producer}
 .row
-  .alpha.two.columns= label_tag nil, t(:report_hubs)
+  .alpha.two.columns= label_tag "q_distributor_id_in", t(:report_hubs)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(form: f,
       name: :distributor_id_in,
@@ -9,7 +9,7 @@
       multiple: true,
       remote_url: admin_reports_search_distributors_url))
 .row
-  .alpha.two.columns= label_tag nil, t(:report_producers)
+  .alpha.two.columns= label_tag "supplier_id_in", t(:report_producers)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(name: :supplier_id_in,
       options: [],
@@ -18,7 +18,7 @@
       remote_url: admin_reports_search_suppliers_url))
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
+  .alpha.two.columns= label_tag "q_order_cycle_id_in", t(:report_customers_cycle)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(form: f,
       name: :order_cycle_id_in,
@@ -27,7 +27,7 @@
       multiple: true,
       remote_url: admin_reports_search_order_cycles_url))
 .row
-  .alpha.two.columns= label_tag nil, t(:fee_name)
+  .alpha.two.columns= label_tag "q_enterprise_fee_id_in", t(:fee_name)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(form: f,
       name: :enterprise_fee_id_in,
@@ -37,7 +37,7 @@
       remote_url: admin_reports_search_enterprise_fees_url(search_url_query)))
 
 .row
-  .alpha.two.columns= label_tag nil, t(:fee_owner)
+  .alpha.two.columns= label_tag "q_enterprise_fee_owner_id_in", t(:fee_owner)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(form: f,
       name: :enterprise_fee_owner_id_in,
@@ -47,7 +47,7 @@
       remote_url: admin_reports_search_enterprise_fee_owners_url(search_url_query)))
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers)
+  .alpha.two.columns= label_tag "q_customer_id_in", t(:report_customers)
   .omega.fourteen.columns
     = render(SearchableDropdownComponent.new(form: f,
       name: :customer_id_in,

--- a/app/views/admin/reports/filters/_fee_summary.html.haml
+++ b/app/views/admin/reports/filters/_fee_summary.html.haml
@@ -1,29 +1,29 @@
 .row
-  .alpha.two.columns= label_tag nil, t(:report_hubs)
+  .alpha.two.columns= label_tag "q_distributor_ids", t(:report_hubs)
   .omega.fourteen.columns
     = collection_select(:q, :distributor_ids, @report.permissions.allowed_distributors, :id, :name, {selected: params.dig(:q, :distributor_ids)}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_producers)
+  .alpha.two.columns= label_tag "q_producer_ids", t(:report_producers)
   .omega.fourteen.columns
     = collection_select(:q, :producer_ids, @report.permissions.allowed_producers, :id, :name, {selected: params.dig(:q, :producer_ids)}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:order_cycles)
+  .alpha.two.columns= label_tag "q_order_cycle_ids", t(:order_cycles)
   .omega.fourteen.columns
     = collection_select(:q, :order_cycle_ids, @report.permissions.allowed_order_cycles, :id, :name, {selected: params.dig(:q, :order_cycle_ids)}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_enterprise_fee)
+  .alpha.two.columns= label_tag "q_enterprise_fee_ids", t(:report_enterprise_fee)
   .omega.fourteen.columns
     = collection_select(:q, :enterprise_fee_ids, @report.permissions.allowed_enterprise_fees, :id, :name, {selected: params.dig(:q, :enterprise_fee_ids)}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t('spree.shipping_methods')
+  .alpha.two.columns= label_tag "q_shipping_method_ids", t('spree.shipping_methods')
   .omega.fourteen.columns
     = collection_select(:q, :shipping_method_ids, @report.permissions.allowed_shipping_methods, :id, :name, {selected: params.dig(:q, :shipping_method_ids)}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_payment)
+  .alpha.two.columns= label_tag "q_payment_method_ids", t(:report_payment)
   .omega.fourteen.columns
     = collection_select(:q, :payment_method_ids, @report.permissions.allowed_payment_methods, :id, :name, {selected: params.dig(:q, :payment_method_ids)}, {class: "select2 fullwidth", multiple: true})

--- a/app/views/admin/reports/filters/_order_cycle_management.html.haml
+++ b/app/views/admin/reports/filters/_order_cycle_management.html.haml
@@ -1,18 +1,18 @@
 = render 'admin/reports/date_range_form', f: f
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_hubs)
+  .alpha.two.columns= label_tag "q_distributor_id_in", t(:report_hubs)
   .omega.fourteen.columns= f.collection_select(:distributor_id_in, @data.distributors, :id, :name, {}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
+  .alpha.two.columns= label_tag "q_order_cycle_id_in", t(:report_customers_cycle)
   .omega.fourteen.columns
     = f.select(:order_cycle_id_in, report_order_cycle_options(@data.order_cycles), {selected: params.dig(:q, :order_cycle_id_in)}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_payment)
+  .alpha.two.columns= label_tag "payment_method_in", t(:report_payment)
   .omega.fourteen.columns= select_tag(:payment_method_in, options_for_select(report_payment_method_options(@report.query_result), params[:payment_method_in]), {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:shipping_methods)
+  .alpha.two.columns= label_tag "shipping_method_in", t(:shipping_methods)
   .omega.fourteen.columns= select_tag(:shipping_method_in, options_for_select(report_shipping_method_options(@report.query_result), params[:shipping_method_in]), {class: "select2 fullwidth", multiple: true})

--- a/app/views/admin/reports/filters/_orders_and_distributors.html.haml
+++ b/app/views/admin/reports/filters/_orders_and_distributors.html.haml
@@ -1,5 +1,5 @@
 = render 'admin/reports/date_range_form', f: f
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_hubs)
+  .alpha.two.columns= label_tag "q_distributor_id_in", t(:report_hubs)
   .omega.fourteen.columns= f.collection_select(:distributor_id_in, @data.orders_distributors, :id, :name, {}, {class: "select2 fullwidth", multiple: true})

--- a/app/views/admin/reports/filters/_orders_and_fulfillment.html.haml
+++ b/app/views/admin/reports/filters/_orders_and_fulfillment.html.haml
@@ -1,15 +1,15 @@
 = render 'admin/reports/date_range_form', f: f
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_hubs)
+  .alpha.two.columns= label_tag "q_distributor_id_in", t(:report_hubs)
   .omega.fourteen.columns= f.collection_select(:distributor_id_in, @data.orders_distributors, :id, :name, {}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_producers)
+  .alpha.two.columns= label_tag "supplier_id_in", t(:report_producers)
   .omega.fourteen.columns= select_tag(:supplier_id_in, options_from_collection_for_select(@data.orders_suppliers, :id, :name, params[:supplier_id_in]), {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
+  .alpha.two.columns= label_tag "q_order_cycle_id_in", t(:report_customers_cycle)
   .omega.fourteen.columns
     = f.select(:order_cycle_id_in, report_order_cycle_options(@data.order_cycles), {selected: params.dig(:q, :order_cycle_id_in)}, {class: "select2 fullwidth", multiple: true})
 .row

--- a/app/views/admin/reports/filters/_packing.html.haml
+++ b/app/views/admin/reports/filters/_packing.html.haml
@@ -2,16 +2,16 @@
          locals: { f: f, field: 'order_completed_at' }
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_hubs)
+  .alpha.two.columns= label_tag "q_order_distributor_id_in", t(:report_hubs)
   .omega.fourteen.columns
     = collection_select("q", "order_distributor_id_in", @data.orders_distributors, :id, :name, {selected: params.dig(:q, :order_distributor_id_in)}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_producers)
+  .alpha.two.columns= label_tag "q_supplier_id_in", t(:report_producers)
   .omega.fourteen.columns
     = select_tag("q[supplier_id_in]", options_from_collection_for_select(@data.orders_suppliers, :id, :name, params.dig(:q, :supplier_id_in)), {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
+  .alpha.two.columns= label_tag "q_order_cycle_id_in", t(:report_customers_cycle)
   .omega.fourteen.columns
     = select_tag("q[order_cycle_id_in]", options_for_select(report_order_cycle_options(@data.order_cycles), params.dig(:q, :order_cycle_id_in)), {class: "select2 fullwidth", multiple: true})

--- a/app/views/admin/reports/filters/_payments.html.haml
+++ b/app/views/admin/reports/filters/_payments.html.haml
@@ -1,6 +1,6 @@
 = render 'admin/reports/date_range_form', f: f
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_distributor)
+  .alpha.two.columns= label_tag "q_distributor_id_eq", t(:report_distributor)
   .omega.fourteen.columns
     = f.collection_select(:distributor_id_eq, @data.distributors, :id, :name, {:include_blank => t(:report_all)}, {:class => "select2 fullwidth light"})

--- a/app/views/admin/reports/filters/_products_and_inventory.html.haml
+++ b/app/views/admin/reports/filters/_products_and_inventory.html.haml
@@ -1,19 +1,19 @@
 .row
-  .alpha.two.columns= label_tag nil, t(:report_distributor)
+  .alpha.two.columns= label_tag "distributor_id", t(:report_distributor)
   .omega.fourteen.columns
     = select_tag(:distributor_id,
       options_from_collection_for_select(@data.distributors, :id, :name, params[:distributor_id]),
       {:include_blank => true, :class => "select2 fullwidth light"})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_supplier)
+  .alpha.two.columns= label_tag "supplier_id", t(:report_customers_supplier)
   .omega.fourteen.columns
     = select_tag(:supplier_id,
       options_from_collection_for_select(@data.suppliers, :id, :name, params[:supplier_id]),
       {:include_blank => true, :class => "select2 fullwidth light"})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_order_cycle)
+  .alpha.two.columns= label_tag "order_cycle_id", t(:report_order_cycle)
   .omega.fourteen.columns
     = select_tag(:order_cycle_id,
       options_for_select(report_order_cycle_options(@data.order_cycles), params[:order_cycle_id]),

--- a/app/views/admin/reports/filters/_sales_tax.html.haml
+++ b/app/views/admin/reports/filters/_sales_tax.html.haml
@@ -1,6 +1,6 @@
 = render 'admin/reports/date_range_form', f: f
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_distributor)
+  .alpha.two.columns= label_tag "q_distributor_id_eq", t(:report_distributor)
   .omega.fourteen.columns
     = f.collection_select(:distributor_id_eq, @data.distributors, :id, :name, {:include_blank => t(:all)}, {:class => "select2 fullwidth light"})

--- a/app/views/admin/reports/filters/_sales_tax_totals_by_order.html.haml
+++ b/app/views/admin/reports/filters/_sales_tax_totals_by_order.html.haml
@@ -1,8 +1,8 @@
 .row
-  .alpha.two.columns= label_tag nil, t(:report_producers)
+  .alpha.two.columns= label_tag "supplier_id_in", t(:report_producers)
   .omega.fourteen.columns= select_tag(:supplier_id_in, options_from_collection_for_select(@data.orders_suppliers, :id, :name, params[:supplier_id_in]), {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
+  .alpha.two.columns= label_tag "q_order_cycle_id_in", t(:report_customers_cycle)
   .omega.fourteen.columns
     = f.select(:order_cycle_id_in, report_order_cycle_options(@data.order_cycles), {selected: params.dig(:q, :order_cycle_id_in)}, {class: "select2 fullwidth", multiple: true})

--- a/app/views/admin/reports/filters/_sales_tax_totals_by_producer.html.haml
+++ b/app/views/admin/reports/filters/_sales_tax_totals_by_producer.html.haml
@@ -1,13 +1,13 @@
 .row
-  .alpha.two.columns= label_tag nil, t(:report_producers)
+  .alpha.two.columns= label_tag "supplier_id_in", t(:report_producers)
   .omega.fourteen.columns= select_tag(:supplier_id_in, options_from_collection_for_select(@data.orders_suppliers, :id, :name, params[:supplier_id_in]), {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
+  .alpha.two.columns= label_tag "q_order_cycle_id_in", t(:report_customers_cycle)
   .omega.fourteen.columns
     = f.select(:order_cycle_id_in, report_order_cycle_options(@data.order_cycles), {selected: params.dig(:q, :order_cycle_id_in)}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers)
+  .alpha.two.columns= label_tag "q_customer_id_in", t(:report_customers)
   .omega.fourteen.columns
     = f.select(:customer_id_in, customer_email_options(@data.order_customers), {selected: params.dig(:q, :customer_id_in)}, {class: "select2 fullwidth", multiple: true})

--- a/app/views/admin/reports/filters/_suppliers.html.haml
+++ b/app/views/admin/reports/filters/_suppliers.html.haml
@@ -1,14 +1,14 @@
 = render 'admin/reports/date_range_form', f: f
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_hubs)
+  .alpha.two.columns= label_tag "q_distributor_id_in", t(:report_hubs)
   .omega.fourteen.columns= f.collection_select(:distributor_id_in, @data.orders_distributors, :id, :name, {}, {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_producers)
+  .alpha.two.columns= label_tag "supplier_id_in", t(:report_producers)
   .omega.fourteen.columns= select_tag(:supplier_id_in, options_from_collection_for_select(@data.orders_suppliers, :id, :name, params[:supplier_id_in]), {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
+  .alpha.two.columns= label_tag "q_order_cycle_id_in", t(:report_customers_cycle)
   .omega.fourteen.columns
     = f.select(:order_cycle_id_in, report_order_cycle_options(@data.order_cycles), {selected: params.dig(:q, :order_cycle_id_in)}, {class: "select2 fullwidth", multiple: true})

--- a/app/views/admin/reports/filters/_users_and_enterprises.html.haml
+++ b/app/views/admin/reports/filters/_users_and_enterprises.html.haml
@@ -1,7 +1,7 @@
 .row
-  .alpha.two.columns= label_tag nil, t(:report_enterprises)
+  .alpha.two.columns= label_tag "enterprise_id_in", t(:report_enterprises)
   .omega.fourteen.columns= select_tag(:enterprise_id_in, options_from_collection_for_select(Enterprise.all, :id, :name, params[:enterprise_id_in]), {class: "select2 fullwidth", multiple: true})
 
 .row
-  .alpha.two.columns= label_tag nil, t(:report_users)
+  .alpha.two.columns= label_tag "user_id_in", t(:report_users)
   .omega.fourteen.columns= select_tag(:user_id_in, options_from_collection_for_select(Spree::User.all, :id, :email, params[:user_id_in]), {class: "select2 fullwidth", multiple: true})

--- a/app/views/admin/reports/filters/_xero_invoices.html.haml
+++ b/app/views/admin/reports/filters/_xero_invoices.html.haml
@@ -1,10 +1,10 @@
 = render 'admin/reports/date_range_form', f: f
 
 .row
-  .two.columns.alpha= label_tag nil, t(:report_hubs)
+  .two.columns.alpha= label_tag "q_distributor_id_eq", t(:report_hubs)
   .fourteen.columns.omega= f.collection_select(:distributor_id_eq, @data.distributors, :id, :name, {:include_blank => 'All'}, {:class => "select2 fullwidth light"})
 .row
-  .two.columns.alpha= label_tag nil, t(:report_order_cycle)
+  .two.columns.alpha= label_tag "q_order_cycle_id_eq", t(:report_order_cycle)
   .fourteen.columns.omega= f.select(:order_cycle_id_eq,
     options_for_select(report_order_cycle_options(@data.order_cycles), params.dig(:q, :order_cycle_id_eq)),
     {:include_blank => true}, {:class => "select2 fullwidth light"})

--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -6,13 +6,13 @@
 
     .field-block.alpha.four.columns
       .date-range-filter.field
-        = label_tag nil, t(:date_range)
+        = label_tag "orders_date_range", t(:date_range)
         .date-range-fields{ data: { controller: "flatpickr", "flatpickr-mode-value": "range" } }
-          = text_field_tag nil, nil, class: "datepicker", data: { "flatpickr-target": "instance", action: "flatpickr_clear@window->flatpickr#clear" }
+          = text_field_tag nil, nil, id: "orders_date_range", class: "datepicker", data: { "flatpickr-target": "instance", action: "flatpickr_clear@window->flatpickr#clear" }
           = text_field_tag "q[completed_at_gteq]", nil, "ng-model": "q.completed_at_gteq", data: { "flatpickr-target": "start" }, style: "display: none"
           = text_field_tag "q[completed_at_lteq]", nil, "ng-model": "q.completed_at_lteq", data: { "flatpickr-target": "end" }, style: "display: none"
       .field
-        = label_tag nil, t(:status)
+        = label_tag "q_state_eq", t(:status)
         = select_tag("q[state_eq]",
             options_for_select(Spree::Order.state_machines[:state].states.collect {|s| [t("spree.order_state.#{s.name}"), s.value]}),
             { include_blank: true, class: "primary", "data-controller": "tom-select" })
@@ -36,17 +36,17 @@
           = check_box_tag "q[completed_at_not_null]", 1, true
           = t(:show_only_complete_orders)
       .field
-        = label_tag nil, t(:shipping_method)
+        = label_tag "shipping_method_id", t(:shipping_method)
         = select_tag(:shipping_method_id,
           options_for_select(Spree::ShippingMethod.managed_by(spree_current_user).map {|s| [s.name, s.id]}),
           { include_blank: true, class: "primary", "data-controller": "tom-select" })
     .field-block.alpha.eight.columns
-      = label_tag nil, t(:distributors)
+      = label_tag "q_distributor_id_in", t(:distributors)
       = select_tag("q[distributor_id_in]",
           options_for_select(Enterprise.is_distributor.managed_by(spree_current_user).map {|e| [e.name, e.id]}, params[:distributor_ids]),
           { class: "fullwidth", multiple: true, data: { controller: "tom-select", "tom-select-options-value": { plugins: ['remove_button'], maxItems: nil } }})
     .field-block.omega.eight.columns
-      = label_tag nil, t(:order_cycles)
+      = label_tag "q_order_cycle_id_in", t(:order_cycles)
       = select_tag("q[order_cycle_id_in]",
         options_for_select(OrderCycle.managed_by(spree_current_user).where('order_cycles.orders_close_at is not null').order('order_cycles.orders_close_at DESC').map {|oc| [oc.name, oc.id]}, params[:order_cycle_ids]),
         { class: "fullwidth", multiple: true, data: { controller: "tom-select", "tom-select-options-value": { plugins: ['remove_button'], maxItems: nil } }})

--- a/app/views/spree/admin/payment_methods/_form.html.haml
+++ b/app/views/spree/admin/payment_methods/_form.html.haml
@@ -5,36 +5,36 @@
     = t '.deactivation_warning'
   .row
     .alpha.four.columns
-      = label_tag nil, t('.name')
+      = label_tag "payment_method_name", t('.name')
     .omega.twelve.columns
       = text_field :payment_method, :name, class: 'fullwidth'
   .row
     .alpha.four.columns
-      = label_tag nil, t('.description')
+      = label_tag "payment_method_description", t('.description')
     .omega.twelve.columns
       = text_area :payment_method, :description, {cols: 60, rows: 6, class: 'fullwidth'}
   - if spree_current_user.admin?
     .row
       .alpha.four.columns
-        = label_tag nil, t('.environment')
+        = label_tag "gtwy-env", t('.environment')
       .omega.twelve.columns
         = collection_select(:payment_method, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {id: 'gtwy-env', class: 'select2 fullwidth'})
   .row
     .alpha.four.columns
-      = label_tag nil, t('.display')
+      = label_tag "payment_method_display_on", t('.display')
     .omega.twelve.columns
       = select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t('.' + display.to_s), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
   .row
     .alpha.four.columns
-      = label_tag nil, t('.active')
+      %span.label-like= t('.active')
     .two.columns
       = radio_button :payment_method, :active, true
       &nbsp;
-      = label_tag nil, t('.active_yes')
+      = label_tag "payment_method_active_true", t('.active_yes')
     .omega.six.columns
       = radio_button :payment_method, :active, false
       &nbsp;
-      = label_tag nil, t('.active_no')
+      = label_tag "payment_method_active_false", t('.active_no')
 
   .row
     .alpha.four.columns

--- a/app/views/spree/admin/payments/show.html.haml
+++ b/app/views/spree/admin/payments/show.html.haml
@@ -15,6 +15,6 @@
 
 .align-center
   %h5
-    = label_tag nil, Spree.t(:amount)
+    %span= Spree.t(:amount)
     \:
     %span.green= @payment.amount

--- a/app/webpacker/css/admin/shared/forms.scss
+++ b/app/webpacker/css/admin/shared/forms.scss
@@ -66,7 +66,8 @@ textarea {
   width: 100%;
 }
 
-label {
+label,
+span.label-like {
   display: inline-block;
   font-weight: 600;
   font-size: 85%;

--- a/spec/views/admin/invoice_settings/edit.html.haml_spec.rb
+++ b/spec/views/admin/invoice_settings/edit.html.haml_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe "admin/invoice_settings/edit.html.haml" do
+  helper Spree::Admin::NavigationHelper
+
+  before do
+    stub_template "spree/admin/shared/_configuration_menu.html.haml" => ""
+    allow(view).to receive(:spree_current_user).and_return(build(:user))
+    allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).and_return(false)
+  end
+
+  it "has labels correctly associated with their checkboxes" do
+    render
+
+    expect(rendered).to have_css('label[for="preferences_enable_invoices_"]')
+    expect(rendered).to have_css('input[id="preferences_enable_invoices_"]')
+
+    expect(rendered).to have_css('label[for="preferences_invoice_style2_"]')
+    expect(rendered).to have_css('input[id="preferences_invoice_style2_"]')
+
+    expect(rendered).to have_css('label[for="preferences_enterprise_number_required_on_invoices_"]')
+    expect(rendered).to have_css('input[id="preferences_enterprise_number_required_on_invoices_"]')
+  end
+end

--- a/spec/views/spree/admin/orders/_filters.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/_filters.html.haml_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe "spree/admin/orders/_filters.html.haml" do
+  helper Spree::Admin::NavigationHelper
+  helper Spree::Admin::BaseHelper
+
+  before do
+    user = create(:user)
+    allow(view).to receive_messages spree_current_user: user
+    allow(Spree::ShippingMethod).to receive(:managed_by).and_return(Spree::ShippingMethod.none)
+    allow(Enterprise).to receive(:is_distributor).and_return(
+      double(managed_by: Enterprise.none)
+    )
+    allow(OrderCycle).to receive(:managed_by).and_return(
+      OrderCycle.none
+    )
+  end
+
+  it "has a label correctly associated with the date range input" do
+    render
+
+    # The label's 'for' attribute must match the input's 'id'
+    expect(rendered).to have_css('label[for="orders_date_range"]')
+    expect(rendered).to have_css('input[id="orders_date_range"]')
+  end
+
+  it "has a label correctly associated with the status select" do
+    render
+
+    expect(rendered).to have_css('label[for="q_state_eq"]')
+    expect(rendered).to have_css('select[id="q_state_eq"]')
+  end
+
+  it "has a label correctly associated with the shipping method select" do
+    render
+
+    expect(rendered).to have_css('label[for="shipping_method_id"]')
+    expect(rendered).to have_css('select[id="shipping_method_id"]')
+  end
+
+  it "has a label correctly associated with the distributor select" do
+    render
+
+    expect(rendered).to have_css('label[for="q_distributor_id_in"]')
+    expect(rendered).to have_css('select[id="q_distributor_id_in"]')
+  end
+
+  it "has a label correctly associated with the order cycle select" do
+    render
+
+    expect(rendered).to have_css('label[for="q_order_cycle_id_in"]')
+    expect(rendered).to have_css('select[id="q_order_cycle_id_in"]')
+  end
+end


### PR DESCRIPTION
## What? Why?

- Closes #13133

All 67 `label_tag nil` instances in admin views have been replaced with properly associated labels (using `for` attributes that match input `id` attributes). This is required by WCAG 1.3.1 Info and Relationships and 4.1.2 Name, Role, Value.

Without correct `for`/`id` associations, screen readers cannot announce the label for each input when a user tabs to it.

**Changes cover:**
- `admin/orders` filters (date range, status, shipping method, distributor, order cycle)
- `admin/reports` date range, rendering options, and all 16 report filter partials
- `admin/invoice_settings` (3 checkboxes)
- `spree/admin/payment_methods` form (name, description, environment, display, active radio buttons)
- `spree/admin/payments` show page (removed erroneous label tag from a display element)

For group labels (radio button groups, checkbox groups, composite components) that don't map to a single input `id`, `<span class="label-like">` is used with matching CSS styling added to `forms.scss`.

## What should we test?

- Visit `/admin/orders` — use ANDI or a screen reader to verify the date range, status, shipping method, distributor, and order cycle filter labels are announced when focusing each input
- Visit `/admin/reports/orders_and_fulfillment` — verify all filter labels (hubs, producers, order cycles) are associated with their select inputs
- Visit `/admin/payment_methods/new` — verify name, description, display, and radio button labels work correctly
- Check that visual appearance of all labels is unchanged

Programmatic check: inspect rendered HTML and verify every `<label>` element has a `for` attribute matching an `id` of an input/select/textarea.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

Screen readers now correctly announce filter and form labels throughout the admin interface.

## Dependencies

None.