### PR TITLE
Add specs to prevent flatpickr date format string corruption in locale files

### DIFF
--- a/spec/javascripts/stimulus/flatpickr_controller_test.js
+++ b/spec/javascripts/stimulus/flatpickr_controller_test.js
@@ -31,5 +31,15 @@ describe("FlatpickrController", () => {
       expect(locale).toHaveProperty("weekAbbreviation");
       expect(locale.weekAbbreviation).toBe("Sem");
     });
+
+    it("returns locale object for Finnish (fi)", async () => {
+      const controller = new FlatpickrController();
+      const locale = await controller.importFlatpickrLocale("fi");
+      expect(locale).toBeInstanceOf(Object);
+      expect(locale).toHaveProperty("weekdays");
+      expect(locale).toHaveProperty("months");
+      expect(locale.weekdays.shorthand).toContain("ma");
+      expect(locale.months.shorthand).toContain("tammi");
+    });
   });
 });

--- a/spec/lib/flatpickr_date_formats_spec.rb
+++ b/spec/lib/flatpickr_date_formats_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe "Flatpickr date format strings in locale files" do
 
       locale_files.each do |file|
         locale_code = File.basename(file, ".yml")
-        pending "locale is known to have a broken date/time format" if known_broken_locales.include?(locale_code)
+        if known_broken_locales.include?(locale_code)
+          pending "locale is known to have a broken date/time format"
+        end
 
         formats = date_picker_formats(file)
         format = formats[format_key]

--- a/spec/lib/flatpickr_date_formats_spec.rb
+++ b/spec/lib/flatpickr_date_formats_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Flatpickr date format strings in locale files" do
 
       locale_files.each do |file|
         locale_code = File.basename(file, ".yml")
-        next if known_broken_locales.include?(locale_code)
+        pending "locale is known to have a broken date/time format" if known_broken_locales.include?(locale_code)
 
         formats = date_picker_formats(file)
         format = formats[format_key]

--- a/spec/lib/flatpickr_date_formats_spec.rb
+++ b/spec/lib/flatpickr_date_formats_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+# Valid flatpickr format token characters (single-character tokens and common separators).
+# See: https://flatpickr.js.org/formatting/
+#
+# Tokens: Z D F G H J K M S U W Y d h i j l m n s u w y
+# Separators: . - / : (space)
+# Escape: \  (makes the next character literal)
+VALID_FLATPICKR_FORMAT_REGEX = %r{\A[ZDFGHJKMSUWYdhijlmnsuwy.\-/: \\]+\z}
+
+# Known locales with incorrect (translator-provided) format strings.
+# These should be fixed in Transifex and removed from this list as they are corrected.
+# See: https://github.com/openfoodfoundation/openfoodnetwork/issues/13360
+KNOWN_BROKEN_FLATPICKR_LOCALES = %w[cy el eu ko pa sr tr uk].freeze
+
+RSpec.describe "Flatpickr date format strings in locale files" do
+  def locale_files
+    Rails.root.glob("config/locales/*.yml")
+  end
+
+  def date_picker_formats(file)
+    yaml = YAML.safe_load_file(file, permitted_classes: [Symbol])
+    return {} unless yaml
+
+    root = yaml.values.first
+    return {} unless root.is_a?(Hash)
+
+    date_picker = root.dig("spree", "date_picker")
+    return {} unless date_picker.is_a?(Hash)
+
+    {
+      date: date_picker["flatpickr_date_format"],
+      datetime: date_picker["flatpickr_datetime_format"]
+    }.compact
+  end
+
+  it "locale files are present" do
+    expect(locale_files).not_to be_empty
+  end
+
+  shared_examples "valid flatpickr format" do |format_key|
+    it "#{format_key} is a valid flatpickr format string in all locales" do
+      invalid = []
+
+      locale_files.each do |file|
+        locale_code = File.basename(file, ".yml")
+        next if KNOWN_BROKEN_FLATPICKR_LOCALES.include?(locale_code)
+
+        formats = date_picker_formats(file)
+        format = formats[format_key]
+        next unless format
+
+        invalid << "#{locale_code}: '#{format}'" unless format.match?(VALID_FLATPICKR_FORMAT_REGEX)
+      end
+
+      expect(invalid)
+        .to be_empty,
+            "Invalid #{format_key} found in locale files:\n" \
+            "#{invalid.join("\n")}\n\n" \
+            "Flatpickr format strings use single-character tokens (e.g. Y=year, m=month).\n" \
+            "They must not be translated. Valid tokens: ZDFGHJKMSUWYdhijlmnsuwy\n" \
+            "Valid separators: . - / : space\n" \
+            "See: https://flatpickr.js.org/formatting/"
+    end
+  end
+
+  include_examples "valid flatpickr format", :date
+  include_examples "valid flatpickr format", :datetime
+
+  describe "Finnish locale specifically" do
+    it "has valid flatpickr_date_format" do
+      formats = date_picker_formats(Rails.root.join("config/locales/fi.yml"))
+      expect(formats[:date]).to eq("d.m.Y")
+    end
+
+    it "has valid flatpickr_datetime_format" do
+      formats = date_picker_formats(Rails.root.join("config/locales/fi.yml"))
+      expect(formats[:datetime]).to eq("d.m.Y H:i")
+    end
+  end
+end

--- a/spec/lib/flatpickr_date_formats_spec.rb
+++ b/spec/lib/flatpickr_date_formats_spec.rb
@@ -2,19 +2,6 @@
 
 require "yaml"
 
-# Valid flatpickr format token characters (single-character tokens and common separators).
-# See: https://flatpickr.js.org/formatting/
-#
-# Tokens: Z D F G H J K M S U W Y d h i j l m n s u w y
-# Separators: . - / : (space)
-# Escape: \  (makes the next character literal)
-VALID_FLATPICKR_FORMAT_REGEX = %r{\A[ZDFGHJKMSUWYdhijlmnsuwy.\-/: \\]+\z}
-
-# Known locales with incorrect (translator-provided) format strings.
-# These should be fixed in Transifex and removed from this list as they are corrected.
-# See: https://github.com/openfoodfoundation/openfoodnetwork/issues/13360
-KNOWN_BROKEN_FLATPICKR_LOCALES = %w[cy el eu ko pa sr tr uk].freeze
-
 RSpec.describe "Flatpickr date format strings in locale files" do
   def locale_files
     Rails.root.glob("config/locales/*.yml")
@@ -42,17 +29,28 @@ RSpec.describe "Flatpickr date format strings in locale files" do
 
   shared_examples "valid flatpickr format" do |format_key|
     it "#{format_key} is a valid flatpickr format string in all locales" do
+      # Valid flatpickr format token characters (single-character tokens and common separators).
+      # See: https://flatpickr.js.org/formatting/
+      # Tokens: Z D F G H J K M S U W Y d h i j l m n s u w y
+      # Separators: . - / : (space) — Escape: \ (makes the next character literal)
+      valid_format_regex = %r{\A[ZDFGHJKMSUWYdhijlmnsuwy.\-/: \\]+\z}
+
+      # Known locales with incorrect (translator-provided) format strings.
+      # These should be fixed in Transifex and removed as they are corrected.
+      # See: https://github.com/openfoodfoundation/openfoodnetwork/issues/13360
+      known_broken_locales = %w[cy el eu ko pa sr tr uk]
+
       invalid = []
 
       locale_files.each do |file|
         locale_code = File.basename(file, ".yml")
-        next if KNOWN_BROKEN_FLATPICKR_LOCALES.include?(locale_code)
+        next if known_broken_locales.include?(locale_code)
 
         formats = date_picker_formats(file)
         format = formats[format_key]
         next unless format
 
-        invalid << "#{locale_code}: '#{format}'" unless format.match?(VALID_FLATPICKR_FORMAT_REGEX)
+        invalid << "#{locale_code}: '#{format}'" unless format.match?(valid_format_regex)
       end
 
       expect(invalid)


### PR DESCRIPTION
## What? Why?

- Closes #13360

Finnish locale had `flatpickr_date_format: "Vuosi"` (Finnish for "Year") and
`flatpickr_datetime_format: "Vuosi H:i"` instead of `"d.m.Y"` and `"d.m.Y H:i"`.
Transifex translators mistakenly treated these flatpickr format codes as human-readable
strings and translated them.

Because flatpickr interprets each character as a format token, `"Vuosi"` was rendered as:
- `V` = literal (not a token)
- `u` = Unix milliseconds → `1749326700000`
- `o` = literal (not a token)
- `s` = seconds → `00`
- `i` = minutes → `05`

Producing the corrupted output `V1749326700000o005 12:35` visible in the issue.

The format string fix for Finnish was already applied in commit 95412bd (PR #13960).
This PR adds regression tests so CI catches the same class of mistake in any locale.

Several other locales have the same problem (cy, el, eu, ko, pa, sr, tr, uk) — these
are documented in the spec as `KNOWN_BROKEN_FLATPICKR_LOCALES` and should be fixed
through Transifex as a follow-up.

## What should we test?

- Check the Ruby spec passes: `./bin/rspec spec/lib/flatpickr_date_formats_spec.rb`
- Check the JS test passes: `npx jest spec/javascripts/stimulus/flatpickr_controller_test.js`
- Set locale to Finnish (fi) and go to `/admin/order_cycles/new`
- Select a date for the cycle open/close
- Confirm the date shows as `DD.MM.YYYY HH:mm` (e.g. `07.06.2025 12:45`) not a garbled string

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

## Dependencies

Depends on / follows from PR #13960 which fixed the fi.yml format strings.