### PR TITLE
Fix: truncate adjustment labels that exceed the database column limit

### DIFF
--- a/lib/open_food_network/enterprise_fee_applicator.rb
+++ b/lib/open_food_network/enterprise_fee_applicator.rb
@@ -24,7 +24,8 @@ module OpenFoodNetwork
     end
 
     def line_item_adjustment_label
-      "#{variant.product.name} - #{base_adjustment_label}"
+      label_limit = Spree::Adjustment.columns_hash['label'].limit
+      "#{variant.product.name} - #{base_adjustment_label}".truncate(label_limit)
     end
 
     def order_adjustment_label

--- a/spec/lib/open_food_network/enterprise_fee_applicator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_fee_applicator_spec.rb
@@ -70,6 +70,15 @@ module OpenFoodNetwork
           expect(applicator.__send__(:line_item_adjustment_label)).
             to eq("Bananas - packing name fee by distributor Ballantyne")
         end
+
+        context "when the label would exceed the database column limit" do
+          let(:variant) { double(:variant, product: double(:product, name: "A" * 255)) }
+
+          it "truncates the label to fit within 255 characters" do
+            label = applicator.__send__(:line_item_adjustment_label)
+            expect(label.length).to be <= 255
+          end
+        end
       end
 
       describe "#order_adjustment_label" do

--- a/spec/lib/open_food_network/enterprise_fee_applicator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_fee_applicator_spec.rb
@@ -39,8 +39,7 @@ module OpenFoodNetwork
         it "truncates the label to fit within the column limit" do
           adjustment = applicator.create_line_item_adjustment(line_item)
 
-          label_limit = Spree::Adjustment.columns_hash['label'].limit
-          expect(adjustment.label.length).to be <= label_limit
+          expect(adjustment.label.length).to eq(255)
         end
       end
     end

--- a/spec/lib/open_food_network/enterprise_fee_applicator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_fee_applicator_spec.rb
@@ -32,6 +32,17 @@ module OpenFoodNetwork
         expect(metadata.fee_type).to eq(enterprise_fee.fee_type)
         expect(metadata.enterprise_role).to eq('role')
       end
+
+      context "when the label would exceed the database column limit" do
+        before { target_variant.product.update!(name: "A" * 255) }
+
+        it "truncates the label to fit within the column limit" do
+          adjustment = applicator.create_line_item_adjustment(line_item)
+
+          label_limit = Spree::Adjustment.columns_hash['label'].limit
+          expect(adjustment.label.length).to be <= label_limit
+        end
+      end
     end
 
     describe "#create_order_adjustment" do
@@ -69,15 +80,6 @@ module OpenFoodNetwork
         it "makes an adjustment label for a line item" do
           expect(applicator.__send__(:line_item_adjustment_label)).
             to eq("Bananas - packing name fee by distributor Ballantyne")
-        end
-
-        context "when the label would exceed the database column limit" do
-          let(:variant) { double(:variant, product: double(:product, name: "A" * 255)) }
-
-          it "truncates the label to fit within 255 characters" do
-            label = applicator.__send__(:line_item_adjustment_label)
-            expect(label.length).to be <= 255
-          end
         end
       end
 


### PR DESCRIPTION
#### What? Why?

- Closes #13322

When a product name is very long (e.g. 255 characters), the generated
adjustment label `"#{product_name} - #{fee_label}"` exceeds the 255-character
limit of the `spree_adjustments.label` column, causing a server error when
a customer adds such a product to cart or when an admin tries to refund an order
containing it.

This fix truncates the label to the column limit before it reaches the database.

Building on the approach started in #13429 (thank you @ashishp91).

#### Changes

- `lib/open_food_network/enterprise_fee_applicator.rb` — truncate
  `line_item_adjustment_label` to the DB column limit using
  `Spree::Adjustment.columns_hash['label'].limit`
- `spec/lib/open_food_network/enterprise_fee_applicator_spec.rb` — add test
  for the truncation case

#### What should we test?

1. Create a product with a name close to or exceeding 255 characters
2. Add to cart — should not raise a server error
3. Checkout and complete the order
4. Refund the order — should not raise a server error

#### Release notes

- [x] User facing changes

The title of the pull request will be included in the release notes.