### PR TITLE
Remove random order number out of comparison

### DIFF
--- a/spec/requests/spree/admin/orders_spec.rb
+++ b/spec/requests/spree/admin/orders_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe Spree::Admin::OrdersController do
         expect(response.body).to include("flashes").twice
         # flash[:error] only include the last entry, it lets us check the error message
         # is correctly formated
-        expect(flash[:error]).to eq "Order ##{order1.number} could not be credited : No credit owed"
+        expect(flash[:error]).to end_with "could not be credited : No credit owed"
         expect(response.body).not_to include("order_#{order.id}", "order_#{order1.id}")
       end
     end


### PR DESCRIPTION
## What? Why?

The spec `spec/requests/spree/admin/orders_spec.rb:386` was failing randomly because the flashes were appearing in random order. Checking only for the text that's the same in both flashes stabilises the spec.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
