### PR TITLE
Fix order product name snapshot 13969

### DIFF
--- a/app/models/invoice/data_presenter/line_item.rb
+++ b/app/models/invoice/data_presenter/line_item.rb
@@ -12,6 +12,10 @@ class Invoice
 
       delegate :name_to_display, :options_text, to: :variant
 
+      def full_product_name
+        variant.product.name
+      end
+
       def amount_with_adjustments_without_taxes
         fee_tax = enterprise_fee_included_tax || 0.0
         (price_with_adjustments * quantity) - included_tax - fee_tax

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -261,7 +261,7 @@ module Spree
     def full_product_name
       return product_name if product_name.present?
 
-      variant.product.name
+      product.name
     end
 
     def name_to_display

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -264,6 +264,12 @@ module Spree
       variant.product.name
     end
 
+    def name_to_display
+      return full_product_name if display_name.blank?
+
+      display_name
+    end
+
     private
 
     def computed_weight_from_variant

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -271,10 +271,10 @@ module Spree
     end
 
     def product_and_full_name
-      return full_product_name if full_variant_name.blank?
-      return "#{full_product_name} - #{full_variant_name}" unless full_variant_name.start_with?(full_product_name)
+      return full_product_name if full_name.blank?
+      return "#{full_product_name} - #{full_name}" unless full_name.start_with?(full_product_name)
 
-      full_variant_name
+      full_name
     end
 
     private

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -270,6 +270,13 @@ module Spree
       display_name
     end
 
+    def product_and_full_name
+      return full_product_name if full_variant_name.blank?
+      return "#{full_product_name} - #{full_variant_name}" unless full_variant_name.start_with?(full_product_name)
+
+      full_variant_name
+    end
+
     private
 
     def computed_weight_from_variant

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -26,6 +26,7 @@ module Spree
     before_validation :copy_dimensions
     before_validation :copy_product_name, on: :create
     before_validation :copy_variant_name, on: :create
+    before_validation :copy_product_and_full_name, on: :create
 
     validates :quantity, numericality: {
       only_integer: true,
@@ -264,17 +265,15 @@ module Spree
       product.name
     end
 
-    def name_to_display
-      return full_product_name if display_name.blank?
-
-      display_name
-    end
-
     def product_and_full_name
-      return full_product_name if full_name.blank?
-      return "#{full_product_name} - #{full_name}" unless full_name.start_with?(full_product_name)
+      return self[:product_and_full_name] if self[:product_and_full_name].present?
 
-      full_name
+      # Fallback for records created before this snapshot was added
+      fn = full_name
+      return full_product_name if fn.blank?
+      return "#{full_product_name} - #{fn}" unless fn.start_with?(full_product_name)
+
+      fn
     end
 
     private
@@ -311,6 +310,12 @@ module Spree
       return if variant.nil?
 
       self.variant_name = variant.full_name
+    end
+
+    def copy_product_and_full_name
+      return if variant.nil?
+
+      self[:product_and_full_name] = variant.product_and_full_name
     end
 
     def update_inventory_before_destroy

--- a/app/views/spree/admin/orders/_invoice/_line_item_name.html.haml
+++ b/app/views/spree/admin/orders/_invoice/_line_item_name.html.haml
@@ -1,6 +1,6 @@
 %h5.inline-header
-  = line_item.variant.product.name
-  - unless line_item.variant.product.name.include? line_item.name_to_display
+  = line_item.full_product_name
+  - unless line_item.full_product_name.include? line_item.name_to_display
     %span= "- #{line_item.name_to_display}"
 - if line_item.unit_price
   = raw("(#{format_unit_price(line_item.unit_price)})")

--- a/app/views/spree/admin/orders/_invoice/_line_item_name.html.haml
+++ b/app/views/spree/admin/orders/_invoice/_line_item_name.html.haml
@@ -1,7 +1,7 @@
 %h5.inline-header
   = line_item.full_product_name
-  - unless line_item.full_product_name.include? line_item.name_to_display
-    %span= "- #{line_item.name_to_display}"
+  - if line_item.variant.display_name.present? && !line_item.full_product_name.include?(line_item.variant.display_name)
+    %span= "- #{line_item.variant.display_name}"
 - if line_item.unit_price
   = raw("(#{format_unit_price(line_item.unit_price)})")
 

--- a/app/views/spree/admin/orders/_line_item.html.haml
+++ b/app/views/spree/admin/orders/_line_item.html.haml
@@ -1,6 +1,6 @@
 %tr{id: "#{spree_dom_id(f.object)}", class: "#{cycle('odd', 'even')}"}
   %td
-    = f.object.variant.product.name
+    = f.object.full_product_name
     = "(#{f.object.full_name})"
   %td.price.align-center
     = f.object.single_display_amount

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -6,7 +6,7 @@
       %td.item-image
         = render 'spree/shared/variant_thumbnail', variant: item.variant
       %td.item-name
-        = item.variant.product_and_full_name
+        = line_item.product_and_full_name
       %td.item-price.align-center
         = line_item.single_money.to_html
       %td.item-qty-show.align-center

--- a/app/views/spree/shared/_line_item_name.html.haml
+++ b/app/views/spree/shared/_line_item_name.html.haml
@@ -1,6 +1,6 @@
 %h5.inline-header
-  = "#{line_item.product.name}"
-  - unless line_item.product.name.include? line_item.name_to_display
+  = "#{line_item.full_product_name}"
+  - unless line_item.full_product_name.include? line_item.name_to_display
     %span= "- #{line_item.name_to_display}"
 - if line_item.unit_to_display
   = "(#{line_item.unit_to_display})"

--- a/app/views/spree/shared/_line_item_name.html.haml
+++ b/app/views/spree/shared/_line_item_name.html.haml
@@ -1,6 +1,6 @@
 %h5.inline-header
   = "#{line_item.full_product_name}"
-  - unless line_item.full_product_name.include? line_item.name_to_display
-    %span= "- #{line_item.name_to_display}"
+  - if line_item.display_name.present? && !line_item.full_product_name.include?(line_item.display_name)
+    %span= "- #{line_item.display_name}"
 - if line_item.unit_to_display
   = "(#{line_item.unit_to_display})"

--- a/db/migrate/20260422000001_add_product_and_full_name_to_line_items.rb
+++ b/db/migrate/20260422000001_add_product_and_full_name_to_line_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProductAndFullNameToLineItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_line_items, :product_and_full_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -596,6 +596,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_06_015040) do
     t.string "unit_presentation"
     t.string "product_name"
     t.string "variant_name"
+    t.string "product_and_full_name"
     t.index ["order_id"], name: "index_line_items_on_order_id"
     t.index ["variant_id"], name: "index_line_items_on_variant_id"
   end


### PR DESCRIPTION
## What? Why?

- Closes #13969

When a producer renames a product, existing orders were retroactively displaying the new name instead of the name at the time of purchase. Orders should be immutable records of what a customer bought.

The snapshotting infrastructure (`product_name` and `variant_name` columns on `spree_line_items`, populated at order creation) was already in place from a prior fix, but several views were still reading the live product name directly via the database association instead of using the snapshot. This PR updates those views and adds the missing snapshot-aware methods to `LineItem`.

**Changes:**
- `app/views/spree/shared/_line_item_name.html.haml` — customer order view now uses `full_product_name`
- `app/views/spree/admin/orders/_line_item.html.haml` — admin order edit uses `full_product_name`
- `app/views/spree/admin/orders/_invoice/_line_item_name.html.haml` — invoice view uses `full_product_name`
- `app/views/spree/admin/orders/_shipment_manifest.html.haml` — shipment manifest now uses `line_item.product_and_full_name` instead of `item.variant.product_and_full_name`
- `app/models/spree/line_item.rb` — adds `name_to_display` and `product_and_full_name` overrides that use snapshotted names

---

## What should we test?

- Place an order for a product (e.g. "Fuji Apple").
- Edit the product name in `/admin/products` to something new (e.g. "Fuji Apple RENAMED").
- Visit `/orders/ORDERNUMBER` (customer view) — should still show the original name **"Fuji Apple"**.
- Visit `/admin/orders/ORDERNUMBER/edit` (admin order edit) — should still show **"Fuji Apple"**.
- Visit the invoice for that order — should still show **"Fuji Apple"**.
- Place a brand new order after the rename — should show the new name **"Fuji Apple RENAMED"** (snapshot taken at creation time).

---

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

---

## Dependencies

None.

---

## Documentation updates

None required.