### PR TITLE
[Flaky spec] Make sure clone link is present before clicking

### DIFF
--- a/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_component.html.haml
+++ b/app/components/vertical_ellipsis_menu_component/vertical_ellipsis_menu_component.html.haml
@@ -1,4 +1,4 @@
 .vertical-ellipsis-menu{ "data-controller": "vertical-ellipsis-menu" }
   %i.fa.fa-ellipsis-v{ "data-action": "click->vertical-ellipsis-menu#toggle" }
-  .vertical-ellipsis-menu-content{ "data-vertical-ellipsis-menu-target": "content" }
+  .vertical-ellipsis-menu-content{ "data-turbo-prefetch": "false", "data-vertical-ellipsis-menu-target": "content" }
     = content

--- a/spec/support/products_helper.rb
+++ b/spec/support/products_helper.rb
@@ -103,7 +103,6 @@ module ProductsHelper
   def click_product_clone(product_name)
     within row_containing_name(product_name) do
       page.find(".vertical-ellipsis-menu").click
-      expect(page).to have_link "Clone"
       click_link('Clone')
     end
   end

--- a/spec/support/products_helper.rb
+++ b/spec/support/products_helper.rb
@@ -103,6 +103,7 @@ module ProductsHelper
   def click_product_clone(product_name)
     within row_containing_name(product_name) do
       page.find(".vertical-ellipsis-menu").click
+      expect(page).to have_link "Clone"
       click_link('Clone')
     end
   end


### PR DESCRIPTION
## What? Why?

- Closes #14182  <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
~~I am not sure if that's going to fix the issue but it looks like an obvious thing to fix.~~

Turbo prefetches links when you hover them, for this flaky test we are testing the presence of some menu which resulted in a prefetch request which would sometimes fail. I don't think it's really useful in the this context to prefetch the link, so I disabled it. It should also make specs a bit faster, as we won't be loading page we don't care about.


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green spec :green_circle: 

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.