### PR TITLE
Fix error when confirming order fails.

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -64,7 +64,6 @@ class CheckoutController < BaseController
   private
 
   def render_error
-    # TODO fix this , error on moving to summary ?
     @paid_with_credit = calculate_credit(@order) if payment_step? || summary_step?
 
     flash.now[:error] ||= I18n.t('checkout.errors.saving_failed')

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -64,7 +64,8 @@ class CheckoutController < BaseController
   private
 
   def render_error
-    @paid_with_credit = calculate_credit(@order) if payment_step?
+    # TODO fix this , error on moving to summary ?
+    @paid_with_credit = calculate_credit(@order) if payment_step? || summary_step?
 
     flash.now[:error] ||= I18n.t('checkout.errors.saving_failed')
 


### PR DESCRIPTION
## What? Why?

- Closes #14184  <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
When an error happens when confirming an order, re rendering the summary step fails because `@paid_with_credit` is not calculated. This PR fix this 


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Set up an enterprise requiring term and condition to place an order. You can do that by uploading a terms and condition file in the enterprise configuration page, in the "Business Details" section.
As a customer :
- Start an order with the enterprise and proceed to checkout
- On the summary step, make sure the "I agree to the platform Terms of service." is unticked.
- Try completing the order :
  -> you see the summary page again with an error message.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.