### PR TITLE
[Linked Variants] Hide linked variants for producers

### DIFF
--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -53,6 +53,11 @@ module Admin
         .enterprises_granting_linked_variants
     end
 
+    def managed_product_enterprises
+      @managed_product_enterprises ||= OpenFoodNetwork::Permissions.new(spree_current_user)
+        .managed_product_enterprises
+    end
+
     # Query only name of the model to avoid loading the whole record
     def selected_option(id, model)
       return [] unless id

--- a/app/views/admin/products_v3/_product_variant_row.html.haml
+++ b/app/views/admin/products_v3/_product_variant_row.html.haml
@@ -11,6 +11,8 @@
 
       -# Filter out variant a user has not permission to update, but keep variant with no supplier
       - next if variant.supplier.present? && !allowed_producers.include?(variant.supplier)
+      -# Filter out other hub's variants that are linked to mine
+      - next if variant.hub.present? && !managed_product_enterprises.include?(variant.hub)
 
       = form.fields_for("products][#{product_index}][variants_attributes", variant, index: variant_index) do |variant_form|
         %tr.condensed{ id: dom_id(variant), 'data-controller': "variant", 'class': "nested-form-wrapper", 'data-new-record': variant.new_record? ? "true" : false }

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -126,24 +126,21 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
     end
 
     it "displays a select box for the unit of measure for the product's variants" do
-      pending( "[BUU] Change producer, unit type and tax category #11060" )
-      p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1,
-                                      variant_unit_name: '')
+      p1.variants.first.update! variant_unit: 'weight', variant_unit_scale: 1, variant_unit_name: ''
 
       visit spree.admin_products_path
 
-      expect(page).to have_select "variant_unit_with_scale", selected: "Weight (g)"
+      expect(page).to have_select "Unit scale", selected: "Weight (g)"
     end
 
     it "displays a text field for the item name when unit is set to 'Items'" do
-      pending( "[BUU] Change producer, unit type and tax category #11060" )
-      p = FactoryBot.create(:product, variant_unit: 'items', variant_unit_scale: nil,
-                                      variant_unit_name: 'packet')
+      p1.variants.first.update! variant_unit: 'items', variant_unit_scale: nil,
+                                variant_unit_name: 'packet'
 
       visit spree.admin_products_path
 
-      expect(page).to have_select "variant_unit_with_scale", selected: "Items"
-      expect(page).to have_field "variant_unit_name", with: "packet"
+      expect(page).to have_select "Unit scale", selected: "Items"
+      expect(page).to have_field "Items", with: "packet"
     end
 
     context "with sourced variant" do

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
 
     context "with sourced variant" do
       let(:source_producer) { create(:supplier_enterprise) }
+      let(:hub) { create(:distributor_enterprise) }
       let(:p3) { create(:product, name: "Product3", supplier_id: source_producer.id) }
 
       let!(:v3_source) { p3.variants.first }
@@ -156,13 +157,20 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
                          hub: producer)
       }
       let!(:enterprise_relationship) {
-        # Other producer grants me access to manage their variant
+        # Producer grants me access to manage their variant
         create(:enterprise_relationship, parent: source_producer, child: producer,
                                          permissions_list: [:manage_products])
       }
 
+      # I don't manage this hub, so shouldn't see see the sourced variant
+      let!(:v3_sourced_hidden) {
+        create(:variant, display_name: "Variant3-hidden", product: p3, supplier: source_producer,
+                         hub:)
+      }
+
       before do
         v3_sourced.source_variants << v3_source
+        v3_sourced_hidden.source_variants << v3_source
         visit admin_products_url
       end
 
@@ -171,6 +179,9 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
           expect(page).to have_selector 'span[title*="Sourced from: "]'
           expect(page).to have_selector 'span[title*="Hub: My Enterprise"]'
         end
+
+        # But not variants sourced by other hubs
+        expect(page).not_to have_selector row_containing_name("Variant3-hidden")
       end
     end
   end

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -33,9 +33,10 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
 
   describe "listing" do
     let!(:p1) { create(:product, name: "Product1") }
-    let!(:p2) { create(:product, name: "Product2") }
+    let(:p2) { create(:product, name: "Product2") }
 
     it "displays a list of products" do
+      p2
       visit admin_products_path
 
       within ".products" do
@@ -146,11 +147,11 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
     context "with sourced variant" do
       let(:source_producer) { create(:supplier_enterprise) }
       let(:hub) { create(:distributor_enterprise) }
-      let(:p3) { create(:product, name: "Product3", supplier_id: source_producer.id) }
+      let!(:p1) { create(:product, name: "Product1", supplier_id: source_producer.id) }
 
-      let!(:v3_source) { p3.variants.first }
-      let!(:v3_sourced) {
-        create(:variant, display_name: "Variant3-sourced", product: p3, supplier: source_producer,
+      let!(:v_source) { p1.variants.first }
+      let!(:v_sourced) {
+        create(:variant, display_name: "Variant-sourced", product: p1, supplier: source_producer,
                          hub: producer)
       }
       let!(:enterprise_relationship) {
@@ -160,25 +161,25 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
       }
 
       # I don't manage this hub, so shouldn't see see the sourced variant
-      let!(:v3_sourced_hidden) {
-        create(:variant, display_name: "Variant3-hidden", product: p3, supplier: source_producer,
+      let!(:v_sourced_hidden) {
+        create(:variant, display_name: "Variant-hidden", product: p1, supplier: source_producer,
                          hub:)
       }
 
       before do
-        v3_sourced.source_variants << v3_source
-        v3_sourced_hidden.source_variants << v3_source
+        v_sourced.source_variants << v_source
+        v_sourced_hidden.source_variants << v_source
         visit admin_products_url
       end
 
       it "shows sourced variant with indicator" do
-        within row_containing_name("Variant3-sourced") do
+        within row_containing_name("Variant-sourced") do
           expect(page).to have_selector 'span[title*="Sourced from: "]'
           expect(page).to have_selector 'span[title*="Hub: My Enterprise"]'
         end
 
         # But not variants sourced by other hubs
-        expect(page).not_to have_selector row_containing_name("Variant3-hidden")
+        expect(page).not_to have_selector row_containing_name("Variant-hidden")
       end
     end
   end


### PR DESCRIPTION
⚠️ Please use clockify code 76a Source variant when working on this


## What? Why?

- Closes #14160

Also some spec cleanup.

## What should we test?
From issue: 

1. As a producer give permission to a hub to create linked variant from your products
2. As a hub create linked variants
3. As the producer: Observe that these linked variants are not shown in the bulk products screen
