### PR TITLE
[Linked Variants] Restrict changing producer on linked variant

### DIFF
--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -12,8 +12,7 @@ module Admin
     def index
       fetch_products
       render "index",
-             locals: { producer_options:, categories:, tax_category_options:, available_tags:,
-                       flash:, allowed_producers: }
+             locals: { producer_options:, available_tags:, flash:, allowed_producers: }
 
       session[:products_return_to_url] = request.url
     end
@@ -34,8 +33,7 @@ module Admin
 
         render "index", status: :unprocessable_entity,
                         locals: {
-                          producer_options:, categories:, tax_category_options:, available_tags:,
-                          allowed_producers:, flash:
+                          producer_options:, available_tags:, allowed_producers:, flash:
                         }
       end
     end
@@ -101,7 +99,6 @@ module Admin
         format.turbo_stream {
           render :clone, status:,
                          locals: { product:, cloned_product:, product_index:, producer_options:,
-                                   category_options: categories, tax_category_options:,
                                    allowed_producers: }
         }
       end
@@ -127,8 +124,7 @@ module Admin
 
       respond_with do |format|
         format.turbo_stream {
-          locals = { linked_variant:, variant:, product_index:, variant_index:,
-                     producer_options:, category_options: categories, tax_category_options: }
+          locals = { linked_variant:, variant:, product_index:, variant_index:, producer_options: }
           render :create_linked_variant, status:, locals:
         }
       end
@@ -181,14 +177,6 @@ module Admin
 
     def producer_options
       allowed_producers.map { |p| [p.name, p.id] }
-    end
-
-    def categories
-      Spree::Taxon.order(:name).map { |c| [c.name, c.id] }
-    end
-
-    def tax_category_options
-      Spree::TaxCategory.order(:name).pluck(:name, :id)
     end
 
     def available_tags

--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -176,7 +176,7 @@ module Admin
     end
 
     def producer_options
-      allowed_producers.map { |p| [p.name, p.id] }
+      return allowed_producers.first if allowed_producers.one?
     end
 
     def available_tags

--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -12,7 +12,7 @@ module Admin
     def index
       fetch_products
       render "index",
-             locals: { producer_options:, available_tags:, flash:, allowed_producers: }
+             locals: { available_tags:, flash:, allowed_producers: }
 
       session[:products_return_to_url] = request.url
     end
@@ -33,7 +33,7 @@ module Admin
 
         render "index", status: :unprocessable_entity,
                         locals: {
-                          producer_options:, available_tags:, allowed_producers:, flash:
+                          available_tags:, allowed_producers:, flash:
                         }
       end
     end
@@ -98,7 +98,7 @@ module Admin
       respond_with do |format|
         format.turbo_stream {
           render :clone, status:,
-                         locals: { product:, cloned_product:, product_index:, producer_options:,
+                         locals: { product:, cloned_product:, product_index:,
                                    allowed_producers: }
         }
       end
@@ -124,7 +124,7 @@ module Admin
 
       respond_with do |format|
         format.turbo_stream {
-          locals = { linked_variant:, variant:, product_index:, variant_index:, producer_options: }
+          locals = { linked_variant:, variant:, product_index:, variant_index: }
           render :create_linked_variant, status:, locals:
         }
       end
@@ -173,10 +173,6 @@ module Admin
     def allowed_producers
       OpenFoodNetwork::Permissions.new(spree_current_user)
         .managed_product_enterprises.is_primary_producer.by_name
-    end
-
-    def producer_options
-      return allowed_producers.first if allowed_producers.one?
     end
 
     def available_tags

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -10,9 +10,9 @@ module Admin
       end
     end
 
-    def prepare_new_variant(product, producer_options)
+    def prepare_new_variant(product, producer_id = nil)
       product.variants.build do |new_variant|
-        new_variant.supplier_id = producer_options&.id
+        new_variant.supplier_id = producer_id
         new_variant.tax_category_id = product.variants.first.tax_category_id
       end
     end
@@ -37,8 +37,8 @@ module Admin
 
     # if user hasn't saved any preferences on products page and there's only one producer;
     # we need to hide producer column
-    def hide_producer_column?(producer_options)
-      spree_current_user.column_preferences.bulk_edit_product.empty? && producer_options.present?
+    def hide_producer_column?(allowed_producers)
+      spree_current_user.column_preferences.bulk_edit_product.empty? && allowed_producers.one?
     end
 
     # check if the user is in the "admins" group or if it's enabled for any of

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -53,6 +53,11 @@ module Admin
         .enterprises_granting_linked_variants
     end
 
+    def managed_product_enterprises
+      @managed_product_enterprises ||= OpenFoodNetwork::Permissions.new(spree_current_user)
+        .managed_product_enterprises
+    end
+
     # Query only name of the model to avoid loading the whole record
     def selected_option(id, model)
       return [] unless id

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -11,9 +11,8 @@ module Admin
     end
 
     def prepare_new_variant(product, producer_options)
-      # e.g producer_options = [['producer name', id]]
       product.variants.build do |new_variant|
-        new_variant.supplier_id = producer_options.first.second if producer_options.one?
+        new_variant.supplier_id = producer_options&.id
         new_variant.tax_category_id = product.variants.first.tax_category_id
       end
     end
@@ -39,7 +38,7 @@ module Admin
     # if user hasn't saved any preferences on products page and there's only one producer;
     # we need to hide producer column
     def hide_producer_column?(producer_options)
-      spree_current_user.column_preferences.bulk_edit_product.empty? && producer_options.one?
+      spree_current_user.column_preferences.bulk_edit_product.empty? && producer_options.present?
     end
 
     # check if the user is in the "admins" group or if it's enabled for any of

--- a/app/views/admin/products_v3/_content.html.haml
+++ b/app/views/admin/products_v3/_content.html.haml
@@ -1,4 +1,4 @@
--# locals: (products:, pagy:, search_term:, producer_options:, producer_id:, category_id:, available_tags:, tags:, flashes:, display_search_filter:, allowed_producers:, per_page:)
+-# locals: (products:, pagy:, search_term:, producer_id:, category_id:, available_tags:, tags:, flashes:, display_search_filter:, allowed_producers:, per_page:)
 %turbo-frame#products-content{ target: "_top", refresh: "morph" }
   .spinner-overlay{ "data-controller": "loading", "data-products-target": "loading", class: "hidden" }
     .spinner-container
@@ -8,8 +8,8 @@
     .sixteen.columns
       = render partial: 'admin/shared/flashes', locals: { flashes: } if defined? flashes
       = render partial: 'filters', locals: { search_term:,
+                                              allowed_producers:,
                                               producer_id:,
-                                              producer_options:,
                                               category_id:,
                                               available_tags:,
                                               tags:,
@@ -18,7 +18,7 @@
     .container.results
       .sixteen.columns
         = render partial: 'sort', locals: { pagy:, search_term:, producer_id:, category_id:, tags:, per_page: }
-        = render partial: 'table', locals: { products:, producer_options:, allowed_producers: }
+        = render partial: 'table', locals: { products:, allowed_producers: }
     - if pagy.present? && pagy.pages > 1
       = render partial: 'admin/shared/stimulus_pagination', locals: { pagy: pagy }
   - else

--- a/app/views/admin/products_v3/_content.html.haml
+++ b/app/views/admin/products_v3/_content.html.haml
@@ -1,4 +1,4 @@
--# locals: (products:, pagy:, search_term:, producer_options:, producer_id:, category_options:, category_id:, tax_category_options:, available_tags:, tags:, flashes:, display_search_filter:, allowed_producers:, per_page:)
+-# locals: (products:, pagy:, search_term:, producer_options:, producer_id:, category_id:, available_tags:, tags:, flashes:, display_search_filter:, allowed_producers:, per_page:)
 %turbo-frame#products-content{ target: "_top", refresh: "morph" }
   .spinner-overlay{ "data-controller": "loading", "data-products-target": "loading", class: "hidden" }
     .spinner-container
@@ -10,7 +10,6 @@
       = render partial: 'filters', locals: { search_term:,
                                               producer_id:,
                                               producer_options:,
-                                              category_options:,
                                               category_id:,
                                               available_tags:,
                                               tags:,
@@ -19,7 +18,7 @@
     .container.results
       .sixteen.columns
         = render partial: 'sort', locals: { pagy:, search_term:, producer_id:, category_id:, tags:, per_page: }
-        = render partial: 'table', locals: { products:, producer_options:, category_options:, tax_category_options: , allowed_producers: }
+        = render partial: 'table', locals: { products:, producer_options:, allowed_producers: }
     - if pagy.present? && pagy.pages > 1
       = render partial: 'admin/shared/stimulus_pagination', locals: { pagy: pagy }
   - else

--- a/app/views/admin/products_v3/_filters.html.haml
+++ b/app/views/admin/products_v3/_filters.html.haml
@@ -6,7 +6,7 @@
   .query
     .search-input
       = text_field_tag :search_term, search_term, placeholder: t('.search_products')
-  - if producer_options.many?
+  - if producer_options.nil?
     .producers
       = label_tag :producer_id, t('.producers.label')
       = render(SearchableDropdownComponent.new(name: :producer_id,

--- a/app/views/admin/products_v3/_filters.html.haml
+++ b/app/views/admin/products_v3/_filters.html.haml
@@ -6,7 +6,7 @@
   .query
     .search-input
       = text_field_tag :search_term, search_term, placeholder: t('.search_products')
-  - if producer_options.nil?
+  - if allowed_producers.many?
     .producers
       = label_tag :producer_id, t('.producers.label')
       = render(SearchableDropdownComponent.new(name: :producer_id,

--- a/app/views/admin/products_v3/_product_variant_row.html.haml
+++ b/app/views/admin/products_v3/_product_variant_row.html.haml
@@ -1,4 +1,4 @@
--# locals: (form:, product:, product_index:, producer_options:, category_options:, tax_category_options:, allowed_producers:, should_slide_in: false)
+-# locals: (form:, product:, product_index:, producer_options:, allowed_producers:, should_slide_in: false)
 = form.fields_for("products", product, index: product_index) do |product_form|
   %tbody.relaxed{ id: dom_id(product), data: { 'record-id': product_form.object.id,
                           controller: "nested-form product",
@@ -16,12 +16,12 @@
 
       = form.fields_for("products][#{product_index}][variants_attributes", variant, index: variant_index) do |variant_form|
         %tr.condensed{ id: dom_id(variant), 'data-controller': "variant", 'class': "nested-form-wrapper", 'data-new-record': variant.new_record? ? "true" : false }
-          = render partial: 'variant_row', locals: { variant:, f: variant_form, product_index:, category_options:, tax_category_options:, producer_options: }
+          = render partial: 'variant_row', locals: { variant:, f: variant_form, product_index: }
 
     = form.fields_for("products][#{product_index}][variants_attributes][NEW_RECORD", prepare_new_variant(product, producer_options)) do |new_variant_form|
       %template{ 'data-nested-form-target': "template" }
         %tr.condensed{ 'data-controller': "variant", 'class': "nested-form-wrapper", 'data-new-record': "true" }
-          = render partial: 'variant_row', locals: { variant: new_variant_form.object, f: new_variant_form, category_options:, tax_category_options:, producer_options: }
+          = render partial: 'variant_row', locals: { variant: new_variant_form.object, f: new_variant_form}
 
     %tr{ 'data-nested-form-target': "target" }
     %tr.condensed

--- a/app/views/admin/products_v3/_product_variant_row.html.haml
+++ b/app/views/admin/products_v3/_product_variant_row.html.haml
@@ -11,6 +11,8 @@
 
       -# Filter out variant a user has not permission to update, but keep variant with no supplier
       - next if variant.supplier.present? && !allowed_producers.include?(variant.supplier)
+      -# Filter out other hub's variants that are linked to mine
+      - next if variant.hub.present? && !managed_product_enterprises.include?(variant.hub)
 
       = form.fields_for("products][#{product_index}][variants_attributes", variant, index: variant_index) do |variant_form|
         %tr.condensed{ id: dom_id(variant), 'data-controller': "variant", 'class': "nested-form-wrapper", 'data-new-record': variant.new_record? ? "true" : false }

--- a/app/views/admin/products_v3/_product_variant_row.html.haml
+++ b/app/views/admin/products_v3/_product_variant_row.html.haml
@@ -1,4 +1,4 @@
--# locals: (form:, product:, product_index:, producer_options:, allowed_producers:, should_slide_in: false)
+-# locals: (form:, product:, product_index:, allowed_producers:, should_slide_in: false)
 = form.fields_for("products", product, index: product_index) do |product_form|
   %tbody.relaxed{ id: dom_id(product), data: { 'record-id': product_form.object.id,
                           controller: "nested-form product",
@@ -18,7 +18,7 @@
         %tr.condensed{ id: dom_id(variant), 'data-controller': "variant", 'class': "nested-form-wrapper", 'data-new-record': variant.new_record? ? "true" : false }
           = render partial: 'variant_row', locals: { variant:, f: variant_form, product_index: }
 
-    = form.fields_for("products][#{product_index}][variants_attributes][NEW_RECORD", prepare_new_variant(product, producer_options)) do |new_variant_form|
+    = form.fields_for("products][#{product_index}][variants_attributes][NEW_RECORD", prepare_new_variant(product, allowed_producers)) do |new_variant_form|
       %template{ 'data-nested-form-target': "template" }
         %tr.condensed{ 'data-controller': "variant", 'class': "nested-form-wrapper", 'data-new-record': "true" }
           = render partial: 'variant_row', locals: { variant: new_variant_form.object, f: new_variant_form}

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,4 +1,4 @@
--# locals: (products:, producer_options:, category_options:, tax_category_options:, allowed_producers:)
+-# locals: (products:, producer_options:, allowed_producers:)
 = form_with url: admin_products_bulk_update_path, method: :post, id: "products-form",
             builder: BulkFormBuilder,
             html: { data: { 'turbo-frame': "_self",
@@ -72,4 +72,4 @@
         %th.align-left.col-inherits_properties= t('admin.products_page.columns.inherits_properties')
         %th.align-right= t('admin.products_page.columns.actions')
     - products.each_with_index do |product, product_index|
-      = render partial: 'product_variant_row', locals: { form:, product:, product_index:, producer_options:, category_options:, tax_category_options: , allowed_producers:}
+      = render partial: 'product_variant_row', locals: { form:, product:, product_index:, producer_options: , allowed_producers:}

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -1,4 +1,4 @@
--# locals: (products:, producer_options:, allowed_producers:)
+-# locals: (products:, allowed_producers:)
 = form_with url: admin_products_bulk_update_path, method: :post, id: "products-form",
             builder: BulkFormBuilder,
             html: { data: { 'turbo-frame': "_self",
@@ -16,7 +16,7 @@
   - @tags.each do |tag|
     = hidden_field_tag 'tags_name_in[]', tag
 
-  %table.products{ 'data-column-preferences-target': "table", class: (hide_producer_column?(producer_options) ? 'hide-producer' : '') }
+  %table.products{ 'data-column-preferences-target': "table", class: (hide_producer_column?(allowed_producers) ? 'hide-producer' : '') }
     %colgroup
       -# The `min-width` property works in Chrome but not Firefox so is considered progressive enhancement.
       %col.col-image{ width:"44px" }= # (image size + padding)
@@ -72,4 +72,4 @@
         %th.align-left.col-inherits_properties= t('admin.products_page.columns.inherits_properties')
         %th.align-right= t('admin.products_page.columns.actions')
     - products.each_with_index do |product, product_index|
-      = render partial: 'product_variant_row', locals: { form:, product:, product_index:, producer_options: , allowed_producers:}
+      = render partial: 'product_variant_row', locals: { form:, product:, product_index:, allowed_producers:}

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -1,5 +1,5 @@
 -# haml-lint:disable ViewLength (This file is big, but doesn't make sense to split up at this point)
--# locals: (variant:, f:, product_index: nil, category_options:, tax_category_options:, producer_options:)
+-# locals: (variant:, f:, product_index: nil)
 - method_on_demand, method_on_hand = variant.new_record? ? [:on_demand_desired, :on_hand_desired ]: [:on_demand, :on_hand]
 %td.col-image
   -# empty

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -56,14 +56,18 @@
         = f.check_box method_on_demand, 'data-action': 'change->toggle-control#disableIfPresent change->popout#closeIfChecked'
         = t(:on_demand)
 %td.col-producer.field.naked_inputs
-  = render(SearchableDropdownComponent.new(form: f,
-      name: :supplier_id,
-      aria_label: t('.producer_field_name'),
-      options: variant.supplier_id ? [[variant.supplier.name, variant.supplier_id]] : [],
-      selected_option: variant.supplier_id,
-      remote_url: admin_ajax_search_producers_url,
-      placeholder_value: t('admin.products_v3.filters.select_producer')))
-  = error_message_on variant, :supplier
+  - if variant.hub_id.blank?
+    = render(SearchableDropdownComponent.new(form: f,
+        name: :supplier_id,
+        aria_label: t('.producer_field_name'),
+        options: variant.supplier_id ? [[variant.supplier.name, variant.supplier_id]] : [],
+        selected_option: variant.supplier_id,
+        remote_url: admin_ajax_search_producers_url,
+        placeholder_value: t('admin.products_v3.filters.select_producer')))
+    = error_message_on variant, :supplier
+  - else
+    .content
+      = variant.supplier.name
 %td.col-category.field.naked_inputs
   = render(SearchableDropdownComponent.new(form: f,
       name: :primary_taxon_id,

--- a/app/views/admin/products_v3/clone.turbo_stream.haml
+++ b/app/views/admin/products_v3/clone.turbo_stream.haml
@@ -1,4 +1,4 @@
--# locals: (product:, cloned_product:, product_index:, producer_options:, category_options: category, tax_category_options:, allowed_producers:)
+-# locals: (product:, cloned_product:, product_index:, producer_options:, allowed_producers:)
 - unless flash[:error]
     - product_body = nil
     - form_with do |form|
@@ -7,8 +7,6 @@
             product: cloned_product,
             product_index:,
             producer_options:,
-            category_options:,
-            tax_category_options:,
             allowed_producers:,
             should_slide_in: true },
             formats: :html)

--- a/app/views/admin/products_v3/clone.turbo_stream.haml
+++ b/app/views/admin/products_v3/clone.turbo_stream.haml
@@ -1,4 +1,4 @@
--# locals: (product:, cloned_product:, product_index:, producer_options:, allowed_producers:)
+-# locals: (product:, cloned_product:, product_index:, allowed_producers:)
 - unless flash[:error]
     - product_body = nil
     - form_with do |form|
@@ -6,7 +6,6 @@
             locals: { form:,
             product: cloned_product,
             product_index:,
-            producer_options:,
             allowed_producers:,
             should_slide_in: true },
             formats: :html)

--- a/app/views/admin/products_v3/create_linked_variant.turbo_stream.haml
+++ b/app/views/admin/products_v3/create_linked_variant.turbo_stream.haml
@@ -1,13 +1,10 @@
--# locals: (variant:, linked_variant:, product_index:, variant_index:, producer_options:, category_options:, tax_category_options:)
+-# locals: (variant:, linked_variant:, product_index:, variant_index:)
 -# Pre-render the form, because you can't do it inside turbo stream block
 - variant_row = nil
 - fields_for("products][#{product_index}][variants_attributes", variant, index: variant_index) do |f|
   - variant_row = render(partial: 'variant_row', formats: :html,
                          locals: { f:,
-                           variant:,
-                           producer_options:,
-                           category_options:,
-                           tax_category_options:})
+                           variant:})
 = turbo_stream.after dom_id(linked_variant) do
   %tr.condensed{ id: dom_id(variant), 'data-controller': "variant", 'class': "nested-form-wrapper slide-in",'data-variant-bulk-form-outlet': "#products-form"}
     = variant_row

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -1,4 +1,4 @@
--# locals: (producer_options:, available_tags:, flash:, allowed_producers:)
+-# locals: (available_tags:, flash:, allowed_producers:)
 - content_for :page_title do
   = t('.header.title')
 - content_for :page_actions do
@@ -15,7 +15,7 @@
 #products_v3_page{ 'data-turbo': true }
   = render partial: "content", locals: { products: @products, pagy: @pagy, search_term: @search_term,
                                 per_page: @per_page,
-                                producer_options:, producer_id: @producer_id,
+                                producer_id: @producer_id,
                                 category_id: @category_id,
                                 available_tags:, tags: @tags,
                                 flashes: flash,

--- a/app/views/admin/products_v3/index.html.haml
+++ b/app/views/admin/products_v3/index.html.haml
@@ -1,4 +1,4 @@
--# locals: (producer_options:, categories:, tax_category_options:, available_tags:, flash:, allowed_producers:)
+-# locals: (producer_options:, available_tags:, flash:, allowed_producers:)
 - content_for :page_title do
   = t('.header.title')
 - content_for :page_actions do
@@ -16,8 +16,8 @@
   = render partial: "content", locals: { products: @products, pagy: @pagy, search_term: @search_term,
                                 per_page: @per_page,
                                 producer_options:, producer_id: @producer_id,
-                                category_options: categories, category_id: @category_id,
-                                tax_category_options:, available_tags:, tags: @tags,
+                                category_id: @category_id,
+                                available_tags:, tags: @tags,
                                 flashes: flash,
                                 display_search_filter: (@products.any? || @search_term.present? || @category_id.present?),
                                 allowed_producers:}

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -119,7 +119,7 @@
 
       .content {
         // Plain content fields need help to align with text in inputs (due to vertical-align)
-        margin: $vpadding-txt + 1px 0;
+        margin: ($vpadding-txt + 1px) ($hpadding-txt + 2px);
 
         @extend .line-clamp-1;
       }

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -126,24 +126,21 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
     end
 
     it "displays a select box for the unit of measure for the product's variants" do
-      pending( "[BUU] Change producer, unit type and tax category #11060" )
-      p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1,
-                                      variant_unit_name: '')
+      p1.variants.first.update! variant_unit: 'weight', variant_unit_scale: 1, variant_unit_name: ''
 
       visit spree.admin_products_path
 
-      expect(page).to have_select "variant_unit_with_scale", selected: "Weight (g)"
+      expect(page).to have_select "Unit scale", selected: "Weight (g)"
     end
 
     it "displays a text field for the item name when unit is set to 'Items'" do
-      pending( "[BUU] Change producer, unit type and tax category #11060" )
-      p = FactoryBot.create(:product, variant_unit: 'items', variant_unit_scale: nil,
-                                      variant_unit_name: 'packet')
+      p1.variants.first.update! variant_unit: 'items', variant_unit_scale: nil,
+                                variant_unit_name: 'packet'
 
       visit spree.admin_products_path
 
-      expect(page).to have_select "variant_unit_with_scale", selected: "Items"
-      expect(page).to have_field "variant_unit_name", with: "packet"
+      expect(page).to have_select "Unit scale", selected: "Items"
+      expect(page).to have_field "Items", with: "packet"
     end
 
     context "with sourced variant" do

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
     end
 
     context "with sourced variant" do
-      let(:source_producer) { create(:supplier_enterprise) }
+      let(:source_producer) { create(:supplier_enterprise, name: "Producer Enterprise") }
       let(:hub) { create(:distributor_enterprise) }
       let!(:p1) { create(:product, name: "Product1", supplier_id: source_producer.id) }
 
@@ -176,6 +176,10 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
         within row_containing_name("Variant-sourced") do
           expect(page).to have_selector 'span[title*="Sourced from: "]'
           expect(page).to have_selector 'span[title*="Hub: My Enterprise"]'
+
+          # Can't change the producer of a linked variant
+          expect(page).not_to have_select "Producer"
+          expect(page).to have_content "Producer Enterprise"
         end
 
         # But not variants sourced by other hubs

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
 
     context "with sourced variant" do
       let(:source_producer) { create(:supplier_enterprise) }
+      let(:hub) { create(:distributor_enterprise) }
       let(:p3) { create(:product, name: "Product3", supplier_id: source_producer.id) }
 
       let!(:v3_source) { p3.variants.first }
@@ -156,13 +157,20 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
                          hub: producer)
       }
       let!(:enterprise_relationship) {
-        # Other producer grants me access to manage their variant
+        # Producer grants me access to manage their variant
         create(:enterprise_relationship, parent: source_producer, child: producer,
                                          permissions_list: [:manage_products])
       }
 
+      # I don't manage this hub, so shouldn't see see the sourced variant
+      let!(:v3_sourced_hidden) {
+        create(:variant, display_name: "Variant3-hidden", product: p3, supplier: source_producer,
+                         hub:)
+      }
+
       before do
         v3_sourced.source_variants << v3_source
+        v3_sourced_hidden.source_variants << v3_source
         visit admin_products_url
       end
 
@@ -171,6 +179,9 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
           expect(page).to have_selector 'span[title*="Sourced from: "]'
           expect(page).to have_selector 'span[title*="Hub: My Enterprise"]'
         end
+
+        # But not variants sourced by other hubs
+        expect(page).not_to have_selector row_containing_name("Variant3-hidden")
       end
     end
   end

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -33,9 +33,10 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
 
   describe "listing" do
     let!(:p1) { create(:product, name: "Product1") }
-    let!(:p2) { create(:product, name: "Product2") }
+    let(:p2) { create(:product, name: "Product2") }
 
     it "displays a list of products" do
+      p2
       visit admin_products_path
 
       within ".products" do
@@ -146,11 +147,11 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
     context "with sourced variant" do
       let(:source_producer) { create(:supplier_enterprise) }
       let(:hub) { create(:distributor_enterprise) }
-      let(:p3) { create(:product, name: "Product3", supplier_id: source_producer.id) }
+      let!(:p1) { create(:product, name: "Product1", supplier_id: source_producer.id) }
 
-      let!(:v3_source) { p3.variants.first }
-      let!(:v3_sourced) {
-        create(:variant, display_name: "Variant3-sourced", product: p3, supplier: source_producer,
+      let!(:v_source) { p1.variants.first }
+      let!(:v_sourced) {
+        create(:variant, display_name: "Variant-sourced", product: p1, supplier: source_producer,
                          hub: producer)
       }
       let!(:enterprise_relationship) {
@@ -160,25 +161,25 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
       }
 
       # I don't manage this hub, so shouldn't see see the sourced variant
-      let!(:v3_sourced_hidden) {
-        create(:variant, display_name: "Variant3-hidden", product: p3, supplier: source_producer,
+      let!(:v_sourced_hidden) {
+        create(:variant, display_name: "Variant-hidden", product: p1, supplier: source_producer,
                          hub:)
       }
 
       before do
-        v3_sourced.source_variants << v3_source
-        v3_sourced_hidden.source_variants << v3_source
+        v_sourced.source_variants << v_source
+        v_sourced_hidden.source_variants << v_source
         visit admin_products_url
       end
 
       it "shows sourced variant with indicator" do
-        within row_containing_name("Variant3-sourced") do
+        within row_containing_name("Variant-sourced") do
           expect(page).to have_selector 'span[title*="Sourced from: "]'
           expect(page).to have_selector 'span[title*="Hub: My Enterprise"]'
         end
 
         # But not variants sourced by other hubs
-        expect(page).not_to have_selector row_containing_name("Variant3-hidden")
+        expect(page).not_to have_selector row_containing_name("Variant-hidden")
       end
     end
   end

--- a/spec/views/admin/products_v3/_filters.html.haml_spec.rb
+++ b/spec/views/admin/products_v3/_filters.html.haml_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe "admin/products_v3/_filters.html.haml" do
   it "shows the producer filter with the default option initially" do
     allow(view).to receive_messages locals.merge(
       allowed_producers: [
-        double(Enterprise, id: 1),
-        double(Enterprise, id: 2),
+        instance_double(Enterprise, id: 1),
+        instance_double(Enterprise, id: 2),
       ],
     )
 
@@ -33,7 +33,7 @@ RSpec.describe "admin/products_v3/_filters.html.haml" do
   it "doesn't show the producer filter when there's only one option" do
     allow(view).to receive_messages locals.merge(
       allowed_producers: [
-        double(Enterprise, id: 1),
+        instance_double(Enterprise, id: 1),
       ],
     )
 

--- a/spec/views/admin/products_v3/_filters.html.haml_spec.rb
+++ b/spec/views/admin/products_v3/_filters.html.haml_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "admin/products_v3/_filters.html.haml" do
     {
       spree_current_user:,
       search_term: "",
-      producer_options: [],
+      producer_options: nil,
       producer_id: nil,
       category_id: nil,
     }

--- a/spec/views/admin/products_v3/_filters.html.haml_spec.rb
+++ b/spec/views/admin/products_v3/_filters.html.haml_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "admin/products_v3/_filters.html.haml" do
       search_term: "",
       producer_options: [],
       producer_id: nil,
-      category_options: [],
       category_id: nil,
     }
   end

--- a/spec/views/admin/products_v3/_filters.html.haml_spec.rb
+++ b/spec/views/admin/products_v3/_filters.html.haml_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "admin/products_v3/_filters.html.haml" do
     {
       spree_current_user:,
       search_term: "",
-      producer_options: nil,
+      allowed_producers: [],
       producer_id: nil,
       category_id: nil,
     }
@@ -18,9 +18,9 @@ RSpec.describe "admin/products_v3/_filters.html.haml" do
 
   it "shows the producer filter with the default option initially" do
     allow(view).to receive_messages locals.merge(
-      producer_options: [
-        ["Ada's Apples", 1],
-        ["Ben's Bananas", 2],
+      allowed_producers: [
+        double(Enterprise, id: 1),
+        double(Enterprise, id: 2),
       ],
     )
 
@@ -32,8 +32,8 @@ RSpec.describe "admin/products_v3/_filters.html.haml" do
 
   it "doesn't show the producer filter when there's only one option" do
     allow(view).to receive_messages locals.merge(
-      producer_options: [
-        ["Ada's Apples", 1],
+      allowed_producers: [
+        double(Enterprise, id: 1),
       ],
     )
 


### PR DESCRIPTION
⚠️ Please use clockify code 76a Source variant when working on this

## What? Why?
We don't want people to be able to choose a producer for a linked variant if they don't have permission for it. The simplest fix is to disallow changing the producer at all.

- Closes #14142

Review from commit `Don't allow changing producer on linked variant`.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
- Choose an existing  linked variant to inspect. If none:
   - Give permissions to one hub to create linked variants from one producer
   - Create the linked variant
- See the hub cannot change the producer on the linked variant

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
- https://github.com/openfoodfoundation/openfoodnetwork/pull/14190
