### PR TITLE
[Admin/products] Fix column header/content misalignment on admin product page

### DIFF
--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -31,7 +31,7 @@
       %col.col-tax_category{ width:"8%" }
       - if variant_tag_enabled?(spree_current_user)
         %col.col-tags{ width:"8%" }
-      %col.col-inherits_properties{ width:"8%" }
+      %col.col-inherits_properties{ width:"5%" }
       %col{ width:"5%", style:"min-width: 3em"}= # Actions
     %thead
       %tr

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -31,7 +31,7 @@
       %col.col-tax_category{ width:"8%" }
       - if variant_tag_enabled?(spree_current_user)
         %col.col-tags{ width:"8%" }
-      %col.col-inherits_properties{ width:"5%" }
+      %col.col-inherits_properties{ width:"8%" }
       %col{ width:"5%", style:"min-width: 3em"}= # Actions
     %thead
       %tr

--- a/app/views/admin/products_v3/_table.html.haml
+++ b/app/views/admin/products_v3/_table.html.haml
@@ -58,10 +58,10 @@
         %th.col-image.align-left= # image
         = render partial: 'spree/admin/shared/stimulus_sortable_header',
             locals: { column: :name, sorted: params.dig(:q, :s), default: 'name asc' }
-        %th.align-left.col-sku.with-input= t('admin.products_page.columns.sku')
-        %th.align-left.col-unit_scale.with-input= t('admin.products_page.columns.unit_scale')
-        %th.align-left.col-unit.with-input= t('admin.products_page.columns.unit')
-        %th.align-left.col-price.with-input= t('admin.products_page.columns.price')
+        %th.align-left.col-sku= t('admin.products_page.columns.sku')
+        %th.align-left.col-unit_scale= t('admin.products_page.columns.unit_scale')
+        %th.align-left.col-unit= t('admin.products_page.columns.unit')
+        %th.align-left.col-price= t('admin.products_page.columns.price')
         = render partial: 'spree/admin/shared/stimulus_sortable_header',
             locals: { column: :on_hand, sorted: params.dig(:q, :s), default: 'name asc' }
         %th.align-left.col-producer= t('admin.products_page.columns.producer')

--- a/app/webpacker/css/admin/pages/_unit_popout.scss
+++ b/app/webpacker/css/admin/pages/_unit_popout.scss
@@ -10,7 +10,7 @@
       white-space: nowrap;
       border-color: transparent;
       font-weight: normal;
-      padding-left: $border-radius; // Super compact
+      padding-left: $hpadding-txt - 1px; // Align text with adjacent input columns
       padding-right: 1rem; // Retain space for arrow
       height: auto;
       min-width: 2em;

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -127,11 +127,6 @@
       background-color: $color-tbl-cell-bg;
     }
 
-    // Align inherits_properties content with its header (relaxed rows have 3px horizontal padding)
-    .relaxed td.col-inherits_properties {
-      padding-left: $padding-tbl-cell;
-    }
-
     // "Relaxed" row groups, containing condensed rows.
     //
     // `display:table` enforces strict rules and won't allow border styles on tbody.

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -45,7 +45,6 @@
     padding-top: 0; // Hide border because .form-actions is there. It is added with th padding instead.
     border-collapse: separate; // This is needed for the outer padding. Also should be helpful to give more flexibility of borders between rows.
 
-    // Additional horizontal padding to align with input contents
     thead {
       position: sticky;
       top: 0;
@@ -68,15 +67,6 @@
         background-color: white;
 
         padding: 4px 0;
-      }
-
-      th.with-input {
-        // Additional padding to line up with content of input
-        padding-left: $padding-tbl-cell + $hpadding-txt;
-
-        &.align-right {
-          padding-right: $padding-tbl-cell + $hpadding-txt;
-        }
       }
     }
 
@@ -135,6 +125,11 @@
     td {
       position: relative; // Ensure that overflowing content is covered by the following cell. We don't use overflow: hidden because that messes with the popover.
       background-color: $color-tbl-cell-bg;
+    }
+
+    // Align inherits_properties content with its header (relaxed rows have 3px horizontal padding)
+    .relaxed td.col-inherits_properties {
+      padding-left: $padding-tbl-cell;
     }
 
     // "Relaxed" row groups, containing condensed rows.


### PR DESCRIPTION
## What? Why?

- Closes #13448

The admin products table at /admin/products had column headers visually
  shifted to the right compared to the data below them. The original code added
   a with-input CSS class to some headers to compensate, but it over-corrected —
   pushing headers further right than the content rather than aligning them.
  Additionally, the "Inherits Properties" column header was being clipped
  because its column width was too narrow.  

  **Changes**                                                                  
  1. Removed the `with-input` class from SKU, Unit Scale, Unit, and Price
  column headers, giving all headers consistent left spacing                   
  2. Deleted the now-unused `th.with-input` CSS block
  3. Fixed the Unit/On Hand popout button padding so its text aligns with      
  adjacent columns
  4. Added a padding rule for Inherits Properties cells to match their header  
  5. Increased the Inherits Properties column width from 5% to 8% to prevent
  the header label from being clipped    


## What should we test?
 1. Log in as admin and navigate to `/admin/products`
  2. Enable the `variant_tag` feature flag
  3. Confirm all column headers align with their content below                 
  4. Confirm the "Inherits Properties?" header is fully visible and not clipped

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled


**before:**
<img width="1708" height="430" alt="before" src="https://github.com/user-attachments/assets/75e0806b-5d86-4fd7-8ebf-2105eefd4b60" />
**after:**
<img width="1359" height="276" alt="after" src="https://github.com/user-attachments/assets/6a368341-4bc2-479f-a18e-246cc22a7b92" />

