### PR TITLE
Include  product from the coordinator's inventory stays active after inventory is turned off

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -160,7 +160,6 @@ group :test, :development do
   gem 'debug', '>= 1.0.0'
   gem "factory_bot_rails", '6.2.0', require: false
   gem 'fuubar', '~> 2.5.1'
-  gem 'json_spec', '~> 1.1.4'
   gem 'knapsack_pro'
   gem 'letter_opener', '>= 1.4.1'
   gem 'rspec-rails', ">= 3.5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,9 +460,6 @@ GEM
       rexml (~> 3.2)
     json-schema (4.1.1)
       addressable (>= 2.8)
-    json_spec (1.1.5)
-      multi_json (~> 1.0)
-      rspec (>= 2.0, < 4.0)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
     jwt (2.10.2)
@@ -1042,7 +1039,6 @@ DEPENDENCIES
   jquery-rails (= 4.4.0)
   jquery-ui-rails (~> 4.2)
   json
-  json_spec (~> 1.1.4)
   jsonapi-serializer
   jwt (~> 2.3)
   knapsack_pro
@@ -1274,7 +1270,6 @@ CHECKSUMS
   json-jwt (1.17.0) sha256=6ff99026b4c54281a9431179f76ceb81faa14772d710ef6169785199caadc4cc
   json-ld (3.3.2) sha256=b9531893bf5bdc01db428e96953845a23adb1097125ce918ae0f97c4a6e1ab27
   json-schema (4.1.1) sha256=89a8399745a710c2c7be3ff9564f67a0ae982c82f7590a95ab9cebe374fa2d49
-  json_spec (1.1.5) sha256=7a77b97a92c787e2aa3fbc4a1239afc3342c781151dc98cfb81461b3b7cad10f
   jsonapi-serializer (2.2.0) sha256=f8141ac6f0c1e17e8513df68f8341afe2d7bffc285841d7090bc07f07efb0029
   jwt (2.10.2) sha256=31e1ee46f7359883d5e622446969fe9c118c3da87a0b1dca765ce269c3a0c4f4
   knapsack_pro (9.2.3) sha256=354b402cb08709b98f9ffa32d69e989f3bdd829a6c989649d60a9a0256421eed

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -128,13 +128,17 @@ module Admin
     end
 
     def for_order_cycle
+      inventory_enabled = helpers.feature?(:inventory, @order_cycle&.coordinator) &&
+                          !helpers.feature?(:variant_tag, @order_cycle&.coordinator)
+
       respond_to do |format|
         format.json do
           render(
             json: @collection,
             each_serializer: Api::Admin::ForOrderCycle::EnterpriseSerializer,
             order_cycle: @order_cycle,
-            spree_current_user:
+            spree_current_user:,
+            inventory_enabled:
           )
         end
       end

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -32,7 +32,8 @@ module Admin
           redirect_to edit_admin_order_cycle_path(@order_cycle)
         end
         format.json do
-          render_as_json @order_cycle, current_user: spree_current_user
+          render_as_json @order_cycle, current_user: spree_current_user,
+                                       inventory_enabled: inventory_enabled?(@order_cycle)
         end
       end
     end
@@ -41,7 +42,8 @@ module Admin
       respond_to do |format|
         format.html
         format.json do
-          render_as_json @order_cycle, current_user: spree_current_user
+          render_as_json @order_cycle, current_user: spree_current_user,
+                                       inventory_enabled: inventory_enabled?(@order_cycle)
         end
       end
     end
@@ -311,6 +313,11 @@ module Admin
                           error_class: DateTimeChangeError }
                       ), spree_current_user
       )
+    end
+
+    def inventory_enabled?(order_cycle)
+      OpenFoodNetwork::FeatureToggle.enabled?(:inventory, order_cycle.coordinator) &&
+        !OpenFoodNetwork::FeatureToggle.enabled?(:variant_tag, order_cycle.coordinator)
     end
   end
 end

--- a/app/controllers/api/v0/exchange_products_controller.rb
+++ b/app/controllers/api/v0/exchange_products_controller.rb
@@ -100,6 +100,12 @@ module Api
       end
 
       def inventory_enabled?
+        # We don't have an order cycle when laoding product to create a new one, at this stage
+        # there is no way to select product_selection_from_coordinator_inventory_only?  options
+        # so the state of the inventory doesn't matter as no filtering will be applied in the
+        # renderer.
+        return false if @order_cycle.nil?
+
         OpenFoodNetwork::FeatureToggle.enabled?(:inventory, @order_cycle.coordinator) &&
           !OpenFoodNetwork::FeatureToggle.enabled?(:variant_tag, @order_cycle.coordinator)
       end

--- a/app/controllers/api/v0/exchange_products_controller.rb
+++ b/app/controllers/api/v0/exchange_products_controller.rb
@@ -48,8 +48,8 @@ module Api
       end
 
       def renderer
-        @renderer ||= ExchangeProductsRenderer.
-          new(@order_cycle, spree_current_user)
+        @renderer ||= ExchangeProductsRenderer
+          .new(@order_cycle, spree_current_user, inventory_enabled: inventory_enabled?)
       end
 
       def load_data_from_exchange
@@ -84,7 +84,8 @@ module Api
         serialized_products = ActiveModel::ArraySerializer.new(
           results,
           each_serializer: Api::Admin::ForOrderCycle::SuppliedProductSerializer,
-          order_cycle: @order_cycle
+          order_cycle: @order_cycle,
+          inventory_enabled: inventory_enabled?
         )
 
         render json: {
@@ -96,6 +97,11 @@ module Api
       def exchange_params
         params.permit(:enterprise_id, :exchange_id, :order_cycle_id, :incoming).
           to_h.with_indifferent_access
+      end
+
+      def inventory_enabled?
+        OpenFoodNetwork::FeatureToggle.enabled?(:inventory, @order_cycle.coordinator) &&
+          !OpenFoodNetwork::FeatureToggle.enabled?(:variant_tag, @order_cycle.coordinator)
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,7 +23,7 @@ module ApplicationHelper
     end
   end
 
-  # Checks weather a feature is enabled for any of the given actors.
+  # Checks whether a feature is enabled for any of the given actors.
   def feature?(feature, *actors)
     OpenFoodNetwork::FeatureToggle.enabled?(feature, *actors)
   end

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -201,12 +201,13 @@ class OrderCycle < ApplicationRecord
   def variants_distributed_by(distributor)
     return Spree::Variant.where("1=0") if distributor.blank?
 
-    Spree::Variant.
-      joins(:exchanges).
-      merge(distributor.inventory_variants).
-      merge(Exchange.in_order_cycle(self)).
-      merge(Exchange.outgoing).
-      merge(Exchange.to_enterprise(distributor))
+    query = Spree::Variant.joins(:exchanges)
+
+    query = query.merge(distributor.inventory_variants) if inventory_enabled?(distributor)
+
+    query.merge(Exchange.in_order_cycle(self))
+      .merge(Exchange.outgoing)
+      .merge(Exchange.to_enterprise(distributor))
   end
 
   def products_distributed_by(distributor)
@@ -369,5 +370,10 @@ class OrderCycle < ApplicationRecord
 
     self.processed_at = nil
     self.mails_sent = false
+  end
+
+  def inventory_enabled?(distributor)
+    OpenFoodNetwork::FeatureToggle.enabled?(:inventory, distributor) &&
+      !OpenFoodNetwork::FeatureToggle.enabled?(:variant_tag, distributor)
   end
 end

--- a/app/serializers/api/admin/exchange_serializer.rb
+++ b/app/serializers/api/admin/exchange_serializer.rb
@@ -17,7 +17,8 @@ module Api
       private
 
       def visible_incoming_variants
-        if object.order_cycle.prefers_product_selection_from_coordinator_inventory_only?
+        if inventory_enabled? &&
+           object.order_cycle.prefers_product_selection_from_coordinator_inventory_only?
           permitted_incoming_variants.visible_for(object.order_cycle.coordinator)
         else
           permitted_incoming_variants
@@ -25,7 +26,7 @@ module Api
       end
 
       def visible_outgoing_variants
-        if object.receiver.prefers_product_selection_from_inventory_only?
+        if inventory_enabled? && object.receiver.prefers_product_selection_from_inventory_only?
           permitted_outgoing_variants.visible_for(object.receiver)
         else
           permitted_outgoing_variants.not_hidden_for(object.receiver)
@@ -54,6 +55,10 @@ module Api
 
       def tags
         preloaded_tag_list.map { |tag| { text: tag } }
+      end
+
+      def inventory_enabled?
+        options[:inventory_enabled]
       end
     end
   end

--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -34,9 +34,9 @@ module Api
 
         def products_scope
           products_relation = object.supplied_products
-          if order_cycle.prefers_product_selection_from_coordinator_inventory_only?
-            products_relation = products_relation.
-              visible_for(order_cycle.coordinator)
+          if inventory_enabled? &&
+             order_cycle.prefers_product_selection_from_coordinator_inventory_only?
+            products_relation = products_relation.visible_for(order_cycle.coordinator)
           end
           products_relation
         end
@@ -47,6 +47,10 @@ module Api
 
         def order_cycle
           options[:order_cycle]
+        end
+
+        def inventory_enabled?
+          options[:inventory_enabled]
         end
       end
     end

--- a/app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb
@@ -16,6 +16,7 @@ module Api
 
         def variants
           variants = if order_cycle.present? &&
+                        inventory_enabled? &&
                         order_cycle.prefers_product_selection_from_coordinator_inventory_only?
                        object.variants.visible_for(order_cycle.coordinator)
                      else
@@ -28,6 +29,10 @@ module Api
 
         def order_cycle
           options[:order_cycle]
+        end
+
+        def inventory_enabled?
+          options[:inventory_enabled]
         end
       end
     end

--- a/app/serializers/api/admin/order_cycle_serializer.rb
+++ b/app/serializers/api/admin/order_cycle_serializer.rb
@@ -35,7 +35,8 @@ module Api
         ActiveModel::ArraySerializer.
           new(scoped_exchanges, each_serializer: Api::Admin::ExchangeSerializer,
                                 current_user: options[:current_user],
-                                preloaded_tags: BatchTaggableTagsQuery.call(scoped_exchanges))
+                                preloaded_tags: BatchTaggableTagsQuery.call(scoped_exchanges),
+                                inventory_enabled: options[:inventory_enabled])
       end
 
       def editable_variants_for_incoming_exchanges

--- a/app/services/exchange_products_renderer.rb
+++ b/app/services/exchange_products_renderer.rb
@@ -3,9 +3,10 @@
 require 'open_food_network/order_cycle_permissions'
 
 class ExchangeProductsRenderer
-  def initialize(order_cycle, user)
+  def initialize(order_cycle, user, **options)
     @order_cycle = order_cycle
     @user = user
+    @options = options
   end
 
   def exchange_products(incoming, enterprise)
@@ -25,6 +26,8 @@ class ExchangeProductsRenderer
 
   private
 
+  attr_reader :options
+
   def products_for_incoming_exchange(enterprise)
     supplied_products(enterprise.id)
   end
@@ -37,6 +40,7 @@ class ExchangeProductsRenderer
 
   def filter_visible(relation)
     if @order_cycle.present? &&
+       options[:inventory_enabled] &&
        @order_cycle.prefers_product_selection_from_coordinator_inventory_only?
       relation = relation.visible_for(@order_cycle.coordinator)
     end
@@ -75,7 +79,8 @@ class ExchangeProductsRenderer
   def visible_incoming_variants(incoming_exchange_sender)
     variants_relation = permitted_incoming_variants(incoming_exchange_sender)
 
-    if @order_cycle.prefers_product_selection_from_coordinator_inventory_only?
+    if options[:inventory_enabled] &&
+       @order_cycle.prefers_product_selection_from_coordinator_inventory_only?
       variants_relation = variants_relation.visible_for(@order_cycle.coordinator)
     end
 

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -613,50 +613,61 @@ RSpec.describe Admin::EnterprisesController do
   end
 
   describe "for_order_cycle" do
-    let!(:user) { create(:user) }
-    let!(:enterprise) { create(:enterprise, sells: 'any', owner: user) }
-    let(:permission_mock) { double(:permission) }
+    let(:user) { create(:user) }
+    let(:enterprise) { create(:enterprise, sells: 'any', owner: user) }
+    let(:permission_mock) { instance_double(OpenFoodNetwork::OrderCyclePermissions) }
 
     before do
       # As a user with permission
-      allow(controller).to receive_messages spree_current_user: user
-      allow(OrderCycle).to receive_messages find_by: "existing OrderCycle"
-      allow(Enterprise).to receive_messages find_by: "existing Enterprise"
-      allow(OrderCycle).to receive_messages new: "new OrderCycle"
-
+      allow(controller).to receive(:spree_current_user).and_return(user)
+      allow(Enterprise).to receive(:find_by).and_return(enterprise)
       allow(OpenFoodNetwork::OrderCyclePermissions).to receive(:new) { permission_mock }
       allow(permission_mock).to receive(:visible_enterprises) { [] }
       allow(ActiveModel::ArraySerializer).to receive(:new) { "" }
     end
 
     context "when no order_cycle or coordinator is provided in params" do
-      before { get :for_order_cycle, format: :json }
       it "initializes permissions with nil" do
-        expect(OpenFoodNetwork::OrderCyclePermissions).to have_received(:new).with(user, nil)
+        expect(OpenFoodNetwork::OrderCyclePermissions).to receive(:new).with(user, nil)
+
+        get :for_order_cycle, format: :json
       end
     end
 
     context "when an order_cycle_id is provided in params" do
-      before { get :for_order_cycle, as: :json, params: { order_cycle_id: 1 } }
       it "initializes permissions with the existing OrderCycle" do
-        expect(OpenFoodNetwork::OrderCyclePermissions).to have_received(:new)
-          .with(user, "existing OrderCycle")
+        order_cycle = instance_double(OrderCycle)
+        allow(OrderCycle).to receive(:find_by).and_return(order_cycle)
+
+        expect(OpenFoodNetwork::OrderCyclePermissions).to receive(:new)
+          .with(user, order_cycle)
+
+        get :for_order_cycle, as: :json, params: { order_cycle_id: 1 }
       end
     end
 
     context "when a coordinator is provided in params" do
-      before { get :for_order_cycle, as: :json, params: { coordinator_id: 1 } }
       it "initializes permissions with a new OrderCycle" do
-        expect(OpenFoodNetwork::OrderCyclePermissions).to have_received(:new).with(user,
-                                                                                   "new OrderCycle")
+        new_order_cycle = instance_double(OrderCycle)
+        allow(OrderCycle).to receive(:new).and_return(new_order_cycle)
+
+        expect(OpenFoodNetwork::OrderCyclePermissions).to receive(:new).with(user, new_order_cycle)
+
+        get :for_order_cycle, as: :json, params: { coordinator_id: 1 }
       end
     end
 
     context "when both an order cycle and a coordinator are provided in params" do
-      before { get :for_order_cycle, as: :json, params: { order_cycle_id: 1, coordinator_id: 1 } }
       it "initializes permissions with the existing OrderCycle" do
-        expect(OpenFoodNetwork::OrderCyclePermissions).to have_received(:new)
-          .with(user, "existing OrderCycle")
+        order_cycle = instance_double(OrderCycle)
+        allow(OrderCycle).to receive(:find_by).and_return(order_cycle)
+
+        new_order_cycle = instance_double(OrderCycle)
+        allow(OrderCycle).to receive(:new).and_return(new_order_cycle)
+
+        expect(OpenFoodNetwork::OrderCyclePermissions).to receive(:new).with(user, order_cycle)
+
+        get :for_order_cycle, as: :json, params: { order_cycle_id: 1, coordinator_id: 1 }
       end
     end
   end

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -637,6 +637,7 @@ RSpec.describe Admin::EnterprisesController do
     context "when an order_cycle_id is provided in params" do
       it "initializes permissions with the existing OrderCycle" do
         order_cycle = instance_double(OrderCycle)
+        allow(order_cycle).to receive(:coordinator).and_return(enterprise)
         allow(OrderCycle).to receive(:find_by).and_return(order_cycle)
 
         expect(OpenFoodNetwork::OrderCyclePermissions).to receive(:new)
@@ -649,6 +650,7 @@ RSpec.describe Admin::EnterprisesController do
     context "when a coordinator is provided in params" do
       it "initializes permissions with a new OrderCycle" do
         new_order_cycle = instance_double(OrderCycle)
+        allow(new_order_cycle).to receive(:coordinator).and_return(enterprise)
         allow(OrderCycle).to receive(:new).and_return(new_order_cycle)
 
         expect(OpenFoodNetwork::OrderCyclePermissions).to receive(:new).with(user, new_order_cycle)
@@ -660,6 +662,7 @@ RSpec.describe Admin::EnterprisesController do
     context "when both an order cycle and a coordinator are provided in params" do
       it "initializes permissions with the existing OrderCycle" do
         order_cycle = instance_double(OrderCycle)
+        allow(order_cycle).to receive(:coordinator).and_return(enterprise)
         allow(OrderCycle).to receive(:find_by).and_return(order_cycle)
 
         new_order_cycle = instance_double(OrderCycle)
@@ -668,6 +671,21 @@ RSpec.describe Admin::EnterprisesController do
         expect(OpenFoodNetwork::OrderCyclePermissions).to receive(:new).with(user, order_cycle)
 
         get :for_order_cycle, as: :json, params: { order_cycle_id: 1, coordinator_id: 1 }
+      end
+    end
+
+    context "with inventory enabled", feature: :inventory do
+      it "passes inventory_enabled true to serializer" do
+        order_cycle = create(:order_cycle)
+        expect(controller).to receive(:render).with(
+          json: nil,
+          each_serializer: Class,
+          order_cycle: Object,
+          spree_current_user: user,
+          inventory_enabled: true
+        )
+
+        get :for_order_cycle, as: :json, params: { order_cycle_id: order_cycle.id }
       end
     end
   end

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -227,38 +227,55 @@ RSpec.describe OrderCycle do
       expect(oc.products).to match_array [p0, p1, p2]
     end
 
-    context "listing variant distributed by a particular distributor" do
-      context "when default settings are in play" do
-        it "returns an empty list when no distributor is given" do
-          expect(oc.variants_distributed_by(nil)).to eq([])
-        end
+    describe "#variants_distributed_by" do
+      it "returns an empty list when no distributor is given" do
+        expect(oc.variants_distributed_by(nil)).to eq([])
+      end
 
-        it "returns all variants in the outgoing exchange for the distributor provided" do
-          expect(oc.variants_distributed_by(d2)).to include p1.variants.first, p1_v_visible
-          expect(oc.variants_distributed_by(d2)).not_to include p1_v_hidden, p1_v_deleted
-          expect(oc.variants_distributed_by(d1)).to include p2_v
-        end
+      it "returns all variants in the outgoing exchange for the distributor provided" do
+        expect(oc.variants_distributed_by(d2)).to include p1.variants.first, p1_v_visible,
+                                                          p1_v_hidden
+        expect(oc.variants_distributed_by(d2)).not_to include p1_v_deleted
+        expect(oc.variants_distributed_by(d1)).to include p2_v
+      end
 
-        context "with soft-deleted variants" do
-          it "does not consider soft-deleted variants to be currently distributed in the oc" do
-            p2_v.delete
+      context "with soft-deleted variants" do
+        it "does not consider soft-deleted variants to be currently distributed in the oc" do
+          p2_v.delete
 
-            expect(oc.variants_distributed_by(d1)).not_to include p2_v
-          end
+          expect(oc.variants_distributed_by(d1)).not_to include p2_v
         end
       end
 
-      context "when hub prefers product selection from inventory only" do
-        before do
-          allow(d1).to receive(:prefers_product_selection_from_inventory_only?) { true }
+      context "when inventory is enabled", feature: :inventory do
+        context "when default settings are in play" do
+          it "returns all variants in the outgoing exchange for the distributor provided" do
+            expect(oc.variants_distributed_by(d2)).to include p1.variants.first, p1_v_visible
+            expect(oc.variants_distributed_by(d2)).not_to include p1_v_hidden, p1_v_deleted
+            expect(oc.variants_distributed_by(d1)).to include p2_v
+          end
+
+          context "with soft-deleted variants" do
+            it "does not consider soft-deleted variants to be currently distributed in the oc" do
+              p2_v.delete
+
+              expect(oc.variants_distributed_by(d1)).not_to include p2_v
+            end
+          end
         end
 
-        it "returns an empty list when no distributor is given" do
-          expect(oc.variants_distributed_by(nil)).to eq([])
-        end
+        context "when hub prefers product selection from inventory only" do
+          before do
+            allow(d1).to receive(:prefers_product_selection_from_inventory_only?) { true }
+          end
 
-        it "returns only variants in the exchange that are also in the distributor's inventory" do
-          expect(oc.variants_distributed_by(d1)).not_to include p2_v
+          it "returns an empty list when no distributor is given" do
+            expect(oc.variants_distributed_by(nil)).to eq([])
+          end
+
+          it "returns only variants in the exchange that are also in the distributor's inventory" do
+            expect(oc.variants_distributed_by(d1)).not_to include p2_v
+          end
         end
       end
     end

--- a/spec/serializers/api/admin/exchange_serializer_spec.rb
+++ b/spec/serializers/api/admin/exchange_serializer_spec.rb
@@ -3,12 +3,13 @@
 require 'open_food_network/order_cycle_permissions'
 
 RSpec.describe Api::Admin::ExchangeSerializer do
+  subject(:serializer) { described_class.new exchange }
+
   let(:v1) { create(:variant) }
   let(:v2) { create(:variant) }
   let(:v3) { create(:variant) }
-  let(:permissions_mock) { double(:permissions) }
+  let(:permissions_mock) { instance_double(OpenFoodNetwork::OrderCyclePermissions) }
   let(:permitted_variants) { Spree::Variant.where(id: [v1, v2]) }
-  let(:serializer) { Api::Admin::ExchangeSerializer.new exchange }
 
   context "serializing incoming exchanges" do
     let(:exchange) { create(:exchange, incoming: true, variants: [v1, v2, v3]) }
@@ -32,11 +33,12 @@ RSpec.describe Api::Admin::ExchangeSerializer do
       end
 
       it "filters variants within the exchange based on permissions, and visibility in inventory" do
-        visible_variants = serializer.variants
-        expect(permissions_mock).to have_received(:visible_variants_for_incoming_exchanges_from)
+        expect(permissions_mock).to receive(:visible_variants_for_incoming_exchanges_from)
           .with(exchange.sender)
-        expect(permitted_variants).to have_received(:visible_for)
-          .with(exchange.order_cycle.coordinator)
+        expect(permitted_variants).to receive(:visible_for).with(exchange.order_cycle.coordinator)
+
+        visible_variants = serializer.variants
+
         expect(exchange.variants).to include v1, v2, v3
         expect(visible_variants.keys).to include v1.id
         expect(visible_variants.keys).not_to include v2.id, v3.id
@@ -50,10 +52,12 @@ RSpec.describe Api::Admin::ExchangeSerializer do
       end
 
       it "filters variants within the exchange based on permissions only" do
-        visible_variants = serializer.variants
-        expect(permissions_mock).to have_received(:visible_variants_for_incoming_exchanges_from)
+        expect(permissions_mock).to receive(:visible_variants_for_incoming_exchanges_from)
           .with(exchange.sender)
-        expect(permitted_variants).not_to have_received(:visible_for)
+        expect(permitted_variants).not_to receive(:visible_for)
+
+        visible_variants = serializer.variants
+
         expect(exchange.variants).to include v1, v2, v3
         expect(visible_variants.keys).to include v1.id, v2.id
         expect(visible_variants.keys).not_to include v3.id
@@ -83,11 +87,13 @@ RSpec.describe Api::Admin::ExchangeSerializer do
       end
 
       it "filters variants within the exchange based on permissions only" do
-        visible_variants = serializer.variants
-        expect(permissions_mock).to have_received(:visible_variants_for_outgoing_exchanges_to)
+        expect(permissions_mock).to receive(:visible_variants_for_outgoing_exchanges_to)
           .with(exchange.receiver)
-        expect(permitted_variants).to have_received(:not_hidden_for).with(exchange.receiver)
-        expect(permitted_variants).not_to have_received(:visible_for)
+        expect(permitted_variants).to receive(:not_hidden_for).with(exchange.receiver)
+        expect(permitted_variants).not_to receive(:visible_for)
+
+        visible_variants = serializer.variants
+
         expect(exchange.variants).to include v1, v2, v3
         expect(visible_variants.keys).to include v1.id, v2.id
         expect(visible_variants.keys).not_to include v3.id
@@ -102,11 +108,13 @@ RSpec.describe Api::Admin::ExchangeSerializer do
       end
 
       it "filters variants within the exchange based on permissions, and inventory visibility" do
-        visible_variants = serializer.variants
-        expect(permissions_mock).to have_received(:visible_variants_for_outgoing_exchanges_to)
+        expect(permissions_mock).to receive(:visible_variants_for_outgoing_exchanges_to)
           .with(exchange.receiver)
-        expect(permitted_variants).to have_received(:visible_for).with(exchange.receiver)
-        expect(permitted_variants).not_to have_received(:not_hidden_for)
+        expect(permitted_variants).to receive(:visible_for).with(exchange.receiver)
+        expect(permitted_variants).not_to receive(:not_hidden_for)
+
+        visible_variants = serializer.variants
+
         expect(exchange.variants).to include v1, v2, v3
         expect(visible_variants.keys).to include v1.id
         expect(visible_variants.keys).not_to include v2.id, v3.id

--- a/spec/serializers/api/admin/exchange_serializer_spec.rb
+++ b/spec/serializers/api/admin/exchange_serializer_spec.rb
@@ -3,13 +3,14 @@
 require 'open_food_network/order_cycle_permissions'
 
 RSpec.describe Api::Admin::ExchangeSerializer do
-  subject(:serializer) { described_class.new exchange }
+  subject(:serializer) { described_class.new(exchange, inventory_enabled:) }
 
   let(:v1) { create(:variant) }
   let(:v2) { create(:variant) }
   let(:v3) { create(:variant) }
   let(:permissions_mock) { instance_double(OpenFoodNetwork::OrderCyclePermissions) }
   let(:permitted_variants) { Spree::Variant.where(id: [v1, v2]) }
+  let(:inventory_enabled) { false }
 
   context "serializing incoming exchanges" do
     let(:exchange) { create(:exchange, incoming: true, variants: [v1, v2, v3]) }
@@ -32,16 +33,32 @@ RSpec.describe Api::Admin::ExchangeSerializer do
           .to receive(:prefers_product_selection_from_coordinator_inventory_only?) { true }
       end
 
-      it "filters variants within the exchange based on permissions, and visibility in inventory" do
+      it "filters variant base on permission and ignore inventory setting" do
         expect(permissions_mock).to receive(:visible_variants_for_incoming_exchanges_from)
           .with(exchange.sender)
-        expect(permitted_variants).to receive(:visible_for).with(exchange.order_cycle.coordinator)
+        expect(permitted_variants).not_to receive(:visible_for)
 
         visible_variants = serializer.variants
-
         expect(exchange.variants).to include v1, v2, v3
-        expect(visible_variants.keys).to include v1.id
-        expect(visible_variants.keys).not_to include v2.id, v3.id
+        expect(visible_variants.keys).to include v1.id, v2.id
+        expect(visible_variants.keys).not_to include v3.id
+      end
+
+      context "with inventory enabled" do
+        let(:inventory_enabled) { true }
+
+        it "filters variants within the exchange based on permissions, " \
+           "and visibility in inventory" do
+          expect(permissions_mock).to receive(:visible_variants_for_incoming_exchanges_from)
+            .with(exchange.sender)
+          expect(permitted_variants).to receive(:visible_for).with(exchange.order_cycle.coordinator)
+
+          visible_variants = serializer.variants
+
+          expect(exchange.variants).to include v1, v2, v3
+          expect(visible_variants.keys).to include v1.id
+          expect(visible_variants.keys).not_to include v2.id, v3.id
+        end
       end
     end
 
@@ -107,17 +124,35 @@ RSpec.describe Api::Admin::ExchangeSerializer do
           .to receive(:prefers_product_selection_from_inventory_only?) { true }
       end
 
-      it "filters variants within the exchange based on permissions, and inventory visibility" do
+      it "filters variants within the exchange based on permissions, " \
+         "and ignore inventory setting" do
         expect(permissions_mock).to receive(:visible_variants_for_outgoing_exchanges_to)
           .with(exchange.receiver)
-        expect(permitted_variants).to receive(:visible_for).with(exchange.receiver)
-        expect(permitted_variants).not_to receive(:not_hidden_for)
+        expect(permitted_variants).to receive(:not_hidden_for).with(exchange.receiver)
+        expect(permitted_variants).not_to receive(:visible_for)
 
         visible_variants = serializer.variants
 
         expect(exchange.variants).to include v1, v2, v3
-        expect(visible_variants.keys).to include v1.id
-        expect(visible_variants.keys).not_to include v2.id, v3.id
+        expect(visible_variants.keys).to include v1.id, v2.id
+        expect(visible_variants.keys).not_to include v3.id
+      end
+
+      context "with inventory enabled" do
+        let(:inventory_enabled) { true }
+
+        it "filters variants within the exchange based on permissions, and inventory visibility" do
+          expect(permissions_mock).to receive(:visible_variants_for_outgoing_exchanges_to)
+            .with(exchange.receiver)
+          expect(permitted_variants).to receive(:visible_for).with(exchange.receiver)
+          expect(permitted_variants).not_to receive(:not_hidden_for)
+
+          visible_variants = serializer.variants
+
+          expect(exchange.variants).to include v1, v2, v3
+          expect(visible_variants.keys).to include v1.id
+          expect(visible_variants.keys).not_to include v2.id, v3.id
+        end
       end
     end
   end

--- a/spec/serializers/api/admin/for_order_cycle/enterprise_serializer_spec.rb
+++ b/spec/serializers/api/admin/for_order_cycle/enterprise_serializer_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Admin::ForOrderCycle::EnterpriseSerializer do
+  subject(:serialized_enterprise) {
+    described_class.new(enterprise, spree_current_user:, order_cycle:, inventory_enabled:).to_json
+  }
+
+  let(:enterprise) { create(:distributor_enterprise, name: "My enterprise") }
+  let(:spree_current_user) { instance_double(Spree::User) }
+  let(:order_cycle) { instance_double(OrderCycle, coordinator: enterprise) }
+  let(:issue_validator_mock) {
+    instance_double(OpenFoodNetwork::EnterpriseIssueValidator, issues_summary: nil)
+  }
+  let(:inventory_enabled) { false }
+
+  before do
+    allow(order_cycle).to receive(:prefers_product_selection_from_coordinator_inventory_only?)
+      .and_return(false)
+    expect(Enterprise).to receive(:managed_by).and_return([enterprise])
+    allow(OpenFoodNetwork::EnterpriseIssueValidator).to receive(:new)
+      .and_return(issue_validator_mock)
+  end
+
+  describe "smoke test" do
+    it "returns expected data format" do
+      result = parse_json(serialized_enterprise)
+
+      expect(result["name"]).to eq("My enterprise")
+      expect(result["issues_summary_supplier"]).to match(String)
+      expect(result["issues_summary_distributor"]).to be_nil
+      expect(result["is_primary_producer"]).to eq(false)
+      expect(result["is_distributor"]).to eq(true)
+      expect(result["sells"]).to eq("any")
+    end
+  end
+
+  describe "issues_summary_supplier" do
+    context "when no other issue" do
+      it "returns No Products" do
+        result = parse_json(serialized_enterprise)
+        expect(result["issues_summary_supplier"]).to eq("No Products")
+      end
+
+      context "whith associated products" do
+        let!(:product) { create(:simple_product, supplier_id: enterprise.id) }
+
+        it "returns nil" do
+          result = parse_json(serialized_enterprise)
+
+          expect(result["issues_summary_supplier"]).to be_nil
+        end
+
+        context "with order prefers_product_selection_from_coordinator_inventory_only? enabled" do
+          let!(:inventory_item) {
+            create(:inventory_item, enterprise:, variant: product.variants.first, visible: false)
+          }
+
+          before do
+            allow(order_cycle).to receive(
+              :prefers_product_selection_from_coordinator_inventory_only?
+            ).and_return(true)
+          end
+
+          it "ignores the inventory setting and return nil" do
+            result = parse_json(serialized_enterprise)
+
+            expect(result["issues_summary_supplier"]).to be_nil
+          end
+
+          context "with inventory enabled" do
+            let(:inventory_enabled) { true }
+
+            it "returns No Product as the inventory item is hidden" do
+              result = parse_json(serialized_enterprise)
+
+              expect(result["issues_summary_supplier"]).to eq("No Products")
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def parse_json(data)
+    JSON.parse(data)
+  end
+end

--- a/spec/serializers/api/admin/for_order_cycle/enterprise_serializer_spec.rb
+++ b/spec/serializers/api/admin/for_order_cycle/enterprise_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Api::Admin::ForOrderCycle::EnterpriseSerializer do
   subject(:serialized_enterprise) {
-    described_class.new(enterprise, spree_current_user:, order_cycle:, inventory_enabled:).to_json
+    described_class.new(enterprise, spree_current_user:, order_cycle:, inventory_enabled:)
   }
 
   let(:enterprise) { create(:distributor_enterprise, name: "My enterprise") }
@@ -16,38 +16,33 @@ RSpec.describe Api::Admin::ForOrderCycle::EnterpriseSerializer do
   before do
     allow(order_cycle).to receive(:prefers_product_selection_from_coordinator_inventory_only?)
       .and_return(false)
-    expect(Enterprise).to receive(:managed_by).and_return([enterprise])
+    allow(Enterprise).to receive(:managed_by).and_return([enterprise])
     allow(OpenFoodNetwork::EnterpriseIssueValidator).to receive(:new)
       .and_return(issue_validator_mock)
   end
 
   describe "smoke test" do
     it "returns expected data format" do
-      result = parse_json(serialized_enterprise)
-
-      expect(result["name"]).to eq("My enterprise")
-      expect(result["issues_summary_supplier"]).to match(String)
-      expect(result["issues_summary_distributor"]).to be_nil
-      expect(result["is_primary_producer"]).to eq(false)
-      expect(result["is_distributor"]).to eq(true)
-      expect(result["sells"]).to eq("any")
+      expect(serialized_enterprise.name).to eq("My enterprise")
+      expect(serialized_enterprise.issues_summary_supplier).to match(String)
+      expect(serialized_enterprise.issues_summary_distributor).to be_nil
+      expect(serialized_enterprise.is_primary_producer).to eq(false)
+      expect(serialized_enterprise.is_distributor).to eq(true)
+      expect(serialized_enterprise.sells).to eq("any")
     end
   end
 
   describe "issues_summary_supplier" do
     context "when no other issue" do
       it "returns No Products" do
-        result = parse_json(serialized_enterprise)
-        expect(result["issues_summary_supplier"]).to eq("No Products")
+        expect(serialized_enterprise.issues_summary_supplier).to eq("No Products")
       end
 
       context "whith associated products" do
         let!(:product) { create(:simple_product, supplier_id: enterprise.id) }
 
         it "returns nil" do
-          result = parse_json(serialized_enterprise)
-
-          expect(result["issues_summary_supplier"]).to be_nil
+          expect(serialized_enterprise.issues_summary_supplier).to be_nil
         end
 
         context "with order prefers_product_selection_from_coordinator_inventory_only? enabled" do
@@ -62,26 +57,18 @@ RSpec.describe Api::Admin::ForOrderCycle::EnterpriseSerializer do
           end
 
           it "ignores the inventory setting and return nil" do
-            result = parse_json(serialized_enterprise)
-
-            expect(result["issues_summary_supplier"]).to be_nil
+            expect(serialized_enterprise.issues_summary_supplier).to be_nil
           end
 
           context "with inventory enabled" do
             let(:inventory_enabled) { true }
 
             it "returns No Product as the inventory item is hidden" do
-              result = parse_json(serialized_enterprise)
-
-              expect(result["issues_summary_supplier"]).to eq("No Products")
+              expect(serialized_enterprise.issues_summary_supplier).to eq("No Products")
             end
           end
         end
       end
     end
-  end
-
-  def parse_json(data)
-    JSON.parse(data)
   end
 end

--- a/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
+++ b/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
-  subject(:serialized_product) { described_class.new(product, order_cycle:).to_json }
+  subject(:serialized_product) {
+    described_class.new(product, order_cycle:, inventory_enabled:).to_json
+  }
 
   let(:coordinator) { create(:distributor_enterprise) }
   let(:order_cycle) { instance_double(OrderCycle, coordinator:) }
+  let(:inventory_enabled) { false }
   let!(:product) { create(:simple_product) }
   let!(:non_inventory_variant) { product.variants.first }
   let!(:inventory_variant) { create(:variant, product: product.reload) }
@@ -12,33 +15,41 @@ RSpec.describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
     create(:inventory_item, enterprise: coordinator, variant: inventory_variant, visible: true)
   }
 
-  context "when order cycle shows only variants in the coordinator's inventory" do
-    before do
-      allow(order_cycle).to receive(:prefers_product_selection_from_coordinator_inventory_only?) {
-                              true
-                            }
-    end
+  describe "variants" do
+    context "when order cycle shows only variants in the coordinator's inventory" do
+      before do
+        allow(order_cycle).to receive(:prefers_product_selection_from_coordinator_inventory_only?) {
+                                true
+                              }
+      end
 
-    describe "variants" do
-      it "renders only variants that are in the coordinators inventory" do
-        expect(serialized_product).to have_json_size(1).at_path 'variants'
-        expect(serialized_product).to be_json_eql(inventory_variant.id).at_path 'variants/0/id'
+      it "ignores the setting and renders all variants" do
+        expect(serialized_product).to have_json_size(2).at_path 'variants'
+      end
+
+      context "when inventory enabled" do
+        let(:inventory_enabled) { true }
+
+        it "renders only variants that are in the coordinators inventory" do
+          expect(serialized_product).to have_json_size(1).at_path 'variants'
+          expect(serialized_product).to be_json_eql(inventory_variant.id).at_path 'variants/0/id'
+        end
       end
     end
-  end
 
-  context "when order cycle shows all available products" do
-    before do
-      allow(order_cycle).to receive(:prefers_product_selection_from_coordinator_inventory_only?) {
-                              false
-                            }
-    end
+    context "when order cycle shows all available products" do
+      before do
+        allow(order_cycle).to receive(:prefers_product_selection_from_coordinator_inventory_only?) {
+                                false
+                              }
+      end
 
-    describe "supplied products" do
-      it "renders variants regardless of whether they are in the coordinators inventory" do
-        expect(serialized_product).to have_json_size(2).at_path 'variants'
-        variant_ids = parse_json(serialized_product)['variants'].pluck('id')
-        expect(variant_ids).to include non_inventory_variant.id, inventory_variant.id
+      describe "supplied products" do
+        it "renders variants regardless of whether they are in the coordinators inventory" do
+          expect(serialized_product).to have_json_size(2).at_path 'variants'
+          variant_ids = parse_json(serialized_product)['variants'].pluck('id')
+          expect(variant_ids).to include non_inventory_variant.id, inventory_variant.id
+        end
       end
     end
   end

--- a/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
+++ b/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
@@ -24,15 +24,19 @@ RSpec.describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
       end
 
       it "ignores the setting and renders all variants" do
-        expect(serialized_product).to have_json_size(2).at_path 'variants'
+        results = JSON.parse(serialized_product)
+
+        expect(results["variants"].length).to eq(2)
       end
 
       context "when inventory enabled" do
         let(:inventory_enabled) { true }
 
         it "renders only variants that are in the coordinators inventory" do
-          expect(serialized_product).to have_json_size(1).at_path 'variants'
-          expect(serialized_product).to be_json_eql(inventory_variant.id).at_path 'variants/0/id'
+          results = JSON.parse(serialized_product)
+
+          expect(results["variants"].length).to eq(1)
+          expect(results["variants"][0]["id"]).to eq(inventory_variant.id)
         end
       end
     end
@@ -46,8 +50,10 @@ RSpec.describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
 
       describe "supplied products" do
         it "renders variants regardless of whether they are in the coordinators inventory" do
-          expect(serialized_product).to have_json_size(2).at_path 'variants'
-          variant_ids = parse_json(serialized_product)['variants'].pluck('id')
+          results = JSON.parse(serialized_product)
+
+          expect(results["variants"].length).to eq(2)
+          variant_ids = results['variants'].pluck('id')
           expect(variant_ids).to include non_inventory_variant.id, inventory_variant.id
         end
       end

--- a/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
+++ b/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
-  let(:coordinator)         { create(:distributor_enterprise) }
-  let(:order_cycle)         { double(:order_cycle, coordinator:) }
+  subject(:serialized_product) { described_class.new(product, order_cycle:).to_json }
+
+  let(:coordinator) { create(:distributor_enterprise) }
+  let(:order_cycle) { instance_double(OrderCycle, coordinator:) }
   let!(:product) { create(:simple_product) }
   let!(:non_inventory_variant) { product.variants.first }
   let!(:inventory_variant) { create(:variant, product: product.reload) }
-  let(:serialized_product) {
-    Api::Admin::ForOrderCycle::SuppliedProductSerializer.new(product,
-                                                             order_cycle: ).to_json
-  }
   let!(:inventory_item) {
     create(:inventory_item, enterprise: coordinator, variant: inventory_variant, visible: true)
   }

--- a/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
+++ b/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
-  subject(:serialized_product) {
-    described_class.new(product, order_cycle:, inventory_enabled:).to_json
-  }
+  subject(:serialized_product) { described_class.new(product, order_cycle:, inventory_enabled:) }
 
   let(:coordinator) { create(:distributor_enterprise) }
   let(:order_cycle) { instance_double(OrderCycle, coordinator:) }
@@ -24,19 +22,15 @@ RSpec.describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
       end
 
       it "ignores the setting and renders all variants" do
-        results = JSON.parse(serialized_product)
-
-        expect(results["variants"].length).to eq(2)
+        expect(serialized_product.variants.length).to eq(2)
       end
 
       context "when inventory enabled" do
         let(:inventory_enabled) { true }
 
         it "renders only variants that are in the coordinators inventory" do
-          results = JSON.parse(serialized_product)
-
-          expect(results["variants"].length).to eq(1)
-          expect(results["variants"][0]["id"]).to eq(inventory_variant.id)
+          expect(serialized_product.variants.length).to eq(1)
+          expect(serialized_product.variants[0][:id]).to eq(inventory_variant.id)
         end
       end
     end
@@ -50,10 +44,8 @@ RSpec.describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
 
       describe "supplied products" do
         it "renders variants regardless of whether they are in the coordinators inventory" do
-          results = JSON.parse(serialized_product)
-
-          expect(results["variants"].length).to eq(2)
-          variant_ids = results['variants'].pluck('id')
+          expect(serialized_product.variants.length).to eq(2)
+          variant_ids = serialized_product.variants.pluck(:id)
           expect(variant_ids).to include non_inventory_variant.id, inventory_variant.id
         end
       end

--- a/spec/services/exchange_products_renderer_spec.rb
+++ b/spec/services/exchange_products_renderer_spec.rb
@@ -3,13 +3,21 @@
 RSpec.describe ExchangeProductsRenderer do
   let(:order_cycle) { create(:order_cycle) }
   let(:coordinator) { order_cycle.coordinator }
-  let(:renderer) { described_class.new(order_cycle, coordinator.owner) }
+  let(:renderer) { described_class.new(order_cycle, coordinator.owner, inventory_enabled:) }
+  let(:inventory_enabled) { false }
 
   describe "#exchange_products" do
     describe "for an incoming exchange" do
       let(:exchange) { order_cycle.exchanges.incoming.first }
 
-      it "loads products" do
+      it "loads products in order" do
+        products = renderer.exchange_products(true, exchange.sender)
+        expected_products = Spree::Product.in_supplier(exchange.sender).map(&:name)
+
+        expect(products.map(&:name)).to eq(expected_products)
+      end
+
+      it "loads product for the given supplier" do
         products = renderer.exchange_products(true, exchange.sender)
 
         expect(products.first.variants.first.supplier.name).to eq(
@@ -17,24 +25,31 @@ RSpec.describe ExchangeProductsRenderer do
         )
       end
 
-      it "loads products in order" do
-        products = renderer.exchange_products(true, exchange.sender)
-        sorted_products_names = products.map(&:name).sort
+      context "showing products from coordinator inventory only" do
+        before {
+          order_cycle.update prefers_product_selection_from_coordinator_inventory_only: true
+        }
 
-        expect(products.map(&:name)).to eq(sorted_products_names)
+        it "ignores the setting and load all products" do
+          # Add variant already in the exchange to the coordinator's inventory
+          exchange.variants.first.inventory_items = [create(:inventory_item,
+                                                            enterprise: order_cycle.coordinator)]
+          products = renderer.exchange_products(true, exchange.sender)
+          expected_products = Spree::Product.in_supplier(exchange.sender).map(&:name)
+
+          expect(products.map(&:name)).to eq expected_products
+        end
       end
     end
 
     describe "for an outgoing exchange" do
       let(:exchange) { order_cycle.exchanges.outgoing.first }
 
-      it "loads products" do
+      it "loads products from the exchange suppliers" do
         products = renderer.exchange_products(false, exchange.receiver)
 
-        suppliers = [exchange.variants[0].supplier.name,
-                     exchange.variants[1].supplier.name]
-        expect(suppliers).to include products.first.variants.first.supplier.name
-        expect(suppliers).to include products.second.variants.first.supplier.name
+        expected_suppliers = exchange.variants.map{ |v| v.supplier.name }
+        expect(products.map{ |p| p.variants.first.supplier.name }).to eq(expected_suppliers)
       end
 
       it "loads products in order" do
@@ -49,20 +64,34 @@ RSpec.describe ExchangeProductsRenderer do
           order_cycle.update prefers_product_selection_from_coordinator_inventory_only: true
         }
 
-        it "loads no products if there are no products from the coordinator inventory" do
-          products = renderer.exchange_products(false, exchange.receiver)
-
-          expect(products).to be_empty
-        end
-
-        it "loads products from the coordinator inventory" do
+        it "ignores the setting and load all products" do
           # Add variant already in the exchange to the coordinator's inventory
           exchange.variants.first.inventory_items = [create(:inventory_item,
                                                             enterprise: order_cycle.coordinator)]
-
           products = renderer.exchange_products(false, exchange.receiver)
 
-          expect(products).to eq [exchange.variants.first.product]
+          expected_products = exchange.variants.map { |v| v.product.name }
+          expect(products.map(&:name)).to eq expected_products
+        end
+
+        context "with inventory enabled" do
+          let(:inventory_enabled) { true }
+
+          it "loads no products if there are no products from the coordinator inventory" do
+            products = renderer.exchange_products(false, exchange.receiver)
+
+            expect(products).to be_empty
+          end
+
+          it "loads products from the coordinator inventory" do
+            # Add variant already in the exchange to the coordinator's inventory
+            exchange.variants.first.inventory_items = [create(:inventory_item,
+                                                              enterprise: order_cycle.coordinator)]
+
+            products = renderer.exchange_products(false, exchange.receiver)
+
+            expect(products).to eq [exchange.variants.first.product]
+          end
         end
       end
     end
@@ -96,16 +125,26 @@ RSpec.describe ExchangeProductsRenderer do
           order_cycle.prefers_product_selection_from_coordinator_inventory_only = true
         end
 
-        it "renders visible inventory variants" do
-          variants = renderer.exchange_variants(true, exchange_with_visible_variant.sender)
+        it "ignores the setting and renders all variants" do
+          variants = renderer.exchange_variants(true, exchange_with_hidden_variant.sender)
 
           expect(variants.size).to eq 1
         end
 
-        it "does not render hidden inventory variants" do
-          variants = renderer.exchange_variants(true, exchange_with_hidden_variant.sender)
+        context "when inventory enabled" do
+          let(:inventory_enabled) { true }
 
-          expect(variants.size).to eq 0
+          it "renders visible inventory variants" do
+            variants = renderer.exchange_variants(true, exchange_with_visible_variant.sender)
+
+            expect(variants.size).to eq 1
+          end
+
+          it "does not render hidden inventory variants" do
+            variants = renderer.exchange_variants(true, exchange_with_hidden_variant.sender)
+
+            expect(variants.size).to eq 0
+          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -257,7 +257,6 @@ RSpec.configure do |config|
 
   # Helpers
   config.include FactoryBot::Syntax::Methods
-  config.include JsonSpec::Helpers
 
   config.include Rails.application.routes.url_helpers
   config.include Spree::UrlHelpers


### PR DESCRIPTION
## What? Why?

- Closes #14200 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
With inventory enabled, and editing an order cycle, there is the option to use Choose product from the Coordinator's Inventory's only. If the inventory then gets turned off, the option stays active. This PR fix the issue by ignoring the option when the inventory is not enabled.

## WhatI should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
Pick an enterprise with the inventory enabled. 
You can enable the inventory for a specific enterprise by adding a new "actor" the inventory feature. The actor looks like this "Enterprise;3" , where 3 is the enterprise OFN UID which you can fiend on the enterprise setting page. NOTE, the "variant_tag" feature takes precedence over the "inventory" feature if both are enabled, so you will most likely need to remove the "enterprise_with_no_inventory" group from the "variant_tag" feature.

Simple order cycle : 
Log in as an enterprise manager for said enterprise : 
- Add some product to the inventory (make sure to not add all of them), via the "Inventory" sub menu on the "Products" page in the back office
- Create a new order cycle with the enterprise as coordinator, make sure to save it. 
- Now you should have access to the "Advanced settings" button on the top right.
- Via the advance setting, Set Choose Products from "Coordinators Inventory Only"
  -> You should only see products you added in the inventory
- Select some and save your order cycle
- Open the shop page for the order cycle you just created
  -> You should only see the products you selected
- In the feature settings, add an "actor" the "variant tag" feature ( as explained above). We could just remove the enterprise from the inventory feature, but we also want to test that the "variant tag" feature takes precedence over the inventory one.
- Re open the order cycle you created 
  --> You should not have access to "Choose Products from" in the Advance settings   
  --> You should be able to select all the products the enterprise has 
- Select some products that are not in the inventory and save the order cycle
- Open the shop page for the order cycle
  --> you only should see the products you selected, including products that are not in the inventory 

Order cycle for hubs :
Use the same scenario has above but this time for a hub. Choose Products from "Coordinators Inventory Only" should apply (or not) to the incoming products in the order cycle.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
