### PR TITLE
Use GitHub's built-in redis service in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,10 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
-      # Redis settings shared with all jobs
-      redis: &redis
+      # Separate redis container for each node
+      redis${{ matrix.ci_node_index }}: &redis
         image: redis # ofn-install uses latest stable version
+        ports: ["6379:6379"]
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"
@@ -126,7 +127,8 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
-      redis: *redis
+      # Separate redis container for each node
+      redis${{ matrix.ci_node_index }}: *redis
     strategy:
       fail-fast: false
       matrix:
@@ -222,7 +224,8 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
-      redis: *redis
+      # Separate redis container for each node
+      redis${{ matrix.ci_node_index }}: *redis
     strategy:
       fail-fast: false
       matrix:
@@ -309,7 +312,8 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
-      redis: *redis
+      # Separate redis container for each node
+      redis${{ matrix.ci_node_index }}: *redis
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,15 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
+      # Redis settings shared with all jobs
+      redis: &redis
+        image: redis # ofn-install uses latest stable version
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
       matrix:
@@ -43,11 +52,6 @@ jobs:
         ci_node_index: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v6
-
-      - name: Setup redis
-        uses: supercharge/redis-github-action@1.8.1
-        with:
-          redis-version: 6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -122,6 +126,7 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
+      redis: *redis
     strategy:
       fail-fast: false
       matrix:
@@ -134,11 +139,6 @@ jobs:
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
     steps:
       - uses: actions/checkout@v6
-
-      - name: Setup redis
-        uses: supercharge/redis-github-action@1.8.1
-        with:
-          redis-version: 6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -222,6 +222,7 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
+      redis: *redis
     strategy:
       fail-fast: false
       matrix:
@@ -234,11 +235,6 @@ jobs:
         ci_node_index: [0, 1]
     steps:
       - uses: actions/checkout@v6
-
-      - name: Setup redis
-        uses: supercharge/redis-github-action@1.8.1
-        with:
-          redis-version: 6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -313,6 +309,7 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
+      redis: *redis
     strategy:
       fail-fast: false
       matrix:
@@ -325,11 +322,6 @@ jobs:
         ci_node_index: [0, 1, 2]
     steps:
       - uses: actions/checkout@v6
-
-      - name: Setup redis
-        uses: supercharge/redis-github-action@1.8.1
-        with:
-          redis-version: 6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ env:
   TIMEZONE: UTC
   COVERAGE: true
   RAILS_ENV: test
+  OFN_REDIS_TEST_URL: "redis://localhost:6379/0"
+  OFN_REDIS_CABLE_URL: "redis://localhost:6379/1"
+  OFN_REDIS_JOBS_URL: "redis://localhost:6379/2"
+
 permissions:
   contents: read
 
@@ -31,8 +35,8 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
-      # Separate redis container for each node
-      redis${{ matrix.ci_node_index }}: &redis
+      # Redis settings shared with all jobs
+      redis: &redis
         image: redis # ofn-install uses latest stable version
         ports: ["6379:6379"]
         # Set health checks to wait until redis has started
@@ -127,8 +131,7 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
-      # Separate redis container for each node
-      redis${{ matrix.ci_node_index }}: *redis
+      redis: *redis
     strategy:
       fail-fast: false
       matrix:
@@ -224,8 +227,7 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
-      # Separate redis container for each node
-      redis${{ matrix.ci_node_index }}: *redis
+      redis: *redis
     strategy:
       fail-fast: false
       matrix:
@@ -312,8 +314,7 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
-      # Separate redis container for each node
-      redis${{ matrix.ci_node_index }}: *redis
+      redis: *redis
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,16 @@ jobs:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
           POSTGRES_PASSWORD: f00d
+      # Redis settings shared with all jobs
+      redis: &redis
+        image: redis # ofn-install uses latest stable version
+        ports: ["6379:6379"]
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
       matrix:
@@ -44,11 +54,6 @@ jobs:
         ci_node_index: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v6
-
-      - name: Setup redis
-        uses: supercharge/redis-github-action@1.8.1
-        with:
-          redis-version: 6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -115,6 +120,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres: *postgres
+      redis: *redis
     strategy:
       fail-fast: false
       matrix:
@@ -127,11 +133,6 @@ jobs:
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
     steps:
       - uses: actions/checkout@v6
-
-      - name: Setup redis
-        uses: supercharge/redis-github-action@1.8.1
-        with:
-          redis-version: 6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -205,6 +206,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres: *postgres
+      redis: *redis
     strategy:
       fail-fast: false
       matrix:
@@ -217,11 +219,6 @@ jobs:
         ci_node_index: [0, 1]
     steps:
       - uses: actions/checkout@v6
-
-      - name: Setup redis
-        uses: supercharge/redis-github-action@1.8.1
-        with:
-          redis-version: 6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -287,6 +284,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres: *postgres
+      redis: *redis
     strategy:
       fail-fast: false
       matrix:
@@ -299,11 +297,6 @@ jobs:
         ci_node_index: [0, 1, 2]
     steps:
       - uses: actions/checkout@v6
-
-      - name: Setup redis
-        uses: supercharge/redis-github-action@1.8.1
-        with:
-          redis-version: 6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 1s
+          --health-timeout 1s
+          --health-retries 30
         env:
           POSTGRES_DB: open_food_network_test
           POSTGRES_USER: ofn
@@ -39,9 +39,9 @@ jobs:
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 1s
+          --health-timeout 1s
+          --health-retries 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION

## What? Why?
Instead of downloading a docker image, every, single, time.

I have to admit I'm still a bit confused because some results seem to conflict. I've left one extra commit in to share my learning.
In any case, it seems to work 😅 

- Closes #14161 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
1. green specs
2. no redis warnings or errors
3. quicker test runs 🤞 