### PR TITLE
Show tag suggestions when adding tags to variants on products page 

### DIFF
--- a/app/components/tag_list_input_component/tag_list_input_component.scss
+++ b/app/components/tag_list_input_component/tag_list_input_component.scss
@@ -76,32 +76,33 @@
   }
 
   ul.suggestion-list {
-    margin-top: 5px;
-    padding: 5px 0;
+    margin-top: 4px;
+    padding: 0;
     z-index: $tag-drop-down-z-index;
     width: fit-content;
-    background-color: #fff;
-    border: 1px solid rgba(0, 0, 0, 0.2);
+    color: $near-black;
+    background-color: $color-body-bg;
+    @include border-radius($border-radius);
     box-shadow: $shadow-dropdown;
     list-style-type: none;
-    max-height: 280px;
+    max-height: 21em;
     overflow-y: auto;
     position: relative;
 
     li.suggestion-item {
-      padding: 5px 10px;
+      padding: 8px;
+      border-left: 3px solid transparent;
       cursor: pointer;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      color: #000;
-      background-color: #fff;
-      width: stretch;
+      line-height: 20px;
 
       &.active,
       &:hover {
-        color: #fff;
-        background-color: $color-link-visited;
+        border-left-color: $orient;
+        background-color: $lighter-grey;
+        color: $near-black;
       }
     }
   }

--- a/app/components/tag_list_input_component/tag_list_input_controller.js
+++ b/app/components/tag_list_input_component/tag_list_input_controller.js
@@ -104,7 +104,7 @@ export default class extends Autocomplete {
 
   // Override original to add tag filtering
   replaceResults(html) {
-    const filteredHtml = this.#filterResults(html);
+    const filteredHtml = this.#filterResults(this.#addPageTagsToHtml(html));
 
     if (filteredHtml.length == 0) {
       this.hideAndRemoveOptions();
@@ -129,6 +129,38 @@ export default class extends Autocomplete {
   };
 
   //private
+
+  #collectPageTags() {
+    const tags = new Set();
+    for (const el of document.querySelectorAll('[data-tag-list-input-target="tagList"]')) {
+      if (el === this.tagListTarget || !el.value) continue;
+      for (const tag of el.value.split(",")) {
+        if (tag.trim()) tags.add(tag.trim());
+      }
+    }
+    return tags;
+  }
+
+  #addPageTagsToHtml(serverHtml) {
+    const pageTags = this.#collectPageTags();
+    if (pageTags.size === 0) return serverHtml;
+
+    const query = this.inputTarget.value.trim().toLowerCase();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(serverHtml, "text/html");
+    const existingValues = new Set(
+      [...doc.getElementsByTagName("li")].map(li => li.dataset.autocompleteValue)
+    );
+
+    let extra = "";
+    for (const tag of pageTags) {
+      if (!existingValues.has(tag) && tag.toLowerCase().includes(query)) {
+        extra += `<li class="suggestion-item" role="option" data-autocomplete-value="${tag}" data-autocomplete-label="${tag}">${tag}</li>`;
+      }
+    }
+
+    return extra + serverHtml;
+  }
 
   #filterResults(html) {
     const existingTags = this.tagListTarget.value.split(",");

--- a/app/components/tag_list_input_component/tag_list_input_controller.js
+++ b/app/components/tag_list_input_component/tag_list_input_controller.js
@@ -106,8 +106,10 @@ export default class extends Autocomplete {
   replaceResults(html) {
     const filteredHtml = this.#filterResults(html);
 
-    // Don't show result if we don't have anything to show
-    if (filteredHtml.length == 0) return;
+    if (filteredHtml.length == 0) {
+      this.hideAndRemoveOptions();
+      return;
+    }
 
     super.replaceResults(filteredHtml);
   }

--- a/app/components/tag_list_input_component/tag_list_input_controller.js
+++ b/app/components/tag_list_input_component/tag_list_input_controller.js
@@ -149,7 +149,7 @@ export default class extends Autocomplete {
     const parser = new DOMParser();
     const doc = parser.parseFromString(serverHtml, "text/html");
     const existingValues = new Set(
-      [...doc.getElementsByTagName("li")].map(li => li.dataset.autocompleteValue)
+      [...doc.getElementsByTagName("li")].map((li) => li.dataset.autocompleteValue),
     );
 
     let extra = "";

--- a/app/controllers/admin/tag_rules_controller.rb
+++ b/app/controllers/admin/tag_rules_controller.rb
@@ -51,20 +51,27 @@ module Admin
       end
     end
 
-    # Use to populate autocomplete with available rule for the given tag/enterprise
+    # Used by the tag input autocomplete to suggest existing variant tags
     def variant_tag_rules
-      tag_rules =
-        TagRule.matching_variant_tag_rules_by_enterprises(params[:enterprise_id], params[:q])
+      enterprise_ids = enterprises.pluck(:id)
 
-      @formatted_tag_rules = tag_rules.each_with_object({}) do |rule, mapping|
-        rule.preferred_variant_tags.split(",").each do |tag|
-          if mapping[tag]
-            mapping[tag][:rules] += 1
-          else
-            mapping[tag] = { tag:, rules: 1 }
-          end
-        end
-      end.values
+      # Tags already applied to variants, most recently used first
+      variant_ids = Spree::Variant.where(supplier_id: enterprise_ids).select(:id)
+      variant_tags = ActsAsTaggableOn::Tag
+        .joins(:taggings)
+        .where(taggings: { taggable_type: "Spree::Variant", taggable_id: variant_ids })
+        .group("acts_as_taggable_on_tags.id, acts_as_taggable_on_tags.name")
+        .order("MAX(taggings.created_at) DESC")
+        .pluck(:name)
+
+      # Tags from FilterVariants tag rules saved for this enterprise, most recently modified first
+      rule_tags = TagRule::FilterVariants.for(enterprise_ids).order(updated_at: :desc).flat_map do |rule|
+        rule.tags.split(",").map(&:strip)
+      end
+
+      query = params[:q].to_s
+      all_tags = (variant_tags + rule_tags).uniq.reject(&:empty?)
+      @tags = query.present? ? all_tags.select { |t| t.downcase.include?(query.downcase) } : all_tags
 
       respond_with do |format|
         format.html { render :variant_tag_rules, layout: false }

--- a/app/controllers/admin/tag_rules_controller.rb
+++ b/app/controllers/admin/tag_rules_controller.rb
@@ -60,7 +60,7 @@ module Admin
       variant_tags = ActsAsTaggableOn::Tag
         .joins(:taggings)
         .where(taggings: { taggable_type: "Spree::Variant", taggable_id: variant_ids })
-        .group("acts_as_taggable_on_tags.id, acts_as_taggable_on_tags.name")
+        .group("tags.id, tags.name")
         .order("MAX(taggings.created_at) DESC")
         .pluck(:name)
 

--- a/app/controllers/admin/tag_rules_controller.rb
+++ b/app/controllers/admin/tag_rules_controller.rb
@@ -65,13 +65,13 @@ module Admin
         .pluck(:name)
 
       # Tags from FilterVariants tag rules saved for this enterprise, most recently modified first
-      rule_tags = TagRule::FilterVariants.for(enterprise_ids).order(updated_at: :desc).flat_map do |rule|
+      rule_tags = TagRule::FilterVariants.for(enterprise_ids).order(updated_at: :desc)
+        .flat_map do |rule|
         rule.tags.split(",").map(&:strip)
       end
 
-      query = params[:q].to_s
       all_tags = (variant_tags + rule_tags).uniq.reject(&:empty?)
-      @tags = query.present? ? all_tags.select { |t| t.downcase.include?(query.downcase) } : all_tags
+      @tags = filter_tags(all_tags, params[:q].to_s)
 
       respond_with do |format|
         format.html { render :variant_tag_rules, layout: false }
@@ -79,6 +79,12 @@ module Admin
     end
 
     private
+
+    def filter_tags(tags, query)
+      return tags if query.blank?
+
+      tags.select { |t| t.downcase.include?(query.downcase) }
+    end
 
     def collection_actions
       [:index, :map_by_tag]

--- a/app/models/tag_rule.rb
+++ b/app/models/tag_rule.rb
@@ -22,14 +22,6 @@ class TagRule < ApplicationRecord
     end
   end
 
-  def self.matching_variant_tag_rules_by_enterprises(enterprise_id, tag)
-    rules = where(type: "TagRule::FilterVariants").for(enterprise_id)
-
-    return [] if rules.empty?
-
-    rules.select { |r| r.preferred_variant_tags =~ /#{tag}/ }
-  end
-
   # The following method must be overriden in a concrete tagRule
   def tags
     raise NotImplementedError, 'please use concrete TagRule'

--- a/app/views/admin/tag_rules/variant_tag_rules.html.haml
+++ b/app/views/admin/tag_rules/variant_tag_rules.html.haml
@@ -1,3 +1,3 @@
-- @formatted_tag_rules.each do |tag_rule|
-  %li.suggestion-item{ role: "option", "data-autocomplete-value": tag_rule[:tag], "data-autocomplete-label": tag_rule[:tag] }
-    = t("admin.products_v3.tag_rules.rules_per_tag", tag: tag_rule[:tag], count: tag_rule[:rules])
+- @tags.each do |tag|
+  %li.suggestion-item{ role: "option", "data-autocomplete-value": tag, "data-autocomplete-label": tag }
+    = tag

--- a/spec/controllers/admin/tag_rules_controller_spec.rb
+++ b/spec/controllers/admin/tag_rules_controller_spec.rb
@@ -72,47 +72,79 @@ RSpec.describe Admin::TagRulesController do
     render_views
 
     let(:enterprise) { create(:distributor_enterprise) }
+    let(:product) { create(:product, supplier: enterprise) }
+    let!(:variant1) { create(:variant, product:, supplier: enterprise, tag_list: "organic,local") }
+    let!(:rule) {
+      create(:filter_variants_tag_rule, enterprise:, preferred_customer_tags: "vip",
+                                        preferred_variant_tags: "premium")
+    }
     let(:q) { "" }
-    let!(:rule1) {
-      create(:filter_variants_tag_rule, enterprise:, preferred_customer_tags: "Tag-1",
-                                        preferred_variant_tags: "variant-tag-1" )
-    }
-    let!(:rule2) {
-      create(:filter_variants_tag_rule, enterprise:, preferred_customer_tags: "Tag-1",
-                                        preferred_variant_tags: "variant2-tag-1" )
-    }
-    let!(:rule3) {
-      create(:filter_variants_tag_rule, enterprise:, preferred_customer_tags: "organic",
-                                        preferred_variant_tags: "variant-organic" )
-    }
-    let!(:rule4) {
-      create(:filter_variants_tag_rule, enterprise:, preferred_customer_tags: "organic",
-                                        preferred_variant_tags: "variant-tag-1" )
-    }
 
     before do
       controller_login_as_enterprise_user [enterprise]
     end
 
-    it "returns a list of tag rules and number of assiciated rules" do
+    it "returns tags from variant tag lists" do
       spree_get(:variant_tag_rules, format: :html, enterprise_id: enterprise.id, q:)
 
       expect(response).to render_template :variant_tag_rules
-      expect(response.body).to include "variant-tag-1 has 2 rules"
-      expect(response.body).to include "variant2-tag-1 has 1 rule"
-      expect(response.body).to include "variant-organic has 1 rule"
+      expect(response.body).to include "organic"
+      expect(response.body).to include "local"
+    end
+
+    it "returns variant tags from FilterVariants tag rules" do
+      spree_get(:variant_tag_rules, format: :html, enterprise_id: enterprise.id, q:)
+
+      expect(response.body).to include "premium"
+    end
+
+    it "does not return customer tags from tag rules" do
+      spree_get(:variant_tag_rules, format: :html, enterprise_id: enterprise.id, q:)
+
+      expect(response.body).not_to include "vip"
+    end
+
+    it "does not return tags from non-FilterVariants tag rules" do
+      create(:filter_order_cycles_tag_rule, enterprise:, preferred_customer_tags: "wholesale",
+                                            preferred_exchange_tags: "oc-tag")
+
+      spree_get(:variant_tag_rules, format: :html, enterprise_id: enterprise.id, q:)
+
+      expect(response.body).not_to include "wholesale"
+      expect(response.body).not_to include "oc-tag"
+    end
+
+    it "returns tags most recently applied to a variant first" do
+      variant2 = create(:variant, product:, supplier: enterprise, tag_list: "newer-tag")
+      # Ensure variant1's taggings are older
+      ActsAsTaggableOn::Tagging.where(taggable: variant2).update_all(created_at: 1.hour.from_now)
+
+      spree_get(:variant_tag_rules, format: :html, enterprise_id: enterprise.id, q:)
+
+      expect(assigns(:tags).index("newer-tag")).to be < assigns(:tags).index("organic")
+    end
+
+    it "does not return tags from another enterprise" do
+      other_enterprise = create(:distributor_enterprise)
+      other_product = create(:product, supplier: other_enterprise)
+      create(:variant, product: other_product, supplier: other_enterprise, tag_list: "other-tag")
+
+      spree_get(:variant_tag_rules, format: :html, enterprise_id: enterprise.id, q:)
+
+      expect(response.body).not_to include "other-tag"
     end
 
     context "with search string" do
       let(:q) { "org" }
 
-      it "returns a list of tag rules matching the string" do
+      it "returns only tags matching the search string" do
         spree_get(:variant_tag_rules, format: :html, enterprise_id: enterprise.id, q:)
 
         expect(response).to render_template :variant_tag_rules
-        expect(response.body).not_to include "variant-tag-1 has 2 rules"
-        expect(response.body).not_to include "variant2-tag-1 has 1 rule"
-        expect(response.body).to include "variant-organic has 1 rule"
+        expect(response.body).to include "organic"
+        expect(response.body).not_to include "local"
+        expect(response.body).not_to include "vip"
+        expect(response.body).not_to include "premium"
       end
     end
   end

--- a/spec/controllers/admin/tag_rules_controller_spec.rb
+++ b/spec/controllers/admin/tag_rules_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Admin::TagRulesController do
     render_views
 
     let(:enterprise) { create(:distributor_enterprise) }
-    let(:product) { create(:product, supplier: enterprise) }
+    let(:product) { create(:product, supplier_id: enterprise.id) }
     let!(:variant1) { create(:variant, product:, supplier: enterprise, tag_list: "organic,local") }
     let!(:rule) {
       create(:filter_variants_tag_rule, enterprise:, preferred_customer_tags: "vip",
@@ -126,7 +126,7 @@ RSpec.describe Admin::TagRulesController do
 
     it "does not return tags from another enterprise" do
       other_enterprise = create(:distributor_enterprise)
-      other_product = create(:product, supplier: other_enterprise)
+      other_product = create(:product, supplier_id: other_enterprise.id)
       create(:variant, product: other_product, supplier: other_enterprise, tag_list: "other-tag")
 
       spree_get(:variant_tag_rules, format: :html, enterprise_id: enterprise.id, q:)

--- a/spec/javascripts/stimulus/tag_list_input_controller_test.js
+++ b/spec/javascripts/stimulus/tag_list_input_controller_test.js
@@ -10,25 +10,23 @@ import tag_list_input_controller from "tag_list_input_component/tag_list_input_c
 // Mock jest to return an autocomplete list
 global.fetch = jest.fn(() => {
   const html = `
-    <li 
-      data-testid="item" 
+    <li
+      data-testid="item"
       class="suggestion-item"
       data-autocomplete-label="tag-1"
       data-autocomplete-value="tag-1"
       role="option"
-      id="stimulus-autocomplete-option-4"
     >
-      tag-1 has 1 rule
+      tag-1
     </li>
-    <li 
+    <li
       data-testid="item"
       class="suggestion-item"
-      data-autocomplete-label="rule-2"
-      data-autocomplete-value="rule-2"
+      data-autocomplete-label="some-other-tag"
+      data-autocomplete-value="some-other-tag"
       role="option"
-      id="stimulus-autocomplete-option-5"
     >
-      rule-2 has 2 rules
+      some-other-tag
     </li>`;
 
   return Promise.resolve({
@@ -425,23 +423,21 @@ describe("TagListInputController", () => {
                 >
               </div>
               <ul class="suggestion-list" data-tag-list-input-target="results">
-                <li 
-                  class="suggestion-item" 
-                  data-autocomplete-label="rule-1" 
-                  data-autocomplete-value="rule-1" 
-                  role="option" 
-                  id="stimulus-autocomplete-option-4"
+                <li
+                  class="suggestion-item"
+                  data-autocomplete-label="some-tag"
+                  data-autocomplete-value="some-tag"
+                  role="option"
                 >
-                  rule-1 has 1 rule
+                  some-tag
                 </li>
-                <li 
-                  class="suggestion-item" 
-                  data-autocomplete-label="rule-2" 
-                  data-autocomplete-value="rule-2" 
-                  role="option" 
-                  id="stimulus-autocomplete-option-5"
-                 >
-                  rule-2 has 2 rules
+                <li
+                  class="suggestion-item"
+                  data-autocomplete-label="some-other-tag"
+                  data-autocomplete-value="some-other-tag"
+                  role="option"
+                >
+                  some-other-tag
                 </li>
               </ul>
             </div>
@@ -471,7 +467,30 @@ describe("TagListInputController", () => {
       // the dom has been updated with the autocomplete data
       const items = await screen.findAllByTestId("item");
       expect(items.length).toBe(1);
-      expect(items[0].textContent.trim()).toBe("rule-2 has 2 rules");
+      expect(items[0].textContent.trim()).toBe("some-other-tag");
+    });
+
+    it("hides the dropdown when all returned tags are already in the list", async () => {
+      fetch.mockImplementationOnce(() => {
+        const html = `
+          <li
+            data-testid="item"
+            class="suggestion-item"
+            data-autocomplete-label="tag-1"
+            data-autocomplete-value="tag-1"
+            role="option"
+          >
+            tag-1
+          </li>`;
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(html) });
+      });
+
+      variant_add_tag.dispatchEvent(new FocusEvent("focus"));
+      jest.runAllTimers();
+      await screen.findByTestId("suggestion-list");
+
+      const suggestionList = screen.getByTestId("suggestion-list");
+      expect(suggestionList.childElementCount).toBe(0);
     });
   });
 });

--- a/spec/javascripts/stimulus/tag_list_input_controller_test.js
+++ b/spec/javascripts/stimulus/tag_list_input_controller_test.js
@@ -540,11 +540,11 @@ describe("TagListInputController", () => {
 
         const suggestionList = screen.getByTestId("suggestion-list");
         const options = [...suggestionList.querySelectorAll("li[role='option']")];
-        const values = options.map(li => li.dataset.autocompleteValue);
+        const values = options.map((li) => li.dataset.autocompleteValue);
 
-        expect(values[0]).toBe("page-only-tag");     // unsaved page tags appear first
+        expect(values[0]).toBe("page-only-tag"); // unsaved page tags appear first
         expect(values).toContain("some-other-tag"); // from server
-        expect(values).not.toContain("tag-1");      // filtered out — already on this variant
+        expect(values).not.toContain("tag-1"); // filtered out — already on this variant
       });
     });
 

--- a/spec/javascripts/stimulus/tag_list_input_controller_test.js
+++ b/spec/javascripts/stimulus/tag_list_input_controller_test.js
@@ -470,6 +470,84 @@ describe("TagListInputController", () => {
       expect(items[0].textContent.trim()).toBe("some-other-tag");
     });
 
+    describe("when other tag inputs on the page have unsaved tags", () => {
+      beforeEach(() => {
+        document.body.innerHTML = `
+          <div
+            data-controller="tag-list-input"
+            data-action="autocomplete.change->tag-list-input#addTag"
+            data-tag-list-input-url-value="/admin/tag_rules/variant_tag_rules?enterprise_id=3"
+           >
+            <input
+              value="tag-1,tag-2,tag-3"
+              data-tag-list-input-target="tagList"
+              type="hidden"
+              name="variant_tag_list"
+              id="variant_tag_list"
+            >
+            <div class="tags-input"><div class="tags">
+              <ul class="tag-list" data-tag-list-input-target="list">
+                <template data-tag-list-input-target="template">
+                  <li class="tag-item"><div class="tag-template"><span></span></div></li>
+                </template>
+              </ul>
+              <input
+                type="text"
+                name="variant_add_tag"
+                id="variant_add_tag"
+                data-action="keydown.enter->tag-list-input#keyboardAddTag keyup->tag-list-input#filterInput blur->tag-list-input#onBlur focus->tag-list-input#onInputChange"
+                data-tag-list-input-target="input"
+                style="display: block;"
+              >
+            </div></div>
+            <ul data-testid="suggestion-list" class="suggestion-list" data-tag-list-input-target="results" hidden></ul>
+          </div>
+          <div
+            data-controller="tag-list-input"
+            data-action="autocomplete.change->tag-list-input#addTag"
+            data-tag-list-input-url-value="/admin/tag_rules/variant_tag_rules?enterprise_id=3"
+           >
+            <input
+              value="page-only-tag,tag-1"
+              data-tag-list-input-target="tagList"
+              type="hidden"
+              name="variant_tag_list_2"
+            >
+            <div class="tags-input"><div class="tags">
+              <ul class="tag-list" data-tag-list-input-target="list">
+                <template data-tag-list-input-target="template">
+                  <li class="tag-item"><div class="tag-template"><span></span></div></li>
+                </template>
+              </ul>
+              <input
+                type="text"
+                name="variant_add_tag_2"
+                data-action="keydown.enter->tag-list-input#keyboardAddTag keyup->tag-list-input#filterInput blur->tag-list-input#onBlur focus->tag-list-input#onInputChange"
+                data-tag-list-input-target="input"
+                style="display: block;"
+              >
+            </div></div>
+            <ul class="suggestion-list" data-tag-list-input-target="results" hidden></ul>
+          </div>`;
+      });
+
+      it("includes unsaved page tags in autocomplete suggestions", async () => {
+        variant_add_tag.dispatchEvent(new FocusEvent("focus"));
+        jest.runAllTimers();
+
+        // Wait for the async fetch to resolve and populate suggestions
+        await screen.findByText("some-other-tag");
+
+        const suggestionList = screen.getByTestId("suggestion-list");
+        const options = [...suggestionList.querySelectorAll("li[role='option']")];
+        const values = options.map(li => li.dataset.autocompleteValue);
+
+        expect(values[0]).toBe("page-only-tag");     // unsaved page tags appear first
+        expect(values).toContain("some-other-tag"); // from server
+        expect(values).not.toContain("tag-1");      // filtered out — already on this variant
+      });
+    });
+
     it("hides the dropdown when all returned tags are already in the list", async () => {
       fetch.mockImplementationOnce(() => {
         const html = `

--- a/spec/models/tag_rule_spec.rb
+++ b/spec/models/tag_rule_spec.rb
@@ -7,40 +7,6 @@ RSpec.describe TagRule do
     end
   end
 
-  describe ".matching_variant_tag_rules_by_enterprises" do
-    let(:enterprise) { create(:enterprise) }
-    let!(:rule1) {
-      create(:filter_variants_tag_rule, enterprise:, preferred_variant_tags: "filtered" )
-    }
-    let!(:rule2) {
-      create(:filter_variants_tag_rule, enterprise:, preferred_variant_tags: "filtered" )
-    }
-    let!(:rule3) {
-      create(:filter_variants_tag_rule, enterprise: create(:enterprise),
-                                        preferred_variant_tags: "filtered" )
-    }
-    let!(:rule4) {
-      create(:filter_variants_tag_rule, enterprise:, preferred_variant_tags: "other-tag" )
-    }
-    let!(:rule5) {
-      create(:filter_order_cycles_tag_rule, enterprise:, preferred_exchange_tags: "filtered" )
-    }
-
-    it "returns a list of rule partially matching the tag" do
-      rules = described_class.matching_variant_tag_rules_by_enterprises(enterprise.id, "filte")
-
-      expect(rules).to include rule1, rule2
-      expect(rules).not_to include rule3, rule4, rule5
-    end
-
-    context "when no matching rules" do
-      it "returns an empty array" do
-        rules = described_class.matching_variant_tag_rules_by_enterprises(enterprise.id, "no-tag")
-        expect(rules).to eq([])
-      end
-    end
-  end
-
   describe '#tags' do
     subject(:rule) { Class.new(TagRule).new }
 


### PR DESCRIPTION
## What? Why?

- Closes #13959 

When adding tags to variants on the admin products page, there was no way to discover what tags already existed -- you had to type them in from memory. this adds an autocomplete dropdown to the variant tag input that suggests existing tags as you type. 

The tag pool includes tags alrady applied to variants (sorted by most recently used first) and tags from existing `FilterVariants` rules for the enterprise. Tags typed into other variant inputs on the page but not yet saved are also suggested, so you can apply the same new tag to multiple variants in one session before saving. The dropdown hides automatically when nothing matches.         

Additionally, the Stimulus controller filters out tags already applied to the current variant, and the dropdown style was matched to the Tom Select dropdowns used elsewhere on the products page.                                                              




## What should we test?
  - Visit the admin products page (/admin/products) with the variant tag feature flag enabled (Flipper.enable(:variant_tag))
  - Click into a variant tag input and confirm suggestions appear               
  - Type a partial tag name and confirm the list filters correctly
  - Type something with no match and confirm the dropdown hides                 
  - Add a tag to one variant (don't save), then open the dropdown on another variant — confirm the unsaved tag appears as a suggestion at the top of the list                                                                          
  - Confirm tags already applied to the current variant are not shown as suggestions                                                                   
   


## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

**Before**
<img width="1458" height="722" alt="before" src="https://github.com/user-attachments/assets/3fbc5217-1f3c-413a-9aae-33c4a2a97222" />

**After**
<img width="1385" height="569" alt="Screenshot from 2026-04-27 17-56-43" src="https://github.com/user-attachments/assets/706fc995-06fe-438f-a0ed-813742b5e417" />


