### PR TITLE
Remove ignored columns

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -22,12 +22,6 @@ module Spree
     include ProductSortByStocks
 
     self.belongs_to_required_by_default = false
-    # These columns have been moved to variant. Currently this is only for documentation purposes,
-    # because they are declared as attr_accessor below, declaring them as ignored columns has no
-    # effect
-    self.ignored_columns += [
-      :primary_taxon_id, :variant_unit, :variant_unit_scale, :variant_unit_name
-    ]
 
     acts_as_paranoid
 

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -26,7 +26,7 @@ module Spree
     # because they are declared as attr_accessor below, declaring them as ignored columns has no
     # effect
     self.ignored_columns += [
-      :supplier_id, :primary_taxon_id, :variant_unit, :variant_unit_scale, :variant_unit_name
+      :primary_taxon_id, :variant_unit, :variant_unit_scale, :variant_unit_name
     ]
 
     acts_as_paranoid

--- a/db/migrate/20260306015100_remove_supplier_id_from_spree_products.rb
+++ b/db/migrate/20260306015100_remove_supplier_id_from_spree_products.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RemoveSupplierIdFromSpreeProducts < ActiveRecord::Migration[6.1]
+  def change
+    remove_foreign_key :spree_products, :enterprises, column: :supplier_id,
+                                                      name: :spree_products_supplier_id_fk
+    remove_index :spree_products, :supplier_id
+    remove_column :spree_products, :supplier_id, :integer
+  end
+end

--- a/db/migrate/20260306015200_remove_ignored_columns_from_spree_products.rb
+++ b/db/migrate/20260306015200_remove_ignored_columns_from_spree_products.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RemoveIgnoredColumnsFromSpreeProducts < ActiveRecord::Migration[6.1]
+  def change
+    change_table :spree_products, bulk: true do
+      remove_column :spree_products, :primary_taxon_id, :integer
+      remove_column :spree_products, :variant_unit, :string
+      remove_column :spree_products, :variant_unit_scale, :float
+      remove_column :spree_products, :variant_unit_name, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -730,16 +730,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_06_015300) do
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "group_buy"
     t.float "group_buy_unit_size"
-    t.string "variant_unit", limit: 255
-    t.float "variant_unit_scale"
-    t.string "variant_unit_name", limit: 255
     t.text "notes"
-    t.integer "primary_taxon_id"
     t.boolean "inherits_properties", default: true, null: false
     t.string "sku", limit: 255, default: "", null: false
     t.index ["deleted_at"], name: "index_products_on_deleted_at"
     t.index ["name"], name: "index_products_on_name"
-    t.index ["primary_taxon_id"], name: "index_spree_products_on_primary_taxon_id"
   end
 
   create_table "spree_properties", id: :serial, force: :cascade do |t|
@@ -1250,7 +1245,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_06_015300) do
   add_foreign_key "spree_product_properties", "spree_properties", column: "property_id", name: "spree_product_properties_property_id_fk"
   add_foreign_key "spree_products", "spree_shipping_categories", column: "shipping_category_id", name: "spree_products_shipping_category_id_fk"
   add_foreign_key "spree_products", "spree_tax_categories", column: "tax_category_id", name: "spree_products_tax_category_id_fk"
-  add_foreign_key "spree_products", "spree_taxons", column: "primary_taxon_id", name: "spree_products_primary_taxon_id_fk"
   add_foreign_key "spree_return_authorizations", "spree_orders", column: "order_id", name: "spree_return_authorizations_order_id_fk"
   add_foreign_key "spree_roles_users", "spree_roles", column: "role_id", name: "spree_roles_users_role_id_fk"
   add_foreign_key "spree_roles_users", "spree_users", column: "user_id", name: "spree_roles_users_user_id_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -728,7 +728,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_06_015300) do
     t.integer "shipping_category_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.integer "supplier_id"
     t.boolean "group_buy"
     t.float "group_buy_unit_size"
     t.string "variant_unit", limit: 255
@@ -741,7 +740,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_06_015300) do
     t.index ["deleted_at"], name: "index_products_on_deleted_at"
     t.index ["name"], name: "index_products_on_name"
     t.index ["primary_taxon_id"], name: "index_spree_products_on_primary_taxon_id"
-    t.index ["supplier_id"], name: "index_spree_products_on_supplier_id"
   end
 
   create_table "spree_properties", id: :serial, force: :cascade do |t|
@@ -1250,7 +1248,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_06_015300) do
   add_foreign_key "spree_prices", "spree_variants", column: "variant_id", name: "spree_prices_variant_id_fk"
   add_foreign_key "spree_product_properties", "spree_products", column: "product_id", name: "spree_product_properties_product_id_fk"
   add_foreign_key "spree_product_properties", "spree_properties", column: "property_id", name: "spree_product_properties_property_id_fk"
-  add_foreign_key "spree_products", "enterprises", column: "supplier_id", name: "spree_products_supplier_id_fk"
   add_foreign_key "spree_products", "spree_shipping_categories", column: "shipping_category_id", name: "spree_products_shipping_category_id_fk"
   add_foreign_key "spree_products", "spree_tax_categories", column: "tax_category_id", name: "spree_products_tax_category_id_fk"
   add_foreign_key "spree_products", "spree_taxons", column: "primary_taxon_id", name: "spree_products_primary_taxon_id_fk"


### PR DESCRIPTION
**:information_source: Please use Clockify code `#76a Sourced variant` for review and testing.**


## What? Why?

- Precursor to #14201

## What should we test?
As we're removing unused things, I think we just need 
🟢 green specs.


## Release Notes
As this deletes database columns, we could consider incrementing a minor version number.

## Dependencies
The below PR needs to be tagged in a release before this PR is merged, because it removes the final reference to the products.supplier column:
- [x] #14272 🚀 deployed in [v5.4.18](https://github.com/openfoodfoundation/openfoodnetwork/releases/tag/v5.4.18)
