### PR TITLE
Fix pr author auto assign github workflow

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -11,4 +11,4 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v3
+      - uses: toshimaru/auto-author-assign@v3.0.2


### PR DESCRIPTION
## What? Why?

- Closes # <!-- Insert issue number here. -->
The recent github action upgrade broke the auto author assign workflow : https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/25537502837/job/74956164476?pr=14263 

This PR specify the full version of `auto- author-assign' : https://github.com/toshimaru/auto-author-assign


## What should we test?
We 'll have to check the workflow is working once it has been merged. 

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.