### PR TITLE
Gracefully ignore missing target

### DIFF
--- a/app/webpacker/controllers/file_loading_controller.js
+++ b/app/webpacker/controllers/file_loading_controller.js
@@ -21,7 +21,9 @@ export default class extends Controller {
 
     const response = fetch(this.linkTarget.href).then((response) => {
       if (response.status == 200) {
-        this.loadingTarget.classList.add(HIDE_CLASS);
+        if (this.hasLoadingTarget) {
+          this.loadingTarget.classList.add(HIDE_CLASS);
+        }
         this.loadedTarget.classList.remove(HIDE_CLASS);
       } else {
         this.setTimeout();


### PR DESCRIPTION
- Closes #14226 (I hope)

Sometimes this target wasn't found in a flaky spec result. I don't know exactly what was happening, but this change seems to help.
I've run it three times with success, at the same time I re-ran a failing build on master, which failed again.