### PR TITLE
Fix reports to use variant supplier

### DIFF
--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -56,19 +56,6 @@ module Spree
     attribute :restock_item, type: :boolean, default: true
 
     # -- Scopes
-    scope :managed_by, lambda { |user|
-      if user.admin?
-        where(nil)
-      else
-        # Find line items that are from orders distributed by the user or supplied by the user
-        joins(variant: :product).
-          joins(:order).
-          where('spree_orders.distributor_id IN (?) OR spree_products.supplier_id IN (?)',
-                user.enterprises, user.enterprises).
-          select('spree_line_items.*')
-      end
-    }
-
     scope :in_orders, lambda { |orders|
       where(order_id: orders)
     }

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -134,10 +134,10 @@ module Spree
       if user.admin?
         where(nil)
       else
-        # Find orders that are distributed by the user or have products supplied by the user
+        # Find orders that are distributed by the user or have variants supplied by the user
         # WARNING: This only filters orders, not line items.
         with_line_items_variants_and_products_outer.
-          where('spree_orders.distributor_id IN (?) OR spree_products.supplier_id IN (?)',
+          where('spree_orders.distributor_id IN (?) OR spree_variants.supplier_id IN (?)',
                 user.enterprises.select(&:id),
                 user.enterprises.select(&:id)).
           select('DISTINCT spree_orders.*')

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -135,8 +135,7 @@ module Spree
         where(nil)
       else
         # Find orders that are distributed by the user or have products supplied by the user
-        # WARNING: This only filters orders,
-        #   you'll need to filter line items separately using LineItem.managed_by
+        # WARNING: This only filters orders, not line items.
         with_line_items_variants_and_products_outer.
           where('spree_orders.distributor_id IN (?) OR spree_products.supplier_id IN (?)',
                 user.enterprises.select(&:id),

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -136,10 +136,9 @@ module Spree
       else
         # Find orders that are distributed by the user or have variants supplied by the user
         # WARNING: This only filters orders, not line items.
-        enterprise_ids = user.enterprises.select(&:id)
         with_line_items_variants_outer.
-          where(distributor_id: enterprise_ids).or(
-            where(spree_variants: { supplier_id: enterprise_ids })
+          where(distributor_id: user.enterprises).or(
+            where(spree_variants: { supplier_id: user.enterprises })
           ).
           select('DISTINCT spree_orders.*')
       end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -136,10 +136,11 @@ module Spree
       else
         # Find orders that are distributed by the user or have variants supplied by the user
         # WARNING: This only filters orders, not line items.
+        enterprise_ids = user.enterprises.select(&:id)
         with_line_items_variants_outer.
-          where('spree_orders.distributor_id IN (?) OR spree_variants.supplier_id IN (?)',
-                user.enterprises.select(&:id),
-                user.enterprises.select(&:id)).
+          where(distributor_id: enterprise_ids).or(
+            where(spree_variants: { supplier_id: enterprise_ids })
+          ).
           select('DISTINCT spree_orders.*')
       end
     }

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -136,7 +136,7 @@ module Spree
       else
         # Find orders that are distributed by the user or have variants supplied by the user
         # WARNING: This only filters orders, not line items.
-        with_line_items_variants_and_products_outer.
+        with_line_items_variants_outer.
           where('spree_orders.distributor_id IN (?) OR spree_variants.supplier_id IN (?)',
                 user.enterprises.select(&:id),
                 user.enterprises.select(&:id)).
@@ -171,8 +171,8 @@ module Spree
         .order("spree_addresses.lastname DESC, spree_addresses.firstname DESC")
     }
 
-    scope :with_line_items_variants_and_products_outer, lambda {
-      left_outer_joins(line_items: { variant: :product })
+    scope :with_line_items_variants_outer, lambda {
+      left_outer_joins(line_items: :variant)
     }
 
     # All the states an order can be in after completing the checkout

--- a/app/services/permissions/order.rb
+++ b/app/services/permissions/order.rb
@@ -15,7 +15,7 @@ module Permissions
     # needed for queries showing line items per producer.
     def visible_orders
       orders = Spree::Order.
-        with_line_items_variants_and_products_outer.
+        with_line_items_variants_outer.
         where(visible_orders_where_values)
 
       filtered_orders(orders)
@@ -107,14 +107,14 @@ module Permissions
     end
 
     def produced_orders
-      Spree::Order.with_line_items_variants_and_products_outer.
+      Spree::Order.with_line_items_variants_outer.
         where(
           spree_variants: { supplier_id: @permissions.managed_enterprises.select("enterprises.id") }
         )
     end
 
     def produced_orders_where_values
-      Spree::Order.with_line_items_variants_and_products_outer.
+      Spree::Order.with_line_items_variants_outer.
         where(
           distributor_id: granted_distributor_ids,
           spree_variants: { supplier_id: enterprises_with_associated_orders }

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -989,6 +989,54 @@ RSpec.describe Spree::Order do
         expect(Spree::Order.not_empty).not_to include order_without_line_items
       end
     end
+
+    describe "managed_by" do
+      let!(:o1) { create(:order, :with_line_item, distributor: d1) }
+      let!(:o2) { create(:order, :with_line_item, distributor: d1) }
+      let(:d1) { create(:enterprise) }
+      let(:user) { create(:user) }
+      subject { described_class.managed_by user }
+
+      context "supplied by me" do
+        let(:s1) { create(:enterprise) }
+        let(:s2) { create(:enterprise) }
+        let(:v1) { create(:variant, supplier: s1) }
+        let(:v2) { create(:variant, supplier: s2) }
+        let!(:o1) { create(:order, :with_line_item, variant: v1, distributor: d1) }
+        let!(:o2) { create(:order, :with_line_item, variant: v2, distributor: d1) }
+
+        it "shows only orders supplied by user" do
+          pending
+          s1.enterprise_roles.build(user:).save
+
+          expect(subject.count).to eq(1)
+          expect(subject).to include o1
+        end
+      end
+
+      context "distributed by me" do
+        let(:d2) { create(:enterprise) }
+        let!(:o1) { create(:order, :with_line_item, distributor: d1) }
+        let!(:o2) { create(:order, :with_line_item, distributor: d2) }
+
+        it "shows only orders distributed by user" do
+          d1.enterprise_roles.build(user:).save
+
+          expect(subject.count).to eq(1)
+          expect(subject).to include o1
+        end
+      end
+
+      context "admin user" do
+        let(:user) { create(:admin_user) }
+
+        it "shows all orders for admin user" do
+          expect(subject.count).to eq(2)
+          expect(subject).to include o1
+          expect(subject).to include o2
+        end
+      end
+    end
   end
 
   describe "sending confirmation emails" do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1006,7 +1006,6 @@ RSpec.describe Spree::Order do
         let!(:o2) { create(:order, :with_line_item, variant: v2, distributor: d1) }
 
         it "shows only orders supplied by user" do
-          pending
           s1.enterprise_roles.build(user:).save
 
           expect(subject.count).to eq(1)

--- a/spec/system/admin/reports/payments_report_spec.rb
+++ b/spec/system/admin/reports/payments_report_spec.rb
@@ -25,12 +25,13 @@ RSpec.describe "Payments Reports" do
   let(:order_cycle) { create(:simple_order_cycle) }
   let(:product) { create(:product, supplier_id: supplier.id) }
   let(:supplier) { create(:supplier_enterprise) }
+  let(:user) { order.distributor.owner }
 
   before do
     create(:line_item_with_shipment, order:, product:)
     create(:line_item_with_shipment, order: other_order, product:)
 
-    login_as_admin
+    login_as user
     visit admin_reports_path
   end
 
@@ -95,6 +96,34 @@ RSpec.describe "Payments Reports" do
         paypal_payment.amount.to_f,
         order.outstanding_balance + other_order.outstanding_balance,
       ].join(" "))
+    end
+  end
+
+  context "as supplier" do
+    let(:user) { supplier.owner }
+
+    it "shows orders with payment state, their balance and totals" do
+      click_link "Itemised Payment Totals"
+      run_report
+
+      expect(page.find("table.report__table thead tr").text).to have_content([
+        "Payment State",
+        "Distributor",
+        "Product Total ($)",
+        "Shipping Total ($)",
+        "Outstanding Balance ($)",
+        "Total ($)"
+      ].join(" "))
+
+      pending
+      expect(page.find("table.report__table tbody tr").text).to have_content([
+        order.payment_state,
+        order.distributor.name,
+        order.item_total.to_f + other_order.item_total.to_f,
+        order.ship_total.to_f + other_order.ship_total.to_f,
+        order.outstanding_balance.to_f + other_order.outstanding_balance.to_f,
+        order.total.to_f + other_order.total.to_f
+      ].compact.join(" "))
     end
   end
 end

--- a/spec/system/admin/reports/payments_report_spec.rb
+++ b/spec/system/admin/reports/payments_report_spec.rb
@@ -115,7 +115,6 @@ RSpec.describe "Payments Reports" do
         "Total ($)"
       ].join(" "))
 
-      pending
       expect(page.find("table.report__table tbody tr").text).to have_content([
         order.payment_state,
         order.distributor.name,


### PR DESCRIPTION
## What? Why?
 Some reports were still looking for the supplier on the Product, but since the product refactor, it has been moved to Variant.

I couldn't find an existing bug report for this.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
I haven't tested myself, but I think this is how it would be affected:

As a non-super-admin user,
- Create a new product, supplied by your enterprise
- Create an order with that product
- Run any report of Payments, Customers, OC Mgmt reports:
   - Before this PR: the new product won't show
   - After: the new product will show

