### PR TITLE
Publish SOLID WebID on DFC API

### DIFF
--- a/engines/dfc_provider/app/controllers/dfc_provider/persons_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/persons_controller.rb
@@ -16,6 +16,7 @@ module DfcProvider
 
       id = person_prefs_url(params[:person_id])
       webid = person_webid_url(params[:person_id])
+      type_index = person_private_type_index_url(params[:person_id])
       prefs = {
         '@graph': [
           {
@@ -24,12 +25,35 @@ module DfcProvider
           },
           {
             '@id': "#{webid}#me",
-            'solid:privateTypeIndex': "TBC"
+            'solid:privateTypeIndex': type_index
           }
         ]
       }
 
       render(json: prefs, content_type: "application/ld+json")
+    end
+
+    def private_type_index
+      # You can only see your own for now.
+      return not_found if current_user.id != params[:person_id].to_i
+
+      id = person_private_type_index_url(params[:person_id])
+      index = {
+        '@graph': [
+          {
+            '@id': id,
+            '@type': ["solid:TypeIndex", "solid:ListedDocument"]
+          },
+          {
+            '@id': "#{id}#reg1",
+            '@type': "solid:TypeRegistration",
+            'solid:forClass': "dfc-b:Organization",
+            'solid:instanceContainer': organizations_url
+          }
+        ]
+      }
+
+      render(json: index, content_type: "application/ld+json")
     end
 
     private

--- a/engines/dfc_provider/app/controllers/dfc_provider/persons_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/persons_controller.rb
@@ -3,11 +3,33 @@
 # Controller used to provide the Persons API for the DFC application
 module DfcProvider
   class PersonsController < DfcProvider::ApplicationController
-    before_action :check_user_accessibility
+    before_action :check_user_accessibility, only: :show
 
     def show
       person = PersonBuilder.person(user)
       render json: DfcIo.export(person)
+    end
+
+    def prefs
+      # You can only see your own preferences for now.
+      return not_found if current_user.id != params[:person_id].to_i
+
+      id = person_prefs_url(params[:person_id])
+      webid = person_webid_url(params[:person_id])
+      prefs = {
+        '@graph': [
+          {
+            '@id': id,
+            '@type': "pim:ConfigurationFile",
+          },
+          {
+            '@id': "#{webid}#me",
+            'solid:privateTypeIndex': "TBC"
+          }
+        ]
+      }
+
+      render(json: prefs, content_type: "application/ld+json")
     end
 
     private

--- a/engines/dfc_provider/app/controllers/dfc_provider/webids_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/webids_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module DfcProvider
+  # Publish WebIDs
+  #
+  # - https://docs.dfc-standard.org/dfc-standard-documentation/technical-specifications/data-storage-and-discovery#dfc-platform-webid
+  class WebidsController < DfcProvider::ApplicationController
+    skip_before_action :check_authorization, only: :show
+
+    # Publish our platform WebID
+    def show
+      id = webid_url
+      webid = {
+        '@graph': [
+          {
+            '@id': id,
+            '@type': "foaf:PersonalProfileDocument",
+            'foaf:maker': "#{id}#me",
+            'foaf:primaryTopic': "#{id}#me"
+          },
+          {
+            '@id': "#{id}#me",
+            '@type': [
+              "dfc-t:Platform",
+              "foaf:Agent"
+            ],
+            'foaf:name': t(:title),
+            'dfc-t:supportedProtocolVersion': "2.0.0",
+            'dfc-t:supportedOntologyVersion': "1.16.0",
+            'dfc-t:hasIdentityService': "https://login.lescommuns.org/auth/realms/data-food-consortium"
+          }
+        ]
+      }
+
+      render(json: webid, content_type: "application/ld+json")
+    end
+  end
+end

--- a/engines/dfc_provider/app/controllers/dfc_provider/webids_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/webids_controller.rb
@@ -38,6 +38,7 @@ module DfcProvider
     # Publicly show a user WebID
     def user_webid
       id = person_webid_url(params[:person_id])
+      prefs_id = person_prefs_url(params[:person_id])
       webid = {
         '@graph': [
           {
@@ -49,7 +50,7 @@ module DfcProvider
           {
             '@id': "#{id}#me",
             '@type': "foaf:Agent",
-            'pim:preferencesFile': "TBC"
+            'pim:preferencesFile': prefs_id
           }
         ]
       }

--- a/engines/dfc_provider/app/controllers/dfc_provider/webids_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/webids_controller.rb
@@ -5,7 +5,7 @@ module DfcProvider
   #
   # - https://docs.dfc-standard.org/dfc-standard-documentation/technical-specifications/data-storage-and-discovery#dfc-platform-webid
   class WebidsController < DfcProvider::ApplicationController
-    skip_before_action :check_authorization, only: :show
+    skip_before_action :check_authorization
 
     # Publish our platform WebID
     def show
@@ -28,6 +28,28 @@ module DfcProvider
             'dfc-t:supportedProtocolVersion': "2.0.0",
             'dfc-t:supportedOntologyVersion': "1.16.0",
             'dfc-t:hasIdentityService': "https://login.lescommuns.org/auth/realms/data-food-consortium"
+          }
+        ]
+      }
+
+      render(json: webid, content_type: "application/ld+json")
+    end
+
+    # Publicly show a user WebID
+    def user_webid
+      id = person_webid_url(params[:person_id])
+      webid = {
+        '@graph': [
+          {
+            '@id': id,
+            '@type': "foaf:PersonalProfileDocument",
+            'foaf:maker': "#{id}#me",
+            'foaf:primaryTopic': "#{id}#me"
+          },
+          {
+            '@id': "#{id}#me",
+            '@type': "foaf:Agent",
+            'pim:preferencesFile': "TBC"
           }
         ]
       }

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -18,5 +18,7 @@ DfcProvider::Engine.routes.draw do
   resources :supplied_products, only: [:index]
   resources :product_groups, only: [:show]
 
+  resource :webid, only: [:show]
+
   resource :affiliate_sales_data, only: [:show]
 end

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -14,7 +14,9 @@ DfcProvider::Engine.routes.draw do
   end
   resources :events, only: [:create]
   resources :organizations, only: [:index, :show]
-  resources :persons, only: [:show]
+  resources :persons, only: [:show] do
+    get :webid, to: "webids#user_webid"
+  end
   resources :supplied_products, only: [:index]
   resources :product_groups, only: [:show]
 

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -16,6 +16,7 @@ DfcProvider::Engine.routes.draw do
   resources :organizations, only: [:index, :show]
   resources :persons, only: [:show] do
     get :webid, to: "webids#user_webid"
+    get :prefs
   end
   resources :supplied_products, only: [:index]
   resources :product_groups, only: [:show]

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -17,6 +17,7 @@ DfcProvider::Engine.routes.draw do
   resources :persons, only: [:show] do
     get :webid, to: "webids#user_webid"
     get :prefs
+    get :private_type_index
   end
   resources :supplied_products, only: [:index]
   resources :product_groups, only: [:show]

--- a/engines/dfc_provider/spec/requests/persons_spec.rb
+++ b/engines/dfc_provider/spec/requests/persons_spec.rb
@@ -55,8 +55,35 @@ RSpec.describe "Persons", swagger_doc: "dfc.yaml" do
           expect(graph[0]["@type"]).to(eq("pim:ConfigurationFile"))
 
           expect(graph[1]["@id"]).to(eq("http://test.host/api/dfc/persons/9000/webid#me"))
-          expect(graph[1]["solid:privateTypeIndex"]).to(eq("TBC"))
-          # expect(graph[1]["solid:privateTypeIndex"]).to(eq("http://test.host/api/dfc/persons/9000/private_type_index"))
+          expect(graph[1]["solid:privateTypeIndex"]).to(eq("http://test.host/api/dfc/persons/9000/private_type_index"))
+        end
+      end
+    end
+  end
+
+  path("/api/dfc/persons/{person_id}/private_type_index") do
+    subject(:ld) {
+      JSON.parse(response.body, object_class: ActiveSupport::HashWithIndifferentAccess)
+    }
+    let(:graph) { ld["@graph"] }
+    let(:user) { create(:oidc_user, id: 9_000) }
+
+    get("Show private preferences") do
+      parameter(name: :person_id, in: :path, type: :string)
+
+      produces("application/ld+json")
+
+      response("200", "successful") do
+        let(:Authorization) { auth_header_token_for(user) }
+        let(:person_id) { user.id }
+
+        run_test! do
+          graph = subject["@graph"]
+
+          expect(graph[0]["@id"]).to(eq("http://test.host/api/dfc/persons/9000/private_type_index"))
+          expect(graph[0]["@type"]).to(eq(["solid:TypeIndex", "solid:ListedDocument"]))
+
+          expect(graph[1]["solid:instanceContainer"]).to(eq("http://test.host/api/dfc/organizations"))
         end
       end
     end

--- a/engines/dfc_provider/spec/requests/persons_spec.rb
+++ b/engines/dfc_provider/spec/requests/persons_spec.rb
@@ -31,4 +31,34 @@ RSpec.describe "Persons", swagger_doc: "dfc.yaml" do
       end
     end
   end
+
+  path("/api/dfc/persons/{person_id}/prefs") do
+    subject(:ld) {
+      JSON.parse(response.body, object_class: ActiveSupport::HashWithIndifferentAccess)
+    }
+    let(:graph) { ld["@graph"] }
+    let(:user) { create(:oidc_user, id: 9_000) }
+
+    get("Show private preferences") do
+      parameter(name: :person_id, in: :path, type: :string)
+
+      produces("application/ld+json")
+
+      response("200", "successful") do
+        let(:Authorization) { auth_header_token_for(user) }
+        let(:person_id) { user.id }
+
+        run_test! do
+          graph = subject["@graph"]
+
+          expect(graph[0]["@id"]).to(eq("http://test.host/api/dfc/persons/9000/prefs"))
+          expect(graph[0]["@type"]).to(eq("pim:ConfigurationFile"))
+
+          expect(graph[1]["@id"]).to(eq("http://test.host/api/dfc/persons/9000/webid#me"))
+          expect(graph[1]["solid:privateTypeIndex"]).to(eq("TBC"))
+          # expect(graph[1]["solid:privateTypeIndex"]).to(eq("http://test.host/api/dfc/persons/9000/private_type_index"))
+        end
+      end
+    end
+  end
 end

--- a/engines/dfc_provider/spec/requests/webids_spec.rb
+++ b/engines/dfc_provider/spec/requests/webids_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Webids", swagger_doc: "dfc.yaml" do
           graph = subject["@graph"]
           expect(graph[0]["@id"]).to(eq("http://test.host/api/dfc/persons/9000/webid"))
           expect(graph[0]["@type"]).to(eq("foaf:PersonalProfileDocument"))
-          expect(graph[1]["pim:preferencesFile"]).to(eq("TBC"))
+          expect(graph[1]["pim:preferencesFile"]).to(eq("http://test.host/api/dfc/persons/9000/prefs"))
         end
       end
     end

--- a/engines/dfc_provider/spec/requests/webids_spec.rb
+++ b/engines/dfc_provider/spec/requests/webids_spec.rb
@@ -3,20 +3,41 @@
 require_relative "../swagger_helper"
 
 RSpec.describe "Webids", swagger_doc: "dfc.yaml" do
+  subject {
+    JSON.parse(response.body, object_class: ActiveSupport::HashWithIndifferentAccess)
+  }
+
   path("/api/dfc/webid") do
     get("Show platform WebID") do
       produces("application/ld+json")
 
       response("200", "successful") do
-        subject {
-          JSON.parse(response.body, object_class: ActiveSupport::HashWithIndifferentAccess)
-        }
-
         run_test! do
           graph = subject["@graph"]
           expect(graph[0]["@id"]).to(eq("http://test.host/api/dfc/webid"))
           expect(graph[0]["@type"]).to(eq("foaf:PersonalProfileDocument"))
           expect(graph[1]["foaf:name"]).to(eq("Open Food Network"))
+        end
+      end
+    end
+  end
+
+  path("/api/dfc/persons/{id}/webid") do
+    let(:user) { create(:oidc_user, id: 9_000) }
+
+    get("Show user WebID") do
+      parameter(name: :id, in: :path, type: :string)
+
+      produces("application/ld+json")
+
+      response("200", "successful") do
+        let(:id) { user.id }
+
+        run_test! do
+          graph = subject["@graph"]
+          expect(graph[0]["@id"]).to(eq("http://test.host/api/dfc/persons/9000/webid"))
+          expect(graph[0]["@type"]).to(eq("foaf:PersonalProfileDocument"))
+          expect(graph[1]["pim:preferencesFile"]).to(eq("TBC"))
         end
       end
     end

--- a/engines/dfc_provider/spec/requests/webids_spec.rb
+++ b/engines/dfc_provider/spec/requests/webids_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../swagger_helper"
+
+RSpec.describe "Webids", swagger_doc: "dfc.yaml" do
+  path("/api/dfc/webid") do
+    get("Show platform WebID") do
+      produces("application/ld+json")
+
+      response("200", "successful") do
+        subject {
+          JSON.parse(response.body, object_class: ActiveSupport::HashWithIndifferentAccess)
+        }
+
+        run_test! do
+          graph = subject["@graph"]
+          expect(graph[0]["@id"]).to(eq("http://test.host/api/dfc/webid"))
+          expect(graph[0]["@type"]).to(eq("foaf:PersonalProfileDocument"))
+          expect(graph[1]["foaf:name"]).to(eq("Open Food Network"))
+        end
+      end
+    end
+  end
+end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -783,6 +783,30 @@ paths:
                     "@type": dfc-b:Person
         '404':
           description: not found
+  "/api/dfc/persons/{person_id}/prefs":
+    get:
+      summary: Show private preferences
+      parameters:
+      - name: person_id
+        in: path
+        required: true
+        schema:
+          type: string
+      tags:
+      - Persons
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@graph":
+                    - "@id": http://test.host/api/dfc/persons/9000/prefs
+                      "@type": pim:ConfigurationFile
+                    - "@id": http://test.host/api/dfc/persons/9000/webid#me
+                      solid:privateTypeIndex: TBC
   "/api/dfc/enterprises/{enterprise_id}/platforms":
     parameters:
     - name: enterprise_id
@@ -1242,6 +1266,6 @@ paths:
                       foaf:primaryTopic: http://test.host/api/dfc/persons/9000/webid#me
                     - "@id": http://test.host/api/dfc/persons/9000/webid#me
                       "@type": foaf:Agent
-                      pim:preferencesFile: TBC
+                      pim:preferencesFile: http://test.host/api/dfc/persons/9000/prefs
 servers:
 - url: "/"

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -1216,5 +1216,32 @@ paths:
                       dfc-t:supportedProtocolVersion: 2.0.0
                       dfc-t:supportedOntologyVersion: 1.16.0
                       dfc-t:hasIdentityService: https://login.lescommuns.org/auth/realms/data-food-consortium
+  "/api/dfc/persons/{id}/webid":
+    get:
+      summary: Show user WebID
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      tags:
+      - Webids
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@graph":
+                    - "@id": http://test.host/api/dfc/persons/9000/webid
+                      "@type": foaf:PersonalProfileDocument
+                      foaf:maker: http://test.host/api/dfc/persons/9000/webid#me
+                      foaf:primaryTopic: http://test.host/api/dfc/persons/9000/webid#me
+                    - "@id": http://test.host/api/dfc/persons/9000/webid#me
+                      "@type": foaf:Agent
+                      pim:preferencesFile: TBC
 servers:
 - url: "/"

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -806,7 +806,35 @@ paths:
                     - "@id": http://test.host/api/dfc/persons/9000/prefs
                       "@type": pim:ConfigurationFile
                     - "@id": http://test.host/api/dfc/persons/9000/webid#me
-                      solid:privateTypeIndex: TBC
+                      solid:privateTypeIndex: http://test.host/api/dfc/persons/9000/private_type_index
+  "/api/dfc/persons/{person_id}/private_type_index":
+    get:
+      summary: Show private preferences
+      parameters:
+      - name: person_id
+        in: path
+        required: true
+        schema:
+          type: string
+      tags:
+      - Persons
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@graph":
+                    - "@id": http://test.host/api/dfc/persons/9000/private_type_index
+                      "@type":
+                      - solid:TypeIndex
+                      - solid:ListedDocument
+                    - "@id": http://test.host/api/dfc/persons/9000/private_type_index#reg1
+                      "@type": solid:TypeRegistration
+                      solid:forClass: dfc-b:Organization
+                      solid:instanceContainer: http://test.host/api/dfc/organizations
   "/api/dfc/enterprises/{enterprise_id}/platforms":
     parameters:
     - name: enterprise_id

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -1190,5 +1190,31 @@ paths:
                 dfc-b:hasPhysicalCharacteristic: []
                 dfc-b:hasNutrientCharacteristic: []
                 dfc-b:hasAllergenCharacteristic: []
+  "/api/dfc/webid":
+    get:
+      summary: Show platform WebID
+      tags:
+      - Webids
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                    "@graph":
+                    - "@id": http://test.host/api/dfc/webid
+                      "@type": foaf:PersonalProfileDocument
+                      foaf:maker: http://test.host/api/dfc/webid#me
+                      foaf:primaryTopic: http://test.host/api/dfc/webid#me
+                    - "@id": http://test.host/api/dfc/webid#me
+                      "@type":
+                      - dfc-t:Platform
+                      - foaf:Agent
+                      foaf:name: Open Food Network
+                      dfc-t:supportedProtocolVersion: 2.0.0
+                      dfc-t:supportedOntologyVersion: 1.16.0
+                      dfc-t:hasIdentityService: https://login.lescommuns.org/auth/realms/data-food-consortium
 servers:
 - url: "/"


### PR DESCRIPTION
## What? Why?

- #14188


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The DFC standard v2 requires to publish a WebID to comply with the SOLID framework. In theory, this should enable any app to discover the platform's data from one URL.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
