### PR TITLE
Remove oauth2 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,6 @@ gem 'devise'
 gem 'devise-encryptable'
 gem 'devise-i18n'
 gem 'jwt', '~> 2.3'
-gem 'oauth2', '~> 1.4.7' # Used for Stripe Connect
 
 gem 'datafoodconsortium-connector'
 gem 'datafoodconsortium-connector-v1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,7 +514,6 @@ GEM
       i18n (>= 0.6.4, <= 2)
     msgpack (1.8.0)
     multi_json (1.21.1)
-    multi_xml (0.6.0)
     mutex_m (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
@@ -534,12 +533,6 @@ GEM
       racc (~> 1.4)
     nokogiri-html5-inference (0.3.0)
       nokogiri (~> 1.14)
-    oauth2 (1.4.11)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
-      multi_json (~> 1.3)
-      multi_xml (~> 0.5)
-      rack (>= 1.2, < 4)
     observer (0.1.2)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
@@ -1059,7 +1052,6 @@ DEPENDENCIES
   mini_portile2 (~> 2.8)
   monetize (~> 1.11)
   newrelic_rpm
-  oauth2 (~> 1.4.7)
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   openid_connect
@@ -1308,7 +1300,6 @@ CHECKSUMS
   money (6.16.0) sha256=cf476f5f19188e247ec20f6509cff64dc35d395ee018bad799b1a9ea8bd4754a
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
-  multi_xml (0.6.0) sha256=d24393cf958adb226db884b976b007914a89c53ad88718e25679d7008823ad52
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
@@ -1319,7 +1310,6 @@ CHECKSUMS
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
   nokogiri (1.19.3) sha256=78312cbac32a40c812780d9678221b79d51288eec00054c1a8d15f7ce05960e8
   nokogiri-html5-inference (0.3.0) sha256=04f078ad36843da11973773dbdd034672eb397373b0766ab11679e4a7b86c01e
-  oauth2 (1.4.11) sha256=6739fcc8872bc94f476b0cae3e8bd78a56d8364b1b79b0757794c25e152d5c10
   observer (0.1.2) sha256=d8a3107131ba661138d748e7be3dbafc0d82e732fffba9fccb3d7829880950ac
   omniauth (2.1.4) sha256=42a05b0496f0d22e1dd85d42aaf602f064e36bb47a6826a27ab55e5ba608763c
   omniauth-rails_csrf_protection (2.0.1) sha256=c6e3204d7e3925bb537cb52d50fdfc9f05293f1a9d87c5d4ab4ca3a39ba8c32d


### PR DESCRIPTION
## What? Why?

- Closes #13670
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
Despite the comment indicating`oauth2` is used for Stripe, I can't see any code using it, so I removed the dependency. Plus it's blocking upgrading `jwt` which has a high security vulnerability : https://github.com/openfoodfoundation/openfoodnetwork/security/dependabot/360

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Check that payment with Stripe are working as expected.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
