### PR TITLE
Allow unsafe redirect for paypal payment

### DIFF
--- a/app/controllers/payment_gateways/paypal_controller.rb
+++ b/app/controllers/payment_gateways/paypal_controller.rb
@@ -17,9 +17,7 @@ module PaymentGateways
     def express
       return redirect_to order_failed_route if @any_out_of_stock == true
 
-      pp_request = provider.build_set_express_checkout(
-        express_checkout_request_details(@order)
-      )
+      pp_request = provider.build_set_express_checkout(express_checkout_request_details(@order))
 
       begin
         pp_response = provider.set_express_checkout(pp_request)
@@ -27,7 +25,9 @@ module PaymentGateways
           # At this point Paypal has *provisionally* accepted that the payment can now be placed,
           # and the user will be redirected to a Paypal payment page. On completion, the user is
           # sent back and the response is handled in the #confirm action in this controller.
-          redirect_to provider.express_checkout_url(pp_response, useraction: 'commit')
+          redirect_to(
+            provider.express_checkout_url(pp_response, useraction: 'commit'), allow_other_host: true
+          )
         else
           Rails.logger.error(
             "PaypalController#express: #{pp_response.errors.map(&:long_message).join(' ')}"

--- a/spec/controllers/payment_gateways/paypal_controller_spec.rb
+++ b/spec/controllers/payment_gateways/paypal_controller_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe PaymentGateways::PaypalController do
   describe "#express" do
     let(:order) { create(:order_with_totals_and_distribution) }
     let(:response) { true }
-    let(:provider_success_url) { "https://test.host/success" }
+    let(:provider_success_url) { "https://mock-paypal.com/success" }
     let(:response_mock) { double(:response, success?: response, errors: [] ) }
     let(:provider_mock) {
       double(:provider, set_express_checkout: response_mock,


### PR DESCRIPTION
## What? Why?

- Closes #14310  <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
Allow checkout using paypal for be redirected to paypal website.


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Place an order using paypal express payment method
  -> you should be redirected to the paypal website
- Complete the order.
- We can test this directly on this hotfix release tag: `v5.4.16.1`

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.