### PR TITLE
fix dropdown suggestion list to overlay rows instead of expand them

### DIFF
--- a/app/components/tag_list_input_component/tag_list_input_component.scss
+++ b/app/components/tag_list_input_component/tag_list_input_component.scss
@@ -1,6 +1,7 @@
 // Tags input
 .tags-input {
   display: block;
+  position: relative;
 
   .tags {
     -moz-appearance: textfield;
@@ -87,7 +88,7 @@
     list-style-type: none;
     max-height: 21em;
     overflow-y: auto;
-    position: relative;
+    position: absolute;
 
     li.suggestion-item {
       padding: 8px;


### PR DESCRIPTION
## What? Why?

- Closes #14309

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
The tag autocomplete suggestion list was using `position: relative`, causing it to expand product rows down when open. Changed to `position: absolute` with `position: relative` added to the parent `.tags-input` so the dropdown floats above content beneat it, consistent with the behavior of other dropdowns on the page.


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit the admin products page, click into a variant tag field and start typing. The suggestion dropdown should appear hovering over the rows below without expanding the current row. 

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ x] User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->


## Before

<img width="1385" height="569" alt="Screenshot from 2026-04-27 17-56-43" src="https://github.com/user-attachments/assets/94a77f16-881f-4423-bf1b-7eeedb4322ec" />

## After

<img width="1390" height="612" alt="Screenshot from 2026-05-20 14-20-59" src="https://github.com/user-attachments/assets/c9b6fcd3-bcb4-4004-82dc-7afd2e956f5e" />


