### PR TITLE
Fix error when payment_method is nil

### DIFF
--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -4,7 +4,7 @@ module Spree
   class Payment < ApplicationRecord
     module Processing
       def process!
-        return internal_purchase! if payment_method.internal?
+        return internal_purchase! if payment_method&.internal?
 
         return unless validate!
 

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -142,6 +142,15 @@ RSpec.describe Spree::Payment do
           expect(payment.state).to eq('invalid')
         end
 
+        context "no payment_method" do
+          let(:payment_method) { nil }
+
+          it "should invalidate if payment method isn't set" do
+            expect(payment).not_to receive(:purchase!)
+            expect { payment.process! }.not_to change { payment.state }
+          end
+        end
+
         context "the payment is already authorized" do
           before do
             allow(payment).to receive(:response_code) { "pi_123" }


### PR DESCRIPTION
I'm not 100% sure this is the right fix, please review my comments in the below issue.
Any ideas on how to replicate it?

## What? Why?

- Closes #14319

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Try placing order with a variety of payment method :
- Cash 
- Stripe
- Paypal 

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
