### PR TITLE
Ensure owner is always set on variant when validating

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -111,7 +111,9 @@ module Spree
     before_validation :ensure_unit_value
     before_validation :update_weight_from_unit_value
     before_validation :convert_variant_weight_to_decimal
-    before_validation :copy_supplier_to_owner, if: :supplier_id_changed?
+    before_validation :copy_supplier_to_owner, if: ->(variant) {
+      variant.supplier_id_changed? || variant.owner_id.blank?
+    }
 
     before_save :assign_units, if: ->(variant) {
       variant.new_record? || variant.changed_attributes.keys.intersection(NAME_FIELDS).any?

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -1034,13 +1034,25 @@ RSpec.describe Spree::Variant do
     end
   end
 
-  describe "updating supplier/owner" do
-    it "during transition period, updates owner when updating supplier" do
+  describe "updating supplier/owner during transition period" do
+    it "updates owner when updating supplier" do
       new_supplier = create(:supplier_enterprise)
       variant.supplier = new_supplier
       variant.save!
 
       expect(variant.reload.owner).to eq new_supplier
+    end
+
+    context "variant doesn't have owner yet" do
+      let(:variant) { create(:variant).tap{ |v| v.update_columns owner_id: nil } }
+
+      it "updates owner on validation, if not yet set" do
+        variant.display_name = "updated"
+        expect(variant).to be_valid
+
+        variant.save!
+        expect(variant.reload.owner).to eq variant.supplier
+      end
     end
   end
 end


### PR DESCRIPTION
I probably could have removed the if condition entirely, but I wondered if running it every time you save a variant, it would cause extra unnecessary queries (I noticed when introducing it that it loads the enterprise record)

## What? Why?

- Completes #14325 for any instances that haven't had a manual data migration

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
On a server that hasn't had the manual migration, test that you can update any field on a variant.

It appears that staging.coopcircuits.fr hasn't had the migration yet. 
* To replicate the above bug, first deploy release v5.4.18 and try to update a product
* Then deploy this PR to ensure it is resolved.

## Release notes
I think it should be announced just in case so have marked user-facing.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
