### PR TITLE
 Fix missing products in bulk coop allocation report

### DIFF
--- a/lib/reporting/reports/bulk_coop/allocation.rb
+++ b/lib/reporting/reports/bulk_coop/allocation.rb
@@ -5,7 +5,7 @@ module Reporting
     module BulkCoop
       class Allocation < Base
         def query_result
-          table_items.group_by(&:order).values
+          table_items.group_by { |li| [li.order, li.variant] }.values
         end
 
         def columns

--- a/spec/lib/reports/bulk_coop/allocation_spec.rb
+++ b/spec/lib/reports/bulk_coop/allocation_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Reporting::Reports::BulkCoop::Allocation do
+  subject { described_class.new(user, {}) }
+
+  let(:user) { create(:admin_user) }
+  let(:distributor) { create(:distributor_enterprise) }
+  let(:order_cycle) { create(:simple_order_cycle) }
+  let(:order) { create(:order, completed_at: 1.day.ago, order_cycle:, distributor:) }
+
+  describe '#query_result' do
+    context 'when a customer orders multiple products in the same order' do
+      let(:li1) { build(:line_item_with_shipment, variant: create(:variant)) }
+      let(:li2) { build(:line_item_with_shipment, variant: create(:variant)) }
+
+      before do
+        order.line_items << li1
+        order.line_items << li2
+      end
+
+      it 'returns one row per product, not one row per order' do
+        expect(subject.query_result.length).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What? Why?

When a customer orders multiple products in the same order, only the first
  product was appearing in the Bulk Co-op Allocation report. The other products
  were silently dropped because line items were grouped by order, causing all
  products to collapse into one row showing only the first.
  
 Previously, all of a customer's line items were grouped into a single row,
  causing only the first product to appear. This was fixed by giving each
  customer+product combination its own row.

You can see the issue in difference in the reports below (before the fix).  The Allocation Report is only showing the product 'Rice' whereas the Supplier report of the same order is showing both 'Rice' and 'Salsa'.
  
<img width="1849" height="980" alt="Bulk Co-op Allocation Report (before)" src="https://github.com/user-attachments/assets/a113c101-d35e-4a72-8bc0-c3c16b83d3f2" />

  
<img width="1720" height="991" alt="Bulk Co-op Supplier Report (before)" src="https://github.com/user-attachments/assets/88abc16b-bd28-4e22-abff-a3713baa4589" />

 - Closes #9785



## What should we test?
  1. Create two bulk products (group buy enabled)
  2. Place a completed order containing both products
  3. Run Reports → Bulk Co-op → Allocation
  4. Confirm both products appear for that customer
  5. Confirm the Supplier report still shows the same products

## Release notes

Changelog Category (reviewers may add a label for the release notes):

Technical only (bug fix, no user-facing feature change)


The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
