### PR TITLE
Rename owner to enterprise

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -9,6 +9,7 @@ module Spree
     include VariantUnits::VariantAndLineItemNaming
     include VariantStock
 
+    self.ignored_columns += ['owner']
     self.belongs_to_required_by_default = false
 
     # 2 not to be persisted attributes to store preferences.

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -41,7 +41,7 @@ module Spree
     belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', optional: false
     belongs_to :primary_taxon, class_name: 'Spree::Taxon', touch: true, optional: false
     belongs_to :supplier, class_name: 'Enterprise', optional: false, touch: true
-    belongs_to :enterprise, class_name: 'Enterprise', optional: true, touch: true
+    belongs_to :enterprise, optional: true, touch: true
     belongs_to :hub, class_name: 'Enterprise', optional: true
 
     delegate :name, :name=, :description, :description=, :meta_keywords, to: :product

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -40,7 +40,7 @@ module Spree
     belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', optional: false
     belongs_to :primary_taxon, class_name: 'Spree::Taxon', touch: true, optional: false
     belongs_to :supplier, class_name: 'Enterprise', optional: false, touch: true
-    belongs_to :owner, class_name: 'Enterprise', optional: false, touch: true
+    belongs_to :enterprise, class_name: 'Enterprise', optional: true, touch: true
     belongs_to :hub, class_name: 'Enterprise', optional: true
 
     delegate :name, :name=, :description, :description=, :meta_keywords, to: :product
@@ -111,8 +111,8 @@ module Spree
     before_validation :ensure_unit_value
     before_validation :update_weight_from_unit_value
     before_validation :convert_variant_weight_to_decimal
-    before_validation :copy_supplier_to_owner, if: ->(variant) {
-      variant.supplier_id_changed? || variant.owner_id.blank?
+    before_validation :copy_supplier_to_enterprise, if: ->(variant) {
+      variant.supplier_id_changed? || variant.enterprise_id.blank?
     }
 
     before_save :assign_units, if: ->(variant) {
@@ -351,8 +351,8 @@ module Spree
       self.shipping_category ||= DefaultShippingCategory.find_or_create
     end
 
-    def copy_supplier_to_owner
-      self.owner_id = supplier_id
+    def copy_supplier_to_enterprise
+      self.enterprise_id = supplier_id
     end
 
     def convert_variant_weight_to_decimal

--- a/db/migrate/20260601031443_add_enterprise_to_spree_variants.rb
+++ b/db/migrate/20260601031443_add_enterprise_to_spree_variants.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEnterpriseToSpreeVariants < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :spree_variants, :enterprise, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_11_053830) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_01_031443) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -1004,6 +1004,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_11_053830) do
     t.string "variant_unit_name", limit: 255
     t.bigint "hub_id"
     t.bigint "owner_id"
+    t.bigint "enterprise_id"
+    t.index ["enterprise_id"], name: "index_spree_variants_on_enterprise_id"
     t.index ["hub_id"], name: "index_spree_variants_on_hub_id"
     t.index ["owner_id"], name: "index_spree_variants_on_owner_id"
     t.index ["primary_taxon_id"], name: "index_spree_variants_on_primary_taxon_id"
@@ -1264,6 +1266,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_11_053830) do
   add_foreign_key "spree_tax_rates", "spree_zones", column: "zone_id", name: "spree_tax_rates_zone_id_fk"
   add_foreign_key "spree_users", "spree_addresses", column: "bill_address_id", name: "spree_users_bill_address_id_fk"
   add_foreign_key "spree_users", "spree_addresses", column: "ship_address_id", name: "spree_users_ship_address_id_fk"
+  add_foreign_key "spree_variants", "enterprises"
   add_foreign_key "spree_variants", "enterprises", column: "hub_id"
   add_foreign_key "spree_variants", "enterprises", column: "owner_id"
   add_foreign_key "spree_variants", "enterprises", column: "supplier_id"

--- a/spec/factories/variant_factory.rb
+++ b/spec/factories/variant_factory.rb
@@ -19,7 +19,6 @@ FactoryBot.define do
 
     primary_taxon { Spree::Taxon.first || FactoryBot.create(:taxon) }
     supplier { Enterprise.is_primary_producer.first || FactoryBot.create(:supplier_enterprise) }
-    owner { supplier }
 
     # creating a product here  will end up creating an extra variant, as creating product will
     # create a "standard variant" by default. We could try to pass the variant instance we

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Spree::Variant do
   it { is_expected.to have_many :semantic_links }
   it { is_expected.to belong_to(:product).required }
   it { is_expected.to belong_to(:supplier).required }
-  # it's currently effectively optional because it gets added before_validation
-  it { pending "removal of supplier"; is_expected.to belong_to(:owner).required }
+  # it's currently optional until data migration has completed, just in case.
+  it { pending "removal of supplier"; is_expected.to belong_to(:enterprise).required }
   it { is_expected.to belong_to(:hub).optional }
   it { is_expected.to have_many(:inventory_units) }
   it { is_expected.to have_many(:line_items) }
@@ -1034,24 +1034,24 @@ RSpec.describe Spree::Variant do
     end
   end
 
-  describe "updating supplier/owner during transition period" do
-    it "updates owner when updating supplier" do
+  describe "updating supplier/enterprise during transition period" do
+    it "updates enterprise when updating supplier" do
       new_supplier = create(:supplier_enterprise)
       variant.supplier = new_supplier
       variant.save!
 
-      expect(variant.reload.owner).to eq new_supplier
+      expect(variant.reload.enterprise).to eq new_supplier
     end
 
-    context "variant doesn't have owner yet" do
-      let(:variant) { create(:variant).tap{ |v| v.update_columns owner_id: nil } }
+    context "variant doesn't have enterprise set yet" do
+      let(:variant) { create(:variant).tap{ |v| v.update_columns enterprise_id: nil } }
 
-      it "updates owner on validation, if not yet set" do
+      it "updates enterprise on validation, if not yet set" do
         variant.display_name = "updated"
         expect(variant).to be_valid
 
         variant.save!
-        expect(variant.reload.owner).to eq variant.supplier
+        expect(variant.reload.enterprise).to eq variant.supplier
       end
     end
   end


### PR DESCRIPTION
## What? Why?

   **:information_source: Please use Clockify code `#76a Sourced variant` for review and testing.**

- Part 1.1 of  #14201


I proposed it here: https://github.com/openfoodfoundation/openfoodnetwork/issues/14201#issuecomment-4550409555
> I think this is probably clearer than the slightly ambiguous "owner" and makes the code slightly simpler too.

The old column will need to be deleted in a separate PR to avoid errors during deployment.


## What should we test?
- Update any variant, from the Bulk Products screen or Edit Variant screen.
- Create a new variant and update it.



## Dependencies
- Builds upon #14330 
