### PR TITLE
[Sourced variant] Rename owner to enterprise2 

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -9,7 +9,6 @@ module Spree
     include VariantUnits::VariantAndLineItemNaming
     include VariantStock
 
-    self.ignored_columns += ['owner']
     self.belongs_to_required_by_default = false
 
     # 2 not to be persisted attributes to store preferences.

--- a/db/migrate/20260601032848_remove_owner_from_spree_variants.rb
+++ b/db/migrate/20260601032848_remove_owner_from_spree_variants.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveOwnerFromSpreeVariants < ActiveRecord::Migration[7.1]
+  def change
+    remove_reference :spree_variants, :owner, foreign_key: { to_table: :enterprises }
+  end
+end

--- a/db/migrate/20260601034847_copy_supplier_to_enterprise_in_spree_variants.rb
+++ b/db/migrate/20260601034847_copy_supplier_to_enterprise_in_spree_variants.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CopySupplierToEnterpriseInSpreeVariants < ActiveRecord::Migration[7.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE spree_variants
+      SET enterprise_id = supplier_id
+      WHERE supplier_id IS NOT NULL AND enterprise_id IS NULL
+    SQL
+  end
+
+  def down
+    # No down migration needed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_01_031443) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_01_032848) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -1003,11 +1003,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_01_031443) do
     t.float "variant_unit_scale"
     t.string "variant_unit_name", limit: 255
     t.bigint "hub_id"
-    t.bigint "owner_id"
     t.bigint "enterprise_id"
     t.index ["enterprise_id"], name: "index_spree_variants_on_enterprise_id"
     t.index ["hub_id"], name: "index_spree_variants_on_hub_id"
-    t.index ["owner_id"], name: "index_spree_variants_on_owner_id"
     t.index ["primary_taxon_id"], name: "index_spree_variants_on_primary_taxon_id"
     t.index ["product_id"], name: "index_variants_on_product_id"
     t.index ["shipping_category_id"], name: "index_spree_variants_on_shipping_category_id"
@@ -1268,7 +1266,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_01_031443) do
   add_foreign_key "spree_users", "spree_addresses", column: "ship_address_id", name: "spree_users_ship_address_id_fk"
   add_foreign_key "spree_variants", "enterprises"
   add_foreign_key "spree_variants", "enterprises", column: "hub_id"
-  add_foreign_key "spree_variants", "enterprises", column: "owner_id"
   add_foreign_key "spree_variants", "enterprises", column: "supplier_id"
   add_foreign_key "spree_variants", "spree_products", column: "product_id", name: "spree_variants_product_id_fk"
   add_foreign_key "spree_variants", "spree_shipping_categories", column: "shipping_category_id"

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -596,20 +596,20 @@ RSpec.describe Spree::Variant do
     end
 
     describe ".with_properties" do
-      let!(:variant_without_wanted_property_on_supplier) {
-        create(:variant, supplier: supplier_without_wanted_property)
+      let!(:variant_from_ipm_supplier) {
+        create(:variant, supplier: ipm_supplier)
       }
-      let!(:variant_with_wanted_property_on_supplier) {
-        create(:variant, supplier: supplier_with_wanted_property)
+      let!(:variant_from_organic_supplier) {
+        create(:variant, supplier: organic_supplier)
       }
-      let(:supplier_with_wanted_property) {
-        create(:supplier_enterprise, properties: [wanted_property])
+      let(:organic_supplier) {
+        create(:supplier_enterprise, properties: [organic])
       }
-      let(:supplier_without_wanted_property) {
-        create(:supplier_enterprise, properties: [unwanted_property])
+      let(:ipm_supplier) {
+        create(:supplier_enterprise, properties: [ipm])
       }
-      let(:wanted_property) { create(:property, presentation: 'Certified Organic') }
-      let(:unwanted_property) { create(:property, presentation: 'Latest Hype') }
+      let(:organic) { create(:property, presentation: 'Certified Organic') }
+      let(:ipm) { create(:property, presentation: 'Integrated Pest Management') }
 
       it "returns no products without a property id" do
         expect(Spree::Variant.with_properties([])).to eq []
@@ -617,8 +617,8 @@ RSpec.describe Spree::Variant do
 
       it "returns only variants with the wanted property set on supplier" do
         expect(
-          Spree::Variant.with_properties([wanted_property.id])
-        ).to match_array [variant_with_wanted_property_on_supplier]
+          Spree::Variant.with_properties([organic.id])
+        ).to match_array [variant_from_organic_supplier]
       end
     end
   end


### PR DESCRIPTION
## What? Why?

   **:information_source: Please use Clockify code `#76a Sourced variant` for review and testing.**

- Part 1.2 of #14201 

Now the new `enterprise` column and association are ready, we can backfill it safely without risk of updates being lost during migration.


## What should we test?
- Update any variant, from the Bulk Products screen or Edit Variant screen.
- Create a new variant and update it.

## Dependencies
- [x] https://github.com/openfoodfoundation/openfoodnetwork/pull/14356 must be released before this is merged.
