### PR TITLE
Remove variant unit type validation on product import

### DIFF
--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -32,7 +32,6 @@ module ProductImport
         assign_enterprise_field(entry)
         enterprise_validation(entry)
         unit_fields_validation(entry)
-        variant_of_product_validation(entry)
         price_validation(entry)
         on_hand_on_demand_validation(entry)
 
@@ -225,31 +224,6 @@ module ProductImport
 
     def empty_or_placeholder_value(value)
       value.blank? || value.to_s.strip == "-"
-    end
-
-    def variant_of_product_validation(entry)
-      return if entry.producer.blank? || entry.name.blank?
-
-      validate_unit_type_unchanged(entry)
-      validate_variant_unit_name_unchanged(entry)
-    end
-
-    def validate_unit_type_unchanged(entry)
-      return if entry.unit_type.blank?
-
-      reference_entry = all_entries_for_product(entry).first
-      return if entry.unit_type.to_s == reference_entry.unit_type.to_s
-
-      mark_as_not_updatable(entry, "unit_type")
-    end
-
-    def validate_variant_unit_name_unchanged(entry)
-      return if entry.variant_unit_name.blank?
-
-      reference_entry = all_entries_for_product(entry).first
-      return if entry.variant_unit_name.to_s == reference_entry.variant_unit_name.to_s
-
-      mark_as_values_must_be_same(entry, "variant_unit_name")
     end
 
     def producer_validation(entry)

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -85,7 +85,9 @@ module ProductImport
     end
 
     def match_variant?(variant)
-      match_display_name?(variant) && variant.unit_value.to_d == unit_value.to_d
+      match_display_name?(variant) &&
+        variant.unit_value.to_d == unit_value.to_d &&
+        (variant_unit.nil? || variant.variant_unit == variant_unit)
     end
 
     private

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -494,17 +494,17 @@ RSpec.describe ProductImport::ProductImporter do
       importer.validate_entries
       entries = JSON.parse(importer.entries_json)
 
-      expect(filter('valid', entries)).to eq 3
-      expect(filter('invalid', entries)).to eq 2
-      expect(filter('create_product', entries)).to eq 3
+      expect(filter('valid', entries)).to eq 4
+      expect(filter('invalid', entries)).to eq 1
+      expect(filter('create_product', entries)).to eq 4
     end
 
     it "saves and updates" do
       importer.save_entries
 
-      expect(importer.products_created_count).to eq 3
+      expect(importer.products_created_count).to eq 4
       expect(importer.updated_ids).to be_a(Array)
-      expect(importer.updated_ids.count).to eq 3
+      expect(importer.updated_ids.count).to eq 4
 
       small_bag = Spree::Variant.find_by(display_name: 'Small Bag')
       expect(small_bag.product.name).to eq 'Potatoes'
@@ -512,7 +512,10 @@ RSpec.describe ProductImport::ProductImporter do
       expect(small_bag.on_hand).to eq 5
 
       big_bag = Spree::Variant.find_by(display_name: "Big Bag")
-      expect(big_bag).to be_blank
+      expect(big_bag.product.name).to eq 'Potatoes'
+      expect(big_bag.price).to eq 5.50
+      expect(big_bag.on_hand).to eq 6
+      expect(big_bag.product.id).to eq small_bag.product.id
 
       small_sack = Spree::Variant.find_by(display_name: "Small Sack")
       expect(small_sack.product.name).to eq "Potatoes"
@@ -566,7 +569,7 @@ RSpec.describe ProductImport::ProductImporter do
     end
   end
 
-  describe "updating non-updatable fields on existing variants" do
+  describe "importing item-type variants for a product with existing weight variants" do
     let(:csv_data) {
       CSV.generate do |csv|
         csv << ["name", "producer", "category", "on_hand", "price", "units", "variant_unit_name",
@@ -579,17 +582,13 @@ RSpec.describe ProductImport::ProductImporter do
     }
     let(:importer) { import_data csv_data }
 
-    it "does not allow updating" do
+    it "creates new variants rather than updating the existing weight variants" do
       importer.validate_entries
       entries = JSON.parse(importer.entries_json)
 
-      expect(filter('valid', entries)).to eq 0
-      expect(filter('invalid', entries)).to eq 2
-
-      importer.entries.each do |entry|
-        expect(entry.errors.messages.values)
-          .to include ['cannot be updated on existing products via product import']
-      end
+      expect(filter('valid', entries)).to eq 2
+      expect(filter('invalid', entries)).to eq 0
+      expect(filter('create_product', entries)).to eq 2
     end
   end
 

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Product Import" do
       expect(page).to have_field("_products_5_name", with: potatoes.name.to_s)
     end
 
-    it "displays info about invalid entries" do
+    it "displays info about invalid entries and no save button if any items are invalid" do
       csv_data = <<~CSV
         name, producer, category, on_hand, price, units, unit_type, shipping_category_id
         Carrots, User Enterprise, Vegetables, 5, 3.20, 500, g, #{shipping_category_id_str}
@@ -128,6 +128,8 @@ RSpec.describe "Product Import" do
       expect(page).to have_selector '.invalid-count', text: "2"
       expect(page).to have_selector ".create-count", text: "2"
       expect(page).not_to have_selector '.update-count'
+
+      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
     end
 
     it "allows variants of the same product to have different variant unit names" do

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Product Import" do
       expect(page).to have_field("_products_5_name", with: potatoes.name.to_s)
     end
 
-    it "displays info about invalid entries but no save button if all items are invalid" do
+    it "displays info about invalid entries" do
       csv_data = <<~CSV
         name, producer, category, on_hand, price, units, unit_type, shipping_category_id
         Carrots, User Enterprise, Vegetables, 5, 3.20, 500, g, #{shipping_category_id_str}
@@ -125,14 +125,12 @@ RSpec.describe "Product Import" do
       proceed_to_validation
 
       expect(page).to have_selector '.item-count', text: "4"
-      expect(page).to have_selector '.invalid-count', text: "3"
-      expect(page).to have_selector ".create-count", text: "1"
+      expect(page).to have_selector '.invalid-count', text: "2"
+      expect(page).to have_selector ".create-count", text: "2"
       expect(page).not_to have_selector '.update-count'
-
-      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
     end
 
-    it "displays info about inconsistent variant unit names, within the same product" do
+    it "allows variants of the same product to have different variant unit names" do
       csv_data = <<~CSV
         name, producer, category, on_hand, price, units, unit_type, variant_unit_name, \
           shipping_category_id
@@ -148,12 +146,14 @@ RSpec.describe "Product Import" do
       click_button 'Upload'
 
       proceed_to_validation
-      find('div.header-description', text: 'Items contain errors').click
-      expect(page).to have_content "Variant_unit_name must be the same for products " \
-                                   "with the same name"
-      expect(page).to have_content "Imported file contains invalid entries"
 
-      expect(page).not_to have_selector 'input[type=submit][value="Save"]'
+      expect(page).to have_selector '.item-count', text: "2"
+      expect(page).not_to have_selector '.invalid-count'
+      expect(page).to have_selector '.create-count', text: "2"
+
+      save_data
+
+      expect(page).to have_selector '.created-count', text: '2'
     end
 
     it "handles saving of named tax and shipping categories" do
@@ -449,7 +449,7 @@ RSpec.describe "Product Import" do
           )
         end
 
-        it "displays the appropriate error message, when variant unit names are inconsistent" do
+        it "allows variants of the same product to have different variant unit names" do
           csv_data = <<~CSV
             name, distributor, producer, category, on_hand, price, unit_type, units, on_demand, \
               variant_unit_name
@@ -464,15 +464,10 @@ RSpec.describe "Product Import" do
           click_button 'Upload'
           proceed_to_validation
 
-          find('div.header-description', text: 'Items contain errors').click
-          expect(page).to have_content "Variant_unit_name must be the same for products " \
-                                       "with the same name"
-          expect(page).to have_content "Imported file contains invalid entries"
-          expect(page).not_to have_selector 'input[type=submit][value="Save"]'
-
-          visit main_app.admin_inventory_path
-
-          expect(page).not_to have_content "Aubergine"
+          expect(page).to have_selector '.item-count', text: "2"
+          expect(page).not_to have_selector '.invalid-count'
+          expect(page).to have_selector '.inv-create-count', text: '1'
+          expect(page).to have_selector '.inv-update-count', text: '1'
         end
 
         it "invalidates units value if 0 or non-numeric" do

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -466,8 +466,8 @@ RSpec.describe "Product Import" do
 
           expect(page).to have_selector '.item-count', text: "2"
           expect(page).not_to have_selector '.invalid-count'
-          expect(page).to have_selector '.inv-create-count', text: '1'
-          expect(page).to have_selector '.inv-update-count', text: '1'
+          expect(page).to have_selector '.inv-create-count', text: '2'
+          expect(page).not_to have_selector '.inv-update-count'
         end
 
         it "invalidates units value if 0 or non-numeric" do


### PR DESCRIPTION
## What? Why?

- Closes #13933 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

 The product import feature rejected any CSV file where variants of the same product used different
 unit types (e.g. one variant in kg and another sold by the item). This was tech-debt from when
 all variants of a product were required to share a unit type. That constraint was lifted when unit fields were moved from the product level to the variant level, but the import validation was never updated to match.

  **Changes**

  - Removed validate_unit_type_unchanged and validate_variant_unit_name_unchanged from
  EntryValidator — these were the methods enforcing the old cross-variant unit type constraint.
  - Added variant_unit to the match_variant? check in SpreadsheetEntry — ensures that a CSV row with  a different unit type from an existing variant creates a new variant rather than accidentally
  overwriting it 

FYI my first PR and done as part of the OFN AI working group with Claude Code - feedback very welcome 🙏 


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Create a new variant beneath a product that has a different variant unit type to the original variant (e.g. Fredo's Farm Hub Carrots unit type = grams, create a new Carrots variant with a unit type = item).
<img width="1147" height="264" alt="Screenshot 2026-06-02 at 16 16 00" src="https://github.com/user-attachments/assets/84b4bb81-0ade-4857-9ee6-7357f705059a" />

- Create a product import CSV that includes these two Carrots variants, and add a new line to create a new variant with another different unit type (e.g. kg) to fully test
- Go to Product Import page and import the CSV
- Before the fix; error is thrown saying 'variant_unit_name must be the same for products with the same name'
- After the fix, no error is thrown and products are updated/created successfully

 Updated existing unit tests to reflect the new expected behaviour. All 99 product import specs pass. Also added 

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes


<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
User guide will need to be updated to remove the reference to ['unit_type must be the same across variants for products sold as items'.](https://guide.openfoodnetwork.org/basic-features/products-1/product-and-inventory-import#:~:text=For%20products%20sold%20as%20items%2C%20the%20unit_type%20must%20be%20the%20same%20across%20variants%20(e.g.%20rolls%20below).) I can do this once merged.