### PR TITLE
Render DFC collections in containers for v2 requests

### DIFF
--- a/engines/dfc_provider/app/controllers/dfc_provider/application_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/application_controller.rb
@@ -71,7 +71,7 @@ module DfcProvider
     end
 
     def profile
-      request.headers["Accept"][/\bprofile="?([^";,\s]+)"?/, 1]
+      @profile ||= request.headers["Accept"][/\bprofile="?([^";,\s]+)"?/, 1]
     end
 
     def import
@@ -83,12 +83,17 @@ module DfcProvider
       OpenFoodNetwork::FeatureToggle.enabled?(feature, *actors)
     end
 
-    def render_dfc(*)
-      if profile == "dfc-v2"
-        render_v2(*)
-      else
-        render json: DfcIo.export(*)
-      end
+    def render_dfc(subject = nil, *)
+      return render_v1(*subject, *) if profile != "dfc-v2"
+      return render_v2(subject, *) unless subject.is_a?(Array)
+
+      # DFCv2 requires containers for listing resources in an index action.
+      container = Container.new(url_for, members: subject)
+      render_v2(container, *subject, *)
+    end
+
+    def render_v1(*)
+      render json: DfcIo.export(*)
     end
 
     def render_v2(*)

--- a/engines/dfc_provider/app/controllers/dfc_provider/catalog_items_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/catalog_items_controller.rb
@@ -12,7 +12,7 @@ module DfcProvider
       enterprise = EnterpriseBuilder.enterprise(current_enterprise)
       catalog_items = enterprise.catalogItems
 
-      render json: DfcIo.export(
+      render_dfc(
         enterprise,
         *catalog_items,
         *catalog_items.map(&:product),
@@ -24,7 +24,7 @@ module DfcProvider
     def show
       catalog_item = CatalogItemBuilder.catalog_item(variant)
       offers = catalog_item.offers
-      render json: DfcIo.export(catalog_item, *offers)
+      render_dfc(catalog_item, *offers)
     end
 
     def update

--- a/engines/dfc_provider/app/controllers/dfc_provider/catalog_items_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/catalog_items_controller.rb
@@ -13,8 +13,7 @@ module DfcProvider
       catalog_items = enterprise.catalogItems
 
       render_dfc(
-        enterprise,
-        *catalog_items,
+        catalog_items,
         *catalog_items.map(&:product),
         *catalog_items.map(&:product).flat_map(&:isVariantOf),
         *catalog_items.flat_map(&:offers),

--- a/engines/dfc_provider/app/controllers/dfc_provider/enterprise_groups_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/enterprise_groups_controller.rb
@@ -10,7 +10,8 @@ module DfcProvider
         EnterpriseBuilder.enterprise_group(group)
       end
       person.affiliatedOrganizations = enterprises
-      render_dfc(person, *enterprises)
+
+      render_dfc(enterprises)
     end
 
     def show

--- a/engines/dfc_provider/app/controllers/dfc_provider/enterprise_groups_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/enterprise_groups_controller.rb
@@ -10,7 +10,7 @@ module DfcProvider
         EnterpriseBuilder.enterprise_group(group)
       end
       person.affiliatedOrganizations = enterprises
-      render json: DfcIo.export(person, *enterprises)
+      render_dfc(person, *enterprises)
     end
 
     def show
@@ -18,7 +18,7 @@ module DfcProvider
       address = AddressBuilder.address(group.address)
       enterprise = EnterpriseBuilder.enterprise_group(group)
       enterprise.localizations = [address]
-      render json: DfcIo.export(enterprise, address)
+      render_dfc(enterprise, address)
     end
   end
 end

--- a/engines/dfc_provider/app/controllers/dfc_provider/enterprises_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/enterprises_controller.rb
@@ -10,7 +10,7 @@ module DfcProvider
         EnterpriseBuilder.enterprise(enterprise)
       end
 
-      render json: DfcIo.export(
+      render_dfc(
         *enterprises,
         *enterprises.map(&:mainContact),
         *enterprises.flat_map(&:localizations),
@@ -28,7 +28,7 @@ module DfcProvider
       end
       enterprise.registerSemanticProperty("dfc-b:affiliates") { group_ids }
 
-      render json: DfcIo.export(
+      render_dfc(
         enterprise,
         enterprise.mainContact,
         *enterprise.localizations,

--- a/engines/dfc_provider/app/controllers/dfc_provider/offers_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/offers_controller.rb
@@ -6,7 +6,7 @@ module DfcProvider
 
     def show
       subject = OfferBuilder.build(variant)
-      render json: DfcIo.export(subject)
+      render_dfc(subject)
     end
 
     def update

--- a/engines/dfc_provider/app/controllers/dfc_provider/organizations_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/organizations_controller.rb
@@ -8,6 +8,8 @@
 # See the EnterprisesController for the backwards-compatible DFC v1 endpoint.
 module DfcProvider
   class OrganizationsController < DfcProvider::ApplicationController
+    before_action { @profile = "dfc-v2" }
+
     # List OFN enterprises as DFC Organizations.
     def index
       enterprises = current_user.enterprises.map do |enterprise|
@@ -16,7 +18,7 @@ module DfcProvider
 
       organizations = DfcV2Migration.up(enterprises)
 
-      render_container(organizations)
+      render_dfc(organizations)
     end
 
     def show
@@ -24,22 +26,13 @@ module DfcProvider
       dfc_enterprise = EnterpriseBuilder.enterprise(enterprise)
       organization = DfcV2Migration.up([dfc_enterprise]).first
 
-      render_v2(
+      render_dfc(
         organization,
         organization.mainContact,
         *organization.localizations,
         *organization.socialMedias,
         *organization.certifications,
       )
-    end
-
-    private
-
-    # The DFC v2 requires containers.
-    def render_container(members)
-      container = Container.new(organizations_url, members:)
-
-      render_v2(container, *members)
     end
   end
 end

--- a/engines/dfc_provider/app/controllers/dfc_provider/persons_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/persons_controller.rb
@@ -7,7 +7,7 @@ module DfcProvider
 
     def show
       person = PersonBuilder.person(user)
-      render json: DfcIo.export(person)
+      render_dfc(person)
     end
 
     def prefs

--- a/engines/dfc_provider/app/controllers/dfc_provider/product_groups_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/product_groups_controller.rb
@@ -6,7 +6,7 @@ module DfcProvider
     def show
       spree_product = permissions.visible_products.find(params[:id])
       product = ProductGroupBuilder.product_group(spree_product)
-      render json: DfcIo.export(product)
+      render_dfc(product)
     end
 
     private

--- a/engines/dfc_provider/app/controllers/dfc_provider/social_medias_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/social_medias_controller.rb
@@ -10,7 +10,7 @@ module DfcProvider
 
       return not_found unless social_media
 
-      render json: DfcIo.export(social_media)
+      render_dfc(social_media)
     end
   end
 end

--- a/engines/dfc_provider/app/controllers/dfc_provider/supplied_products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/supplied_products_controller.rb
@@ -24,7 +24,7 @@ module DfcProvider
       catalog_items = enterprises.flat_map(&:catalogItems)
 
       render_dfc(
-        *catalog_items,
+        catalog_items,
         *catalog_items.map(&:product),
         *catalog_items.map(&:product).flat_map(&:isVariantOf),
         *catalog_items.flat_map(&:offers),

--- a/engines/dfc_provider/app/controllers/dfc_provider/supplied_products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/supplied_products_controller.rb
@@ -23,7 +23,7 @@ module DfcProvider
       end
       catalog_items = enterprises.flat_map(&:catalogItems)
 
-      render json: DfcIo.export(
+      render_dfc(
         *catalog_items,
         *catalog_items.map(&:product),
         *catalog_items.map(&:product).flat_map(&:isVariantOf),
@@ -33,7 +33,7 @@ module DfcProvider
 
     def show
       product = SuppliedProductBuilder.supplied_product(variant)
-      render json: DfcIo.export(product)
+      render_dfc(product)
     end
 
     def create
@@ -47,7 +47,7 @@ module DfcProvider
       )
 
       supplied_product = SuppliedProductBuilder.supplied_product(variant)
-      render json: DfcIo.export(supplied_product)
+      render_dfc(supplied_product)
     end
 
     def update

--- a/engines/dfc_provider/spec/requests/catalog_items_spec.rb
+++ b/engines/dfc_provider/spec/requests/catalog_items_spec.rb
@@ -3,6 +3,7 @@
 require_relative "../swagger_helper"
 
 RSpec.describe "CatalogItems", swagger_doc: "dfc.yaml" do
+  let(:Accept) { "application/json" }
   let(:Authorization) { nil }
   let(:user) { create(:oidc_user, id: 12_345) }
   let(:enterprise) {
@@ -108,6 +109,17 @@ RSpec.describe "CatalogItems", swagger_doc: "dfc.yaml" do
         end
 
         context "with given enterprise id" do
+          let(:enterprise_id) { 10_000 }
+
+          run_test! do
+            expect(response.body).to include "Apple"
+            expect(response.body).to include "AR"
+            expect(response.body).to include "offers/10001"
+          end
+        end
+
+        context "in DFC v2 format" do
+          let(:Accept) { 'application/ld+json; profile="dfc-v2"' }
           let(:enterprise_id) { 10_000 }
 
           run_test! do

--- a/engines/dfc_provider/spec/requests/enterprise_groups_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprise_groups_spec.rb
@@ -3,39 +3,61 @@
 require_relative "../swagger_helper"
 
 RSpec.describe "EnterpriseGroups", swagger_doc: "dfc.yaml" do
+  let(:Accept) { "application/json" }
   let(:user) { create(:oidc_user, id: 12_345) }
   let(:group) {
     create(
       :enterprise_group,
       id: 60_000, owner: user, name: "Sustainable Farmers", address:,
-      enterprises: [enterprise],
+      enterprises: [enterprise1, enterprise2],
     )
   }
   let(:address) { create(:address, id: 40_000, address1: "8 Acres Drive") }
-  let(:enterprise) { create(:enterprise, id: 10_000) }
+  let(:enterprise1) { create(:enterprise, id: 10_001) }
+  let(:enterprise2) { create(:enterprise, id: 10_002) }
 
   before { login_as user }
 
   path "/api/dfc/enterprise_groups" do
     get "List groups" do
-      produces "application/json"
+      produces "application/json", 'application/ld+json; profile="dfc-v2"'
 
       response "200", "successful" do
         let!(:groups) { [group] }
 
-        run_test! do
-          graph = json_response["@graph"]
+        context "in DFC v1 format" do
+          run_test! do
+            expect(subject["@type"]).to eq "dfc-b:Enterprise"
+            expect(subject).to include(
+              "@id" => "http://test.host/api/dfc/enterprise_groups/60000",
+              "dfc-b:name" => "Sustainable Farmers",
+              "dfc-b:affiliatedBy" => [
+                "http://test.host/api/dfc/enterprises/10001",
+                "http://test.host/api/dfc/enterprises/10002",
+              ],
+            )
+          end
+        end
 
-          expect(graph[0]["@type"]).to eq "dfc-b:Person"
-          expect(graph[0]).to include(
-            "dfc-b:affiliates" => "http://test.host/api/dfc/enterprise_groups/60000",
-          )
+        context "in DFC v2 format" do
+          let(:Accept) { 'application/ld+json; profile="dfc-v2"' }
 
-          expect(graph[1]["@type"]).to eq "dfc-b:Enterprise"
-          expect(graph[1]).to include(
-            "dfc-b:name" => "Sustainable Farmers",
-            "dfc-b:affiliatedBy" => "http://test.host/api/dfc/enterprises/10000",
-          )
+          run_test! do
+            expect(graph[0]).to include(
+              "@id" => "http://test.host/api/dfc/enterprise_groups",
+              "@type" => "ldp:Container",
+              "ldp:contains" => "http://test.host/api/dfc/enterprise_groups/60000",
+            )
+            expect(graph[1]).to include(
+              "@id" => "http://test.host/api/dfc/enterprise_groups/60000",
+              "@type" => "dfc-b:Enterprise",
+              "dfc-b:name" => "Sustainable Farmers",
+              "dfc-b:affiliatedBy" => [
+                "http://test.host/api/dfc/enterprises/10001",
+                "http://test.host/api/dfc/enterprises/10002",
+              ],
+            )
+          end
         end
       end
     end
@@ -56,7 +78,10 @@ RSpec.describe "EnterpriseGroups", swagger_doc: "dfc.yaml" do
             "@type" => "dfc-b:Enterprise",
             "dfc-b:name" => "Sustainable Farmers",
             "dfc-b:hasAddress" => "http://test.host/api/dfc/addresses/40000",
-            "dfc-b:affiliatedBy" => "http://test.host/api/dfc/enterprises/10000",
+            "dfc-b:affiliatedBy" => [
+              "http://test.host/api/dfc/enterprises/10001",
+              "http://test.host/api/dfc/enterprises/10002",
+            ],
           )
 
           expect(graph[1]).to include(

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -82,6 +82,10 @@ RSpec.describe "SuppliedProducts", swagger_doc: "dfc.yaml" do
             let(:Accept) { 'application/ld+json; profile="dfc-v2"' }
 
             run_test! do
+              expect(graph[0]).to include(
+                "@id" => "http://test.host/api/dfc/supplied_products",
+                "@type" => "ldp:Container",
+              )
               expect(response.body).to include "Pesto"
             end
           end

--- a/engines/dfc_provider/spec/requests/supplied_products_spec.rb
+++ b/engines/dfc_provider/spec/requests/supplied_products_spec.rb
@@ -3,6 +3,7 @@
 require_relative "../swagger_helper"
 
 RSpec.describe "SuppliedProducts", swagger_doc: "dfc.yaml" do
+  let(:Accept) { "application/json" }
   let!(:user) { create(:oidc_user) }
   let!(:enterprise) { create(:distributor_enterprise, id: 10_000, owner: user) }
   let!(:product) {
@@ -71,8 +72,18 @@ RSpec.describe "SuppliedProducts", swagger_doc: "dfc.yaml" do
         end
 
         context "as user owning two enterprises" do
-          run_test! do
-            expect(response.body).to include "Pesto"
+          context "in DFC v1 format" do
+            run_test! do
+              expect(response.body).to include "Pesto"
+            end
+          end
+
+          context "in DFC v2 format" do
+            let(:Accept) { 'application/ld+json; profile="dfc-v2"' }
+
+            run_test! do
+              expect(response.body).to include "Pesto"
+            end
           end
         end
       end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -184,15 +184,6 @@ paths:
                   value:
                     "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
                     "@graph":
-                    - "@id": http://test.host/api/dfc/enterprises/10000
-                      "@type": dfc-b:Enterprise
-                      dfc-b:hasAddress: http://test.host/api/dfc/addresses/40000
-                      dfc-b:name: Fred's Farm
-                      dfc-b:hasDescription: Beautiful
-                      dfc-b:manages: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
-                      dfc-b:supplies: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
-                      dfc-b:hasMainContact: http://test.host/api/dfc/enterprises/10000#mainContact
-                      ofn:long_description: "<p>Hello, world!</p><p>This is a paragraph.</p>"
                     - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       "@type": dfc-b:CatalogItem
                       dfc-b:references: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
@@ -226,15 +217,6 @@ paths:
                   value:
                     "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
                     "@graph":
-                    - "@id": http://test.host/api/dfc/enterprises/10000
-                      "@type": dfc-b:Enterprise
-                      dfc-b:hasAddress: http://test.host/api/dfc/addresses/40000
-                      dfc-b:name: Fred's Farm
-                      dfc-b:hasDescription: Beautiful
-                      dfc-b:manages: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
-                      dfc-b:supplies: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
-                      dfc-b:hasMainContact: http://test.host/api/dfc/enterprises/10000#mainContact
-                      ofn:long_description: "<p>Hello, world!</p><p>This is a paragraph.</p>"
                     - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       "@type": dfc-b:CatalogItem
                       dfc-b:references: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
@@ -268,15 +250,6 @@ paths:
                   value:
                     "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
                     "@graph":
-                    - "@id": http://test.host/api/dfc/enterprises/10000
-                      "@type": dfc-b:Enterprise
-                      dfc-b:hasAddress: http://test.host/api/dfc/addresses/40000
-                      dfc-b:name: Fred's Farm
-                      dfc-b:hasDescription: Beautiful
-                      dfc-b:manages: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
-                      dfc-b:supplies: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
-                      dfc-b:hasMainContact: http://test.host/api/dfc/enterprises/10000#mainContact
-                      ofn:long_description: "<p>Hello, world!</p><p>This is a paragraph.</p>"
                     - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       "@type": dfc-b:CatalogItem
                       dfc-b:references: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
@@ -310,15 +283,44 @@ paths:
                   value:
                     "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
                     "@graph":
-                    - "@id": http://test.host/api/dfc/enterprises/10000
-                      "@type": dfc-b:Enterprise
-                      dfc-b:hasAddress: http://test.host/api/dfc/addresses/40000
-                      dfc-b:name: Fred's Farm
-                      dfc-b:hasDescription: Beautiful
-                      dfc-b:manages: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
-                      dfc-b:supplies: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
-                      dfc-b:hasMainContact: http://test.host/api/dfc/enterprises/10000#mainContact
-                      ofn:long_description: "<p>Hello, world!</p><p>This is a paragraph.</p>"
+                    - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items/10001
+                      "@type": dfc-b:CatalogItem
+                      dfc-b:references: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                      dfc-b:sku: AR
+                      dfc-b:stockLimitation: 0
+                      dfc-b:offeredThrough: http://test.host/api/dfc/enterprises/10000/offers/10001
+                      dfc-b:managedBy: http://test.host/api/dfc/enterprises/10000
+                    - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: Apple - 1g
+                      dfc-b:description: Red
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
+                      ofn:spree_product_id: 90000
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
+                    - "@id": http://test.host/api/dfc/product_groups/90000
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: Apple
+                      dfc-b:hasVariant: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                    - "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 0
+            application/ld+json; profile="dfc-v2"; charset=utf-8:
+              examples:
+                in DFC v2 format:
+                  value:
+                    "@context": https://www.datafoodconsortium.org
+                    "@graph":
+                    - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items
+                      "@type": ldp:Container
+                      ldp:contains: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                     - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       "@type": dfc-b:CatalogItem
                       dfc-b:references: http://test.host/api/dfc/enterprises/10000/supplied_products/10001

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -1489,10 +1489,51 @@ paths:
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 5
-                as user owning two enterprises:
+                in DFC v1 format:
                   value:
                     "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
                     "@graph":
+                    - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items/10001
+                      "@type": dfc-b:CatalogItem
+                      dfc-b:references: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                      dfc-b:sku: BP
+                      dfc-b:stockLimitation: 5
+                      dfc-b:offeredThrough: http://test.host/api/dfc/enterprises/10000/offers/10001
+                      dfc-b:managedBy: http://test.host/api/dfc/enterprises/10000
+                    - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: Pesto - 1g
+                      dfc-b:description: Basil Pesto
+                      dfc-b:hasType: dfc-pt:processed-vegetable
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
+                      ofn:spree_product_id: 90000
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
+                      ofn:image: http://test.host/rails/active_storage/url/logo-white.png
+                    - "@id": http://test.host/api/dfc/product_groups/90000
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: Pesto
+                      dfc-b:hasVariant: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                    - "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 5
+            application/ld+json; profile="dfc-v2"; charset=utf-8:
+              examples:
+                in DFC v2 format:
+                  value:
+                    "@context": https://www.datafoodconsortium.org
+                    "@graph":
+                    - "@id": http://test.host/api/dfc/supplied_products
+                      "@type": ldp:Container
+                      ldp:contains: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                     - "@id": http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       "@type": dfc-b:CatalogItem
                       dfc-b:references: http://test.host/api/dfc/enterprises/10000/supplied_products/10001

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -520,18 +520,32 @@ paths:
           content:
             application/json; charset=utf-8:
               examples:
-                successful:
+                in DFC v1 format:
                   value:
                     "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
+                    "@id": http://test.host/api/dfc/enterprise_groups/60000
+                    "@type": dfc-b:Enterprise
+                    dfc-b:name: Sustainable Farmers
+                    dfc-b:hasDescription: this is a group
+                    dfc-b:affiliatedBy:
+                    - http://test.host/api/dfc/enterprises/10001
+                    - http://test.host/api/dfc/enterprises/10002
+            application/ld+json; profile="dfc-v2"; charset=utf-8:
+              examples:
+                in DFC v2 format:
+                  value:
+                    "@context": https://www.datafoodconsortium.org
                     "@graph":
-                    - "@id": http://test.host/api/dfc/persons/12345
-                      "@type": dfc-b:Person
-                      dfc-b:affiliates: http://test.host/api/dfc/enterprise_groups/60000
+                    - "@id": http://test.host/api/dfc/enterprise_groups
+                      "@type": ldp:Container
+                      ldp:contains: http://test.host/api/dfc/enterprise_groups/60000
                     - "@id": http://test.host/api/dfc/enterprise_groups/60000
                       "@type": dfc-b:Enterprise
                       dfc-b:name: Sustainable Farmers
                       dfc-b:hasDescription: this is a group
-                      dfc-b:affiliatedBy: http://test.host/api/dfc/enterprises/10000
+                      dfc-b:affiliatedBy:
+                      - http://test.host/api/dfc/enterprises/10001
+                      - http://test.host/api/dfc/enterprises/10002
   "/api/dfc/enterprise_groups/{id}":
     get:
       summary: Show groups
@@ -558,7 +572,9 @@ paths:
                       dfc-b:hasAddress: http://test.host/api/dfc/addresses/40000
                       dfc-b:name: Sustainable Farmers
                       dfc-b:hasDescription: this is a group
-                      dfc-b:affiliatedBy: http://test.host/api/dfc/enterprises/10000
+                      dfc-b:affiliatedBy:
+                      - http://test.host/api/dfc/enterprises/10001
+                      - http://test.host/api/dfc/enterprises/10002
                     - "@id": http://test.host/api/dfc/addresses/40000
                       "@type": dfc-b:Address
                       dfc-b:hasStreet: 8 Acres Drive


### PR DESCRIPTION
**:information_source: Use Clockify code `#13323 Connecting Farms and Markets` while working on this.**

## What? Why?

- #14188 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

:warning: There are a couple of breaking changes for v1 in here. I don't think that they will impact real life scenarios but I may not be aware of all users of the DFC API.

With these changes, all endpoints will support rendering in DFC v2 format as JSON-LD. The data content is not migrated to the new models yet. Enterprises are not send as Organization yet (coming soon). But everything is sent with the newest context and using containers where required. LDP Containers are required in DFC v2 when publishing lists of resources like our index actions do.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- @RachL, are you aware of any integrations that are active, supported and should be tested?

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
