### PR TITLE
Show order notes in confirmation emails

### DIFF
--- a/app/views/spree/order_mailer/_special_instructions.html.haml
+++ b/app/views/spree/order_mailer/_special_instructions.html.haml
@@ -6,3 +6,11 @@
         = t :email_special_instructions
       %br
       #{@order.special_instructions}
+- if @order.note.present?
+  %br
+  %p
+    %small
+      %strong
+        = t :email_order_note
+      %br
+      #{@order.note}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2669,6 +2669,7 @@ en:
   email_shipping_collection_time: "Ready for collection:"
   email_shipping_collection_instructions: "Collection instructions:"
   email_special_instructions: "Your notes:"
+  email_order_note: "Note:"
 
   email_signup_greeting: Hello!
   email_signup_welcome: "Welcome to %{sitename}!"

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -229,6 +229,22 @@ RSpec.describe Spree::OrderMailer do
 
         expect(mail.body.encoded).to include "https://www.openfoodnetwork.org"
       end
+
+      context "when the order has a note" do
+        before { order.update!(note: "We substituted the apples with pears.") }
+
+        it "includes the note in the customer email" do
+          mail = Spree::OrderMailer.confirm_email_for_customer(order.id)
+          expect(mail.body.encoded).to include "We substituted the apples with pears."
+        end
+      end
+
+      context "when the order has no note" do
+        it "does not include a note section in the customer email" do
+          mail = Spree::OrderMailer.confirm_email_for_customer(order.id)
+          expect(mail.body.encoded).not_to include "Note:"
+        end
+      end
     end
 
     describe "for shops" do
@@ -243,6 +259,15 @@ RSpec.describe Spree::OrderMailer do
         ContentConfig.footer_email = "email@example.com"
         Spree::OrderMailer.confirm_email_for_shop(order.id).deliver_now
         expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
+
+      context "when the order has a note" do
+        before { order.update!(note: "We substituted the apples with pears.") }
+
+        it "includes the note in the shop email" do
+          mail = Spree::OrderMailer.confirm_email_for_shop(order.id)
+          expect(mail.body.encoded).to include "We substituted the apples with pears."
+        end
       end
     end
   end

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -269,6 +269,31 @@ RSpec.describe Spree::OrderMailer do
           expect(mail.body.encoded).to include "We substituted the apples with pears."
         end
       end
+
+      context "when the order has no note" do
+        it "does not include a note section in the shop email" do
+          mail = Spree::OrderMailer.confirm_email_for_shop(order.id)
+          expect(mail.body.encoded).not_to include "Note:"
+        end
+      end
+    end
+
+    context "when the order note is updated" do
+      before { order.update!(note: "Original note.") }
+
+      it "reflects the updated note in the customer email" do
+        order.update!(note: "Updated note after substitution.")
+        mail = Spree::OrderMailer.confirm_email_for_customer(order.id)
+        expect(mail.body.encoded).to include "Updated note after substitution."
+        expect(mail.body.encoded).not_to include "Original note."
+      end
+
+      it "reflects the updated note in the shop email" do
+        order.update!(note: "Updated note after substitution.")
+        mail = Spree::OrderMailer.confirm_email_for_shop(order.id)
+        expect(mail.body.encoded).to include "Updated note after substitution."
+        expect(mail.body.encoded).not_to include "Original note."
+      end
     end
   end
 

--- a/spec/mailers/previews/order_mailer_preview.rb
+++ b/spec/mailers/previews/order_mailer_preview.rb
@@ -2,6 +2,20 @@
 
 class OrderMailerPreview < ActionMailer::Preview
   def confirm_email_for_customer
-    Spree::OrderMailer.confirm_email_for_customer(Spree::Order.complete.last)
+    order = Spree::Order.complete.last
+    order.assign_attributes(note: "")
+    Spree::OrderMailer.confirm_email_for_customer(order)
+  end
+
+  def confirm_email_for_customer_with_note
+    order = Spree::Order.complete.last
+    order.assign_attributes(note: "We substituted the organic apples with pears from a local farm.")
+    Spree::OrderMailer.confirm_email_for_customer(order)
+  end
+
+  def confirm_email_for_shop_with_note
+    order = Spree::Order.complete.last
+    order.assign_attributes(note: "We substituted the organic apples with pears from a local farm.")
+    Spree::OrderMailer.confirm_email_for_shop(order)
   end
 end


### PR DESCRIPTION
## What? Why?

Hub managers frequently need to communicate order changes to buyers (e.g. a product substitution). Currently there is no way to include a note when resending a confirmation email. This adds the existing `note` field on the order to both the customer and shop confirmation emails, displayed below the special instructions section and only shown when the note is non-empty.

Closes: openfoodfoundation/openfoodnetwork#14380

## What should we test?

1. Go to an order in the admin (**Orders** → click an order)
2. Add a note in the **Notes** field and save
3. From the order page, resend the confirmation email to the customer
4. Verify the note appears in the email under the special instructions section
5. Verify the same note appears in the shop notification email
6. Repeat with an order that has **no note** — confirm the note section is absent entirely from both emails

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

## Dependencies

Related: openfoodfoundation/openfoodnetwork#13179 (truncated notes field on the edit order page — flagged in the wishlist issue as potentially worth addressing at the same time, but kept out of scope here to stay focused)

## Documentation updates

The [OFN User Guide](https://guide.openfoodnetwork.org/) section on managing orders may want to note that hub managers can use the order Notes field to communicate changes when resending confirmation emails.

📸 Screenshots attached below (customer without note, customer with note, shop with note).

<img width="900" height="1382" alt="shop-with-note" src="https://github.com/user-attachments/assets/94c11499-2856-4f3a-93ab-989f78efc779" />
<img width="900" height="1382" alt="customer-with-note" src="https://github.com/user-attachments/assets/c4311965-7608-4365-8677-3f9ae839c30a" />
openfo
<img width="900" height="1382" alt="customer-no-note" src="https://github.com/user-attachments/assets/c4522728-890b-440e-89cf-8029fa2abfae" />