### PR TITLE
Allow filtering and sorting customer list by tag

### DIFF
--- a/app/views/admin/customers/index.html.haml
+++ b/app/views/admin/customers/index.html.haml
@@ -25,7 +25,11 @@
         %label{ for: 'hub_id', "ng-bind": "shop_id ? '#{t('admin.shop')}' : '#{t('admin.variant_overrides.index.select_a_shop')}'" }
         %br
         %input.ofn-select2.fullwidth#shop_id{ "ng-model": 'shop_id', name: 'shop_id', data: 'shops', "on-selecting": 'confirmRefresh' }
-      .seven.columns.omega &nbsp;
+      .filter_select.four.columns
+        %label{ for: 'tag_filter', "ng-class": '{disabled: !shop_id}' }=t('admin.tags')
+        %br
+        %input.fullwidth{ type: "text", id: 'tag_filter', placeholder: t('.filter_by_tag'), "ng-model": 'tagFilter', "ng-disabled": '!shop_id' }
+      .three.columns.omega &nbsp;
 
   %hr.divider{ "ng-show": "!RequestMonitor.loading && filteredCustomers.length > 0" }
 
@@ -71,13 +75,14 @@
               %a{ :href => '', 'ng-click' => "sorting.toggle('last_name')" }=t('admin.last_name')
             %th.code{ 'ng-show' => 'columns.code.visible' }
               %a{ :href => '', 'ng-click' => "sorting.toggle('code')" }=t('admin.customers.index.code')
-            %th.tags{ 'ng-show' => 'columns.tags.visible' }=t('admin.tags')
+            %th.tags{ 'ng-show' => 'columns.tags.visible' }
+              %a{ :href => '', 'ng-click' => "sorting.toggle('tag_list')", 'data-turbo' => 'false' }=t('admin.tags')
             %th.bill_address{ 'ng-show' => 'columns.bill_address.visible' }=t('admin.customers.index.bill_address')
             %th.ship_address{ 'ng-show' => 'columns.ship_address.visible' }=t('admin.customers.index.ship_address')
             %th.balance{ 'ng-show' => 'columns.balance.visible' }=t('admin.customers.index.balance')
             %th.credit{ 'ng-show' => 'columns.credit.visible' }=t('admin.customers.index.credit')
         %tbody
-          %tr.customer{ 'ng-repeat' => "customer in filteredCustomers = ( customers | filter:quickSearch | orderBy: sorting.predicate:sorting.reverse ) | limitTo:customerLimit track by customer.id", 'ng-class-even' => "'even'", 'ng-class-odd' => "'odd'", :id => "c_{{customer.id}}" }
+          %tr.customer{ 'ng-repeat' => "customer in filteredCustomers = ( customers | filter:quickSearch | filter:{tag_list: tagFilter} | orderBy: sorting.predicate:sorting.reverse ) | limitTo:customerLimit track by customer.id", 'ng-class-even' => "'even'", 'ng-class-odd' => "'odd'", :id => "c_{{customer.id}}" }
             -# %td.bulk
               -# %input{ :type => "checkbox", :name => 'bulk', 'ng-model' => 'customer.checked' }
             %td.id{ 'ng-show' => 'columns.id.visible'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -894,6 +894,7 @@ en:
         update_address: "Update Address"
         confirm_delete: "Sure to delete?"
         search_by_email: "Search by email/code..."
+        filter_by_tag: "Filter by tag"
         guest_label: "Guest checkout"
         credit_owed: "Credit Owed"
         balance_due: "Balance Due"

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -258,6 +258,59 @@ RSpec.describe 'Customers' do
             end
           end
         end
+
+        context "when using the tag filter input" do
+          before do
+            customer2.update!(tag_list: "vip")
+
+            select2_select managed_distributor1.name, from: "shop_id"
+            expect(page).to have_selector "tr#c_#{customer1.id}"
+            fill_in "tag_filter", with: "vip"
+          end
+
+          it "displays only customers matching the tag" do
+            expect(page).to have_content(customer2.email)
+            expect(page).not_to have_content(customer1.email)
+          end
+
+          it "shows all customers when the filter is cleared" do
+            fill_in "tag_filter", with: ""
+            expect(page).to have_content(customer1.email)
+            expect(page).to have_content(customer2.email)
+          end
+        end
+
+        context "when sorting by tags" do
+          before do
+            customer1.update!(tag_list: "apple")
+            customer2.update!(tag_list: "zebra")
+
+            select2_select managed_distributor1.name, from: "shop_id"
+            expect(page).to have_selector "tr#c_#{customer1.id}"
+          end
+
+          it "sorts ascending then descending when the Tags header is clicked" do
+            within "#customers thead" do
+              click_on "Tags"
+            end
+
+            # After ascending sort, apple (customer1) appears before zebra (customer2)
+            rows = all("#customers .customer")
+            apple_pos = rows.index { |r| r["id"] == "c_#{customer1.id}" }
+            zebra_pos = rows.index { |r| r["id"] == "c_#{customer2.id}" }
+            expect(apple_pos).to be < zebra_pos
+
+            within "#customers thead" do
+              click_on "Tags"
+            end
+
+            # After descending sort, zebra appears before apple
+            rows = all("#customers .customer")
+            apple_pos = rows.index { |r| r["id"] == "c_#{customer1.id}" }
+            zebra_pos = rows.index { |r| r["id"] == "c_#{customer2.id}" }
+            expect(zebra_pos).to be < apple_pos
+          end
+        end
       end
 
       it "allows updating of attributes" do


### PR DESCRIPTION
## What? Why?

- Closes #14385
- Closes openfoodfoundation/wishlist#503

Hub managers working with large customer lists had no way to find customers by tag or sort by tag. This adds a "Filter by tag" text input to the customer list header and makes the Tags column header clickable for A→Z / Z→A sorting.

## What should we test?

- Visit `/admin/customers`
- Select a shop to load customers
- Type a tag name in the "Filter by tag" input — list should narrow to matching customers only; clearing the input restores the full list
- Click the **Tags** column header — list should sort A→Z; click again for Z→A
- With customers with multiple tags, click the **Tags** column header — list should sort A→Z; click again for Z→A
- Confirm the filter input is disabled until a shop is selected

## Screenshots

**Filter by tag** (typing "w" narrows list to customers with the "wholesale" tag):

![Filter by tag](https://raw.githubusercontent.com/David-OFN-CA/openfoodnetwork/pr-14383-screenshots/docs/screenshots/screenshot-1-filter-by-tag.png)

**Sort by Tags** (customers sorted A→Z by tag: member → retail → wholesale):

![Sort by tags](https://raw.githubusercontent.com/David-OFN-CA/openfoodnetwork/pr-14383-screenshots/docs/screenshots/screenshot-2-sort-by-tags.png)

## Release notes

Changelog Category:
- [x] User facing changes

## Dependencies

None.

## Documentation updates

None.