### PR TITLE
Show negative enterprise fees in shopfront price breakdown

### DIFF
--- a/lib/open_food_network/enterprise_fee_calculator.rb
+++ b/lib/open_food_network/enterprise_fee_calculator.rb
@@ -23,7 +23,7 @@ module OpenFoodNetwork
       indexed_enterprise_fees_for(variant).each_with_object({}) do |enterprise_fee, fees|
         fees[enterprise_fee.fee_type.to_sym] ||= 0
         fees[enterprise_fee.fee_type.to_sym] += calculate_fee_for variant, enterprise_fee
-      end.select { |_fee_type, amount| amount > 0 }
+      end.reject { |_fee_type, amount| amount.zero? }
     end
 
     def fees_for(variant)
@@ -37,7 +37,7 @@ module OpenFoodNetwork
         fees[applicator.enterprise_fee.fee_type.to_sym] ||= 0
         fees[applicator.enterprise_fee.fee_type.to_sym] +=
           calculate_fee_for variant, applicator.enterprise_fee
-      end.select { |_fee_type, amount| amount > 0 }
+      end.reject { |_fee_type, amount| amount.zero? }
     end
 
     def fees_name_by_type_for(variant)

--- a/spec/lib/open_food_network/enterprise_fee_calculator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_fee_calculator_spec.rb
@@ -166,6 +166,14 @@ RSpec.describe OpenFoodNetwork::EnterpriseFeeCalculator do
             .fees_by_type_for(product1.variants.first))
             .to eq(admin: -1.23, sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45)
         end
+
+        it "drops zero fees while keeping negative ones in the same breakdown" do
+          ef_admin.calculator.update_attribute :preferred_amount, -1.23
+          ef_sales.calculator.update_attribute :preferred_amount, 0
+          expect(OpenFoodNetwork::EnterpriseFeeCalculator.new(distributor, order_cycle)
+            .fees_by_type_for(product1.variants.first))
+            .to eq(admin: -1.23, packing: 7.89, transport: 0.12, fundraising: 3.45)
+        end
       end
 
       describe "indexed computation" do
@@ -187,6 +195,14 @@ RSpec.describe OpenFoodNetwork::EnterpriseFeeCalculator do
           expect(OpenFoodNetwork::EnterpriseFeeCalculator.new(distributor, order_cycle)
             .indexed_fees_by_type_for(product1.variants.first))
             .to eq(admin: -1.23, sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45)
+        end
+
+        it "drops zero fees while keeping negative ones in the same breakdown" do
+          ef_admin.calculator.update_attribute :preferred_amount, -1.23
+          ef_sales.calculator.update_attribute :preferred_amount, 0
+          expect(OpenFoodNetwork::EnterpriseFeeCalculator.new(distributor, order_cycle)
+            .indexed_fees_by_type_for(product1.variants.first))
+            .to eq(admin: -1.23, packing: 7.89, transport: 0.12, fundraising: 3.45)
         end
       end
     end

--- a/spec/lib/open_food_network/enterprise_fee_calculator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_fee_calculator_spec.rb
@@ -159,6 +159,13 @@ RSpec.describe OpenFoodNetwork::EnterpriseFeeCalculator do
             .fees_by_type_for(product1.variants.first))
             .to eq(sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45)
         end
+
+        it "includes negative fees (used as discounts)" do
+          ef_admin.calculator.update_attribute :preferred_amount, -1.23
+          expect(OpenFoodNetwork::EnterpriseFeeCalculator.new(distributor, order_cycle)
+            .fees_by_type_for(product1.variants.first))
+            .to eq(admin: -1.23, sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45)
+        end
       end
 
       describe "indexed computation" do
@@ -173,6 +180,13 @@ RSpec.describe OpenFoodNetwork::EnterpriseFeeCalculator do
           expect(OpenFoodNetwork::EnterpriseFeeCalculator.new(distributor, order_cycle)
             .indexed_fees_by_type_for(product1.variants.first))
             .to eq(sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45)
+        end
+
+        it "includes negative fees (used as discounts)" do
+          ef_admin.calculator.update_attribute :preferred_amount, -1.23
+          expect(OpenFoodNetwork::EnterpriseFeeCalculator.new(distributor, order_cycle)
+            .indexed_fees_by_type_for(product1.variants.first))
+            .to eq(admin: -1.23, sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45)
         end
       end
     end


### PR DESCRIPTION
## What? Why?

- Closes #14017

Negative enterprise fees (used as discounts by some enterprises) calculated correctly on orders and appeared correctly in reports, but were silently excluded from the shopfront price-breakdown pie chart.

Root cause: `EnterpriseFeeCalculator#indexed_fees_by_type_for` and `#fees_by_type_for` both filtered results with `.select { |_fee_type, amount| amount > 0 }`, dropping any fee type whose net amount was negative before the data reached the variant serializer and the Angular pie-chart template.

Fix: change both guards to `.reject { |_fee_type, amount| amount.zero? }` — this preserves negative values while still excluding true-zero entries.

*(Note: PR opened by an AI agent on behalf of @David-OFN-CA)*

## What should we test?

1. Create an enterprise fee with a **negative** amount (e.g. `-20%` flat rate) and add it to an order cycle.
2. Visit the shop, click the pie chart icon on a variant that has the fee applied.
3. Before this fix: the negative fee is absent from the breakdown.
4. After this fix: the negative fee appears in the breakdown (e.g. as "Admin: -$2.00").
5. Confirm that fees with a `0` value are still excluded from the pie chart.
6. Confirm orders with only positive fees are unaffected.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

## Screenshot

<img width="1200" height="763" alt="pr-14396-negative-fee-screenshot" src="https://github.com/user-attachments/assets/a707b015-3447-4909-9c5c-aa05b827d84f" />