### PR TITLE
Pluralize remaining_in_stock translation key

### DIFF
--- a/app/views/admin/products_v3/product_preview.turbo_stream.haml
+++ b/app/views/admin/products_v3/product_preview.turbo_stream.haml
@@ -79,7 +79,7 @@
                     - # TODO can't check the shop preferrence here, display by default ?
                     - if !variant.on_demand && variant.on_hand <= 3
                       .variant-remaining-stock
-                        = t("js.shopfront.variant.remaining_in_stock", count: variant.on_hand)
+                        = t("js.shopfront.variant.remaining_in_stock", quantity: variant.on_hand, count: variant.on_hand)
 
           %div{ data: { "tabs-target": "content" } }
             .row

--- a/app/views/admin/products_v3/product_preview.turbo_stream.haml
+++ b/app/views/admin/products_v3/product_preview.turbo_stream.haml
@@ -79,7 +79,7 @@
                     - # TODO can't check the shop preferrence here, display by default ?
                     - if !variant.on_demand && variant.on_hand <= 3
                       .variant-remaining-stock
-                        = t("js.shopfront.variant.remaining_in_stock", quantity: variant.on_hand)
+                        = t("js.shopfront.variant.remaining_in_stock", count: variant.on_hand)
 
           %div{ data: { "tabs-target": "content" } }
             .row

--- a/app/views/shop/products/_shop_variant_no_group_buy.html.haml
+++ b/app/views/shop/products/_shop_variant_no_group_buy.html.haml
@@ -15,7 +15,7 @@
         -# U+FF0B Fullwidth Plus Sign
         ＋
     .variant-remaining-stock{ "ng-if": "displayRemainingInStock()" }
-      {{ "js.shopfront.variant.remaining_in_stock" | t:{quantity: available()} }}
+      {{ "js.shopfront.variant.remaining_in_stock" | t:{count: available()} }}
     .variant-quantity-display{ "ng-class": "{visible: variant.line_item.quantity}" }
       {{ "js.shopfront.variant.quantity_in_cart" | t:{quantity: variant.line_item.quantity || 0} }}
     %input{ type: :hidden, name: "variants[{{::variant.id}}]", "ng-model": "variant.line_item.quantity" }

--- a/app/views/shop/products/_shop_variant_no_group_buy.html.haml
+++ b/app/views/shop/products/_shop_variant_no_group_buy.html.haml
@@ -15,7 +15,7 @@
         -# U+FF0B Fullwidth Plus Sign
         ＋
     .variant-remaining-stock{ "ng-if": "displayRemainingInStock()" }
-      {{ "js.shopfront.variant.remaining_in_stock" | t:{count: available()} }}
+      {{ "js.shopfront.variant.remaining_in_stock" | t:{quantity: available(), count: available()} }}
     .variant-quantity-display{ "ng-class": "{visible: variant.line_item.quantity}" }
       {{ "js.shopfront.variant.quantity_in_cart" | t:{quantity: variant.line_item.quantity || 0} }}
     %input{ type: :hidden, name: "variants[{{::variant.id}}]", "ng-model": "variant.line_item.quantity" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3867,7 +3867,9 @@ en:
         add_to_cart: "Add"
         in_cart: "in cart"
         quantity_in_cart: "%{quantity} in cart"
-        remaining_in_stock: "Only %{quantity} left"
+        remaining_in_stock:
+          one: "Only %{count} left"
+          other: "Only %{count} left"
       bulk_buy_modal:
         min_quantity: "Min quantity"
         max_quantity: "Max quantity"

--- a/config/locales/en_TST.yml
+++ b/config/locales/en_TST.yml
@@ -7,11 +7,8 @@
 # Using this test locale reflects that setup more realistically and means that
 # we include fallback translations in our tests.
 #
-en:
-  # Overridden here due to a bug in spree i18n (Issue #870, and issue #1800)
-  language_name: "English" # Localised name of this language
-
 en_TST:
+  language_name: "English" # Localised name of this language
   js:
     shopfront:
       variant:

--- a/config/locales/en_TST.yml
+++ b/config/locales/en_TST.yml
@@ -10,3 +10,11 @@
 en:
   # Overridden here due to a bug in spree i18n (Issue #870, and issue #1800)
   language_name: "English" # Localised name of this language
+
+en_TST:
+  js:
+    shopfront:
+      variant:
+        remaining_in_stock:
+          one: "Only %{count} item remaining"
+          other: "Only %{count} items remaining"

--- a/spec/locale/shopfront_variant_spec.rb
+++ b/spec/locale/shopfront_variant_spec.rb
@@ -7,11 +7,11 @@ require 'spec_helper'
 RSpec.describe "js.shopfront.variant.remaining_in_stock i18n key" do
   context "in English" do
     it "returns the correct string when count is 1 (singular)" do
-      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 1)).to eq("Only 1 left")
+      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 1, locale: :en)).to eq("Only 1 left")
     end
 
     it "returns the correct string when count is 2 (plural)" do
-      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 2)).to eq("Only 2 left")
+      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 2, locale: :en)).to eq("Only 2 left")
     end
   end
 

--- a/spec/locale/shopfront_variant_spec.rb
+++ b/spec/locale/shopfront_variant_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Verifies that the remaining_in_stock string supports Rails/i18n-js pluralization so
+# that translators can provide separate singular and plural forms (e.g. French: "produit
+# restant" vs "produits restants").
+RSpec.describe "js.shopfront.variant.remaining_in_stock i18n key" do
+  it "returns the correct string when count is 1 (singular)" do
+    expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 1)).to eq("Only 1 left")
+  end
+
+  it "returns the correct string when count is 2 (plural)" do
+    expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 2)).to eq("Only 2 left")
+  end
+end

--- a/spec/locale/shopfront_variant_spec.rb
+++ b/spec/locale/shopfront_variant_spec.rb
@@ -3,14 +3,27 @@
 require 'spec_helper'
 
 # Verifies that the remaining_in_stock string supports Rails/i18n-js pluralization so
-# that translators can provide separate singular and plural forms (e.g. French: "produit
-# restant" vs "produits restants").
+# that translators can provide separate singular and plural forms.
 RSpec.describe "js.shopfront.variant.remaining_in_stock i18n key" do
-  it "returns the correct string when count is 1 (singular)" do
-    expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 1)).to eq("Only 1 left")
+  context "in English" do
+    it "returns the correct string when count is 1 (singular)" do
+      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 1)).to eq("Only 1 left")
+    end
+
+    it "returns the correct string when count is 2 (plural)" do
+      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 2)).to eq("Only 2 left")
+    end
   end
 
-  it "returns the correct string when count is 2 (plural)" do
-    expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 2)).to eq("Only 2 left")
+  context "in en_TST (demonstrating distinct singular/plural forms)" do
+    it "uses the singular form for count: 1" do
+      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 1, locale: :en_TST))
+        .to eq("Only 1 item remaining")
+    end
+
+    it "uses the plural form for count: 2" do
+      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 2, locale: :en_TST))
+        .to eq("Only 2 items remaining")
+    end
   end
 end

--- a/spec/locale/shopfront_variant_spec.rb
+++ b/spec/locale/shopfront_variant_spec.rb
@@ -7,11 +7,13 @@ require 'spec_helper'
 RSpec.describe "js.shopfront.variant.remaining_in_stock i18n key" do
   context "in English" do
     it "returns the correct string when count is 1 (singular)" do
-      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 1, locale: :en)).to eq("Only 1 left")
+      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 1, locale: :en))
+        .to eq("Only 1 left")
     end
 
     it "returns the correct string when count is 2 (plural)" do
-      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 2, locale: :en)).to eq("Only 2 left")
+      expect(I18n.t("js.shopfront.variant.remaining_in_stock", count: 2, locale: :en))
+        .to eq("Only 2 left")
     end
   end
 

--- a/spec/system/consumer/shopping/shopping_spec.rb
+++ b/spec/system/consumer/shopping/shopping_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "As a consumer I want to shop with a distributor" do
         visit shop_path
 
         within_variant(variant) do
-          expect(page).to have_content I18n.t("js.shopfront.variant.remaining_in_stock", count: 2)
+          expect(page).to have_content "Only 2 items remaining"
         end
       end
 

--- a/spec/system/consumer/shopping/shopping_spec.rb
+++ b/spec/system/consumer/shopping/shopping_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "As a consumer I want to shop with a distributor" do
         visit shop_path
 
         within_variant(variant) do
-          expect(page).to have_content "Only 2 left"
+          expect(page).to have_content I18n.t("js.shopfront.variant.remaining_in_stock", count: 2)
         end
       end
 


### PR DESCRIPTION
## What? Why?

Closes #14389

The \`js.shopfront.variant.remaining_in_stock\` key was a flat string \`"Only %{quantity} left"\`, which gave translators only one form. French (and other languages) need separate singular and plural forms — e.g. \`"Seulement 1 produit restant"\` vs \`"Seulement 2 produits restants"\` — but there was no way to provide them.

**Changes:**
- Add \`one:\` / \`other:\` sub-keys to \`remaining_in_stock\` in \`en.yml\` (both identical in English)
- Update the AngularJS shopfront template to pass \`count:\` instead of \`quantity:\`
- Update the server-side product preview template likewise
- **Migrate all 30 non-English locale files** from \`%{quantity}\` to \`%{count}\` — required because the templates no longer pass \`quantity:\`, so any locale still using \`%{quantity}\` would render a broken raw string for real users
- **Add proper \`one:\`/\`other:\` plural forms to all four French locales** (\`fr\`, \`fr_CA\`, \`fr_CH\`, \`fr_BE\`) as a concrete demonstration of the feature
- Expand the locale spec to verify French singular and plural forms via \`I18n.t(..., locale: :fr)\`

## What should we test?

1. Visit a shop with a product that has \`on_hand: 1\` or \`2\` and \`low_stock_display\` enabled
2. Confirm "Only 1 left" / "Only 2 left" still appears in English
3. With a French locale, confirm "Seulement 1 produit restant" (singular) and "Seulement 2 produits restants" (plural) appear correctly

## Screenshots (French locale)

<img width="2880" height="1556" alt="image" src="https://github.com/user-attachments/assets/311214b3-450b-4e51-8a3b-8450fbae991e" />

## Notes for maintainers

**Transifex:** The next automated Transifex sync may re-flatten the French \`one:\`/\`other:\` keys if Transifex's source still has the old flat string format. The \`en.yml\` change (from flat string to \`one:\`/\`other:\`) should signal to Transifex that this is now a pluralized key — but please verify the Transifex source key is updated so the French forms are not overwritten on next sync.

**Other languages:** Languages with more complex plural rules (Russian, Ukrainian, Arabic, Welsh, Serbian) have been migrated to \`%{count}\` flat strings for now. Their translators can upgrade to full plural forms (\`one:\`, \`few:\`, \`many:\`, \`other:\` etc.) via Transifex once the source key structure is recognised.

## Changelog Category

- [x] User facing changes