### PR TITLE
Remove api_v1 feature toggle, making API v1 generally available

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -14,7 +14,6 @@ module Api
       attr_accessor :current_api_user
 
       before_action :authenticate_user
-      before_action :restrict_feature
 
       rescue_from StandardError, with: :error_during_processing
       rescue_from CanCan::AccessDenied, with: :unauthorized
@@ -37,10 +36,6 @@ module Api
         return if (@current_api_user = Spree::User.find_by(spree_api_key: api_key.to_s))
 
         invalid_api_key
-      end
-
-      def restrict_feature
-        not_found unless OpenFoodNetwork::FeatureToggle.enabled?(:api_v1, @current_api_user)
       end
 
       def current_ability

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -33,9 +33,6 @@ module OpenFoodNetwork
         An API endpoint for reports at
         <code>/api/v0/reports/:report_type(/:report_subtype)</code>
       DESC
-      "api_v1" => <<~DESC,
-        Enable the new API at <code>/api/v1</code>
-      DESC
       "match_shipping_categories" => <<~DESC,
         During checkout, show only shipping methods that support <em>all</em>
         shipping categories. Activating this feature for an enterprise owner

--- a/spec/requests/api/v1/customer_account_transaction_spec.rb
+++ b/spec/requests/api/v1/customer_account_transaction_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml", feature: :api_v1 do
+RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml" do
   let!(:enterprise) { create(:enterprise) }
   let(:customer) { create(:customer) }
 

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "Customers", swagger_doc: "v1.yaml", feature: :api_v1 do
+RSpec.describe "Customers", swagger_doc: "v1.yaml" do
   let!(:enterprise1) { create(:enterprise, name: "The Farm") }
   let!(:enterprise2) { create(:enterprise) }
   let!(:enterprise3) { create(:enterprise) }

--- a/swagger/v1.yaml
+++ b/swagger/v1.yaml
@@ -77,7 +77,7 @@ components:
                 billing_address:
                   type: object
                   nullable: true
-                  example: 
+                  example:
                 shipping_address:
                   type: object
                   nullable: true
@@ -190,7 +190,7 @@ components:
                   billing_address:
                     type: object
                     nullable: true
-                    example: 
+                    example:
                   shipping_address:
                     type: object
                     nullable: true
@@ -481,7 +481,7 @@ paths:
                 billing_address:
                   type: object
                   nullable: true
-                  example: 
+                  example:
                 shipping_address:
                   type: object
                   nullable: true
@@ -574,7 +574,7 @@ paths:
                           billing_address:
                             type: object
                             nullable: true
-                            example: 
+                            example:
                           shipping_address:
                             type: object
                             nullable: true
@@ -704,7 +704,7 @@ paths:
                 billing_address:
                   type: object
                   nullable: true
-                  example: 
+                  example:
                 shipping_address:
                   type: object
                   nullable: true


### PR DESCRIPTION
 ## What? Why?

  - Closes #14012

  API v1 has been gated behind the `api_v1` feature toggle: unless the flag was  enabled for a user, every `/api/v1` endpoint returned 404, so the API was  invisible except to selected pilot users. The funded credit-payments work (UK  digital inclusion milestone) and the wider operational API roadmap both need  v1 generally available, so this removes the toggle.

  Authentication and authorization are unaffected. The toggle was only a  visibility gate (and a usage-monitoring measure that API-key requests already  cover). authenticate_user still identifies callers via session or  X-Api-Token/token API key, and CanCan still scopes all data to enterprises the  caller manages — verified live: an invalid API key still gets 401, and  anonymous requests get empty result sets, not data.

  Changes (5 files, +7/−15, no migration):
  - `base_controller.rb`: remove the `restrict_feature before-action` and method —  the single gate inherited by all v1 controllers  
  - `feature_toggle.rb`: remove `api_v1` from `CURRENT_FEATURES`; `FeatureToggle.setup!`  already removes stored Flipper records not in this list on boot, so the flag  cleans itself up without a migration  - the two v1 request specs: drop the `feature: :api_v1` metadata (`spec_helper`  raises on tags not in `CURRENT_FEATURES`)
  - `swagger/v1.yaml`: regenerated via `rswag`; whitespace-only churn, no endpoint  changes

  While live-testing the customer transaction endpoint I found a pre-existing  bug, unrelated to this change — filed separately as #14407.

##  What should we test?

  - Restart the app, then visit /admin/feature-toggle/features as super admin:  `api_v1` is no longer listed; other toggles are unaffected.
  - Visit `/api-docs` and select "API V1 Docs": all v1 endpoints are documented  and "Try it out" works.
  - GET `/api/v1/customers` as an enterprise owner (session or API key): 200 with  that enterprise's customers, without enabling any feature.
  - GET `/api/v1/customers` anonymously: 200 with empty data (previously 404).  - GET `/api/v1/customers` with an invalid X-Api-Token: still 401 — auth is  unchanged.
  - POST `/api/v1/customer_account_transaction` as an enterprise owner: 201 — the  credit endpoint works without the flag.

 ## Release notes

  Changelog Category (reviewers may add a label for the release notes):

  - [x] API changes (V0, V1, DFC or Webhook)

##  Documentation updates

  - [ ] The wiki page listing current feature toggles, if it includes  `api_v1` — entry should be removed.
  - [ ] The API documentation page(s) on the wiki /  dev.openfoodnetwork.org that describe v1 as experimental or instruct instance  managers to enable the `api_v1` flag — should now say v1 is generally available.
  - [ ]  Any instance-manager / super-admin guide section that walks  through enabling the flag for a user.

## Screenshots
Toggle Removed
<img width="613" height="529" alt="Screenshot from 2026-06-12 17-33-02" src="https://github.com/user-attachments/assets/89b46a94-c85a-4157-8bb4-114a04bafe1a" />
API-Docs page
<img width="730" height="725" alt="Screenshot from 2026-06-12 17-33-31" src="https://github.com/user-attachments/assets/296164bb-c4da-475d-b150-a83134c15980" />
API-Docs page works
<img width="731" height="935" alt="Screenshot from 2026-06-12 17-33-52" src="https://github.com/user-attachments/assets/6ad7a6fe-d209-40ee-b289-e45e42e89091" />
Key still has to be turned on for user
<img width="1516" height="1006" alt="Screenshot from 2026-06-12 17-41-42" src="https://github.com/user-attachments/assets/67733533-02bd-4dd3-984b-c7ccaa6172e2" />
API token works (not logged in)
<img width="922" height="1002" alt="Screenshot from 2026-06-12 17-34-56" src="https://github.com/user-attachments/assets/ca3bcb72-72ce-47bc-b1da-b28a50ffcd57" />
Wrong token returns error
<img width="1029" height="207" alt="Screenshot from 2026-06-12 17-47-57" src="https://github.com/user-attachments/assets/cb440c92-19a7-460d-9efe-ec22fc259494" />





