### PR TITLE
Fix Payments tab redirect for awaiting_return and returned orders

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -148,12 +148,14 @@ module Spree
       # At this point admin should have passed through Customer Details step
       # where order.next is called which leaves the order in payment step
       #
-      # Orders in complete or canceled step also allows to access this controller
+      # Orders in complete, canceled, resumed, awaiting_return or returned
+      # state also allow access to this controller
       #
       # Otherwise redirect user to that step
       def can_transition_to_payment
         return if @order.confirmation? || @order.payment? ||
-                  @order.complete? || @order.canceled? || @order.resumed?
+                  @order.complete? || @order.canceled? || @order.resumed? ||
+                  @order.awaiting_return? || @order.returned?
 
         flash[:notice] = Spree.t(:fill_in_customer_info)
         redirect_to spree.edit_admin_order_customer_url(@order)

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -293,6 +293,28 @@ RSpec.describe Spree::Admin::PaymentsController do
       end
     end
 
+    context "order is awaiting_return" do
+      let!(:payment_method) { create(:payment_method, distributors: [shop]) }
+      let!(:order) { create(:order, distributor: shop, state: "awaiting_return") }
+      let!(:payment) { create(:payment, order:, payment_method:, amount: order.total) }
+
+      it "renders the payments tab" do
+        spree_get :index, order_id: order.number
+        expect(response).to have_http_status :ok
+      end
+    end
+
+    context "order is returned" do
+      let!(:payment_method) { create(:payment_method, distributors: [shop]) }
+      let!(:order) { create(:order, distributor: shop, state: "returned") }
+      let!(:payment) { create(:payment, order:, payment_method:, amount: order.total) }
+
+      it "renders the payments tab" do
+        spree_get :index, order_id: order.number
+        expect(response).to have_http_status :ok
+      end
+    end
+
     context "the order contains an item that is out of stock" do
       let!(:order) { create(:order_with_totals, distributor: shop, state: 'payment') }
 


### PR DESCRIPTION
## What? Why?

- Closes #14404 

When a Return Authorization is created against a completed order, the order state
  transitions to `awaiting_return` (or `returned` after the RMA is received). The
  Payments tab remains visible in the admin order edit page, but clicking it redirects
  to Customer Details with "Please fill in the customer details before proceeding to
  payment".

  The cause is `can_transition_to_payment` in `PaymentsController`, which only allows
  access for `confirmation`, `payment`, `complete`, `canceled`, and `resumed` states.
  Both `awaiting_return` and `returned` are post-completion states \u2014 the order has
  already passed through checkout \u2014 so their exclusion from the whitelist is accidental.

  Fix: add `awaiting_return?` and `returned?` to the guard condition.


## What should we test?
- Create a completed order with at least one line item and a shipment.
  - Go to Admin \u2192 Edit Order \u2192 Return Authorizations \u2192 New, and save a new RMA.
  - Click the Payments tab on the order.
  - Expected: Payments list loads normally.
  - Previously: redirected to Customer Details with a misleading flash notice.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X ] User facing changes


<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


