### PR TITLE
Exclude cancelled orders from bulk co-op reports

### DIFF
--- a/lib/reporting/reports/bulk_coop/base.rb
+++ b/lib/reporting/reports/bulk_coop/base.rb
@@ -36,8 +36,7 @@ module Reporting
         def report_line_items
           @report_line_items ||= Reporting::LineItems.new(
             order_permissions,
-            @params,
-            CompleteVisibleOrdersQuery.new(order_permissions).call
+            @params
           )
         end
 

--- a/spec/lib/reports/bulk_coop_report_spec.rb
+++ b/spec/lib/reports/bulk_coop_report_spec.rb
@@ -30,13 +30,13 @@ module Reporting
                 expect(subject.table_items).to eq([li1])
               end
 
-              it 'shows canceled orders' do
+              it 'excludes canceled orders' do
                 o2 = create(:order, state: 'canceled', completed_at: 1.day.ago, order_cycle: oc1,
                                     distributor: d1)
                 line_item = build(:line_item_with_shipment,
                                   variant: group_buy_product.variants.first)
                 o2.line_items << line_item
-                expect(subject.table_items).to include(line_item)
+                expect(subject.table_items).not_to include(line_item)
               end
             end
 
@@ -49,13 +49,13 @@ module Reporting
                 expect(subject.table_items).to eq([li1])
               end
 
-              it 'shows canceled orders' do
+              it 'excludes canceled orders' do
                 o2 = create(:order, state: 'canceled', completed_at: 1.day.ago, order_cycle: oc1,
                                     distributor: d1)
                 line_item = build(:line_item_with_shipment,
                                   variant: group_buy_product.variants.first)
                 o2.line_items << line_item
-                expect(subject.table_items).to include(line_item)
+                expect(subject.table_items).not_to include(line_item)
               end
             end
           end
@@ -87,6 +87,17 @@ module Reporting
                 result = subject.query_result.flatten
                 expect(result).to include(li1)
               end
+            end
+          end
+
+          context "filtering by order state" do
+            it 'excludes cancelled orders' do
+              o2 = create(:order, state: 'canceled', completed_at: 1.day.ago, order_cycle: oc1,
+                                  distributor: d1)
+              cancelled_li = build(:line_item_with_shipment)
+              o2.line_items << cancelled_li
+
+              expect(subject.table_items).not_to include(cancelled_li)
             end
           end
 


### PR DESCRIPTION
## What? Why?

Closes #10159

Cancelled orders were appearing in all bulk co-op reports. BulkCoop::Base#report_line_items was passing CompleteVisibleOrdersQuery.new(order_permissions).call as an explicit orders_relation to Reporting::LineItems. This bypassed the default relation in LineItems#initialize, which already excludes cancelled orders via .not_state(:canceled).

Fix: Remove the explicit orders_relation argument so LineItems uses its default, which correctly excludes cancelled orders.

## What should we test?
- Create an order, complete it, then cancel it
- Visit any bulk co-op report (Allocation, Supplier, Packing Sheets, Customer Payments)
- Confirm the cancelled order does not appear in the results
- Confirm completed (non-cancelled) orders still appear as expected

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes


<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->


