### PR TITLE
Fix order cycle mail Report grouping by product and price.

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -32,7 +32,7 @@ class ProducerMailer < ApplicationMailer
 
     line_items = line_items_from(@order_cycle, @producer)
 
-    @grouped_line_items = line_items.group_by(&:product_and_full_name)
+    @grouped_line_items = line_items.group_by { |item| [item.product_and_full_name, item.price] }
     @distributors_pickup_times = distributors_pickup_times_for(line_items)
     @receival_instructions = @order_cycle.receival_instructions_for(@producer)
     @total = total_from_line_items(line_items)

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -34,7 +34,7 @@
         %th.text-right
           = t :included_tax
     %tbody
-      - @grouped_line_items.each_pair do |product_and_full_name, line_items|
+      - @grouped_line_items.each_pair do |(product_and_full_name, price), line_items|
         %tr
           %td
             = line_items.first.variant.sku

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe ProducerMailer do
 
     let(:zebra_rows) do
       parsed_email.all('table.order-summary.line-items tbody tr:not(.total-row)').select do |tr|
-          tr.text.include?(p1.name)
+        tr.text.include?(p1.name)
       end
     end
 

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -292,4 +292,28 @@ RSpec.describe ProducerMailer do
       end
     end
   end
+
+  context "when product price is modified in another order" do
+    let!(:order_with_modified_price) do
+      order = create(:order, distributor: d1, order_cycle:, state: 'complete')
+      order.line_items << create(:line_item, quantity: 2, variant: p1.variants.first, price: 16.50)
+      order.finalize!
+      order.save
+      order
+    end
+
+    it "checks whether quantity multiplied by price is equivalent to subtotal" do
+      row = parsed_email.all('table.order-summary.line-items tbody tr:not(.total-row)').find do |tr|
+        tr.text.include?('Zebra')
+      end
+
+      expect(row).not_to be_nil
+
+      cells = row.all('td').map { |td| td.text.strip }
+      quantity = cells[2].to_i
+      price = BigDecimal(cells[3].delete('$,'), 10)
+      subtotal = BigDecimal(cells[4].delete('$,'), 10)
+      expect(price * quantity).to eq(subtotal)
+    end
+  end
 end

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -302,18 +302,33 @@ RSpec.describe ProducerMailer do
       order
     end
 
-    it "checks whether quantity multiplied by price is equivalent to subtotal" do
-      row = parsed_email.all('table.order-summary.line-items tbody tr:not(.total-row)').find do |tr|
-        tr.text.include?('Zebra')
+    let(:zebra_rows) do
+      parsed_email.all('table.order-summary.line-items tbody tr:not(.total-row)').select do |tr|
+          tr.text.include?(p1.name)
       end
+    end
 
-      expect(row).not_to be_nil
+    it "shows product on separate rows for the different prices" do
+      expect(zebra_rows.size).to eq(2)
 
-      cells = row.all('td').map { |td| td.text.strip }
-      quantity = cells[2].to_i
-      price = BigDecimal(cells[3].delete('$,'), 10)
-      subtotal = BigDecimal(cells[4].delete('$,'), 10)
-      expect(price * quantity).to eq(subtotal)
+      quantities = zebra_rows.map { |tr| tr.all('td')[2].text.strip }
+      expect(quantities).to contain_exactly('3', '2')
+
+      prices = zebra_rows.map { |tr| tr.all('td')[3].text.strip }
+      expect(prices).to contain_exactly('$10.00', '$16.50')
+
+      subtotals = zebra_rows.map { |tr| tr.all('td')[4].text.strip }
+      expect(subtotals).to contain_exactly('$30.00', '$33.00')
+    end
+
+    it "validates subtotal to be equal to quantity multiplied by price for each row" do
+      zebra_rows.each do |row|
+        cells = row.all('td').map { |td| td.text.strip }
+        quantity = cells[2].to_i
+        price = BigDecimal(cells[3].delete('$,'), 10)
+        subtotal = BigDecimal(cells[4].delete('$,'), 10)
+        expect(price * quantity).to eq(subtotal)
+      end
     end
   end
 end


### PR DESCRIPTION
## What? Why?

- Closes #13413 

In the Producer Order Cycle Mail Report, products from different orders were grouped solely by product name. As a result, when the same product appeared in multiple orders at different unit prices, the quantity multiplied by unit price did not match the displayed total price because the price differences were not reflected.
This solution groups line items by both product name and unit price. In the report, same products with identical prices continue to be integrated into a single row, while products with different prices are displayed in separate rows, ensuring that unit prices and totals are reported accurately.


## What should we test?

1. Open an order cycle
2. Make an order with product A
3. Modify price of product A
4. Make another order with product A
5. Wait for end of cycle and check mail received by producer


## Release notes

<!-- Please select one for your PR and delete the other. -->

- [X] User facing changes


