### PR TITLE
feat(dfc): add orders endpoint (show, create, update, delete)

### DIFF
--- a/app/jobs/complete_backorder_job.rb
+++ b/app/jobs/complete_backorder_job.rb
@@ -22,7 +22,9 @@ class CompleteBackorderJob < ApplicationJob
 
     return if order&.lines.blank?
 
-    urls = FdcUrlBuilder.new(order.lines[0].offer.offeredItem.semanticId)
+    offered_item = order.lines[0].offer.offeredItem
+    semantic_id = offered_item.respond_to?(:semanticId) ? offered_item.semanticId : offered_item
+    urls = FdcUrlBuilder.new(semantic_id)
 
     BackorderUpdater.new.update(order, user, distributor, order_cycle)
 

--- a/app/jobs/complete_backorder_job.rb
+++ b/app/jobs/complete_backorder_job.rb
@@ -22,8 +22,7 @@ class CompleteBackorderJob < ApplicationJob
 
     return if order&.lines.blank?
 
-    offered_item = order.lines[0].offer.offeredItem
-    semantic_id = offered_item.respond_to?(:semanticId) ? offered_item.semanticId : offered_item
+    semantic_id = DfcBuilder.semantic_id(order.lines[0].offer.offeredItem)
     urls = FdcUrlBuilder.new(semantic_id)
 
     BackorderUpdater.new.update(order, user, distributor, order_cycle)

--- a/app/jobs/complete_backorder_job.rb
+++ b/app/jobs/complete_backorder_job.rb
@@ -22,7 +22,7 @@ class CompleteBackorderJob < ApplicationJob
 
     return if order&.lines.blank?
 
-    semantic_id = DfcBuilder.semantic_id(order.lines[0].offer.offeredItem)
+    semantic_id = DfcBuilder.extract_semantic_id(order.lines[0].offer.offeredItem)
     urls = FdcUrlBuilder.new(semantic_id)
 
     BackorderUpdater.new.update(order, user, distributor, order_cycle)

--- a/app/models/spree/stock/availability_validator.rb
+++ b/app/models/spree/stock/availability_validator.rb
@@ -5,7 +5,7 @@ module Spree
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
         # OFN specific check for in-memory :skip_stock_check attribute
-        return if line_item.skip_stock_check
+        return if line_item.skip_stock_check || line_item.variant.blank?
 
         quantity_to_validate = line_item.quantity - quantity_in_shipment(line_item)
         return if quantity_to_validate < 1

--- a/app/services/backorder_updater.rb
+++ b/app/services/backorder_updater.rb
@@ -75,7 +75,12 @@ class BackorderUpdater
   def cancel_stale_lines(unprocessed_lines, managed_variants, broker)
     unprocessed_lines.each do |line|
       wholesale_quantity = line.quantity.to_i
-      wholesale_product_id = line.offer.offeredItem.semanticId
+      offered_item = line.offer.offeredItem
+      wholesale_product_id = if offered_item.respond_to?(:semanticId)
+                               offered_item.semanticId
+                             else
+                               offered_item
+                             end
       transformation = broker.wholesale_to_retail(wholesale_product_id)
       linked_variant = managed_variants.linked_to(transformation.retail_product_id)
 

--- a/app/services/backorder_updater.rb
+++ b/app/services/backorder_updater.rb
@@ -75,12 +75,7 @@ class BackorderUpdater
   def cancel_stale_lines(unprocessed_lines, managed_variants, broker)
     unprocessed_lines.each do |line|
       wholesale_quantity = line.quantity.to_i
-      offered_item = line.offer.offeredItem
-      wholesale_product_id = if offered_item.respond_to?(:semanticId)
-                               offered_item.semanticId
-                             else
-                               offered_item
-                             end
+      wholesale_product_id = DfcBuilder.semantic_id(line.offer.offeredItem)
       transformation = broker.wholesale_to_retail(wholesale_product_id)
       linked_variant = managed_variants.linked_to(transformation.retail_product_id)
 

--- a/app/services/backorder_updater.rb
+++ b/app/services/backorder_updater.rb
@@ -75,7 +75,7 @@ class BackorderUpdater
   def cancel_stale_lines(unprocessed_lines, managed_variants, broker)
     unprocessed_lines.each do |line|
       wholesale_quantity = line.quantity.to_i
-      wholesale_product_id = DfcBuilder.semantic_id(line.offer.offeredItem)
+      wholesale_product_id = DfcBuilder.extract_semantic_id(line.offer.offeredItem)
       transformation = broker.wholesale_to_retail(wholesale_product_id)
       linked_variant = managed_variants.linked_to(transformation.retail_product_id)
 

--- a/app/services/fdc_backorderer.rb
+++ b/app/services/fdc_backorderer.rb
@@ -62,7 +62,7 @@ class FdcBackorderer
     # Suggested by FDC team:
     next_id = order.lines.count + 1
 
-    OrderLineBuilder.build(offer, 0).tap do |line|
+    OrderLineBuilder.build_from_offer(offer, 0).tap do |line|
       line.semanticId = "#{order.semanticId}/OrderLines/#{next_id}"
       order.lines << line
     end

--- a/app/services/fdc_backorderer.rb
+++ b/app/services/fdc_backorderer.rb
@@ -70,8 +70,12 @@ class FdcBackorderer
 
   def find_order_line(order, offer)
     order.lines.find do |line|
-      line.offer.offeredItem.semanticId == offer.offeredItem.semanticId
+      semantic_id(line.offer.offeredItem) == semantic_id(offer.offeredItem)
     end
+  end
+
+  def semantic_id(item)
+    item.respond_to?(:semanticId) ? item.semanticId : item
   end
 
   def find_subject(object_or_graph, type)

--- a/app/services/fdc_backorderer.rb
+++ b/app/services/fdc_backorderer.rb
@@ -70,15 +70,9 @@ class FdcBackorderer
 
   def find_order_line(order, offer)
     order.lines.find do |line|
-      semantic_id(line.offer.offeredItem) == semantic_id(offer.offeredItem)
+      DfcBuilder.semantic_id(line.offer.offeredItem) == DfcBuilder.semantic_id(offer.offeredItem)
     end
   end
-
-  # rubocop:disable Rails/Delegate
-  def semantic_id(item)
-    DfcBuilder.semantic_id(item)
-  end
-  # rubocop:enable Rails/Delegate
 
   def find_subject(object_or_graph, type)
     if object_or_graph.is_a?(Array)

--- a/app/services/fdc_backorderer.rb
+++ b/app/services/fdc_backorderer.rb
@@ -74,9 +74,11 @@ class FdcBackorderer
     end
   end
 
+  # rubocop:disable Rails/Delegate
   def semantic_id(item)
     DfcBuilder.semantic_id(item)
   end
+  # rubocop:enable Rails/Delegate
 
   def find_subject(object_or_graph, type)
     if object_or_graph.is_a?(Array)

--- a/app/services/fdc_backorderer.rb
+++ b/app/services/fdc_backorderer.rb
@@ -75,7 +75,7 @@ class FdcBackorderer
   end
 
   def semantic_id(item)
-    item.respond_to?(:semanticId) ? item.semanticId : item
+    DfcBuilder.semantic_id(item)
   end
 
   def find_subject(object_or_graph, type)

--- a/app/services/fdc_backorderer.rb
+++ b/app/services/fdc_backorderer.rb
@@ -69,8 +69,10 @@ class FdcBackorderer
   end
 
   def find_order_line(order, offer)
+    offered_item_id = DfcBuilder.extract_semantic_id(offer.offeredItem)
+
     order.lines.find do |line|
-      DfcBuilder.semantic_id(line.offer.offeredItem) == DfcBuilder.semantic_id(offer.offeredItem)
+      DfcBuilder.extract_semantic_id(line.offer.offeredItem) == offered_item_id
     end
   end
 

--- a/app/services/fdc_url_builder.rb
+++ b/app/services/fdc_url_builder.rb
@@ -5,12 +5,14 @@
 class FdcUrlBuilder
   attr_reader :catalog_url, :orders_url, :sale_session_url
 
-  # At the moment, we start with a product link like this:
-  #
-  # https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/SuppliedProducts/44519466467635
+  # Known product link formats:
+  # * https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/SuppliedProducts/44519466467635
+  # * http://test.host/api/dfc/enterprises/10000/supplied_products/10001 (OFN)
   def initialize(semantic_id)
-    @catalog_url, _slash, _id = semantic_id.rpartition("/")
-    @orders_url = @catalog_url.sub("/SuppliedProducts", "/Orders")
-    @sale_session_url = @catalog_url.sub("/SuppliedProducts", "/SalesSession/#")
+    base_url, _slash, _id = semantic_id.rpartition("/")
+    @catalog_url = base_url.sub("/supplied_products", "/catalog_items")
+    @orders_url = base_url.sub("/SuppliedProducts", "/Orders")
+      .sub("/supplied_products", "/orders")
+    @sale_session_url = base_url.sub("/SuppliedProducts", "/SalesSession/#")
   end
 end

--- a/app/services/fdc_url_builder.rb
+++ b/app/services/fdc_url_builder.rb
@@ -14,5 +14,6 @@ class FdcUrlBuilder
     @orders_url = base_url.sub("/SuppliedProducts", "/Orders")
       .sub("/supplied_products", "/orders")
     @sale_session_url = base_url.sub("/SuppliedProducts", "/SalesSession/#")
+      .sub("/supplied_products", "/SalesSession/#")
   end
 end

--- a/engines/dfc_provider/app/controllers/dfc_provider/application_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/application_controller.rb
@@ -83,27 +83,28 @@ module DfcProvider
       OpenFoodNetwork::FeatureToggle.enabled?(feature, *actors)
     end
 
-    def render_dfc(subject = nil, *)
-      return render_v1(*subject, *) if profile != "dfc-v2"
-      return render_v2(subject, *) unless subject.is_a?(Array)
+    def render_dfc(subject = nil, *subjects, status: :ok)
+      return render_v1(*subject, *subjects, status:) if profile != "dfc-v2"
+      return render_v2(subject, *subjects, status:) unless subject.is_a?(Array)
 
       # DFCv2 requires containers for listing resources in an index action.
       # We need to pass DFCv2 data into the container because the migration
       # will skip the container itself as it's not a DFCv1 class.
       members = migration.up(*subject)
       container = Container.new(url_for, members:)
-      render_v2(container, *subject, *)
+      render_v2(container, *subject, *subjects, status:)
     end
 
-    def render_v1(*)
-      render json: DfcIo.export(*)
+    def render_v1(*subjects, status: :ok)
+      render json: DfcIo.export(*subjects), status:
     end
 
-    def render_v2(*)
-      objects = migration.up(*)
+    def render_v2(*subjects, status: :ok)
+      objects = migration.up(*subjects)
 
       render json: DfcLoader.connector_v2.export(*objects),
-             content_type: 'application/ld+json; profile="dfc-v2"'
+             content_type: 'application/ld+json; profile="dfc-v2"',
+             status:
     end
 
     def migration

--- a/engines/dfc_provider/app/controllers/dfc_provider/application_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/application_controller.rb
@@ -83,27 +83,28 @@ module DfcProvider
       OpenFoodNetwork::FeatureToggle.enabled?(feature, *actors)
     end
 
-    def render_dfc(subject = nil, *)
-      return render_v1(*subject, *) if profile != "dfc-v2"
-      return render_v2(subject, *) unless subject.is_a?(Array)
+    def render_dfc(subject = nil, *rest, status: :ok)
+      return render_v1(*subject, *rest, status: status) if profile != "dfc-v2"
+      return render_v2(subject, *rest, status: status) unless subject.is_a?(Array)
 
       # DFCv2 requires containers for listing resources in an index action.
       # We need to pass DFCv2 data into the container because the migration
       # will skip the container itself as it's not a DFCv1 class.
       members = migration.up(*subject)
       container = Container.new(url_for, members:)
-      render_v2(container, *subject, *)
+      render_v2(container, *subject, *rest, status: status)
     end
 
-    def render_v1(*)
-      render json: DfcIo.export(*)
+    def render_v1(*subjects, status: :ok)
+      render json: DfcIo.export(*subjects), status: status
     end
 
-    def render_v2(*)
-      objects = migration.up(*)
+    def render_v2(*subjects, status: :ok)
+      objects = migration.up(*subjects)
 
       render json: DfcLoader.connector_v2.export(*objects),
-             content_type: 'application/ld+json; profile="dfc-v2"'
+             content_type: 'application/ld+json; profile="dfc-v2"',
+             status: status
     end
 
     def migration

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -44,6 +44,8 @@ module DfcProvider
 
       if OrderBuilder.apply(order, dfc_order)
         order.recreate_all_fees!
+        order.create_tax_charge!
+        order.update_order!
         render_dfc(OrderBuilder.build(order))
       else
         render json: { error: order.errors.full_messages.to_sentence },

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module DfcProvider
+  class OrdersController < DfcProvider::ApplicationController
+    before_action :check_enterprise
+
+    def show
+      dfc_order = OrderBuilder.build(order)
+      lines = OrderBuilder.build_order_lines(dfc_order, order.line_items)
+      offers = lines.map(&:offer)
+      catalog_items = offers.map(&:offeredItem)
+
+      sessions = [build_sale_session(order)]
+      render_dfc(dfc_order, *lines, *offers, *catalog_items, *sessions)
+    end
+
+    def create
+      graph = import
+      dfc_order = select_type(graph, "dfc-b:Order").first if graph
+
+      return head :bad_request unless dfc_order
+
+      @order = current_enterprise.distributed_orders.build(
+        user: current_user,
+        created_by: current_user,
+        email: current_user.email,
+        customer: current_user.customers.find_by(enterprise: current_enterprise),
+      )
+
+      if @order.save && OrderBuilder.apply(@order, dfc_order)
+        subject = OrderBuilder.build(@order)
+        render json: DfcIo.export(subject), status: :created
+      else
+        render json: { error: @order.errors.full_messages.to_sentence },
+               status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def order
+      @order ||= current_enterprise.distributed_orders.find(params[:id])
+    end
+
+    def select_type(graph, semantic_type)
+      graph.select { |i| i.semanticType == semantic_type }
+    end
+
+    def build_sale_session(order)
+      SaleSessionBuilder.build(order.order_cycle).tap do |session|
+        session.semanticId = "/api/dfc/SalesSession/#"
+      end
+    end
+  end
+end

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -36,6 +36,32 @@ module DfcProvider
       end
     end
 
+    def update
+      graph = import
+      dfc_order = select_type(graph, "dfc-b:Order").first if graph
+
+      return head :bad_request unless dfc_order
+
+      if OrderBuilder.apply(order, dfc_order)
+        order.recreate_all_fees!
+        render_dfc(OrderBuilder.build(order))
+      else
+        render json: { error: order.errors.full_messages.to_sentence },
+               status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      if order.allow_cancel?
+        order.send_cancellation_email = false
+        order.cancel!
+        head :no_content
+      else
+        render json: { error: "Cannot cancel order in state '#{order.state}'" },
+               status: :unprocessable_entity
+      end
+    end
+
     private
 
     def order

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -48,7 +48,7 @@ module DfcProvider
 
     def build_sale_session(order)
       SaleSessionBuilder.build(order.order_cycle).tap do |session|
-        session.semanticId = "/api/dfc/SalesSession/#"
+        session.semanticId = enterprise_supplied_products_url(current_enterprise.id)
       end
     end
   end

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -31,6 +31,7 @@ module DfcProvider
         subject = OrderBuilder.build(@order)
         render json: DfcIo.export(subject), status: :created
       else
+        @order.destroy if @order.persisted?
         render json: { error: @order.errors.full_messages.to_sentence },
                status: :unprocessable_entity
       end
@@ -76,7 +77,7 @@ module DfcProvider
 
     def build_sale_session(order)
       SaleSessionBuilder.build(order.order_cycle).tap do |session|
-        session.semanticId = enterprise_supplied_products_url(current_enterprise.id)
+        session.semanticId = "#{enterprise_url(current_enterprise.id)}/SalesSession/#"
       end
     end
   end

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -8,16 +8,13 @@ module DfcProvider
       dfc_order = OrderBuilder.build(order)
       lines = OrderBuilder.build_order_lines(dfc_order, order.line_items)
       offers = lines.map(&:offer)
-      catalog_items = offers.map(&:offeredItem)
+      supplied_products = offers.map(&:offeredItem)
 
       sessions = [build_sale_session(order)]
-      render_dfc(dfc_order, *lines, *offers, *catalog_items, *sessions)
+      render_dfc(dfc_order, *lines, *offers, *supplied_products, *sessions)
     end
 
     def create
-      graph = import
-      dfc_order = select_type(graph, "dfc-b:Order").first if graph
-
       return head :bad_request unless dfc_order
 
       @order = current_enterprise.distributed_orders.build(
@@ -27,30 +24,25 @@ module DfcProvider
         customer: current_user.customers.find_by(enterprise: current_enterprise),
       )
 
-      if @order.save && OrderBuilder.apply(@order, dfc_order)
-        subject = OrderBuilder.build(@order)
-        render json: DfcIo.export(subject), status: :created
+      if @order.save && apply(@order)
+        @order.update_order!
+        render_dfc(OrderBuilder.build(@order), status: :created)
       else
         @order.destroy if @order.persisted?
-        render json: { error: @order.errors.full_messages.to_sentence },
-               status: :unprocessable_entity
+        render_error(@order)
       end
     end
 
     def update
-      graph = import
-      dfc_order = select_type(graph, "dfc-b:Order").first if graph
-
       return head :bad_request unless dfc_order
 
-      if OrderBuilder.apply(order, dfc_order)
+      if apply(order)
         order.recreate_all_fees!
         order.create_tax_charge!
         order.update_order!
         render_dfc(OrderBuilder.build(order))
       else
-        render json: { error: order.errors.full_messages.to_sentence },
-               status: :unprocessable_entity
+        render_error(order)
       end
     end
 
@@ -71,8 +63,25 @@ module DfcProvider
       @order ||= current_enterprise.distributed_orders.find(params[:id])
     end
 
+    def apply(ofn_order)
+      OrderBuilder.apply(ofn_order, dfc_order, variant_scope: current_enterprise.variants)
+    end
+
+    # `DfcIo.import` returns a bare object when the payload contains only one
+    # subject, for example when a client just updates the order status.
+    def dfc_order
+      return @dfc_order if defined?(@dfc_order)
+
+      @dfc_order = select_type(Array.wrap(import), "dfc-b:Order").first
+    end
+
     def select_type(graph, semantic_type)
       graph.select { |i| i.semanticType == semantic_type }
+    end
+
+    def render_error(ofn_order)
+      render json: { error: ofn_order.errors.full_messages.to_sentence },
+             status: :unprocessable_entity
     end
 
     def build_sale_session(order)

--- a/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/orders_controller.rb
@@ -14,6 +14,7 @@ module DfcProvider
       render_dfc(dfc_order, *lines, *offers, *catalog_items, *sessions)
     end
 
+    # rubocop:disable Metrics/AbcSize
     def create
       graph = import
       dfc_order = select_type(graph, "dfc-b:Order").first if graph
@@ -27,15 +28,19 @@ module DfcProvider
         customer: current_user.customers.find_by(enterprise: current_enterprise),
       )
 
-      if @order.save && OrderBuilder.apply(@order, dfc_order)
+      if OrderBuilder.apply(@order, dfc_order, current_enterprise)
+        @order.recreate_all_fees!
+        @order.create_tax_charge!
+        @order.update_order!
         subject = OrderBuilder.build(@order)
-        render json: DfcIo.export(subject), status: :created
+        response.headers["Location"] = subject.semanticId
+        render_dfc(subject, status: :created)
       else
-        @order.destroy if @order.persisted?
         render json: { error: @order.errors.full_messages.to_sentence },
                status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def update
       graph = import
@@ -43,7 +48,7 @@ module DfcProvider
 
       return head :bad_request unless dfc_order
 
-      if OrderBuilder.apply(order, dfc_order)
+      if OrderBuilder.apply(order, dfc_order, current_enterprise)
         order.recreate_all_fees!
         order.create_tax_charge!
         order.update_order!
@@ -71,8 +76,12 @@ module DfcProvider
       @order ||= current_enterprise.distributed_orders.find(params[:id])
     end
 
+    def import
+      super.then { |graph| Array.wrap(graph) }
+    end
+
     def select_type(graph, semantic_type)
-      graph.select { |i| i.semanticType == semantic_type }
+      Array.wrap(graph).select { |i| i.semanticType == semantic_type }
     end
 
     def build_sale_session(order)

--- a/engines/dfc_provider/app/services/catalog_item_builder.rb
+++ b/engines/dfc_provider/app/services/catalog_item_builder.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class CatalogItemBuilder < DfcBuilder
-  def self.catalog_item(variant)
+  def self.catalog_item(variant, include_product: true)
     id = urls.enterprise_catalog_item_url(
       enterprise_id: variant.supplier_id,
       id: variant.id,
     )
     supplier_url = urls.enterprise_url(variant.supplier_id)
-    product = SuppliedProductBuilder.supplied_product(variant)
+    product = SuppliedProductBuilder.supplied_product(variant) if include_product
 
     DfcProvider::CatalogItem.new(
       id, product:,

--- a/engines/dfc_provider/app/services/catalog_item_builder.rb
+++ b/engines/dfc_provider/app/services/catalog_item_builder.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class CatalogItemBuilder < DfcBuilder
-  def self.catalog_item(variant)
+  def self.catalog_item(variant, include_product: true)
     id = urls.enterprise_catalog_item_url(
       enterprise_id: variant.enterprise_id,
       id: variant.id,
     )
     supplier_url = urls.enterprise_url(variant.enterprise_id)
-    product = SuppliedProductBuilder.supplied_product(variant)
+    product = SuppliedProductBuilder.supplied_product(variant) if include_product
 
     DfcProvider::CatalogItem.new(
       id, product:,

--- a/engines/dfc_provider/app/services/dfc_builder.rb
+++ b/engines/dfc_provider/app/services/dfc_builder.rb
@@ -1,8 +1,21 @@
 # frozen_string_literal: true
 
 class DfcBuilder
-  # The DFC sees "empty" stock as unlimited.
-  # http://static.datafoodconsortium.org/conception/DFC%20-%20Business%20rules.pdf
+  def self.catalog_item(variant, include_product: true)
+    id = urls.enterprise_catalog_item_url(
+      enterprise_id: variant.supplier_id,
+      id: variant.id,
+    )
+    product = SuppliedProductBuilder.supplied_product(variant) if include_product
+
+    DataFoodConsortium::ConnectorV1::CatalogItem.new(
+      id, product:,
+          sku: variant.sku,
+          stockLimitation: stock_limitation(variant),
+          offers: [OfferBuilder.build(variant)],
+    )
+  end
+
   def self.stock_limitation(variant)
     variant.on_demand ? nil : variant.total_on_hand
   end

--- a/engines/dfc_provider/app/services/dfc_builder.rb
+++ b/engines/dfc_provider/app/services/dfc_builder.rb
@@ -1,21 +1,6 @@
 # frozen_string_literal: true
 
 class DfcBuilder
-  def self.catalog_item(variant, include_product: true)
-    id = urls.enterprise_catalog_item_url(
-      enterprise_id: variant.supplier_id,
-      id: variant.id,
-    )
-    product = SuppliedProductBuilder.supplied_product(variant) if include_product
-
-    DataFoodConsortium::ConnectorV1::CatalogItem.new(
-      id, product:,
-          sku: variant.sku,
-          stockLimitation: stock_limitation(variant),
-          offers: [OfferBuilder.build(variant)],
-    )
-  end
-
   def self.stock_limitation(variant)
     variant.on_demand ? nil : variant.total_on_hand
   end

--- a/engines/dfc_provider/app/services/dfc_builder.rb
+++ b/engines/dfc_provider/app/services/dfc_builder.rb
@@ -8,4 +8,8 @@ class DfcBuilder
   def self.urls
     DfcProvider::Engine.routes.url_helpers
   end
+
+  def self.semantic_id(item)
+    item.respond_to?(:semanticId) ? item.semanticId : item.to_s
+  end
 end

--- a/engines/dfc_provider/app/services/dfc_builder.rb
+++ b/engines/dfc_provider/app/services/dfc_builder.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DfcBuilder
+  # The DFC sees "empty" stock as unlimited.
+  # http://static.datafoodconsortium.org/conception/DFC%20-%20Business%20rules.pdf
   def self.stock_limitation(variant)
     variant.on_demand ? nil : variant.total_on_hand
   end
@@ -9,7 +11,7 @@ class DfcBuilder
     DfcProvider::Engine.routes.url_helpers
   end
 
-  def self.semantic_id(item)
+  def self.extract_semantic_id(item)
     item.respond_to?(:semanticId) ? item.semanticId : item.to_s
   end
 end

--- a/engines/dfc_provider/app/services/dfc_loader.rb
+++ b/engines/dfc_provider/app/services/dfc_loader.rb
@@ -29,9 +29,13 @@ class DfcLoader
     load_thesaurus(connector, name)
   end
 
+  # Each connector needs its own copy of a thesaurus. Caching only by name
+  # would leave whichever connector asked second without the vocabulary, and it
+  # would then deserialise terms like "dfc-v:Held" into a parsed URI Hash
+  # instead of a SKOSConcept.
   def self.load_thesaurus(connector, name)
     @vocabs ||= {}
-    @vocabs[name] ||= connector.__send__(:loadThesaurus, read_file(name))
+    @vocabs[[connector.class, name]] ||= connector.__send__(:loadThesaurus, read_file(name))
   end
 
   def self.read_file(name)

--- a/engines/dfc_provider/app/services/dfc_loader.rb
+++ b/engines/dfc_provider/app/services/dfc_loader.rb
@@ -31,7 +31,7 @@ class DfcLoader
 
   def self.load_thesaurus(connector, name)
     @vocabs ||= {}
-    @vocabs[name] ||= connector.__send__(:loadThesaurus, read_file(name))
+    @vocabs[[connector.class, name]] ||= connector.__send__(:loadThesaurus, read_file(name))
   end
 
   def self.read_file(name)

--- a/engines/dfc_provider/app/services/offer_builder.rb
+++ b/engines/dfc_provider/app/services/offer_builder.rb
@@ -16,6 +16,10 @@ class OfferBuilder < DfcBuilder
     )
   end
 
+  def self.add_offered_item(offer, variant)
+    offer.offeredItem = SuppliedProductBuilder.supplied_product(variant)
+  end
+
   def self.apply(offer, variant)
     return if offer.nil?
 

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -25,16 +25,34 @@ class OrderBuilder < DfcBuilder
   def self.apply(ofn_order, dfc_order)
     ofn_order.state = "complete" if dfc_order.orderStatus == order_states.HELD
 
-    dfc_order.lines.each do |order_line|
-      variant_id = order_line.offer.offeredItem.split('/supplied_products/').last
-
-      ofn_order.line_items.build(
-        variant_id:,
-        quantity: order_line.quantity
-      )
+    if dfc_order.orderStatus == order_states.COMPLETE
+      ofn_order.completed_at ||= Time.zone.now
     end
 
-    ofn_order.save
+    ofn_order.update(
+      line_items_attributes: line_item_attributes(ofn_order, dfc_order)
+    )
+  end
+
+  def self.line_item_attributes(ofn_order, dfc_order)
+    incoming = dfc_order.lines.each_with_object({}) do |line, hash|
+      next if line.quantity.nil? || line.quantity <= 0
+
+      vid = line.offer.offeredItem.split('/supplied_products/').last
+      hash[vid.to_i] = line.quantity
+    end
+
+    ofn_order.line_items.each_with_object([]) do |li, arr|
+      arr << if incoming.key?(li.variant_id)
+               { id: li.id, quantity: incoming.delete(li.variant_id) }
+             else
+               { id: li.id, _destroy: true }
+             end
+    end.tap do |attrs|
+      incoming.each do |variant_id, quantity|
+        attrs << { variant_id:, quantity: }
+      end
+    end
   end
 
   def self.order_states

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -8,4 +8,44 @@ class OrderBuilder < DfcBuilder
       orderStatus: "dfc-v:Held",
     )
   end
+
+  def self.build(ofn_order)
+    id = urls.enterprise_order_url(
+      enterprise_id: ofn_order.distributor_id,
+      id: ofn_order.id,
+    )
+
+    DataFoodConsortium::ConnectorV1::Order.new(
+      id,
+      client: urls.enterprise_url(ofn_order.distributor_id),
+      orderStatus: "dfc-v:Held",
+    )
+  end
+
+  def self.apply(ofn_order, dfc_order)
+    ofn_order.state = "complete" if dfc_order.orderStatus == order_states.HELD
+
+    dfc_order.lines.each do |order_line|
+      variant_id = order_line.offer.offeredItem.split('/supplied_products/').last
+
+      ofn_order.line_items.build(
+        variant_id:,
+        quantity: order_line.quantity
+      )
+    end
+
+    ofn_order.save
+  end
+
+  def self.order_states
+    DfcLoader.vocabulary("vocabulary").STATES.ORDERSTATE
+  end
+
+  def self.build_order_lines(dfc_order, ofn_line_items)
+    dfc_order.lines = ofn_line_items.map do |line_item|
+      OrderLineBuilder.build(dfc_order, line_item).tap do |order_line|
+        OfferBuilder.add_offered_item(order_line.offer, line_item.variant)
+      end
+    end
+  end
 end

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -23,15 +23,25 @@ class OrderBuilder < DfcBuilder
   end
 
   def self.apply(ofn_order, dfc_order)
+    # Set order state if recognised
+    set_order_state(ofn_order, dfc_order)
+
+    attrs = line_item_attributes(ofn_order, dfc_order)
+    destroy_stale_line_items(ofn_order, attrs)
+
+    ofn_order.update(line_items_attributes: attrs.reject { |a| a[:_destroy] })
+  end
+
+  def self.set_order_state(ofn_order, dfc_order)
     ofn_order.state = "complete" if dfc_order.orderStatus == order_states.HELD
+    ofn_order.completed_at ||= Time.zone.now if dfc_order.orderStatus == order_states.COMPLETE
+  end
 
-    if dfc_order.orderStatus == order_states.COMPLETE
-      ofn_order.completed_at ||= Time.zone.now
-    end
-
-    ofn_order.update(
-      line_items_attributes: line_item_attributes(ofn_order, dfc_order)
-    )
+  def self.destroy_stale_line_items(ofn_order, attrs)
+    # `accepts_nested_attributes_for :line_items` does not permit `:_destroy`,
+    # so remove line items that are no longer present explicitly.
+    stale_ids = attrs.filter_map { |a| a[:id] if a[:_destroy] }
+    ofn_order.line_items.where(id: stale_ids).destroy_all if stale_ids.any?
   end
 
   def self.line_item_attributes(ofn_order, dfc_order)

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -64,12 +64,15 @@ class OrderBuilder < DfcBuilder
 
     ofn_order.line_items.each do |li|
       if incoming.key?(li.variant_id)
+        # Update existing line items
         attrs << { id: li.id, quantity: incoming.delete(li.variant_id) }
       else
+        # Delete line items that weren't provided
         stale_ids << li.id
       end
     end
 
+    # Create any new line items
     incoming.each do |variant_id, quantity|
       attrs << { variant_id:, quantity: }
     end

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -44,14 +44,21 @@ class OrderBuilder < DfcBuilder
   end
 
   def self.line_item_attributes(ofn_order, dfc_order)
-    incoming = dfc_order.lines.each_with_object({}) do |line, hash|
+    incoming = incoming_quantities(dfc_order)
+    build_line_item_attributes(ofn_order, incoming)
+  end
+
+  def self.incoming_quantities(dfc_order)
+    dfc_order.lines.each_with_object({}) do |line, hash|
       next if line.quantity.nil? || line.quantity <= 0
       next if line.offer&.offeredItem.nil?
 
-      vid = semantic_id(line.offer.offeredItem).split(/\/supplied_products\//i).last
+      vid = semantic_id(line.offer.offeredItem).split(%r{/supplied_products/}i).last
       hash[vid.to_i] = line.quantity
     end
+  end
 
+  def self.build_line_item_attributes(ofn_order, incoming)
     attrs = []
     stale_ids = []
 

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -26,7 +26,8 @@ class OrderBuilder < DfcBuilder
     # Set order state if recognised
     set_order_state(ofn_order, dfc_order)
 
-    attrs, stale_ids = line_item_attributes(ofn_order, dfc_order)
+    incoming = incoming_quantities(dfc_order)
+    attrs, stale_ids = build_line_item_attributes(ofn_order, incoming)
     destroy_stale_line_items(ofn_order, stale_ids)
 
     ofn_order.update(line_items_attributes: attrs)
@@ -41,11 +42,6 @@ class OrderBuilder < DfcBuilder
     # `accepts_nested_attributes_for :line_items` does not permit `:_destroy`,
     # so remove line items that are no longer present explicitly.
     ofn_order.line_items.where(id: stale_ids).destroy_all if stale_ids.any?
-  end
-
-  def self.line_item_attributes(ofn_order, dfc_order)
-    incoming = incoming_quantities(dfc_order)
-    build_line_item_attributes(ofn_order, incoming)
   end
 
   def self.incoming_quantities(dfc_order)

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -26,10 +26,10 @@ class OrderBuilder < DfcBuilder
     # Set order state if recognised
     set_order_state(ofn_order, dfc_order)
 
-    attrs = line_item_attributes(ofn_order, dfc_order)
-    destroy_stale_line_items(ofn_order, attrs)
+    attrs, stale_ids = line_item_attributes(ofn_order, dfc_order)
+    destroy_stale_line_items(ofn_order, stale_ids)
 
-    ofn_order.update(line_items_attributes: attrs.reject { |a| a[:_destroy] })
+    ofn_order.update(line_items_attributes: attrs)
   end
 
   def self.set_order_state(ofn_order, dfc_order)
@@ -37,32 +37,37 @@ class OrderBuilder < DfcBuilder
     ofn_order.completed_at ||= Time.zone.now if dfc_order.orderStatus == order_states.COMPLETE
   end
 
-  def self.destroy_stale_line_items(ofn_order, attrs)
+  def self.destroy_stale_line_items(ofn_order, stale_ids)
     # `accepts_nested_attributes_for :line_items` does not permit `:_destroy`,
     # so remove line items that are no longer present explicitly.
-    stale_ids = attrs.filter_map { |a| a[:id] if a[:_destroy] }
     ofn_order.line_items.where(id: stale_ids).destroy_all if stale_ids.any?
   end
 
   def self.line_item_attributes(ofn_order, dfc_order)
     incoming = dfc_order.lines.each_with_object({}) do |line, hash|
       next if line.quantity.nil? || line.quantity <= 0
+      next if line.offer&.offeredItem.nil?
 
-      vid = line.offer.offeredItem.split('/supplied_products/').last
+      vid = semantic_id(line.offer.offeredItem).split(/\/supplied_products\//i).last
       hash[vid.to_i] = line.quantity
     end
 
-    ofn_order.line_items.each_with_object([]) do |li, arr|
-      arr << if incoming.key?(li.variant_id)
-               { id: li.id, quantity: incoming.delete(li.variant_id) }
-             else
-               { id: li.id, _destroy: true }
-             end
-    end.tap do |attrs|
-      incoming.each do |variant_id, quantity|
-        attrs << { variant_id:, quantity: }
+    attrs = []
+    stale_ids = []
+
+    ofn_order.line_items.each do |li|
+      if incoming.key?(li.variant_id)
+        attrs << { id: li.id, quantity: incoming.delete(li.variant_id) }
+      else
+        stale_ids << li.id
       end
     end
+
+    incoming.each do |variant_id, quantity|
+      attrs << { variant_id:, quantity: }
+    end
+
+    [attrs, stale_ids]
   end
 
   def self.order_states

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -18,62 +18,84 @@ class OrderBuilder < DfcBuilder
     DataFoodConsortium::ConnectorV1::Order.new(
       id,
       client: urls.enterprise_url(ofn_order.distributor_id),
-      orderStatus: "dfc-v:Held",
+      orderStatus: order_status(ofn_order),
     )
   end
 
-  def self.apply(ofn_order, dfc_order)
-    # Set order state if recognised
-    set_order_state(ofn_order, dfc_order)
-
-    incoming = incoming_quantities(dfc_order)
-    attrs, stale_ids = build_line_item_attributes(ofn_order, incoming)
-    destroy_stale_line_items(ofn_order, stale_ids)
-
-    ofn_order.update(line_items_attributes: attrs)
+  # A backorder stays "Held" until the order cycle closes and the client
+  # completes it. We don't record that distinction on an OFN order yet, so we
+  # report the one status we can be sure about. The client (see
+  # FdcBackorderer#lookup_open_order) relies on "Held" to find its open orders.
+  def self.order_status(ofn_order)
+    ofn_order.state == "canceled" ? "dfc-v:Cancelled" : "dfc-v:Held"
   end
 
-  def self.set_order_state(ofn_order, dfc_order)
-    ofn_order.state = "complete" if dfc_order.orderStatus == order_states.HELD
-    ofn_order.completed_at ||= Time.zone.now if dfc_order.orderStatus == order_states.COMPLETE
+  # Applies a DFC order to an OFN order.
+  #
+  # Line items are applied before the order status because completing an order
+  # changes how line items are saved: `Spree::OrderInventory` only assigns
+  # inventory units for orders that are already complete.
+  #
+  # Returns false and leaves the order untouched if the payload is invalid.
+  def self.apply(ofn_order, dfc_order, variant_scope: Spree::Variant)
+    attrs, stale_ids, unknown =
+      OrderLineItemsBuilder.attributes(ofn_order, dfc_order, variant_scope)
+
+    if unknown.any?
+      ofn_order.errors.add(:line_items, "reference unknown products: #{unknown.join(', ')}")
+      return false
+    end
+
+    ofn_order.transaction do
+      ofn_order.update!(line_items_attributes: attrs)
+      destroy_stale_line_items(ofn_order, stale_ids)
+      apply_order_status(ofn_order, dfc_order)
+    end
+
+    true
+  rescue ActiveRecord::RecordInvalid
+    false
+  end
+
+  def self.apply_order_status(ofn_order, dfc_order)
+    case dfc_order.orderStatus
+    when order_states.HELD, order_states.COMPLETE
+      complete(ofn_order)
+    when order_states.CANCELLED
+      cancel(ofn_order)
+    end
+  end
+
+  # An order we received is a real order: it needs a shipment so that stock is
+  # reserved, and `completed_at` so that the rest of OFN treats it as placed.
+  # Without `completed_at` it would show up as the ordering user's shopping
+  # cart (`Spree::User#last_incomplete_spree_order`) and could never be
+  # cancelled (`Spree::Order#allow_cancel?`).
+  def self.complete(ofn_order)
+    return if ofn_order.completed?
+    return if ofn_order.line_items.empty?
+
+    ofn_order.create_proposed_shipments
+    ofn_order.state = "complete"
+    ofn_order.finalize!
+  end
+
+  def self.cancel(ofn_order)
+    ofn_order.send_cancellation_email = false
+    ofn_order.cancel! if ofn_order.allow_cancel?
   end
 
   def self.destroy_stale_line_items(ofn_order, stale_ids)
     # `accepts_nested_attributes_for :line_items` does not permit `:_destroy`,
     # so remove line items that are no longer present explicitly.
-    ofn_order.line_items.where(id: stale_ids).destroy_all if stale_ids.any?
-  end
+    return if stale_ids.empty?
 
-  def self.incoming_quantities(dfc_order)
-    dfc_order.lines.each_with_object({}) do |line, hash|
-      next if line.quantity.nil? || line.quantity <= 0
-      next if line.offer&.offeredItem.nil?
+    ofn_order.line_items.where(id: stale_ids).destroy_all
 
-      vid = semantic_id(line.offer.offeredItem).split(%r{/supplied_products/}i).last
-      hash[vid.to_i] = line.quantity
-    end
-  end
-
-  def self.build_line_item_attributes(ofn_order, incoming)
-    attrs = []
-    stale_ids = []
-
-    ofn_order.line_items.each do |li|
-      if incoming.key?(li.variant_id)
-        # Update existing line items
-        attrs << { id: li.id, quantity: incoming.delete(li.variant_id) }
-      else
-        # Delete line items that weren't provided
-        stale_ids << li.id
-      end
-    end
-
-    # Create any new line items
-    incoming.each do |variant_id, quantity|
-      attrs << { variant_id:, quantity: }
-    end
-
-    [attrs, stale_ids]
+    # `destroy_all` on the association relation doesn't update the parent's
+    # loaded collection. Tax adjustments would then be recalculated against
+    # deleted line items.
+    ofn_order.line_items.reload
   end
 
   def self.order_states

--- a/engines/dfc_provider/app/services/order_builder.rb
+++ b/engines/dfc_provider/app/services/order_builder.rb
@@ -15,27 +15,54 @@ class OrderBuilder < DfcBuilder
       id: ofn_order.id,
     )
 
+    status = case ofn_order.state
+             when "canceled" then "dfc-v:Cancelled"
+             when "complete" then "dfc-v:Complete"
+             else "dfc-v:Held"
+             end
+
     DataFoodConsortium::ConnectorV1::Order.new(
       id,
       client: urls.enterprise_url(ofn_order.distributor_id),
-      orderStatus: "dfc-v:Held",
+      orderStatus: status,
     )
   end
 
-  def self.apply(ofn_order, dfc_order)
-    # Set order state if recognised
-    set_order_state(ofn_order, dfc_order)
-
-    incoming = incoming_quantities(dfc_order)
+  def self.apply(ofn_order, dfc_order, enterprise = nil)
+    enterprise ||= ofn_order.distributor
+    incoming = incoming_quantities(dfc_order, enterprise)
     attrs, stale_ids = build_line_item_attributes(ofn_order, incoming)
-    destroy_stale_line_items(ofn_order, stale_ids)
 
-    ofn_order.update(line_items_attributes: attrs)
+    ofn_order.transaction do
+      # For new records, save empty first inside transaction to avoid
+      # products_available_from_new_distribution and to allow rollback
+      if ofn_order.new_record?
+        ofn_order.state = "cart" unless ofn_order.state == "cart"
+        ofn_order.completed_at = nil
+        ofn_order.save!
+      end
+
+      ofn_order.assign_attributes(line_items_attributes: attrs)
+      destroy_stale_line_items(ofn_order, stale_ids) if stale_ids.any?
+
+      ofn_order.save!
+
+      # Now set order state after line items exist
+      set_order_state(ofn_order, dfc_order)
+      ofn_order.save! if ofn_order.changed?
+    end
+
+    true
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::Rollback
+    false
   end
 
   def self.set_order_state(ofn_order, dfc_order)
-    ofn_order.state = "complete" if dfc_order.orderStatus == order_states.HELD
-    ofn_order.completed_at ||= Time.zone.now if dfc_order.orderStatus == order_states.COMPLETE
+    case dfc_order.orderStatus
+    when order_states.HELD, order_states.COMPLETE
+      ofn_order.state = "complete" if ofn_order.state != "complete"
+      ofn_order.completed_at ||= Time.zone.now
+    end
   end
 
   def self.destroy_stale_line_items(ofn_order, stale_ids)
@@ -44,13 +71,14 @@ class OrderBuilder < DfcBuilder
     ofn_order.line_items.where(id: stale_ids).destroy_all if stale_ids.any?
   end
 
-  def self.incoming_quantities(dfc_order)
-    dfc_order.lines.each_with_object({}) do |line, hash|
+  def self.incoming_quantities(dfc_order, _enterprise = nil)
+    dfc_order.lines.each_with_object(Hash.new(0)) do |line, hash|
       next if line.quantity.nil? || line.quantity <= 0
       next if line.offer&.offeredItem.nil?
 
-      vid = semantic_id(line.offer.offeredItem).split(%r{/supplied_products/}i).last
-      hash[vid.to_i] = line.quantity
+      sid = semantic_id(line.offer.offeredItem)
+      vid = sid.split(%r{/supplied_products/}i).last.to_i
+      hash[vid] += line.quantity.to_i
     end
   end
 

--- a/engines/dfc_provider/app/services/order_line_builder.rb
+++ b/engines/dfc_provider/app/services/order_line_builder.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class OrderLineBuilder < DfcBuilder
-  def self.build(offer, quantity)
+  def self.build(dfc_order, ofn_line_item)
+    DataFoodConsortium::ConnectorV1::OrderLine.new(
+      "#{dfc_order.semanticId}/OrderLines/#{ofn_line_item.id}",
+      offer: OfferBuilder.build(ofn_line_item.variant),
+      quantity: ofn_line_item.quantity,
+    )
+  end
+
+  def self.build_from_offer(offer, quantity)
     DataFoodConsortium::ConnectorV1::OrderLine.new(
       nil, offer:, quantity:,
     )

--- a/engines/dfc_provider/app/services/order_line_items_builder.rb
+++ b/engines/dfc_provider/app/services/order_line_items_builder.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Translates the order lines of a DFC order into OFN line item attributes.
+class OrderLineItemsBuilder < DfcBuilder
+  # Returns the nested attributes to apply, the ids of line items that are no
+  # longer part of the order, and the semantic ids of any products we couldn't
+  # recognise.
+  def self.attributes(ofn_order, dfc_order, variant_scope)
+    incoming, unknown = incoming_quantities(dfc_order, variant_scope)
+    attrs, stale_ids = reconcile(ofn_order, incoming)
+
+    [attrs, stale_ids, unknown]
+  end
+
+  def self.incoming_quantities(dfc_order, variant_scope)
+    quantities = {}
+    unknown = []
+
+    dfc_order.lines.each do |line|
+      next if line.quantity.nil? || line.quantity <= 0
+      next if line.offer&.offeredItem.nil?
+
+      product_id = extract_semantic_id(line.offer.offeredItem)
+      variant = find_variant(product_id, variant_scope)
+
+      if variant
+        # The same product may be ordered in several lines.
+        quantities[variant.id] = quantities[variant.id].to_i + line.quantity
+      else
+        unknown << product_id
+      end
+    end
+
+    [quantities, unknown]
+  end
+
+  # The offered item has to be a product of the enterprise the order is placed
+  # with. We can't take an arbitrary variant id from the payload.
+  def self.find_variant(product_id, variant_scope)
+    id = product_id[%r{/supplied_products/(\d+)\z}, 1]
+
+    variant_scope.find_by(id:) if id
+  end
+
+  def self.reconcile(ofn_order, incoming)
+    attrs = []
+    stale_ids = []
+
+    ofn_order.line_items.each do |line_item|
+      if incoming.key?(line_item.variant_id)
+        attrs << { id: line_item.id, quantity: incoming.delete(line_item.variant_id) }
+      else
+        stale_ids << line_item.id
+      end
+    end
+
+    incoming.each do |variant_id, quantity|
+      attrs << { variant_id:, quantity: }
+    end
+
+    [attrs, stale_ids]
+  end
+
+  private_class_method :incoming_quantities, :find_variant, :reconcile
+end

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -16,7 +16,7 @@ class SuppliedProductBuilder < DfcBuilder
     product_group = ProductGroupBuilder.product_group(variant.product)
 
     if include_catalog_items
-      catalog_items = [DfcBuilder.catalog_item(variant, include_product: false)]
+      catalog_items = [CatalogItemBuilder.catalog_item(variant, include_product: false)]
     end
 
     DfcProvider::SuppliedProduct.new(

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -8,12 +8,16 @@ class SuppliedProductBuilder < DfcBuilder
     )
   end
 
-  def self.supplied_product(variant)
+  def self.supplied_product(variant, include_catalog_items: true)
     product_uri = urls.enterprise_url(
       variant.enterprise_id,
       spree_product_id: variant.product_id
     )
     product_group = ProductGroupBuilder.product_group(variant.product)
+
+    if include_catalog_items
+      catalog_items = [DfcBuilder.catalog_item(variant, include_product: false)]
+    end
 
     DfcProvider::SuppliedProduct.new(
       semantic_id(variant),
@@ -24,7 +28,8 @@ class SuppliedProductBuilder < DfcBuilder
       isVariantOf: [product_group],
       spree_product_uri: product_uri,
       spree_product_id: variant.product.id,
-      image_url: variant.product&.image&.url(:product)
+      image_url: variant.product&.image&.url(:product),
+      catalogItems: catalog_items,
     )
   end
 

--- a/engines/dfc_provider/app/services/supplied_product_builder.rb
+++ b/engines/dfc_provider/app/services/supplied_product_builder.rb
@@ -8,12 +8,16 @@ class SuppliedProductBuilder < DfcBuilder
     )
   end
 
-  def self.supplied_product(variant)
+  def self.supplied_product(variant, include_catalog_items: true)
     product_uri = urls.enterprise_url(
       variant.supplier_id,
       spree_product_id: variant.product_id
     )
     product_group = ProductGroupBuilder.product_group(variant.product)
+
+    if include_catalog_items
+      catalog_items = [DfcBuilder.catalog_item(variant, include_product: false)]
+    end
 
     DfcProvider::SuppliedProduct.new(
       semantic_id(variant),
@@ -24,7 +28,8 @@ class SuppliedProductBuilder < DfcBuilder
       isVariantOf: [product_group],
       spree_product_uri: product_uri,
       spree_product_id: variant.product.id,
-      image_url: variant.product&.image&.url(:product)
+      image_url: variant.product&.image&.url(:product),
+      catalogItems: catalog_items,
     )
   end
 

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -5,7 +5,7 @@ DfcProvider::Engine.routes.draw do
   resources :enterprises, only: [:index, :show] do
     resources :catalog_items, only: [:index, :show, :update]
     resources :offers, only: [:show, :update]
-    resources :orders, only: [:show, :create]
+    resources :orders, only: [:show, :create, :update, :destroy]
     resources :platforms, only: [:index, :show, :update]
     resources :supplied_products, only: [:create, :show, :update]
     resources :social_medias, only: [:show]

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -5,6 +5,7 @@ DfcProvider::Engine.routes.draw do
   resources :enterprises, only: [:index, :show] do
     resources :catalog_items, only: [:index, :show, :update]
     resources :offers, only: [:show, :update]
+    resources :orders, only: [:show, :create]
     resources :platforms, only: [:index, :show, :update]
     resources :supplied_products, only: [:create, :show, :update]
     resources :social_medias, only: [:show]

--- a/engines/dfc_provider/spec/requests/orders_lifecycle_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_lifecycle_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+# The swagger specs in orders_spec.rb document each endpoint on its own, using
+# orders built by factories. These specs cover the lifecycle of an order that
+# was created through the API itself, which is how the backorder flow uses it.
+RSpec.describe "Orders lifecycle" do
+  let(:user) { create(:oidc_user, email: "user@example.com") }
+  let(:enterprise) { create(:distributor_enterprise, owner: user) }
+  let(:variant) { create(:variant, enterprise:, on_demand: false, on_hand: 10) }
+  let(:headers) { { "CONTENT_TYPE" => "application/json" } }
+  let(:orders_url) { "/api/dfc/enterprises/#{enterprise.id}/orders" }
+
+  before do
+    login_as user
+    enterprise.customers.create!(user:, email: user.email)
+  end
+
+  # A DFC order graph like the one FdcBackorderer sends.
+  def order_payload(status: "dfc-v:Held", quantity: 1, product_id: supplied_product_url(variant))
+    base = "http://test.host#{orders_url}"
+
+    {
+      "@context" => "https://www.datafoodconsortium.org",
+      "@graph" => [
+        { "@id" => base,
+          "@type" => "dfc-b:Order",
+          "dfc-b:hasPart" => "#{base}/OrderLines/1",
+          "dfc-b:hasOrderStatus" => status },
+        { "@id" => "#{base}/OrderLines/1",
+          "@type" => "dfc-b:OrderLine",
+          "dfc-b:quantity" => quantity,
+          "dfc-b:concerns" => "#{base}/offers/1" },
+        { "@id" => "#{base}/offers/1",
+          "@type" => "dfc-b:Offer",
+          "dfc-b:offeredItem" => product_id },
+      ]
+    }.to_json
+  end
+
+  def supplied_product_url(variant)
+    "http://test.host/api/dfc/enterprises/#{variant.enterprise_id}/supplied_products/#{variant.id}"
+  end
+
+  def create_order!
+    post orders_url, headers:, params: order_payload
+    expect(response).to have_http_status(:created), response.body
+    enterprise.distributed_orders.last
+  end
+
+  describe "creating an order" do
+    it "creates an order that the rest of OFN recognises as placed" do
+      order = create_order!
+
+      expect(order.state).to eq "complete"
+      expect(order).to be_completed
+      expect(Spree::Order.complete).to include order
+    end
+
+    it "calculates the order total" do
+      order = create_order!
+
+      expect(order.item_total).to eq variant.price
+      expect(order.total).to be_positive
+    end
+
+    it "reserves stock" do
+      expect { create_order! }.to change { variant.reload.on_hand }.from(10).to(9)
+    end
+
+    it "doesn't become the ordering user's shopping cart" do
+      create_order!
+
+      expect(user.last_incomplete_spree_order).to be_nil
+    end
+
+    it "rejects a product of another enterprise" do
+      other_variant = create(:variant, enterprise: create(:enterprise))
+
+      post orders_url, headers:,
+                       params: order_payload(product_id: supplied_product_url(other_variant))
+
+      expect(response).to have_http_status :unprocessable_entity
+      expect(response.body).to include "unknown products"
+      expect(enterprise.distributed_orders).to be_empty
+    end
+
+    it "rejects a product id that isn't a supplied product URL" do
+      post orders_url, headers:,
+                       params: order_payload(product_id: "https://example.net/products/1")
+
+      expect(response).to have_http_status :unprocessable_entity
+      expect(enterprise.distributed_orders).to be_empty
+    end
+  end
+
+  describe "completing an order" do
+    it "accepts the completion the client sends at the end of the order cycle" do
+      order = create_order!
+
+      put "#{orders_url}/#{order.id}", headers:,
+                                       params: order_payload(status: "dfc-v:Complete", quantity: 2)
+
+      expect(response).to have_http_status :ok
+      expect(order.reload.line_items.first.quantity).to eq 2
+    end
+
+    it "accepts a payload containing only the order" do
+      order = create_order!
+      body = {
+        "@context" => "https://www.datafoodconsortium.org/",
+        "@id" => "http://test.host#{orders_url}/#{order.id}",
+        "@type" => "dfc-b:Order",
+        "dfc-b:hasOrderStatus" => "dfc-v:Held",
+      }.to_json
+
+      put "#{orders_url}/#{order.id}", headers:, params: body
+
+      expect(response).to have_http_status :ok
+    end
+  end
+
+  describe "cancelling an order" do
+    it "cancels an order created through this API" do
+      order = create_order!
+
+      delete "#{orders_url}/#{order.id}"
+
+      expect(response).to have_http_status :no_content
+      expect(order.reload.state).to eq "canceled"
+    end
+
+    it "reports the cancellation" do
+      order = create_order!
+      delete "#{orders_url}/#{order.id}"
+
+      get "#{orders_url}/#{order.id}"
+
+      expect(response.body).to include "dfc-v:Cancelled"
+    end
+  end
+
+  describe "an invalid update" do
+    it "leaves the order untouched" do
+      order = create_order!
+      original = order.line_items.map { |li| [li.variant_id, li.quantity] }
+
+      unknown_product = "#{supplied_product_url(variant)}0"
+
+      put "#{orders_url}/#{order.id}", headers:,
+                                       params: order_payload(product_id: unknown_product)
+
+      expect(response).to have_http_status :unprocessable_entity
+      expect(order.reload.line_items.map { |li| [li.variant_id, li.quantity] }).to eq original
+    end
+  end
+end

--- a/engines/dfc_provider/spec/requests/orders_lifecycle_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_lifecycle_spec.rb
@@ -141,6 +141,27 @@ RSpec.describe "Orders lifecycle" do
     end
   end
 
+  describe "cancelling via the order status" do
+    it "cancels the order" do
+      order = create_order!
+
+      put "#{orders_url}/#{order.id}", headers:,
+                                       params: order_payload(status: "dfc-v:Cancelled")
+
+      expect(response).to have_http_status :ok
+      expect(order.reload.state).to eq "canceled"
+    end
+
+    it "returns the stock" do
+      order = create_order!
+
+      expect {
+        put "#{orders_url}/#{order.id}", headers:,
+                                         params: order_payload(status: "dfc-v:Cancelled")
+      }.to change { variant.reload.on_hand }.from(9).to(10)
+    end
+  end
+
   describe "an invalid update" do
     it "leaves the order untouched" do
       order = create_order!
@@ -153,6 +174,17 @@ RSpec.describe "Orders lifecycle" do
 
       expect(response).to have_http_status :unprocessable_entity
       expect(order.reload.line_items.map { |li| [li.variant_id, li.quantity] }).to eq original
+    end
+
+    it "reports a line item the order can't hold" do
+      order = create_order!
+
+      put "#{orders_url}/#{order.id}", headers:,
+                                       params: order_payload(quantity: 999)
+
+      expect(response).to have_http_status :unprocessable_entity
+      expect(response.body).to include "is out of stock"
+      expect(order.reload.line_items.first.quantity).to eq 1
     end
   end
 end

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -88,6 +88,187 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
         end
       end
     end
+
+    put "Update Order" do
+      produces "application/json"
+      consumes "application/json"
+
+      parameter name: :order_id, in: :path
+      parameter name: :body, in: :body, schema: {
+        example: Rails.root.join('spec/fixtures/files/fdc-update-backorder.json').read
+      }
+
+      let(:body) {
+        Rails.root.join('spec/fixtures/files/fdc-update-backorder.json').read
+      }
+
+      let(:order) {
+        variant.save
+        variant.update! on_hand: 10
+        create(:completed_order_with_totals, :with_line_item, id: 11_000,
+                                                              distributor: enterprise, variant:)
+      }
+
+      response "200", "success" do
+        let(:enterprise_id) { enterprise.id }
+        let(:order_id) { order.id }
+
+        run_test! {
+          ofn_order = enterprise.distributed_orders.find(order.id)
+          target_line = ofn_order.line_items.find_by!(variant_id: variant.id)
+          expect(target_line.quantity).to eq 5
+        }
+      end
+
+      response "200", "order completed" do
+        let(:enterprise_id) { enterprise.id }
+        let(:order_id) { order.id }
+        let(:body) {
+          json = JSON.parse(
+            Rails.root.join('spec/fixtures/files/fdc-update-backorder.json').read
+          )
+          json["@graph"].find { |n|
+            n["@type"] == "dfc-b:Order"
+          }["dfc-b:hasOrderStatus"] = "dfc-v:Complete"
+          json.to_json
+        }
+
+        run_test! {
+          ofn_order = enterprise.distributed_orders.find(order.id)
+          expect(ofn_order.completed_at).to be_present
+        }
+      end
+
+      response "400", "bad request" do
+        context "with empty request body" do
+          let(:enterprise_id) { enterprise.id }
+          let(:order_id) { order.id }
+          let(:body) { nil }
+
+          run_test! {
+            expect(response).to have_http_status :bad_request
+          }
+        end
+      end
+
+      response "401", "unauthorized" do
+        let(:enterprise_id) { enterprise.id }
+        let(:order_id) { order.id }
+
+        before { login_as nil }
+
+        run_test! {
+          expect(response).to have_http_status :unauthorized
+        }
+      end
+
+      response "404", "not found" do
+        context "without order" do
+          let(:enterprise_id) { enterprise.id }
+          let(:order_id) { "blah" }
+
+          run_test! {
+            expect(response).to have_http_status :not_found
+          }
+        end
+
+        context "without enterprise" do
+          let(:enterprise_id) { "blah" }
+          let(:order_id) { order.id }
+
+          run_test! {
+            expect(response).to have_http_status :not_found
+          }
+        end
+
+        context "with unrelated enterprise" do
+          let(:enterprise_id) { create(:enterprise).id }
+          let(:order_id) { order.id }
+
+          run_test! {
+            expect(response).to have_http_status :not_found
+          }
+        end
+      end
+
+      response "422", "unprocessable entity" do
+        let(:enterprise_id) { enterprise.id }
+        let(:order_id) { order.id }
+        let(:body) {
+          json = JSON.parse(
+            Rails.root.join('spec/fixtures/files/fdc-update-backorder.json').read
+          )
+          offer = json["@graph"].find { |n| n["@type"] == "dfc-b:Offer" }
+          offer["dfc-b:offeredItem"] =
+            "http://test.host/api/dfc/enterprises/10000/supplied_products/99999"
+          json.to_json
+        }
+
+        run_test! {
+          expect(response.body).to include "Line items variant must exist"
+        }
+      end
+    end
+
+    delete "Cancel Order" do
+      parameter name: :order_id, in: :path, type: :string
+
+      let(:order) {
+        variant.save
+        variant.update! on_hand: 1
+        create(:completed_order_with_totals, :with_line_item, id: 11_000,
+                                                              distributor: enterprise, variant:)
+      }
+
+      response "204", "no content" do
+        let(:enterprise_id) { enterprise.id }
+        let(:order_id) { order.id }
+
+        run_test! {
+          expect(order.reload.state).to eq "canceled"
+        }
+      end
+
+      response "401", "unauthorized" do
+        let(:enterprise_id) { enterprise.id }
+        let(:order_id) { order.id }
+
+        before { login_as nil }
+
+        run_test! {
+          expect(response).to have_http_status :unauthorized
+        }
+      end
+
+      response "404", "not found" do
+        context "without order" do
+          let(:enterprise_id) { enterprise.id }
+          let(:order_id) { "blah" }
+
+          run_test! {
+            expect(response).to have_http_status :not_found
+          }
+        end
+
+        context "without enterprise" do
+          let(:enterprise_id) { "blah" }
+          let(:order_id) { order.id }
+
+          run_test! {
+            expect(response).to have_http_status :not_found
+          }
+        end
+
+        context "with unrelated enterprise" do
+          let(:enterprise_id) { create(:enterprise).id }
+          let(:order_id) { order.id }
+
+          run_test! {
+            expect(response).to have_http_status :not_found
+          }
+        end
+      end
+    end
   end
 
   path "/api/dfc/enterprises/{enterprise_id}/orders" do

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -268,6 +268,17 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
           }
         end
       end
+
+      response "422", "unprocessable entity" do
+        let(:enterprise_id) { enterprise.id }
+        let(:order) { create(:order, id: 11_001, distributor: enterprise) }
+        let(:order_id) { order.id }
+
+        run_test! {
+          expect(response).to have_http_status :unprocessable_entity
+          expect(response.body).to include "Cannot cancel order"
+        }
+      end
     end
   end
 
@@ -279,6 +290,11 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
       consumes "application/json"
 
       parameter name: :body, in: :body, schema: {
+        # To update fixture, add this to orders_controller.rb#create:
+        #   File.write(Rails.root.join('spec/fixtures/files/fdc-send-backorder.json'),
+        #              JSON.pretty_generate(JSON.parse(request.body.read)))
+        # Then execute:
+        #   rspec engines/dfc_provider/spec/system/orders_backorder_spec.rb
         example: Rails.root.join('spec/fixtures/files/fdc-send-backorder.json').read
       }
 

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require_relative "../swagger_helper"
+
+RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
+  let(:user) { create(:oidc_user, id: 12_345, email: "user@example.com") }
+  let(:enterprise) {
+    create(
+      :distributor_enterprise,
+      id: 10_000, owner: user, name: "Fred's Farm", description: "Beautiful",
+      address: build(:address, id: 40_000),
+    )
+  }
+  let(:product) {
+    create(
+      :base_product,
+      id: 90_000, name: "Apple", description: "Red",
+      variants: [variant],
+    )
+  }
+  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "AR", supplier: enterprise) }
+
+  before { login_as user }
+
+  path "/api/dfc/enterprises/{enterprise_id}/orders/{order_id}" do
+    parameter name: :enterprise_id, in: :path, type: :string
+
+    get "Show Order" do
+      produces "application/json"
+      parameter name: :order_id, in: :path
+
+      let(:order) {
+        variant.save
+        variant.update! on_hand: 1
+        create(:completed_order_with_totals, :with_line_item, id: 11_000,
+                                                              distributor: enterprise, variant:)
+      }
+
+      response "200", "success" do
+        let(:enterprise_id) { enterprise.id }
+        let(:order_id) { order.id }
+
+        run_test! {
+          expect(response.body).to include "dfc-b:Order",       "orders/11000"
+          expect(response.body).to include "dfc-b:OrderLine",   "OrderLines/"
+          expect(response.body).to include "dfc-b:Offer",       "offers/", "dfc-b:offeredItem"
+          expect(response.body).to include "dfc-b:SuppliedProduct", "supplied_products/10001"
+        }
+      end
+
+      response "401", "unauthorized" do
+        let(:enterprise_id) { enterprise.id }
+        let(:order_id) { order.id }
+
+        before { login_as nil }
+
+        run_test! {
+          expect(response.body).to be_empty
+        }
+      end
+
+      response "404", "not found" do
+        context "without order" do
+          let(:enterprise_id) { enterprise.id }
+          let(:order_id) { "blah" }
+
+          run_test! {
+            expect(response.body).to be_empty
+          }
+        end
+
+        context "without enterprise" do
+          let(:enterprise_id) { "blah" }
+          let(:order_id) { order.id }
+
+          run_test! {
+            expect(response.body).to be_empty
+          }
+        end
+
+        context "with unrelated enterprise" do
+          let(:enterprise_id) { create(:enterprise).id }
+          let(:order_id) { order.id }
+
+          run_test! {
+            expect(response.body).to be_empty
+          }
+        end
+      end
+    end
+  end
+
+  path "/api/dfc/enterprises/{enterprise_id}/orders" do
+    parameter name: :enterprise_id, in: :path, type: :string
+
+    post "Create Order" do
+      produces "application/json"
+      consumes "application/json"
+
+      parameter name: :body, in: :body, schema: {
+        example: Rails.root.join('spec/fixtures/files/fdc-send-backorder.json').read
+      }
+
+      let(:body) { |example|
+        example.metadata[:operation][:parameters].first[:schema][:example]
+      }
+
+      response "201", "created" do
+        before do
+          enterprise.customers.create!(user:, email: user.email)
+          product
+          variant.on_hand = 1
+        end
+
+        context "with line items" do
+          let(:enterprise_id) { enterprise.id }
+
+          run_test! {
+            expect(enterprise.distributed_orders.count).to eq 1
+            ofn_order = enterprise.distributed_orders.first
+            expect(ofn_order.created_by).to eq user
+            expect(ofn_order.email).to eq "user@example.com"
+            expect(ofn_order.customer.email).to eq user.email
+            expect(ofn_order.state).to eq "complete"
+
+            expect(ofn_order.line_items.count).to eq 1
+            expect(ofn_order.line_items.first.variant).to eq variant
+            expect(ofn_order.line_items.first.quantity).to eq 1
+
+            response.body.gsub!(
+              "orders/#{ofn_order.id}",
+              "orders/10001"
+            )
+
+            expect(response.body).to include "dfc-b:Order"
+            expect(response.body).to include "/api/dfc/enterprises/10000/orders/10001"
+          }
+        end
+      end
+
+      response "400", "bad request" do
+        context "with empty request body" do
+          let(:enterprise_id) { enterprise.id }
+          let(:body) { nil }
+
+          run_test! {
+            expect(enterprise.distributed_orders).to be_empty
+          }
+        end
+      end
+
+      response "401", "unauthorized" do
+        let(:enterprise_id) { enterprise.id }
+
+        before { login_as nil }
+
+        run_test! {
+          expect(enterprise.distributed_orders).to be_empty
+        }
+      end
+
+      response "404", "not found" do
+        context "without enterprises" do
+          let(:enterprise_id) { "blah" }
+
+          run_test! {
+            expect(enterprise.distributed_orders).to be_empty
+          }
+        end
+
+        context "with unrelated enterprise" do
+          let(:enterprise_id) { create(:enterprise).id }
+
+          run_test! {
+            expect(enterprise.distributed_orders).to be_empty
+          }
+        end
+      end
+
+      response "422", "unprocessable entity" do
+        let(:enterprise_id) { enterprise.id }
+
+        context "variant not found" do
+          run_test! {
+            expect(enterprise.distributed_orders.first.line_items).to be_empty
+
+            expect(response.body).to include "Line items variant must exist"
+          }
+        end
+      end
+    end
+  end
+end

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
       variants: [variant],
     )
   }
-  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "AR", enterprise: enterprise) }
+  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "AR", enterprise:) }
 
   before { login_as user }
 

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
 
         context "variant not found" do
           run_test! {
-            expect(enterprise.distributed_orders.first.line_items).to be_empty
+            expect(enterprise.distributed_orders).to be_empty
 
             expect(response.body).to include "Line items variant must exist"
           }

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
       variants: [variant],
     )
   }
-  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "AR", supplier: enterprise) }
+  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "AR", enterprise: enterprise) }
 
   before { login_as user }
 

--- a/engines/dfc_provider/spec/requests/orders_spec.rb
+++ b/engines/dfc_provider/spec/requests/orders_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
         }
 
         run_test! {
-          expect(response.body).to include "Line items variant must exist"
+          expect(response.body).to include "Line items reference unknown products"
         }
       end
     end
@@ -381,7 +381,7 @@ RSpec.describe "Orders", swagger_doc: "dfc.yaml" do
           run_test! {
             expect(enterprise.distributed_orders).to be_empty
 
-            expect(response.body).to include "Line items variant must exist"
+            expect(response.body).to include "Line items reference unknown products"
           }
         end
       end

--- a/engines/dfc_provider/spec/services/dfc_loader_spec.rb
+++ b/engines/dfc_provider/spec/services/dfc_loader_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe DfcLoader do
     expect(connector.PRODUCT_TYPES.DRINK.semanticId).to end_with "#drink"
   end
 
+  it "loads vocabularies into each connector, whatever the order" do
+    # A dfc-v2 request may be served before any v1 request after boot. The v1
+    # connector still has to understand vocabulary terms afterwards, otherwise
+    # it deserialises them into a parsed URI Hash.
+    DfcLoader.instance_variable_set(:@vocabs, nil)
+    DfcLoader.instance_variable_set(:@connector_v2, nil)
+    DfcLoader.connector_v2
+
+    expect(DfcLoader.vocabulary("vocabulary").STATES.ORDERSTATE.HELD)
+      .to be_a DataFoodConsortium::ConnectorV1::SKOSConcept
+  end
+
   it "retries loading when the first attempt fails" do
     DfcLoader.instance_variable_set(:@connector, nil)
 

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -49,24 +49,33 @@ RSpec.describe OrderBuilder do
 
     context "with OrderLines" do
       let!(:variant) { create(:variant, id: 10_000) }
+      let!(:variant2) { create(:variant, id: 10_001) }
 
       before do
-        offer = DataFoodConsortium::ConnectorV1::Offer.new(
+        offer1 = DataFoodConsortium::ConnectorV1::Offer.new(
           nil, offeredItem: "http://test.host/api/dfc/enterprises/blah/supplied_products/10000"
         )
-        order_line = DataFoodConsortium::ConnectorV1::OrderLine.new(
-          nil, offer:, quantity: 3
+        offer2 = DataFoodConsortium::ConnectorV1::Offer.new(
+          nil, offeredItem: "http://test.host/api/dfc/enterprises/blah/supplied_products/10001"
+        )
+        order_line1 = DataFoodConsortium::ConnectorV1::OrderLine.new(
+          nil, offer: offer1, quantity: 3
+        )
+        order_line2 = DataFoodConsortium::ConnectorV1::OrderLine.new(
+          nil, offer: offer2, quantity: 5
         )
 
-        dfc_order.lines = [order_line, order_line]
+        dfc_order.lines = [order_line1, order_line2]
       end
 
       it "creates line items" do
         expect(subject).to be true
 
         expect(ofn_order.line_items.count).to eq 2
-        expect(ofn_order.line_items.first.variant).to eq variant
-        expect(ofn_order.line_items.first.quantity).to eq 3
+        li1 = ofn_order.line_items.find_by!(variant:)
+        expect(li1.quantity).to eq 3
+        li2 = ofn_order.line_items.find_by!(variant: variant2)
+        expect(li2.quantity).to eq 5
       end
     end
   end

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -79,4 +79,44 @@ RSpec.describe OrderBuilder do
       end
     end
   end
+
+  describe ".line_item_attributes" do
+    let!(:ofn_order) { create(:order, id: 1) }
+    let!(:existing_variant) { create(:variant, id: 101_000, on_demand: true) }
+    let!(:existing_line_item) {
+      create(:line_item, order: ofn_order, variant: existing_variant, quantity: 2)
+    }
+
+    let(:dfc_order) {
+      order = DataFoodConsortium::ConnectorV1::Order.new(nil)
+      offer = DataFoodConsortium::ConnectorV1::Offer.new(
+        nil, offeredItem: "http://test.host/api/dfc/enterprises/blah/supplied_products/101000"
+      )
+      order.lines = [
+        DataFoodConsortium::ConnectorV1::OrderLine.new(nil, offer:, quantity: 5),
+      ]
+      order
+    }
+
+    subject(:attributes) { described_class.line_item_attributes(ofn_order, dfc_order) }
+
+    it "updates the quantity of an existing line item" do
+      expect(attributes.find { |a| a[:id] == existing_line_item.id }[:quantity]).to eq 5
+    end
+
+    it "creates line items for new variants" do
+      offer = DataFoodConsortium::ConnectorV1::Offer.new(
+        nil, offeredItem: "http://test.host/api/dfc/enterprises/blah/supplied_products/101001"
+      )
+      dfc_order.lines << DataFoodConsortium::ConnectorV1::OrderLine.new(nil, offer:, quantity: 3)
+
+      expect(attributes).to include(variant_id: 101_001, quantity: 3)
+    end
+
+    it "marks omitted line items for destruction" do
+      dfc_order.lines = []
+
+      expect(attributes.find { |a| a[:id] == existing_line_item.id }[:_destroy]).to eq true
+    end
+  end
 end

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -18,4 +18,56 @@ RSpec.describe OrderBuilder do
       expect(result.orderStatus).to eq "dfc-v:Held"
     end
   end
+
+  describe '.build' do
+    let(:distributor) { create(:distributor_enterprise, id: 10_000) }
+    let(:ofn_order) { create(:completed_order_with_totals, distributor:, id: 1) }
+    subject(:result) { described_class.build(ofn_order) }
+
+    it "builds and stores a DFC order object" do
+      expect(result.semanticId).to  eq "http://test.host/api/dfc/enterprises/10000/orders/1"
+      expect(result.client).to      eq "http://test.host/api/dfc/enterprises/10000"
+      expect(result.orderStatus).to eq "dfc-v:Held"
+      expect(result.lines.count).to eq 0
+    end
+  end
+
+  describe ".apply" do
+    subject { described_class.apply(ofn_order, dfc_order) }
+    let!(:ofn_order) { create(:order, id: 1) }
+    let(:dfc_order) {
+      DataFoodConsortium::ConnectorV1::Order.new(
+        nil,
+        orderStatus: DfcLoader.vocabulary("vocabulary").STATES.ORDERSTATE.HELD,
+      )
+    }
+
+    it "applies attribute changes to order" do
+      expect(subject).to be true
+      expect(ofn_order.state).to eq "complete"
+    end
+
+    context "with OrderLines" do
+      let!(:variant) { create(:variant, id: 10_000) }
+
+      before do
+        offer = DataFoodConsortium::ConnectorV1::Offer.new(
+          nil, offeredItem: "http://test.host/api/dfc/enterprises/blah/supplied_products/10000"
+        )
+        order_line = DataFoodConsortium::ConnectorV1::OrderLine.new(
+          nil, offer:, quantity: 3
+        )
+
+        dfc_order.lines = [order_line, order_line]
+      end
+
+      it "creates line items" do
+        expect(subject).to be true
+
+        expect(ofn_order.line_items.count).to eq 2
+        expect(ofn_order.line_items.first.variant).to eq variant
+        expect(ofn_order.line_items.first.quantity).to eq 3
+      end
+    end
+  end
 end

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -101,7 +101,8 @@ RSpec.describe OrderBuilder do
     subject(:attributes) { described_class.line_item_attributes(ofn_order, dfc_order) }
 
     it "updates the quantity of an existing line item" do
-      expect(attributes.find { |a| a[:id] == existing_line_item.id }[:quantity]).to eq 5
+      attrs, _stale = attributes
+      expect(attrs.find { |a| a[:id] == existing_line_item.id }[:quantity]).to eq 5
     end
 
     it "creates line items for new variants" do
@@ -110,13 +111,15 @@ RSpec.describe OrderBuilder do
       )
       dfc_order.lines << DataFoodConsortium::ConnectorV1::OrderLine.new(nil, offer:, quantity: 3)
 
-      expect(attributes).to include(variant_id: 101_001, quantity: 3)
+      attrs, _stale = attributes
+      expect(attrs).to include(variant_id: 101_001, quantity: 3)
     end
 
     it "marks omitted line items for destruction" do
       dfc_order.lines = []
 
-      expect(attributes.find { |a| a[:id] == existing_line_item.id }[:_destroy]).to eq true
+      _attrs, stale_ids = attributes
+      expect(stale_ids).to include(existing_line_item.id)
     end
   end
 end

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -50,6 +50,9 @@ RSpec.describe OrderBuilder do
     context "with OrderLines" do
       let!(:variant) { create(:variant, id: 10_000) }
       let!(:variant2) { create(:variant, id: 10_001) }
+      let!(:existing_line_item) {
+        create(:line_item, order: ofn_order, variant:, quantity: 2)
+      }
 
       before do
         offer1 = DataFoodConsortium::ConnectorV1::Offer.new(
@@ -64,7 +67,6 @@ RSpec.describe OrderBuilder do
         order_line2 = DataFoodConsortium::ConnectorV1::OrderLine.new(
           nil, offer: offer2, quantity: 5
         )
-
         dfc_order.lines = [order_line1, order_line2]
       end
 
@@ -77,49 +79,18 @@ RSpec.describe OrderBuilder do
         li2 = ofn_order.line_items.find_by!(variant: variant2)
         expect(li2.quantity).to eq 5
       end
-    end
-  end
 
-  describe ".line_item_attributes" do
-    let!(:ofn_order) { create(:order, id: 1) }
-    let!(:existing_variant) { create(:variant, id: 101_000, on_demand: true) }
-    let!(:existing_line_item) {
-      create(:line_item, order: ofn_order, variant: existing_variant, quantity: 2)
-    }
+      it "updates the quantity of an existing line item" do
+        expect(subject).to be true
+        li = ofn_order.line_items.find_by!(variant:)
+        expect(li.quantity).to eq 3
+      end
 
-    let(:dfc_order) {
-      order = DataFoodConsortium::ConnectorV1::Order.new(nil)
-      offer = DataFoodConsortium::ConnectorV1::Offer.new(
-        nil, offeredItem: "http://test.host/api/dfc/enterprises/blah/supplied_products/101000"
-      )
-      order.lines = [
-        DataFoodConsortium::ConnectorV1::OrderLine.new(nil, offer:, quantity: 5),
-      ]
-      order
-    }
-
-    subject(:attributes) { described_class.line_item_attributes(ofn_order, dfc_order) }
-
-    it "updates the quantity of an existing line item" do
-      attrs, _stale = attributes
-      expect(attrs.find { |a| a[:id] == existing_line_item.id }[:quantity]).to eq 5
-    end
-
-    it "creates line items for new variants" do
-      offer = DataFoodConsortium::ConnectorV1::Offer.new(
-        nil, offeredItem: "http://test.host/api/dfc/enterprises/blah/supplied_products/101001"
-      )
-      dfc_order.lines << DataFoodConsortium::ConnectorV1::OrderLine.new(nil, offer:, quantity: 3)
-
-      attrs, _stale = attributes
-      expect(attrs).to include(variant_id: 101_001, quantity: 3)
-    end
-
-    it "marks omitted line items for destruction" do
-      dfc_order.lines = []
-
-      _attrs, stale_ids = attributes
-      expect(stale_ids).to include(existing_line_item.id)
+      it "deletes omitted line items" do
+        dfc_order.lines = []
+        expect(subject).to be true
+        expect(ofn_order.line_items.reload.count).to eq 0
+      end
     end
   end
 end

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe OrderBuilder do
       )
     }
 
-    it "applies attribute changes to order" do
+    it "doesn't complete an order without line items" do
       expect(subject).to be true
-      expect(ofn_order.state).to eq "complete"
+      expect(ofn_order.state).to eq "cart"
     end
 
     context "with OrderLines" do
@@ -68,6 +68,18 @@ RSpec.describe OrderBuilder do
           nil, offer: offer2, quantity: 5
         )
         dfc_order.lines = [order_line1, order_line2]
+      end
+
+      it "completes the order" do
+        expect(subject).to be true
+
+        ofn_order.reload
+        expect(ofn_order.state).to eq "complete"
+
+        # An order without completed_at is not complete to the rest of OFN: it
+        # can't be cancelled and it shows up as the user's shopping cart.
+        expect(ofn_order).to be_completed
+        expect(ofn_order.shipments).to be_present
       end
 
       it "creates line items" do

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -27,8 +27,18 @@ RSpec.describe OrderBuilder do
     it "builds and stores a DFC order object" do
       expect(result.semanticId).to  eq "http://test.host/api/dfc/enterprises/10000/orders/1"
       expect(result.client).to      eq "http://test.host/api/dfc/enterprises/10000"
-      expect(result.orderStatus).to eq "dfc-v:Held"
+      expect(result.orderStatus).to eq "dfc-v:Complete"
       expect(result.lines.count).to eq 0
+    end
+
+    it "maps cart state to Held" do
+      ofn_order.update_columns(state: "cart", completed_at: nil)
+      expect(described_class.build(ofn_order).orderStatus).to eq "dfc-v:Held"
+    end
+
+    it "maps canceled state to Cancelled" do
+      ofn_order.cancel!
+      expect(described_class.build(ofn_order).orderStatus).to eq "dfc-v:Cancelled"
     end
   end
 

--- a/engines/dfc_provider/spec/services/order_builder_spec.rb
+++ b/engines/dfc_provider/spec/services/order_builder_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe OrderBuilder do
     it "builds and stores a DFC order object" do
       expect(result.semanticId).to  eq "http://test.host/api/dfc/enterprises/10000/orders/1"
       expect(result.client).to      eq "http://test.host/api/dfc/enterprises/10000"
-      expect(result.orderStatus).to eq "dfc-v:Complete"
+      expect(result.orderStatus).to eq "dfc-v:Held"
       expect(result.lines.count).to eq 0
     end
 

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require_relative "../system_helper"
+
+# Test the dfc/orders endpoint with the backorderer
+#
+# Confirms the requirement that two OFN instances can talk together (or the
+# same instance talking to itself): a distributor places an order whose line
+# items are linked to a supplier's supplied products, and a backorder is placed
+# against the supplier's catalog through the DFC API.
+RSpec.describe "Orders backorder integration" do
+  include AuthorizationHelper
+
+  let(:host) { Rails.application.default_url_options[:host] }
+
+  # Supplier sells their product on OFN via DFC api
+  let(:supplier_owner) { create(:oidc_user, id: 12_345) }
+  let(:supplier) {
+    create(:distributor_enterprise, id: 10_000, name: "Fred's Farm", owner: supplier_owner)
+  }
+  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "SUP", supplier:) }
+  let(:semantic_id) {
+    "http://#{host}/api/dfc/enterprises/#{supplier.id}/supplied_products/#{variant.id}"
+  }
+  let!(:supplier_order_cycle) {
+    create(:simple_order_cycle, distributors: [supplier], variants: [variant])
+  }
+
+  # Distributor has imported a copy of the product and is selling it
+  # The distributor must be authorised with the email address of the supplier owner.
+  # Because they are on the same OFN instance in this test, they must be the same user.
+  let(:distributor_owner) { supplier_owner }
+  let(:distributor) {
+    create(:distributor_enterprise, id: 11_000, owner: distributor_owner, name: "Shane's Shop")
+  }
+  let(:distributor_variant) {
+    create(:variant, id: 11_001, unit_value: 1, sku: "DIST", on_hand: 10,
+                     supplier: distributor).tap { |v|
+      v.semantic_links.create(semantic_id:) # variant is linked to supplier variant
+      v.on_demand = false
+    }
+  }
+  let(:distributor_order_cycle) {
+    create(:simple_order_cycle, distributors: [distributor], variants: [distributor_variant])
+  }
+
+  # Customer orders the distributed product
+  let(:distributor_order) {
+    create(:order_with_totals_and_distribution,
+           variant: distributor_variant,
+           distributor:, order_cycle: distributor_order_cycle)
+  }
+
+  before {
+    # For this test, OFN is talking to itself. We currently don't allow that IRL.
+    allow(PrivateAddressCheck).to receive(:private_address?).and_return(false)
+
+    # Pretend that user has authenticated with OIDC
+    distributor_owner.oidc_account.update!(token: allow_token_for(email: distributor_owner.email))
+
+    variant.on_hand = 100
+  }
+
+  describe "BackorderJob" do
+    let(:supplier_order) { supplier.distributed_orders.first }
+
+    it "creates an order for the source variant" do
+      # For debugging you can check log/test.log, eg:
+      # echo "" > log/test.log; tail -f log/test.log | egrep "(Started|Completed)"
+
+      expect {
+        # BackorderJob.perform_now(order) # Cannot perform whole job as it gets stuck on record lock
+        BackorderJob.new.place_backorder(distributor_order)
+      }.to change { supplier.distributed_orders.count }.by(1)
+
+      expect(supplier_order.created_by).to eq distributor_owner
+      expect(supplier_order.user).to eq distributor_owner
+      expect(supplier_order.email).to eq distributor_owner.email
+      expect(supplier_order.state).to eq "complete"
+
+      expect(supplier_order.line_items.count).to eq 1
+      expect(supplier_order.line_items.first.variant).to eq variant
+      expect(supplier_order.line_items.first.quantity).to eq 1
+    end
+
+    # The backorder should be synchronised at the end of the order cycle via
+    # CompleteBackorderJob, which re-exports the imported supplier order. This
+    # currently fails under the DFC connector v1 migration: imported orders
+    # carry bare references (and the connector deserialises them into raw
+    # Hashes/Strings rather than inlined SemanticObjects), so the backorder
+    # updater/broker and the re-export break. These are pre-existing backorder
+    # integration bugs, tracked separately from this orders-endpoint PR.
+    xit "synchronises quantities at the end of the order cycle" do
+      distributor_order.line_items.first.update! quantity: 2
+      supplier_line_item = supplier_order.line_items.first
+
+      expect {
+        # No route exists yet for updating the placed backorder, so we run the
+        # completion job directly instead of via its URL:
+        # CompleteBackorderJob.perform_now(distributor_owner, distributor,
+        #                                 distributor_order_cycle, backorder_url)
+        perform_enqueued_jobs(only: CompleteBackorderJob)
+        supplier_line_item.reload
+      }.to change { supplier_line_item.quantity }.to(2)
+    rescue Faraday::UnprocessableEntityError => e
+      # Output error message for convenient debugging
+      expect(e.response[:body]).to be_blank
+    end
+  end
+end

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe "Orders backorder integration" do
   let(:supplier) {
     create(:distributor_enterprise, id: 10_000, name: "Fred's Farm", owner: supplier_owner)
   }
-  let(:variant) { build(:base_variant, id: 10_001, unit_value: 1, sku: "SUP", supplier:) }
+  let(:variant) {
+    build(:base_variant, id: 10_001, unit_value: 1, sku: "SUP", enterprise: supplier)
+  }
   let(:semantic_id) {
     "http://#{host}/api/dfc/enterprises/#{supplier.id}/supplied_products/#{variant.id}"
   }
@@ -35,7 +37,7 @@ RSpec.describe "Orders backorder integration" do
   }
   let(:distributor_variant) {
     create(:variant, id: 11_001, unit_value: 1, sku: "DIST", on_hand: 10,
-                     supplier: distributor).tap { |v|
+                     enterprise: distributor).tap { |v|
       v.semantic_links.create(semantic_id:) # variant is linked to supplier variant
       v.on_demand = false
     }

--- a/engines/dfc_provider/spec/system/orders_backorder_spec.rb
+++ b/engines/dfc_provider/spec/system/orders_backorder_spec.rb
@@ -85,28 +85,30 @@ RSpec.describe "Orders backorder integration" do
       expect(supplier_order.line_items.first.quantity).to eq 1
     end
 
-    # The backorder should be synchronised at the end of the order cycle via
-    # CompleteBackorderJob, which re-exports the imported supplier order. This
-    # currently fails under the DFC connector v1 migration: imported orders
-    # carry bare references (and the connector deserialises them into raw
-    # Hashes/Strings rather than inlined SemanticObjects), so the backorder
-    # updater/broker and the re-export break. These are pre-existing backorder
-    # integration bugs, tracked separately from this orders-endpoint PR.
+    # Blocked by a DFC connector v1 bug, not by the orders endpoint: importing
+    # an order whose `dfc-b:orderedBy` is a bare URI reference turns that
+    # property into a parsed-URI Hash, which then can't be exported again.
+    #
+    #   order = DfcIo.import('{"@context":"https://www.datafoodconsortium.org",
+    #     "@graph":[{"@id":"http://test.host/orders/5","@type":"dfc-b:Order",
+    #     "dfc-b:orderedBy":"http://test.host/enterprises/1"}]}')
+    #   order.client
+    #   # => {scheme: "http", authority: "test.host", ...}
+    #   DfcIo.export(order)
+    #   # => RuntimeError: The type of the property 'dfc-b:orderedBy' is 'Hash'
+    #   #    but a primitive, a SemanticObject or an Array is required.
+    #
+    # CompleteBackorderJob re-exports the order it fetched, so it fails there.
     xit "synchronises quantities at the end of the order cycle" do
-      distributor_order.line_items.first.update! quantity: 2
+      BackorderJob.new.place_backorder(distributor_order)
+
       supplier_line_item = supplier_order.line_items.first
+      distributor_order.line_items.first.update! quantity: 2
 
       expect {
-        # No route exists yet for updating the placed backorder, so we run the
-        # completion job directly instead of via its URL:
-        # CompleteBackorderJob.perform_now(distributor_owner, distributor,
-        #                                 distributor_order_cycle, backorder_url)
         perform_enqueued_jobs(only: CompleteBackorderJob)
         supplier_line_item.reload
-      }.to change { supplier_line_item.quantity }.to(2)
-    rescue Faraday::UnprocessableEntityError => e
-      # Output error message for convenient debugging
-      expect(e.response[:body]).to be_blank
+      }.to change { supplier_line_item.quantity }.from(1).to(2)
     end
   end
 end

--- a/engines/dfc_provider/spec/system_helper.rb
+++ b/engines/dfc_provider/spec/system_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec/system_helper'
+
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }

--- a/spec/fixtures/files/fdc-send-backorder.json
+++ b/spec/fixtures/files/fdc-send-backorder.json
@@ -1,0 +1,51 @@
+{
+  "@context": "https://www.datafoodconsortium.org",
+  "@graph": [
+    {
+      "@id": "http://test.host/api/dfc/enterprises/10000/orders",
+      "@type": "dfc-b:Order",
+      "dfc-b:belongsTo": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+      "dfc-b:hasPart": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+      "dfc-b:orderedBy": "http://test.host/api/dfc/enterprises/11000",
+      "dfc-b:hasOrderStatus": "dfc-v:Held"
+    },
+    {
+      "@id": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+      "@type": "dfc-b:OrderLine",
+      "dfc-b:quantity": 1,
+      "dfc-b:concerns": "http://test.host/api/dfc/enterprises/10000/offers/10001"
+    },
+    {
+      "@id": "http://test.host/api/dfc/enterprises/10000/offers/10001",
+      "@type": "dfc-b:Offer",
+      "dfc-b:hasPrice": {
+        "@type": "dfc-b:Price",
+        "dfc-b:value": 19.99,
+        "dfc-b:hasUnit": "dfc-m:AustralianDollar"
+      },
+      "dfc-b:stockLimitation": 0,
+      "dfc-b:offeredItem": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001"
+    },
+    {
+      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001",
+      "@type": "dfc-b:SuppliedProduct",
+      "dfc-b:name": "Apple",
+      "dfc-b:description": "Red",
+      "dfc-b:hasQuantity": {
+        "@type": "dfc-b:QuantitativeValue",
+        "dfc-b:hasUnit": "dfc-m:Gram",
+        "dfc-b:value": 1
+      },
+      "dfc-b:referencedBy": "http://test.host/api/dfc/enterprises/10000/catalog_items/10001",
+      "dfc-b:isVariantOf": "http://test.host/api/dfc/product_groups/90000",
+      "ofn:spree_product_id": 90000,
+      "ofn:spree_product_uri": "http://test.host/api/dfc/enterprises/10000?spree_product_id=90000"
+    },
+    {
+      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+      "@type": "dfc-b:SaleSession",
+      "dfc-b:beginDate": "Wed Mar 19 2025 04:40:16 UTC",
+      "dfc-b:endDate": "Thu Mar 27 2025 04:40:16 UTC"
+    }
+  ]
+}

--- a/spec/fixtures/files/fdc-update-backorder.json
+++ b/spec/fixtures/files/fdc-update-backorder.json
@@ -1,0 +1,51 @@
+{
+  "@context": "https://www.datafoodconsortium.org",
+  "@graph": [
+    {
+      "@id": "http://test.host/api/dfc/enterprises/10000/orders",
+      "@type": "dfc-b:Order",
+      "dfc-b:belongsTo": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+      "dfc-b:hasPart": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+      "dfc-b:orderedBy": "http://test.host/api/dfc/enterprises/11000",
+      "dfc-b:hasOrderStatus": "dfc-v:Held"
+    },
+    {
+      "@id": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+      "@type": "dfc-b:OrderLine",
+      "dfc-b:quantity": 5,
+      "dfc-b:concerns": "http://test.host/api/dfc/enterprises/10000/offers/10001"
+    },
+    {
+      "@id": "http://test.host/api/dfc/enterprises/10000/offers/10001",
+      "@type": "dfc-b:Offer",
+      "dfc-b:hasPrice": {
+        "@type": "dfc-b:Price",
+        "dfc-b:value": 19.99,
+        "dfc-b:hasUnit": "dfc-m:AustralianDollar"
+      },
+      "dfc-b:stockLimitation": 0,
+      "dfc-b:offeredItem": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001"
+    },
+    {
+      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001",
+      "@type": "dfc-b:SuppliedProduct",
+      "dfc-b:name": "Apple",
+      "dfc-b:description": "Red",
+      "dfc-b:hasQuantity": {
+        "@type": "dfc-b:QuantitativeValue",
+        "dfc-b:hasUnit": "dfc-m:Gram",
+        "dfc-b:value": 1
+      },
+      "dfc-b:referencedBy": "http://test.host/api/dfc/enterprises/10000/catalog_items/10001",
+      "dfc-b:isVariantOf": "http://test.host/api/dfc/product_groups/90000",
+      "ofn:spree_product_id": 90000,
+      "ofn:spree_product_uri": "http://test.host/api/dfc/enterprises/10000?spree_product_id=90000"
+    },
+    {
+      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+      "@type": "dfc-b:SaleSession",
+      "dfc-b:beginDate": "Wed Mar 19 2025 04:40:16 UTC",
+      "dfc-b:endDate": "Thu Mar 27 2025 04:40:16 UTC"
+    }
+  ]
+}

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -5,6 +5,16 @@ module Spree
     RSpec.describe AvailabilityValidator do
       let(:validator) { AvailabilityValidator.new({}) }
 
+      context "new line item without variant" do
+        let(:order) { create(:order) }
+        let(:line_item) { order.line_items.build }
+
+        it "fails gracefully" do
+          validator.validate(line_item)
+          expect(line_item).not_to be_valid
+        end
+      end
+
       context "line item without existing inventory units" do
         let(:order) { create(:order_with_line_items) }
         let(:line_item) { order.line_items.first }

--- a/spec/services/fdc_url_builder_spec.rb
+++ b/spec/services/fdc_url_builder_spec.rb
@@ -11,4 +11,15 @@ RSpec.describe FdcUrlBuilder do
     expect(subject.orders_url).to eq "https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/Orders"
     expect(subject.sale_session_url).to eq "https://env-0105831.jcloud-ver-jpe.ik-server.com/api/dfc/Enterprises/test-hodmedod/SalesSession/#"
   end
+
+  context "OFN URLs" do
+    let(:product_link) {
+      "http://test.host/api/dfc/enterprises/10000/supplied_products/10001"
+    }
+
+    it "knows the right URLs" do
+      expect(subject.catalog_url).to eq "http://test.host/api/dfc/enterprises/10000/catalog_items"
+      expect(subject.orders_url).to eq "http://test.host/api/dfc/enterprises/10000/orders"
+    end
+  end
 end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -208,6 +208,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
                       ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -250,6 +251,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
                       ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -292,6 +294,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
                       ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -334,6 +337,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
                       ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -622,6 +626,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -700,6 +705,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -778,6 +784,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -857,6 +864,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -919,6 +927,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -981,6 +990,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -1102,6 +1112,308 @@ paths:
                 "@type": dfc-b:Offer
                 dfc-b:hasPrice: 9.99
                 dfc-b:stockLimitation: 7
+  "/api/dfc/enterprises/{enterprise_id}/orders/{order_id}":
+    parameters:
+    - name: enterprise_id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Show Order
+      parameters:
+      - name: order_id
+        in: path
+        required: true
+      tags:
+      - Orders
+      responses:
+        '200':
+          description: success
+          content:
+            application/json; charset=utf-8:
+              examples:
+                success:
+                  value:
+                    "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
+                    "@graph":
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000
+                      "@type": dfc-b:Order
+                      dfc-b:hasPart:
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/65
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/66
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/67
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/68
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/69
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/70
+                      dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
+                      dfc-b:hasOrderStatus: dfc-v:Held
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/65
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/161
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/66
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/163
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/67
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/165
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/68
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/167
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/69
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/169
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/70
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/10000/offers/10001
+                    - "@id": http://test.host/api/dfc/enterprises/63/offers/161
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 4
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/161
+                    - "@id": http://test.host/api/dfc/enterprises/63/offers/163
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 4
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/163
+                    - "@id": http://test.host/api/dfc/enterprises/63/offers/165
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 4
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/165
+                    - "@id": http://test.host/api/dfc/enterprises/63/offers/167
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 4
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/167
+                    - "@id": http://test.host/api/dfc/enterprises/63/offers/169
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 4
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/169
+                    - "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 0
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/161
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #23 - 4251 - 1g'
+                      dfc-b:description: |-
+                        Culpa ratione minus explicabo iste at vitae. Quis magnam maxime tenetur quas aliquam accusamus officiis. Nulla molestias ipsum veniam quas.
+                        Odit perferendis repudiandae aliquam atque tenetur nobis. Ducimus atque ullam quisquam veniam porro. Voluptas iste distinctio sunt suscipit officiis. Placeat harum aliquam fugiat suscipit minima.
+                        Quidem labore iure aspernatur atque nulla. Ad quia iste possimus amet praesentium fugiat. Ea est maiores dicta sed cupiditate. Cum non quaerat laborum quas sapiente sit. Doloremque consequatur vitae voluptates perspiciatis.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/161
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/101
+                      ofn:spree_product_id: 101
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=101
+                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/163
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #24 - 5277 - 1g'
+                      dfc-b:description: |-
+                        Dolor cum earum mollitia nemo amet necessitatibus. Vero suscipit libero odit iste beatae. Harum distinctio iste fugiat cum quas. Laudantium expedita dicta animi odit officia quia. Fuga vel voluptas tempore id aperiam corrupti quia.
+                        Magnam impedit reprehenderit rem consequatur aspernatur. Blanditiis architecto quisquam sunt molestias amet porro aliquam. Culpa debitis iusto quos optio hic. Nostrum corporis officiis minima veritatis.
+                        Adipisci quibusdam culpa dolorem aspernatur blanditiis eveniet officiis. Sequi deserunt magnam iusto incidunt nostrum porro ullam. Similique earum quaerat saepe maxime. Ab iste quia pariatur consequatur. Nam ipsa quisquam laudantium ipsam nostrum cum.
+                        Nobis ea tempora assumenda illo amet at ducimus. Vero voluptates nemo odio repudiandae deleniti. Beatae quis magnam a voluptate cupiditate.
+                        Blanditiis ab inventore consequatur ipsum magni. Fugiat impedit laudantium tenetur ab odio nemo ut. Sequi earum eveniet magni maxime a deserunt modi. Quae quod dolores vero quaerat. Optio quisquam ullam officia ducimus rerum nisi ipsum amet.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/163
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/102
+                      ofn:spree_product_id: 102
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=102
+                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/165
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #25 - 2153 - 1g'
+                      dfc-b:description: |-
+                        Quis delectus reprehenderit dicta mollitia nam. Sapiente incidunt molestias dolor temporibus quibusdam beatae recusandae aliquam. Debitis sapiente veritatis vero autem.
+                        Suscipit mollitia corrupti enim nulla voluptatum asperiores quia commodi. Ipsum repellendus animi autem repudiandae provident non. Accusantium voluptatibus accusamus expedita debitis. Temporibus aliquid quibusdam optio sit fugiat reprehenderit. Dolore laboriosam tenetur facere minima autem aperiam quos adipisci.
+                        Facilis laudantium natus quibusdam tenetur. Reprehenderit doloribus animi quis laudantium non. Amet laboriosam quidem reprehenderit assumenda ratione quia dicta.
+                        Accusamus quas sit repellendus assumenda sequi. Aliquid praesentium tenetur mollitia quisquam temporibus. Exercitationem reiciendis aperiam dolorem quidem dolor.
+                        Ex vero quia error possimus. Beatae voluptas saepe deserunt illo. Voluptatibus reprehenderit animi harum beatae corporis. Neque omnis tempora illo nam maxime dolor dicta ipsa. Corrupti adipisci sed minus saepe consequatur provident.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/165
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/103
+                      ofn:spree_product_id: 103
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=103
+                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/167
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #26 - 4790 - 1g'
+                      dfc-b:description: Natus fugit soluta perferendis nemo est adipisci.
+                        Reiciendis pariatur earum culpa fuga doloribus. Deleniti aut
+                        cum error rem magni at. Eveniet occaecati nobis velit perferendis.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/167
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/104
+                      ofn:spree_product_id: 104
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=104
+                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/169
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #27 - 554 - 1g'
+                      dfc-b:description: |-
+                        Molestias accusantium expedita tempore praesentium. Optio corrupti in quas nemo a quae soluta. Molestiae consequuntur quaerat atque provident porro ipsa. Amet recusandae consequatur iure soluta sapiente quae expedita. Ducimus fugit aspernatur corporis eaque nemo quas earum ut.
+                        Nobis aspernatur accusantium aut maxime minus dolor eaque. Animi aspernatur saepe corporis velit. Consequuntur tempore dolorum quos voluptatem numquam sapiente.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/169
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/105
+                      ofn:spree_product_id: 105
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=105
+                    - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #22 - 9859 - 1g'
+                      dfc-b:description: |-
+                        Autem aspernatur alias repellendus quisquam voluptas. Reiciendis nobis voluptatibus recusandae architecto suscipit rem. Odit laudantium sed illum itaque fuga ullam saepe. Eveniet tenetur praesentium incidunt facere eaque sapiente animi. Provident veniam cum magni enim hic quidem earum optio.
+                        Ut sunt distinctio expedita quo nisi officiis libero quos. Praesentium dicta molestiae dolorem assumenda culpa ab. Dicta dolor quasi sit distinctio nulla. Animi sapiente quo nesciunt aut.
+                        Atque molestiae sapiente quidem eveniet eos. Voluptates dolorem iure autem impedit sed doloribus amet. Eveniet doloribus ducimus ipsa eius tempore sapiente nisi. Molestiae rem est tenetur earum omnis.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/100
+                      ofn:spree_product_id: 100
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=100
+                    - "@id": "/api/dfc/SalesSession/#"
+                      "@type": dfc-b:SaleSession
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
+  "/api/dfc/enterprises/{enterprise_id}/orders":
+    parameters:
+    - name: enterprise_id
+      in: path
+      required: true
+      schema:
+        type: string
+    post:
+      summary: Create Order
+      parameters: []
+      tags:
+      - Orders
+      responses:
+        '201':
+          description: created
+          content:
+            application/json; charset=utf-8:
+              examples:
+                with line items:
+                  value:
+                    "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
+                    "@id": http://test.host/api/dfc/enterprises/10000/orders/10001
+                    "@type": dfc-b:Order
+                    dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
+                    dfc-b:hasOrderStatus: dfc-v:Held
+        '400':
+          description: bad request
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
+        '422':
+          description: unprocessable entity
+          content:
+            application/json; charset=utf-8:
+              examples:
+                variant not found:
+                  value:
+                    error: Line items variant must exist and Line items price is not
+                      a number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example: |
+                {
+                  "@context": "https://www.datafoodconsortium.org",
+                  "@graph": [
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/orders",
+                      "@type": "dfc-b:Order",
+                      "dfc-b:belongsTo": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+                      "dfc-b:hasPart": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+                      "dfc-b:orderedBy": "http://test.host/api/dfc/enterprises/11000",
+                      "dfc-b:hasOrderStatus": "dfc-v:Held"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+                      "@type": "dfc-b:OrderLine",
+                      "dfc-b:quantity": 1,
+                      "dfc-b:concerns": "http://test.host/api/dfc/enterprises/10000/offers/10001"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/offers/10001",
+                      "@type": "dfc-b:Offer",
+                      "dfc-b:hasPrice": {
+                        "@type": "dfc-b:Price",
+                        "dfc-b:value": 19.99,
+                        "dfc-b:hasUnit": "dfc-m:AustralianDollar"
+                      },
+                      "dfc-b:stockLimitation": 0,
+                      "dfc-b:offeredItem": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001",
+                      "@type": "dfc-b:SuppliedProduct",
+                      "dfc-b:name": "Apple",
+                      "dfc-b:description": "Red",
+                      "dfc-b:hasQuantity": {
+                        "@type": "dfc-b:QuantitativeValue",
+                        "dfc-b:hasUnit": "dfc-m:Gram",
+                        "dfc-b:value": 1
+                      },
+                      "dfc-b:referencedBy": "http://test.host/api/dfc/enterprises/10000/catalog_items/10001",
+                      "dfc-b:isVariantOf": "http://test.host/api/dfc/product_groups/90000",
+                      "ofn:spree_product_id": 90000,
+                      "ofn:spree_product_uri": "http://test.host/api/dfc/enterprises/10000?spree_product_id=90000"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+                      "@type": "dfc-b:SaleSession",
+                      "dfc-b:beginDate": "Wed Mar 19 2025 04:40:16 UTC",
+                      "dfc-b:endDate": "Thu Mar 27 2025 04:40:16 UTC"
+                    }
+                  ]
+                }
   "/api/dfc/organizations":
     get:
       summary: List organizations
@@ -1473,6 +1785,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -1509,6 +1822,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -1557,6 +1871,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/213
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000
                     ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -1572,6 +1887,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/215
                     dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000
@@ -1632,6 +1948,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 1.0
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                     dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -1140,78 +1140,78 @@ paths:
                     - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000
                       "@type": dfc-b:Order
                       dfc-b:hasPart:
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/65
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/66
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/67
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/68
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/69
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/70
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1250
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1251
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1252
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1253
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1254
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1255
                       dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
                       dfc-b:hasOrderStatus: dfc-v:Held
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/65
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1250
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/161
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/66
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2843
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1251
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/163
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/67
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2845
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1252
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/165
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/68
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2847
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1253
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/167
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/69
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2849
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1254
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/169
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/70
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2851
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1255
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
                       dfc-b:concerns: http://test.host/api/dfc/enterprises/10000/offers/10001
-                    - "@id": http://test.host/api/dfc/enterprises/63/offers/161
+                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2843
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/161
-                    - "@id": http://test.host/api/dfc/enterprises/63/offers/163
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2843
+                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2845
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/163
-                    - "@id": http://test.host/api/dfc/enterprises/63/offers/165
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2845
+                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2847
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/165
-                    - "@id": http://test.host/api/dfc/enterprises/63/offers/167
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2847
+                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2849
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/167
-                    - "@id": http://test.host/api/dfc/enterprises/63/offers/169
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2849
+                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2851
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/169
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2851
                     - "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
@@ -1220,100 +1220,219 @@ paths:
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 0
                       dfc-b:offeredItem: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
-                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/161
+                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2843
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #23 - 4251 - 1g'
+                      dfc-b:name: 'Product #23 - 7992 - 1g'
                       dfc-b:description: |-
-                        Culpa ratione minus explicabo iste at vitae. Quis magnam maxime tenetur quas aliquam accusamus officiis. Nulla molestias ipsum veniam quas.
-                        Odit perferendis repudiandae aliquam atque tenetur nobis. Ducimus atque ullam quisquam veniam porro. Voluptas iste distinctio sunt suscipit officiis. Placeat harum aliquam fugiat suscipit minima.
-                        Quidem labore iure aspernatur atque nulla. Ad quia iste possimus amet praesentium fugiat. Ea est maiores dicta sed cupiditate. Cum non quaerat laborum quas sapiente sit. Doloremque consequatur vitae voluptates perspiciatis.
+                        Deserunt sunt illo eius facilis. Esse praesentium sit hic dignissimos quaerat. Velit labore hic qui est.
+                        Maxime sit recusandae veritatis ipsa necessitatibus ex at possimus. Nemo quia a quas ipsa eos. Iste molestias harum quia doloribus quos cum exercitationem.
+                        Nihil assumenda aspernatur sit occaecati officia perspiciatis eius. Sed quia recusandae iste ea. Dolorum alias assumenda repudiandae ducimus esse nostrum id beatae. Libero perspiciatis beatae ad voluptatum. Sequi fugit excepturi illum officia totam.
+                        Accusantium debitis veniam veritatis ipsa nesciunt vero expedita minus. Odit beatae inventore dolorem perspiciatis dolore nemo ducimus. Reiciendis omnis a provident ullam incidunt quas facere inventore.
+                        Excepturi suscipit quod voluptatum ipsam deserunt. Dolor nostrum omnis nisi numquam animi. Consectetur blanditiis rem possimus laborum maxime maiores eius.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/161
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/101
-                      ofn:spree_product_id: 101
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=101
-                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/163
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2843
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1688
+                      ofn:spree_product_id: 1688
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1688
+                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2845
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #24 - 5277 - 1g'
+                      dfc-b:name: 'Product #24 - 3181 - 1g'
                       dfc-b:description: |-
-                        Dolor cum earum mollitia nemo amet necessitatibus. Vero suscipit libero odit iste beatae. Harum distinctio iste fugiat cum quas. Laudantium expedita dicta animi odit officia quia. Fuga vel voluptas tempore id aperiam corrupti quia.
-                        Magnam impedit reprehenderit rem consequatur aspernatur. Blanditiis architecto quisquam sunt molestias amet porro aliquam. Culpa debitis iusto quos optio hic. Nostrum corporis officiis minima veritatis.
-                        Adipisci quibusdam culpa dolorem aspernatur blanditiis eveniet officiis. Sequi deserunt magnam iusto incidunt nostrum porro ullam. Similique earum quaerat saepe maxime. Ab iste quia pariatur consequatur. Nam ipsa quisquam laudantium ipsam nostrum cum.
-                        Nobis ea tempora assumenda illo amet at ducimus. Vero voluptates nemo odio repudiandae deleniti. Beatae quis magnam a voluptate cupiditate.
-                        Blanditiis ab inventore consequatur ipsum magni. Fugiat impedit laudantium tenetur ab odio nemo ut. Sequi earum eveniet magni maxime a deserunt modi. Quae quod dolores vero quaerat. Optio quisquam ullam officia ducimus rerum nisi ipsum amet.
+                        Eligendi consectetur blanditiis non beatae praesentium. Fugiat eius repellat aliquam dolorum magni sunt. Delectus odio accusamus architecto blanditiis beatae animi. Culpa impedit veritatis natus laboriosam nisi excepturi.
+                        Atque tenetur quos culpa quas corporis debitis laborum. Ad perspiciatis quis minus sequi quam dicta ducimus. Eveniet vero qui sunt beatae ut laborum maxime. Occaecati unde amet repellat eius assumenda ducimus eos possimus.
+                        Vel a quis tempora ratione totam maiores iste corrupti. Mollitia labore rerum quam accusantium. Commodi reiciendis earum dicta magnam reprehenderit.
+                        Repellendus nisi reprehenderit autem harum impedit veniam quia. Numquam pariatur reiciendis dolore vero sequi. Non voluptatem explicabo assumenda iure totam deserunt dolorum. Soluta possimus vero laborum magnam amet ex. Error impedit officia harum in ducimus voluptas.
+                        Placeat cumque pariatur laudantium odit et commodi. Eos perspiciatis cupiditate at facere commodi blanditiis. Odio rem vero ducimus architecto. Ad deserunt autem veniam velit dignissimos ex. At nesciunt occaecati repudiandae repellendus soluta.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/163
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/102
-                      ofn:spree_product_id: 102
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=102
-                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/165
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2845
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1689
+                      ofn:spree_product_id: 1689
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1689
+                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2847
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #25 - 2153 - 1g'
+                      dfc-b:name: 'Product #25 - 1231 - 1g'
                       dfc-b:description: |-
-                        Quis delectus reprehenderit dicta mollitia nam. Sapiente incidunt molestias dolor temporibus quibusdam beatae recusandae aliquam. Debitis sapiente veritatis vero autem.
-                        Suscipit mollitia corrupti enim nulla voluptatum asperiores quia commodi. Ipsum repellendus animi autem repudiandae provident non. Accusantium voluptatibus accusamus expedita debitis. Temporibus aliquid quibusdam optio sit fugiat reprehenderit. Dolore laboriosam tenetur facere minima autem aperiam quos adipisci.
-                        Facilis laudantium natus quibusdam tenetur. Reprehenderit doloribus animi quis laudantium non. Amet laboriosam quidem reprehenderit assumenda ratione quia dicta.
-                        Accusamus quas sit repellendus assumenda sequi. Aliquid praesentium tenetur mollitia quisquam temporibus. Exercitationem reiciendis aperiam dolorem quidem dolor.
-                        Ex vero quia error possimus. Beatae voluptas saepe deserunt illo. Voluptatibus reprehenderit animi harum beatae corporis. Neque omnis tempora illo nam maxime dolor dicta ipsa. Corrupti adipisci sed minus saepe consequatur provident.
+                        Doloremque illum unde ullam facilis nisi soluta. Totam pariatur necessitatibus modi veritatis fuga corrupti odio. Atque ratione ullam similique quas quibusdam culpa. Velit fugiat accusamus porro reiciendis possimus.
+                        Placeat quam explicabo laudantium nobis praesentium sit labore hic. Repellat sed voluptatibus animi libero. Nihil excepturi cum fugit inventore facere.
+                        Animi expedita culpa facere aliquam. Dolorum dolorem aliquam similique harum voluptas facere nisi consequuntur. Vitae quis velit delectus modi.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/165
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/103
-                      ofn:spree_product_id: 103
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=103
-                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/167
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2847
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1690
+                      ofn:spree_product_id: 1690
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1690
+                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2849
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #26 - 4790 - 1g'
-                      dfc-b:description: Natus fugit soluta perferendis nemo est adipisci.
-                        Reiciendis pariatur earum culpa fuga doloribus. Deleniti aut
-                        cum error rem magni at. Eveniet occaecati nobis velit perferendis.
-                      dfc-b:hasQuantity:
-                        "@type": dfc-b:QuantitativeValue
-                        dfc-b:hasUnit: dfc-m:Gram
-                        dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/167
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/104
-                      ofn:spree_product_id: 104
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=104
-                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/169
-                      "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #27 - 554 - 1g'
+                      dfc-b:name: 'Product #26 - 7241 - 1g'
                       dfc-b:description: |-
-                        Molestias accusantium expedita tempore praesentium. Optio corrupti in quas nemo a quae soluta. Molestiae consequuntur quaerat atque provident porro ipsa. Amet recusandae consequatur iure soluta sapiente quae expedita. Ducimus fugit aspernatur corporis eaque nemo quas earum ut.
-                        Nobis aspernatur accusantium aut maxime minus dolor eaque. Animi aspernatur saepe corporis velit. Consequuntur tempore dolorum quos voluptatem numquam sapiente.
+                        Quisquam sed eius dolorum nostrum maiores vero. Totam sunt et vel tempore excepturi placeat maiores. Nobis accusamus pariatur aspernatur similique numquam amet corporis at. Ipsa voluptatem tempore recusandae corporis magni officia. Atque a ullam sunt esse magni optio mollitia.
+                        Labore molestiae tempore totam a nihil saepe expedita autem. Doloribus totam voluptatibus omnis cupiditate non excepturi natus illo. Non vitae harum odit occaecati amet molestias sequi omnis. Ullam porro cum quas non veniam delectus.
+                        Vitae tenetur aperiam totam iure quibusdam qui voluptates facere. Voluptate enim quod inventore voluptas. Tempore commodi aperiam quas accusantium similique accusamus.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/169
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/105
-                      ofn:spree_product_id: 105
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=105
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2849
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1691
+                      ofn:spree_product_id: 1691
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1691
+                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2851
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #27 - 4296 - 1g'
+                      dfc-b:description: |-
+                        Delectus voluptates harum dignissimos velit. Occaecati nam ratione molestias quo quas nesciunt minima maxime. Iste reprehenderit repellat sapiente rem aspernatur corrupti labore nisi.
+                        Et voluptas impedit dicta nam officia quae. Officiis neque doloremque tempora nesciunt quo. Id aperiam enim tenetur quam.
+                        Recusandae consequuntur aliquam rem saepe velit. Dolores eum quam nam consectetur. Tempora atque quam repellat molestias ipsum odio accusantium.
+                        Expedita molestias quia natus provident illum non sunt. Aliquam et fugiat voluptate optio. Doloremque et soluta quas nobis corrupti veniam. Doloremque impedit eligendi similique dolor veniam non. Dolores provident quisquam magnam veritatis velit qui earum eum.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2851
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1692
+                      ofn:spree_product_id: 1692
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1692
                     - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #22 - 9859 - 1g'
+                      dfc-b:name: 'Product #22 - 8203 - 1g'
                       dfc-b:description: |-
-                        Autem aspernatur alias repellendus quisquam voluptas. Reiciendis nobis voluptatibus recusandae architecto suscipit rem. Odit laudantium sed illum itaque fuga ullam saepe. Eveniet tenetur praesentium incidunt facere eaque sapiente animi. Provident veniam cum magni enim hic quidem earum optio.
-                        Ut sunt distinctio expedita quo nisi officiis libero quos. Praesentium dicta molestiae dolorem assumenda culpa ab. Dicta dolor quasi sit distinctio nulla. Animi sapiente quo nesciunt aut.
-                        Atque molestiae sapiente quidem eveniet eos. Voluptates dolorem iure autem impedit sed doloribus amet. Eveniet doloribus ducimus ipsa eius tempore sapiente nisi. Molestiae rem est tenetur earum omnis.
+                        Amet dignissimos eum suscipit saepe. Necessitatibus dolorem ipsam atque asperiores nisi enim rem similique. Voluptates reiciendis libero corrupti perspiciatis amet vitae incidunt cupiditate. Delectus ut nobis deleniti harum mollitia minima rerum dolorem. Eaque asperiores repellendus perspiciatis eligendi temporibus omnis voluptatibus inventore.
+                        Dolorum nesciunt incidunt porro beatae placeat error deserunt sapiente. Eum modi magni possimus neque quidem omnis dolorem mollitia. Unde vitae natus alias nobis dolor dolorum iste.
+                        Illo quisquam sapiente consequuntur harum. Atque quam rem explicabo repudiandae rerum nisi ipsa libero. Tempore pariatur sint unde sit itaque reprehenderit vel. Placeat velit enim sint aliquam natus nobis.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
                       dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/100
-                      ofn:spree_product_id: 100
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=100
-                    - "@id": "/api/dfc/SalesSession/#"
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1687
+                      ofn:spree_product_id: 1687
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=1687
+                    - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products
                       "@type": dfc-b:SaleSession
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
+    put:
+      summary: Update Order
+      parameters:
+      - name: order_id
+        in: path
+        required: true
+      tags:
+      - Orders
+      responses:
+        '200':
+          description: order completed
+          content:
+            application/json; charset=utf-8:
+              examples:
+                success:
+                  value:
+                    "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
+                    "@id": http://test.host/api/dfc/enterprises/10000/orders/11000
+                    "@type": dfc-b:Order
+                    dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
+                    dfc-b:hasOrderStatus: dfc-v:Held
+                order completed:
+                  value:
+                    "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
+                    "@id": http://test.host/api/dfc/enterprises/10000/orders/11000
+                    "@type": dfc-b:Order
+                    dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
+                    dfc-b:hasOrderStatus: dfc-v:Held
+        '400':
+          description: bad request
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
+        '422':
+          description: unprocessable entity
+          content:
+            application/json; charset=utf-8:
+              examples:
+                unprocessable entity:
+                  value:
+                    error: Line items variant must exist and Line items price is not
+                      a number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example: |
+                {
+                  "@context": "https://www.datafoodconsortium.org",
+                  "@graph": [
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/orders",
+                      "@type": "dfc-b:Order",
+                      "dfc-b:belongsTo": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+                      "dfc-b:hasPart": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+                      "dfc-b:orderedBy": "http://test.host/api/dfc/enterprises/11000",
+                      "dfc-b:hasOrderStatus": "dfc-v:Held"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+                      "@type": "dfc-b:OrderLine",
+                      "dfc-b:quantity": 5,
+                      "dfc-b:concerns": "http://test.host/api/dfc/enterprises/10000/offers/10001"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/offers/10001",
+                      "@type": "dfc-b:Offer",
+                      "dfc-b:hasPrice": {
+                        "@type": "dfc-b:Price",
+                        "dfc-b:value": 19.99,
+                        "dfc-b:hasUnit": "dfc-m:AustralianDollar"
+                      },
+                      "dfc-b:stockLimitation": 0,
+                      "dfc-b:offeredItem": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001",
+                      "@type": "dfc-b:SuppliedProduct",
+                      "dfc-b:name": "Apple",
+                      "dfc-b:description": "Red",
+                      "dfc-b:hasQuantity": {
+                        "@type": "dfc-b:QuantitativeValue",
+                        "dfc-b:hasUnit": "dfc-m:Gram",
+                        "dfc-b:value": 1
+                      },
+                      "dfc-b:referencedBy": "http://test.host/api/dfc/enterprises/10000/catalog_items/10001",
+                      "dfc-b:isVariantOf": "http://test.host/api/dfc/product_groups/90000",
+                      "ofn:spree_product_id": 90000,
+                      "ofn:spree_product_uri": "http://test.host/api/dfc/enterprises/10000?spree_product_id=90000"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+                      "@type": "dfc-b:SaleSession",
+                      "dfc-b:beginDate": "Wed Mar 19 2025 04:40:16 UTC",
+                      "dfc-b:endDate": "Thu Mar 27 2025 04:40:16 UTC"
+                    }
+                  ]
+                }
+    delete:
+      summary: Cancel Order
+      parameters:
+      - name: order_id
+        in: path
+        required: true
+        schema:
+          type: string
+      tags:
+      - Orders
+      responses:
+        '204':
+          description: no content
         '401':
           description: unauthorized
         '404':
@@ -1871,7 +1990,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
-                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/213
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/3016
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000
                     ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -1887,7 +2006,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
-                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/215
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/3018
                     dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -1140,78 +1140,78 @@ paths:
                     - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000
                       "@type": dfc-b:Order
                       dfc-b:hasPart:
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1250
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1251
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1252
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1253
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1254
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1255
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1978
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1979
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1980
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1981
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1982
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1983
                       dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
                       dfc-b:hasOrderStatus: dfc-v:Held
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1250
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1978
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2843
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1251
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1458/offers/4197
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1979
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2845
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1252
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1458/offers/4199
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1980
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2847
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1253
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1458/offers/4201
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1981
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2849
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1254
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1458/offers/4203
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1982
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2851
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1255
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1458/offers/4205
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1983
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
                       dfc-b:concerns: http://test.host/api/dfc/enterprises/10000/offers/10001
-                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2843
+                    - "@id": http://test.host/api/dfc/enterprises/1458/offers/4197
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2843
-                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2845
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1458/supplied_products/4197
+                    - "@id": http://test.host/api/dfc/enterprises/1458/offers/4199
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2845
-                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2847
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1458/supplied_products/4199
+                    - "@id": http://test.host/api/dfc/enterprises/1458/offers/4201
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2847
-                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2849
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1458/supplied_products/4201
+                    - "@id": http://test.host/api/dfc/enterprises/1458/offers/4203
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2849
-                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2851
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1458/supplied_products/4203
+                    - "@id": http://test.host/api/dfc/enterprises/1458/offers/4205
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2851
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1458/supplied_products/4205
                     - "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
@@ -1220,101 +1220,100 @@ paths:
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 0
                       dfc-b:offeredItem: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
-                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2843
+                    - "@id": http://test.host/api/dfc/enterprises/1458/supplied_products/4197
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #23 - 7992 - 1g'
+                      dfc-b:name: 'Product #23 - 7353 - 1g'
                       dfc-b:description: |-
-                        Deserunt sunt illo eius facilis. Esse praesentium sit hic dignissimos quaerat. Velit labore hic qui est.
-                        Maxime sit recusandae veritatis ipsa necessitatibus ex at possimus. Nemo quia a quas ipsa eos. Iste molestias harum quia doloribus quos cum exercitationem.
-                        Nihil assumenda aspernatur sit occaecati officia perspiciatis eius. Sed quia recusandae iste ea. Dolorum alias assumenda repudiandae ducimus esse nostrum id beatae. Libero perspiciatis beatae ad voluptatum. Sequi fugit excepturi illum officia totam.
-                        Accusantium debitis veniam veritatis ipsa nesciunt vero expedita minus. Odit beatae inventore dolorem perspiciatis dolore nemo ducimus. Reiciendis omnis a provident ullam incidunt quas facere inventore.
-                        Excepturi suscipit quod voluptatum ipsam deserunt. Dolor nostrum omnis nisi numquam animi. Consectetur blanditiis rem possimus laborum maxime maiores eius.
+                        Magni omnis rem minus natus iure. Dicta animi officiis perferendis ad nam suscipit ab quod. Dolor placeat error perspiciatis excepturi cumque exercitationem quam et.
+                        Exercitationem sunt rerum tempore quam itaque accusamus possimus praesentium. Nostrum commodi rerum magnam magni sint. Temporibus asperiores molestiae eveniet nihil sed maiores labore. Tenetur cupiditate non beatae id eos.
+                        Esse sunt voluptatibus consequatur at nam nulla. Similique ipsam ad modi quam eligendi suscipit tempora dolorum. At ex expedita ratione veniam itaque optio. Temporibus expedita omnis suscipit perferendis illo fugit. Dolorum sit veritatis repudiandae quidem eos deserunt repellat.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2843
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1688
-                      ofn:spree_product_id: 1688
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1688
-                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2845
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1458/catalog_items/4197
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2453
+                      ofn:spree_product_id: 2453
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1458?spree_product_id=2453
+                    - "@id": http://test.host/api/dfc/enterprises/1458/supplied_products/4199
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #24 - 3181 - 1g'
+                      dfc-b:name: 'Product #24 - 1888 - 1g'
                       dfc-b:description: |-
-                        Eligendi consectetur blanditiis non beatae praesentium. Fugiat eius repellat aliquam dolorum magni sunt. Delectus odio accusamus architecto blanditiis beatae animi. Culpa impedit veritatis natus laboriosam nisi excepturi.
-                        Atque tenetur quos culpa quas corporis debitis laborum. Ad perspiciatis quis minus sequi quam dicta ducimus. Eveniet vero qui sunt beatae ut laborum maxime. Occaecati unde amet repellat eius assumenda ducimus eos possimus.
-                        Vel a quis tempora ratione totam maiores iste corrupti. Mollitia labore rerum quam accusantium. Commodi reiciendis earum dicta magnam reprehenderit.
-                        Repellendus nisi reprehenderit autem harum impedit veniam quia. Numquam pariatur reiciendis dolore vero sequi. Non voluptatem explicabo assumenda iure totam deserunt dolorum. Soluta possimus vero laborum magnam amet ex. Error impedit officia harum in ducimus voluptas.
-                        Placeat cumque pariatur laudantium odit et commodi. Eos perspiciatis cupiditate at facere commodi blanditiis. Odio rem vero ducimus architecto. Ad deserunt autem veniam velit dignissimos ex. At nesciunt occaecati repudiandae repellendus soluta.
+                        Consequatur assumenda tempore minima recusandae neque ullam veritatis architecto. Dignissimos magni magnam recusandae officiis repellendus dolores. Laborum dolorem non nam perferendis sunt reiciendis optio.
+                        Similique cupiditate quam quis praesentium cum quaerat atque. At eos quas omnis voluptatem eaque nostrum architecto natus. Voluptatibus ea beatae porro modi dolorum officia debitis voluptatem. Debitis placeat saepe recusandae libero consectetur nihil omnis. Animi atque occaecati aliquam magni enim ipsum.
+                        Eius iusto soluta nihil ab explicabo tenetur. Dolor blanditiis ex sint explicabo ea pariatur nulla. In nam facere exercitationem blanditiis a doloremque. Praesentium consequuntur aliquid harum temporibus voluptas non magnam.
+                        Quaerat quae ea quia occaecati consequuntur laborum distinctio numquam. Rerum natus veniam praesentium placeat cupiditate animi soluta sed. Neque aspernatur ab qui excepturi tempore deleniti.
+                        Nihil sed dolorum delectus id commodi. In nemo et natus perspiciatis repellat iusto quia tempore. Voluptatum repudiandae maxime sit rem sed sequi. Porro accusantium exercitationem ipsam debitis dicta soluta pariatur eveniet.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2845
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1689
-                      ofn:spree_product_id: 1689
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1689
-                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2847
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1458/catalog_items/4199
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2454
+                      ofn:spree_product_id: 2454
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1458?spree_product_id=2454
+                    - "@id": http://test.host/api/dfc/enterprises/1458/supplied_products/4201
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #25 - 1231 - 1g'
+                      dfc-b:name: 'Product #25 - 638 - 1g'
                       dfc-b:description: |-
-                        Doloremque illum unde ullam facilis nisi soluta. Totam pariatur necessitatibus modi veritatis fuga corrupti odio. Atque ratione ullam similique quas quibusdam culpa. Velit fugiat accusamus porro reiciendis possimus.
-                        Placeat quam explicabo laudantium nobis praesentium sit labore hic. Repellat sed voluptatibus animi libero. Nihil excepturi cum fugit inventore facere.
-                        Animi expedita culpa facere aliquam. Dolorum dolorem aliquam similique harum voluptas facere nisi consequuntur. Vitae quis velit delectus modi.
+                        Ipsum ratione dignissimos ullam architecto saepe accusamus soluta totam. Fugit maiores atque dignissimos deserunt. Odio velit eligendi reiciendis quia.
+                        Qui voluptates rerum pariatur asperiores velit quod. Odio non ducimus repellendus expedita aliquam eos quisquam. Autem nobis ducimus quaerat quos quia consequatur quis architecto. Natus sequi quam assumenda tempore quo.
+                        A error optio placeat doloremque ullam est eaque. Quo qui ad laudantium ea dolorum. Voluptates at libero maiores debitis facere nobis hic tempore. Labore adipisci laboriosam beatae error. Temporibus eaque magni aperiam dolore atque dolorem soluta reiciendis.
+                        Temporibus voluptatum excepturi quo sapiente ab molestias ex fugiat. Eligendi iste natus labore minus doloremque reprehenderit. Occaecati sint quisquam mollitia saepe soluta atque.
+                        Minima quod amet occaecati magnam. Libero minima quos ex esse sed. Blanditiis molestiae deserunt laudantium eum veritatis itaque beatae.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2847
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1690
-                      ofn:spree_product_id: 1690
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1690
-                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2849
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1458/catalog_items/4201
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2455
+                      ofn:spree_product_id: 2455
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1458?spree_product_id=2455
+                    - "@id": http://test.host/api/dfc/enterprises/1458/supplied_products/4203
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #26 - 7241 - 1g'
+                      dfc-b:name: 'Product #26 - 9373 - 1g'
                       dfc-b:description: |-
-                        Quisquam sed eius dolorum nostrum maiores vero. Totam sunt et vel tempore excepturi placeat maiores. Nobis accusamus pariatur aspernatur similique numquam amet corporis at. Ipsa voluptatem tempore recusandae corporis magni officia. Atque a ullam sunt esse magni optio mollitia.
-                        Labore molestiae tempore totam a nihil saepe expedita autem. Doloribus totam voluptatibus omnis cupiditate non excepturi natus illo. Non vitae harum odit occaecati amet molestias sequi omnis. Ullam porro cum quas non veniam delectus.
-                        Vitae tenetur aperiam totam iure quibusdam qui voluptates facere. Voluptate enim quod inventore voluptas. Tempore commodi aperiam quas accusantium similique accusamus.
+                        Laboriosam suscipit quia omnis nemo ratione exercitationem. Officia omnis sint tempora porro ad voluptatum. Omnis temporibus quaerat rerum nobis impedit. Quisquam repellendus eum maxime dolores officiis accusantium. Odio sint ad saepe eaque tenetur libero.
+                        Adipisci consequuntur veritatis beatae eligendi tempora architecto odio non. Dignissimos recusandae velit ullam aperiam. Earum veniam repellat officiis fugiat tenetur veritatis.
+                        Minima incidunt recusandae hic aliquid fugiat. In rerum cum corrupti dolores necessitatibus. Velit alias optio tempora placeat facilis.
+                        Saepe a facere exercitationem voluptatum. Aspernatur rerum ab officiis ipsa libero quis dolor. Excepturi expedita maiores accusamus hic. Magnam soluta animi repellendus deserunt quas temporibus aliquid. Quod adipisci optio perferendis atque facilis praesentium eveniet quam.
+                        Praesentium sed qui ullam laborum eveniet ipsam aliquam et. Maxime reprehenderit sequi tenetur ea quas. Repudiandae molestias eligendi iste culpa corrupti ullam id. Temporibus itaque ex soluta earum officiis ea autem dolorum.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2849
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1691
-                      ofn:spree_product_id: 1691
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1691
-                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2851
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1458/catalog_items/4203
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2456
+                      ofn:spree_product_id: 2456
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1458?spree_product_id=2456
+                    - "@id": http://test.host/api/dfc/enterprises/1458/supplied_products/4205
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #27 - 4296 - 1g'
+                      dfc-b:name: 'Product #27 - 1064 - 1g'
                       dfc-b:description: |-
-                        Delectus voluptates harum dignissimos velit. Occaecati nam ratione molestias quo quas nesciunt minima maxime. Iste reprehenderit repellat sapiente rem aspernatur corrupti labore nisi.
-                        Et voluptas impedit dicta nam officia quae. Officiis neque doloremque tempora nesciunt quo. Id aperiam enim tenetur quam.
-                        Recusandae consequuntur aliquam rem saepe velit. Dolores eum quam nam consectetur. Tempora atque quam repellat molestias ipsum odio accusantium.
-                        Expedita molestias quia natus provident illum non sunt. Aliquam et fugiat voluptate optio. Doloremque et soluta quas nobis corrupti veniam. Doloremque impedit eligendi similique dolor veniam non. Dolores provident quisquam magnam veritatis velit qui earum eum.
+                        Laboriosam suscipit repellat id iure aliquam sequi occaecati. Dolores et itaque placeat quod voluptatem. Laborum explicabo iste recusandae eius nisi delectus occaecati. Unde voluptas harum vitae minus. Molestiae similique voluptate veritatis quas recusandae laudantium.
+                        Laudantium odit assumenda eaque quod ea iure minima. Repellendus aspernatur rerum odit maiores officia cum hic cupiditate. Quod vero ab doloribus soluta alias. Provident omnis consectetur magnam unde est veniam.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2851
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1692
-                      ofn:spree_product_id: 1692
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1692
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1458/catalog_items/4205
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2457
+                      ofn:spree_product_id: 2457
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1458?spree_product_id=2457
                     - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #22 - 8203 - 1g'
+                      dfc-b:name: 'Product #22 - 8910 - 1g'
                       dfc-b:description: |-
-                        Amet dignissimos eum suscipit saepe. Necessitatibus dolorem ipsam atque asperiores nisi enim rem similique. Voluptates reiciendis libero corrupti perspiciatis amet vitae incidunt cupiditate. Delectus ut nobis deleniti harum mollitia minima rerum dolorem. Eaque asperiores repellendus perspiciatis eligendi temporibus omnis voluptatibus inventore.
-                        Dolorum nesciunt incidunt porro beatae placeat error deserunt sapiente. Eum modi magni possimus neque quidem omnis dolorem mollitia. Unde vitae natus alias nobis dolor dolorum iste.
-                        Illo quisquam sapiente consequuntur harum. Atque quam rem explicabo repudiandae rerum nisi ipsa libero. Tempore pariatur sint unde sit itaque reprehenderit vel. Placeat velit enim sint aliquam natus nobis.
+                        Maxime delectus earum numquam qui esse nisi. Iste nihil totam laudantium nostrum ipsam voluptas temporibus neque. Aperiam iusto illum facere quo. Excepturi assumenda atque sint mollitia ut.
+                        Iste exercitationem minima corrupti quisquam vitae voluptate eligendi. Pariatur magni similique quos molestias voluptatem. Saepe sequi ex omnis quisquam.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
                       dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1687
-                      ofn:spree_product_id: 1687
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=1687
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2452
+                      ofn:spree_product_id: 2452
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=2452
                     - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products
                       "@type": dfc-b:SaleSession
         '401':
@@ -1437,6 +1436,14 @@ paths:
           description: unauthorized
         '404':
           description: not found
+        '422':
+          description: unprocessable entity
+          content:
+            application/json; charset=utf-8:
+              examples:
+                unprocessable entity:
+                  value:
+                    error: Cannot cancel order in state 'cart'
   "/api/dfc/enterprises/{enterprise_id}/orders":
     parameters:
     - name: enterprise_id
@@ -1990,7 +1997,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
-                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/3016
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/4370
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000
                     ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -2006,7 +2013,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
-                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/3018
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/4372
                     dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -1151,78 +1151,78 @@ paths:
                     - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000
                       "@type": dfc-b:Order
                       dfc-b:hasPart:
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1250
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1251
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1252
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1253
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1254
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1255
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1978
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1979
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1980
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1981
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1982
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1983
                       dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
                       dfc-b:hasOrderStatus: dfc-v:Held
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1250
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1978
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2843
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1251
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1458/offers/4197
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1979
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2845
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1252
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1458/offers/4199
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1980
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2847
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1253
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1458/offers/4201
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1981
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2849
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1254
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1458/offers/4203
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1982
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2851
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1255
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1458/offers/4205
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1983
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
                       dfc-b:concerns: http://test.host/api/dfc/enterprises/10000/offers/10001
-                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2843
+                    - "@id": http://test.host/api/dfc/enterprises/1458/offers/4197
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2843
-                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2845
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1458/supplied_products/4197
+                    - "@id": http://test.host/api/dfc/enterprises/1458/offers/4199
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2845
-                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2847
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1458/supplied_products/4199
+                    - "@id": http://test.host/api/dfc/enterprises/1458/offers/4201
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2847
-                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2849
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1458/supplied_products/4201
+                    - "@id": http://test.host/api/dfc/enterprises/1458/offers/4203
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2849
-                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2851
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1458/supplied_products/4203
+                    - "@id": http://test.host/api/dfc/enterprises/1458/offers/4205
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2851
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1458/supplied_products/4205
                     - "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
@@ -1231,101 +1231,100 @@ paths:
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 0
                       dfc-b:offeredItem: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
-                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2843
+                    - "@id": http://test.host/api/dfc/enterprises/1458/supplied_products/4197
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #23 - 7992 - 1g'
+                      dfc-b:name: 'Product #23 - 7353 - 1g'
                       dfc-b:description: |-
-                        Deserunt sunt illo eius facilis. Esse praesentium sit hic dignissimos quaerat. Velit labore hic qui est.
-                        Maxime sit recusandae veritatis ipsa necessitatibus ex at possimus. Nemo quia a quas ipsa eos. Iste molestias harum quia doloribus quos cum exercitationem.
-                        Nihil assumenda aspernatur sit occaecati officia perspiciatis eius. Sed quia recusandae iste ea. Dolorum alias assumenda repudiandae ducimus esse nostrum id beatae. Libero perspiciatis beatae ad voluptatum. Sequi fugit excepturi illum officia totam.
-                        Accusantium debitis veniam veritatis ipsa nesciunt vero expedita minus. Odit beatae inventore dolorem perspiciatis dolore nemo ducimus. Reiciendis omnis a provident ullam incidunt quas facere inventore.
-                        Excepturi suscipit quod voluptatum ipsam deserunt. Dolor nostrum omnis nisi numquam animi. Consectetur blanditiis rem possimus laborum maxime maiores eius.
+                        Magni omnis rem minus natus iure. Dicta animi officiis perferendis ad nam suscipit ab quod. Dolor placeat error perspiciatis excepturi cumque exercitationem quam et.
+                        Exercitationem sunt rerum tempore quam itaque accusamus possimus praesentium. Nostrum commodi rerum magnam magni sint. Temporibus asperiores molestiae eveniet nihil sed maiores labore. Tenetur cupiditate non beatae id eos.
+                        Esse sunt voluptatibus consequatur at nam nulla. Similique ipsam ad modi quam eligendi suscipit tempora dolorum. At ex expedita ratione veniam itaque optio. Temporibus expedita omnis suscipit perferendis illo fugit. Dolorum sit veritatis repudiandae quidem eos deserunt repellat.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2843
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1688
-                      ofn:spree_product_id: 1688
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1688
-                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2845
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1458/catalog_items/4197
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2453
+                      ofn:spree_product_id: 2453
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1458?spree_product_id=2453
+                    - "@id": http://test.host/api/dfc/enterprises/1458/supplied_products/4199
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #24 - 3181 - 1g'
+                      dfc-b:name: 'Product #24 - 1888 - 1g'
                       dfc-b:description: |-
-                        Eligendi consectetur blanditiis non beatae praesentium. Fugiat eius repellat aliquam dolorum magni sunt. Delectus odio accusamus architecto blanditiis beatae animi. Culpa impedit veritatis natus laboriosam nisi excepturi.
-                        Atque tenetur quos culpa quas corporis debitis laborum. Ad perspiciatis quis minus sequi quam dicta ducimus. Eveniet vero qui sunt beatae ut laborum maxime. Occaecati unde amet repellat eius assumenda ducimus eos possimus.
-                        Vel a quis tempora ratione totam maiores iste corrupti. Mollitia labore rerum quam accusantium. Commodi reiciendis earum dicta magnam reprehenderit.
-                        Repellendus nisi reprehenderit autem harum impedit veniam quia. Numquam pariatur reiciendis dolore vero sequi. Non voluptatem explicabo assumenda iure totam deserunt dolorum. Soluta possimus vero laborum magnam amet ex. Error impedit officia harum in ducimus voluptas.
-                        Placeat cumque pariatur laudantium odit et commodi. Eos perspiciatis cupiditate at facere commodi blanditiis. Odio rem vero ducimus architecto. Ad deserunt autem veniam velit dignissimos ex. At nesciunt occaecati repudiandae repellendus soluta.
+                        Consequatur assumenda tempore minima recusandae neque ullam veritatis architecto. Dignissimos magni magnam recusandae officiis repellendus dolores. Laborum dolorem non nam perferendis sunt reiciendis optio.
+                        Similique cupiditate quam quis praesentium cum quaerat atque. At eos quas omnis voluptatem eaque nostrum architecto natus. Voluptatibus ea beatae porro modi dolorum officia debitis voluptatem. Debitis placeat saepe recusandae libero consectetur nihil omnis. Animi atque occaecati aliquam magni enim ipsum.
+                        Eius iusto soluta nihil ab explicabo tenetur. Dolor blanditiis ex sint explicabo ea pariatur nulla. In nam facere exercitationem blanditiis a doloremque. Praesentium consequuntur aliquid harum temporibus voluptas non magnam.
+                        Quaerat quae ea quia occaecati consequuntur laborum distinctio numquam. Rerum natus veniam praesentium placeat cupiditate animi soluta sed. Neque aspernatur ab qui excepturi tempore deleniti.
+                        Nihil sed dolorum delectus id commodi. In nemo et natus perspiciatis repellat iusto quia tempore. Voluptatum repudiandae maxime sit rem sed sequi. Porro accusantium exercitationem ipsam debitis dicta soluta pariatur eveniet.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2845
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1689
-                      ofn:spree_product_id: 1689
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1689
-                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2847
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1458/catalog_items/4199
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2454
+                      ofn:spree_product_id: 2454
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1458?spree_product_id=2454
+                    - "@id": http://test.host/api/dfc/enterprises/1458/supplied_products/4201
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #25 - 1231 - 1g'
+                      dfc-b:name: 'Product #25 - 638 - 1g'
                       dfc-b:description: |-
-                        Doloremque illum unde ullam facilis nisi soluta. Totam pariatur necessitatibus modi veritatis fuga corrupti odio. Atque ratione ullam similique quas quibusdam culpa. Velit fugiat accusamus porro reiciendis possimus.
-                        Placeat quam explicabo laudantium nobis praesentium sit labore hic. Repellat sed voluptatibus animi libero. Nihil excepturi cum fugit inventore facere.
-                        Animi expedita culpa facere aliquam. Dolorum dolorem aliquam similique harum voluptas facere nisi consequuntur. Vitae quis velit delectus modi.
+                        Ipsum ratione dignissimos ullam architecto saepe accusamus soluta totam. Fugit maiores atque dignissimos deserunt. Odio velit eligendi reiciendis quia.
+                        Qui voluptates rerum pariatur asperiores velit quod. Odio non ducimus repellendus expedita aliquam eos quisquam. Autem nobis ducimus quaerat quos quia consequatur quis architecto. Natus sequi quam assumenda tempore quo.
+                        A error optio placeat doloremque ullam est eaque. Quo qui ad laudantium ea dolorum. Voluptates at libero maiores debitis facere nobis hic tempore. Labore adipisci laboriosam beatae error. Temporibus eaque magni aperiam dolore atque dolorem soluta reiciendis.
+                        Temporibus voluptatum excepturi quo sapiente ab molestias ex fugiat. Eligendi iste natus labore minus doloremque reprehenderit. Occaecati sint quisquam mollitia saepe soluta atque.
+                        Minima quod amet occaecati magnam. Libero minima quos ex esse sed. Blanditiis molestiae deserunt laudantium eum veritatis itaque beatae.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2847
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1690
-                      ofn:spree_product_id: 1690
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1690
-                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2849
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1458/catalog_items/4201
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2455
+                      ofn:spree_product_id: 2455
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1458?spree_product_id=2455
+                    - "@id": http://test.host/api/dfc/enterprises/1458/supplied_products/4203
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #26 - 7241 - 1g'
+                      dfc-b:name: 'Product #26 - 9373 - 1g'
                       dfc-b:description: |-
-                        Quisquam sed eius dolorum nostrum maiores vero. Totam sunt et vel tempore excepturi placeat maiores. Nobis accusamus pariatur aspernatur similique numquam amet corporis at. Ipsa voluptatem tempore recusandae corporis magni officia. Atque a ullam sunt esse magni optio mollitia.
-                        Labore molestiae tempore totam a nihil saepe expedita autem. Doloribus totam voluptatibus omnis cupiditate non excepturi natus illo. Non vitae harum odit occaecati amet molestias sequi omnis. Ullam porro cum quas non veniam delectus.
-                        Vitae tenetur aperiam totam iure quibusdam qui voluptates facere. Voluptate enim quod inventore voluptas. Tempore commodi aperiam quas accusantium similique accusamus.
+                        Laboriosam suscipit quia omnis nemo ratione exercitationem. Officia omnis sint tempora porro ad voluptatum. Omnis temporibus quaerat rerum nobis impedit. Quisquam repellendus eum maxime dolores officiis accusantium. Odio sint ad saepe eaque tenetur libero.
+                        Adipisci consequuntur veritatis beatae eligendi tempora architecto odio non. Dignissimos recusandae velit ullam aperiam. Earum veniam repellat officiis fugiat tenetur veritatis.
+                        Minima incidunt recusandae hic aliquid fugiat. In rerum cum corrupti dolores necessitatibus. Velit alias optio tempora placeat facilis.
+                        Saepe a facere exercitationem voluptatum. Aspernatur rerum ab officiis ipsa libero quis dolor. Excepturi expedita maiores accusamus hic. Magnam soluta animi repellendus deserunt quas temporibus aliquid. Quod adipisci optio perferendis atque facilis praesentium eveniet quam.
+                        Praesentium sed qui ullam laborum eveniet ipsam aliquam et. Maxime reprehenderit sequi tenetur ea quas. Repudiandae molestias eligendi iste culpa corrupti ullam id. Temporibus itaque ex soluta earum officiis ea autem dolorum.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2849
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1691
-                      ofn:spree_product_id: 1691
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1691
-                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2851
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1458/catalog_items/4203
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2456
+                      ofn:spree_product_id: 2456
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1458?spree_product_id=2456
+                    - "@id": http://test.host/api/dfc/enterprises/1458/supplied_products/4205
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #27 - 4296 - 1g'
+                      dfc-b:name: 'Product #27 - 1064 - 1g'
                       dfc-b:description: |-
-                        Delectus voluptates harum dignissimos velit. Occaecati nam ratione molestias quo quas nesciunt minima maxime. Iste reprehenderit repellat sapiente rem aspernatur corrupti labore nisi.
-                        Et voluptas impedit dicta nam officia quae. Officiis neque doloremque tempora nesciunt quo. Id aperiam enim tenetur quam.
-                        Recusandae consequuntur aliquam rem saepe velit. Dolores eum quam nam consectetur. Tempora atque quam repellat molestias ipsum odio accusantium.
-                        Expedita molestias quia natus provident illum non sunt. Aliquam et fugiat voluptate optio. Doloremque et soluta quas nobis corrupti veniam. Doloremque impedit eligendi similique dolor veniam non. Dolores provident quisquam magnam veritatis velit qui earum eum.
+                        Laboriosam suscipit repellat id iure aliquam sequi occaecati. Dolores et itaque placeat quod voluptatem. Laborum explicabo iste recusandae eius nisi delectus occaecati. Unde voluptas harum vitae minus. Molestiae similique voluptate veritatis quas recusandae laudantium.
+                        Laudantium odit assumenda eaque quod ea iure minima. Repellendus aspernatur rerum odit maiores officia cum hic cupiditate. Quod vero ab doloribus soluta alias. Provident omnis consectetur magnam unde est veniam.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2851
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1692
-                      ofn:spree_product_id: 1692
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1692
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1458/catalog_items/4205
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2457
+                      ofn:spree_product_id: 2457
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1458?spree_product_id=2457
                     - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #22 - 8203 - 1g'
+                      dfc-b:name: 'Product #22 - 8910 - 1g'
                       dfc-b:description: |-
-                        Amet dignissimos eum suscipit saepe. Necessitatibus dolorem ipsam atque asperiores nisi enim rem similique. Voluptates reiciendis libero corrupti perspiciatis amet vitae incidunt cupiditate. Delectus ut nobis deleniti harum mollitia minima rerum dolorem. Eaque asperiores repellendus perspiciatis eligendi temporibus omnis voluptatibus inventore.
-                        Dolorum nesciunt incidunt porro beatae placeat error deserunt sapiente. Eum modi magni possimus neque quidem omnis dolorem mollitia. Unde vitae natus alias nobis dolor dolorum iste.
-                        Illo quisquam sapiente consequuntur harum. Atque quam rem explicabo repudiandae rerum nisi ipsa libero. Tempore pariatur sint unde sit itaque reprehenderit vel. Placeat velit enim sint aliquam natus nobis.
+                        Maxime delectus earum numquam qui esse nisi. Iste nihil totam laudantium nostrum ipsam voluptas temporibus neque. Aperiam iusto illum facere quo. Excepturi assumenda atque sint mollitia ut.
+                        Iste exercitationem minima corrupti quisquam vitae voluptate eligendi. Pariatur magni similique quos molestias voluptatem. Saepe sequi ex omnis quisquam.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
                       dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1687
-                      ofn:spree_product_id: 1687
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=1687
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/2452
+                      ofn:spree_product_id: 2452
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=2452
                     - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products
                       "@type": dfc-b:SaleSession
         '401':
@@ -1448,6 +1447,14 @@ paths:
           description: unauthorized
         '404':
           description: not found
+        '422':
+          description: unprocessable entity
+          content:
+            application/json; charset=utf-8:
+              examples:
+                unprocessable entity:
+                  value:
+                    error: Cannot cancel order in state 'cart'
   "/api/dfc/enterprises/{enterprise_id}/orders":
     parameters:
     - name: enterprise_id
@@ -2037,7 +2044,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
-                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/3016
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/4370
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000
                     ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -2053,7 +2060,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
-                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/3018
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/4372
                     dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -199,6 +199,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
                       ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -232,6 +233,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
                       ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -265,6 +267,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
                       ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -298,6 +301,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
                       ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -633,6 +637,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -711,6 +716,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -789,6 +795,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -868,6 +875,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -930,6 +938,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -992,6 +1001,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -1113,6 +1123,308 @@ paths:
                 "@type": dfc-b:Offer
                 dfc-b:hasPrice: 9.99
                 dfc-b:stockLimitation: 7
+  "/api/dfc/enterprises/{enterprise_id}/orders/{order_id}":
+    parameters:
+    - name: enterprise_id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Show Order
+      parameters:
+      - name: order_id
+        in: path
+        required: true
+      tags:
+      - Orders
+      responses:
+        '200':
+          description: success
+          content:
+            application/json; charset=utf-8:
+              examples:
+                success:
+                  value:
+                    "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
+                    "@graph":
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000
+                      "@type": dfc-b:Order
+                      dfc-b:hasPart:
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/65
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/66
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/67
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/68
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/69
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/70
+                      dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
+                      dfc-b:hasOrderStatus: dfc-v:Held
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/65
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/161
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/66
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/163
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/67
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/165
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/68
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/167
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/69
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/169
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/70
+                      "@type": dfc-b:OrderLine
+                      dfc-b:quantity: 1
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/10000/offers/10001
+                    - "@id": http://test.host/api/dfc/enterprises/63/offers/161
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 4
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/161
+                    - "@id": http://test.host/api/dfc/enterprises/63/offers/163
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 4
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/163
+                    - "@id": http://test.host/api/dfc/enterprises/63/offers/165
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 4
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/165
+                    - "@id": http://test.host/api/dfc/enterprises/63/offers/167
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 4
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/167
+                    - "@id": http://test.host/api/dfc/enterprises/63/offers/169
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 4
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/169
+                    - "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
+                      "@type": dfc-b:Offer
+                      dfc-b:hasPrice:
+                        "@type": dfc-b:Price
+                        dfc-b:value: 19.99
+                        dfc-b:hasUnit: dfc-m:AustralianDollar
+                      dfc-b:stockLimitation: 0
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/161
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #23 - 4251 - 1g'
+                      dfc-b:description: |-
+                        Culpa ratione minus explicabo iste at vitae. Quis magnam maxime tenetur quas aliquam accusamus officiis. Nulla molestias ipsum veniam quas.
+                        Odit perferendis repudiandae aliquam atque tenetur nobis. Ducimus atque ullam quisquam veniam porro. Voluptas iste distinctio sunt suscipit officiis. Placeat harum aliquam fugiat suscipit minima.
+                        Quidem labore iure aspernatur atque nulla. Ad quia iste possimus amet praesentium fugiat. Ea est maiores dicta sed cupiditate. Cum non quaerat laborum quas sapiente sit. Doloremque consequatur vitae voluptates perspiciatis.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/161
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/101
+                      ofn:spree_product_id: 101
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=101
+                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/163
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #24 - 5277 - 1g'
+                      dfc-b:description: |-
+                        Dolor cum earum mollitia nemo amet necessitatibus. Vero suscipit libero odit iste beatae. Harum distinctio iste fugiat cum quas. Laudantium expedita dicta animi odit officia quia. Fuga vel voluptas tempore id aperiam corrupti quia.
+                        Magnam impedit reprehenderit rem consequatur aspernatur. Blanditiis architecto quisquam sunt molestias amet porro aliquam. Culpa debitis iusto quos optio hic. Nostrum corporis officiis minima veritatis.
+                        Adipisci quibusdam culpa dolorem aspernatur blanditiis eveniet officiis. Sequi deserunt magnam iusto incidunt nostrum porro ullam. Similique earum quaerat saepe maxime. Ab iste quia pariatur consequatur. Nam ipsa quisquam laudantium ipsam nostrum cum.
+                        Nobis ea tempora assumenda illo amet at ducimus. Vero voluptates nemo odio repudiandae deleniti. Beatae quis magnam a voluptate cupiditate.
+                        Blanditiis ab inventore consequatur ipsum magni. Fugiat impedit laudantium tenetur ab odio nemo ut. Sequi earum eveniet magni maxime a deserunt modi. Quae quod dolores vero quaerat. Optio quisquam ullam officia ducimus rerum nisi ipsum amet.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/163
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/102
+                      ofn:spree_product_id: 102
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=102
+                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/165
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #25 - 2153 - 1g'
+                      dfc-b:description: |-
+                        Quis delectus reprehenderit dicta mollitia nam. Sapiente incidunt molestias dolor temporibus quibusdam beatae recusandae aliquam. Debitis sapiente veritatis vero autem.
+                        Suscipit mollitia corrupti enim nulla voluptatum asperiores quia commodi. Ipsum repellendus animi autem repudiandae provident non. Accusantium voluptatibus accusamus expedita debitis. Temporibus aliquid quibusdam optio sit fugiat reprehenderit. Dolore laboriosam tenetur facere minima autem aperiam quos adipisci.
+                        Facilis laudantium natus quibusdam tenetur. Reprehenderit doloribus animi quis laudantium non. Amet laboriosam quidem reprehenderit assumenda ratione quia dicta.
+                        Accusamus quas sit repellendus assumenda sequi. Aliquid praesentium tenetur mollitia quisquam temporibus. Exercitationem reiciendis aperiam dolorem quidem dolor.
+                        Ex vero quia error possimus. Beatae voluptas saepe deserunt illo. Voluptatibus reprehenderit animi harum beatae corporis. Neque omnis tempora illo nam maxime dolor dicta ipsa. Corrupti adipisci sed minus saepe consequatur provident.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/165
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/103
+                      ofn:spree_product_id: 103
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=103
+                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/167
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #26 - 4790 - 1g'
+                      dfc-b:description: Natus fugit soluta perferendis nemo est adipisci.
+                        Reiciendis pariatur earum culpa fuga doloribus. Deleniti aut
+                        cum error rem magni at. Eveniet occaecati nobis velit perferendis.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/167
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/104
+                      ofn:spree_product_id: 104
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=104
+                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/169
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #27 - 554 - 1g'
+                      dfc-b:description: |-
+                        Molestias accusantium expedita tempore praesentium. Optio corrupti in quas nemo a quae soluta. Molestiae consequuntur quaerat atque provident porro ipsa. Amet recusandae consequatur iure soluta sapiente quae expedita. Ducimus fugit aspernatur corporis eaque nemo quas earum ut.
+                        Nobis aspernatur accusantium aut maxime minus dolor eaque. Animi aspernatur saepe corporis velit. Consequuntur tempore dolorum quos voluptatem numquam sapiente.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/169
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/105
+                      ofn:spree_product_id: 105
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=105
+                    - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #22 - 9859 - 1g'
+                      dfc-b:description: |-
+                        Autem aspernatur alias repellendus quisquam voluptas. Reiciendis nobis voluptatibus recusandae architecto suscipit rem. Odit laudantium sed illum itaque fuga ullam saepe. Eveniet tenetur praesentium incidunt facere eaque sapiente animi. Provident veniam cum magni enim hic quidem earum optio.
+                        Ut sunt distinctio expedita quo nisi officiis libero quos. Praesentium dicta molestiae dolorem assumenda culpa ab. Dicta dolor quasi sit distinctio nulla. Animi sapiente quo nesciunt aut.
+                        Atque molestiae sapiente quidem eveniet eos. Voluptates dolorem iure autem impedit sed doloribus amet. Eveniet doloribus ducimus ipsa eius tempore sapiente nisi. Molestiae rem est tenetur earum omnis.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/100
+                      ofn:spree_product_id: 100
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=100
+                    - "@id": "/api/dfc/SalesSession/#"
+                      "@type": dfc-b:SaleSession
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
+  "/api/dfc/enterprises/{enterprise_id}/orders":
+    parameters:
+    - name: enterprise_id
+      in: path
+      required: true
+      schema:
+        type: string
+    post:
+      summary: Create Order
+      parameters: []
+      tags:
+      - Orders
+      responses:
+        '201':
+          description: created
+          content:
+            application/json; charset=utf-8:
+              examples:
+                with line items:
+                  value:
+                    "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
+                    "@id": http://test.host/api/dfc/enterprises/10000/orders/10001
+                    "@type": dfc-b:Order
+                    dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
+                    dfc-b:hasOrderStatus: dfc-v:Held
+        '400':
+          description: bad request
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
+        '422':
+          description: unprocessable entity
+          content:
+            application/json; charset=utf-8:
+              examples:
+                variant not found:
+                  value:
+                    error: Line items variant must exist and Line items price is not
+                      a number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example: |
+                {
+                  "@context": "https://www.datafoodconsortium.org",
+                  "@graph": [
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/orders",
+                      "@type": "dfc-b:Order",
+                      "dfc-b:belongsTo": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+                      "dfc-b:hasPart": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+                      "dfc-b:orderedBy": "http://test.host/api/dfc/enterprises/11000",
+                      "dfc-b:hasOrderStatus": "dfc-v:Held"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+                      "@type": "dfc-b:OrderLine",
+                      "dfc-b:quantity": 1,
+                      "dfc-b:concerns": "http://test.host/api/dfc/enterprises/10000/offers/10001"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/offers/10001",
+                      "@type": "dfc-b:Offer",
+                      "dfc-b:hasPrice": {
+                        "@type": "dfc-b:Price",
+                        "dfc-b:value": 19.99,
+                        "dfc-b:hasUnit": "dfc-m:AustralianDollar"
+                      },
+                      "dfc-b:stockLimitation": 0,
+                      "dfc-b:offeredItem": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001",
+                      "@type": "dfc-b:SuppliedProduct",
+                      "dfc-b:name": "Apple",
+                      "dfc-b:description": "Red",
+                      "dfc-b:hasQuantity": {
+                        "@type": "dfc-b:QuantitativeValue",
+                        "dfc-b:hasUnit": "dfc-m:Gram",
+                        "dfc-b:value": 1
+                      },
+                      "dfc-b:referencedBy": "http://test.host/api/dfc/enterprises/10000/catalog_items/10001",
+                      "dfc-b:isVariantOf": "http://test.host/api/dfc/product_groups/90000",
+                      "ofn:spree_product_id": 90000,
+                      "ofn:spree_product_uri": "http://test.host/api/dfc/enterprises/10000?spree_product_id=90000"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+                      "@type": "dfc-b:SaleSession",
+                      "dfc-b:beginDate": "Wed Mar 19 2025 04:40:16 UTC",
+                      "dfc-b:endDate": "Thu Mar 27 2025 04:40:16 UTC"
+                    }
+                  ]
+                }
   "/api/dfc/organizations":
     get:
       summary: List organizations
@@ -1484,6 +1796,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -1520,6 +1833,7 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                       dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                       ofn:spree_product_id: 90000
@@ -1604,6 +1918,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/213
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000
                     ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -1619,6 +1934,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/215
                     dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000
@@ -1679,6 +1995,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 1.0
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
                     dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -1151,78 +1151,78 @@ paths:
                     - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000
                       "@type": dfc-b:Order
                       dfc-b:hasPart:
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/65
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/66
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/67
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/68
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/69
-                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/70
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1250
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1251
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1252
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1253
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1254
+                      - http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1255
                       dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
                       dfc-b:hasOrderStatus: dfc-v:Held
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/65
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1250
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/161
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/66
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2843
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1251
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/163
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/67
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2845
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1252
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/165
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/68
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2847
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1253
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/167
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/69
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2849
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1254
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
-                      dfc-b:concerns: http://test.host/api/dfc/enterprises/63/offers/169
-                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/70
+                      dfc-b:concerns: http://test.host/api/dfc/enterprises/1235/offers/2851
+                    - "@id": http://test.host/api/dfc/enterprises/10000/orders/11000/OrderLines/1255
                       "@type": dfc-b:OrderLine
                       dfc-b:quantity: 1
                       dfc-b:concerns: http://test.host/api/dfc/enterprises/10000/offers/10001
-                    - "@id": http://test.host/api/dfc/enterprises/63/offers/161
+                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2843
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/161
-                    - "@id": http://test.host/api/dfc/enterprises/63/offers/163
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2843
+                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2845
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/163
-                    - "@id": http://test.host/api/dfc/enterprises/63/offers/165
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2845
+                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2847
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/165
-                    - "@id": http://test.host/api/dfc/enterprises/63/offers/167
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2847
+                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2849
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/167
-                    - "@id": http://test.host/api/dfc/enterprises/63/offers/169
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2849
+                    - "@id": http://test.host/api/dfc/enterprises/1235/offers/2851
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
                         "@type": dfc-b:Price
                         dfc-b:value: 19.99
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 4
-                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/63/supplied_products/169
+                      dfc-b:offeredItem: http://test.host/api/dfc/enterprises/1235/supplied_products/2851
                     - "@id": http://test.host/api/dfc/enterprises/10000/offers/10001
                       "@type": dfc-b:Offer
                       dfc-b:hasPrice:
@@ -1231,100 +1231,219 @@ paths:
                         dfc-b:hasUnit: dfc-m:AustralianDollar
                       dfc-b:stockLimitation: 0
                       dfc-b:offeredItem: http://test.host/api/dfc/enterprises/10000/supplied_products/10001
-                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/161
+                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2843
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #23 - 4251 - 1g'
+                      dfc-b:name: 'Product #23 - 7992 - 1g'
                       dfc-b:description: |-
-                        Culpa ratione minus explicabo iste at vitae. Quis magnam maxime tenetur quas aliquam accusamus officiis. Nulla molestias ipsum veniam quas.
-                        Odit perferendis repudiandae aliquam atque tenetur nobis. Ducimus atque ullam quisquam veniam porro. Voluptas iste distinctio sunt suscipit officiis. Placeat harum aliquam fugiat suscipit minima.
-                        Quidem labore iure aspernatur atque nulla. Ad quia iste possimus amet praesentium fugiat. Ea est maiores dicta sed cupiditate. Cum non quaerat laborum quas sapiente sit. Doloremque consequatur vitae voluptates perspiciatis.
+                        Deserunt sunt illo eius facilis. Esse praesentium sit hic dignissimos quaerat. Velit labore hic qui est.
+                        Maxime sit recusandae veritatis ipsa necessitatibus ex at possimus. Nemo quia a quas ipsa eos. Iste molestias harum quia doloribus quos cum exercitationem.
+                        Nihil assumenda aspernatur sit occaecati officia perspiciatis eius. Sed quia recusandae iste ea. Dolorum alias assumenda repudiandae ducimus esse nostrum id beatae. Libero perspiciatis beatae ad voluptatum. Sequi fugit excepturi illum officia totam.
+                        Accusantium debitis veniam veritatis ipsa nesciunt vero expedita minus. Odit beatae inventore dolorem perspiciatis dolore nemo ducimus. Reiciendis omnis a provident ullam incidunt quas facere inventore.
+                        Excepturi suscipit quod voluptatum ipsam deserunt. Dolor nostrum omnis nisi numquam animi. Consectetur blanditiis rem possimus laborum maxime maiores eius.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/161
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/101
-                      ofn:spree_product_id: 101
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=101
-                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/163
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2843
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1688
+                      ofn:spree_product_id: 1688
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1688
+                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2845
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #24 - 5277 - 1g'
+                      dfc-b:name: 'Product #24 - 3181 - 1g'
                       dfc-b:description: |-
-                        Dolor cum earum mollitia nemo amet necessitatibus. Vero suscipit libero odit iste beatae. Harum distinctio iste fugiat cum quas. Laudantium expedita dicta animi odit officia quia. Fuga vel voluptas tempore id aperiam corrupti quia.
-                        Magnam impedit reprehenderit rem consequatur aspernatur. Blanditiis architecto quisquam sunt molestias amet porro aliquam. Culpa debitis iusto quos optio hic. Nostrum corporis officiis minima veritatis.
-                        Adipisci quibusdam culpa dolorem aspernatur blanditiis eveniet officiis. Sequi deserunt magnam iusto incidunt nostrum porro ullam. Similique earum quaerat saepe maxime. Ab iste quia pariatur consequatur. Nam ipsa quisquam laudantium ipsam nostrum cum.
-                        Nobis ea tempora assumenda illo amet at ducimus. Vero voluptates nemo odio repudiandae deleniti. Beatae quis magnam a voluptate cupiditate.
-                        Blanditiis ab inventore consequatur ipsum magni. Fugiat impedit laudantium tenetur ab odio nemo ut. Sequi earum eveniet magni maxime a deserunt modi. Quae quod dolores vero quaerat. Optio quisquam ullam officia ducimus rerum nisi ipsum amet.
+                        Eligendi consectetur blanditiis non beatae praesentium. Fugiat eius repellat aliquam dolorum magni sunt. Delectus odio accusamus architecto blanditiis beatae animi. Culpa impedit veritatis natus laboriosam nisi excepturi.
+                        Atque tenetur quos culpa quas corporis debitis laborum. Ad perspiciatis quis minus sequi quam dicta ducimus. Eveniet vero qui sunt beatae ut laborum maxime. Occaecati unde amet repellat eius assumenda ducimus eos possimus.
+                        Vel a quis tempora ratione totam maiores iste corrupti. Mollitia labore rerum quam accusantium. Commodi reiciendis earum dicta magnam reprehenderit.
+                        Repellendus nisi reprehenderit autem harum impedit veniam quia. Numquam pariatur reiciendis dolore vero sequi. Non voluptatem explicabo assumenda iure totam deserunt dolorum. Soluta possimus vero laborum magnam amet ex. Error impedit officia harum in ducimus voluptas.
+                        Placeat cumque pariatur laudantium odit et commodi. Eos perspiciatis cupiditate at facere commodi blanditiis. Odio rem vero ducimus architecto. Ad deserunt autem veniam velit dignissimos ex. At nesciunt occaecati repudiandae repellendus soluta.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/163
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/102
-                      ofn:spree_product_id: 102
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=102
-                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/165
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2845
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1689
+                      ofn:spree_product_id: 1689
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1689
+                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2847
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #25 - 2153 - 1g'
+                      dfc-b:name: 'Product #25 - 1231 - 1g'
                       dfc-b:description: |-
-                        Quis delectus reprehenderit dicta mollitia nam. Sapiente incidunt molestias dolor temporibus quibusdam beatae recusandae aliquam. Debitis sapiente veritatis vero autem.
-                        Suscipit mollitia corrupti enim nulla voluptatum asperiores quia commodi. Ipsum repellendus animi autem repudiandae provident non. Accusantium voluptatibus accusamus expedita debitis. Temporibus aliquid quibusdam optio sit fugiat reprehenderit. Dolore laboriosam tenetur facere minima autem aperiam quos adipisci.
-                        Facilis laudantium natus quibusdam tenetur. Reprehenderit doloribus animi quis laudantium non. Amet laboriosam quidem reprehenderit assumenda ratione quia dicta.
-                        Accusamus quas sit repellendus assumenda sequi. Aliquid praesentium tenetur mollitia quisquam temporibus. Exercitationem reiciendis aperiam dolorem quidem dolor.
-                        Ex vero quia error possimus. Beatae voluptas saepe deserunt illo. Voluptatibus reprehenderit animi harum beatae corporis. Neque omnis tempora illo nam maxime dolor dicta ipsa. Corrupti adipisci sed minus saepe consequatur provident.
+                        Doloremque illum unde ullam facilis nisi soluta. Totam pariatur necessitatibus modi veritatis fuga corrupti odio. Atque ratione ullam similique quas quibusdam culpa. Velit fugiat accusamus porro reiciendis possimus.
+                        Placeat quam explicabo laudantium nobis praesentium sit labore hic. Repellat sed voluptatibus animi libero. Nihil excepturi cum fugit inventore facere.
+                        Animi expedita culpa facere aliquam. Dolorum dolorem aliquam similique harum voluptas facere nisi consequuntur. Vitae quis velit delectus modi.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/165
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/103
-                      ofn:spree_product_id: 103
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=103
-                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/167
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2847
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1690
+                      ofn:spree_product_id: 1690
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1690
+                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2849
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #26 - 4790 - 1g'
-                      dfc-b:description: Natus fugit soluta perferendis nemo est adipisci.
-                        Reiciendis pariatur earum culpa fuga doloribus. Deleniti aut
-                        cum error rem magni at. Eveniet occaecati nobis velit perferendis.
-                      dfc-b:hasQuantity:
-                        "@type": dfc-b:QuantitativeValue
-                        dfc-b:hasUnit: dfc-m:Gram
-                        dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/167
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/104
-                      ofn:spree_product_id: 104
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=104
-                    - "@id": http://test.host/api/dfc/enterprises/63/supplied_products/169
-                      "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #27 - 554 - 1g'
+                      dfc-b:name: 'Product #26 - 7241 - 1g'
                       dfc-b:description: |-
-                        Molestias accusantium expedita tempore praesentium. Optio corrupti in quas nemo a quae soluta. Molestiae consequuntur quaerat atque provident porro ipsa. Amet recusandae consequatur iure soluta sapiente quae expedita. Ducimus fugit aspernatur corporis eaque nemo quas earum ut.
-                        Nobis aspernatur accusantium aut maxime minus dolor eaque. Animi aspernatur saepe corporis velit. Consequuntur tempore dolorum quos voluptatem numquam sapiente.
+                        Quisquam sed eius dolorum nostrum maiores vero. Totam sunt et vel tempore excepturi placeat maiores. Nobis accusamus pariatur aspernatur similique numquam amet corporis at. Ipsa voluptatem tempore recusandae corporis magni officia. Atque a ullam sunt esse magni optio mollitia.
+                        Labore molestiae tempore totam a nihil saepe expedita autem. Doloribus totam voluptatibus omnis cupiditate non excepturi natus illo. Non vitae harum odit occaecati amet molestias sequi omnis. Ullam porro cum quas non veniam delectus.
+                        Vitae tenetur aperiam totam iure quibusdam qui voluptates facere. Voluptate enim quod inventore voluptas. Tempore commodi aperiam quas accusantium similique accusamus.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/63/catalog_items/169
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/105
-                      ofn:spree_product_id: 105
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/63?spree_product_id=105
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2849
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1691
+                      ofn:spree_product_id: 1691
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1691
+                    - "@id": http://test.host/api/dfc/enterprises/1235/supplied_products/2851
+                      "@type": dfc-b:SuppliedProduct
+                      dfc-b:name: 'Product #27 - 4296 - 1g'
+                      dfc-b:description: |-
+                        Delectus voluptates harum dignissimos velit. Occaecati nam ratione molestias quo quas nesciunt minima maxime. Iste reprehenderit repellat sapiente rem aspernatur corrupti labore nisi.
+                        Et voluptas impedit dicta nam officia quae. Officiis neque doloremque tempora nesciunt quo. Id aperiam enim tenetur quam.
+                        Recusandae consequuntur aliquam rem saepe velit. Dolores eum quam nam consectetur. Tempora atque quam repellat molestias ipsum odio accusantium.
+                        Expedita molestias quia natus provident illum non sunt. Aliquam et fugiat voluptate optio. Doloremque et soluta quas nobis corrupti veniam. Doloremque impedit eligendi similique dolor veniam non. Dolores provident quisquam magnam veritatis velit qui earum eum.
+                      dfc-b:hasQuantity:
+                        "@type": dfc-b:QuantitativeValue
+                        dfc-b:hasUnit: dfc-m:Gram
+                        dfc-b:value: 1.0
+                      dfc-b:referencedBy: http://test.host/api/dfc/enterprises/1235/catalog_items/2851
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1692
+                      ofn:spree_product_id: 1692
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/1235?spree_product_id=1692
                     - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
                       "@type": dfc-b:SuppliedProduct
-                      dfc-b:name: 'Product #22 - 9859 - 1g'
+                      dfc-b:name: 'Product #22 - 8203 - 1g'
                       dfc-b:description: |-
-                        Autem aspernatur alias repellendus quisquam voluptas. Reiciendis nobis voluptatibus recusandae architecto suscipit rem. Odit laudantium sed illum itaque fuga ullam saepe. Eveniet tenetur praesentium incidunt facere eaque sapiente animi. Provident veniam cum magni enim hic quidem earum optio.
-                        Ut sunt distinctio expedita quo nisi officiis libero quos. Praesentium dicta molestiae dolorem assumenda culpa ab. Dicta dolor quasi sit distinctio nulla. Animi sapiente quo nesciunt aut.
-                        Atque molestiae sapiente quidem eveniet eos. Voluptates dolorem iure autem impedit sed doloribus amet. Eveniet doloribus ducimus ipsa eius tempore sapiente nisi. Molestiae rem est tenetur earum omnis.
+                        Amet dignissimos eum suscipit saepe. Necessitatibus dolorem ipsam atque asperiores nisi enim rem similique. Voluptates reiciendis libero corrupti perspiciatis amet vitae incidunt cupiditate. Delectus ut nobis deleniti harum mollitia minima rerum dolorem. Eaque asperiores repellendus perspiciatis eligendi temporibus omnis voluptatibus inventore.
+                        Dolorum nesciunt incidunt porro beatae placeat error deserunt sapiente. Eum modi magni possimus neque quidem omnis dolorem mollitia. Unde vitae natus alias nobis dolor dolorum iste.
+                        Illo quisquam sapiente consequuntur harum. Atque quam rem explicabo repudiandae rerum nisi ipsa libero. Tempore pariatur sint unde sit itaque reprehenderit vel. Placeat velit enim sint aliquam natus nobis.
                       dfc-b:hasQuantity:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
                       dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/10001
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/100
-                      ofn:spree_product_id: 100
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=100
-                    - "@id": "/api/dfc/SalesSession/#"
+                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/1687
+                      ofn:spree_product_id: 1687
+                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=1687
+                    - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products
                       "@type": dfc-b:SaleSession
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
+    put:
+      summary: Update Order
+      parameters:
+      - name: order_id
+        in: path
+        required: true
+      tags:
+      - Orders
+      responses:
+        '200':
+          description: order completed
+          content:
+            application/json; charset=utf-8:
+              examples:
+                success:
+                  value:
+                    "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
+                    "@id": http://test.host/api/dfc/enterprises/10000/orders/11000
+                    "@type": dfc-b:Order
+                    dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
+                    dfc-b:hasOrderStatus: dfc-v:Held
+                order completed:
+                  value:
+                    "@context": https://w3id.org/dfc/ontology/context/context_1.16.0.json
+                    "@id": http://test.host/api/dfc/enterprises/10000/orders/11000
+                    "@type": dfc-b:Order
+                    dfc-b:orderedBy: http://test.host/api/dfc/enterprises/10000
+                    dfc-b:hasOrderStatus: dfc-v:Held
+        '400':
+          description: bad request
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
+        '422':
+          description: unprocessable entity
+          content:
+            application/json; charset=utf-8:
+              examples:
+                unprocessable entity:
+                  value:
+                    error: Line items variant must exist and Line items price is not
+                      a number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example: |
+                {
+                  "@context": "https://www.datafoodconsortium.org",
+                  "@graph": [
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/orders",
+                      "@type": "dfc-b:Order",
+                      "dfc-b:belongsTo": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+                      "dfc-b:hasPart": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+                      "dfc-b:orderedBy": "http://test.host/api/dfc/enterprises/11000",
+                      "dfc-b:hasOrderStatus": "dfc-v:Held"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/orders/OrderLines/1",
+                      "@type": "dfc-b:OrderLine",
+                      "dfc-b:quantity": 5,
+                      "dfc-b:concerns": "http://test.host/api/dfc/enterprises/10000/offers/10001"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/offers/10001",
+                      "@type": "dfc-b:Offer",
+                      "dfc-b:hasPrice": {
+                        "@type": "dfc-b:Price",
+                        "dfc-b:value": 19.99,
+                        "dfc-b:hasUnit": "dfc-m:AustralianDollar"
+                      },
+                      "dfc-b:stockLimitation": 0,
+                      "dfc-b:offeredItem": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products/10001",
+                      "@type": "dfc-b:SuppliedProduct",
+                      "dfc-b:name": "Apple",
+                      "dfc-b:description": "Red",
+                      "dfc-b:hasQuantity": {
+                        "@type": "dfc-b:QuantitativeValue",
+                        "dfc-b:hasUnit": "dfc-m:Gram",
+                        "dfc-b:value": 1
+                      },
+                      "dfc-b:referencedBy": "http://test.host/api/dfc/enterprises/10000/catalog_items/10001",
+                      "dfc-b:isVariantOf": "http://test.host/api/dfc/product_groups/90000",
+                      "ofn:spree_product_id": 90000,
+                      "ofn:spree_product_uri": "http://test.host/api/dfc/enterprises/10000?spree_product_id=90000"
+                    },
+                    {
+                      "@id": "http://test.host/api/dfc/enterprises/10000/supplied_products",
+                      "@type": "dfc-b:SaleSession",
+                      "dfc-b:beginDate": "Wed Mar 19 2025 04:40:16 UTC",
+                      "dfc-b:endDate": "Thu Mar 27 2025 04:40:16 UTC"
+                    }
+                  ]
+                }
+    delete:
+      summary: Cancel Order
+      parameters:
+      - name: order_id
+        in: path
+        required: true
+        schema:
+          type: string
+      tags:
+      - Orders
+      responses:
+        '204':
+          description: no content
         '401':
           description: unauthorized
         '404':
@@ -1918,7 +2037,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
-                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/213
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/3016
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000
                     ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
@@ -1934,7 +2053,7 @@ paths:
                       "@type": dfc-b:QuantitativeValue
                       dfc-b:hasUnit: dfc-m:Gram
                       dfc-b:value: 6.0
-                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/215
+                    dfc-b:referencedBy: http://test.host/api/dfc/enterprises/10000/catalog_items/3018
                     dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
                     dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
                     ofn:spree_product_id: 90000

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -1372,8 +1372,7 @@ paths:
               examples:
                 unprocessable entity:
                   value:
-                    error: Line items variant must exist and Line items price is not
-                      a number
+                    error: 'Line items reference unknown products: http://test.host/api/dfc/enterprises/10000/supplied_products/99999'
       requestBody:
         content:
           application/json:
@@ -1493,8 +1492,7 @@ paths:
               examples:
                 variant not found:
                   value:
-                    error: Line items variant must exist and Line items price is not
-                      a number
+                    error: 'Line items reference unknown products: http://test.host/api/dfc/enterprises/10000/supplied_products/10001'
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Implements DFC-compatible order CRUD endpoints for the DFC Provider engine.

- GET  /enterprises/:id/orders/:id — Show order with lines, offers, catalog items
- POST /enterprises/:id/orders    — Create order from DFC-JSON graph payload
- PUT  /enterprises/:id/orders/:id   — Update order line items and completion status
- DELETE /enterprises/:id/orders/:id — Cancel order via state transition

The update endpoint uses `line_items_attributes` for incremental updates rather than destroy_all + rebuild, preserving data integrity. Completed orders set `completed_at` and call `recreate_all_fees!` to handle enterprise fees and order adjustments.

**THESE CODE CHANGES WERE CREATED USING AI TOOLS**

Closes #12181