### PR TITLE
Fix missing description on customer credit transactions created via the   API

### DIFF
--- a/app/controllers/api/v1/customer_account_transaction_controller.rb
+++ b/app/controllers/api/v1/customer_account_transaction_controller.rb
@@ -27,7 +27,8 @@ module Api
       end
 
       def description
-        I18n.t(".api_customer_credit", description: params[:description])
+        raw_description = customer_account_transaction_params[:description]
+        I18n.t(".api_customer_credit", description: raw_description)
       end
     end
   end

--- a/spec/requests/api/v1/customer_account_transaction_spec.rb
+++ b/spec/requests/api/v1/customer_account_transaction_spec.rb
@@ -102,6 +102,26 @@ RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml", feature: :
       end
     end
 
+    describe "with a wrapped request body" do
+      let(:params) do
+        {
+          customer_account_transaction: {
+            customer_id: customer.id.to_s,
+            amount: "10.25",
+            description: "Payment processed by POS",
+          }
+        }
+      end
+
+      it "preserves the description nested in the wrapped body" do
+        post "/api/v1/customer_account_transaction", params: params
+
+        expect(response).to have_http_status(:created)
+        expect(CustomerAccountTransaction.last.description)
+          .to eq("API credit: Payment processed by POS")
+      end
+    end
+
     describe "concurrency", concurrency: true do
       let(:breakpoint) { Mutex.new }
       let(:params) do


### PR DESCRIPTION
## What? Why?

- Closes #14407 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
When a client creates a customer credit via POST  ` /api/v1/customer_account_transaction` with a properly wrapped request body — ` { "customer_account_transaction": { "customer_id": 1, "amount": "10.25",  "description": "Payment processed by POS" } }`  — the transaction's description came back empty ("API credit: " with nothing  after it). The note explaining what the payment was for was silently dropped.

  Root cause: the controller reads every field from inside the wrapped  customer_account_transaction params except the description, which it  mistakenly read from the top level of the request (`params[:description]`). For  a correctly wrapped body there is no top-level description, so it came through  as nil.

  The existing request specs didn't catch this because they send the body  unwrapped (flat keys). Rails' wrap_parameters copies those flat keys to the  top level too, so params[:description] happened to work in the tests but not  for a real wrapped request.

  This is a pre-existing bug, found while testing the API v1 toggle removal  (#14012).

##  Changes

  - `app/controllers/api/v1/customer_account_transaction_controller.rb` — read the  description from `customer_account_transaction_params[:description]`,  consistent with how every other field is read.
  - `spec/requests/api/v1/customer_account_transaction_spec.rb` — added a  regression test that posts a properly wrapped body and asserts the description  is preserved. It fails on the old code (got: "API credit: ") and passes with
  the fix.

##  What should we test?

  - Send POST `/api/v1/customer_account_transaction` with a wrapped JSON body  containing a description, e.g. `{ "customer_account_transaction": {  "customer_id": <id>, "amount": "10.25", "description": "Payment processed by 
  POS" } }`.
  - Confirm the created transaction's description is "API credit: Payment  processed by POS" (previously it was just "API credit: ").

##  Release notes

  Changelog Category:

  - [x] API changes (V0, V1, DFC or Webhook)

