### PR TITLE
Enable running system specs in containers without special ENV var

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -47,7 +47,6 @@ services:
       webpack:
         condition: service_started
     environment:
-      DOCKER: true
       DEV_CACHING: true
       OFN_DB_HOST: db
       OFN_REDIS_URL: redis://redis/
@@ -78,7 +77,6 @@ services:
       - .:/usr/src/app
       - gems:/bundles
     environment:
-      DOCKER: true
       DEV_CACHING: true
       OFN_DB_HOST: db
       OFN_REDIS_URL: redis://redis/

--- a/config/initializers/ferrum_pdf.rb
+++ b/config/initializers/ferrum_pdf.rb
@@ -11,7 +11,7 @@ FerrumPdf.configure do |config|
   config.pdf_options.scale = 0.85 # Scale down the content to fit better on the page, matching the wicked_pdf scale
   config.pdf_options.print_background = true
 
-  next unless ENV["CI"] || ENV["DOCKER"]
+  next unless ENV["CI"] || Process.uid.zero?
 
   config.browser_options = {
     "no-sandbox" => nil,

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,11 +6,6 @@
 
 Docker is intended to provide a common virtual environment available to all developers. Please note that it is not commonly used by developers at this time.
 
-## Limitations
-1. The docker environment can't directly control your host system browser, which means that browser specs (under `/spec/system/`) and email previews will not work. You may be able to find a solution with [this article](https://evilmartians.com/chronicles/system-of-a-test-setting-up-end-to-end-rails-testing). If so, please contribute!
-
-2. You can try circumventing this by setting the option `DOCKER=true` on the `.env.test.local` file, which will disable the `sandbox` mode for Chrome, used for system tests.
-
 ## Installing Docker
 ### Requirements
 * You should have at least 2 GB free on your local machine to download Docker images and create Docker containers for this app.

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -7,7 +7,10 @@ headless = ActiveModel::Type::Boolean.new.cast(ENV.fetch("HEADLESS", true))
 browser_options = {
   "ignore-certificate-errors" => nil,
 }
-browser_options["no-sandbox"] = nil if ENV['CI'] || ENV['DOCKER']
+
+# Chromium refuses to run as root unless sandboxing is disabled.
+# This is the case in CI and in containers, where we often run as root.
+browser_options["no-sandbox"] = nil if ENV["CI"] || Process.uid.zero?
 
 Capybara.register_driver(:cuprite_ofn) do |app|
   Capybara::Cuprite::Driver.new(


### PR DESCRIPTION


## What? Why?

I chose to run AI agents in an Incus container but system specs were failing. The issue had been solved for Docker already but depended on an additional ENV var. Now we check the _root_ cause for the issue.

Thanks Claude, for finding the cause.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- No test. This is not officially supported. But you are welcome to try your local container setup.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
