### PR TITLE
Add search filter to superuser Enterprises page

### DIFF
--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -263,10 +263,30 @@ module Admin
         OpenFoodNetwork::Permissions.new(spree_current_user).visible_enterprises
           .includes(:shipping_methods, :payment_methods).ransack(params[:q]).result
       else
-        OpenFoodNetwork::Permissions.new(spree_current_user).
-          editable_enterprises.
+        bulk_update_collection
+      end
+    end
+
+    def bulk_update_collection
+      permissions = OpenFoodNetwork::Permissions.new(spree_current_user)
+      enterprise_ids = bulk_update_enterprise_ids
+
+      if enterprise_ids.present?
+        permissions.editable_enterprises.where(id: enterprise_ids).
+          order('is_primary_producer ASC, name')
+      else
+        permissions.editable_enterprises.
           order('is_primary_producer ASC, name')
       end
+    end
+
+    def bulk_update_enterprise_ids
+      return if params[:sets_enterprise_set].blank?
+
+      collection_attributes = params[:sets_enterprise_set][:collection_attributes]
+      return if collection_attributes.blank?
+
+      collection_attributes.values.pluck(:id).compact
     end
 
     def collection_actions

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -250,6 +250,8 @@ module Admin
         if spree_current_user.admin?
           OpenFoodNetwork::Permissions.new(spree_current_user).
             editable_enterprises.
+            ransack(params[:q]).result.
+            distinct.
             order('is_primary_producer ASC, name')
         elsif json_request?
           OpenFoodNetwork::Permissions.new(spree_current_user)

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -276,7 +276,7 @@ module Admin
     # Include only enterprises being updated
     def bulk_update_collection
       permissions = OpenFoodNetwork::Permissions.new(spree_current_user)
-      submitted_attributes = params.dig(:sets_enterprise_set, :collection_attributes) || {}
+      submitted_attributes = bulk_params.fetch(:collection_attributes, {})
       enterprise_ids = submitted_attributes.values.pluck(:id).compact
 
       permissions.editable_enterprises
@@ -356,7 +356,7 @@ module Admin
     def check_can_change_bulk_sells
       return if spree_current_user.admin?
 
-      params[:sets_enterprise_set][:collection_attributes].each_value do |enterprise_params|
+      bulk_params.fetch(:collection_attributes, {}).each_value do |enterprise_params|
         unless spree_current_user == Enterprise.find_by(id: enterprise_params[:id]).owner
           enterprise_params.delete :sells
         end
@@ -390,7 +390,7 @@ module Admin
     def check_can_change_bulk_owner
       return if spree_current_user.admin?
 
-      bulk_params[:collection_attributes].each_value do |enterprise_params|
+      bulk_params.fetch(:collection_attributes, {}).each_value do |enterprise_params|
         enterprise_params.delete :owner_id
       end
     end

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -273,26 +273,15 @@ module Admin
       end
     end
 
+    # Include only enterprises being updated
     def bulk_update_collection
       permissions = OpenFoodNetwork::Permissions.new(spree_current_user)
-      enterprise_ids = bulk_update_enterprise_ids
+      enterprise_ids = params[:sets_enterprise_set][:collection_attributes]
+        .values.pluck(:id).compact
 
-      if enterprise_ids.present?
-        permissions.editable_enterprises.where(id: enterprise_ids).
-          order('is_primary_producer ASC, name')
-      else
-        permissions.editable_enterprises.
-          order('is_primary_producer ASC, name')
-      end
-    end
-
-    def bulk_update_enterprise_ids
-      return if params[:sets_enterprise_set].blank?
-
-      collection_attributes = params[:sets_enterprise_set][:collection_attributes]
-      return if collection_attributes.blank?
-
-      collection_attributes.values.pluck(:id).compact
+      permissions.editable_enterprises
+        .where(id: enterprise_ids)
+        .order('is_primary_producer ASC, name')
     end
 
     def collection_actions

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -276,8 +276,8 @@ module Admin
     # Include only enterprises being updated
     def bulk_update_collection
       permissions = OpenFoodNetwork::Permissions.new(spree_current_user)
-      enterprise_ids = params[:sets_enterprise_set][:collection_attributes]
-        .values.pluck(:id).compact
+      submitted_attributes = params.dig(:sets_enterprise_set, :collection_attributes) || {}
+      enterprise_ids = submitted_attributes.values.pluck(:id).compact
 
       permissions.editable_enterprises
         .where(id: enterprise_ids)
@@ -474,7 +474,7 @@ module Admin
     end
 
     def bulk_params
-      @bulk_params ||= params.require(:sets_enterprise_set).permit(
+      @bulk_params ||= params.fetch(:sets_enterprise_set, ActionController::Parameters.new).permit(
         collection_attributes: PermittedAttributes::Enterprise.attributes
       ).to_h.with_indifferent_access
     end

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -237,8 +237,9 @@ module Admin
 
     def search_filter_params
       q = params[:q]
-      q.is_a?(ActionController::Parameters) ? q.to_unsafe_h : nil
+      q.is_a?(ActionController::Parameters) ? q.to_unsafe_h : {}
     end
+    helper_method :search_filter_params
 
     def collection
       case action

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -118,7 +118,7 @@ module Admin
       if @enterprise_set.save
         flash[:success] = I18n.t(:enterprise_bulk_update_success_notice)
 
-        redirect_to main_app.admin_enterprises_path
+        redirect_to main_app.admin_enterprises_path(q: search_filter_params)
       else
         touched_enterprises = @enterprise_set.collection.select(&:changed?)
         @enterprise_set.collection.to_a.select! { |e| touched_enterprises.include? e }
@@ -235,6 +235,11 @@ module Admin
       @countries = Spree::Country.order(:name)
     end
 
+    def search_filter_params
+      q = params[:q]
+      q.is_a?(ActionController::Parameters) ? q.to_unsafe_h : nil
+    end
+
     def collection
       case action
       when :for_order_cycle
@@ -255,13 +260,13 @@ module Admin
             order('is_primary_producer ASC, name')
         elsif json_request?
           OpenFoodNetwork::Permissions.new(spree_current_user)
-            .editable_enterprises.ransack(params[:q]).result
+            .editable_enterprises.ransack(params[:q]).result.distinct
         else
           Enterprise.where("1=0")
         end
       when :visible
         OpenFoodNetwork::Permissions.new(spree_current_user).visible_enterprises
-          .includes(:shipping_methods, :payment_methods).ransack(params[:q]).result
+          .includes(:shipping_methods, :payment_methods).ransack(params[:q]).result.distinct
       else
         bulk_update_collection
       end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -11,7 +11,7 @@ class Enterprise < ApplicationRecord
   VALID_INSTAGRAM_REGEX = %r{\A[a-zA-Z0-9._]{1,30}([^/-]*)\z}
 
   searchable_attributes :sells, :is_primary_producer, :name
-  searchable_associations :properties
+  searchable_associations :properties, :owner, :users
   searchable_scopes :is_primary_producer, :is_distributor, :is_hub, :activated, :visible,
                     :ready_for_checkout, :not_ready_for_checkout
 

--- a/app/services/sets/enterprise_set.rb
+++ b/app/services/sets/enterprise_set.rb
@@ -3,7 +3,11 @@
 module Sets
   class EnterpriseSet < ModelSet
     def initialize(collection, attributes = {})
-      super(Enterprise, collection, attributes)
+      # The bulk update form only edits existing enterprises (no "add new row" UI), so
+      # any submitted id that isn't found in the collection is stale or out of scope,
+      # never a genuine new record. Reject creation unconditionally rather than
+      # fabricating an Enterprise without a :name, which crashes on save.
+      super(Enterprise, collection, attributes, proc { true })
     end
   end
 end

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -1,3 +1,21 @@
+%fieldset.no-border
+  %legend= t('.search_legend')
+  = form_tag admin_enterprises_path, method: :get, class: "row" do
+    .alpha.five.columns
+      = label_tag :q_name_i_cont, t('.name')
+      = text_field_tag 'q[name_i_cont]', params.dig(:q, :name_i_cont), class: "fullwidth"
+    .five.columns
+      = label_tag :q_owner_email_i_cont, t('.owner_email')
+      = text_field_tag 'q[owner_email_i_cont]', params.dig(:q, :owner_email_i_cont), class: "fullwidth"
+    .five.columns
+      = label_tag :q_users_email_i_cont, t('.member_email')
+      = text_field_tag 'q[users_email_i_cont]', params.dig(:q, :users_email_i_cont), class: "fullwidth"
+    .omega.one.columns
+      = button t('.search'), 'icon-search', class: "small"
+    .row
+      .omega.sixteen.columns
+        = link_to t('.clear'), admin_enterprises_path, class: "button small secondary"
+
 = form_for @enterprise_set, url: main_app.bulk_update_admin_enterprises_path do |f|
   %table#listing_enterprises.index
     %colgroup

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -8,7 +8,7 @@
       = label_tag :q_owner_email_i_cont, t('.owner_email')
       = text_field_tag 'q[owner_email_i_cont]', params.dig(:q, :owner_email_i_cont), class: "fullwidth"
     .five.columns
-      = label_tag :q_users_email_i_cont, t('.member_email')
+      = label_tag :q_users_email_i_cont, t('.manager_email')
       = text_field_tag 'q[users_email_i_cont]', params.dig(:q, :users_email_i_cont), class: "fullwidth"
     .row
       .eight.columns.alpha

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -10,11 +10,11 @@
     .five.columns
       = label_tag :q_users_email_i_cont, t('.member_email')
       = text_field_tag 'q[users_email_i_cont]', params.dig(:q, :users_email_i_cont), class: "fullwidth"
-    .omega.one.columns
-      = button t('.search'), 'icon-search', class: "small"
     .row
-      .omega.sixteen.columns
-        = link_to t('.clear'), admin_enterprises_path, class: "button small secondary"
+      .eight.columns.alpha
+        = button t('.search'), 'icon-search', class: "small"
+      .eight.columns.omega
+        = link_to t('.clear'), admin_enterprises_path, class: "button small secondary float-right"
 
 = form_for @enterprise_set, url: main_app.bulk_update_admin_enterprises_path do |f|
   %table#listing_enterprises.index

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -3,13 +3,13 @@
   = form_tag admin_enterprises_path, method: :get, class: "row" do
     .alpha.five.columns
       = label_tag :q_name_i_cont, t('.name')
-      = text_field_tag 'q[name_i_cont]', params.dig(:q, :name_i_cont), class: "fullwidth"
+      = text_field_tag 'q[name_i_cont]', search_filter_params.dig(:name_i_cont), class: "fullwidth"
     .five.columns
       = label_tag :q_owner_email_i_cont, t('.owner_email')
-      = text_field_tag 'q[owner_email_i_cont]', params.dig(:q, :owner_email_i_cont), class: "fullwidth"
+      = text_field_tag 'q[owner_email_i_cont]', search_filter_params.dig(:owner_email_i_cont), class: "fullwidth"
     .five.columns
       = label_tag :q_users_email_i_cont, t('.manager_email')
-      = text_field_tag 'q[users_email_i_cont]', params.dig(:q, :users_email_i_cont), class: "fullwidth"
+      = text_field_tag 'q[users_email_i_cont]', search_filter_params.dig(:users_email_i_cont), class: "fullwidth"
     .row
       .eight.columns.alpha
         = button t('.search'), 'icon-search', class: "small"
@@ -17,7 +17,7 @@
         = link_to t('.clear'), admin_enterprises_path, class: "button small secondary float-right"
 
 = form_for @enterprise_set, url: main_app.bulk_update_admin_enterprises_path do |f|
-  - params.fetch(:q, {}).each do |key, value|
+  - search_filter_params.each do |key, value|
     = hidden_field_tag "q[#{key}]", value
   %table#listing_enterprises.index
     %colgroup

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -4,16 +4,15 @@
     .alpha.five.columns
       = label_tag :q_name_i_cont, t('.name')
       = text_field_tag 'q[name_i_cont]', search_filter_params.dig(:name_i_cont), class: "fullwidth"
-    .five.columns
+    .four.columns
       = label_tag :q_owner_email_i_cont, t('.owner_email')
       = text_field_tag 'q[owner_email_i_cont]', search_filter_params.dig(:owner_email_i_cont), class: "fullwidth"
-    .five.columns
+    .four.columns
       = label_tag :q_users_email_i_cont, t('.manager_email')
       = text_field_tag 'q[users_email_i_cont]', search_filter_params.dig(:users_email_i_cont), class: "fullwidth"
-    .row
-      .sixteen.columns.alpha.omega.text-center
-        = button t('.search'), 'icon-search', class: "small"
-        = link_to t('.clear'), admin_enterprises_path, class: "button small secondary", style: "margin-left: 10px;"
+    .three.columns
+      = button t('.search'), 'icon-search', class: "small"
+      = link_to t('.clear'), admin_enterprises_path, class: "button small secondary", style: "margin-top: 2em;"
 
 = form_for @enterprise_set, url: main_app.bulk_update_admin_enterprises_path do |f|
   - search_filter_params.each do |key, value|

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -54,7 +54,7 @@
             = render 'actions', enterprise: enterprise
       - if @enterprises.empty?
         %tr
-          %td{colspan: "4"}= t(:none)
+          %td{colspan: "6"}= t(:none)
   = f.submit t(:update)
 
   = render partial: 'admin/shared/pagy_links', locals: { pagy: @pagy }

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -17,6 +17,8 @@
         = link_to t('.clear'), admin_enterprises_path, class: "button small secondary float-right"
 
 = form_for @enterprise_set, url: main_app.bulk_update_admin_enterprises_path do |f|
+  - params.fetch(:q, {}).each do |key, value|
+    = hidden_field_tag "q[#{key}]", value
   %table#listing_enterprises.index
     %colgroup
       %col{style: "width: 25%;"}/

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -11,10 +11,9 @@
       = label_tag :q_users_email_i_cont, t('.manager_email')
       = text_field_tag 'q[users_email_i_cont]', search_filter_params.dig(:users_email_i_cont), class: "fullwidth"
     .row
-      .eight.columns.alpha
+      .sixteen.columns.alpha.omega.text-center
         = button t('.search'), 'icon-search', class: "small"
-      .eight.columns.omega
-        = link_to t('.clear'), admin_enterprises_path, class: "button small secondary float-right"
+        = link_to t('.clear'), admin_enterprises_path, class: "button small secondary", style: "margin-left: 10px;"
 
 = form_for @enterprise_set, url: main_app.bulk_update_admin_enterprises_path do |f|
   - search_filter_params.each do |key, value|

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -55,6 +55,7 @@
       - if @enterprises.empty?
         %tr
           %td{colspan: "6"}= t(:none)
-  = f.submit t(:update)
+  - unless @enterprises.empty?
+    = f.submit t(:update)
 
   = render partial: 'admin/shared/pagy_links', locals: { pagy: @pagy }

--- a/app/views/admin/enterprises/_admin_index.html.haml
+++ b/app/views/admin/enterprises/_admin_index.html.haml
@@ -52,10 +52,10 @@
             %td= enterprise_form.select :owner_id, enterprise.users.map{ |e| [ e.email, e.id ] }, {}, class: "select2 fullwidth"
           %td.enterprise-actions
             = render 'actions', enterprise: enterprise
-      - if @enterprises.empty?
+      - if @enterprise_set.collection.empty?
         %tr
           %td{colspan: "6"}= t(:none)
-  - unless @enterprises.empty?
+  - unless @enterprise_set.collection.empty?
     = f.submit t(:update)
 
   = render partial: 'admin/shared/pagy_links', locals: { pagy: @pagy }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1599,12 +1599,17 @@ en:
         enterprise_fees: Enterprise Fees
         enterprise_fees_tip: This enterprise has no fees
       admin_index:
+        search_legend: Search Enterprises
         name: Name
         role: Role
         sells: Sells
         visible: Visible?
         owner: Owner
         producer: Producer
+        search: Search
+        clear: Clear
+        owner_email: Owner Email
+        member_email: Member Email
         sells_options:
           unspecified: unspecified
           none: none

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1609,7 +1609,7 @@ en:
         search: Search
         clear: Clear
         owner_email: Owner Email
-        member_email: Member Email
+        manager_email: Manager Email
         sells_options:
           unspecified: unspecified
           none: none

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -777,7 +777,7 @@ RSpec.describe Admin::EnterprisesController do
 
         it "returns all enterprises when no filter params given" do
           get :index, format: :html
-          expect(assigns(:collection).size).to be >= 5
+          expect(assigns(:collection).size).to be 5
         end
       end
     end

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -610,6 +610,96 @@ RSpec.describe Admin::EnterprisesController do
         expect(profile_enterprise2.owner).to eq new_owner
       end
     end
+
+    context "with more editable enterprises than are submitted" do
+      let!(:unsubmitted_enterprise) { create(:enterprise, sells: 'none', owner: original_owner) }
+
+      it "updates only the submitted enterprise and leaves others untouched" do
+        allow(controller).to receive_messages spree_current_user: admin_user
+        bulk_enterprise_params = { sets_enterprise_set: { collection_attributes: {
+          '0' => { id: profile_enterprise1.id, visible: 'false' }
+        } } }
+
+        spree_put :bulk_update, bulk_enterprise_params
+
+        expect(flash[:success]).to be_present
+        expect(profile_enterprise1.reload.visible).to eq 'false'
+        expect(unsubmitted_enterprise.reload.visible).not_to eq 'false'
+      end
+    end
+
+    context "when there are more editable enterprises than fit on one page" do
+      before { stub_const("Pagy::DEFAULT", Pagy::DEFAULT.merge(limit: 1)) }
+
+      let!(:other_enterprise) { create(:enterprise, sells: 'none', owner: original_owner) }
+
+      it "still updates an enterprise excluded from the first page of the full list" do
+        allow(controller).to receive_messages spree_current_user: admin_user
+        bulk_enterprise_params = { sets_enterprise_set: { collection_attributes: {
+          '0' => { id: profile_enterprise2.id, visible: 'false' }
+        } } }
+
+        spree_put :bulk_update, bulk_enterprise_params
+
+        expect(flash[:success]).to be_present
+        expect(profile_enterprise2.reload.visible).to eq 'false'
+      end
+    end
+
+    context "with an empty collection_attributes" do
+      it "does not raise and makes no changes" do
+        allow(controller).to receive_messages spree_current_user: admin_user
+        bulk_enterprise_params = { sets_enterprise_set: { collection_attributes: {} } }
+
+        expect {
+          spree_put :bulk_update, bulk_enterprise_params
+        }.not_to raise_error
+
+        expect(flash[:success]).to be_present
+      end
+    end
+
+    context "when a submitted enterprise id no longer exists" do
+      it "silently skips it and still saves the rest of the batch" do
+        allow(controller).to receive_messages spree_current_user: admin_user
+        non_existent_id = Enterprise.maximum(:id).to_i + 1_000_000
+
+        bulk_enterprise_params = { sets_enterprise_set: { collection_attributes: {
+          '0' => { id: profile_enterprise1.id, visible: 'false' },
+          '1' => { id: non_existent_id, visible: 'false' }
+        } } }
+
+        expect {
+          spree_put :bulk_update, bulk_enterprise_params
+        }.not_to raise_error
+
+        expect(flash[:success]).to be_present
+        expect(profile_enterprise1.reload.visible).to eq 'false'
+        expect(Enterprise.exists?(non_existent_id)).to be false
+      end
+    end
+
+    context "as manager, when submitting an id for an enterprise they don't manage" do
+      let!(:unmanaged_enterprise) { create(:enterprise, sells: 'none', owner: original_owner) }
+
+      it "strips :sells and :owner_id for that id and skips it without error" do
+        profile_enterprise1.enterprise_roles.build(user: new_owner).save
+        allow(controller).to receive_messages spree_current_user: new_owner
+        bulk_enterprise_params = { sets_enterprise_set: { collection_attributes: {
+          '0' => { id: profile_enterprise1.id, visible: 'false' },
+          '1' => { id: unmanaged_enterprise.id, sells: 'any', owner_id: new_owner.id }
+        } } }
+
+        expect {
+          spree_put :bulk_update, bulk_enterprise_params
+        }.not_to raise_error
+
+        expect(flash[:success]).to be_present
+        expect(profile_enterprise1.reload.visible).to eq 'false'
+        expect(unmanaged_enterprise.reload.sells).to eq 'none'
+        expect(unmanaged_enterprise.reload.owner).to eq original_owner
+      end
+    end
   end
 
   describe "for_order_cycle" do

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -736,6 +736,50 @@ RSpec.describe Admin::EnterprisesController do
           expect(assigns(:collection)).to include enterprise1, enterprise2, enterprise3
         end
       end
+
+      describe "ransack filtering" do
+        let!(:search_user) { create(:user, email: "searchy@example.com") }
+        let!(:filter_enterprise1) {
+          create(:enterprise, name: "Alpha Foods", owner: search_user)
+        }
+        let!(:filter_enterprise2) {
+          create(:enterprise, name: "Beta Bakery", owner: search_user)
+        }
+
+        it "filters by name (case-insensitive)" do
+          get :index, params: { q: { name_i_cont: "alpha" } }, format: :html
+          expect(assigns(:collection)).to include filter_enterprise1
+          expect(assigns(:collection)).not_to include filter_enterprise2
+        end
+
+        it "filters by owner email" do
+          get :index, params: { q: { owner_email_i_cont: "searchy" } }, format: :html
+          expect(assigns(:collection)).to include filter_enterprise1, filter_enterprise2
+          expect(assigns(:collection)).not_to include enterprise3
+        end
+
+        it "filters by member email" do
+          manager = create(:user, email: "manager@example.com")
+          create(:enterprise_role, user: manager, enterprise: filter_enterprise1)
+
+          get :index, params: { q: { users_email_i_cont: "manager" } }, format: :html
+          expect(assigns(:collection)).to include filter_enterprise1
+          expect(assigns(:collection)).not_to include filter_enterprise2
+        end
+
+        it "combines multiple filter fields" do
+          get :index, params: {
+            q: { name_i_cont: "beta", owner_email_i_cont: "searchy" }
+          }, format: :html
+          expect(assigns(:collection)).to include filter_enterprise2
+          expect(assigns(:collection)).not_to include filter_enterprise1
+        end
+
+        it "returns all enterprises when no filter params given" do
+          get :index, format: :html
+          expect(assigns(:collection).size).to be >= 5
+        end
+      end
     end
 
     context "as an enterprise user" do

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -567,6 +567,20 @@ RSpec.describe Admin::EnterprisesController do
         spree_put :bulk_update, bulk_enterprise_params
         expect(assigns(:enterprise_set).collection).to eq [profile_enterprise1]
       end
+
+      it "does not raise when a manager submits bulk_update with no sets_enterprise_set param" do
+        # check_can_change_bulk_sells reads the submitted collection directly (for non-admins
+        # only) and must be guarded the same way as bulk_update_collection/bulk_params, since a
+        # manager also has :bulk_update ability and can hit this before_action.
+        profile_enterprise1.enterprise_roles.build(user: new_owner).save
+        allow(controller).to receive_messages spree_current_user: new_owner
+
+        expect {
+          spree_put :bulk_update, q: { name_i_cont: "no such enterprise" }
+        }.not_to raise_error
+
+        expect(flash[:success]).to be_present
+      end
     end
 
     context "as the owner of an enterprise" do

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -700,6 +700,40 @@ RSpec.describe Admin::EnterprisesController do
         expect(unmanaged_enterprise.reload.owner).to eq original_owner
       end
     end
+
+    context "when a search filter (q param) is present" do
+      it "preserves the filter on redirect after a successful update" do
+        allow(controller).to receive_messages spree_current_user: admin_user
+        bulk_enterprise_params = {
+          q: { name_i_cont: profile_enterprise1.name },
+          sets_enterprise_set: { collection_attributes: {
+            '0' => { id: profile_enterprise1.id, visible: 'false' }
+          } }
+        }
+
+        spree_put :bulk_update, bulk_enterprise_params
+
+        expect(response).to redirect_to admin_enterprises_path(
+          q: { name_i_cont: profile_enterprise1.name }
+        )
+      end
+
+      it "does not raise when q is submitted in array notation instead of a hash" do
+        allow(controller).to receive_messages spree_current_user: admin_user
+        bulk_enterprise_params = {
+          q: ["a", "b"],
+          sets_enterprise_set: { collection_attributes: {
+            '0' => { id: profile_enterprise1.id, visible: 'false' }
+          } }
+        }
+
+        expect {
+          spree_put :bulk_update, bulk_enterprise_params
+        }.not_to raise_error
+
+        expect(flash[:success]).to be_present
+      end
+    end
   end
 
   describe "for_order_cycle" do
@@ -799,6 +833,17 @@ RSpec.describe Admin::EnterprisesController do
         .with([visible_enterprise], ams_prefix: 'basic', spree_current_user: user).and_call_original
       get :visible, format: :json
     end
+
+    it "does not duplicate an enterprise with multiple matching managers" do
+      manager_a = create(:user, email: "team-a@example.com")
+      manager_b = create(:user, email: "team-b@example.com")
+      create(:enterprise_role, user: manager_a, enterprise: visible_enterprise)
+      create(:enterprise_role, user: manager_b, enterprise: visible_enterprise)
+
+      get :visible, params: { q: { users_email_i_cont: "team" } }, format: :json
+
+      expect(assigns(:collection).to_a.count { |e| e == visible_enterprise }).to eq 1
+    end
   end
 
   describe "index" do
@@ -894,6 +939,17 @@ RSpec.describe Admin::EnterprisesController do
           get :index, format: :json
           expect(assigns(:collection)).to include enterprise1, enterprise2
           expect(assigns(:collection)).not_to include enterprise3
+        end
+
+        it "does not duplicate an enterprise with multiple matching managers" do
+          manager_a = create(:user, email: "team-a@example.com")
+          manager_b = create(:user, email: "team-b@example.com")
+          create(:enterprise_role, user: manager_a, enterprise: enterprise1)
+          create(:enterprise_role, user: manager_b, enterprise: enterprise1)
+
+          get :index, params: { q: { users_email_i_cont: "team" } }, format: :json
+
+          expect(assigns(:collection).to_a.count { |e| e == enterprise1 }).to eq 1
         end
       end
     end

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -944,6 +944,24 @@ RSpec.describe Admin::EnterprisesController do
           expect(assigns(:collection).size).to be 5
         end
       end
+
+      context "when the requested page is out of range but matches exist" do
+        render_views
+
+        it "does not render the bulk-update button for the empty rendered page" do
+          stub_const("Pagy::DEFAULT", Pagy::DEFAULT.merge(limit: 1))
+
+          get :index, params: { page: 99 }, format: :html
+
+          # @collection (aliased as @enterprises in the view) reflects the full, unpaginated
+          # filtered result — it is NOT empty here, which is exactly why gating the button on
+          # it was wrong: fields_for :collection iterates @enterprise_set.collection, the
+          # paginated slice, which IS empty on an out-of-range page.
+          expect(assigns(:collection)).not_to be_empty
+          expect(assigns(:enterprise_set).collection).to be_empty
+          expect(response.body).not_to include 'name="commit"'
+        end
+      end
     end
 
     context "as an enterprise user" do

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -659,6 +659,21 @@ RSpec.describe Admin::EnterprisesController do
       end
     end
 
+    context "with no sets_enterprise_set param at all" do
+      it "does not raise and makes no changes" do
+        # Reproduces submitting the bulk-update form when a search filter's result is
+        # empty: `fields_for :collection` renders no fields, so the whole
+        # `sets_enterprise_set` key is absent from the request, not just empty.
+        allow(controller).to receive_messages spree_current_user: admin_user
+
+        expect {
+          spree_put :bulk_update, q: { name_i_cont: "no such enterprise" }
+        }.not_to raise_error
+
+        expect(flash[:success]).to be_present
+      end
+    end
+
     context "when a submitted enterprise id no longer exists" do
       it "silently skips it and still saves the rest of the batch" do
         allow(controller).to receive_messages spree_current_user: admin_user

--- a/spec/requests/admin/enterprises_controller_spec.rb
+++ b/spec/requests/admin/enterprises_controller_spec.rb
@@ -19,4 +19,14 @@ RSpec.describe Admin::EnterprisesController do
       expect(response).to redirect_to(admin_enterprises_path)
     end
   end
+
+  describe 'GET #index' do
+    it "does not raise when q is submitted in array notation instead of a hash" do
+      expect {
+        get admin_enterprises_path(q: ["foo", "bar"])
+      }.not_to raise_error
+
+      expect(response).to have_http_status(:success)
+    end
+  end
 end


### PR DESCRIPTION
## What? Why?

- Closes #14436

Superusers have no way to search or filter the /admin/enterprises page — they must
page through the full paginated list to locate a specific enterprise. This creates
friction in support workflows and is particularly problematic for deletion, since the
delete action is only available from the list view (the existing workaround of clicking
into an enterprise does not help with deletion).

Hub and shop owners have a client-side quickSearch on their enterprises view, but this
was never carried over to the superuser view, which is a different paginated bulk-edit
form. A client-side filter would only search the current page, so a server-side Ransack
filter is used instead — consistent with how filtering works elsewhere in the admin
(Orders, Order Cycles, Subscriptions).

Three case-insensitive search fields are added above the existing list:
- Name — find an enterprise directly by name
- Owner email — find enterprises where a specific user is the registered owner
- Member email — find enterprises where a specific user is an owner or manager

Community discussion: https://community.openfoodnetwork.org/t/add-search-filter-to-the-superuser-enterprises-page-to-improve-hub-operator-support/3968



## What should we test?
- Log in as a superuser and go to /admin/enterprises.
- Confirm a search form appears above the enterprise list with Name, Owner Email,
  and Member Email fields plus Search and Clear buttons.
- Filter by a partial enterprise name — confirm only matching enterprises appear
  and pagination reflects the filtered count.
- Filter by an owner's email address — confirm only enterprises owned by that user appear.
- Filter by a manager's email address — confirm enterprises where that user is a manager
  (but not the owner) also appear.
- Combine two fields — confirm AND logic applies (only enterprises matching both).
- Click Clear — confirm the full list is restored.
- Log in as a hub/shop owner and go to /admin/enterprises — confirm the search form
  is not visible.
- Confirm all existing list actions (edit, delete, bulk update) still work on filtered results.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes


The title of the pull request will be included in the release notes.


