### PR TITLE
Increase final_weight_volume precision from scale 2 to scale 3

### DIFF
--- a/db/migrate/20250317221440_change_final_weight_volume_to_scale_3_in_spree_line_items.rb
+++ b/db/migrate/20250317221440_change_final_weight_volume_to_scale_3_in_spree_line_items.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeFinalWeightVolumeToScale3InSpreeLineItems < ActiveRecord::Migration[7.0]
+  def up
+    change_column :spree_line_items, :final_weight_volume, :decimal, precision: 10, scale: 3
+  end
+
+  def down
+    change_column :spree_line_items, :final_weight_volume, :decimal, precision: 10, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -589,7 +589,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_11_223814) do
     t.integer "max_quantity"
     t.string "currency", limit: 255
     t.decimal "distribution_fee", precision: 10, scale: 2
-    t.decimal "final_weight_volume", precision: 10, scale: 2
+    t.decimal "final_weight_volume", precision: 10, scale: 3
     t.integer "tax_category_id"
     t.decimal "weight", precision: 8, scale: 2
     t.decimal "height", precision: 8, scale: 2

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -639,6 +639,48 @@ RSpec.describe Spree::LineItem do
       end
     end
 
+    context "with a volume product whose unit_value has 3 decimal places (e.g. 125mL)" do
+      # Regression test for https://github.com/openfoodfoundation/openfoodnetwork/issues/13911
+      # final_weight_volume DECIMAL(10,2) rounded 0.125 × 1 = 0.125 up to 0.13,
+      # corrupting unit_presentation to "130mL" instead of "125mL".
+      let!(:p) {
+        create(:product, variant_unit: "volume", variant_unit_scale: 0.001,
+                         unit_value: 0.125)
+      }
+      let!(:v) { p.variants.first }
+      let!(:o) { create(:order) }
+
+      context "when creating a line item with qty=1" do
+        let!(:li) { create(:line_item, order: o, variant: v, quantity: 1) }
+
+        it "stores final_weight_volume without rounding to 2 decimal places" do
+          expect(li.reload.final_weight_volume).to eq(0.125)
+        end
+      end
+
+      context "when creating a line item with qty=3" do
+        let!(:li) { create(:line_item, order: o, variant: v, quantity: 3) }
+
+        it "stores final_weight_volume without rounding to 2 decimal places" do
+          expect(li.reload.final_weight_volume).to eq(0.375)
+        end
+      end
+
+      context "when changing quantity from 1 to 2" do
+        let!(:li) { create(:line_item, order: o, variant: v, quantity: 1) }
+
+        before { li.update!(quantity: 2) }
+
+        it "stores the correct final_weight_volume" do
+          expect(li.reload.final_weight_volume).to eq(0.250)
+        end
+
+        it "preserves the correct unit_presentation" do
+          expect(li.reload.unit_presentation).to eq("125mL")
+        end
+      end
+    end
+
     describe "generating the full name" do
       let(:li) { described_class.new }
 


### PR DESCRIPTION
## What? Why?

- Closes #13911 and #12874 

_(Should I also make a PR to adress email issue ? Even with the precision fix, historical line items already stored with rounded fwv values will continue to show wrong unit_presentation. Grouping by li.variant.product_and_full_name (the variant's consistent current name) instead of li.product_and_full_name (the per-line-item snapshot) ensures all orders for the same variant are aggregated into one row, matching the behaviour of the packing-by-product report.)_

Fixes a rounding bug that causes incorrect unit_presentation on line items for variants whose unit_value has 3 significant decimal places (e.g. 0.125 L = 125mL yogurts).

With DECIMAL(10,2), 0.125 × 1 = 0.125 is rounded UP to 0.13 on storage because PostgreSQL rounds 0.125 to 0.13 (half-away-from-zero). This causes assign_units to compute unit_presentation = '130mL' instead of '125mL'. The error then propagates when customers change quantity (e.g. qty 1→2 produces fwv = 0.13 × 2 = 0.26, still '130mL').

Changing to DECIMAL(10,3) stores 0.125 exactly, eliminating the rounding.

This is a direct port of PR #12970 by @bouaik, rebased on current master as part of fixing issue #13911 (error in producer end-of-cycle email report).

## What should we test?

 ### What the bug was                                                                                                                                                                     
                                                                                                                                                                                          
 For any variant with unit_value ending in .125 (e.g. a 125mL yogurt = 0.125 L), storing final_weight_volume = 0.125 × 1 = 0.125 in a DECIMAL(10,2) column rounds it UP to 0.13           
 (PostgreSQL rounds half-away-from-zero). This causes assign_units to compute unit_presentation = "130mL" instead of "125mL". When the customer then changes qty (e.g. 1→2), the stored   
 0.13 propagates: 0.13 × 2 = 0.26 → "130mL" still.                                                                                                                                        
                                                                                                                                                                                          
 With DECIMAL(10,3), 0.125 is stored exactly.                                                                                                                                                                                                                                                     
                                                                                                                                                                                          
 ### 1. Run the migration                                                                                                                                                                 
                                                                                                                                                                                          
 ```bash                                                                                                                                                                                  
   bundle exec rails db:migrate                                                                                                                                                           
 ```                                                                                                                                                                                      
                                                                                                                                                                                          
 Verify the column changed:                                                                                                                                                               
                                                                                                                                                                                          
 ```sql                                                                                                                                                                                   
   SELECT column_name, numeric_precision, numeric_scale                                                                                                                                   
   FROM information_schema.columns                                                                                                                                                        
   WHERE table_name = 'spree_line_items'                                                                                                                                                  
     AND column_name = 'final_weight_volume';                                                                                                                                             
   -- Expected: numeric_scale = 3 (was 2)                                                                                                                                                 
 ```                                                                                                                                                                                      
                                                                                                                                             
 ### 2. Automated — unit test (in spec/models/spree/line_item_spec.rb)                                                                                                                    
                                                                                                                                                                                          
 Add and run these scenarios for a volume product with unit_value = 0.125 L:                                                                                                              
                                                                                                                                                                                          
                                                         
 │ Scenario                       │ Expected final_weight_volume │ Expected unit_presentation │ Before fix                  │                                                             
                                                    
 │ Create line item, qty=1        │ 0.125                        │ "125mL" ✓                  │ 0.13 → "130mL" ✗            │                                                             
                                                             
 │ Create line item, qty=3        │ 0.375                        │ "125mL" ✓                  │ 0.38 → "126.67mL" ✗         │                                                             
                                     
 │ Create qty=1, then change to 2 │ 0.250                        │ "125mL" ✓                  │ 0.13 × 2 = 0.26 → "130mL" ✗ │                                                             
                                                    
 │ Create qty=2 directly          │ 0.250                        │ "125mL" ✓                  │ Already correct             │                                                             
                                  
                                                                                                                                                                                         
 ### 3. Manual — shop & email                                                                                                                                                             
                                                                                                                                                                                          
 1. Create a product with unit = Volume (mL), value = 125mL, price e.g. 1.60                                                                                                              
 2. Open an order cycle and add the variant to it                                                                                                                                         
 3. Place two orders as a customer:                                                                                                                                                       
     - Order A: add 1 unit to cart (do NOT change qty)                                                                                                                                    
     - Order B: add 1 unit to cart, then change to 2                                                                                                                                      
 4. Close the order cycle → check the producer end-of-cycle email                                                                                                                         
                                                                                                                                                                                          
 Before the fix: the email shows two separate rows ("125mL" and "130mL") for the same variant                                                                                             
 After the fix: one aggregated row "125mL" with the correct combined quantity
                                                                                                                        
 ### 4. Regression — weight-variable products                                                                                                                                             
                                                                                                                                                                                          
 For a product sold by actual weight (e.g. variant_unit = "weight"), final_weight_volume is intentionally set by the hub after delivery to record the actual measured weight. Verify:     
                                                                                                                                                                                          
 - Creating a weight-product line item still stores fwv = unit_value × qty correctly                                                                                                      
 - Updating final_weight_volume manually via Bulk Order Management still adjusts the price proportionally                                                                                 
 - The precision increase (to 3 dp) does not change any existing weight-product behaviour     

## Release notes

Not sure :
- [ ] User facing changes
- [ ] Technical changes only
