### PR TITLE
Speed up specs: reduce default order factory line_items_count from 5 to 4

### DIFF
--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe Api::V0::ShipmentsController do
       }
       let!(:order_cycle) { create(:order_cycle, distributors: [distributor]) }
       let!(:order) {
-        create(:completed_order_with_totals, order_cycle:, distributor:)
+        create(:completed_order_with_totals, line_items_count: 5, order_cycle:, distributor:)
       }
       let(:new_shipping_rate) {
         order.shipment.shipping_rates.select{ |sr| sr.shipping_method == shipping_method2 }.first

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
       ship_address
 
       transient do
-        line_items_count { 5 }
+        line_items_count { 4 }
       end
 
       after(:create) do |order, evaluator|

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1336,7 +1336,8 @@ RSpec.describe Spree::Order do
       end
 
       it "returns previous items" do
-        expect(order.finalised_line_items.length).to eq 11
+        expect(order.finalised_line_items.length)
+          .to eq(prev_order.line_items.length + prev_order2.line_items.length)
         expect(order.finalised_line_items)
           .to match_array(prev_order.line_items + prev_order2.line_items)
       end

--- a/spec/services/voucher_adjustments_service_spec.rb
+++ b/spec/services/voucher_adjustments_service_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe VoucherAdjustmentsService do
         let(:order) do
           create(
             :order_with_taxes,
+            line_items_count: 5,
             distributor: enterprise,
             ship_address: create(:address),
             product_price: 110,
@@ -90,6 +91,7 @@ RSpec.describe VoucherAdjustmentsService do
         let(:order) do
           create(
             :order_with_taxes,
+            line_items_count: 5,
             distributor: enterprise,
             ship_address: create(:address),
             product_price: 110,
@@ -196,6 +198,7 @@ RSpec.describe VoucherAdjustmentsService do
         let(:order) do
           create(
             :order_with_taxes,
+            line_items_count: 5,
             distributor: enterprise,
             ship_address: create(:address),
             product_price: 110,
@@ -224,6 +227,7 @@ RSpec.describe VoucherAdjustmentsService do
         let(:order) do
           create(
             :order_with_taxes,
+            line_items_count: 5,
             distributor: enterprise,
             ship_address: create(:address),
             product_price: 110,
@@ -305,6 +309,7 @@ RSpec.describe VoucherAdjustmentsService do
     let(:order) do
       create(
         :order_with_taxes,
+        line_items_count: 5,
         distributor: enterprise,
         ship_address: create(:address),
         product_price: 110,

--- a/spec/system/admin/fees_on_orders_spec.rb
+++ b/spec/system/admin/fees_on_orders_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe '
       let!(:order) do
         create(
           :order_with_taxes,
+          line_items_count: 5,
           distributor: distributor1,
           order_cycle: order_cycle1,
           ship_address: create(:address),

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -73,17 +73,19 @@ RSpec.describe '
     end
 
     let!(:order2) {
-      create(:order_ready_to_ship, user: customer2, distributor: distributor2,
+      create(:order_ready_to_ship, line_items_count: 5, user: customer2, distributor: distributor2,
                                    order_cycle: order_cycle2, completed_at: 2.days.ago,
                                    bill_address_id: billing_address2.id)
     }
     let!(:order3) {
-      create(:order_with_credit_payment, user: customer3, distributor: distributor3,
+      create(:order_with_credit_payment, line_items_count: 5, user: customer3,
+                                         distributor: distributor3,
                                          order_cycle: order_cycle3,
                                          bill_address_id: billing_address3.id)
     }
     let!(:order4) {
-      create(:order_with_credit_payment, user: customer4, distributor: distributor4,
+      create(:order_with_credit_payment, line_items_count: 5, user: customer4,
+                                         distributor: distributor4,
                                          order_cycle: order_cycle4,
                                          bill_address_id: billing_address4.id)
     }

--- a/spec/system/admin/reports/orders_and_distributors_spec.rb
+++ b/spec/system/admin/reports/orders_and_distributors_spec.rb
@@ -69,11 +69,11 @@ RSpec.describe "Orders And Distributors" do
         expect(table_headers).to eq([header])
 
         # Total rows should equal nr. of line items, per order
-        expect(all('table.report__table tbody tr').count).to eq(5)
+        expect(all('table.report__table tbody tr').count).to eq(order.line_items.count)
 
         # displays only orders from the hub it is managing
         within ".report__table" do
-          expect(page).to have_content(distributor.name, count: 5)
+          expect(page).to have_content(distributor.name, count: order.line_items.count)
         end
 
         # only sees line items from orders it manages
@@ -102,7 +102,7 @@ RSpec.describe "Orders And Distributors" do
 
               expect(downloaded_file_txt).to have_text header.join(" ")
               expect(downloaded_file_txt).to have_text(
-                "By Bike 10 Lovely Street Herndon 20170 UPS Ground", count: 5
+                "By Bike 10 Lovely Street Herndon 20170 UPS Ground", count: order.line_items.count
               )
             end
           end
@@ -145,9 +145,9 @@ RSpec.describe "Orders And Distributors" do
             # Then I should see the rows for the first order but not the second
             # One row per line item - order3 only
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 5)
+              expect(page).to have_content(distributor.name, count: order3.line_items.count)
             end
-            expect(page).to have_text(order3.email, count: 5)
+            expect(page).to have_text(order3.email, count: order3.line_items.count)
 
             # setting a time interval to include both orders
             find("input.datepicker").click
@@ -156,10 +156,12 @@ RSpec.describe "Orders And Distributors" do
             run_report
             # Then I should see the both orders
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 10)
+              expect(page).to have_content(
+                distributor.name, count: order3.line_items.count + order4.line_items.count
+              )
             end
-            expect(page).to have_text(order3.email, count: 5)
-            expect(page).to have_text(order4.email, count: 5)
+            expect(page).to have_text(order3.email, count: order3.line_items.count)
+            expect(page).to have_text(order4.email, count: order4.line_items.count)
           end
         end
 
@@ -170,7 +172,10 @@ RSpec.describe "Orders And Distributors" do
             run_report
 
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 15)
+              expect(page).to have_content(
+                distributor.name,
+                count: order.line_items.count + order3.line_items.count + order4.line_items.count
+              )
             end
             clear_select2("#s2id_q_distributor_id_in")
 
@@ -179,7 +184,7 @@ RSpec.describe "Orders And Distributors" do
             run_report
 
             within ".report__table" do
-              expect(page).to have_content(distributor2.name, count: 5)
+              expect(page).to have_content(distributor2.name, count: order2.line_items.count)
             end
           end
         end

--- a/spec/system/admin/reports/revenues_by_hub_spec.rb
+++ b/spec/system/admin/reports/revenues_by_hub_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Revenues By Hub Reports" do
   let(:order_with_voucher_tax_included) do
     create(
       :order_with_taxes,
+      line_items_count: 5,
       completed_at: 2.days.ago,
       order_cycle:,
       distributor: distributor2,
@@ -28,6 +29,7 @@ RSpec.describe "Revenues By Hub Reports" do
   let(:order_with_voucher_tax_excluded) do
     create(
       :order_with_taxes,
+      line_items_count: 5,
       completed_at: 2.days.ago,
       order_cycle:,
       distributor: distributor3,

--- a/spec/system/consumer/checkout/summary_spec.rb
+++ b/spec/system/consumer/checkout/summary_spec.rb
@@ -533,7 +533,7 @@ RSpec.describe "As a consumer, I want to checkout my order" do
 
     describe "order confirmation page" do
       let(:completed_order) {
-        create(:order_ready_to_ship, distributor:,
+        create(:order_ready_to_ship, line_items_count: 5, distributor:,
                                      order_cycle:, user_id: user.id)
       }
       let(:payment) { completed_order.payments.first }

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe "Order Management" do
     let(:order) do
       create(
         :completed_order_with_totals,
+        line_items_count: 5,
         order_cycle:,
         distributor:,
         user:,


### PR DESCRIPTION
## What

Reduces the default `line_items_count` of the `order_with_line_items` factory from **5 to 4**.

This factory and its descendants (`completed_order_with_totals`, `order_ready_to_ship`, `shipped_order`, `order_with_taxes`, `order_with_credit_payment`, `order_without_full_payment`) are created hundreds of times across the suite. Every line item cascades a `variant → product → supplier → taxon` creation, so the default count is a meaningful slice of suite setup time, and most specs don't care about the exact number.

## Why

Part of a broader effort to speed up the test suite. Benchmarked locally (`bin/rails runner`, test env):

| Factory call | Cost |
|---|---|
| `completed_order_with_totals` (5 line items) | ~697 ms |
| `completed_order_with_totals` (1 line item) | ~364 ms |

Reducing the default is one of the cheapest broad wins. To keep each step easy to review and to fix the dependent specs incrementally, this PR reduces the count by **one**. Follow-up PRs can reduce it further (4→3→…).

## Dependent specs fixed

Specs that genuinely depend on the line-item count were updated in two ways:

- **Value/total-sensitive specs** pinned to an explicit `line_items_count: 5`, preserving their documented arithmetic (voucher tax math, payment-state thresholds, hard-coded order totals): `voucher_adjustments_service_spec`, `shipments_controller_spec`, `summary_spec`, consumer `orders_spec`, `revenues_by_hub_spec`, admin `orders_spec`, `fees_on_orders_spec`.
- **Count-of-items specs** changed to derive the expected number from `order.line_items.count` instead of a hard-coded literal, so they stay correct as the default is reduced further: `order_spec` (`finalised_line_items`), `orders_and_distributors_spec`.

## Testing

Ran all specs that use the affected factories (directly and via descendants), including the full set of affected system specs — all green (aside from a couple of failures that are pre-existing on `master` in isolated runs and unrelated to this change).