### PR TITLE
Add webhook event for orders placed with payment due

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -413,6 +413,8 @@ module Spree
 
       deliver_order_confirmation_email
 
+      Orders::WebhookService.create_payment_due_job(order: self) if payment_state == 'balance_due'
+
       state_changes.create(
         previous_state: 'cart',
         next_state: 'complete',

--- a/app/services/orders/webhook_payload.rb
+++ b/app/services/orders/webhook_payload.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Create a webhook payload for an order-level event, such as an order placed
+# while a payment is still due. The payload will be delivered asynchronously.
+
+module Orders
+  class WebhookPayload
+    def initialize(order:, payment:, enterprise:)
+      @order = order
+      @payment = payment
+      @enterprise = enterprise
+    end
+
+    def to_hash
+      {
+        order: @order.slice(:number, :email, :total, :currency)
+          .merge(outstanding_balance: @order.new_outstanding_balance),
+        payment_method: {
+          name: @payment&.payment_method&.name,
+          type: @payment&.payment_method&.type
+        },
+        enterprise: @enterprise.slice(:abn, :acn, :name)
+          .merge(address: @enterprise.address.slice(:address1, :address2, :city, :zipcode))
+      }.with_indifferent_access
+    end
+  end
+end

--- a/app/services/orders/webhook_service.rb
+++ b/app/services/orders/webhook_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Notify configured webhook endpoints when an order is placed while a payment is
+# still due, so an integration can initiate an external payment flow (e.g. a
+# local currency) without the Open Food Network natively supporting it.
+# The payload is delivered asynchronously.
+
+module Orders
+  class WebhookService
+    def self.create_payment_due_job(order:)
+      return if order.order_cycle.nil?
+
+      payment = order.pending_payments.first
+      payload = WebhookPayload.new(order:, payment:, enterprise: order.distributor).to_hash
+
+      coordinator = order.order_cycle.coordinator
+      Payments::WebhookService.webhook_urls(coordinator).each do |url|
+        WebhookDeliveryJob.perform_later(url, "order.payment_due", payload)
+      end
+    end
+  end
+end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -276,6 +276,26 @@ RSpec.describe Spree::Order do
       expect(order.updater).to receive(:shipping_address_from_distributor)
       order.finalize!
     end
+
+    context "when a payment is still due" do
+      let(:order) { create(:order_ready_for_confirmation) }
+
+      it "notifies the order.payment_due webhook" do
+        expect(Orders::WebhookService).to receive(:create_payment_due_job).with(order:)
+        order.finalize!
+      end
+    end
+
+    context "when the order is paid in full" do
+      let(:order) { create(:order_ready_for_confirmation) }
+
+      it "does not notify the order.payment_due webhook" do
+        order.payments.first.capture!
+
+        expect(Orders::WebhookService).not_to receive(:create_payment_due_job)
+        order.finalize!
+      end
+    end
   end
 
   describe "#process_payments!" do

--- a/spec/services/orders/webhook_payload_spec.rb
+++ b/spec/services/orders/webhook_payload_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe Orders::WebhookPayload do
+  describe "#to_hash" do
+    let(:order_cycle) { create(:simple_order_cycle) }
+    let(:order) { create(:completed_order_with_totals, order_cycle:) }
+    let(:payment) { create(:payment, order:) }
+
+    subject { described_class.new(order:, payment:, enterprise: order.distributor) }
+
+    it "returns a hash with the order, payment method and enterprise data" do
+      enterprise = order.distributor
+
+      payload = {
+        order: {
+          number: order.number,
+          email: order.email,
+          total: order.total,
+          currency: order.currency,
+          outstanding_balance: order.new_outstanding_balance
+        },
+        payment_method: {
+          name: payment.payment_method.name,
+          type: payment.payment_method.type
+        },
+        enterprise: {
+          abn: enterprise.abn,
+          acn: enterprise.acn,
+          name: enterprise.name,
+          address: {
+            address1: enterprise.address.address1,
+            address2: enterprise.address.address2,
+            city: enterprise.address.city,
+            zipcode: enterprise.address.zipcode
+          }
+        }
+      }.with_indifferent_access
+
+      expect(subject.to_hash).to eq(payload)
+    end
+
+    context "without a pending payment" do
+      subject { described_class.new(order:, payment: nil, enterprise: order.distributor) }
+
+      it "returns nil payment method details" do
+        expect(subject.to_hash[:payment_method]).to eq(
+          "name" => nil, "type" => nil
+        )
+      end
+    end
+  end
+end

--- a/spec/services/orders/webhook_service_spec.rb
+++ b/spec/services/orders/webhook_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe Orders::WebhookService do
+  let(:order_cycle) { create(:simple_order_cycle) }
+  let(:order) { create(:completed_order_with_totals, order_cycle:) }
+  let!(:payment) { create(:payment, order:) }
+
+  before { order.payments.reload }
+
+  subject { described_class.create_payment_due_job(order:) }
+
+  describe "creating payloads" do
+    context "with order cycle coordinator owner webhook endpoints configured" do
+      before do
+        order.order_cycle.coordinator.owner.webhook_endpoints.payment_status.create!(
+          url: "http://coordinator.payment.url"
+        )
+      end
+
+      it "enqueues an order.payment_due delivery for the coordinator owner" do
+        expect{ subject }
+          .to enqueue_job(WebhookDeliveryJob).exactly(1).times
+          .with("http://coordinator.payment.url", "order.payment_due", any_args)
+      end
+
+      it "includes the order, amount due and payment method in the payload" do
+        data = {
+          order: {
+            number: order.number,
+            email: order.email,
+            total: order.total,
+            currency: order.currency,
+            outstanding_balance: order.new_outstanding_balance
+          },
+          payment_method: {
+            name: payment.payment_method.name,
+            type: payment.payment_method.type
+          }
+        }
+
+        expect{ subject }
+          .to enqueue_job(WebhookDeliveryJob).exactly(1).times
+          .with("http://coordinator.payment.url", "order.payment_due", hash_including(data))
+      end
+
+      context "with coordinator managers with webhook endpoints configured" do
+        let(:user1) { create(:user) }
+        let(:user2) { create(:user) }
+
+        before do
+          coordinator = order.order_cycle.coordinator
+          coordinator.users << user1
+          coordinator.users << user2
+        end
+
+        it "enqueues a delivery for every unique configured endpoint" do
+          user1.webhook_endpoints.payment_status.create!(url: "http://coordinator.payment.url")
+          user2.webhook_endpoints.payment_status.create!(url: "http://user2.payment.url")
+
+          expect{ subject }
+            .to enqueue_job(WebhookDeliveryJob)
+            .with("http://coordinator.payment.url", "order.payment_due", any_args)
+            .and enqueue_job(WebhookDeliveryJob)
+            .with("http://user2.payment.url", "order.payment_due", any_args)
+        end
+      end
+    end
+
+    context "with no webhook configured" do
+      it "does not enqueue a delivery" do
+        expect{ subject }.not_to enqueue_job(WebhookDeliveryJob)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What? Why?

- Closes #14406

The existing `payment.<state>` webhook only fires on payment **state transitions**. For cash/offline payment methods that transition only happens when the hub manager manually marks the order as paid, so there is no webhook at order placement time.

This adds an `order.payment_due` webhook that fires when an order is **placed while a payment is still due** (the order's `payment_state` is `balance_due`). It lets an integration initiate an external payment flow — e.g. a local currency, or any provider OFN doesn't natively support — and notify the customer, instead of the hub manager having to do it by hand.

How it works:
- Emitted from `Spree::Order#finalize!` (the `after_transition to: :complete` hook = order placed), guarded on `payment_state == 'balance_due'`.
- Delivered to the coordinator's/managers' configured **`payment_status`** webhook endpoints, consistent with the existing payment webhooks.
- Payload (`Orders::WebhookPayload`) carries the order number, customer email, total, **amount due** (`outstanding_balance`), currency, the **pending payment method name/type**, and the enterprise — enough for an integration to identify the method chosen and act on it.
- It does **not** fire for methods processed immediately at checkout (e.g. Stripe, PayPal), which finalize as `paid` rather than `balance_due`. The payment-method type in the payload also lets integrations filter.
- Existing payment webhook behaviour is unchanged.

The complementary API endpoint to let an integration push the payment status back into OFN (mentioned in the issue) is intentionally left as separate, follow-up work.

## What should we test?

- Configure a `payment_status` webhook endpoint for an order cycle coordinator (owner or manager).
- Place an order using an offline/cash payment method (so a balance is due) → an `order.payment_due` event is delivered with the order, amount due and payment-method details.
- Place an order paid in full at checkout (e.g. Stripe) → no `order.payment_due` event is delivered.

Automated coverage added: `spec/services/orders/webhook_service_spec.rb`, `spec/services/orders/webhook_payload_spec.rb`, and `#finalize!` examples in `spec/models/spree/order_spec.rb`.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] API changes (V0, V1, DFC or Webhook)

## Dependencies

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
