### PR TITLE
Reduce default order factory line_items_count from 5 to 1

### DIFF
--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -324,7 +324,9 @@ RSpec.describe Api::V0::ShipmentsController do
     end
 
     context 'for a completed order with shipment' do
-      let(:order) { create :completed_order_with_totals }
+      # At least two line items so that #remove can delete one without emptying
+      # the order (and destroying its shipment).
+      let(:order) { create :completed_order_with_totals, line_items_count: 2 }
 
       before { params[:id] = order.shipments.first.to_param }
 

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe Api::V0::ShipmentsController do
       }
       let!(:order_cycle) { create(:order_cycle, distributors: [distributor]) }
       let!(:order) {
-        create(:completed_order_with_totals, order_cycle:, distributor:)
+        create(:completed_order_with_totals, line_items_count: 5, order_cycle:, distributor:)
       }
       let(:new_shipping_rate) {
         order.shipment.shipping_rates.select{ |sr| sr.shipping_method == shipping_method2 }.first

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
       ship_address
 
       transient do
-        line_items_count { 4 }
+        line_items_count { 3 }
       end
 
       after(:create) do |order, evaluator|

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
       ship_address
 
       transient do
-        line_items_count { 2 }
+        line_items_count { 1 }
       end
 
       after(:create) do |order, evaluator|

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
       ship_address
 
       transient do
-        line_items_count { 5 }
+        line_items_count { 4 }
       end
 
       after(:create) do |order, evaluator|

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
       ship_address
 
       transient do
-        line_items_count { 3 }
+        line_items_count { 2 }
       end
 
       after(:create) do |order, evaluator|

--- a/spec/jobs/amend_backorder_job_spec.rb
+++ b/spec/jobs/amend_backorder_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe AmendBackorderJob do
-  let(:order) { create(:completed_order_with_totals) }
+  let(:order) { create(:completed_order_with_totals, line_items_count: 2) }
   let(:distributor) { order.distributor }
   let(:beans) { beans_item.variant }
   let(:beans_item) { order.line_items[0] }

--- a/spec/jobs/backorder_job_spec.rb
+++ b/spec/jobs/backorder_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe BackorderJob do
-  let(:order) { create(:completed_order_with_totals) }
+  let(:order) { create(:completed_order_with_totals, line_items_count: 2) }
   let(:beans) { order.line_items.first.variant }
   let(:chia_seed) { chia_item.variant }
   let(:chia_item) { order.line_items.second }

--- a/spec/jobs/complete_backorder_job_spec.rb
+++ b/spec/jobs/complete_backorder_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CompleteBackorderJob do
       exchange.semantic_links.create!(semantic_id: o.semanticId)
     end
   }
-  let(:ofn_order) { create(:completed_order_with_totals) }
+  let(:ofn_order) { create(:completed_order_with_totals, line_items_count: 2) }
   let(:distributor) { ofn_order.distributor }
   let(:order_cycle) { ofn_order.order_cycle }
   let(:exchange) { order_cycle.exchanges.outgoing.first }

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1336,7 +1336,7 @@ RSpec.describe Spree::Order do
       end
 
       it "returns previous items" do
-        expect(order.finalised_line_items.length).to eq 9
+        expect(order.finalised_line_items.length).to eq 7
         expect(order.finalised_line_items)
           .to match_array(prev_order.line_items + prev_order2.line_items)
       end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Spree::Order do
     end
 
     it "can find a line item matching a given variant" do
-      expect(order.find_line_item_by_variant(order.line_items.third.variant)).not_to be_nil
+      expect(order.find_line_item_by_variant(order.line_items.last.variant)).not_to be_nil
       expect(order.find_line_item_by_variant(build(:variant))).to be_nil
     end
   end
@@ -1336,7 +1336,7 @@ RSpec.describe Spree::Order do
       end
 
       it "returns previous items" do
-        expect(order.finalised_line_items.length).to eq 7
+        expect(order.finalised_line_items.length).to eq 5
         expect(order.finalised_line_items)
           .to match_array(prev_order.line_items + prev_order2.line_items)
       end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1336,7 +1336,7 @@ RSpec.describe Spree::Order do
       end
 
       it "returns previous items" do
-        expect(order.finalised_line_items.length).to eq 11
+        expect(order.finalised_line_items.length).to eq 9
         expect(order.finalised_line_items)
           .to match_array(prev_order.line_items + prev_order2.line_items)
       end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1336,7 +1336,7 @@ RSpec.describe Spree::Order do
       end
 
       it "returns previous items" do
-        expect(order.finalised_line_items.length).to eq 5
+        expect(order.finalised_line_items.length).to eq 3
         expect(order.finalised_line_items)
           .to match_array(prev_order.line_items + prev_order2.line_items)
       end

--- a/spec/services/backorder_updater_spec.rb
+++ b/spec/services/backorder_updater_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe BackorderUpdater do
-  let(:order) { create(:completed_order_with_totals) }
+  let(:order) { create(:completed_order_with_totals, line_items_count: 2) }
   let(:order_cycle) { order.order_cycle }
   let(:distributor) { order.distributor }
   let(:beans) { beans_item.variant }

--- a/spec/services/orders/check_stock_service_spec.rb
+++ b/spec/services/orders/check_stock_service_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Orders::CheckStockService do
   subject { described_class.new(order:) }
 
-  let(:order) { create(:order_with_line_items) }
+  let(:order) { create(:order_with_line_items, line_items_count: 2) }
 
   describe "#sufficient_stock?" do
     it "returns true if enough stock" do

--- a/spec/services/voucher_adjustments_service_spec.rb
+++ b/spec/services/voucher_adjustments_service_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe VoucherAdjustmentsService do
         let(:order) do
           create(
             :order_with_taxes,
+            line_items_count: 5,
             distributor: enterprise,
             ship_address: create(:address),
             product_price: 110,
@@ -90,6 +91,7 @@ RSpec.describe VoucherAdjustmentsService do
         let(:order) do
           create(
             :order_with_taxes,
+            line_items_count: 5,
             distributor: enterprise,
             ship_address: create(:address),
             product_price: 110,
@@ -196,6 +198,7 @@ RSpec.describe VoucherAdjustmentsService do
         let(:order) do
           create(
             :order_with_taxes,
+            line_items_count: 5,
             distributor: enterprise,
             ship_address: create(:address),
             product_price: 110,
@@ -224,6 +227,7 @@ RSpec.describe VoucherAdjustmentsService do
         let(:order) do
           create(
             :order_with_taxes,
+            line_items_count: 5,
             distributor: enterprise,
             ship_address: create(:address),
             product_price: 110,
@@ -305,6 +309,7 @@ RSpec.describe VoucherAdjustmentsService do
     let(:order) do
       create(
         :order_with_taxes,
+        line_items_count: 5,
         distributor: enterprise,
         ship_address: create(:address),
         product_price: 110,

--- a/spec/system/admin/fees_on_orders_spec.rb
+++ b/spec/system/admin/fees_on_orders_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe '
       let!(:order) do
         create(
           :order_with_taxes,
+          line_items_count: 5,
           distributor: distributor1,
           order_cycle: order_cycle1,
           ship_address: create(:address),

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -73,17 +73,19 @@ RSpec.describe '
     end
 
     let!(:order2) {
-      create(:order_ready_to_ship, user: customer2, distributor: distributor2,
+      create(:order_ready_to_ship, line_items_count: 5, user: customer2, distributor: distributor2,
                                    order_cycle: order_cycle2, completed_at: 2.days.ago,
                                    bill_address_id: billing_address2.id)
     }
     let!(:order3) {
-      create(:order_with_credit_payment, user: customer3, distributor: distributor3,
+      create(:order_with_credit_payment, line_items_count: 5, user: customer3,
+                                         distributor: distributor3,
                                          order_cycle: order_cycle3,
                                          bill_address_id: billing_address3.id)
     }
     let!(:order4) {
-      create(:order_with_credit_payment, user: customer4, distributor: distributor4,
+      create(:order_with_credit_payment, line_items_count: 5, user: customer4,
+                                         distributor: distributor4,
                                          order_cycle: order_cycle4,
                                          bill_address_id: billing_address4.id)
     }

--- a/spec/system/admin/reports/orders_and_distributors_spec.rb
+++ b/spec/system/admin/reports/orders_and_distributors_spec.rb
@@ -69,11 +69,11 @@ RSpec.describe "Orders And Distributors" do
         expect(table_headers).to eq([header])
 
         # Total rows should equal nr. of line items, per order
-        expect(all('table.report__table tbody tr').count).to eq(2)
+        expect(all('table.report__table tbody tr').count).to eq(1)
 
         # displays only orders from the hub it is managing
         within ".report__table" do
-          expect(page).to have_content(distributor.name, count: 2)
+          expect(page).to have_content(distributor.name, count: 1)
         end
 
         # only sees line items from orders it manages
@@ -102,7 +102,7 @@ RSpec.describe "Orders And Distributors" do
 
               expect(downloaded_file_txt).to have_text header.join(" ")
               expect(downloaded_file_txt).to have_text(
-                "By Bike 10 Lovely Street Herndon 20170 UPS Ground", count: 2
+                "By Bike 10 Lovely Street Herndon 20170 UPS Ground", count: 1
               )
             end
           end
@@ -145,9 +145,9 @@ RSpec.describe "Orders And Distributors" do
             # Then I should see the rows for the first order but not the second
             # One row per line item - order3 only
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 2)
+              expect(page).to have_content(distributor.name, count: 1)
             end
-            expect(page).to have_text(order3.email, count: 2)
+            expect(page).to have_text(order3.email, count: 1)
 
             # setting a time interval to include both orders
             find("input.datepicker").click
@@ -156,10 +156,10 @@ RSpec.describe "Orders And Distributors" do
             run_report
             # Then I should see the both orders
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 4)
+              expect(page).to have_content(distributor.name, count: 2)
             end
-            expect(page).to have_text(order3.email, count: 2)
-            expect(page).to have_text(order4.email, count: 2)
+            expect(page).to have_text(order3.email, count: 1)
+            expect(page).to have_text(order4.email, count: 1)
           end
         end
 
@@ -170,7 +170,7 @@ RSpec.describe "Orders And Distributors" do
             run_report
 
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 6)
+              expect(page).to have_content(distributor.name, count: 3)
             end
             clear_select2("#s2id_q_distributor_id_in")
 
@@ -179,7 +179,7 @@ RSpec.describe "Orders And Distributors" do
             run_report
 
             within ".report__table" do
-              expect(page).to have_content(distributor2.name, count: 2)
+              expect(page).to have_content(distributor2.name, count: 1)
             end
           end
         end

--- a/spec/system/admin/reports/orders_and_distributors_spec.rb
+++ b/spec/system/admin/reports/orders_and_distributors_spec.rb
@@ -69,11 +69,11 @@ RSpec.describe "Orders And Distributors" do
         expect(table_headers).to eq([header])
 
         # Total rows should equal nr. of line items, per order
-        expect(all('table.report__table tbody tr').count).to eq(5)
+        expect(all('table.report__table tbody tr').count).to eq(4)
 
         # displays only orders from the hub it is managing
         within ".report__table" do
-          expect(page).to have_content(distributor.name, count: 5)
+          expect(page).to have_content(distributor.name, count: 4)
         end
 
         # only sees line items from orders it manages
@@ -102,7 +102,7 @@ RSpec.describe "Orders And Distributors" do
 
               expect(downloaded_file_txt).to have_text header.join(" ")
               expect(downloaded_file_txt).to have_text(
-                "By Bike 10 Lovely Street Herndon 20170 UPS Ground", count: 5
+                "By Bike 10 Lovely Street Herndon 20170 UPS Ground", count: 4
               )
             end
           end
@@ -145,9 +145,9 @@ RSpec.describe "Orders And Distributors" do
             # Then I should see the rows for the first order but not the second
             # One row per line item - order3 only
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 5)
+              expect(page).to have_content(distributor.name, count: 4)
             end
-            expect(page).to have_text(order3.email, count: 5)
+            expect(page).to have_text(order3.email, count: 4)
 
             # setting a time interval to include both orders
             find("input.datepicker").click
@@ -156,10 +156,10 @@ RSpec.describe "Orders And Distributors" do
             run_report
             # Then I should see the both orders
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 10)
+              expect(page).to have_content(distributor.name, count: 8)
             end
-            expect(page).to have_text(order3.email, count: 5)
-            expect(page).to have_text(order4.email, count: 5)
+            expect(page).to have_text(order3.email, count: 4)
+            expect(page).to have_text(order4.email, count: 4)
           end
         end
 
@@ -170,7 +170,7 @@ RSpec.describe "Orders And Distributors" do
             run_report
 
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 15)
+              expect(page).to have_content(distributor.name, count: 12)
             end
             clear_select2("#s2id_q_distributor_id_in")
 
@@ -179,7 +179,7 @@ RSpec.describe "Orders And Distributors" do
             run_report
 
             within ".report__table" do
-              expect(page).to have_content(distributor2.name, count: 5)
+              expect(page).to have_content(distributor2.name, count: 4)
             end
           end
         end

--- a/spec/system/admin/reports/orders_and_distributors_spec.rb
+++ b/spec/system/admin/reports/orders_and_distributors_spec.rb
@@ -69,11 +69,11 @@ RSpec.describe "Orders And Distributors" do
         expect(table_headers).to eq([header])
 
         # Total rows should equal nr. of line items, per order
-        expect(all('table.report__table tbody tr').count).to eq(4)
+        expect(all('table.report__table tbody tr').count).to eq(3)
 
         # displays only orders from the hub it is managing
         within ".report__table" do
-          expect(page).to have_content(distributor.name, count: 4)
+          expect(page).to have_content(distributor.name, count: 3)
         end
 
         # only sees line items from orders it manages
@@ -102,7 +102,7 @@ RSpec.describe "Orders And Distributors" do
 
               expect(downloaded_file_txt).to have_text header.join(" ")
               expect(downloaded_file_txt).to have_text(
-                "By Bike 10 Lovely Street Herndon 20170 UPS Ground", count: 4
+                "By Bike 10 Lovely Street Herndon 20170 UPS Ground", count: 3
               )
             end
           end
@@ -145,9 +145,9 @@ RSpec.describe "Orders And Distributors" do
             # Then I should see the rows for the first order but not the second
             # One row per line item - order3 only
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 4)
+              expect(page).to have_content(distributor.name, count: 3)
             end
-            expect(page).to have_text(order3.email, count: 4)
+            expect(page).to have_text(order3.email, count: 3)
 
             # setting a time interval to include both orders
             find("input.datepicker").click
@@ -156,10 +156,10 @@ RSpec.describe "Orders And Distributors" do
             run_report
             # Then I should see the both orders
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 8)
+              expect(page).to have_content(distributor.name, count: 6)
             end
-            expect(page).to have_text(order3.email, count: 4)
-            expect(page).to have_text(order4.email, count: 4)
+            expect(page).to have_text(order3.email, count: 3)
+            expect(page).to have_text(order4.email, count: 3)
           end
         end
 
@@ -170,7 +170,7 @@ RSpec.describe "Orders And Distributors" do
             run_report
 
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 12)
+              expect(page).to have_content(distributor.name, count: 9)
             end
             clear_select2("#s2id_q_distributor_id_in")
 
@@ -179,7 +179,7 @@ RSpec.describe "Orders And Distributors" do
             run_report
 
             within ".report__table" do
-              expect(page).to have_content(distributor2.name, count: 4)
+              expect(page).to have_content(distributor2.name, count: 3)
             end
           end
         end

--- a/spec/system/admin/reports/orders_and_distributors_spec.rb
+++ b/spec/system/admin/reports/orders_and_distributors_spec.rb
@@ -69,11 +69,11 @@ RSpec.describe "Orders And Distributors" do
         expect(table_headers).to eq([header])
 
         # Total rows should equal nr. of line items, per order
-        expect(all('table.report__table tbody tr').count).to eq(3)
+        expect(all('table.report__table tbody tr').count).to eq(2)
 
         # displays only orders from the hub it is managing
         within ".report__table" do
-          expect(page).to have_content(distributor.name, count: 3)
+          expect(page).to have_content(distributor.name, count: 2)
         end
 
         # only sees line items from orders it manages
@@ -102,7 +102,7 @@ RSpec.describe "Orders And Distributors" do
 
               expect(downloaded_file_txt).to have_text header.join(" ")
               expect(downloaded_file_txt).to have_text(
-                "By Bike 10 Lovely Street Herndon 20170 UPS Ground", count: 3
+                "By Bike 10 Lovely Street Herndon 20170 UPS Ground", count: 2
               )
             end
           end
@@ -145,9 +145,9 @@ RSpec.describe "Orders And Distributors" do
             # Then I should see the rows for the first order but not the second
             # One row per line item - order3 only
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 3)
+              expect(page).to have_content(distributor.name, count: 2)
             end
-            expect(page).to have_text(order3.email, count: 3)
+            expect(page).to have_text(order3.email, count: 2)
 
             # setting a time interval to include both orders
             find("input.datepicker").click
@@ -156,10 +156,10 @@ RSpec.describe "Orders And Distributors" do
             run_report
             # Then I should see the both orders
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 6)
+              expect(page).to have_content(distributor.name, count: 4)
             end
-            expect(page).to have_text(order3.email, count: 3)
-            expect(page).to have_text(order4.email, count: 3)
+            expect(page).to have_text(order3.email, count: 2)
+            expect(page).to have_text(order4.email, count: 2)
           end
         end
 
@@ -170,7 +170,7 @@ RSpec.describe "Orders And Distributors" do
             run_report
 
             within ".report__table" do
-              expect(page).to have_content(distributor.name, count: 9)
+              expect(page).to have_content(distributor.name, count: 6)
             end
             clear_select2("#s2id_q_distributor_id_in")
 
@@ -179,7 +179,7 @@ RSpec.describe "Orders And Distributors" do
             run_report
 
             within ".report__table" do
-              expect(page).to have_content(distributor2.name, count: 3)
+              expect(page).to have_content(distributor2.name, count: 2)
             end
           end
         end

--- a/spec/system/admin/reports/revenues_by_hub_spec.rb
+++ b/spec/system/admin/reports/revenues_by_hub_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Revenues By Hub Reports" do
   let(:order_with_voucher_tax_included) do
     create(
       :order_with_taxes,
+      line_items_count: 5,
       completed_at: 2.days.ago,
       order_cycle:,
       distributor: distributor2,
@@ -28,6 +29,7 @@ RSpec.describe "Revenues By Hub Reports" do
   let(:order_with_voucher_tax_excluded) do
     create(
       :order_with_taxes,
+      line_items_count: 5,
       completed_at: 2.days.ago,
       order_cycle:,
       distributor: distributor3,

--- a/spec/system/consumer/checkout/summary_spec.rb
+++ b/spec/system/consumer/checkout/summary_spec.rb
@@ -533,7 +533,7 @@ RSpec.describe "As a consumer, I want to checkout my order" do
 
     describe "order confirmation page" do
       let(:completed_order) {
-        create(:order_ready_to_ship, distributor:,
+        create(:order_ready_to_ship, line_items_count: 5, distributor:,
                                      order_cycle:, user_id: user.id)
       }
       let(:payment) { completed_order.payments.first }

--- a/spec/system/consumer/checkout/summary_spec.rb
+++ b/spec/system/consumer/checkout/summary_spec.rb
@@ -497,8 +497,9 @@ RSpec.describe "As a consumer, I want to checkout my order" do
                                               order_cycle:, user_id: user.id)
       }
       let!(:prev_order) {
-        create(:completed_order_with_totals,
-               order_cycle:, distributor:, user_id: order.user_id)
+        # At least two line items so the "additional items" message is pluralised.
+        create(:completed_order_with_totals, line_items_count: 2,
+                                             order_cycle:, distributor:, user_id: order.user_id)
       }
 
       context "when distributor allows order changes" do

--- a/spec/system/consumer/shopping/cart_spec.rb
+++ b/spec/system/consumer/shopping/cart_spec.rb
@@ -271,11 +271,11 @@ RSpec.describe "full-page cart" do
       let(:address) { create(:address) }
       let(:user) { create(:user, bill_address: address, ship_address: address) }
       let!(:prev_order1) {
-        create(:completed_order_with_totals, order_cycle:, distributor:,
+        create(:completed_order_with_totals, line_items_count: 2, order_cycle:, distributor:,
                                              user:)
       }
       let!(:prev_order2) {
-        create(:completed_order_with_totals, order_cycle:, distributor:,
+        create(:completed_order_with_totals, line_items_count: 2, order_cycle:, distributor:,
                                              user:)
       }
 

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe "Order Management" do
     let(:order) do
       create(
         :completed_order_with_totals,
+        line_items_count: 5,
         order_cycle:,
         distributor:,
         user:,


### PR DESCRIPTION
## What

Reduces the default `line_items_count` of the `order_with_line_items` factory from **5 to 1**, in four small, independently-reviewable commits (5→4, 4→3, 3→2, 2→1).

This factory and its descendants (`completed_order_with_totals`, `order_ready_to_ship`, `shipped_order`, `order_with_taxes`, `order_with_credit_payment`, `order_without_full_payment`) are created throughout the suite. Every line item cascades a `variant → product → supplier → taxon` creation, and the large majority of specs don't care how many line items an order has.

> Supersedes #14449 (closed; its branch was rebased so GitHub wouldn't reopen it).

## ⚠️ Honest finding: no measurable CI speed-up

This started as a test-suite speed-up effort, but **we could not observe a reduction in CI wall-clock — the full run is still ~3.5 hours.** Sharing the analysis transparently:

A local micro-benchmark (`bin/rails runner`, test env) confirms the factory itself is cheaper per call:

| Factory call | Cost |
|---|---|
| `completed_order_with_totals` (5 line items) | ~697 ms |
| `completed_order_with_totals` (1 line item) | ~364 ms |

But that per-order saving (~330 ms) is a small fraction of total suite time. Even across the (hundreds of) order-factory calls in the suite, the aggregate saving is on the order of a few minutes of CPU time — distributed across the parallel CI workers, that's within run-to-run noise. CI wall-clock is dominated by other costs (Rails boot per worker, system-spec browser/Capybara time, and the sheer number of examples), not order data setup.

## Why merge it anyway

Even without the hoped-for speed-up, the change is worth keeping:
- Less DB churn — fewer records created per order (real, if modest).
- Clearer intent — specs that genuinely need multiple line items now **say so** explicitly instead of relying on a magic default.
- A cleaner baseline for further suite-performance work.

Opening it up for the team's review to decide.

## Reviewing by commit

Each commit is self-contained: the factory change for that step plus the spec adjustments it required. Reviewing commit-by-commit shows exactly which specs depended on each count.

## How dependent specs were handled

- **Value/total-sensitive specs** (voucher tax math, payment-state thresholds, hard-coded order totals) are pinned to an explicit `line_items_count: 5`, preserving their documented arithmetic.
- **Specs that need several distinct line items** (backorder "beans + chia", check-stock "reduced + out of stock", shipment removal, "previous order" messages) now declare an explicit `line_items_count` instead of relying on the default.
- **Count-of-items specs** use static values (e.g. `order_spec` `finalised_line_items`, `orders_and_distributors_spec` report-row counts), updated at each step, preferring readable/reliable literals over derived counts.

## Testing

At each step, ran every spec that uses the affected factories (directly and via descendants), including the full set of affected system specs — all green. The only failures observed were pre-existing on `master` in isolated runs (a few invoice/mailer/data-presenter specs that depend on full-suite seed data) and are unrelated to this change.