### PR TITLE
Allow deleting customers with zero credit balance

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -19,11 +19,14 @@ class Customer < ApplicationRecord
   belongs_to :enterprise
   belongs_to :user, class_name: "Spree::User", optional: true
   has_many :orders, class_name: "Spree::Order", dependent: :nullify
-  has_many :customer_account_transactions, dependent: :restrict_with_error
+  # deletion handled manually in cleanup callback
+  has_many :customer_account_transactions, dependent: nil
   before_validation :downcase_email
   before_validation :empty_code
   before_create :associate_user
-  before_destroy :update_orders_and_delete_canceled_subscriptions
+  # All validations before any mutations to avoid partial cleanup
+  before_destroy :validate_destroy
+  before_destroy :cleanup_associated_records
 
   belongs_to :bill_address, class_name: "Spree::Address", optional: true
   alias_method :billing_address, :bill_address
@@ -73,11 +76,27 @@ class Customer < ApplicationRecord
     self.user = user || Spree::User.find_by(email:)
   end
 
-  def update_orders_and_delete_canceled_subscriptions
-    if Subscription.where(customer_id: id).not_canceled.any?
-      errors.add(:base, I18n.t('admin.customers.destroy.has_associated_subscriptions'))
+  def validate_destroy
+    if credit_balance != 0
+      errors.add(:base, I18n.t('admin.customers.destroy.has_outstanding_credit'))
       throw :abort
     end
-    Subscription.where(customer_id: id).destroy_all
+    return unless Subscription.where(customer_id: id).not_canceled.any?
+
+    errors.add(:base, I18n.t('admin.customers.destroy.has_associated_subscriptions'))
+    throw :abort
+  end
+
+  def cleanup_associated_records
+    # Single transaction ensures both deletions are atomic
+    ActiveRecord::Base.transaction do
+      records = Subscription.where(customer_id: id).destroy_all
+      unless records.all?(&:destroyed?)
+        raise ActiveRecord::RecordNotDestroyed, "Failed to destroy all subscriptions"
+      end
+
+      # delete_all through model to bypass readonly? and association proxy
+      CustomerAccountTransaction.where(customer_id: id).delete_all
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -901,6 +901,7 @@ en:
         id: Id 
       destroy:
         has_associated_subscriptions: "Delete failed: This customer has active subscriptions. Cancel them first."
+        has_outstanding_credit: "Delete failed: This customer has an outstanding credit balance. Please refund before deleting."
     customer_account_transaction:
       index:
         available_credit: "Available credit: %{available_credit}"

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -193,6 +193,14 @@ RSpec.describe Customer do
           I18n.t("admin.customers.destroy.has_associated_subscriptions")
         )
       end
+
+      it "returns false when associated subscription destroy fails" do
+        create(:subscription, customer:, canceled_at: Time.zone.now)
+
+        allow_any_instance_of(Subscription).to receive(:destroy).and_return(false)
+
+        expect(customer.destroy).to be false
+      end
     end
   end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Customer do
   it { is_expected.to belong_to(:user).optional }
   it { is_expected.to belong_to(:bill_address).optional }
   it { is_expected.to belong_to(:ship_address).optional }
-  it { is_expected.to have_many(:customer_account_transactions).dependent(:restrict_with_error) }
+  it { is_expected.to have_many(:customer_account_transactions) }
 
   describe 'an existing customer' do
     let(:customer) { create(:customer) }
@@ -149,6 +149,49 @@ RSpec.describe Customer do
     context "when no existing customer account transaction" do
       it "returns 0" do
         expect(customer.credit_balance).to eq(0.00)
+      end
+    end
+  end
+
+  describe "#destroy" do
+    let(:customer) { create(:customer) }
+
+    context "when customer has no credit transactions" do
+      it "destroys the customer" do
+        expect(customer.destroy).to be_truthy
+      end
+    end
+
+    context "when customer has credit transactions" do
+      it "destroys the customer and cleans up transactions if balance is zero" do
+        create(:customer_account_transaction, customer:, amount: 10.00)
+        create(:customer_account_transaction, customer:, amount: -10.00)
+        expect { customer.destroy }.to change { CustomerAccountTransaction.count }.by(-2)
+        expect(customer).to be_destroyed
+      end
+
+      it "does not destroy the customer if there is outstanding credit" do
+        create(:customer_account_transaction, customer:, amount: 10.00)
+        expect(customer.destroy).to be false
+        expect(customer.errors[:base]).to include(
+          I18n.t("admin.customers.destroy.has_outstanding_credit")
+        )
+      end
+    end
+
+    context "when customer has subscriptions" do
+      it "destroys the customer and cleans up canceled subscriptions" do
+        create(:subscription, customer:, canceled_at: Time.zone.now)
+        expect { customer.destroy }.to change { Subscription.count }.by(-1)
+        expect(customer).to be_destroyed
+      end
+
+      it "does not destroy the customer if there are active subscriptions" do
+        create(:subscription, customer:)
+        expect(customer.destroy).to be false
+        expect(customer.errors[:base]).to include(
+          I18n.t("admin.customers.destroy.has_associated_subscriptions")
+        )
       end
     end
   end


### PR DESCRIPTION
## What? Why?

- Closes #14326

Customers with credit transactions could not be deleted because `customer_account_transactions` used `dependent: :restrict_with_error`, which blocked deletion regardless of the customer's actual balance. This is a GDPR concern — administrators must be able to delete customer records to comply with data protection regulations.

Changed the destroy logic to:
- Allow deletion when the customer has a zero credit balance (deleting associated transaction records as part of cleanup).
- Block deletion with a clear error message when the customer has an outstanding (non-zero) credit balance.
- Continue to block deletion when the customer has active (non-canceled) subscriptions.
- Clean up canceled subscriptions and all account transactions atomically within a transaction.

## What should we test?
Go to the Customers page in the backoffice and verify the following cases:
1. **Delete a customer with a zero credit balance** — Create a customer, add credit transactions that net to zero (e.g. +10.00 and -10.00), then delete the customer. Verify the customer is deleted and all associated transaction records are removed.

2. **Delete a customer with outstanding credit** — Create a customer, add a credit transaction with a positive amount only, then attempt to delete. Verify deletion is blocked with the error "Delete failed: This customer has an outstanding credit balance. Please refund before deleting."

3. **Delete a customer with canceled subscriptions** — Create a customer with a canceled subscription, then delete. Verify the customer is deleted and the subscription is removed.

4. **Delete a customer with active subscriptions** — Create a customer with an active subscription, then attempt to delete. Verify deletion is blocked with the existing error about active subscriptions.

5. **Delete a customer with no transactions or subscriptions** — Verify basic deletion still works as expected.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled