### PR TITLE
Apply DFCv2 migration to all rendered data for v2 requests

### DIFF
--- a/engines/dfc_provider/app/controllers/dfc_provider/application_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/application_controller.rb
@@ -88,7 +88,8 @@ module DfcProvider
       return render_v2(subject, *) unless subject.is_a?(Array)
 
       # DFCv2 requires containers for listing resources in an index action.
-      container = Container.new(url_for, members: subject)
+      members = DfcV2Migration.up(*subject)
+      container = Container.new(url_for, members:)
       render_v2(container, *subject, *)
     end
 
@@ -97,8 +98,11 @@ module DfcProvider
     end
 
     def render_v2(*)
+      objects = DfcV2Migration.up(*)
+
       connector = DataFoodConsortium::Connector::Connector.instance
-      render json: connector.export(*), content_type: 'application/ld+json; profile="dfc-v2"'
+      render json: connector.export(*objects),
+             content_type: 'application/ld+json; profile="dfc-v2"'
     end
   end
 end

--- a/engines/dfc_provider/app/controllers/dfc_provider/organizations_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/organizations_controller.rb
@@ -16,22 +16,19 @@ module DfcProvider
         EnterpriseBuilder.enterprise(enterprise)
       end
 
-      organizations = DfcV2Migration.up(enterprises)
-
-      render_dfc(organizations)
+      render_dfc(enterprises)
     end
 
     def show
       enterprise = current_user.enterprises.find(params[:id])
       dfc_enterprise = EnterpriseBuilder.enterprise(enterprise)
-      organization = DfcV2Migration.up([dfc_enterprise]).first
 
       render_dfc(
-        organization,
-        organization.mainContact,
-        *organization.localizations,
-        *organization.socialMedias,
-        *organization.certifications,
+        dfc_enterprise,
+        dfc_enterprise.mainContact,
+        *dfc_enterprise.localizations,
+        *dfc_enterprise.socialMedias,
+        *dfc_enterprise.certifications,
       )
     end
   end

--- a/engines/dfc_provider/app/services/dfc_v2_migration.rb
+++ b/engines/dfc_provider/app/services/dfc_v2_migration.rb
@@ -28,22 +28,9 @@ module DfcV2Migration
     # internally stored ids for enterprises.
     id = enterprise.semanticId.sub("/api/dfc/enterprises/", "/api/dfc/organizations/")
 
-    DataFoodConsortium::Connector::Organization.new(
-      id,
-      name: enterprise.name,
-      description: enterprise.description,
-      vatNumber: enterprise.vatNumber,
-      suppliedProducts: enterprise.suppliedProducts,
-      catalogItems: enterprise.catalogItems,
-      emails: enterprise.emails,
-      localizations: enterprise.localizations,
-      phoneNumbers: enterprise.phoneNumbers,
-      socialMedias: enterprise.socialMedias,
-      logo: enterprise.logo,
-      mainContact: enterprise.mainContact,
-      websites: enterprise.websites,
-      certifications: enterprise.certifications,
-    )
+    DataFoodConsortium::Connector::Organization.new(id).tap do |org|
+      copy_property_values(enterprise, org)
+    end
   end
 
   def self.up_person(person)
@@ -63,11 +50,19 @@ module DfcV2Migration
     v2_class = DataFoodConsortium::Connector.const_get(class_name)
 
     v2_class.new(id, **).tap do |o|
-      o.semanticProperties.each do |property|
-        next if property.value.present?
+      copy_property_values(object, o)
+    end
+  end
 
-        property.value = object.semanticPropertyValue(property.name)
-      end
+  def self.copy_property_values(from, to)
+    to.semanticProperties.each do |property|
+      next if property.value.present?
+
+      value = from.semanticPropertyValue(property.name)
+
+      next if value.blank?
+
+      property.value = value
     end
   end
 end

--- a/engines/dfc_provider/app/services/dfc_v2_migration.rb
+++ b/engines/dfc_provider/app/services/dfc_v2_migration.rb
@@ -48,15 +48,10 @@ module DfcV2Migration
 
   def self.up_person(person)
     id = person.semanticId.sub("/api/dfc/enterprises/", "/api/dfc/organizations/")
-
-    DataFoodConsortium::Connector::Person.new(
-      id,
-      firstName: person.firstName,
-      lastName: person.lastName,
-    )
+    up_generic(person, id)
   end
 
-  def self.up_generic(object)
+  def self.up_generic(object, id = object.semanticId, **)
     v1_class = object.class.ancestors.find do |ancestor|
       ancestor.module_parent == DataFoodConsortium::ConnectorV1
     end
@@ -67,8 +62,10 @@ module DfcV2Migration
     class_name = v1_class.name.demodulize
     v2_class = DataFoodConsortium::Connector.const_get(class_name)
 
-    v2_class.new(object.semanticId).tap do |o|
+    v2_class.new(id, **).tap do |o|
       o.semanticProperties.each do |property|
+        next if property.value.present?
+
         property.value = object.semanticPropertyValue(property.name)
       end
     end

--- a/engines/dfc_provider/app/services/dfc_v2_migration.rb
+++ b/engines/dfc_provider/app/services/dfc_v2_migration.rb
@@ -2,33 +2,56 @@
 
 # Transform DFC v1 data to DFC v2.
 module DfcV2Migration
-  def self.up(enterprises)
-    enterprises.map do |enterprise|
-      # We introduce new ids for our enterprises on the new version of the API.
-      # This is not strictly necessary but will make the API more consistent
-      # in the future. Since DFC v2 is a big breaking change, we may use that
-      # to ignore any requirement to be backwards compatible here.
-      #
-      # If an old integration upgrades to DFC v2, they have to update their
-      # internally stored ids for enterprises.
-      id = enterprise.semanticId.sub("/api/dfc/enterprises/", "/api/dfc/organizations/")
-
-      DataFoodConsortium::Connector::Organization.new(
-        id,
-        name: enterprise.name,
-        description: enterprise.description,
-        vatNumber: enterprise.vatNumber,
-        suppliedProducts: enterprise.suppliedProducts,
-        catalogItems: enterprise.catalogItems,
-        emails: enterprise.emails,
-        localizations: enterprise.localizations,
-        phoneNumbers: enterprise.phoneNumbers,
-        socialMedias: enterprise.socialMedias,
-        logo: enterprise.logo,
-        mainContact: enterprise.mainContact,
-        websites: enterprise.websites,
-        certifications: enterprise.certifications,
-      )
+  def self.up(*objects)
+    objects.map do |object|
+      case object
+      when DataFoodConsortium::ConnectorV1::Enterprise
+        up_enterprise(object)
+      when DataFoodConsortium::ConnectorV1::Person
+        up_person(object)
+      else
+        # Many classes didn't change in content at all, address for example.
+        # We can just return the v1 class as it's the same.
+        object
+      end
     end
+  end
+
+  def self.up_enterprise(enterprise)
+    # We introduce new ids for our enterprises on the new version of the API.
+    # This is not strictly necessary but will make the API more consistent
+    # in the future. Since DFC v2 is a big breaking change, we may use that
+    # to ignore any requirement to be backwards compatible here.
+    #
+    # If an old integration upgrades to DFC v2, they have to update their
+    # internally stored ids for enterprises.
+    id = enterprise.semanticId.sub("/api/dfc/enterprises/", "/api/dfc/organizations/")
+
+    DataFoodConsortium::Connector::Organization.new(
+      id,
+      name: enterprise.name,
+      description: enterprise.description,
+      vatNumber: enterprise.vatNumber,
+      suppliedProducts: enterprise.suppliedProducts,
+      catalogItems: enterprise.catalogItems,
+      emails: enterprise.emails,
+      localizations: enterprise.localizations,
+      phoneNumbers: enterprise.phoneNumbers,
+      socialMedias: enterprise.socialMedias,
+      logo: enterprise.logo,
+      mainContact: enterprise.mainContact,
+      websites: enterprise.websites,
+      certifications: enterprise.certifications,
+    )
+  end
+
+  def self.up_person(person)
+    id = person.semanticId.sub("/api/dfc/enterprises/", "/api/dfc/organizations/")
+
+    DataFoodConsortium::Connector::Person.new(
+      id,
+      firstName: person.firstName,
+      lastName: person.lastName,
+    )
   end
 end

--- a/engines/dfc_provider/app/services/dfc_v2_migration.rb
+++ b/engines/dfc_provider/app/services/dfc_v2_migration.rb
@@ -9,9 +9,10 @@ module DfcV2Migration
         up_enterprise(object)
       when DataFoodConsortium::ConnectorV1::Person
         up_person(object)
+      when VirtualAssembly::Semantizer::SemanticObject
+        up_generic(object)
       else
-        # Many classes didn't change in content at all, address for example.
-        # We can just return the v1 class as it's the same.
+        # Not sure what this is but we can't migrate it and leave it as is.
         object
       end
     end
@@ -53,5 +54,23 @@ module DfcV2Migration
       firstName: person.firstName,
       lastName: person.lastName,
     )
+  end
+
+  def self.up_generic(object)
+    v1_class = object.class.ancestors.find do |ancestor|
+      ancestor.module_parent == DataFoodConsortium::ConnectorV1
+    end
+
+    # It may be DfcV2 already, or something unknown.
+    return object if v1_class.nil?
+
+    class_name = v1_class.name.demodulize
+    v2_class = DataFoodConsortium::Connector.const_get(class_name)
+
+    v2_class.new(object.semanticId).tap do |o|
+      o.semanticProperties.each do |property|
+        property.value = object.semanticPropertyValue(property.name)
+      end
+    end
   end
 end

--- a/engines/dfc_provider/app/services/enterprise_builder.rb
+++ b/engines/dfc_provider/app/services/enterprise_builder.rb
@@ -50,7 +50,7 @@ class EnterpriseBuilder < DfcBuilder
       urls.enterprise_url(member.id)
     end
 
-    DataFoodConsortium::ConnectorV1::Enterprise.new(
+    DfcProvider::Enterprise.new(
       urls.enterprise_group_url(group.id),
       name: group.name,
       description: group.description,

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -10,7 +10,7 @@ DfcProvider::Engine.routes.draw do
     resources :social_medias, only: [:show]
   end
   resources :enterprise_groups, only: [:index, :show] do
-    resources :affiliated_by, only: [:create, :destroy], module: 'enterprise_groups'
+    resources :affiliated_by, only: [:create, :destroy], module: "enterprise_groups"
   end
   resources :events, only: [:create]
   resources :organizations, only: [:index, :show]

--- a/engines/dfc_provider/spec/requests/enterprise_groups_spec.rb
+++ b/engines/dfc_provider/spec/requests/enterprise_groups_spec.rb
@@ -50,12 +50,15 @@ RSpec.describe "EnterpriseGroups", swagger_doc: "dfc.yaml" do
             )
             expect(graph[1]).to include(
               "@id" => "http://test.host/api/dfc/enterprise_groups/60000",
-              "@type" => "dfc-b:Enterprise",
+              "@type" => "dfc-b:Organization",
               "dfc-b:name" => "Sustainable Farmers",
-              "dfc-b:affiliatedBy" => [
-                "http://test.host/api/dfc/enterprises/10001",
-                "http://test.host/api/dfc/enterprises/10002",
-              ],
+
+              # The DFC Connector is still missing this attribute.
+              # So it's not support for DFC v2 yet.
+              # "dfc-b:affiliatedBy" => [
+              #   "http://test.host/api/dfc/enterprises/10001",
+              #   "http://test.host/api/dfc/enterprises/10002",
+              # ],
             )
           end
         end

--- a/engines/dfc_provider/spec/services/dfc_v2_migration_spec.rb
+++ b/engines/dfc_provider/spec/services/dfc_v2_migration_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe DfcV2Migration do
+  describe ".up" do
+    it "transforms an Enterprise to an Organization" do
+      enterprise = DfcProvider::Enterprise.new(
+        "example.com/api/dfc/enterprises/12",
+        name: "Blueberry Bliss Farm",
+      )
+      result = DfcV2Migration.up(enterprise).first
+      expect(result).to be_a DataFoodConsortium::Connector::Organization
+      expect(result.semanticId).to eq "example.com/api/dfc/organizations/12"
+      expect(result.name).to eq "Blueberry Bliss Farm"
+    end
+
+    it "transforms a Person" do
+      person = DataFoodConsortium::ConnectorV1::Person.new("#p1")
+      result = DfcV2Migration.up(person).first
+      expect(result).to be_a DataFoodConsortium::Connector::Person
+      expect(result.semanticId).to eq "#p1"
+    end
+
+    it "returns everything else unchanged" do
+      address = DataFoodConsortium::ConnectorV1::Address.new("#a1")
+      result = DfcV2Migration.up(address).first
+      expect(result).to be_a DataFoodConsortium::ConnectorV1::Address
+      expect(result).to eq address
+    end
+  end
+end

--- a/engines/dfc_provider/spec/services/dfc_v2_migration_spec.rb
+++ b/engines/dfc_provider/spec/services/dfc_v2_migration_spec.rb
@@ -22,11 +22,40 @@ RSpec.describe DfcV2Migration do
       expect(result.semanticId).to eq "#p1"
     end
 
-    it "returns everything else unchanged" do
-      address = DataFoodConsortium::ConnectorV1::Address.new("#a1")
-      result = DfcV2Migration.up(address).first
-      expect(result).to be_a DataFoodConsortium::ConnectorV1::Address
-      expect(result).to eq address
+    it "returns unknown objects unchanged" do
+      objects = [
+        1, 2, "skip a few", # ♪ ♪ ♫ ♪
+        [], {}, Object.new,
+      ]
+
+      result = DfcV2Migration.up(*objects)
+
+      expect(result).to eq objects
+    end
+  end
+
+  describe ".up_generic" do
+    it "copies all available attributes" do
+      person = DataFoodConsortium::ConnectorV1::Person.new(
+        "#p1",
+        firstName: "Jane",
+      )
+      result = DfcV2Migration.up_generic(person)
+      expect(result.semanticId).to eq "#p1"
+      expect(result.firstName).to eq "Jane"
+      expect(result.lastName).to eq nil
+    end
+
+    it "allows to define attributes" do
+      person = DataFoodConsortium::ConnectorV1::Person.new(
+        "#p1",
+        firstName: "Jane",
+        lastName: "Jackson",
+      )
+      result = DfcV2Migration.up_generic(person, "#jac", firstName: "J")
+      expect(result.semanticId).to eq "#jac"
+      expect(result.firstName).to eq "J"
+      expect(result.lastName).to eq "Jackson"
     end
   end
 end

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -327,7 +327,6 @@ paths:
                       dfc-b:sku: AR
                       dfc-b:stockLimitation: 0
                       dfc-b:offeredThrough: http://test.host/api/dfc/enterprises/10000/offers/10001
-                      dfc-b:managedBy: http://test.host/api/dfc/enterprises/10000
                     - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
                       "@type": dfc-b:SuppliedProduct
                       dfc-b:name: Apple - 1g
@@ -336,9 +335,6 @@ paths:
                         "@type": dfc-b:QuantitativeValue
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
-                      ofn:spree_product_id: 90000
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
                     - "@id": http://test.host/api/dfc/product_groups/90000
                       "@type": dfc-b:SuppliedProduct
                       dfc-b:name: Apple
@@ -1555,7 +1551,6 @@ paths:
                       dfc-b:sku: BP
                       dfc-b:stockLimitation: 5
                       dfc-b:offeredThrough: http://test.host/api/dfc/enterprises/10000/offers/10001
-                      dfc-b:managedBy: http://test.host/api/dfc/enterprises/10000
                     - "@id": http://test.host/api/dfc/enterprises/10000/supplied_products/10001
                       "@type": dfc-b:SuppliedProduct
                       dfc-b:name: Pesto - 1g
@@ -1566,10 +1561,6 @@ paths:
                         dfc-b:hasUnit: dfc-m:Gram
                         dfc-b:value: 1.0
                       dfc-b:image: http://test.host/rails/active_storage/url/logo-white.png
-                      dfc-b:isVariantOf: http://test.host/api/dfc/product_groups/90000
-                      ofn:spree_product_id: 90000
-                      ofn:spree_product_uri: http://test.host/api/dfc/enterprises/10000?spree_product_id=90000
-                      ofn:image: http://test.host/rails/active_storage/url/logo-white.png
                     - "@id": http://test.host/api/dfc/product_groups/90000
                       "@type": dfc-b:SuppliedProduct
                       dfc-b:name: Pesto

--- a/swagger/dfc.yaml
+++ b/swagger/dfc.yaml
@@ -542,12 +542,9 @@ paths:
                       "@type": ldp:Container
                       ldp:contains: http://test.host/api/dfc/enterprise_groups/60000
                     - "@id": http://test.host/api/dfc/enterprise_groups/60000
-                      "@type": dfc-b:Enterprise
+                      "@type": dfc-b:Organization
                       dfc-b:name: Sustainable Farmers
                       dfc-b:hasDescription: this is a group
-                      dfc-b:affiliatedBy:
-                      - http://test.host/api/dfc/enterprises/10001
-                      - http://test.host/api/dfc/enterprises/10002
   "/api/dfc/enterprise_groups/{id}":
     get:
       summary: Show groups
@@ -1188,7 +1185,7 @@ paths:
                       dfc-b:VATnumber: 123 456
                       dfc-b:hasMainContact: http://test.host/api/dfc/enterprises/10000#mainContact
                       dfc-b:isCertifiedBy: "#certification-30000"
-                    - "@id": http://test.host/api/dfc/enterprises/10000#mainContact
+                    - "@id": http://test.host/api/dfc/organizations/10000#mainContact
                       "@type": dfc-b:Person
                       dfc-b:firstName: Fred
                       dfc-b:familyName: Farmer


### PR DESCRIPTION
**:information_source: Use Clockify code `#13323 Connecting Farms and Markets` while working on this.**

## What? Why?

- https://github.com/openfoodfoundation/openfoodnetwork/issues/14188

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This makes the data migration more consistent. Any differences between v1 and v2 will become more obvious because we are loading v2 classes for all objects even when we think that they are the same.

Unfortunately, the DFC Connector doesn't support enterprise groups yet. For v1, we patched that on the Enterprise class but that attribute was never standardised in that way. I decided not to patch the v2 Organization and wait until the DFC supports it completely.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
