### PR TITLE
Fix flaky system-spec login by binding Warden login to the request

### DIFF
--- a/spec/system/admin/request_scoped_login_spec.rb
+++ b/spec/system/admin/request_scoped_login_spec.rb
@@ -3,41 +3,24 @@
 require 'system_helper'
 require 'net/http'
 
-# Deterministic reproduction + proof for the request-scoped Warden login prototype.
-#
-# We simulate the flaky-spec root cause by firing a "stray" request straight at the
-# Capybara test server (as if it had leaked from a previous example) so that it reaches
-# Warden *after* `login_as` but *before* our own `visit`.
+# Regression guard for request-scoped Warden test login (see
+# spec/system/support/request_scoped_login.rb). We reproduce the flaky-spec root cause by
+# firing a "stray" request straight at the Capybara test server — as if it had leaked from a
+# previous example — so that it reaches Warden *after* `login_as` but *before* our `visit`.
+# Without request scoping that stray request consumes the queued login and we land
+# unauthenticated; with it, the login stays bound to our own (header-marked) request.
 RSpec.describe "Request-scoped Warden test login" do
   include AuthenticationHelper
 
-  # Fire a request at the app server through the same global Warden manager, with no
-  # marker header — exactly what a request leaking from the previous example looks like.
-  def fire_stray_request
+  it "keeps the login bound to our request even if a stray request reaches Warden first" do
+    login_as_admin
+
+    # A request with no marker header, exactly like one leaking from the previous example.
     server = Capybara.current_session.server
     Net::HTTP.get_response(URI("http://#{server.host}:#{server.port}/admin"))
-  end
 
-  context "with the stock one-shot helper (no request scoping)" do
-    it "reproduces the bug: the stray request steals the login" do
-      login_as_admin
-      fire_stray_request
+    visit spree.edit_admin_tax_settings_path
 
-      visit spree.edit_admin_tax_settings_path
-
-      # The stray request consumed the queued login, so we land unauthenticated.
-      expect(page).to have_no_css("body.admin")
-    end
-  end
-
-  context "with request scoping", :request_scoped_login do
-    it "keeps the login bound to our marked request" do
-      login_as_admin
-      fire_stray_request
-
-      visit spree.edit_admin_tax_settings_path
-
-      expect(page).to have_css("body.admin")
-    end
+    expect(page).to have_css("body.admin")
   end
 end

--- a/spec/system/admin/request_scoped_login_spec.rb
+++ b/spec/system/admin/request_scoped_login_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+require 'net/http'
+
+# Deterministic reproduction + proof for the request-scoped Warden login prototype.
+#
+# We simulate the flaky-spec root cause by firing a "stray" request straight at the
+# Capybara test server (as if it had leaked from a previous example) so that it reaches
+# Warden *after* `login_as` but *before* our own `visit`.
+RSpec.describe "Request-scoped Warden test login" do
+  include AuthenticationHelper
+
+  # Fire a request at the app server through the same global Warden manager, with no
+  # marker header — exactly what a request leaking from the previous example looks like.
+  def fire_stray_request
+    server = Capybara.current_session.server
+    Net::HTTP.get_response(URI("http://#{server.host}:#{server.port}/admin"))
+  end
+
+  context "with the stock one-shot helper (no request scoping)" do
+    it "reproduces the bug: the stray request steals the login" do
+      login_as_admin
+      fire_stray_request
+
+      visit spree.edit_admin_tax_settings_path
+
+      # The stray request consumed the queued login, so we land unauthenticated.
+      expect(page).to have_no_css("body.admin")
+    end
+  end
+
+  context "with request scoping", :request_scoped_login do
+    it "keeps the login bound to our marked request" do
+      login_as_admin
+      fire_stray_request
+
+      visit spree.edit_admin_tax_settings_path
+
+      expect(page).to have_css("body.admin")
+    end
+  end
+end

--- a/spec/system/admin/tax_settings_spec.rb
+++ b/spec/system/admin/tax_settings_spec.rb
@@ -2,7 +2,7 @@
 
 require 'system_helper'
 
-RSpec.describe 'Account and Billing Settings', :request_scoped_login do
+RSpec.describe 'Account and Billing Settings' do
   include AuthenticationHelper
   include WebHelper
 

--- a/spec/system/admin/tax_settings_spec.rb
+++ b/spec/system/admin/tax_settings_spec.rb
@@ -2,18 +2,18 @@
 
 require 'system_helper'
 
-RSpec.describe 'Account and Billing Settings' do
+RSpec.describe 'Account and Billing Settings', :request_scoped_login do
   include AuthenticationHelper
   include WebHelper
 
   describe "updating" do
     before do
       Spree::Config.set(products_require_tax_category: false)
+      login_as_admin
     end
 
     context "as an admin user" do
       it "loads the page" do
-        login_as_admin
         visit spree.edit_admin_general_settings_path
         click_link "Tax Settings"
 
@@ -21,7 +21,6 @@ RSpec.describe 'Account and Billing Settings' do
       end
 
       it "attributes can be changed" do
-        login_as_admin
         visit spree.edit_admin_tax_settings_path
 
         check 'preferences_products_require_tax_category'

--- a/spec/system/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/system/consumer/shopping/checkout_auth_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe "As a consumer I want to check out my cart" do
     let(:address) { create(:address, firstname: "Foo", lastname: "Bar") }
     let(:user) { create(:user, bill_address: address, ship_address: address) }
 
-    after { Warden.test_reset! }
-
     before do
       pick_order order
       add_product_to_cart order, product

--- a/spec/system/support/request_scoped_login.rb
+++ b/spec/system/support/request_scoped_login.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# PROTOTYPE — opt in per example with `:request_scoped_login` metadata.
+#
+# Binds Warden's test login to the specific request the example makes, instead of
+# "the next request to reach Warden".
+#
+# Background: `Warden::Test::Helpers#login_as` queues a one-shot block on the global
+# `Warden._on_next_request`, and Warden's test-mode hook drains that queue on the FIRST
+# non-asset request to reach Warden. With the Cuprite/JS driver a request can leak from
+# the previous example (an XHR the browser dispatched before Capybara reset the session),
+# reach Warden after our `before { login_as }` but before our `visit`, consume the queued
+# login against its own throw-away session, and leave the real page unauthenticated and
+# redirected to the public login screen. See teamcapybara/capybara#702 and #1692.
+#
+# Fix: tag the example's own request with a marker HTTP header and only apply the queued
+# login to a request carrying that header. A leaked request can't carry it — Chrome cannot
+# retro-add a header (`Network.setExtraHTTPHeaders`) to an already-dispatched request — so
+# it can no longer steal the login. One-shot semantics are preserved: the login is applied
+# exactly once, then the session cookie carries it, so logout / forbidden-redirect still work.
+module RequestScopedLogin
+  HEADER = "X-Warden-Test-Login"
+  ENV_KEY = "HTTP_X_WARDEN_TEST_LOGIN"
+
+  # One-shot holder, mirrors Warden._on_next_request but drained only by the marked request.
+  def self.pending
+    @pending ||= []
+  end
+
+  def self.install_warden_hook!
+    return if @installed
+
+    Warden::Manager.on_request do |proxy|
+      next unless proxy.env[ENV_KEY]
+
+      while (entry = pending.shift)
+        user, opts = entry
+        proxy.set_user(user, opts)
+      end
+    end
+    @installed = true
+  end
+
+  # Overrides Warden::Test::Helpers#login_as for tagged examples.
+  def login_as(user, opts = {})
+    opts = { event: :authentication }.merge(opts)
+    RequestScopedLogin.pending.replace([[user, opts]])
+    page.driver.add_header(RequestScopedLogin::HEADER, "1")
+  end
+end
+
+RequestScopedLogin.install_warden_hook!
+
+RSpec.configure do |config|
+  config.prepend RequestScopedLogin, request_scoped_login: true
+  config.after(:each, request_scoped_login: true) { RequestScopedLogin.pending.clear }
+end

--- a/spec/system/support/request_scoped_login.rb
+++ b/spec/system/support/request_scoped_login.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# PROTOTYPE — opt in per example with `:request_scoped_login` metadata.
-#
 # Binds Warden's test login to the specific request the example makes, instead of
 # "the next request to reach Warden".
 #
@@ -18,6 +16,9 @@
 # retro-add a header (`Network.setExtraHTTPHeaders`) to an already-dispatched request — so
 # it can no longer steal the login. One-shot semantics are preserved: the login is applied
 # exactly once, then the session cookie carries it, so logout / forbidden-redirect still work.
+#
+# Applied to every system spec; the Warden hook is header-gated, so examples that never call
+# `login_as` are unaffected (no header is set, the holder stays empty, the hook no-ops).
 module RequestScopedLogin
   HEADER = "X-Warden-Test-Login"
   ENV_KEY = "HTTP_X_WARDEN_TEST_LOGIN"
@@ -52,6 +53,6 @@ end
 RequestScopedLogin.install_warden_hook!
 
 RSpec.configure do |config|
-  config.prepend RequestScopedLogin, request_scoped_login: true
-  config.after(:each, request_scoped_login: true) { RequestScopedLogin.pending.clear }
+  config.prepend RequestScopedLogin, type: :system
+  config.after(:each, type: :system) { RequestScopedLogin.pending.clear }
 end


### PR DESCRIPTION
## What? Why?

<!-- No tracking issue — flaky-spec infrastructure fix. -->

Some system specs intermittently fail with the logged-in user appearing logged out — e.g. `login_as_admin` followed by `visit` lands on the public login screen instead of the admin area (no `body.admin` sidebar).

**Root cause.** `Warden::Test::Helpers#login_as` doesn't log anyone in directly — it pushes a one-shot block onto the global `Warden._on_next_request`, and Warden's test-mode hook drains that queue on the **first non-asset request to reach Warden** (`/assets/` is the only exemption, so XHR/API calls count). With the Cuprite/JS driver, a request the previous page dispatched before Capybara reset the session can arrive at Warden *after* our `before { login_as }` but *before* our own `visit`. It consumes the queued login against its own throw-away session, leaving our real request unauthenticated.

Capybara can't fully prevent this: `wait_for_pending_requests` only counts requests already inside the Rack stack, and Ferrum stops tracking async requests on navigation. This is the long-standing race in [teamcapybara/capybara#702](https://github.com/teamcapybara/capybara/issues/702) and [#1692](https://github.com/teamcapybara/capybara/issues/1692). (`Warden.test_reset!` does **not** fix it — that clears *stale queued logins*; here a stale *request* consumes a *fresh* login.)

**Solution.** Bind the queued login to **our own request** with a marker HTTP header that a leaked request cannot carry — Chrome won't retro-add a header (`Network.setExtraHTTPHeaders`) to an already-dispatched request:

- `login_as` queues the login *and* sets `X-Warden-Test-Login` on the browser.
- A custom Warden `on_request` hook applies the queued login **only** to a request carrying that header.

One-shot semantics are preserved (login applied once, then the session cookie carries it), so logout and forbidden-redirect flows still behave normally. The hook is header-gated, so system specs that never call `login_as` are unaffected. Applied to all `type: :system` examples in `spec/system/support/request_scoped_login.rb`.

## What should we test?

- This is test-infrastructure only; no app behaviour changes. The full system suite passing on CI is the main check.
- `spec/system/admin/request_scoped_login_spec.rb` deterministically reproduces the race (fires a stray request between `login_as` and `visit`) and asserts the login survives — this is the regression guard.
- `spec/system/admin/tax_settings_spec.rb` passes with its previous retry band-aid removed.
- Login/logout flows behave normally: `spec/system/consumer/authentication_spec.rb` (form login, logout, password reset, locales) and `spec/system/consumer/shopping/checkout_auth_spec.rb`.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

The title of the pull request will be included in the release notes.

## Dependencies

<!-- None. -->

## Documentation updates

<!-- None. -->
