### PR TITLE
[Sourced variants] updates

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -87,7 +87,7 @@ class ProducerMailer < ApplicationMailer
 
       {
         sku: line_item.variant.sku,
-        supplier_name: line_item.variant.supplier.name,
+        supplier_name: line_item.supplier.name,
         product_and_full_name: line_item.product_and_full_name,
         quantity: line_item.quantity,
         first_name: order.billing_address.first_name,

--- a/app/models/invoice/data_presenter/line_item.rb
+++ b/app/models/invoice/data_presenter/line_item.rb
@@ -6,7 +6,7 @@ class Invoice
       attributes :id, :added_tax, :currency, :included_tax, :price_with_adjustments, :quantity,
                  :variant_id, :unit_price, :unit_presentation,
                  :enterprise_fee_additional_tax, :enterprise_fee_included_tax
-      attributes_with_presenter :variant
+      attributes_with_presenter :variant, :supplier
       invoice_generation_attributes :added_tax, :included_tax, :price_with_adjustments,
                                     :quantity, :variant_id
 

--- a/app/models/invoice/data_presenter/product.rb
+++ b/app/models/invoice/data_presenter/product.rb
@@ -4,7 +4,6 @@ class Invoice
   class DataPresenter
     class Product < Invoice::DataPresenter::Base
       attributes :name
-      attributes_with_presenter :supplier
     end
   end
 end

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -15,7 +15,7 @@ module Spree
 
     belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant", inverse_of: :line_items
     has_one :product, through: :variant
-    has_one :supplier, through: :variant
+    has_one :supplier, through: :variant, source: :enterprise
     belongs_to :tax_category, class_name: "Spree::TaxCategory", optional: true
 
     has_many :adjustments, as: :adjustable, dependent: :destroy
@@ -77,7 +77,7 @@ module Spree
     # Here we are simply joining the line item to its variant
     # We dont use joins here to avoid the default scopes, and with that, include deleted variants
     scope :supplied_by_any, lambda { |enterprises|
-      variant_ids = Spree::Variant.unscoped.where(supplier: enterprises).select(:id)
+      variant_ids = Spree::Variant.unscoped.where(enterprise: enterprises).select(:id)
       where(variant_id: variant_ids)
     }
 
@@ -98,9 +98,9 @@ module Spree
     }
 
     scope :editable_by_producers, ->(enterprises_ids) {
-      joins(variant: :supplier, order: :distributor).where(
+      joins(variant: :enterprise, order: :distributor).where(
         distributor: { enable_producers_to_edit_orders: true },
-        spree_variants: { supplier_id: enterprises_ids }
+        spree_variants: { enterprise_id: enterprises_ids }
       )
     }
 

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -40,7 +40,7 @@
             = line_items.first.variant.sku
           - if @distributors_pickup_times.many?
             %td
-              = line_items.first.variant.supplier.name
+              = line_items.first.supplier.name
           %td
             = product_and_full_name
           %td.text-right

--- a/app/views/spree/admin/orders/_invoice_table.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table.html.haml
@@ -16,7 +16,7 @@
           = render 'spree/shared/line_item_name', line_item: item
           %br
           %small
-            %em= item.variant.supplier.name
+            %em= item.supplier.name
         %td{:align => "right"}
           = item.quantity
         %td{:align => "right"}

--- a/app/views/spree/admin/orders/_invoice_table2.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table2.html.haml
@@ -19,7 +19,7 @@
           = render 'spree/shared/line_item_name', line_item: item
           %br
           %small
-            %em= item.variant.supplier.name
+            %em= item.supplier.name
         %td{:align => "right"}
           = item.quantity
         %td{:align => "right"}

--- a/app/views/spree/admin/orders/_invoice_table4.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table4.html.haml
@@ -22,7 +22,7 @@
           = render 'spree/admin/orders/_invoice/line_item_name', line_item: item
           %br
           %small
-            %em= item.variant.product.supplier.name
+            %em= item.supplier.name
         %td{:align => "right"}
           = item.quantity
         %td{:align => "right"}

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -9,15 +9,15 @@
       .sixteen.columns.alpha
         .eight.columns.alpha
           = f.field_container :supplier_id do
-            = f.label :supplier_id, t(".supplier")
+            = f.label :supplier_id, t(".enterprise")
             %span.required *
             = render(SearchableDropdownComponent.new(form: f,
                 name: :supplier_id,
-                aria_label: t('.supplier'),
+                aria_label: t('.enterprise'),
                 options: @producers.select(:name, :id).order(:name).pluck(:name, :id),
                 selected_option: @product.supplier_id,
                 include_blank: true,
-                placeholder_value: t('.search_for_suppliers')))
+                placeholder_value: t('.search_for_enterprises')))
             = f.error_message_on :supplier_id
         .eight.columns.omega
           = f.field_container :name do

--- a/app/views/spree/order_mailer/_order_summary.html.haml
+++ b/app/views/spree/order_mailer/_order_summary.html.haml
@@ -20,7 +20,7 @@
           = render 'spree/shared/line_item_name', line_item: item
           %br
           %small
-            %em= item.variant.supplier.name
+            %em= item.supplier.name
         %td
           - if item.variant.sku.blank?
             \-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4741,9 +4741,8 @@ en:
         new:
           title: "New Product"
           new_product: "New Product"
-          supplier: "Supplier"
-          supplier_select_placeholder: "Select a supplier"
-          search_for_suppliers: "Search for suppliers"
+          enterprise: "Enterprise"
+          search_for_enterprises: "Search for enterprises"
           search_for_units: "Search for units"
           product_name: "Product Name"
           units: "Unit Size"

--- a/lib/reporting/reports/bulk_coop/supplier_report.rb
+++ b/lib/reporting/reports/bulk_coop/supplier_report.rb
@@ -45,7 +45,7 @@ module Reporting
         private
 
         def variant_supplier_name(line_items)
-          line_items.first.variant.supplier.name
+          line_items.first.supplier.name
         end
       end
     end

--- a/lib/reporting/reports/orders_and_fulfillment/base.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/base.rb
@@ -49,11 +49,11 @@ module Reporting
         end
 
         def supplier_name
-          proc { |line_items| line_items.first.variant.supplier.name }
+          proc { |line_items| line_items.first.supplier.name }
         end
 
         def supplier_charges_sales_tax?
-          proc { |line_items| line_items.first.variant.supplier.charges_sales_tax }
+          proc { |line_items| line_items.first.supplier.charges_sales_tax }
         end
 
         def product_name

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Api::V0::OrdersController do
 
       it "returns unauthorized, as the order product's supplier owner" do
         allow(controller).to receive(:spree_current_user) {
-                               order.line_items.first.variant.supplier.owner
+                               order.line_items.first.supplier.owner
                              }
         get :show, params: { id: order.number }
         assert_unauthorized!

--- a/spec/controllers/api/v0/reports/packing_report_spec.rb
+++ b/spec/controllers/api/v0/reports/packing_report_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::V0::ReportsController do
 
     context "as an enterprise user with partial order permissions (supplier with P-OC)" do
       let!(:order) { create(:completed_order_with_totals) }
-      let(:supplier) { order.line_items.first.variant.supplier }
+      let(:supplier) { order.line_items.first.supplier }
       let(:current_user) { supplier.owner }
       let!(:perms) {
         create(:enterprise_relationship, parent: supplier, child: order.distributor,
@@ -83,7 +83,7 @@ RSpec.describe Api::V0::ReportsController do
       'first_name' => '< Hidden >',
       'last_name' => '< Hidden >',
       'phone' => '< Hidden >',
-      "supplier" => line_item.variant.supplier.name,
+      "supplier" => line_item.supplier.name,
       "product" => line_item.product.name,
       "variant" => line_item.full_name,
       "quantity" => line_item.quantity,

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Reporting::Reports::OrdersAndFulfillment::OrderCycleCustomerTotal
         distributor:,
         completed_at: order_date,
       ).tap do |order|
-        order.line_items[0].variant.supplier.update(name: "Apple Farmer")
+        order.line_items[0].supplier.update(name: "Apple Farmer")
         order.line_items[0].update(product_name: "Apples")
         order.line_items[0].variant.update(sku: "APP")
       end

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier_report_spec.rb
@@ -28,7 +28,7 @@ module Reporting
           distributor_name_field = report_table.first[0]
           expect(distributor_name_field).to eq distributor.name
 
-          supplier = order.line_items.first.variant.supplier
+          supplier = order.line_items.first.supplier
           supplier_name_field = report_table.first[1]
           expect(supplier_name_field).to eq supplier.name
         end

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
@@ -26,7 +26,7 @@ module Reporting
           end
 
           it "has a variant row under the distributor" do
-            supplier = order.line_items.first.variant.supplier
+            supplier = order.line_items.first.supplier
             expect(report.rows.first.producer).to eq supplier.name
             expect(report.rows.first.hub).to eq distributor.name
           end
@@ -46,7 +46,7 @@ module Reporting
             create(:completed_order_with_totals, line_items_count: 0, distributor:,
                                                  order_cycle_id: order_cycle.id)
           }
-          let(:supplier){ order.line_items.first.variant.supplier }
+          let(:supplier){ order.line_items.first.supplier }
 
           before do
             3.times do

--- a/spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/orders_cycle_supplier_totals_report_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Reporting::Reports::OrdersAndFulfillment::OrderCycleSupplierTotal
     create(:completed_order_with_totals, line_items_count: 1, distributor:)
   end
   let!(:supplier) do
-    order.line_items.first.variant.supplier
+    order.line_items.first.supplier
   end
   let(:current_user) { distributor.owner }
   let(:params) { { display_summary_row: false, fields_to_hide: [] } }

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -856,7 +856,7 @@ RSpec.describe "searching with ransack" do
   end
 
   context "searching by supplier" do
-    let(:query) { { supplier_id_eq: line_item1.variant.supplier_id } }
+    let(:query) { { supplier_id_eq: line_item1.supplier_id } }
 
     it "filters results" do
       expect(search_result.to_a).to eq [line_item1]

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -596,20 +596,20 @@ RSpec.describe Spree::Variant do
     end
 
     describe ".with_properties" do
-      let!(:variant_without_wanted_property_on_supplier) {
-        create(:variant, supplier: supplier_without_wanted_property)
+      let!(:variant_from_ipm_supplier) {
+        create(:variant, supplier: ipm_supplier)
       }
-      let!(:variant_with_wanted_property_on_supplier) {
-        create(:variant, supplier: supplier_with_wanted_property)
+      let!(:variant_from_organic_supplier) {
+        create(:variant, supplier: organic_supplier)
       }
-      let(:supplier_with_wanted_property) {
-        create(:supplier_enterprise, properties: [wanted_property])
+      let(:organic_supplier) {
+        create(:supplier_enterprise, properties: [organic])
       }
-      let(:supplier_without_wanted_property) {
-        create(:supplier_enterprise, properties: [unwanted_property])
+      let(:ipm_supplier) {
+        create(:supplier_enterprise, properties: [ipm])
       }
-      let(:wanted_property) { create(:property, presentation: 'Certified Organic') }
-      let(:unwanted_property) { create(:property, presentation: 'Latest Hype') }
+      let(:organic) { create(:property, presentation: 'Certified Organic') }
+      let(:ipm) { create(:property, presentation: 'Integrated Pest Management') }
 
       it "returns no products without a property id" do
         expect(Spree::Variant.with_properties([])).to eq []
@@ -617,8 +617,8 @@ RSpec.describe Spree::Variant do
 
       it "returns only variants with the wanted property set on supplier" do
         expect(
-          Spree::Variant.with_properties([wanted_property.id])
-        ).to match_array [variant_with_wanted_property_on_supplier]
+          Spree::Variant.with_properties([organic.id])
+        ).to match_array [variant_from_organic_supplier]
       end
     end
   end

--- a/spec/requests/spree/admin/orders_spec.rb
+++ b/spec/requests/spree/admin/orders_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Spree::Admin::OrdersController do
         }
 
         before do
-          line_item.variant.supplier = distributor
+          line_item.supplier = distributor
           order.shipments << shipment
           order.line_items << line_item
           distributor.shipping_methods << shipment.shipping_method

--- a/spec/services/permissions/order_spec.rb
+++ b/spec/services/permissions/order_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Permissions::Order do
 
         context "which contains my products" do
           before do
-            line_item.variant.supplier = producer
+            line_item.supplier = producer
             line_item.variant.save
           end
 
@@ -168,7 +168,7 @@ RSpec.describe Permissions::Order do
           create(:enterprise_relationship, parent: producer, child: distributor,
                                            permissions_list: [:add_to_order_cycle])
 
-          line_item1.variant.supplier = producer
+          line_item1.supplier = producer
           line_item1.variant.save
         end
 

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe '
     end
 
     it "display all attributes when submitting with error: no name" do
-      select supplier.name, from: 'product_supplier_id'
+      select supplier.name, from: "Enterprise"
       select "Weight (kg)", from: 'product_variant_unit_with_scale'
       fill_in 'product_unit_value', with: "5.00 g"
       assert_selector(:field, placeholder: "5kg g")
@@ -38,7 +38,7 @@ RSpec.describe '
       click_button 'Create'
 
       expect(page).to have_content "Name can't be blank"
-      expect(page).to have_field 'product_supplier_id', with: supplier.id
+      expect(page).to have_field "Enterprise", with: supplier.id
       expect(page).to have_field 'product_unit_value', with: "5.00 g"
       expect(page).to have_field 'product_display_as', with: "Big Box of Chocolates"
       expect(page).to have_field 'product_primary_taxon_id', with: taxon.id
@@ -52,7 +52,7 @@ RSpec.describe '
     end
 
     it "display all attributes when submitting with error: Unit Value must be grater than 0" do
-      select 'New supplier', from: 'product_supplier_id'
+      select 'New supplier', from: "Enterprise"
       fill_in 'product_name', with: "new product name"
       select "Weight (kg)", from: 'product_variant_unit_with_scale'
       fill_in 'product_unit_value', with: "0.00 g"
@@ -68,7 +68,7 @@ RSpec.describe '
       click_button 'Create'
 
       expect(page).to have_field 'product_name', with: "new product name"
-      expect(page).to have_field 'product_supplier_id', with: supplier.id
+      expect(page).to have_field "Enterprise", with: supplier.id
       expect(page).to have_field 'product_unit_value', with: "0 g"
       expect(page).to have_field 'product_display_as', with: "Big Box of Chocolates"
       expect(page).to have_field 'product_primary_taxon_id', with: taxon.id
@@ -94,7 +94,7 @@ RSpec.describe '
     it "assigning important attributes" do
       expect(find_field('product_shipping_category_id').text).to eq(shipping_category.name)
 
-      select 'New supplier', from: 'product_supplier_id'
+      select 'New supplier', from: "Enterprise"
       fill_in 'product_name', with: 'A new product !!!'
       select "Weight (kg)", from: 'product_variant_unit_with_scale'
       fill_in 'product_unit_value', with: 5
@@ -131,7 +131,7 @@ RSpec.describe '
 
     it "creating an on-demand product" do
       fill_in 'product_name', with: 'Hot Cakes'
-      select 'New supplier', from: 'product_supplier_id'
+      select 'New supplier', from: "Enterprise"
       select "Weight (kg)", from: 'product_variant_unit_with_scale'
       fill_in 'product_unit_value', with: 1
       select taxon.name, from: "product_primary_taxon_id"
@@ -153,7 +153,7 @@ RSpec.describe '
 
     it "creating product with empty unit value" do
       fill_in 'product_name', with: 'Hot Cakes'
-      select 'New supplier', from: 'product_supplier_id'
+      select 'New supplier', from: "Enterprise"
       select "Weight (kg)", from: 'product_variant_unit_with_scale'
       fill_in "product_unit_value", with: ""
       select taxon.name, from: "product_primary_taxon_id"
@@ -171,7 +171,7 @@ RSpec.describe '
 
     it "creating product with empty product category fails" do
       fill_in 'product_name', with: 'Hot Cakes'
-      select 'New supplier', from: 'product_supplier_id'
+      select 'New supplier', from: "Enterprise"
       select "Weight (kg)", from: 'product_variant_unit_with_scale'
       fill_in "product_unit_value", with: '1'
       fill_in 'product_price', with: '1.99'
@@ -212,7 +212,7 @@ RSpec.describe '
 
           it "and price is #{price}" do
             fill_in 'product_name', with: 'Priceless Mangoes'
-            select 'New supplier', from: 'product_supplier_id'
+            select 'New supplier', from: "Enterprise"
             select "Weight (kg)", from: 'product_variant_unit_with_scale'
             fill_in "product_unit_value", with: 1
             select taxon.name, from: "product_primary_taxon_id"
@@ -283,17 +283,17 @@ RSpec.describe '
         fill_in 'product_name', with: 'A new product !!!'
         fill_in 'product_price', with: '19.99'
 
-        expect(page).to have_selector('#product_supplier_id')
-        select 'Another Supplier', from: 'product_supplier_id'
+        expect(page).to have_select "Enterprise"
+        select 'Another Supplier', from: "Enterprise"
         select 'Weight (g)', from: 'product_variant_unit_with_scale'
         fill_in 'product_unit_value', with: '500'
         select taxon.name, from: "product_primary_taxon_id"
         select 'None', from: "product_tax_category_id"
 
         # Should only have suppliers listed which the user can manage
-        expect(page).to have_select 'product_supplier_id',
+        expect(page).to have_select "Enterprise",
                                     with_options: [supplier2.name, supplier_permitted.name]
-        expect(page).not_to have_select 'product_supplier_id', with_options: [supplier.name]
+        expect(page).not_to have_select "Enterprise", with_options: [supplier.name]
 
         click_button 'Create'
 

--- a/spec/system/admin/products_v3/create_spec.rb
+++ b/spec/system/admin/products_v3/create_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'As an enterprise user, I can manage my products' do
       find("a", text: "New Product").click
       expect(page).to have_content "New Product"
       fill_in 'product_name', with: 'Big Bag Of Apples'
-      tomselect_select supplier.name, from: 'product[supplier_id]'
+      tomselect_select supplier.name, from: "Enterprise"
       tomselect_search_and_select 'Weight (g)', from: "product_variant_unit_with_scale"
       fill_in 'product_unit_value', with: '100'
       fill_in 'product_price', with: '10.00'

--- a/spec/system/admin/reports/enterprise_summary_fees/enterprise_summary_fee_with_tax_report_by_order_spec.rb
+++ b/spec/system/admin/reports/enterprise_summary_fees/enterprise_summary_fee_with_tax_report_by_order_spec.rb
@@ -91,11 +91,6 @@ RSpec.describe "Enterprise Summary Fee with Tax Report By Order" do
 
     distributor.shipping_methods << shipping_method
     distributor.payment_methods << payment_method
-
-    product.update!({
-                      tax_category_id: tax_category.id,
-                      supplier_id: supplier.id
-                    })
   end
 
   context 'added tax' do


### PR DESCRIPTION
**:information_source: Please use Clockify code `#76a Sourced variant` for review and testing.**


## What? Why?

- Preparatory updates for #14201


This updates the label on the product create screen from "Supplier" to "Enterprise". There's more label updates to do, but I needed to get this one out early.

Although there's a small label change, I don't think this warrants being labelled "user-facing".

## What should we test?
I don't think testing is necessary. I've already checked this update:

* Admin > Products > New Product
* The enterprise dropdown is labelled "Enterprise"
