### PR TITLE
Show inherited producer properties when filtering the shopfront by a consolidated property

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -88,10 +88,29 @@ module Spree
     after_touch :touch_enterprise
 
     # -- Scopes
+    # Matches products carrying any of the given properties, whether the property is set directly
+    # on the product or inherited from its producer (when inherits_properties is true).
+    #
+    # The shopfront sidebar consolidates a property shown both as a product property and an
+    # inherited producer property into a single "Filter by" tag, which sends only
+    # q[with_properties]. Without the inherited branch, products carrying the property purely by
+    # inheritance were filtered out (#14405).
+    #
+    # Note: Ransack sanitises scope arguments against its boolean TRUE/FALSE_VALUES, so a property
+    # id of "1" arrives here as `true` (and "0" as `false`). Using ActiveRecord conditions rather
+    # than raw SQL casts these back to integers on the property_id column, so filtering by id 1
+    # does not raise a 422.
     scope :with_properties, ->(*property_ids) {
-      left_outer_joins(:product_properties).
-        where(inherits_properties: true).
-        where(spree_product_properties: { property_id: property_ids })
+      property_ids = property_ids.flatten
+
+      with_direct_property = where(
+        id: Spree::ProductProperty.where(property_id: property_ids).select(:product_id)
+      )
+      with_inherited_property = where(inherits_properties: true).where(
+        id: Spree::Variant.with_properties(property_ids).select(:product_id)
+      )
+
+      with_direct_property.or(with_inherited_property)
     }
 
     scope :with_order_cycles_outer, lambda {

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -347,6 +347,89 @@ RSpec.describe Spree::Product do
           described_class.with_properties([wanted_property.id, 99_999])
         ).to match_array [product_with_wanted_property]
       end
+
+      context "when the property is inherited from the producer" do
+        let(:enterprise) { create(:supplier_enterprise) }
+        let!(:inheriting_product) {
+          create(:product, enterprise_id: enterprise.id, inherits_properties: true)
+        }
+
+        before do
+          enterprise.producer_properties.create!(property_id: wanted_property.id,
+                                                 value: '1', position: 1)
+        end
+
+        it "matches products that inherit the property from their producer" do
+          expect(described_class.with_properties([wanted_property.id]))
+            .to include(inheriting_product)
+        end
+
+        it "does not match when the product does not inherit properties" do
+          inheriting_product.update!(inherits_properties: false)
+
+          expect(described_class.with_properties([wanted_property.id]))
+            .not_to include(inheriting_product)
+        end
+      end
+
+      context "when invoked through Ransack (the shopfront filter path)" do
+        # Ransack sanitises scope args against its boolean TRUE/FALSE_VALUES, so filtering by
+        # property id "1" reaches the scope as `true` (and "0" as `false`) rather than the id.
+        # Using ActiveRecord conditions casts these back to integers, so filtering by property
+        # id 1 no longer raises on the integer property_id column (regression: shopfront
+        # returned a 422).
+        it "does not raise when filtering by property id 1" do
+          expect { described_class.with_properties(true).to_a }.not_to raise_error
+        end
+
+        it "does not raise when filtering through Ransack" do
+          expect {
+            described_class.ransack("with_properties" => [wanted_property.id.to_s]).result.to_a
+          }.not_to raise_error
+        end
+      end
+
+      context "when the property is set directly but inheritance is disabled" do
+        let!(:direct_product) {
+          create(:product, properties: [wanted_property], inherits_properties: false)
+        }
+
+        it "matches the product (direct properties don't require inheritance)" do
+          expect(described_class.with_properties([wanted_property.id]))
+            .to include(direct_product)
+        end
+      end
+
+      context "when a product has variants from multiple enterprises" do
+        # Inherited properties are matched against any variant's enterprise, consistent with
+        # Spree::Variant.with_properties. (Products normally have a single enterprise across
+        # their variants.)
+        let(:first_enterprise) { create(:supplier_enterprise) }
+        let(:second_enterprise) { create(:supplier_enterprise) }
+        let!(:multi_enterprise_product) {
+          create(:product, enterprise_id: first_enterprise.id, inherits_properties: true)
+        }
+
+        before do
+          create(:variant, product: multi_enterprise_product, enterprise: second_enterprise)
+        end
+
+        it "matches when the first variant's enterprise has the property" do
+          first_enterprise.producer_properties.create!(property_id: wanted_property.id,
+                                                       value: '1', position: 1)
+
+          expect(described_class.with_properties([wanted_property.id]))
+            .to include(multi_enterprise_product)
+        end
+
+        it "matches when a later variant's enterprise has the property" do
+          second_enterprise.producer_properties.create!(property_id: wanted_property.id,
+                                                        value: '1', position: 1)
+
+          expect(described_class.with_properties([wanted_property.id]))
+            .to include(multi_enterprise_product)
+        end
+      end
     end
 
     describe "in_enterprise" do

--- a/spec/services/products_renderer_spec.rb
+++ b/spec/services/products_renderer_spec.rb
@@ -81,6 +81,23 @@ RSpec.describe ProductsRenderer do
           expect(products).to eq([product_apples, product_cherries])
         end
 
+        it "includes products inheriting the property when it is sent via with_properties" do
+          # Regression for #14405: when one producer sets the property at producer level (inherited
+          # by its products) and another producer sets the same property directly on a product, the
+          # shopfront deduplicates the property into the product bucket and sends only
+          # with_properties. Inherited products must still be returned.
+          fruits_supplier.producer_properties.create!({ property_id: property_organic.id,
+                                                        value: '1', position: 1 })
+          product_banana_bread.product_properties.create!({ property_id: property_organic.id,
+                                                            value: '1', position: 1 })
+
+          search_param = { q: { with_properties: [property_organic.id] } }
+          products_renderer = ProductsRenderer.new(distributor, order_cycle, customer, search_param)
+
+          products = products_renderer.products
+          expect(products).to match_array([product_apples, product_cherries, product_banana_bread])
+        end
+
         it "filters products with a product property or a producer property" do
           cakes_supplier.producer_properties.create!({ property_id: property_organic.id,
                                                        value: '1', position: 1 })


### PR DESCRIPTION
## What? Why?

- Closes #14405

Follow-up to #14154 (which closed #13514). That PR visually consolidates a property shown both as a **product property** and an **inherited producer property** into a single "Filter by" tag in the shopfront sidebar. The surviving tag sends only `q[with_properties]`.

The problem: `Spree::Product.with_properties` only looked at `spree_product_properties`, so products that carry the property purely by **inheritance** (producer property + `inherits_properties: true`) were not returned. Selecting the consolidated tag hid those products.

This PR extends the `with_properties` scope to also match producer properties inherited through the product's **first variant supplier** (lowest-id non-deleted variant), which mirrors `#properties_including_inherited` used by the serializer to render the tags — so the filter result and the displayed property tags always agree. It also fixes a smaller bug: the old scope required `inherits_properties: true` even for properties set **directly** on a product, which wrongly excluded them.

While verifying in the shopfront I hit a 422 (`PG::InvalidTextRepresentation: invalid input syntax for integer: "t"`): Ransack sanitises scope arguments against its boolean `TRUE_VALUES`, so filtering by **property id 1** reaches the scope as `true`. The new scope casts its arguments to integers (as ActiveRecord would) so a boolean is never bound to the integer `property_id` column.

This completes the second half of #13514's expected behaviour ("selecting the property shows all products with it, whether inherited or set directly"), which #14154 only partially delivered.

## What should we test?

In a hub with at least two suppliers:
- Supplier A sets a property (e.g. "Organic") at **producer** level, and its products **inherit** producer properties.
- Supplier B sets the same property **directly** on one of its products.

1. Visit the shopfront. Confirm "Organic" appears **once** in "Filter by" (the #14154 consolidation still works).
2. Select "Organic". Confirm the list shows **both** Supplier B's product (direct) **and** Supplier A's inherited products.
3. Set a product's `inherits_properties` to false → it should drop out of the inherited results.
4. Confirm no 422 / AngularJS console errors and the "X selected" count is correct.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

## Dependencies

None.

## Documentation updates

None.