### PR TITLE
Fix misleading Payments tab redirect for orders in cart state

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -148,15 +148,17 @@ module Spree
       # At this point admin should have passed through Customer Details step
       # where order.next is called which leaves the order in payment step
       #
-      # Orders in complete or canceled step also allows to access this controller
+      # Orders in complete, canceled, resumed, awaiting_return or returned
+      # state also allow access to this controller
       #
-      # Otherwise redirect user to that step
+      # Otherwise redirect user to the order edit page with an actionable
+      # message explaining how to prepare the order for payment.
       def can_transition_to_payment
         return if @order.confirmation? || @order.payment? ||
                   @order.complete? || @order.canceled? || @order.resumed?
 
-        flash[:notice] = Spree.t(:fill_in_customer_info)
-        redirect_to spree.edit_admin_order_customer_url(@order)
+        flash[:notice] = Spree.t(:update_fees_before_payment, scope: "admin.payments")
+        redirect_to spree.edit_admin_order_url(@order)
       end
 
       def ensure_sufficient_stock_lines

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4734,6 +4734,7 @@ en:
           paypal:
             no_payment_via_admin_backend: Paypal payments cannot be captured in the Backoffice
         customer_credit_successful: Customer has been successfully credited!
+        update_fees_before_payment: "Please click 'Update and Recalculate Fees' on the Order Details tab before proceeding to payment."
 
       products:
         image_upload_error: "Please upload the image in JPG, PNG, GIF, SVG or WEBP format."

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -306,5 +306,65 @@ RSpec.describe Spree::Admin::PaymentsController do
         expect(response.location).to eq spree.edit_admin_order_url(order)
       end
     end
+
+    context "order is in cart state" do
+      let!(:order) { create(:order_with_totals, distributor: shop, state: "cart") }
+
+      context "with a customer and line items" do
+        before do
+          order.customer = create(:customer, enterprise: shop)
+          order.save!
+        end
+
+        it "redirects to order details with an actionable flash message" do
+          spree_get :index, order_id: order.number
+
+          expect_redirect_to_order_details_with_fees_flash
+        end
+      end
+
+      context "with line items but no customer" do
+        it "redirects to order details with an actionable flash message" do
+          spree_get :index, order_id: order.number
+
+          expect_redirect_to_order_details_with_fees_flash
+        end
+      end
+
+      context "with a customer but no line items" do
+        let!(:order) { create(:order, distributor: shop, state: "cart") }
+
+        before do
+          order.customer = create(:customer, enterprise: shop)
+          order.save!
+        end
+
+        it "redirects to order details with an actionable flash message" do
+          spree_get :index, order_id: order.number
+
+          expect_redirect_to_order_details_with_fees_flash
+        end
+      end
+    end
+
+    context "order is in address state" do
+      let!(:order) { create(:order_with_totals, distributor: shop, state: "address") }
+
+      it "redirects to order details with an actionable flash message" do
+        spree_get :index, order_id: order.number
+
+        expect_redirect_to_order_details_with_fees_flash
+      end
+    end
+
+    def expect_redirect_to_order_details_with_fees_flash
+      expect(response).to have_http_status :found
+
+      expected_flash = "Please click 'Update and Recalculate Fees' " \
+                       "on the Order Details tab before proceeding to payment."
+      expect(flash[:notice]).to eq expected_flash
+
+      expect(response.location).to eq spree.edit_admin_order_url(order)
+    end
   end
 end


### PR DESCRIPTION
Instead of redirecting to Customer Details with 'Please fill in customer info', redirect to the Order Details tab with an actionable message explaining to click 'Update and Recalculate Fees'.

The old message was incorrect — customer details may already be filled in. The real issue is that the order hasn't been advanced past the cart state.

Closes #14490

## What? Why?

- Closes #14490

Changes `can_transition_to_payment` in `PaymentsController` to redirect to the Order Details tab with an actionable flash message instead of the Customer Details tab with a misleading "Please fill in customer info" message.

**The problem:** When a hub manager creates a new admin order and clicks the Payments tab before the order state has been advanced past `cart`, they're redirected to Customer Details with "Please fill in customer info" — even when customer info is already filled in. The real issue is that the order hasn't been advanced from `cart` via "Update and Recalculate Fees".

**The fix:** Redirect to the Order Details tab (where "Update and Recalculate Fees" lives) with a clear message explaining what to do. No state mutations in the guard — keeps it as a pure access control check.


## What should we test?
1. Go to Admin → Orders → New Order
2. Select a distributor and order cycle, create the order
3. Fill in customer details on Customer Details tab, click Update
4. Add line items on Order Details tab
5. Click the Payments tab
   - Expected: redirected to Order Details tab with flash:
     "Please click 'Update and Recalculate Fees' on the Order Details tab before proceeding to payment."
   - Previously: redirected to Customer Details with "Please fill in customer info"
6. Click "Update and Recalculate Fees"
7. Click the Payments tab again
   - Expected: Payments tab loads normally

Also test:
- Create an order with no line items, try to access Payments → same redirect to Order Details
- Existing whitelisted states (payment, complete, canceled, resumed) still load Payments normally

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes

The title of the pull request will be included in the release notes.

