### PR TITLE
Add regression spec for shopfront i18n pluralization fallback

### DIFF
--- a/spec/system/consumer/shopping/shopping_spec.rb
+++ b/spec/system/consumer/shopping/shopping_spec.rb
@@ -119,6 +119,28 @@ RSpec.describe "As a consumer I want to shop with a distributor" do
         end
       end
 
+      # Regression test for https://github.com/openfoodfoundation/openfoodnetwork/issues/14500
+      # es.yml has no remaining_in_stock key of its own, so this exercises the same
+      # en.yml fallback path production hit when a locale is missing the key: without
+      # count: at the shopfront's Angular `t` filter call site, i18n-js renders the raw
+      # pluralization hash instead of interpolating "Only N left".
+      it "falls back to the English pluralized string when the active locale has " \
+         "no remaining_in_stock translation of its own" do
+        distributor.set_preference(:product_low_stock_display, true)
+        variant.update on_hand: 2
+        visit shop_path
+
+        find('.language-switcher').click
+        within '.language-switcher .dropdown' do
+          find('li a[href="/locales/es"]').click
+        end
+
+        within_variant(variant) do
+          expect(page).to have_content "Only 2 left"
+          expect(page).not_to have_content "%{count}"
+        end
+      end
+
       it "alerts us when we enter a quantity greater than the stock available" do
         variant.update on_hand: 5
         visit shop_path


### PR DESCRIPTION
## What
Adds a system spec regression test for #14500.

## Why
The raw-hash display bug (`{"one":"Only %{count} left","other":"Only %{count} left"}` instead of "Only 3 left") was already fixed on master by #14397's follow-up commit `5ee637d5be`, which passes `count:` alongside `quantity:` at both AngularJS template call sites. That fix has no test coverage, so this class of regression could silently reappear.

This spec switches the shopfront to a locale (`es`) that has no `remaining_in_stock` key of its own, forcing the same `en.yml` pluralization fallback path that broke in production. It confirms:
- The current code renders "Only N left" correctly through that fallback.
- Stripping the `count:` param reproduces the exact bug from the issue (verified manually before opening this PR, then reverted).

## Test plan
- [x] `bundle exec rspec spec/system/consumer/shopping/shopping_spec.rb -e "falls back to the English pluralized string"` passes
- [x] Confirmed the same spec fails with the original raw-hash output when `count:` is removed from `_shop_variant_no_group_buy.html.haml`
- [x] `bundle exec rubocop spec/system/consumer/shopping/shopping_spec.rb` — no offenses

Closes #14500

🤖 Generated with [Claude Code](https://claude.com/claude-code)