### PR TITLE
Added Sanitize item names in select2 directive and format selection.

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/ofn-select2.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/ofn-select2.js.coffee
@@ -39,7 +39,6 @@ angular.module("admin.utils").directive "ofnSelect2", ($sanitize, $timeout, $fil
     init = ->
       scope.data.unshift(scope.blank) if scope.blank? && typeof scope.blank is "object"
 
-      item.name = $sanitize(item.name) for item in scope.data
       element.select2
         multiple: scope.multiple
         placeholder: scope.placeholder
@@ -48,6 +47,6 @@ angular.module("admin.utils").directive "ofnSelect2", ($sanitize, $timeout, $fil
           filtered = $filter('filter')(scope.data,scope.filter)
           { results: filtered, text: scope.text }
         formatSelection: (item) ->
-          item[scope.text]
+          $sanitize(item[scope.text])
         formatResult: (item) ->
-          item[scope.text]
+          $sanitize(item[scope.text])


### PR DESCRIPTION
## What? Why?
Closes #14499

The issue was that the Order Cycle filters (data: 'schedules' and data: 'enterprises') were using the same object instances that were shared across the application (Schedules.byID, Enterprises.byID, orderCycle.schedules, coordinator, and producers). As soon as any of those Select2 dropdowns were initialized, $sanitize modified the shared objects in place, so the encoded values started appearing everywhere those objects were rendered.

The backend wasn't the problem, the API responses and the database always stored the data correctly as UTF-8. The corruption only happened on the client side after the Select2 components were initialized.


## What should we test?

- Visit ... page.
=>  /admin/order_cycles

## Release notes
N/A

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

Video:

https://github.com/user-attachments/assets/817f674a-4cf0-4c37-91a8-de54442a78fb
