### PR TITLE
Include English locale digest in cache key to invalidate cached translations on locale file changes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,7 +74,13 @@ module ApplicationHelper
 
   # Update "v1" to invalidate existing cache key
   def cache_key_with_locale(key, locale)
-    Array.wrap(key) + ["v3", locale.to_s, I18nDigests.for_locale(locale)]
+    Array.wrap(key) + [
+      :v3,
+      locale.to_s,
+      I18nDigests.for_locale(locale),
+      :en,
+      I18nDigests.for_locale(:en)
+    ]
   end
 
   def pdf_stylesheet_pack_tag(source)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,7 +78,6 @@ module ApplicationHelper
       :v3,
       locale.to_s,
       I18nDigests.for_locale(locale),
-      :en,
       I18nDigests.for_locale(:en)
     ]
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -88,13 +88,13 @@ RSpec.describe ApplicationHelper do
     it "appends locale and digest to a single key" do
       expect(
         helper.cache_key_with_locale("single-key", "en")
-      ).to eq(["single-key", :v3, "en", en_digest, :en, en_digest])
+      ).to eq(["single-key", :v3, "en", en_digest, en_digest])
     end
 
     it "appends locale and digest to multiple keys" do
       expect(
         helper.cache_key_with_locale(["array", "of", "keys"], "es")
-      ).to eq(["array", "of", "keys", :v3, "es", es_digest, :en, en_digest])
+      ).to eq(["array", "of", "keys", :v3, "es", es_digest, en_digest])
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -82,18 +82,19 @@ RSpec.describe ApplicationHelper do
     let(:es_digest) { "9d8tu23oirhad" }
 
     before { allow(I18nDigests).to receive(:for_locale).with("en") { en_digest } }
+    before { allow(I18nDigests).to receive(:for_locale).with(:en) { en_digest } }
     before { allow(I18nDigests).to receive(:for_locale).with("es") { es_digest } }
 
     it "appends locale and digest to a single key" do
       expect(
         helper.cache_key_with_locale("single-key", "en")
-      ).to eq(["single-key", "v3", "en", en_digest])
+      ).to eq(["single-key", :v3, "en", en_digest, :en, en_digest])
     end
 
     it "appends locale and digest to multiple keys" do
       expect(
         helper.cache_key_with_locale(["array", "of", "keys"], "es")
-      ).to eq(["array", "of", "keys", "v3", "es", es_digest])
+      ).to eq(["array", "of", "keys", :v3, "es", es_digest, :en, en_digest])
     end
   end
 end


### PR DESCRIPTION
## What? Why?

- Closes #14500

When a view is cached for a non-English locale (e.g. `en_US`), the cache key only includes a digest of that locale's translation files. Locales like `en_US` fall back to `en.yml` for untranslated keys. If `en.yml` is updated (e.g. a key changes from a simple string to a pluralized hash), the cached view for `en_US` is not invalidated because its cache key doesn't reflect the change in the English locale file.

This causes stale translations to be served from cache — for example, a raw i18n pluralization hash displayed instead of the resolved "Only N left" string.

This fix adds the English locale (`:en`) and its translation digest to the cache key. Now when English translation files change, cached views for all locales that rely on English as a fallback are invalidated.

## What should we test?

1. **Cache invalidation with fallback locales**
   - Set `I18n.locale` to `en_US` and render a cached view that uses a translation key from `en.yml`
   - Modify the translation in `en.yml`
   - Verify the view is re-rendered with the updated translation (cache key includes the English digest and does not match the old cached version)

2. **Regression: cache key format**
   - Visit a shop page as a guest with a non-English locale
   - Reload the page and confirm the view is served from cache (Rails log shows a cache hit)
   - Verify no translation keys are displayed as raw i18n hash objects

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only
- [ ] User facing changes
- [ ] API changes
- [ ] Feature toggled