### PR TITLE
Customer account transation auth

### DIFF
--- a/app/controllers/api/v1/customer_account_transaction_controller.rb
+++ b/app/controllers/api/v1/customer_account_transaction_controller.rb
@@ -6,6 +6,9 @@ module Api
       def create
         authorize! :create, CustomerAccountTransaction
 
+        customer = Customer.find(customer_account_transaction_params[:customer_id])
+        authorize! :update, customer
+
         default_params = {
           currency: CurrentConfig.get(:currency), created_by: current_api_user
         }

--- a/script/rswag
+++ b/script/rswag
@@ -2,12 +2,14 @@
 
 # Generate the API documentation based on our specs.
 #
-# For API v0 and v1 you can call one of these:
+# API v0: these are not yet documented by specs and a swagger file was generated using AI instead.
 #
-#   ./bin/rake rswag
-#   ./script/rswag --dry-run
+# API v1: you can call one of these for a dry run (much faster because it assumes the specs pass):
 #
-# For the DFC API you need to call:
+#   ./bin/rake rswag spec/requests/api/v1/
+#   ./script/rswag --dry-run spec/requests/api/v1/
+#
+# DFC API: you need to call
 #
 #   ./script/rswag engines/dfc_provider
 #

--- a/spec/requests/api/v1/customer_account_transaction_spec.rb
+++ b/spec/requests/api/v1/customer_account_transaction_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 
 RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml" do
   let!(:enterprise) { create(:enterprise) }
-  let(:customer) { create(:customer) }
+  let(:customer) { create(:customer, enterprise:) }
 
   before do
     login_as enterprise.owner
@@ -79,7 +79,19 @@ RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml" do
         end
       end
 
-      response "422", "Invalid resource" do
+      response "422", "Missing required parameter" do
+        let(:customer_account_transaction) { { customer_id: customer.id.to_s } }
+        schema '$ref': "#/components/schemas/error_response"
+
+        run_test! do
+          expect(json_response[:errors][0][:detail]).to eq(
+            "Invalid resource. Please fix errors and try again."
+          )
+          expect(json_response[:meta][:validation_errors]).to eq ["Amount can't be blank"]
+        end
+      end
+
+      response "422", "Invalid customer ID" do
         let(:customer_account_transaction) { { amount: "10.25" } }
         schema '$ref': "#/components/schemas/error_response"
 

--- a/spec/requests/api/v1/customer_account_transaction_spec.rb
+++ b/spec/requests/api/v1/customer_account_transaction_spec.rb
@@ -48,18 +48,21 @@ RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml" do
       end
 
       response "422", "Unpermitted parameter" do
+        let(:someone_else) { create(:user) }
         let(:customer_account_transaction) do
           {
             id: 101,
             customer_id: customer.id.to_s,
             amount: "10.25",
+            created_by_id: someone_else.id.to_s,
           }
         end
         schema '$ref': "#/components/schemas/error_response"
 
         run_test! do
+          expect(CustomerAccountTransaction.count).to eq 0
           expect(json_response[:errors][0][:detail]).to eq(
-            "Parameters not allowed in this request: id"
+            "Parameters not allowed in this request: id, created_by_id"
           )
         end
       end

--- a/spec/requests/api/v1/customer_account_transaction_spec.rb
+++ b/spec/requests/api/v1/customer_account_transaction_spec.rb
@@ -91,15 +91,14 @@ RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml" do
         end
       end
 
-      response "422", "Invalid customer ID" do
+      response "404", "Invalid customer ID" do
         let(:customer_account_transaction) { { amount: "10.25" } }
         schema '$ref': "#/components/schemas/error_response"
 
         run_test! do
           expect(json_response[:errors][0][:detail]).to eq(
-            "Invalid resource. Please fix errors and try again."
+            "The resource you were looking for could not be found."
           )
-          expect(json_response[:meta][:validation_errors]).to eq ["Customer must exist"]
         end
       end
 
@@ -114,6 +113,22 @@ RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml" do
         end
 
         run_test!
+      end
+
+      response "401", "Access forbidden" do
+        # Customer belongs to enterprise that I don't have permission for
+        let(:customer) { create(:customer, enterprise: create(:enterprise)) }
+
+        let(:customer_account_transaction) do
+          {
+            customer_id: customer.id.to_s,
+            amount: "10.25",
+          }
+        end
+
+        run_test! do
+          expect(customer.reload.credit_balance).to eq 0
+        end
       end
     end
 

--- a/swagger/v1.yaml
+++ b/swagger/v1.yaml
@@ -380,13 +380,19 @@ paths:
               schema:
                 "$ref": "#/components/schemas/customer_account_transaction"
         '422':
-          description: Invalid resource
+          description: Missing required parameter
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error_response"
+        '404':
+          description: Invalid customer ID
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/error_response"
         '401':
-          description: Unauthorized
+          description: Access forbidden
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
# What? Why?

- Closes a vulnerability that was privately shared by @Santoshkumarpuppala (Thank you!)

> I'm a security researcher reporting a vulnerability in Open Food Network privately under coordinated disclosure. I couldn't find a published security contact (no SECURITY.md / GitHub private vulnerability reporting), so I'm writing to you as active maintainers — if there's a better security address, please point me to it and I'll resend. I have not disclosed anything publicly and will hold all specifics until a fix is released. All testing was done locally against an OFN source build — no hosted or third-party system was contacted.
> 
> Summary
> -------
> POST /api/v1/customer_account_transaction lets an authenticated enterprise manager create — and read the running balance of — customer account transactions belonging to a DIFFERENT enterprise. A manager of Enterprise A can credit/debit and read the balances of Enterprise B's customers.
> 
> Affected
> --------
> openfoodfoundation/openfoodnetwork v5.7.0 (confirmed on a local build, Ruby 3.4.8 + PostgreSQL 16).
> Endpoint: POST /api/v1/customer_account_transaction (Api::V1::CustomerAccountTransactionsController).
> Precondition: the v1 API enabled (api_v1 feature flag; off by default). Any user managing at least one enterprise can then reach it.
> 
> Root cause
> ----------
> Two issues combine:
> 1. app/models/spree/ability.rb — add_customer_account_transaction_abilities grants can [:admin, :create, :index], CustomerAccountTransaction class-wide, ignoring which enterprises the user manages (the sibling Customer ability is correctly scoped to Enterprise.managed_by(user)).
> 2. The controller does a class-level authorize! :create, CustomerAccountTransaction and then acts on the customer_id from the request body, with no check that the customer's enterprise is one the caller manages.
> So the check passes for any customer_id, including customers of enterprises the caller doesn't manage. CWE-639 / CWE-862.
> 
> Proof of concept (local, v5.7.0, api_v1 enabled)
> -----------------------------------------------
> Seed Enterprise A (managed by user A) and Enterprise B with a customer (managed by a different user). As user A (manager of A only), POST a transaction for Enterprise B's customer id -> HTTP 201 Created, and the response includes that customer's running balance. The same user posting for its own customer also returns 201 (expected control). The foreign-enterprise request should have been denied.
> 
> Impact
> ------
> Any enterprise manager can tamper with the financial ledgers of other enterprises' customers (credit/debit) and read those customers' balances — a cross-tenant integrity and confidentiality breach. CVSS v3.1 7.1 (CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:H/A:N).
> 
> Remediation
> -----------
> Scope the ability to the caller's enterprises — authorize on the specific transaction/customer instance and confirm its enterprise is in Enterprise.managed_by(user), mirroring the existing Customer ability — instead of granting create/index class-wide. Reject requests whose customer_id resolves to an enterprise the caller doesn't manage.
> 
> I'd appreciate a coordinated fix and, if you assign or coordinate CVEs, please credit [https://github.com/Santoshkumarpuppala](https://www.google.com/url?q=https://github.com/Santoshkumarpuppala&source=gmail&ust=1783433797085000&sa=E). Happy to work to your timeline and to share the full local PoC on request.


## Other risks?
Note that you can't create a transaction in the admin interface, but you can view them.
So I tried manually hacking with curl and was able to confirm that even if I could guess another enterprise's customer IDs, I was blocked from reading their transactions. So we are all good there.

# What should we test?

**Endpoint**: POST /api/v1/customer_account_transaction (Api::V1::CustomerAccountTransactionsController).
**Precondition**: the v1 API enabled (api_v1 feature flag; off by default). Any user managing at least one enterprise can then reach it.

* Authenticate as a user that has access to one enterprise with customers, and does not have access to another enterprise with customers
* Try to create a transaction for a customer in your enterprise. It should succeed and provide the current balance.
* Try to create a transaction for a customer in the other enterprise. It should fail, not change or reveal the balance.


(Note there is documentation for this endpoint here: https://staging.openfoodnetwork.org.au/api-docs/index.html?urls.primaryName=API%20V1%20Docs)


# Release notes
Although this touches the API, it doesn't change how you use it, so I'm not sure the API changes label is warranted here.

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


# Documentation updates
I've added a bit more detail to the permissions page on the wiki while I was looking at it.
Also the auto-generated documentation is updated as part of this PR.