### PR TITLE
Add image upload support for product variants

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -106,6 +106,7 @@ Metrics/ClassLength:
     - 'app/controllers/admin/subscriptions_controller.rb'
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/checkout_controller.rb'
+    - 'app/controllers/spree/admin/images_controller.rb'
     - 'app/controllers/spree/admin/orders_controller.rb'
     - 'app/controllers/spree/admin/payment_methods_controller.rb'
     - 'app/controllers/spree/admin/payments_controller.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -208,6 +208,7 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Exclude:
     - 'app/helpers/admin/injection_helper.rb'
+    - 'app/helpers/admin/products_helper.rb'
     - 'app/helpers/injection_helper.rb'
     - 'app/helpers/spree/admin/base_helper.rb'
     - 'app/helpers/spree/admin/navigation_helper.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -113,6 +113,7 @@ Metrics/ClassLength:
     - 'app/controllers/admin/subscriptions_controller.rb'
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/checkout_controller.rb'
+    - 'app/controllers/spree/admin/images_controller.rb'
     - 'app/controllers/spree/admin/orders_controller.rb'
     - 'app/controllers/spree/admin/payment_methods_controller.rb'
     - 'app/controllers/spree/admin/payments_controller.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -195,11 +195,12 @@ Metrics/MethodLength:
     - 'lib/spree/localized_number.rb'
     - 'lib/tasks/sample_data/product_factory.rb'
 
-# Offense count: 9
+# Offense count: 10
 # Configuration parameters: CountComments, Max, CountAsOne.
 Metrics/ModuleLength:
   Exclude:
     - 'app/helpers/admin/injection_helper.rb'
+    - 'app/helpers/admin/products_helper.rb'
     - 'app/helpers/injection_helper.rb'
     - 'app/helpers/spree/admin/base_helper.rb'
     - 'app/helpers/spree/admin/navigation_helper.rb'

--- a/app/components/modal_component/modal_component.scss
+++ b/app/components/modal_component/modal_component.scss
@@ -14,6 +14,11 @@
     overflow: auto;
   }
 
+  &.fit {
+    max-height: calc(100vh - 6em);
+    overflow-y: auto;
+  }
+
   h1,
   h2,
   h3,

--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -306,6 +306,7 @@ module Admin
           :tax_category,
           :enterprise,
           :taggings,
+          :image,
         ] },
       ]
     end

--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -307,6 +307,7 @@ module Admin
           :tax_category,
           :enterprise,
           :taggings,
+          :image,
         ] },
       ]
     end

--- a/app/controllers/api/v0/product_images_controller.rb
+++ b/app/controllers/api/v0/product_images_controller.rb
@@ -18,13 +18,15 @@ module Api
 
         success_status = previous_image.present? ? :ok : :created
 
-        if image.save
+        Spree::Image.transaction do
+          image.save!
           previous_image&.destroy!
-          render json: image, serializer: ImageSerializer, status: success_status
-        else
-          error_json = { errors: image.errors.full_messages }
-          render json: error_json, status: :unprocessable_entity
         end
+
+        render json: image, serializer: ImageSerializer, status: success_status
+      rescue ActiveRecord::RecordInvalid
+        error_json = { errors: image.errors.full_messages }
+        render json: error_json, status: :unprocessable_entity
       end
     end
   end

--- a/app/controllers/spree/admin/images_controller.rb
+++ b/app/controllers/spree/admin/images_controller.rb
@@ -160,17 +160,19 @@ module Spree
         replacement_image.alt = previous_image.alt
         replacement_image.position = previous_image.position
         replacement_image.attributes = permitted_resource_params.except(:attachment, :viewable_id)
-        replacement_image.viewable_type = 'Spree::Product'
+        replacement_image.viewable_type = previous_image.viewable_type
         replacement_image.viewable_id = params[:image][:viewable_id]
         replacement_image.attachment.attach(permitted_resource_params[:attachment])
 
-        unless replacement_image.save
-          @error_target = replacement_image
-          return false
+        Spree::Image.transaction do
+          replacement_image.save!
+          previous_image.destroy!
         end
 
-        previous_image.destroy!
         @object = @image = replacement_image
+      rescue ActiveRecord::RecordInvalid
+        @error_target = replacement_image
+        false
       end
     end
   end

--- a/app/controllers/spree/admin/images_controller.rb
+++ b/app/controllers/spree/admin/images_controller.rb
@@ -10,8 +10,6 @@ module Spree
       # See here https://github.com/spree/spree/commit/334a011d2b8e16355e4ae77ae07cd93f7cbc8fd1
       belongs_to 'spree/product'
 
-      before_action :load_data
-
       def index
         @url_filters = ::ProductFilters.new.extract(request.query_parameters)
       end
@@ -115,15 +113,6 @@ module Spree
           admin_products_url
         else
           spree.admin_product_images_url(params[:product_id], @url_filters)
-        end
-      end
-
-      def load_data
-        if params[:variant_id]
-          @variant = Spree::Variant.find(params[:variant_id])
-          @product = @variant.product
-        else
-          @product = Product.find(params[:product_id])
         end
       end
 

--- a/app/controllers/spree/admin/images_controller.rb
+++ b/app/controllers/spree/admin/images_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 module Spree
   module Admin
     class ImagesController < ::Admin::ResourceController
@@ -177,4 +176,3 @@ module Spree
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/spree/admin/images_controller.rb
+++ b/app/controllers/spree/admin/images_controller.rb
@@ -94,16 +94,42 @@ module Spree
         Spree::Image.new(viewable: parent)
       end
 
+      def parent
+        return @parent if @parent
+
+        if params[:variant_id]
+          @parent = Spree::Variant.includes(:product).find(params[:variant_id])
+          @variant = @parent
+          @product = @variant.product
+        else
+          @parent = Spree::Product.find(params[:product_id])
+          @product = @parent
+        end
+
+        @parent
+      end
+
       def location_after_save
-        params[:return_url] || spree.admin_product_images_url(params[:product_id], @url_filters)
+        return params[:return_url] if params[:return_url].present?
+
+        if params[:variant_id]
+          admin_products_url
+        else
+          spree.admin_product_images_url(params[:product_id], @url_filters)
+        end
       end
 
       def load_data
-        @product = Product.find(params[:product_id])
+        if params[:variant_id]
+          @variant = Spree::Variant.find(params[:variant_id])
+          @product = @variant.product
+        else
+          @product = Product.find(params[:product_id])
+        end
       end
 
       def set_viewable
-        @image.viewable_type = 'Spree::Product'
+        @image.viewable_type = params[:variant_id] ? 'Spree::Variant' : 'Spree::Product'
         @image.viewable_id = params[:image][:viewable_id]
       end
 

--- a/app/controllers/spree/admin/images_controller.rb
+++ b/app/controllers/spree/admin/images_controller.rb
@@ -10,6 +10,8 @@ module Spree
       # See here https://github.com/spree/spree/commit/334a011d2b8e16355e4ae77ae07cd93f7cbc8fd1
       belongs_to 'spree/product'
 
+      before_action :authorize_parent, only: [:create, :update]
+
       def index
         @url_filters = ::ProductFilters.new.extract(request.query_parameters)
       end
@@ -78,6 +80,10 @@ module Spree
       end
 
       private
+
+      def authorize_parent
+        authorize! :update, parent
+      end
 
       def collection
         parent.image

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -2,11 +2,19 @@
 
 module Admin
   module ProductsHelper
-    def product_image_form_path(product)
-      if product.image.present?
-        edit_admin_product_image_path(product.id, product.image.id)
+    def image_form_path(imageable)
+      if imageable.is_a?(Spree::Variant)
+        product_id = imageable.product_id
+        extra = { variant_id: imageable.id }
       else
-        new_admin_product_image_path(product.id)
+        product_id = imageable.id
+        extra = {}
+      end
+
+      if imageable.image.present?
+        edit_admin_product_image_path(product_id, imageable.image.id, extra)
+      else
+        new_admin_product_image_path(product_id, extra)
       end
     end
 
@@ -111,6 +119,12 @@ module Admin
         alt: product.name,
         caption: nil
       }
+    end
+
+    def image_modal_resource_name(variant, product)
+      resource_name = product.name
+
+      variant&.display_name.present? ? "#{resource_name} - #{variant.display_name}" : resource_name
     end
   end
 end

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -119,6 +119,12 @@ module Admin
       false
     end
 
+    def image_modal_resource_name(variant, product)
+      resource_name = product.name
+
+      variant&.display_name.present? ? "#{resource_name} - #{variant.display_name}" : resource_name
+    end
+
     private
 
     def copy_template_fields(template, new_variant)
@@ -137,12 +143,6 @@ module Admin
         alt: product.name,
         caption: nil
       }
-    end
-
-    def image_modal_resource_name(variant, product)
-      resource_name = product.name
-
-      variant&.display_name.present? ? "#{resource_name} - #{variant.display_name}" : resource_name
     end
   end
 end

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -2,11 +2,19 @@
 
 module Admin
   module ProductsHelper
-    def product_image_form_path(product)
-      if product.image.present?
-        edit_admin_product_image_path(product.id, product.image.id)
+    def image_form_path(imageable)
+      if imageable.is_a?(Spree::Variant)
+        product_id = imageable.product_id
+        extra = { variant_id: imageable.id }
       else
-        new_admin_product_image_path(product.id)
+        product_id = imageable.id
+        extra = {}
+      end
+
+      if imageable.image.present?
+        edit_admin_product_image_path(product_id, imageable.image.id, extra)
+      else
+        new_admin_product_image_path(product_id, extra)
       end
     end
 
@@ -129,6 +137,12 @@ module Admin
         alt: product.name,
         caption: nil
       }
+    end
+
+    def image_modal_resource_name(variant, product)
+      resource_name = product.name
+
+      variant&.display_name.present? ? "#{resource_name} - #{variant.display_name}" : resource_name
     end
   end
 end

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -107,6 +107,12 @@ module Admin
       false
     end
 
+    def image_modal_resource_name(variant, product)
+      resource_name = product.name
+
+      variant&.display_name.present? ? "#{resource_name} - #{variant.display_name}" : resource_name
+    end
+
     private
 
     def product_image_alt_text(image, product)
@@ -119,12 +125,6 @@ module Admin
         alt: product.name,
         caption: nil
       }
-    end
-
-    def image_modal_resource_name(variant, product)
-      resource_name = product.name
-
-      variant&.display_name.present? ? "#{resource_name} - #{variant.display_name}" : resource_name
     end
   end
 end

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -53,6 +53,7 @@ module Spree
                                                dependent: :destroy,
                                                class_name: "Spree::Image",
                                                inverse_of: :viewable
+    has_one :image, class_name: "Spree::Image", as: :viewable, dependent: :destroy
     accepts_nested_attributes_for :images
 
     has_one :default_price,

--- a/app/views/admin/products_v3/_image.html.haml
+++ b/app/views/admin/products_v3/_image.html.haml
@@ -1,0 +1,5 @@
+-# locals: (imageable:, img_class: nil)
+%a.image-field{ href: image_form_path(imageable), 'data-turbo-stream': true }
+  = image_tag imageable.image&.url(:mini) || Spree::Image.default_image_url(:mini),
+    class: img_class, width: 40, height: 40
+  .button.secondary.mini= t('admin.products_page.image.edit')

--- a/app/views/admin/products_v3/_image.html.haml
+++ b/app/views/admin/products_v3/_image.html.haml
@@ -1,5 +1,10 @@
--# locals: (imageable:, img_class: nil)
-%a.image-field{ href: image_form_path(imageable), 'data-turbo-stream': true }
-  = image_tag imageable.image&.url(:mini) || Spree::Image.default_image_url(:mini),
-    class: img_class, width: 40, height: 40
-  .button.secondary.mini= t('admin.products_page.image.edit')
+-# locals: (imageable:, img_class: nil, readonly: false)
+- if readonly
+  .image-field
+    = image_tag imageable.image&.url(:mini) || Spree::Image.default_image_url(:mini),
+      class: img_class, width: 40, height: 40
+- else
+  %a.image-field{ href: image_form_path(imageable), 'data-turbo-stream': true }
+    = image_tag imageable.image&.url(:mini) || Spree::Image.default_image_url(:mini),
+      class: img_class, width: 40, height: 40
+    .button.secondary.mini= t('admin.products_page.image.edit')

--- a/app/views/admin/products_v3/_product_image.html.haml
+++ b/app/views/admin/products_v3/_product_image.html.haml
@@ -1,9 +1,0 @@
--# locals: (product:, readonly: false)
-- if readonly
-  .image-field
-    = image_tag product.image&.url(:mini) || Spree::Image.default_image_url(:mini), width: 40, height: 40
-
-- else
-  %a.image-field{ href: product_image_form_path(product), 'data-turbo-stream': true }
-    = image_tag product.image&.url(:mini) || Spree::Image.default_image_url(:mini), width: 40, height: 40
-    .button.secondary.mini= t('admin.products_page.image.edit')

--- a/app/views/admin/products_v3/_product_row.html.haml
+++ b/app/views/admin/products_v3/_product_row.html.haml
@@ -1,6 +1,5 @@
--# locals: (f:, product:)
-%td.col-image.with-image{ id: "image-#{product.id}" }
-  = render partial: "product_image", locals: { product: }
+%td.col-image.with-image{ id: "product-image-#{product.id}" }
+  = render partial: "image", locals: { imageable: product }
 %td.col-name.field.align-left.header.naked_inputs
   = f.hidden_field :id
   = f.text_field :name, 'aria-label': t('admin.products_page.columns.name')

--- a/app/views/admin/products_v3/_product_variant_row.html.haml
+++ b/app/views/admin/products_v3/_product_variant_row.html.haml
@@ -8,7 +8,7 @@
       - if allowed_source_producers.include?(product.variants.first.enterprise) && !spree_current_user.admin?
         -# Read only product
         %td.col-image.with-image{ id: "image-#{product.id}" }
-          = render partial: "product_image", locals: { product:, readonly: true }
+          = render partial: "image", locals: { imageable: product, readonly: true }
         %td.col-name.field.align-left.header
           = product_form.hidden_field :id
           .content= product.name
@@ -46,7 +46,7 @@
         -# Read only variants
         %tr.condensed.nested-form-wrapper{ id: dom_id(variant) }
           %td.col-image
-            -# empty
+            = render partial: "image", locals: { imageable: variant, readonly: true }
           %td.col-name
             .content= variant.display_name
           %td.col-sku

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -1,8 +1,9 @@
 -# haml-lint:disable ViewLength (This file is big, but doesn't make sense to split up at this point)
 -# locals: (variant:, f:, product_index: nil, allowed_source_producers:)
 - method_on_demand, method_on_hand = variant.new_record? ? [:on_demand_desired, :on_hand_desired ]: [:on_demand, :on_hand]
-%td.col-image{ id: "variant-image-#{variant.id}" }
-  = render partial: "image", locals: { imageable: variant, img_class: "variant_placeholder" }
+%td.col-image.with-image{ id: "variant-image-#{variant.id}" }
+  - unless variant.new_record?
+    = render partial: "image", locals: { imageable: variant, img_class: "variant_placeholder" }
   - variant.source_variants.each do |source_variant|
     = content_tag(:span, "🔗", title: t('admin.products_page.variant_row.sourced_from', source_name: source_variant.full_name, source_id: source_variant.id, hub_name: variant.hub&.name))
 %td.col-name.field.naked_inputs

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -1,10 +1,8 @@
 -# haml-lint:disable ViewLength (This file is big, but doesn't make sense to split up at this point)
 -# locals: (variant:, f:, product_index: nil, allowed_source_producers:)
 - method_on_demand, method_on_hand = variant.new_record? ? [:on_demand_desired, :on_hand_desired ]: [:on_demand, :on_hand]
-%td.col-image
-  = image_tag variant.image&.url(:mini) || Spree::Image.default_image_url(:mini),
-    class: "variant_placeholder",
-    width: 40, height: 40
+%td.col-image{ id: "variant-image-#{variant.id}" }
+  = render partial: "image", locals: { imageable: variant, img_class: "variant_placeholder" }
   - variant.source_variants.each do |source_variant|
     = content_tag(:span, "🔗", title: t('admin.products_page.variant_row.sourced_from', source_name: source_variant.full_name, source_id: source_variant.id, hub_name: variant.hub&.name))
 %td.col-name.field.naked_inputs

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -2,7 +2,9 @@
 -# locals: (variant:, f:, product_index: nil, allowed_source_producers:)
 - method_on_demand, method_on_hand = variant.new_record? ? [:on_demand_desired, :on_hand_desired ]: [:on_demand, :on_hand]
 %td.col-image
-  -# empty
+  = image_tag variant.image&.url(:mini) || Spree::Image.default_image_url(:mini),
+    class: "variant_placeholder",
+    width: 40, height: 40
   - variant.source_variants.each do |source_variant|
     = content_tag(:span, "🔗", title: t('admin.products_page.variant_row.sourced_from', source_name: source_variant.full_name, source_id: source_variant.id, hub_name: variant.hub&.name))
 %td.col-name.field.naked_inputs

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -2,7 +2,9 @@
 -# locals: (variant:, f:, product_index: nil, allowed_source_producers:)
 - method_on_demand, method_on_hand = variant.new_record? ? [:on_demand_desired, :on_hand_desired ]: [:on_demand, :on_hand]
 %td.col-image
-  -# empty
+  = image_tag variant.image&.url(:mini) || Spree::Image.default_image_url(:mini),
+    class: "variant_placeholder",
+    width: 40, height: 40
   - variant.source_variants.each do |source_variant|
     -# todo: remove old parameter hub_name once translations have been updated.
     = content_tag(:span, "🔗", title: t('admin.products_page.variant_row.sourced_from', source_name: source_variant.product_and_full_name, source_id: source_variant.id, producer_name: variant.producer.name))

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -1,8 +1,9 @@
 -# haml-lint:disable ViewLength (This file is big, but doesn't make sense to split up at this point)
 -# locals: (variant:, f:, product_index: nil, allowed_source_producers:)
 - method_on_demand, method_on_hand = variant.new_record? ? [:on_demand_desired, :on_hand_desired ]: [:on_demand, :on_hand]
-%td.col-image{ id: "variant-image-#{variant.id}" }
-  = render partial: "image", locals: { imageable: variant, img_class: "variant_placeholder" }
+%td.col-image.with-image{ id: "variant-image-#{variant.id}" }
+  - unless variant.new_record?
+    = render partial: "image", locals: { imageable: variant, img_class: "variant_placeholder" }
   - variant.source_variants.each do |source_variant|
     -# todo: remove old parameter hub_name once translations have been updated.
     = content_tag(:span, "🔗", title: t('admin.products_page.variant_row.sourced_from', source_name: source_variant.product_and_full_name, source_id: source_variant.id, producer_name: variant.producer.name))

--- a/app/views/admin/products_v3/_variant_row.html.haml
+++ b/app/views/admin/products_v3/_variant_row.html.haml
@@ -1,10 +1,8 @@
 -# haml-lint:disable ViewLength (This file is big, but doesn't make sense to split up at this point)
 -# locals: (variant:, f:, product_index: nil, allowed_source_producers:)
 - method_on_demand, method_on_hand = variant.new_record? ? [:on_demand_desired, :on_hand_desired ]: [:on_demand, :on_hand]
-%td.col-image
-  = image_tag variant.image&.url(:mini) || Spree::Image.default_image_url(:mini),
-    class: "variant_placeholder",
-    width: 40, height: 40
+%td.col-image{ id: "variant-image-#{variant.id}" }
+  = render partial: "image", locals: { imageable: variant, img_class: "variant_placeholder" }
   - variant.source_variants.each do |source_variant|
     -# todo: remove old parameter hub_name once translations have been updated.
     = content_tag(:span, "🔗", title: t('admin.products_page.variant_row.sourced_from', source_name: source_variant.product_and_full_name, source_id: source_variant.id, producer_name: variant.producer.name))

--- a/app/views/spree/admin/images/edit.turbo_stream.haml
+++ b/app/views/spree/admin/images/edit.turbo_stream.haml
@@ -1,6 +1,10 @@
+- viewable = @variant || @product
+
 = turbo_stream.update "edit_image_modal" do
-  = render ModalComponent.new id: "#modal_edit_product_image", instant: true, close_button: false, modal_class: :fit do
-    %h2= t(".title")
+  = render ModalComponent.new id: "#modal_edit_image", instant: true, close_button: false, modal_class: :fit do
+    %h2= t(".title", resource_name: image_modal_resource_name(@variant, @product))
+    %p{ style: "margin-bottom: 1em;" }
+      = t(".subtitle")
     - error_target = @error_target || @image
 
     -# Display image in the same way it appears in the shopfront popup
@@ -17,7 +21,8 @@
     = form_for [:admin, @product, @image],
         html: { multipart: true }, data: { controller: "form" } do |f|
       %input{ type: :hidden, name: :return_url, value: request.referer }
-      = f.hidden_field :viewable_id, value: @product.id
+      = hidden_field_tag :variant_id, @variant.id if @variant
+      = f.hidden_field :viewable_id, value: viewable.id
 
       .modal-actions.justify-end
         %input{ class: "secondary relaxed", type: 'button', value: t('.close'), "data-action": "click->modal#close" }

--- a/app/views/spree/admin/images/edit.turbo_stream.haml
+++ b/app/views/spree/admin/images/edit.turbo_stream.haml
@@ -13,7 +13,7 @@
         %p
           = error
     - else
-      %p= image_tag @image.persisted? ? @image.url(:large) : Spree::Image.default_image_url(:large), width: 433, height: 433
+      %p{ style: "text-align: center;" }= image_tag @image.persisted? ? @image.url(:large) : Spree::Image.default_image_url(:large), width: 433, height: 433
 
 
     -# Submit as turbo stream to avoid full page reload.

--- a/app/views/spree/admin/images/update.turbo_stream.haml
+++ b/app/views/spree/admin/images/update.turbo_stream.haml
@@ -1,3 +1,7 @@
-= turbo_stream.update "image-#{@product.id}" do
-  = render partial: "admin/products_v3/product_image", locals: { product: @product }
+- viewable = @variant || @product
+= turbo_stream.update "#{@variant ? 'variant' : 'product'}-image-#{viewable.id}" do
+  - if @variant
+    = render partial: "admin/products_v3/image", locals: { imageable: @variant, img_class: "variant_placeholder" }
+  - else
+    = render partial: "admin/products_v3/image", locals: { imageable: @product }
   = render partial: "admin/shared/flashes", locals: { flashes: flash } if defined? flash

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -368,4 +368,13 @@
     transform-origin: top;
     animation: slideInTop 0.5s;
   }
+
+  .condensed .col-image img.variant_placeholder {
+    opacity: 0.4;
+    transition: opacity 0.2s ease;
+  }
+
+  .condensed:hover .col-image img.variant_placeholder {
+    opacity: 1;
+  }
 }

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -107,6 +107,11 @@
       padding: $padding-tbl-cell;
       border: none;
 
+      // remove the blue dotted line from the image field
+      a.image-field {
+        border: none;
+      }
+
       .content {
         // Plain content fields need help to align with text in inputs (due to vertical-align)
         margin: ($vpadding-txt + 1px) ($hpadding-txt + 2px);
@@ -159,6 +164,7 @@
       td,
       th {
         padding: $padding-tbl-cell-condensed;
+        vertical-align: middle;
       }
     }
 

--- a/app/webpacker/css/admin/products_v3.scss
+++ b/app/webpacker/css/admin/products_v3.scss
@@ -151,7 +151,7 @@
       }
 
       tr:first-child td {
-        border-top: 4px solid $color-tbl-bg;
+        border-top: 8px solid $color-tbl-bg;
       }
 
       tr:last-child td {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4459,7 +4459,8 @@ en:
     admin:
       images:
         edit:
-          title: Edit product photo
+          title: Edit image for %{resource_name}
+          subtitle: A square size starting from 440px by 440px is recommended.
           close: Back
           upload: Upload photo
       mail_methods:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4461,7 +4461,8 @@ en:
     admin:
       images:
         edit:
-          title: Edit product photo
+          title: Edit image for %{resource_name}
+          subtitle: A square size starting from 440px by 440px is recommended.
           close: Back
           upload: Upload photo
       mail_methods:

--- a/config/locales/en_CA.yml
+++ b/config/locales/en_CA.yml
@@ -4281,7 +4281,6 @@ en_CA:
     admin:
       images:
         edit:
-          title: Edit product photo
           close: Back
           upload: Upload photo
       mail_methods:

--- a/config/locales/en_CA.yml
+++ b/config/locales/en_CA.yml
@@ -4276,7 +4276,6 @@ en_CA:
     admin:
       images:
         edit:
-          title: Edit product photo
           close: Back
           upload: Upload photo
       mail_methods:

--- a/config/locales/en_FR.yml
+++ b/config/locales/en_FR.yml
@@ -4240,7 +4240,6 @@ en_FR:
     admin:
       images:
         edit:
-          title: Edit product photo
           close: Back
           upload: Upload photo
       mail_methods:

--- a/config/locales/en_FR.yml
+++ b/config/locales/en_FR.yml
@@ -4242,7 +4242,6 @@ en_FR:
     admin:
       images:
         edit:
-          title: Edit product photo
           close: Back
           upload: Upload photo
       mail_methods:

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -4279,7 +4279,6 @@ en_GB:
     admin:
       images:
         edit:
-          title: Edit product photo
           close: Back
           upload: Upload photo
       mail_methods:

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -4283,7 +4283,6 @@ en_GB:
     admin:
       images:
         edit:
-          title: Edit product photo
           close: Back
           upload: Upload photo
       mail_methods:

--- a/config/locales/en_IE.yml
+++ b/config/locales/en_IE.yml
@@ -4027,7 +4027,6 @@ en_IE:
     admin:
       images:
         edit:
-          title: Edit product photo
           close: Back
           upload: Upload photo
       mail_methods:

--- a/config/locales/en_IE.yml
+++ b/config/locales/en_IE.yml
@@ -4029,7 +4029,6 @@ en_IE:
     admin:
       images:
         edit:
-          title: Edit product photo
           close: Back
           upload: Upload photo
       mail_methods:

--- a/db/migrate/20260701201850_remove_existing_variant_images.rb
+++ b/db/migrate/20260701201850_remove_existing_variant_images.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RemoveExistingVariantImages < ActiveRecord::Migration[7.2]
+  class SpreeImage < ActiveRecord::Base
+    self.table_name = "spree_assets"
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    SpreeImage.where(viewable_type: "Spree::Variant").delete_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260701201850_remove_existing_variant_images.rb
+++ b/db/migrate/20260701201850_remove_existing_variant_images.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 class RemoveExistingVariantImages < ActiveRecord::Migration[7.2]
-  class SpreeImage < ActiveRecord::Base
-    self.table_name = "spree_assets"
-    self.inheritance_column = :_type_disabled
+  module Spree
+    class Asset < ActiveRecord::Base
+      # This class is to allow the migration to reference the Spree::Asset in record_type.
+      self.table_name = "spree_assets"
+      self.inheritance_column = :_type_disabled
+    end
+  end
 
+  class SpreeImage < Spree::Asset
     has_one :attachment_record,
             -> { where(name: "attachment", record_type: "Spree::Asset") },
             class_name: "ActiveStorage::Attachment",

--- a/db/migrate/20260701201850_remove_existing_variant_images.rb
+++ b/db/migrate/20260701201850_remove_existing_variant_images.rb
@@ -4,10 +4,36 @@ class RemoveExistingVariantImages < ActiveRecord::Migration[7.2]
   class SpreeImage < ActiveRecord::Base
     self.table_name = "spree_assets"
     self.inheritance_column = :_type_disabled
+
+    has_one :attachment_record,
+            -> { where(name: "attachment", record_type: "Spree::Asset") },
+            class_name: "ActiveStorage::Attachment",
+            foreign_key: :record_id,
+            primary_key: :id
+
+    has_one :blob,
+            through: :attachment_record,
+            source: :blob
   end
 
   def up
-    SpreeImage.where(viewable_type: "Spree::Variant").delete_all
+    SpreeImage
+      .where(type: "Spree::Image", viewable_type: "Spree::Variant")
+      .find_each do |image|
+        attachment = image.attachment_record
+        next unless attachment
+
+        blob = attachment.blob
+
+        attachment.destroy!
+
+        blob.purge if blob.attachments.none?
+
+        image.destroy!
+        Rails.logger.info("Removed image ##{image.id} and its associated attachment and blob.")
+      rescue StandardError => e
+        Rails.logger.error("Failed to remove image ##{image.id}: #{e.message}")
+      end
   end
 
   def down

--- a/db/migrate/20260701201850_remove_existing_variant_images.rb
+++ b/db/migrate/20260701201850_remove_existing_variant_images.rb
@@ -32,7 +32,7 @@ class RemoveExistingVariantImages < ActiveRecord::Migration[7.2]
 
         attachment.destroy!
 
-        blob.purge if blob.attachments.none?
+        blob.purge_later if blob.attachments.none?
 
         image.destroy!
         Rails.logger.info("Removed image ##{image.id} and its associated attachment and blob.")

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_11_223814) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_01_201850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"

--- a/spec/helpers/admin/products_helper_spec.rb
+++ b/spec/helpers/admin/products_helper_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::ProductsHelper do
+  include FileHelper
+
   describe '#product_carousel_images_data' do
     context 'when product has images' do
       it 'returns normalized image data for each product image' do
@@ -204,6 +206,80 @@ RSpec.describe Admin::ProductsHelper do
       it "returns true" do
         expect(helper.variant_readonly?(variant, allowed_producers,
                                         allowed_source_producers)).to eq(true)
+      end
+    end
+  end
+
+  describe '#image_form_path' do
+    let(:product) { create(:product) }
+
+    context 'when imageable is a product' do
+      context 'without existing image' do
+        it 'returns new_admin_product_image_path' do
+          expect(helper.image_form_path(product))
+            .to eq "/admin/products/#{product.id}/images/new"
+        end
+      end
+
+      context 'with existing image' do
+        let!(:product) { create(:product_with_image) }
+
+        it 'returns edit_admin_product_image_path' do
+          expect(helper.image_form_path(product))
+            .to eq "/admin/products/#{product.id}/images/#{product.image.id}/edit"
+        end
+      end
+    end
+
+    context 'when imageable is a variant' do
+      let(:variant) { create(:variant, product:) }
+
+      context 'without existing image' do
+        it 'returns new_admin_product_image_path with variant_id' do
+          expect(helper.image_form_path(variant))
+            .to eq "/admin/products/#{product.id}/images/new?variant_id=#{variant.id}"
+        end
+      end
+
+      context 'with existing image' do
+        let!(:variant_image) {
+          Spree::Image.create(
+            attachment: white_logo_file,
+            viewable: variant
+          )
+        }
+
+        it 'returns edit_admin_product_image_path with variant_id' do
+          path = helper.image_form_path(variant.reload)
+          expect(path).to include("/admin/products/#{product.id}/images/#{variant_image.id}/edit")
+          expect(path).to include("variant_id=#{variant.id}")
+        end
+      end
+    end
+  end
+
+  describe '#image_modal_resource_name' do
+    let(:product) { create(:product, name: "Apples") }
+
+    context 'when variant is nil' do
+      it 'returns the product name' do
+        expect(helper.image_modal_resource_name(nil, product)).to eq "Apples"
+      end
+    end
+
+    context 'when variant has a display_name' do
+      let(:variant) { create(:variant, product:, display_name: "Red") }
+
+      it 'returns product name with variant display_name' do
+        expect(helper.image_modal_resource_name(variant, product)).to eq "Apples - Red"
+      end
+    end
+
+    context 'when variant display_name is blank' do
+      let(:variant) { create(:variant, product:, display_name: "") }
+
+      it 'returns only the product name' do
+        expect(helper.image_modal_resource_name(variant, product)).to eq "Apples"
       end
     end
   end

--- a/spec/helpers/admin/products_helper_spec.rb
+++ b/spec/helpers/admin/products_helper_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::ProductsHelper do
+  include FileHelper
+
   describe '#product_carousel_images_data' do
     context 'when product has images' do
       it 'returns normalized image data for each product image' do
@@ -261,6 +263,80 @@ RSpec.describe Admin::ProductsHelper do
       it "returns true" do
         expect(helper.variant_readonly?(variant, allowed_producers,
                                         allowed_source_producers)).to eq(true)
+      end
+    end
+  end
+
+  describe '#image_form_path' do
+    let(:product) { create(:product) }
+
+    context 'when imageable is a product' do
+      context 'without existing image' do
+        it 'returns new_admin_product_image_path' do
+          expect(helper.image_form_path(product))
+            .to eq "/admin/products/#{product.id}/images/new"
+        end
+      end
+
+      context 'with existing image' do
+        let!(:product) { create(:product_with_image) }
+
+        it 'returns edit_admin_product_image_path' do
+          expect(helper.image_form_path(product))
+            .to eq "/admin/products/#{product.id}/images/#{product.image.id}/edit"
+        end
+      end
+    end
+
+    context 'when imageable is a variant' do
+      let(:variant) { create(:variant, product:) }
+
+      context 'without existing image' do
+        it 'returns new_admin_product_image_path with variant_id' do
+          expect(helper.image_form_path(variant))
+            .to eq "/admin/products/#{product.id}/images/new?variant_id=#{variant.id}"
+        end
+      end
+
+      context 'with existing image' do
+        let!(:variant_image) {
+          Spree::Image.create(
+            attachment: white_logo_file,
+            viewable: variant
+          )
+        }
+
+        it 'returns edit_admin_product_image_path with variant_id' do
+          path = helper.image_form_path(variant.reload)
+          expect(path).to include("/admin/products/#{product.id}/images/#{variant_image.id}/edit")
+          expect(path).to include("variant_id=#{variant.id}")
+        end
+      end
+    end
+  end
+
+  describe '#image_modal_resource_name' do
+    let(:product) { create(:product, name: "Apples") }
+
+    context 'when variant is nil' do
+      it 'returns the product name' do
+        expect(helper.image_modal_resource_name(nil, product)).to eq "Apples"
+      end
+    end
+
+    context 'when variant has a display_name' do
+      let(:variant) { create(:variant, product:, display_name: "Red") }
+
+      it 'returns product name with variant display_name' do
+        expect(helper.image_modal_resource_name(variant, product)).to eq "Apples - Red"
+      end
+    end
+
+    context 'when variant display_name is blank' do
+      let(:variant) { create(:variant, product:, display_name: "") }
+
+      it 'returns only the product name' do
+        expect(helper.image_modal_resource_name(variant, product)).to eq "Apples"
       end
     end
   end

--- a/spec/migrations/remove_existing_variant_images_spec.rb
+++ b/spec/migrations/remove_existing_variant_images_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../../db/migrate/20260701201850_remove_existing_variant_images'
+
+RSpec.describe RemoveExistingVariantImages, type: :migration do
+  include FileHelper
+
+  subject(:migration) { described_class.new }
+
+  let(:attachment) { white_logo_file }
+
+  describe '#up' do
+    it "removes all variant images and purges their blobs" do
+      variant = create(:variant)
+      variant_image = Spree::Image.create!(attachment:, viewable: variant)
+      blob_id = variant_image.attachment.blob_id
+      attachment_id = variant_image.attachment.id
+      product_image = Spree::Image.create!(attachment:, viewable: create(:product))
+
+      expect { migration.up }
+        .to change { Spree::Image.where(viewable_type: 'Spree::Variant').count }
+        .from(1).to(0)
+
+      expect(Spree::Image.where(viewable_type: 'Spree::Product').count).to eq 1
+      expect(product_image.reload.attachment).to be_present
+      expect(ActiveStorage::Attachment.find_by(id: attachment_id)).to be_nil
+      expect(ActiveStorage::Blob.find_by(id: blob_id)).to be_nil
+    end
+
+    it "does not remove product images" do
+      product = create(:product)
+      Spree::Image.create!(attachment:, viewable_id: product.id,
+                           viewable_type: 'Spree::Product')
+      Spree::Image.create!(attachment:, viewable_id: product.id,
+                           viewable_type: 'Spree::Product')
+
+      expect { migration.up }.not_to change {
+        Spree::Image.where(viewable_type: 'Spree::Product').count
+      }
+    end
+  end
+end

--- a/spec/migrations/remove_existing_variant_images_spec.rb
+++ b/spec/migrations/remove_existing_variant_images_spec.rb
@@ -17,9 +17,13 @@ RSpec.describe RemoveExistingVariantImages, type: :migration do
       attachment_id = variant_image.attachment.id
       product_image = Spree::Image.create!(attachment:, viewable: create(:product))
 
-      expect { migration.up }
-        .to change { Spree::Image.where(viewable_type: 'Spree::Variant').count }
+      expect {
+        migration.up
+      }.to change { Spree::Image.where(viewable_type: 'Spree::Variant').count }
         .from(1).to(0)
+        .and enqueue_job(ActiveStorage::PurgeJob)
+
+      perform_enqueued_jobs
 
       expect(Spree::Image.where(viewable_type: 'Spree::Product').count).to eq 1
       expect(product_image.reload.attachment).to be_present

--- a/spec/requests/admin/images_spec.rb
+++ b/spec/requests/admin/images_spec.rb
@@ -182,10 +182,11 @@ RSpec.describe "/admin/products/:product_id/images" do
     it "updates the variant image" do
       expect {
         subject
-        variant_image.reload
-      }.to change { variant_image.attachment&.filename.to_s }
+        variant.reload
+      }.to change { variant.image&.attachment&.filename.to_s }
 
-      expect(variant_image.viewable_type).to eq "Spree::Variant"
+      expect(variant.image.viewable_type).to eq "Spree::Variant"
+      expect(variant.image.viewable_id).to eq variant.id
     end
 
     it "redirects to admin_products_url" do

--- a/spec/requests/admin/images_spec.rb
+++ b/spec/requests/admin/images_spec.rb
@@ -105,4 +105,93 @@ RSpec.describe "/admin/products/:product_id/images" do
 
     it_behaves_like "updating images", 200
   end
+
+  describe "POST /admin/products/:product_id/images with variant_id" do
+    let(:variant) { create(:variant, product:) }
+    let(:params) do
+      {
+        image: {
+          attachment: fixture_file_upload("logo.png", "image/png"),
+          viewable_id: variant.id,
+        },
+        variant_id: variant.id,
+      }
+    end
+    subject { post(spree.admin_product_images_path(product), params:) }
+
+    it "creates a new image for the variant" do
+      expect {
+        subject
+        variant.reload
+      }.to change { variant.image&.attachment&.filename.to_s }
+
+      expect(variant.image.viewable_type).to eq "Spree::Variant"
+      expect(variant.image.viewable_id).to eq variant.id
+    end
+
+    it "redirects to admin_products_url" do
+      subject
+      expect(response).to have_http_status :found
+      expect(response.location).to end_with spree.admin_products_path
+    end
+
+    context "with wrong type of file" do
+      let(:params) do
+        {
+          image: {
+            attachment: fixture_file_upload("sample_file_120_products.csv", "text/csv"),
+            viewable_id: variant.id,
+          },
+          variant_id: variant.id,
+        }
+      end
+
+      it "responds with an error" do
+        expect {
+          subject
+          variant.reload
+        }.not_to change { variant.image&.attachment&.filename.to_s }
+
+        expect(response.body).to include "Attachment has an invalid content type"
+      end
+    end
+  end
+
+  describe "PATCH /admin/products/:product_id/images/:id with variant_id" do
+    let(:variant) { create(:variant, product:) }
+    let!(:variant_image) {
+      Spree::Image.create(
+        attachment: fixture_file_upload("logo.png", "image/png"),
+        viewable_id: variant.id,
+        viewable_type: 'Spree::Variant'
+      )
+    }
+    let(:params) do
+      {
+        image: {
+          attachment: fixture_file_upload("thinking-cat.jpg", "image/jpeg"),
+          viewable_id: variant.id,
+        },
+        variant_id: variant.id,
+      }
+    end
+    subject {
+      patch(spree.admin_product_image_path(product, variant_image), params:)
+    }
+
+    it "updates the variant image" do
+      expect {
+        subject
+        variant_image.reload
+      }.to change { variant_image.attachment&.filename.to_s }
+
+      expect(variant_image.viewable_type).to eq "Spree::Variant"
+    end
+
+    it "redirects to admin_products_url" do
+      subject
+      expect(response).to have_http_status :found
+      expect(response.location).to end_with spree.admin_products_path
+    end
+  end
 end

--- a/spec/requests/admin/images_spec.rb
+++ b/spec/requests/admin/images_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "/admin/products/:product_id/images" do
   describe "PATCH /admin/products/:product_id/images/:id with variant_id" do
     let(:variant) { create(:variant, product:) }
     let!(:variant_image) {
-      Spree::Image.create(
+      Spree::Image.create!(
         attachment: fixture_file_upload("logo.png", "image/png"),
         viewable_id: variant.id,
         viewable_type: 'Spree::Variant'

--- a/spec/system/admin/products_v3/actions_spec.rb
+++ b/spec/system/admin/products_v3/actions_spec.rb
@@ -273,6 +273,13 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
           visit admin_products_url
 
+          # Verify readonly product image has no Edit button
+          read_only_product = read_only_variant.product
+          within "#image-#{read_only_product.id}" do
+            expect(page).to have_selector "img"
+            expect(page).not_to have_link "Edit"
+          end
+
           # Check my own variant
           within row_containing_name("My box") do
             page.find(".vertical-ellipsis-menu").click
@@ -320,6 +327,14 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
             # initially obscured by the previous message, then disappears before capybara sees it.
             # expect(page).to have_content "Changes saved"
+          end
+
+          # Verify readonly variant image has no Edit button
+          within("tr:has(.content)", text: "My readonly friends box") do
+            within "td.col-image" do
+              expect(page).to have_selector "img"
+              expect(page).not_to have_link "Edit"
+            end
           end
 
           # Create linked variant sourced from my readonly friend

--- a/spec/system/admin/products_v3/actions_spec.rb
+++ b/spec/system/admin/products_v3/actions_spec.rb
@@ -269,6 +269,13 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
           visit admin_products_url
 
+          # Verify readonly product image has no Edit button
+          read_only_product = read_only_variant.product
+          within "#image-#{read_only_product.id}" do
+            expect(page).to have_selector "img"
+            expect(page).not_to have_link "Edit"
+          end
+
           # Create linked variant sourced from my friend
           within row_containing_name("My friends box") do
             page.find(".vertical-ellipsis-menu").click
@@ -303,6 +310,14 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
             # initially obscured by the previous message, then disappears before capybara sees it.
             # expect(page).to have_content "Changes saved"
+          end
+
+          # Verify readonly variant image has no Edit button
+          within("tr:has(.content)", text: "My readonly friends box") do
+            within "td.col-image" do
+              expect(page).to have_selector "img"
+              expect(page).not_to have_link "Edit"
+            end
           end
 
           # Create linked variant sourced from my readonly friend

--- a/spec/system/admin/products_v3/update_spec.rb
+++ b/spec/system/admin/products_v3/update_spec.rb
@@ -783,7 +783,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
 
       it "saves product image" do
         within ".reveal-modal" do
-          expect(page).to have_content "Edit product photo"
+          expect(page).to have_content "Edit image for Apples"
           expect_page_to_have_image(current_img_url)
 
           # Upload a new image file
@@ -830,6 +830,74 @@ RSpec.describe 'As an enterprise user, I can update my products' do
       let(:current_img_url) { Spree::Image.default_image_url(:large) }
 
       include_examples "updating image"
+    end
+  end
+
+  describe "edit variant image" do
+    shared_examples "updating variant image" do
+      before do
+        visit admin_products_url
+
+        within "#variant-image-#{variant.id}" do
+          click_on "Edit"
+        end
+      end
+
+      it "saves variant image" do
+        within ".reveal-modal" do
+          expect(page).to have_content "Edit image for Apples"
+          expect_page_to_have_image(current_img_url)
+
+          attach_file 'image[attachment]', Rails.public_path.join('500.jpg'), visible: false
+        end
+
+        expect(page).to have_content /Image has been successfully (updated|created)/
+        expect(variant.image.reload.url(:large)).to match /500.jpg$/
+
+        within "#variant-image-#{variant.id}" do
+          expect_page_to_have_image('500.jpg')
+        end
+      end
+
+      it 'shows a modal telling not a valid image when uploading wrong type of file' do
+        within ".reveal-modal" do
+          attach_file 'image[attachment]',
+                      Rails.public_path.join('Terms-of-service.pdf'),
+                      visible: false
+          expect(page).to have_content /Attachment has an invalid content type/
+        end
+      end
+
+      it 'shows a modal telling not a valid image when uploading an invalid image file' do
+        within ".reveal-modal" do
+          attach_file 'image[attachment]',
+                      Rails.public_path.join('invalid_image.jpg'),
+                      visible: false
+          expect(page).to have_content /Attachment is not identified as a valid media file/
+        end
+      end
+    end
+
+    context "with default image" do
+      let!(:product) { create(:product, name: "Apples", supplier_id: producer.id) }
+      let(:variant) { product.variants.first }
+      let(:current_img_url) { Spree::Image.default_image_url(:large) }
+
+      include_examples "updating variant image"
+    end
+
+    context "with existing image" do
+      let!(:product) { create(:product, name: "Apples", supplier_id: producer.id) }
+      let(:variant) { product.variants.first }
+      let!(:variant_image) {
+        Spree::Image.create(
+          attachment: white_logo_file,
+          viewable: variant,
+        )
+      }
+      let(:current_img_url) { variant.image.reload.url(:large) }
+
+      include_examples "updating variant image"
     end
   end
 

--- a/spec/system/admin/products_v3/update_spec.rb
+++ b/spec/system/admin/products_v3/update_spec.rb
@@ -852,7 +852,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
         end
 
         expect(page).to have_content /Image has been successfully (updated|created)/
-        expect(variant.image.reload.url(:large)).to match /500.jpg$/
+        expect(variant.reload.image.url(:large)).to match /500.jpg$/
 
         within "#variant-image-#{variant.id}" do
           expect_page_to_have_image('500.jpg')

--- a/spec/system/admin/products_v3/update_spec.rb
+++ b/spec/system/admin/products_v3/update_spec.rb
@@ -879,7 +879,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
     end
 
     context "with default image" do
-      let!(:product) { create(:product, name: "Apples", supplier_id: producer.id) }
+      let!(:product) { create(:product, name: "Apples") }
       let(:variant) { product.variants.first }
       let(:current_img_url) { Spree::Image.default_image_url(:large) }
 
@@ -887,7 +887,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
     end
 
     context "with existing image" do
-      let!(:product) { create(:product, name: "Apples", supplier_id: producer.id) }
+      let!(:product) { create(:product, name: "Apples") }
       let(:variant) { product.variants.first }
       let!(:variant_image) {
         Spree::Image.create(

--- a/spec/system/admin/products_v3/update_spec.rb
+++ b/spec/system/admin/products_v3/update_spec.rb
@@ -761,7 +761,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
 
       it "saves product image" do
         within ".reveal-modal" do
-          expect(page).to have_content "Edit product photo"
+          expect(page).to have_content "Edit image for Apples"
           expect_page_to_have_image(current_img_url)
 
           # Upload a new image file
@@ -808,6 +808,74 @@ RSpec.describe 'As an enterprise user, I can update my products' do
       let(:current_img_url) { Spree::Image.default_image_url(:large) }
 
       include_examples "updating image"
+    end
+  end
+
+  describe "edit variant image" do
+    shared_examples "updating variant image" do
+      before do
+        visit admin_products_url
+
+        within "#variant-image-#{variant.id}" do
+          click_on "Edit"
+        end
+      end
+
+      it "saves variant image" do
+        within ".reveal-modal" do
+          expect(page).to have_content "Edit image for Apples"
+          expect_page_to_have_image(current_img_url)
+
+          attach_file 'image[attachment]', Rails.public_path.join('500.jpg'), visible: false
+        end
+
+        expect(page).to have_content /Image has been successfully (updated|created)/
+        expect(variant.image.reload.url(:large)).to match /500.jpg$/
+
+        within "#variant-image-#{variant.id}" do
+          expect_page_to_have_image('500.jpg')
+        end
+      end
+
+      it 'shows a modal telling not a valid image when uploading wrong type of file' do
+        within ".reveal-modal" do
+          attach_file 'image[attachment]',
+                      Rails.public_path.join('Terms-of-service.pdf'),
+                      visible: false
+          expect(page).to have_content /Attachment has an invalid content type/
+        end
+      end
+
+      it 'shows a modal telling not a valid image when uploading an invalid image file' do
+        within ".reveal-modal" do
+          attach_file 'image[attachment]',
+                      Rails.public_path.join('invalid_image.jpg'),
+                      visible: false
+          expect(page).to have_content /Attachment is not identified as a valid media file/
+        end
+      end
+    end
+
+    context "with default image" do
+      let!(:product) { create(:product, name: "Apples", supplier_id: producer.id) }
+      let(:variant) { product.variants.first }
+      let(:current_img_url) { Spree::Image.default_image_url(:large) }
+
+      include_examples "updating variant image"
+    end
+
+    context "with existing image" do
+      let!(:product) { create(:product, name: "Apples", supplier_id: producer.id) }
+      let(:variant) { product.variants.first }
+      let!(:variant_image) {
+        Spree::Image.create(
+          attachment: white_logo_file,
+          viewable: variant,
+        )
+      }
+      let(:current_img_url) { variant.image.reload.url(:large) }
+
+      include_examples "updating variant image"
     end
   end
 

--- a/spec/system/admin/products_v3/update_spec.rb
+++ b/spec/system/admin/products_v3/update_spec.rb
@@ -857,7 +857,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
     end
 
     context "with default image" do
-      let!(:product) { create(:product, name: "Apples", supplier_id: producer.id) }
+      let!(:product) { create(:product, name: "Apples") }
       let(:variant) { product.variants.first }
       let(:current_img_url) { Spree::Image.default_image_url(:large) }
 
@@ -865,7 +865,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
     end
 
     context "with existing image" do
-      let!(:product) { create(:product, name: "Apples", supplier_id: producer.id) }
+      let!(:product) { create(:product, name: "Apples") }
       let(:variant) { product.variants.first }
       let!(:variant_image) {
         Spree::Image.create(

--- a/spec/system/admin/products_v3/update_spec.rb
+++ b/spec/system/admin/products_v3/update_spec.rb
@@ -830,7 +830,7 @@ RSpec.describe 'As an enterprise user, I can update my products' do
         end
 
         expect(page).to have_content /Image has been successfully (updated|created)/
-        expect(variant.image.reload.url(:large)).to match /500.jpg$/
+        expect(variant.reload.image.url(:large)).to match /500.jpg$/
 
         within "#variant-image-#{variant.id}" do
           expect_page_to_have_image('500.jpg')


### PR DESCRIPTION
**:warning: Please use `Clockify Roadmap 2026 - #82 - Multiple images` when working on this**


## What? Why?

- Closes #13978

Enterprise users can now upload images for individual product variants from the admin products page. Previously, only product-level images were supported — variant rows showed an empty column with no placeholder, and the image upload overlay only handled products.

This change:

- Adds a `has_one :image` association to `Spree::Variant`, reusing the existing `Spree::Image` model (which was already polymorphic via `viewable_type`/`viewable_id`).
- Updates the images controller to accept a `variant_id` param, setting the correct `viewable_type` (`Spree::Variant` vs `Spree::Product`) and redirecting back to the admin products list after save.
- Replaces the `_product_image` partial with a generic `_image` partial that works for both products and variants.
- Adds a placeholder image (40% opacity, transitioning to full opacity on row hover) for variants without an image.
- Updates the edit-modal title to "Edit image for {product name}" for products and "Edit image for {product name} - {variant name}" for variants, with an explanatory subtitle recommending 440×440px minimum.
- Includes an irreversible data migration to clean up any orphan variant images that may exist from before this feature.

## What should we test?

1. **Placeholder image for variants without an image**
   - Navigate to /admin/products.
   - Verify each variant row shows a default placeholder image at 40% opacity.
   - Hover over a variant row and confirm the placeholder transitions to full opacity.

2. **Upload an image for a variant**
   - Click the "Edit" button on a variant's placeholder image.
   - Confirm the modal title reads "Edit image for {product name} - {variant name}".
   - Confirm the subtitle "A square size starting from 440px by 440px is recommended." is visible.
   - Attach a valid image file and save.
   - Verify the success flash message and that the variant row now shows the uploaded thumbnail.

3. **Upload an invalid file type**
   - Open the edit modal for a variant.
   - Attach a non-image file (e.g. PDF or CSV).
   - Confirm an error message is displayed within the modal.

4. **Update an existing variant image**
   - Upload a second image for a variant that already has one.
   - Verify the thumbnail updates and the success flash message appears.

5. **Product image upload still works**
   - Click the "Edit" button on a product image.
   - Confirm the modal title reads "Edit image for {product name}" (no variant suffix).
   - Upload a new product image and confirm it saves correctly.
 
6. **Readonly product/variant image displays without edit button**
   - Set up a producer relationship granting only `create_linked_variants` permission (not `manage_products`) on another producer's variant.
   - Navigate to /admin/products.
   - Locate the readonly product row - verify the image thumbnail is present but there is no "Edit" button on the image.
   - Locate the readonly variant row - verify the image thumbnail is present but there is no "Edit" button on the image.

7. **Variant image redirects to product list**
   - After uploading or updating a variant image, confirm the browser redirects to the admin products list.

8. **Migration — existing variant images are removed**
   - If the environment has any pre-existing `Spree::Image` records with `viewable_type = 'Spree::Variant'`, verify they are cleaned up after running `db:migrate`. Product images are unaffected.
   - This will be tested by a dev because right now we don't show existing variant images anywhere.
9. **Any other scenario mentioned in the issue and regression testing of the product page.**

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes
- [ ] Technical changes only
- [ ] Feature toggled

## Dependencies
Following issue needs to be merged along with this one:
- https://github.com/openfoodfoundation/openfoodnetwork/issues/14512