### PR TITLE
Skip nodenv install when yarn is already available

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -29,7 +29,7 @@ FileUtils.chdir APP_ROOT do
   system("bundle check 2> /dev/null") || system!(BUNDLE_ENV, "bundle install")
 
   # Install JavaScript dependencies
-  system!("script/nodenv-install.sh")
+  system("command -v yarn 2> /dev/null") || system!("script/nodenv-install.sh")
   system!("bin/yarn")
 
   # puts "\n== Copying sample files =="


### PR DESCRIPTION
## What? Why?

The `bin/setup` script unconditionally runs `script/nodenv-install.sh` to ensure yarn is available, but this script requires `nodenv` to be installed. Developers using alternative Node.js version managers (like `asdf`) who already have yarn installed encounter setup failures because `nodenv` isn't available on their system.

This change adds a check to see if `yarn` is already installed before invoking `nodenv-install.sh`. If yarn is present (installed via asdf or any other method), the nodenv script is skipped entirely. This makes the setup script compatible with multiple Node.js version management approaches while preserving the existing behavior for nodenv users.

## What should we test?

- Run `bin/setup` when yarn is already installed and `nodenv` is not available - should succeed without errors
- Run `bin/setup` when neither yarn nor `nodenv` is installed - should fail with the expected "Please install nodenv" message
- Run `bin/setup` when both yarn and `nodenv` are available - should skip the nodenv install and proceed directly to `bin/yarn`

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes
- [x] Technical changes only
- [ ] Feature toggled