### PR TITLE
Fix flaky admin login in system specs with a per-login Warden token

### DIFF
--- a/spec/system/admin/request_scoped_login_spec.rb
+++ b/spec/system/admin/request_scoped_login_spec.rb
@@ -8,16 +8,38 @@ require 'net/http'
 # firing a "stray" request straight at the Capybara test server — as if it had leaked from a
 # previous example — so that it reaches Warden *after* `login_as` but *before* our `visit`.
 # Without request scoping that stray request consumes the queued login and we land
-# unauthenticated; with it, the login stays bound to our own (header-marked) request.
+# unauthenticated; with it, the login stays bound to our own (token-marked) request.
 RSpec.describe "Request-scoped Warden test login" do
   include AuthenticationHelper
+
+  def fire_stray_request(headers = {})
+    server = Capybara.current_session.server
+    uri = URI("http://#{server.host}:#{server.port}/admin")
+    Net::HTTP.start(uri.host, uri.port) do |http|
+      request = Net::HTTP::Get.new(uri)
+      headers.each { |name, value| request[name] = value }
+      http.request(request)
+    end
+  end
 
   it "keeps the login bound to our request even if a stray request reaches Warden first" do
     login_as_admin
 
-    # A request with no marker header, exactly like one leaking from the previous example.
-    server = Capybara.current_session.server
-    Net::HTTP.get_response(URI("http://#{server.host}:#{server.port}/admin"))
+    # A request with no marker header, exactly like one leaking from an example that never
+    # logged in.
+    fire_stray_request
+
+    visit spree.edit_admin_tax_settings_path
+
+    expect(page).to have_css("body.admin")
+  end
+
+  it "is not stolen by a stray request carrying a previous example's marker token" do
+    login_as_admin
+
+    # A leak from a *previous logged-in* example carries a marker header, but with that
+    # example's own (now stale) token value — never our fresh one.
+    fire_stray_request(RequestScopedLogin::HEADER => "stale-token-from-previous-example")
 
     visit spree.edit_admin_tax_settings_path
 

--- a/spec/system/support/request_scoped_login.rb
+++ b/spec/system/support/request_scoped_login.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "securerandom"
+
 # Binds Warden's test login to the specific request the example makes, instead of
 # "the next request to reach Warden".
 #
@@ -11,42 +13,54 @@
 # login against its own throw-away session, and leave the real page unauthenticated and
 # redirected to the public login screen. See teamcapybara/capybara#702 and #1692.
 #
-# Fix: tag the example's own request with a marker HTTP header and only apply the queued
-# login to a request carrying that header. A leaked request can't carry it — Chrome cannot
-# retro-add a header (`Network.setExtraHTTPHeaders`) to an already-dispatched request — so
-# it can no longer steal the login. One-shot semantics are preserved: the login is applied
-# exactly once, then the session cookie carries it, so logout / forbidden-redirect still work.
+# Fix: tag the example's own request with a marker HTTP header whose value is a fresh,
+# per-`login_as` token, and apply the queued login only to a request carrying THAT token.
+# A leaked request cannot carry it:
+# - a request from a previous example carries that example's (now stale) token, and
+# - Chrome cannot retro-add a header (`Network.setExtraHTTPHeaders`) to an already-dispatched
+#   request,
+# so a leak can never match the current example's token and can no longer steal the login.
+# Using a constant marker value is not enough: every logged-in example sets the same header,
+# so a leak from the previous logged-in example carries it and still races us (this is why
+# the earlier constant-value version stayed flaky).
 #
-# Applied to every system spec; the Warden hook is header-gated, so examples that never call
-# `login_as` are unaffected (no header is set, the holder stays empty, the hook no-ops).
+# One-shot semantics are preserved: the login is keyed by token and deleted on first use, then
+# the session cookie carries it, so logout / forbidden-redirect still work.
+#
+# Applied to every system spec; the Warden hook is token-gated, so examples that never call
+# `login_as` are unaffected (no header is set, so no request carries a known token and the
+# hook no-ops).
 module RequestScopedLogin
   HEADER = "X-Warden-Test-Login"
   ENV_KEY = "HTTP_X_WARDEN_TEST_LOGIN"
 
-  # One-shot holder, mirrors Warden._on_next_request but drained only by the marked request.
+  # One-shot logins keyed by token; each is drained only by a request carrying its token.
   def self.pending
-    @pending ||= []
+    @pending ||= {}
   end
 
   def self.install_warden_hook!
     return if @installed
 
     Warden::Manager.on_request do |proxy|
-      next unless proxy.env[ENV_KEY]
+      token = proxy.env[ENV_KEY]
+      next unless token
 
-      while (entry = pending.shift)
-        user, opts = entry
-        proxy.set_user(user, opts)
-      end
+      entry = pending.delete(token)
+      next unless entry
+
+      user, opts = entry
+      proxy.set_user(user, opts)
     end
     @installed = true
   end
 
-  # Overrides Warden::Test::Helpers#login_as for tagged examples.
+  # Overrides Warden::Test::Helpers#login_as for system specs.
   def login_as(user, opts = {})
     opts = { event: :authentication }.merge(opts)
-    RequestScopedLogin.pending.replace([[user, opts]])
-    page.driver.add_header(RequestScopedLogin::HEADER, "1")
+    token = SecureRandom.hex(16)
+    RequestScopedLogin.pending[token] = [user, opts]
+    page.driver.add_header(RequestScopedLogin::HEADER, token)
   end
 end
 


### PR DESCRIPTION
## What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/11984

Follow-up to #14463, which introduced request-scoped Warden test login to fix flaky
"admin not logged in" system-spec failures. That fix was incomplete: system specs such as
`spec/system/admin/bulk_order_management_spec.rb` still occasionally fail because the browser
lands on the public login screen instead of the admin page (e.g.
`expected to find css "a.delete-line-item" 2 times but there were no matches`, and
`Unable to find css "tr#li_…"`).

Root cause: the request-scoped login marker used a **constant** header value (`"1"`). Every
logged-in example sets the same marker, so a request leaking from the *previous logged-in*
example — a Cuprite XHR the browser dispatched before Capybara reset the session — carries
that same marker. It can reach Warden after our `before { login_as }` but before our `visit`,
match the header gate, and drain the one-shot login onto its own throw-away session. Our
`visit` then arrives unauthenticated. The constant marker only guarded against leaks from
examples that never logged in.

Fix: give each `login_as` a fresh `SecureRandom` token, key the pending login by that token,
and apply it only to a request carrying the matching token. A leaked request carries a
previous example's (stale) token, and Chrome cannot retro-add the fresh token to an
already-dispatched request, so a leak can no longer match the current example's login.
One-shot semantics are preserved (delete-on-match, then the session cookie carries the login),
so logout / forbidden-redirect specs still work.

## What should we test?

Test-infrastructure only — no application code changes, so no user-facing behaviour changes.

- CI should stay green.
- `spec/system/admin/request_scoped_login_spec.rb` is the regression guard. Its new example
  fires a stray request carrying a *stale* marker token; it fails deterministically on the old
  constant-value version and passes with the per-token version.
- Verified by running `spec/system/admin/bulk_order_management_spec.rb` 100× in isolation
  (20 shards × 5): **green with the fix (20/20)**, and **12/20 shards fail once the fix is
  reverted**, reproducing the original failure signature.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

## Dependencies

None.

## Documentation updates

None.
