### PR TITLE
Fix order cycle reports to separate rows by shipping method

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier.rb
@@ -18,6 +18,17 @@ module Reporting
           }
         end
 
+        def query_result
+          report_line_items.list(line_item_includes).group_by { |li|
+            [
+              li.variant_id,
+              li.price,
+              li.order.distributor_id,
+              li.order.shipping_method&.id
+            ]
+          }.values
+        end
+
         def rules
           [
             {

--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor.rb
@@ -17,6 +17,17 @@ module Reporting
           }
         end
 
+        def query_result
+          report_line_items.list(line_item_includes).group_by { |li|
+            [
+              li.variant_id,
+              li.price,
+              li.order.distributor_id,
+              li.order.shipping_method&.id
+            ]
+          }.values
+        end
+
         def rules
           [
             {
@@ -40,7 +51,10 @@ module Reporting
         end
 
         def line_item_includes
-          [{ order: :distributor,
+          [{ order: [
+               :distributor,
+               { shipments: { shipping_rates: :shipping_method } }
+             ],
              variant: [:product, :enterprise] }]
         end
       end

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier_report_spec.rb
@@ -75,7 +75,7 @@ module Reporting
             expect(delivery_row.quantity).to eq(4)
 
             summary_row = report_table.last
-            expect(summary_row[6]).to be_within(0.01).of(70.00)
+            expect(summary_row[6]).to eq(70.00)
           end
         end
       end

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier_report_spec.rb
@@ -32,6 +32,52 @@ module Reporting
           supplier_name_field = report_table.first[1]
           expect(supplier_name_field).to eq supplier.name
         end
+
+        context "with same product ordered via different shipping methods" do
+          let!(:order) { nil }
+          let(:supplier) { create(:supplier_enterprise) }
+          let(:product) {
+            create(:simple_product, enterprise_id: supplier.id, on_demand: true)
+          }
+          let(:variant) { product.variants.first }
+          let!(:pickup) {
+            create(:shipping_method, name: "Pickup", distributors: [distributor])
+          }
+          let!(:delivery) {
+            create(:shipping_method, name: "Delivery", distributors: [distributor])
+          }
+
+          let!(:order1) do
+            create(:order, distributor:, state: 'complete',
+                           completed_at: Time.zone.now).tap do |o|
+              create(:line_item_with_shipment, variant:, quantity: 3, order: o,
+                                               shipping_method: pickup)
+            end
+          end
+
+          let!(:order2) do
+            create(:order, distributor:, state: 'complete',
+                           completed_at: Time.zone.now).tap do |o|
+              create(:line_item_with_shipment, variant:, quantity: 4, order: o,
+                                               shipping_method: delivery)
+            end
+          end
+
+          it "separates rows by shipping method with correct quantities and totals" do
+            expect(report_table.length).to eq(3)
+
+            shipping_methods = report.rows.map(&:shipping_method).compact_blank
+            expect(shipping_methods).to contain_exactly("Pickup", "Delivery")
+
+            pickup_row = report.rows.find { |r| r.shipping_method == "Pickup" }
+            delivery_row = report.rows.find { |r| r.shipping_method == "Delivery" }
+            expect(pickup_row.quantity).to eq(3)
+            expect(delivery_row.quantity).to eq(4)
+
+            summary_row = report_table.last
+            expect(summary_row[6]).to be_within(0.01).of(70.00)
+          end
+        end
       end
     end
   end

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
@@ -2,7 +2,7 @@
 
 module Reporting
   module Reports
-    module OrdersAndFulfillment
+    module OrdersAndFulfillment # rubocop:disable Metrics/ModuleLength
       RSpec.describe OrderCycleSupplierTotalsByDistributor do
         let!(:distributor) { create(:distributor_enterprise) }
         let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor]) }
@@ -89,7 +89,63 @@ module Reporting
             expect(product_names).not_to include("Apple", "Banane")
           end
         end
+
+        context "with same product ordered via different shipping methods" do
+          let!(:order) { nil }
+          let(:supplier) { create(:supplier_enterprise) }
+          let(:product) {
+            create(:simple_product, enterprise_id: supplier.id, on_demand: true)
+          }
+          let(:variant) { product.variants.first }
+          let!(:pickup) {
+            create(:shipping_method, name: "Pickup", distributors: [distributor])
+          }
+          let!(:delivery) {
+            create(:shipping_method, name: "Delivery", distributors: [distributor])
+          }
+
+          let(:current_user) { distributor.owner }
+          let(:params) { { display_summary_row: true } }
+          let(:report) do
+            OrderCycleSupplierTotalsByDistributor.new(current_user, params)
+          end
+
+          let(:report_table) do
+            report.table_rows
+          end
+
+          let!(:order1) do
+            create(:order, distributor:, state: 'complete',
+                           completed_at: Time.zone.now).tap do |o|
+              create(:line_item_with_shipment, variant:, quantity: 3, order: o,
+                                               shipping_method: pickup)
+            end
+          end
+
+          let!(:order2) do
+            create(:order, distributor:, state: 'complete',
+                           completed_at: Time.zone.now).tap do |o|
+              create(:line_item_with_shipment, variant:, quantity: 4, order: o,
+                                               shipping_method: delivery)
+            end
+          end
+
+          it "separates rows by shipping method with correct quantities and totals" do
+            expect(report_table.length).to eq(3)
+
+            shipping_methods = report.rows.map(&:shipping_method).compact_blank
+            expect(shipping_methods).to contain_exactly("Pickup", "Delivery")
+
+            pickup_row = report.rows.find { |r| r.shipping_method == "Pickup" }
+            delivery_row = report.rows.find { |r| r.shipping_method == "Delivery" }
+            expect(pickup_row.quantity).to eq(3)
+            expect(delivery_row.quantity).to eq(4)
+
+            summary_row = report_table.last
+            expect(summary_row[6]).to be_within(0.01).of(70.00)
+          end
+        end
       end
     end
   end
-end
+end # rubocop:enable Metrics/ModuleLength

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor_report_spec.rb
@@ -142,7 +142,7 @@ module Reporting
             expect(delivery_row.quantity).to eq(4)
 
             summary_row = report_table.last
-            expect(summary_row[6]).to be_within(0.01).of(70.00)
+            expect(summary_row[6]).to eq(70.00)
           end
         end
       end

--- a/spec/system/admin/reports/orders_and_fulfillment_spec.rb
+++ b/spec/system/admin/reports/orders_and_fulfillment_spec.rb
@@ -379,20 +379,22 @@ RSpec.describe "Orders And Fulfillment" do
               end
 
               it "aggregates results per variant" do
-                expect(all('table.report__table tbody tr').count).to eq(4)
-                # 1 row per variant = 2 rows
+                expect(all('table.report__table tbody tr').count).to eq(5)
+                # 1 row per variant per shipping method = 3 rows
                 # 2 TOTAL rows
-                # 4 rows total
+                # 5 rows total
 
                 rows = find("table.report__table").all("tbody tr")
                 table = rows.map { |r| r.all("td").map { |c| c.text.strip } }
 
                 expect(table[0]).to eq(["Supplier Name", "Baked Beans", "1g Big",
-                                        "Distributor Name", "3", "10.0", "30.0", "UPS Ground"])
-                expect(table[1]).to eq(["", "", "", "TOTAL", "3", "", "30.0", ""])
-                expect(table[2]).to eq(["Supplier Name", "Baked Beans", "1g Small",
+                                        "Distributor Name", "1", "10.0", "10.0", "UPS Ground"])
+                expect(table[1]).to eq(["Supplier Name", "Baked Beans", "1g Big",
+                                        "Distributor Name", "2", "10.0", "20.0", "UPS Ground"])
+                expect(table[2]).to eq(["", "", "", "TOTAL", "3", "", "30.0", ""])
+                expect(table[3]).to eq(["Supplier Name", "Baked Beans", "1g Small",
                                         "Distributor Name", "7", "10.0", "70.0", "UPS Ground"])
-                expect(table[3]).to eq(["", "", "", "TOTAL", "7", "", "70.0", ""])
+                expect(table[4]).to eq(["", "", "", "TOTAL", "7", "", "70.0", ""])
               end
             end
 
@@ -464,17 +466,19 @@ RSpec.describe "Orders And Fulfillment" do
               rows = find("table.report__table").all("tbody tr")
               table = rows.map { |r| r.all("td").map { |c| c.text.strip } }
 
-              expect(table.count).to eq(4)
-              # 1 row per variant = 2 rows
+              expect(table.count).to eq(5)
+              # 1 row per variant per shipping method = 3 rows
               # 2 TOTAL rows for distributors
-              # 4 rows total
+              # 5 rows total
 
               expect(table[0]).to eq(["Supplier Name", "Baked Beans", "1g Big",
-                                      "Distributor Name", "3", "10.0", "30.0", "UPS Ground"])
-              expect(table[1]).to eq(["", "", "", "TOTAL", "3", "", "30.0", ""])
-              expect(table[2]).to eq(["Supplier Name", "Baked Beans", "1g Small",
+                                      "Distributor Name", "1", "10.0", "10.0", "UPS Ground"])
+              expect(table[1]).to eq(["Supplier Name", "Baked Beans", "1g Big",
+                                      "Distributor Name", "2", "10.0", "20.0", "UPS Ground"])
+              expect(table[2]).to eq(["", "", "", "TOTAL", "3", "", "30.0", ""])
+              expect(table[3]).to eq(["Supplier Name", "Baked Beans", "1g Small",
                                       "Distributor Name", "7", "10.0", "70.0", "UPS Ground"])
-              expect(table[3]).to eq(["", "", "", "TOTAL", "7", "", "70.0", ""])
+              expect(table[4]).to eq(["", "", "", "TOTAL", "7", "", "70.0", ""])
             end
           end
         end


### PR DESCRIPTION
## What? Why?

- Closes #12877

The "Order Cycle Distributor Totals by Supplier" and "Order Cycle Supplier Totals by Distributor" reports incorrectly merge line items for the same product ordered via different shipping methods into a single row. When a product is ordered with different delivery methods (e.g., Pickup vs Delivery), users see one row with combined quantities instead of separate rows for each shipping method, making it impossible to see per-delivery-method totals.

This happens because the base `query_result` method groups line items by `[variant_id, price, distributor_id]`, which doesn't account for shipping method differences. The fix overrides `query_result` in both report classes to include `shipping_method_id` in the grouping key, so line items with different shipping methods produce separate rows. The `order_cycle_supplier_totals_by_distributor` report also needed its `line_item_includes` updated to eagerly load shipment shipping method data.

## What should we test?

- Generate the "Order Cycle Distributor Totals by Supplier" report for an order cycle where the same product was ordered via two different shipping methods (e.g., Pickup and Delivery)
- Verify the report shows separate rows for each shipping method, each with the correct quantity and total cost
- Generate the "Order Cycle Supplier Totals by Distributor" report for the same scenario
- Verify the same separate-row behaviour appears in this report
- Verify the summary row total cost is correct and reflects the sum of both shipping method rows
- Verify existing report behaviour is unchanged when all orders use the same shipping method

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes
- [ ] Technical changes only
- [ ] Feature toggled