### PR TITLE
Fix order updater spec

### DIFF
--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -121,14 +121,14 @@ RSpec.describe OrderManagement::Order::Updater do
         let(:order) { create(:completed_order_with_totals) }
 
         it "updates pending payments" do
-          pending
           payment = create(:payment, order:, amount: order.total)
 
           # update order so the order total will change
           update_order_quantity(order)
+
           order.payments.reload
 
-          expect { updater.update }.to change { payment.reload.amount }.from(50).to(60)
+          expect { updater.update }.to change { payment.reload.amount }.from(10).to(20)
         end
       end
     end


### PR DESCRIPTION
Order now only have 1 line item by default

## What? Why?

- Part of #14539  # <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
:green_circle: Passing specs

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
