### PR TITLE
Fix final_weight_volume rounding and producer mailer grouping (#13911…

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -32,7 +32,9 @@ class ProducerMailer < ApplicationMailer
 
     line_items = line_items_from(@order_cycle, @producer)
 
-    @grouped_line_items = line_items.group_by { |item| [item.product_and_full_name, item.price] }
+    @grouped_line_items = line_items.group_by { |item|
+      [item.variant.product_and_full_name, item.price]
+    }
     @distributors_pickup_times = distributors_pickup_times_for(line_items)
     @receival_instructions = @order_cycle.receival_instructions_for(@producer)
     @total = total_from_line_items(line_items)
@@ -88,7 +90,7 @@ class ProducerMailer < ApplicationMailer
       {
         sku: line_item.variant.sku,
         supplier_name: line_item.supplier.name,
-        product_and_full_name: line_item.product_and_full_name,
+        product_and_full_name: line_item.variant.product_and_full_name,
         quantity: line_item.quantity,
         first_name: order.billing_address.first_name,
         last_name: order.billing_address.last_name,

--- a/db/migrate/20260717124355_change_final_weight_volume_to_scale_11_3_in_spree_line_items.rb
+++ b/db/migrate/20260717124355_change_final_weight_volume_to_scale_11_3_in_spree_line_items.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeFinalWeightVolumeToScale113InSpreeLineItems < ActiveRecord::Migration[7.2]
+  def up
+    change_column :spree_line_items, :final_weight_volume, :decimal, precision: 11, scale: 3
+  end
+
+  def down
+    change_column :spree_line_items, :final_weight_volume, :decimal, precision: 10, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_11_223814) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_17_124355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -589,7 +589,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_11_223814) do
     t.integer "max_quantity"
     t.string "currency", limit: 255
     t.decimal "distribution_fee", precision: 10, scale: 2
-    t.decimal "final_weight_volume", precision: 10, scale: 2
+    t.decimal "final_weight_volume", precision: 11, scale: 3
     t.integer "tax_category_id"
     t.decimal "weight", precision: 8, scale: 2
     t.decimal "height", precision: 8, scale: 2

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -147,6 +147,23 @@ RSpec.describe ProducerMailer do
     expect(mail.body.encoded).to include(p1.name)
   end
 
+  it "groups line items for the same variant into one row even when unit_presentation differs" do
+    # Regression test for issue #13911:
+    # When final_weight_volume had insufficient precision (DECIMAL(10,2)), storing
+    # 0.125 rounded it up to 0.13, causing different unit_presentation values
+    # (e.g. "130mL") across line items for the same variant. This split a single
+    # variant into multiple rows in the producer email.
+    variant = p1.variants.first
+    order.line_items.where(variant:).each_with_index do |li, i|
+      li.update_column(:unit_presentation, i.zero? ? "125mL" : "130mL")
+    end
+
+    rows = parsed_email.all("table.order-summary.line-items tbody tr:not(.total-row)")
+    variant_rows = rows.select { |r| r.text.include?(p1.name) }
+
+    expect(variant_rows.size).to eq(1)
+  end
+
   context 'when flag show_customer_names_to_suppliers is true' do
     before do
       order_cycle.coordinator.show_customer_names_to_suppliers = true

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -639,6 +639,43 @@ RSpec.describe Spree::LineItem do
       end
     end
 
+    describe "with a volume product whose unit_value has 3 decimal places (e.g. 125mL)" do
+      # Regression test for DECIMAL(10,2) rounding bug:
+      # 0.125 × 1 = 0.125 was rounded UP to 0.13 on storage, causing
+      # assign_units to compute unit_presentation = '130mL' instead of '125mL'.
+      # Fixed by increasing final_weight_volume to DECIMAL(11,3).
+      let!(:product) {
+        create(:product, variant_unit: "volume", variant_unit_scale: 0.001, unit_value: 0.125)
+      }
+      let!(:variant) { product.variants.first }
+      let!(:order) { create(:order) }
+
+      it "stores final_weight_volume exactly when qty=1" do
+        li = create(:line_item, order:, variant:, quantity: 1)
+        expect(li.final_weight_volume).to eq(0.125)
+        expect(li.unit_presentation).to eq("125mL")
+      end
+
+      it "stores final_weight_volume exactly when qty=3" do
+        li = create(:line_item, order:, variant:, quantity: 3)
+        expect(li.final_weight_volume).to eq(0.375)
+        expect(li.unit_presentation).to eq("125mL")
+      end
+
+      it "preserves correct unit_presentation when qty changes from 1 to 2" do
+        li = create(:line_item, order:, variant:, quantity: 1)
+        li.update(quantity: 2)
+        expect(li.final_weight_volume).to eq(0.250)
+        expect(li.unit_presentation).to eq("125mL")
+      end
+
+      it "stores final_weight_volume exactly when qty=2 directly" do
+        li = create(:line_item, order:, variant:, quantity: 2)
+        expect(li.final_weight_volume).to eq(0.250)
+        expect(li.unit_presentation).to eq("125mL")
+      end
+    end
+
     describe "generating the full name" do
       let(:li) { described_class.new }
 


### PR DESCRIPTION
…, #12874)

## Root cause

For 125mL yogurt variants (unit_value = 0.125 L), ordering qty=1 causes:
  calculate_final_weight_volume: fwv = 0.125 × 1 = 0.125
  DECIMAL(10,2) storage: 0.125 rounds to 0.13 (half-away-from-zero)
  assign_units: unit_value = 0.13/1 = 0.130 → unit_presentation = '130mL'

The rounding error propagates when customers change quantity (e.g. 1→2 produces fwv = 0.13 × 2 = 0.26 → still '130mL'). ProducerMailer then groups by the per-line-item unit_presentation snapshot, splitting the same variant into multiple rows with different mL values in the producer email.

## Fix 1: Increase final_weight_volume column precision (DECIMAL(11,3))

Changing precision from DECIMAL(10,2) to DECIMAL(11,3):
- Adds one decimal place: 0.125 now stores exactly (was rounded to 0.13)
- Keeps 8 integer digits (same as DECIMAL(10,2)): max value stays ~99M (previous attempt with DECIMAL(10,3) reduced max to ~9M, failing on 11 production records with fwv >= 10,000,000)
- A fresh migration timestamp is used (not porting the reverted PR #14444 timestamp) so servers that attempted the previous migration also receive this fix

## Fix 2: Group producer email by variant's product_and_full_name

Even after the precision fix, historical line items already stored with a rounded fwv will still carry a stale unit_presentation. Grouping by li.variant.product_and_full_name (the variant's canonical name, derived from unit_value) instead of li.product_and_full_name (the per-line-item snapshot) ensures all orders for the same variant aggregate into one row, regardless of what is stored in unit_presentation.

The same fix is applied to the customer detail table in the email.

## Tests added

- spec/models/spree/line_item_spec.rb: 4 scenarios for a 125mL volume product verifying that final_weight_volume and unit_presentation are correct for qty=1, qty=3, qty 1→2, and qty=2 directly
- spec/mailers/producer_mailer_spec.rb: regression test confirming that line items with different unit_presentation values for the same variant still produce a single aggregated row in the email

## What? Why?

- Closes # <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit ... page.
- 

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
