### PR TITLE
Clean up product modal template

### DIFF
--- a/app/views/shop/_product_modal.html.haml
+++ b/app/views/shop/_product_modal.html.haml
@@ -1,29 +1,4 @@
-- # NOTE: make sure that any changes in this template are reflected in app/views/admin/products_v3/product_preview.turbo_stream.haml
 - modal_options = { id: "shop-product-modal-#{@product.id}", instant: true, modal_class: "big", close_button: false, close_x_button: true, 'data-controller': "shop-product-modal" }
 
 = render ModalComponent.new(**modal_options) do
-  .row
-    .columns.small-12.medium-6.large-6.product-header
-      %h3= @product.name
-      - if @supplier
-        %span
-          %em= t("products_from")
-          %span= @supplier.name
-
-      %br
-
-      .filter-shopfront.property-selectors.inline-block
-        %ul
-          - @product.properties_including_inherited.each do |property|
-            - next if property[:name].blank?
-            %li
-              %span= property[:name]
-
-      - if @product.description.present?
-        .product-description{ "data-controller" => "add-blank-to-link" }
-          %p.text-small
-            - # description is sanitized in Spree::Product#description method
-            = @product.description.html_safe
-
-    .columns.small-12.medium-6.large-6.product-img
-      = render ThumbnailCarouselComponent.new(images: @carousel_images, class: (@product.images.any? ? nil : "placeholder"))
+  = render partial: "shared/product/product_details", locals: { product: @product }


### PR DESCRIPTION

## What? Why?

The product modal was re implemented by the carousel and Product grid view PR. This PR make sure they both use the same template. The template is also shared by the product preview in the backoffice. So now any changes to the product modal will automatically apply to the backoffice as well.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit a shop page 
- Check the product modal is working by clicking on the image or the product name

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
