### PR TITLE
Fix enterprise image update for API v0

### DIFF
--- a/app/controllers/api/v0/enterprises_controller.rb
+++ b/app/controllers/api/v0/enterprises_controller.rb
@@ -44,9 +44,11 @@ module Api
         @enterprise = Enterprise.find_by(permalink: params[:id]) || Enterprise.find(params[:id])
         authorize! :update, @enterprise
 
-        if params[:logo] && @enterprise.update!(logo: params[:logo])
+        # A successfull update return an html response instead of json, but we won't fix because 
+        # we don't support API v0 and we don't want to break existing integration
+        if params[:logo] && @enterprise.update(logo: params[:logo])
           render(html: @enterprise.logo_url(:medium), status: :ok)
-        elsif params[:promo] && @enterprise.update!( promo_image: params[:promo] )
+        elsif params[:promo] && @enterprise.update( promo_image: params[:promo] )
           render(html: @enterprise.promo_image_url(:medium), status: :ok)
         else
           invalid_resource!(@enterprise)

--- a/app/controllers/api/v0/enterprises_controller.rb
+++ b/app/controllers/api/v0/enterprises_controller.rb
@@ -44,7 +44,7 @@ module Api
         @enterprise = Enterprise.find_by(permalink: params[:id]) || Enterprise.find(params[:id])
         authorize! :update, @enterprise
 
-        # A successfull update return an html response instead of json, but we won't fix because 
+        # A successfull update return an html response instead of json, but we won't fix because
         # we don't support API v0 and we don't want to break existing integration
         if params[:logo] && @enterprise.update(logo: params[:logo])
           render(html: @enterprise.logo_url(:medium), status: :ok)

--- a/spec/controllers/api/v0/enterprises_controller_spec.rb
+++ b/spec/controllers/api/v0/enterprises_controller_spec.rb
@@ -130,25 +130,52 @@ RSpec.describe Api::V0::EnterprisesController do
       allow(controller).to receive(:spree_current_user) { enterprise_manager }
     end
 
-    describe "submitting a valid image" do
-      let!(:logo) { fixture_file_upload("logo.png", "image/png") }
-      before do
-        allow(Enterprise)
-          .to receive(:find_by).with({ permalink: enterprise.id.to_s }) { enterprise }
+    describe "#update_image" do
+      context "when submitting a valid image" do
+        let!(:logo) { fixture_file_upload("logo.png", "image/png") }
+
+        before do
+          allow(Enterprise)
+            .to receive(:find_by).with({ permalink: enterprise.id.to_s }) { enterprise }
+        end
+
+        it "I can update enterprise logo image" do
+          api_post :update_image, logo:, id: enterprise.id
+          expect(response).to have_http_status :ok
+          expect(response.content_type).to eq "text/html"
+          expect(response.body).to match /logo\.png$/
+        end
+
+        it "I can update enterprise promo image" do
+          api_post :update_image, promo: logo, id: enterprise.id
+          expect(response).to have_http_status :ok
+          expect(response.content_type).to eq "text/html"
+          expect(response.body).to match /logo\.png$/
+        end
       end
 
-      it "I can update enterprise logo image" do
-        api_post :update_image, logo:, id: enterprise.id
-        expect(response).to have_http_status :ok
-        expect(response.content_type).to eq "text/html"
-        expect(response.body).to match /logo\.png$/
-      end
+      context "when submitting an invalid image" do
+        let(:bad_image) { fixture_file_upload("embedded-group-preview.html", "text/html") }
 
-      it "I can update enterprise promo image" do
-        api_post :update_image, promo: logo, id: enterprise.id
-        expect(response).to have_http_status :ok
-        expect(response.content_type).to eq "text/html"
-        expect(response.body).to match /logo\.png$/
+        before do
+          allow(Enterprise)
+            .to receive(:find_by).with({ permalink: enterprise.id.to_s }) { enterprise }
+        end
+
+        it "returns an error for logo image" do
+          api_post :update_image, logo: bad_image, id: enterprise.id
+
+          expect(response).to have_http_status :unprocessable_entity
+          expect(response.content_type).to eq "application/json"
+          expect(response.body).to match /is not identified as a valid media file/
+        end
+
+        it "returns an error for promo image" do
+          api_post :update_image, promo: bad_image, id: enterprise.id
+          expect(response).to have_http_status :unprocessable_entity
+          expect(response.content_type).to eq "application/json"
+          expect(response.body).to match /is not identified as a valid media file/
+        end
       end
     end
   end


### PR DESCRIPTION
## What? Why?

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
The image update used `update!` which meant expected validation errors were reported as exception and reported to Bugsnag. Using `update` instead means validation errors are properly handled and do not pollute Bugsnag. 


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
- Start registering a new enterprise
- On the Logo step, with the developer tools open, try uploading a non image file
  -> you should see an error in the developers tools
- Try uploading an image
  -> it should update the image as expected
- Do the same for the promo image steps


## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.