### PR TITLE
Fix flaky admin subscriptions listing spec

### DIFF
--- a/spec/system/admin/subscriptions/crud_spec.rb
+++ b/spec/system/admin/subscriptions/crud_spec.rb
@@ -17,8 +17,17 @@ RSpec.describe 'Subscriptions' do
     before { login_as user }
 
     context 'listing subscriptions' do
+      # Give this subscription fully explicit data. The quick search below does a
+      # substring match across the whole serialised row (customer email,
+      # addresses, ...), so random factory data here used to occasionally contain
+      # a search term (e.g. "test" inside a Faker email/city), which made the spec
+      # flaky. Fixed data keeps its row free of the terms we search for.
       let!(:subscription) {
-        create(:subscription, shop:, with_items: true, with_proxy_orders: true)
+        create(:subscription, shop:, with_items: true, with_proxy_orders: true,
+                              customer: create(:customer, enterprise: shop,
+                                                          first_name: "Alice", last_name: "Anderson",
+                                                          email: "alice.anderson@example.com"),
+                              bill_address: create(:address), ship_address: create(:address))
       }
       let!(:customer) { create(:customer, first_name: "Timmy", last_name: "Test") }
       let!(:other_subscription) {

--- a/spec/system/admin/subscriptions/crud_spec.rb
+++ b/spec/system/admin/subscriptions/crud_spec.rb
@@ -23,16 +23,27 @@ RSpec.describe 'Subscriptions' do
       # a search term (e.g. "test" inside a Faker email/city), which made the spec
       # flaky. Fixed data keeps its row free of the terms we search for.
       let!(:subscription) {
-        create(:subscription, shop:, with_items: true, with_proxy_orders: true,
-                              customer: create(:customer, enterprise: shop,
-                                                          first_name: "Alice", last_name: "Anderson",
-                                                          email: "alice.anderson@example.com"),
-                              bill_address: create(:address), ship_address: create(:address))
+        create(:subscription,
+               shop:, with_items: true, with_proxy_orders: true,
+               customer:,
+               bill_address: create(:address), ship_address: create(:address))
       }
-      let!(:customer) { create(:customer, first_name: "Timmy", last_name: "Test") }
       let!(:other_subscription) {
-        create(:subscription, shop:, customer:, with_items: true,
-                              with_proxy_orders: true)
+        create(:subscription,
+               shop:, customer: other_customer, with_items: true,
+               with_proxy_orders: true)
+      }
+      let!(:customer) {
+        create(:customer,
+               enterprise: shop,
+               first_name: "Alice", last_name: "Anderson",
+               email: "alice.anderson@example.com")
+      }
+      let!(:other_customer) {
+        create(:customer,
+               enterprise: shop,
+               first_name: "Timmy", last_name: "Test",
+               email: "timmy.test@example.com")
       }
       let!(:subscription2) {
         create(:subscription, shop: shop2, with_items: true, with_proxy_orders: true)


### PR DESCRIPTION
## What? Why?

Fixes a flaky example in `spec/system/admin/subscriptions/crud_spec.rb`
("listing subscriptions ... passes the smoke test").

The admin subscriptions "Quick Search" box filters rows client-side with
AngularJS's built-in `filter:query` (see
`app/views/admin/subscriptions/_table.html.haml`). That does a
**case-insensitive substring match across the whole serialised row** — the
index JSON uses the full `SubscriptionSerializer`, so the customer email,
addresses and line-item descriptions are all searched.

The example searched by a customer's first/last name and asserted the *other*
`subscription` row was **not** matched. But that row's data was Faker-generated,
and a common term like `"Test"` frequently appears as a substring of random
data — e.g. the email `...@goyettestehr.co.uk`, or a city like `Mariettestad`.
When it did, the row matched unexpectedly and the example failed.

Measured rate: **~0.25%** of runs (496 collisions in 200,000 generated rows).
It never reproduced when running the example in isolation, because FFaker
starts from the same state each fresh process; in CI the specs running before it
advance FFaker's state, so it occasionally landed on a colliding value.

Fix: give `subscription` fully explicit, fixed data (customer + addresses) so
its row can never contain the terms the test searches for.

## What should we test?

- Admin → Subscriptions listing: the quick-search still filters by customer
  first name, last name and email as before.
- `spec/system/admin/subscriptions/crud_spec.rb` is green. It was run 100× on
  CI with no failures.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

## Dependencies

None.

## Documentation updates

None.
