### PR TITLE
Make FFaker test data deterministic and reproducible

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -163,6 +163,14 @@ RSpec.configure do |config|
   # "www.example.com", we set the request host to "test.host" to avoid issue with unsafe redirect
   config.before(:all, type: :request) { host! "test.host" }
 
+  # Make FFaker's random data deterministic so that a given run is reproducible.
+  # With random ordering we follow RSpec's seed (reproduce with `--seed`);
+  # otherwise we pin a fixed seed. Data still varies with the RSpec seed but is
+  # no longer a source of unreproducible flakiness. `reset!` before each example
+  # restarts the sequence so data is independent of run order.
+  config.before(:all) { FFaker::Random.seed = config.seed_used? ? config.seed : 0 }
+  config.before(:each) { FFaker::Random.reset! }
+
   # Reset all feature toggles to prevent leaking.
   config.before(:each) do
     Flipper.features.each(&:remove)


### PR DESCRIPTION
## What? Why?

Make FFaker's random test data **deterministic and reproducible**.

FFaker's RNG defaults to a fresh random seed per process (`::Random.new_seed`),
so factory-generated data (emails, addresses, ...) varies from run to run and
**cannot be reproduced**. That has been a recurring source of *unreproducible*
flakiness: e.g. a spec that substring-matches customer data occasionally hits a
random Faker value that collides, fails once, and passes on the next run with no
way to reproduce the failing state.

This pins FFaker to a known seed:

```ruby
config.before(:all)  { FFaker::Random.seed = config.seed_used? ? config.seed : 0 }
config.before(:each) { FFaker::Random.reset! }
```

- Under random ordering we follow RSpec's own seed, so a run is reproducible
  with `--seed <n>` (the seed RSpec already prints).
- Otherwise (our current defined ordering) we pin a fixed seed. Data still
  varies whenever the RSpec seed changes, but it is no longer an *unreproducible*
  variable.
- `reset!` before each example restarts the sequence, so an example's data is
  independent of run order and reproduces the same alone or in the full suite.

This follows FFaker's documented pattern, using `config.seed_used?` (RSpec's
`Configuration` exposes `order=` but no `order` reader).

## What should we test?

This is a test-infrastructure change, so the test suite itself is the subject.
Validation done so far (Knapsack disabled to avoid polluting the shared token):

- The whole `spec/models` suite run in a single process shows the **same 42
  failures with and without this change** (identical failing examples) — those
  are pre-existing single-process order/pollution artifacts, not caused by
  seeding. So the change added **zero** new failures there.
- A previously flaky system spec was green across repeated runs with the change
  active.

Please watch the full CI here: because every spec now sees a fixed data set, it
may surface other latent data-collision flakes that currently pass by luck. Any
that appear are pre-existing bugs made visible (and now reproducible), and can be
fixed as follow-ups.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

## Dependencies

None.

## Documentation updates

None.
