### PR TITLE
Fix intermittent NoMethodError in DFC API from half-loaded connector

### DIFF
--- a/engines/dfc_provider/app/services/dfc_loader.rb
+++ b/engines/dfc_provider/app/services/dfc_loader.rb
@@ -1,31 +1,35 @@
 # frozen_string_literal: true
 
 class DfcLoader
-  def self.connector
-    unless @connector
-      @connector = DataFoodConsortium::ConnectorV1::Connector.instance
-      @connector.loadMeasures(read_file("measures"))
-      @connector.loadFacets(read_file("facets"))
-      @connector.loadProductTypes(read_file("productTypes"))
-      vocabulary("vocabulary") # order states etc
-    end
+  LOCK = Mutex.new
 
-    @connector
+  def self.connector
+    @connector ||= LOCK.synchronize do
+      @connector || DataFoodConsortium::ConnectorV1::Connector.instance.tap do |connector|
+        connector.loadMeasures(read_file("measures"))
+        connector.loadFacets(read_file("facets"))
+        connector.loadProductTypes(read_file("productTypes"))
+        load_thesaurus(connector, "vocabulary") # order states etc
+      end
+    end
   end
 
   def self.connector_v2
-    unless @connector_v2
-      @connector_v2 = DataFoodConsortium::Connector::Connector.instance
-      @connector_v2.loadMeasures(read_file("measures"))
-      @connector_v2.loadFacets(read_file("facets"))
-      @connector_v2.loadProductTypes(read_file("productTypes"))
-      vocabulary("vocabulary") # order states etc
+    @connector_v2 ||= LOCK.synchronize do
+      @connector_v2 || DataFoodConsortium::Connector::Connector.instance.tap do |connector|
+        connector.loadMeasures(read_file("measures"))
+        connector.loadFacets(read_file("facets"))
+        connector.loadProductTypes(read_file("productTypes"))
+        load_thesaurus(connector, "vocabulary") # order states etc
+      end
     end
-
-    @connector_v2
   end
 
   def self.vocabulary(name)
+    load_thesaurus(connector, name)
+  end
+
+  def self.load_thesaurus(connector, name)
     @vocabs ||= {}
     @vocabs[name] ||= connector.__send__(:loadThesaurus, read_file(name))
   end

--- a/engines/dfc_provider/spec/services/dfc_loader_spec.rb
+++ b/engines/dfc_provider/spec/services/dfc_loader_spec.rb
@@ -32,4 +32,22 @@ RSpec.describe DfcLoader do
     connector = DfcLoader.connector_v2
     expect(connector.PRODUCT_TYPES.DRINK.semanticId).to end_with "#drink"
   end
+
+  it "retries loading when the first attempt fails" do
+    DfcLoader.instance_variable_set(:@connector, nil)
+
+    calls = 0
+    allow(DfcLoader).to receive(:read_file).and_wrap_original do |original, name|
+      calls += 1
+      raise Errno::ENOENT, name if calls == 1
+
+      original.call(name)
+    end
+
+    expect { DfcLoader.connector }.to raise_error(Errno::ENOENT)
+
+    # A failed load used to leave a memoised connector with empty MEASURES
+    # behind, so later requests crashed with NoMethodError on Array.
+    expect(DfcLoader.connector.MEASURES.PIECE).not_to be_nil
+  end
 end


### PR DESCRIPTION
## What? Why?

- Closes #14315

`DfcLoader.connector` memoises the connector singleton before `loadMeasures` / `loadFacets` / `loadProductTypes` have run. The connector gem initialises `MEASURES` to an empty Array, so a concurrent request hitting `DfcLoader.connector` during that window gets the singleton while `MEASURES` is still `[]`, and `QuantitativeValueBuilder.unit` crashes with the Bugsnag error `undefined method 'PIECE' for an instance of Array`. The connector (v1 and v2) is now fully loaded before being memoised, behind a mutex, so other threads either wait for it or see the finished instance. A failed load also no longer leaves a half-initialised connector memoised.

## What should we test?

- Request a DFC supplied product, e.g. `/api/dfc/enterprises/X/supplied_products/Y`, and check the quantity unit is present.
- The new spec in `dfc_loader_spec.rb` covers the previously broken case: a failed first load no longer leaves a connector with empty `MEASURES` behind.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only
