### PR TITLE
Use paid currency in partial Taler credit instead of KUDOS

### DIFF
--- a/app/models/spree/payment_method/taler.rb
+++ b/app/models/spree/payment_method/taler.rb
@@ -88,7 +88,9 @@ module Spree
 
         raise "Unsupported action" if status != "paid"
 
-        taler_amount = "KUDOS:#{amount}"
+        full_amount = taler_order.fetch("contract_terms")["amount"]
+        currency = full_amount.split(":", 2).first
+        taler_amount = "#{currency}:#{amount}"
         taler_order.refund(refund: taler_amount, reason: "credit")
 
         spree_money = Spree::Money.new(amount, currency: payment.currency).to_s

--- a/spec/models/spree/payment_method/taler_spec.rb
+++ b/spec/models/spree/payment_method/taler_spec.rb
@@ -88,7 +88,12 @@ RSpec.describe Spree::PaymentMethod::Taler do
     end
 
     it "starts the refund process" do
-      order_status = { order_status: "paid" }
+      order_status = {
+        order_status: "paid",
+        contract_terms: {
+          amount: "KUDOS:2",
+        }
+      }
       stub_request(:get, order_endpoint).to_return(body: order_status.to_json)
       stub_request(:post, refund_endpoint).to_return(body: { taler_refund_uri: }.to_json)
 


### PR DESCRIPTION
## What? Why?

While reviewing the Taler payment method code, I found one place where I had forgotten to replace the demo currency KUDOS with the actual used currency. This is a quick fix relying on the contract terms in the order status object. We use the same in the full refund already.


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Production test by Swiss team.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
