### PR TITLE
Keep SimpleCov chunks long enough to collate coverage after a re-run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           name: simplecov-chunk-controllers-${{ matrix.ci_node_index }}
           path: coverage/*.*
-          retention-days: 2 # doesn't need to be long, because it's the combined results that matter
+          retention-days: 14 # long enough to re-run one job later and still collate all results
           if-no-files-found: ignore
           include-hidden-files: true
 
@@ -179,7 +179,7 @@ jobs:
         with:
           name: simplecov-chunk-system-${{ matrix.ci_node_index }}
           path: coverage/*.*
-          retention-days: 2 # doesn't need to be long, because it's the combined results that matter
+          retention-days: 14 # long enough to re-run one job later and still collate all results
           if-no-files-found: ignore
           include-hidden-files: true
 
@@ -270,7 +270,7 @@ jobs:
         with:
           name: simplecov-chunk-engines-${{ matrix.ci_node_index }}
           path: coverage/*.*
-          retention-days: 2 # doesn't need to be long, because it's the combined results that matter
+          retention-days: 14 # long enough to re-run one job later and still collate all results
           if-no-files-found: ignore
           include-hidden-files: true
 
@@ -352,7 +352,7 @@ jobs:
         with:
           name: simplecov-chunk-the-rest-${{ matrix.ci_node_index }}
           path: coverage/*.*
-          retention-days: 2 # doesn't need to be long, because it's the combined results that matter
+          retention-days: 14 # long enough to re-run one job later and still collate all results
           if-no-files-found: ignore
           include-hidden-files: true
 


### PR DESCRIPTION
## What? Why?

The `collate_simplecov_results` job downloads one `simplecov-chunk-*` artifact per test job (28 of them), merges them into one report and compares it with Undercover. Chunks that expired before collating can't be downloaded and are silently skipped, so the combined report claims that covered code has no test coverage.

That happened on [run 30046321286](https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/30046321286) for #14479. A single `system` shard was re-run three days after the original run, by which time the other jobs' chunks had expired at `retention-days: 2`. The collate job log shows what was left:

```
Filtering artifacts by pattern 'simplecov-chunk-*'
Preparing to download the following artifacts:
- simplecov-chunk-system-5 (ID: 8638640781, Size: 33543 …)
Total of 1 artifact(s) downloaded
```

The combined report came out at 56.75% coverage instead of the usual ~96%, showing half of `Spree::Product` as never executed. Undercover only inspects changed lines, so it blamed the one scope that PR had touched — which was covered by new specs in `spec/models/spree/product_spec.rb`.

Two days was cutting it fine for a re-run. Two weeks covers our weekly release cycle, after which we would rebase and re-run all jobs anyway.

I also considered failing the collate job when it finds fewer than 28 chunks, but that hardcoded count would need maintaining every time a shard count changes, for a problem that is rare and now rarer.

## What should we test?

Nothing to test manually — this only affects how long CI keeps its own artifacts. CI passing on this PR is enough.

If you want to confirm the effect: after this merges, open a build's artifact list and check the `simplecov-chunk-*` entries show a 14 day expiry rather than 2 days.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

## Dependencies

None.

## Documentation updates

None.
