### PR TITLE
Compare code coverage against the merge base with upstream master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -425,7 +425,23 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
       - name: Compare SimpleCov results with Undercover
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git fetch --no-tags origin ${{ github.event.pull_request.base.sha }}:master
-          bundle exec undercover
-        if: ${{ github.ref != 'refs/heads/master' }} # Does not run on master, as we can't fetch master in the master branch
+          base_sha="$PR_BASE_SHA"
+          if [ -z "$base_sha" ]; then
+            # Pushed without a pull request: ask GitHub for the merge base with
+            # upstream master, the same way it does when a PR is opened. Without
+            # this, a fork's own master is used and it may be months behind.
+            upstream=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.parent.full_name // .full_name')
+            base_sha=$(gh api "repos/$upstream/compare/master...${GITHUB_REPOSITORY%%/*}:$GITHUB_SHA" \
+                       --jq '.merge_base_commit.sha')
+          fi
+          # A fork shares its object store with its upstream, so `origin` can serve
+          # a commit that only exists upstream. Depth 1 is enough: undercover falls
+          # back to a direct diff when it can't compute a merge base, and this is
+          # already the merge base.
+          git fetch --no-tags --depth=1 origin "$base_sha"
+          bundle exec undercover --compare "$base_sha"
+        if: ${{ github.ref != 'refs/heads/master' }} # Does not run on master, as we can't compare master to itself


### PR DESCRIPTION
## What? Why?

The Undercover step in `build.yml` passes `github.event.pull_request.base.sha` to
`git fetch`. On a **push** event that value is empty, so the command degrades to:

```
git fetch --no-tags origin :master
```

An empty left-hand refspec means "fetch `HEAD`", so this creates a local `master`
pointing at `origin/HEAD`. In a fork that is the fork's own master, which can be
far behind upstream. Undercover then diffs against that and reports coverage
warnings for files the branch never touched.

A recent example: in [this run](https://github.com/maikels-agent/openfoodnetwork/actions/runs/30407858203)
the commit changed only `build.yml`, but the fork's master was 2.5 months old, so
Undercover analysed 686 files of intervening upstream changes and failed on
`lib/tasks/data.rake` — a rake task that has no specs and was changed upstream in
that window.

Undercover does compute a merge base itself
([`changeset.rb:68`](https://github.com/grodowski/undercover/blob/v0.8.5/lib/undercover/changeset.rb#L68)),
so the logic is fine; it was just being handed the wrong ref.

This asks GitHub for the merge base with the upstream default branch, the same
way it does when a pull request is opened, and passes that to `--compare`.
Pull requests keep using `base.sha` as before. The `.parent.full_name //
.full_name` fallback means the step behaves identically in this repo, which has
no parent and compares against its own master.

Two details worth noting for review:

- The fetch of the base commit stays at `--depth=1`. A fork shares an object
  store with its upstream, so `origin` can serve a commit that only exists
  upstream. On a shallow clone `merge_base` returns `nil` and Undercover falls
  back to a direct two-ref diff — which is correct here, because the ref we pass
  *is* the merge base.
- `gh` is preinstalled on GitHub-hosted runners, and the workflow's existing
  `contents: read` token is enough for both API calls.

The motivation is being able to rely on the coverage check while developing a
branch, before opening a pull request.

## What should we test?

CI itself, in two situations:

- **Push without a pull request.** Push a branch to a fork whose `master` is
  behind upstream. `collate_simplecov_results` should only report coverage
  warnings for code the branch actually changed.
- **Pull request.** Unchanged behaviour — the step takes the `base.sha` path and
  never calls the API.

I verified the push path against a real `--depth=1` clone before opening this,
running the step's script verbatim: it resolved the base to `43d9ce5` (matching
`git merge-base` locally), the depth-1 fetch of that commit from the fork
succeeded, and `Undercover::Changeset#file_paths` returned exactly
`[".github/workflows/build.yml"]` instead of 686 files.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only
