### PR TITLE
Fix two flaky specs: producer properties and concurrent API requests

### DIFF
--- a/spec/requests/api/v1/customer_account_transaction_spec.rb
+++ b/spec/requests/api/v1/customer_account_transaction_spec.rb
@@ -172,6 +172,17 @@ RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml" do
 
     describe "concurrency", concurrency: true do
       let(:breakpoint) { Mutex.new }
+      # `login_as` can't authenticate two concurrent requests. It only queues a one-shot
+      # login, and Warden's test mode hands the whole queue to the first request reaching
+      # it. The other request then finds an empty queue, and no session cookie either
+      # because the first request is still parked at our breakpoint, so it gets a 401,
+      # never reaches `save` and we wait for it forever. Both requests authenticate
+      # themselves with an API key instead, just like an external POS would.
+      let(:api_token) { "token-for-concurrent-requests" }
+      let(:headers) { { "X-Api-Token" => api_token } }
+
+      before { enterprise.owner.update!(spree_api_key: api_token) }
+
       let(:params) do
         {
           customer_account_transaction: {
@@ -193,14 +204,16 @@ RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml" do
 
       it "processes one transaction at the time, ensure correct balance calculation" do
         breakpoint.lock
-        breakpoint_reached_counter = 0
+        # A queue instead of a counter, because two threads incrementing a plain integer
+        # can lose an increment and then we would wait forever.
+        breakpoint_reached = Queue.new
 
         # Set a breakpoint when save is calle. If two requests reach this breakpoint at the
         # same time, they are in a race condition but the the lock in the before_create callback
         # should ensure they are excuted one after the other.
         allow_any_instance_of(CustomerAccountTransaction).to receive(:save)
           .and_wrap_original do |method, *args|
-            breakpoint_reached_counter += 1
+            breakpoint_reached << Thread.current
             breakpoint.synchronize { nil }
             method.call(*args)
           end
@@ -208,28 +221,25 @@ RSpec.describe "CustomerAccountTransactions", swagger_doc: "v1.yaml" do
         # Create two account transactions in parallel
         threads = [
           Thread.new {
-            login_as enterprise.owner
-            post "/api/v1/customer_account_transaction", params: params
+            post "/api/v1/customer_account_transaction", params: params, headers: headers
           },
           Thread.new {
-            login_as enterprise.owner
-            post "/api/v1/customer_account_transaction", params: params2
+            post "/api/v1/customer_account_transaction", params: params2, headers: headers
           },
         ]
 
-        # Wait for the first thread to reach the breakpoint:
-        Timeout.timeout(1) do
-          sleep 0.1 while breakpoint_reached_counter < 1
+        begin
+          # Wait for both requests to reach the breakpoint to confirm that we have a race
+          # condition. They get there within milliseconds but a loaded CI runner can be a
+          # lot slower, so we wait generously.
+          requests_at_breakpoint = Array.new(2) { breakpoint_reached.pop(timeout: 30) }
+          expect(requests_at_breakpoint).to all(be_a(Thread))
+        ensure
+          # Resume and complete both transaction creation, also when we gave up waiting.
+          # Otherwise the threads stay blocked and hold on to their database connection.
+          breakpoint.unlock
+          threads.each(&:join)
         end
-
-        # Wait for the second thread to reach the breakpoint to confirm we have a race condition
-        Timeout.timeout(1) do
-          sleep 0.1 while breakpoint_reached_counter < 2
-        end
-
-        # Resume and complete both transaction creation:
-        breakpoint.unlock
-        threads.each(&:join)
 
         # There is no existing transaction, the thread are competing to create the first
         # transaction. So if the last transaction balance is anything but the sum of the amount

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -537,6 +537,9 @@ RSpec.describe '
 
       click_button 'Update'
 
+      # Wait for the response before looking at the database. Otherwise we may
+      # read it before the update has been processed.
+      expect(page).to have_content 'Enterprise "First Supplier" has been successfully updated!'
       expect(supplier1.producer_properties.reload.count).to eq(1)
 
       # -- Destroy
@@ -544,13 +547,17 @@ RSpec.describe '
         click_link "Properties"
       end
 
+      property = supplier1.producer_properties.first
       accept_alert do
-        property = supplier1.producer_properties.first
         within("#spree_producer_property_#{property.id}") { page.find('a.remove_fields').click }
       end
 
       click_button 'Update'
 
+      # The success message of the update above is still displayed, so we can't
+      # wait for it again. But the removed row disappears from the page only
+      # once the update has been processed and the page reloaded.
+      expect(page).not_to have_selector "#spree_producer_property_#{property.id}", visible: false
       expect(page).to have_content 'Enterprise "First Supplier" has been successfully updated!'
       expect(supplier1.producer_properties.reload).to be_empty
     end


### PR DESCRIPTION
## What? Why?

Two flaky specs, each with its own commit.

### 1. Producer properties system spec

`spec/system/admin/enterprises_spec.rb` "managing producer properties" fails occasionally on CI, for example in
[this master build](https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/30591209065/job/91033739943):

```
Failure/Error: expect(supplier1.producer_properties.reload.count).to eq(1)
  expected: 1
       got: 0
```

The example read the database with a plain `eq` matcher right after clicking Update:

```ruby
click_button 'Update'

expect(supplier1.producer_properties.reload.count).to eq(1)
```

Nothing in that sequence waits for the form submission, and unlike Capybara's own matchers, `eq` doesn't retry. Cuprite only
*seems* to wait for us: after a click, Ferrum waits `Ferrum::Mouse::CLICK_WAIT` (0.1 seconds) to see whether a main frame
navigation started, and only if it noticed one does it wait for the navigation to finish. On a busy CI runner the navigation can
start later than that, so the click returns straight away, we read a database which hasn't been updated yet and get 0.

The screenshot of the CI failure supports this: it shows the update having succeeded, just after we looked.

So we now wait for the response before reading the database.

The destroy part of the same example had the same problem. It did wait for a flash message, but for the *same* message as the
first update, which is still displayed at that point (success messages auto-close only after five seconds), so the wait could be
satisfied by the stale message. We now wait for the removed row to disappear, which happens only once the page has reloaded.

To confirm the diagnosis, I neutralised Ferrum's implicit wait with `FERRUM_CLICK_WAIT=0`, which is what a loaded runner
effectively does. The old example then fails every single time, with exactly the failure seen on CI, and the new one passes.

### 2. Customer account transaction concurrency spec

`spec/requests/api/v1/customer_account_transaction_spec.rb` "processes one transaction at the time" fails occasionally too:

```
Failure/Error:
  Timeout.timeout(1) do
    sleep 0.1 while breakpoint_reached_counter < 2
  end
Timeout::Error: execution expired
```

The example creates two transactions in parallel and blocks both requests in a stubbed `save`, to prove that our database lock
serialises them. But the second request never arrived, so we waited for it in vain.

`login_as` doesn't authenticate a request by itself. It queues a one-shot login on a global list, and Warden's test-mode hook
drains that list into the first request reaching it (`warden-1.2.9/lib/warden.rb:39`):

```ruby
while blk = Warden._on_next_request.shift
  blk.call(proxy)
end
```

Three logins are queued here: one from the outer `before` hook and one from each thread. **That the example usually passes is
luck**: `set_user` releases the GVL, so two requests draining the list at the same time interleave and each of them shifts a
login off it. Tracing which request applies which login shows exactly that:

```
T1 login queued, size=2
T2 login queued, size=3
-> login block T1 APPLIED by thread=37496
-> login block T2 APPLIED by thread=37488   # one each, both authenticated
```

It breaks when one request drains the whole list before the other request reaches Warden at all. The other one then finds an
empty list, and no session cookie either, because the first request is still parked at our breakpoint and hasn't responded yet.
So it is unauthenticated, gets a 401, never reaches `save`, and the counter never reaches two. Forcing that order reproduces the
failure every time:

```
T1 login queued, size=2
T2 login queued, size=3
save reached by thread 33736                 # drained all three
T1 posting, queue=0
statuses=["T1=401", "T2=201"]
```

Both requests now authenticate themselves with an API key, like an external POS would, so they don't compete for a shared
one-shot login.

Two smaller changes to stop the same symptom from coming back:

- The threads counted their arrivals in a plain integer. Two threads incrementing it can lose an increment, and then we would
  wait forever. A `Queue` counts safely.
- One second was a tight deadline for a full request on a loaded CI runner. We now allow plenty of time, and unblock the threads
  even when we do give up, so that they release their database connection.

## What should we test?

Nothing to test manually, both changes are spec-only. CI covers them:

- `spec/system/admin/enterprises_spec.rb` "managing producer properties" should keep passing. I ran it 100 times on CI before
  and after the change and it was green both times. The flake is rarer than 1 in 100, so a green run doesn't prove much on its
  own, which is why the diagnosis was confirmed with `FERRUM_CLICK_WAIT=0` instead.
- `spec/requests/api/v1/customer_account_transaction_spec.rb` should keep passing. I reproduced the old failure locally, then ran
  the whole file 80 times under CPU load with the fix, all green. I also checked that the new wait still fails, loudly and
  without hanging, when a request genuinely doesn't arrive.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

The title of the pull request will be included in the release notes.
