### PR TITLE
Display variant images in product carousels

### DIFF
--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -44,16 +44,17 @@ module Admin
     end
 
     def product_carousel_images_data(product, size: :large)
-      images = product.images.to_a
+      images = product.images.to_a + product.variant_images.to_a
       show_caption = images.many?
 
       return [default_carousel_image(size, product)] if images.empty?
 
-      images.map.with_index do |image, index|
+      images.map do |image|
+        variant = image.viewable if image.viewable.is_a?(Spree::Variant)
         {
           url: image.url(size),
-          alt: product_image_alt_text(image, product),
-          caption: show_caption ? "#{product.name} - #{index + 1}" : nil
+          alt: product_image_alt_text(image, product, variant),
+          caption: show_caption ? image_modal_resource_name(variant, product) : nil
         }
       end
     end
@@ -115,8 +116,8 @@ module Admin
 
     private
 
-    def product_image_alt_text(image, product)
-      image.alt.presence || product.name
+    def product_image_alt_text(image, product, variant)
+      image.alt.presence || image_modal_resource_name(variant, product)
     end
 
     def default_carousel_image(size, product)

--- a/app/helpers/shop_helper.rb
+++ b/app/helpers/shop_helper.rb
@@ -69,21 +69,28 @@ module ShopHelper
   end
 
   def product_carousel_images_data(product, size: :large)
-    images = product.images.to_a
+    images = product.images.to_a + product.variant_images.to_a
     show_caption = images.many?
 
     return [default_carousel_image(size, product)] if images.empty?
 
-    images.map.with_index do |image, index|
+    images.map do |image|
+      variant = image.viewable if image.viewable.is_a?(Spree::Variant)
       {
         url: image.url(size),
-        alt: image.alt.presence || product.name,
-        caption: show_caption ? "#{product.name} - #{index + 1}" : nil
+        alt: image.alt.presence || image_modal_resource_name(variant, product),
+        caption: show_caption ? image_modal_resource_name(variant, product) : nil
       }
     end
   end
 
   private
+
+  def image_modal_resource_name(variant, product)
+    resource_name = product.name
+
+    variant&.display_name.present? ? "#{resource_name} - #{variant.display_name}" : resource_name
+  end
 
   def show_groups_tabs?
     !current_distributor.hide_groups_tab? && current_distributor.groups.any?

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -43,8 +43,8 @@ module Spree
     has_many :prices, -> { order('spree_variants.id, currency') }, through: :variants
 
     has_many :stock_items, through: :variants
-    has_many :variant_images, -> { order(:position) }, source: :images,
-                                                       through: :variants
+    has_many :variant_images, -> { order(:created_at) }, source: :images,
+                                                         through: :variants
 
     validates_lengths_from_database
     validates :name, presence: true

--- a/app/views/admin/products_v3/product_preview.turbo_stream.haml
+++ b/app/views/admin/products_v3/product_preview.turbo_stream.haml
@@ -114,4 +114,5 @@
 
               .columns.small-12.medium-6.large-6.product-img
                 - carousel_images = product_carousel_images_data(@product)
-                = render ThumbnailCarouselComponent.new(images: carousel_images, class: (@product.images.any? ? nil : "placeholder"))
+                - has_any_images = @product.images.any? || @product.variant_images.any?
+                = render ThumbnailCarouselComponent.new(images: carousel_images, class: (has_any_images ? nil : "placeholder"), show_captions: true)

--- a/app/views/shop/_product_modal.html.haml
+++ b/app/views/shop/_product_modal.html.haml
@@ -26,4 +26,5 @@
             = @product.description.html_safe
 
     .columns.small-12.medium-6.large-6.product-img
-      = render ThumbnailCarouselComponent.new(images: @carousel_images, class: (@product.images.any? ? nil : "placeholder"))
+      - has_any_images = @product.images.any? || @product.variant_images.any?
+      = render ThumbnailCarouselComponent.new(images: @carousel_images, class: (has_any_images ? nil : "placeholder"), show_captions: true)

--- a/spec/helpers/admin/products_helper_spec.rb
+++ b/spec/helpers/admin/products_helper_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Admin::ProductsHelper do
         expect(data).not_to be_empty
         expect(data.first[:url]).to eq(product.images.first.url(:large))
         expect(data.first[:alt]).to eq('Front of pack')
-        expect(data.first[:caption]).to eq("#{product.name} - 1")
+        expect(data.first[:caption]).to eq(product.name)
         expect(data.second[:url]).to eq(product.images.second.url(:large))
         expect(data.second[:alt]).to eq('Front of pack')
-        expect(data.second[:caption]).to eq("#{product.name} - 2")
+        expect(data.second[:caption]).to eq(product.name)
       end
 
       it 'falls back to the product name when the image has no alt text' do
@@ -42,6 +42,76 @@ RSpec.describe Admin::ProductsHelper do
                                caption: nil
                              }
                            ])
+      end
+    end
+
+    context 'when product has no images but a variant has images' do
+      let(:product) { create(:product) }
+      let(:variant) { product.variants.first }
+
+      before do
+        Spree::Image.create!(
+          attachment: white_logo_file,
+          viewable: variant
+        )
+      end
+
+      it 'returns the variant image data' do
+        data = helper.product_carousel_images_data(product)
+
+        expect(data.size).to eq 1
+        expect(data.first[:url]).to be_present
+        expect(data.first[:alt]).to eq(product.name)
+        expect(data.first[:caption]).to be_nil
+      end
+    end
+
+    context 'when product has images and a variant also has images' do
+      let(:product) { create(:product) }
+      let(:variant) { product.variants.first }
+
+      before do
+        Spree::Image.create!(
+          attachment: white_logo_file,
+          viewable: product
+        )
+        Spree::Image.create!(
+          attachment: white_logo_file,
+          viewable: variant
+        )
+      end
+
+      it 'returns product images followed by variant images' do
+        data = helper.product_carousel_images_data(product)
+
+        expect(data.size).to eq 2
+        expect(data.first[:caption]).to eq product.name
+        expect(data.second[:caption]).to eq product.name
+      end
+    end
+
+    context 'when a variant image belongs to a variant with a display_name' do
+      let(:product) { create(:product) }
+      let(:variant) { create(:variant, product:, display_name: 'Red') }
+
+      before do
+        Spree::Image.create!(
+          attachment: white_logo_file,
+          viewable: product
+        )
+        Spree::Image.create!(
+          attachment: white_logo_file,
+          viewable: variant
+        )
+      end
+
+      it 'uses the variant display_name in the caption and alt' do
+        data = helper.product_carousel_images_data(product)
+
+        expect(data.size).to eq 2
+        expect(data.first[:caption]).to eq product.name
+        expect(data.second[:caption]).to eq "#{product.name} - Red"
+        expect(data.second[:alt]).to eq "#{product.name} - Red"
       end
     end
   end

--- a/spec/helpers/shop_helper_spec.rb
+++ b/spec/helpers/shop_helper_spec.rb
@@ -48,13 +48,83 @@ RSpec.describe ShopHelper do
         end
       end
 
-      it "returns image data with numbered captions" do
+      it "returns image data with resource name captions" do
         result = helper.product_carousel_images_data(product)
 
         expect(result.size).to eq 3
-        expect(result[0][:caption]).to eq "Test Product - 1"
-        expect(result[1][:caption]).to eq "Test Product - 2"
-        expect(result[2][:caption]).to eq "Test Product - 3"
+        expect(result[0][:caption]).to eq "Test Product"
+        expect(result[1][:caption]).to eq "Test Product"
+        expect(result[2][:caption]).to eq "Test Product"
+      end
+    end
+
+    context "when the product has no images but a variant has images" do
+      let(:product) { create(:simple_product, name: "Test Product") }
+      let(:variant) { product.variants.first }
+
+      before do
+        Spree::Image.create!(
+          attachment: white_logo_file,
+          viewable: variant
+        )
+      end
+
+      it "returns the variant image data" do
+        result = helper.product_carousel_images_data(product)
+
+        expect(result.size).to eq 1
+        expect(result.first[:url]).to be_present
+        expect(result.first[:alt]).to eq "Test Product"
+        expect(result.first[:caption]).to be_nil
+      end
+    end
+
+    context "when the product has images and a variant also has images" do
+      let(:product) { create(:simple_product, name: "Test Product") }
+      let(:variant) { product.variants.first }
+
+      before do
+        Spree::Image.create!(
+          attachment: white_logo_file,
+          viewable: product
+        )
+        Spree::Image.create!(
+          attachment: white_logo_file,
+          viewable: variant
+        )
+      end
+
+      it "returns product images followed by variant images" do
+        result = helper.product_carousel_images_data(product)
+
+        expect(result.size).to eq 2
+        expect(result[0][:caption]).to eq "Test Product"
+        expect(result[1][:caption]).to eq "Test Product"
+      end
+    end
+
+    context "when a variant image belongs to a variant with a display_name" do
+      let(:product) { create(:simple_product, name: "Test Product") }
+      let(:variant) { create(:variant, product:, display_name: "Red") }
+
+      before do
+        Spree::Image.create!(
+          attachment: white_logo_file,
+          viewable: product
+        )
+        Spree::Image.create!(
+          attachment: white_logo_file,
+          viewable: variant
+        )
+      end
+
+      it "uses the variant display_name in the caption and alt" do
+        result = helper.product_carousel_images_data(product)
+
+        expect(result.size).to eq 2
+        expect(result[0][:caption]).to eq "Test Product"
+        expect(result[1][:caption]).to eq "Test Product - Red"
+        expect(result[1][:alt]).to eq "Test Product - Red"
       end
     end
   end

--- a/spec/requests/shop_controller_spec.rb
+++ b/spec/requests/shop_controller_spec.rb
@@ -57,6 +57,27 @@ RSpec.describe "Shop" do
       end
     end
 
+    context "when the product has multiple images" do
+      include FileHelper
+
+      it "renders captions for product and variant images" do
+        product = create(:simple_product, name: "Test Product")
+        variant = create(:variant, product:, display_name: "Red")
+        Spree::Image.create!(attachment: white_logo_file, viewable: product)
+        Spree::Image.create!(attachment: white_logo_file, viewable: variant)
+        order_cycle.exchanges.outgoing.first.variants << variant
+
+        get "/shop/product_modal", params: {
+          product_id: product.id,
+          order_cycle_id: order_cycle.id
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("ofn-thumbnail-carousel__caption")
+        expect(response.body).to include("Test Product - Red")
+      end
+    end
+
     context "when no open order cycle exists" do
       it "returns not found" do
         product = create(:simple_product)


### PR DESCRIPTION
## What? Why?

- Closes #14512

With the variant image upload feature (#14511), images can now be attached to variants. However, the product image carousels introduced in #13981 still only included images uploaded directly to the product, so variant-specific images were uploaded but never shown to shoppers or admins.

This PR makes both carousels display the full set of images for a product by combining `product.images` with `product.variant_images`:

- The `product_carousel_images_data` helper in `ShopHelper` and `Admin::ProductsHelper` now returns product images followed by variant images, and derives the alt/caption from the image's own resource: product images use the product name, while variant images use the product name followed by the variant's display name (e.g. "Apples - Red").
- Captions are now rendered (`show_captions: true`). Previously these carousels never passed `show_captions`, so the computed captions were never displayed; they now identify which product/variant each image belongs to. Numbered captions ("Product - 1") are replaced by resource names.
- The `variant_images` association is now ordered by `created_at` instead of `position`.
- The carousel placeholder logic now accounts for variant images, so a product that only has variant images renders the real images rather than the placeholder.

## What should we test?

- Shopfront: create a product with multiple images and give one of its variants an image. Open the product details modal in `/shop` and confirm the carousel shows the product images followed by the variant image, with captions under each slide (product name for product images, "Product - Variant name" for the variant image).
- Shopfront edge case: with a product that has images but whose variant has no images, confirm the product images still show without a carousel (carousel only renders when the combined image count is more than one).
- Backoffice product preview: edit a product whose variant has images, open the preview product details, and confirm the carousel includes both product and variant images with captions.
- Regression: confirm carousels for products with only product images still render as before, now showing the product name as caption.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes
- [ ] Technical changes only
- [ ] Feature toggled

The title of the pull request will be included in the release notes.

## Dependencies

- Depends on #14511, which must be merged/released together with this PR.