### PR TITLE
Fix enterprise priviledge escalation

### DIFF
--- a/app/controllers/api/v0/enterprises_controller.rb
+++ b/app/controllers/api/v0/enterprises_controller.rb
@@ -5,7 +5,7 @@ module Api
     class EnterprisesController < Api::V0::BaseController
       include GeocodeEnterpriseAddress
 
-      before_action :override_owner, only: [:create, :update]
+      before_action :override_owner, only: [:create]
       before_action :check_type, only: :update
       before_action :override_sells, only: [:create, :update]
       before_action :override_visible, only: [:create, :update]
@@ -30,6 +30,10 @@ module Api
 
       def update
         @enterprise = Enterprise.find_by(permalink: params[:id]) || Enterprise.find(params[:id])
+
+        raise CanCan::AccessDenied if enterprise_params[:owner_id].present? &&
+                                      !allow_updating_owner?(@enterprise)
+
         authorize! :update, @enterprise
 
         if @enterprise.update(enterprise_params)
@@ -89,6 +93,10 @@ module Api
       def enterprise_params
         @enterprise_params ||= PermittedAttributes::Enterprise.new(params).call.
           to_h.with_indifferent_access
+      end
+
+      def allow_updating_owner?(enterprise)
+        current_api_user.owned_enterprises.include? enterprise
       end
     end
   end

--- a/spec/controllers/api/v0/enterprises_controller_spec.rb
+++ b/spec/controllers/api/v0/enterprises_controller_spec.rb
@@ -120,6 +120,37 @@ RSpec.describe Api::V0::EnterprisesController do
         end
       end
     end
+
+    describe "#update" do
+      it "can update enteprise" do
+        enterprise_params = { name: "New name" }
+        api_put :update, id: enterprise.id, enterprise: enterprise_params
+
+        expect(response).to have_http_status :ok
+
+        expect(enterprise.reload.name).to eq("New name")
+      end
+
+      context "with an enterprise the user doesn't own" do
+        let(:other_enterprise) { create(:distributor_enterprise) }
+
+        it "can't update the enterprise" do
+          enterprise_params = { name: "New name" }
+          api_put :update, id: other_enterprise.id, enterprise: enterprise_params
+
+          expect(response).to have_http_status :unauthorized
+        end
+
+        it "can't update the enterprise owner" do
+          enterprise_params = { name: "New name" }
+          expect {
+            api_put :update, id: other_enterprise.id, enterprise: enterprise_params
+          }.not_to change{ other_enterprise.reload.owner_id }
+
+          expect(response).to have_http_status :unauthorized
+        end
+      end
+    end
   end
 
   context "as an enterprise manager" do
@@ -128,6 +159,26 @@ RSpec.describe Api::V0::EnterprisesController do
     before do
       enterprise_manager.enterprise_roles.build(enterprise:).save
       allow(controller).to receive(:spree_current_user) { enterprise_manager }
+    end
+
+    describe "#update" do
+      it "can update the enteprise" do
+        enterprise_params = { name: "New name" }
+        api_put :update, id: enterprise.id, enterprise: enterprise_params
+
+        expect(response).to have_http_status :ok
+
+        expect(enterprise.reload.name).to eq("New name")
+      end
+
+      it "can't update the enterprise owner" do
+        enterprise_params = { owner_id: enterprise_manager.id }
+        expect {
+          api_put :update, id: enterprise.id, enterprise: enterprise_params
+        }.not_to change{ enterprise.reload.owner_id }
+
+        expect(response).to have_http_status :unauthorized
+      end
     end
 
     describe "#update_image" do

--- a/swagger/v0.yaml
+++ b/swagger/v0.yaml
@@ -2527,7 +2527,6 @@ paths:
       summary: Update enterprise
       description: |
         Updates an enterprise. Non-admin users cannot change the `type` field.
-        `owner_id` is always set to the current user.
       tags:
         - Enterprises
       security:


### PR DESCRIPTION
## What? Why?
- Closes https://github.com/openfoodfoundation/openfoodnetwork/security/advisories/GHSA-9vxx-j62q-h56j

The original authorization check allowed an enterprise manager to update the enterprise owner, effectively allowing a privilege escalation. This PR prevent an enterprise manager from updating the enterprise owner.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

As an enterprise manager, with the ability to manage an enterprise that it doesn't own
* Using API V0 endpoint, try updating the `owner_id` for a managed enterprise
    -> it should return an unauthorized response

As an enterprise owner
* Using API v0 endpoint, try updating the `owner_id` for an owned enterprise
    -> the update should be successful


## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.