### PR TITLE
Sort report line items deterministically

### DIFF
--- a/lib/reporting/line_items.rb
+++ b/lib/reporting/line_items.rb
@@ -21,7 +21,8 @@ module Reporting
           "enterprise.name",
           "product.name",
           "spree_variants.display_name",
-          "spree_variants.unit_description"
+          "spree_variants.unit_description",
+          "spree_line_items.id"
         )
 
       if @params[:supplier_id_in].present?


### PR DESCRIPTION
## What? Why?

The `orders_and_fulfillment_spec` fails intermittently with two rows of the same variant swapped:

```
expected: ["Supplier Name", "Baked Beans", "1g Big", "Distributor Name", "1", "10.0", "10.0", "UPS Ground"]
     got: ["Supplier Name", "Baked Beans", "1g Big", "Distributor Name", "2", "10.0", "20.0", "UPS Ground"]
```

Line items of the same variant can end up in separate report rows. In `OrderCycleSupplierTotalsByDistributor`, for example, the query result is grouped by variant, price, distributor **and shipping method**, so the same variant bought in two orders shipped by different shipping methods produces two rows.

Those two rows are equal in every column `Reporting::LineItems#list` sorts by (producer name, product name, variant display name and unit description), so the database was free to return them in either order. On my machine it consistently returns them the other way around from CI.

Sorting by line item id as well breaks the tie by creation. That's stable for the specs and it also means users get a consistent row order between runs of the same report.

This is a follow-up to 1e34237b22, which fixed the same class of problem one tie-break level higher up.

## What should we test?

- Visit any report under _Reports > Orders & Fulfillment_, for example _Order Cycle Supplier Totals By Distributor_.
- Ideally with an order cycle where the same variant was bought in several orders that used different shipping methods, so that the report shows more than one row for that variant.
- The rows should still show the same figures as before, and running the report again should list them in the same order.
- Other reports built on `Reporting::LineItems#list` are affected the same way: Orders & Distributors, Bulk Co-op, Suppliers, Sales Tax and Enterprise Fees With Tax By Producer.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

## Documentation updates

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
