### PR TITLE
Disable script execution when installing node packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
           cache: yarn
 
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Set up database
         run: |
@@ -235,7 +235,7 @@ jobs:
           cache: yarn
 
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Set up database
         run: |
@@ -317,7 +317,7 @@ jobs:
           cache: yarn
 
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Set up database
         run: |
@@ -384,7 +384,7 @@ jobs:
           cache: yarn
 
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Run JS tests
         run: bin/rake karma:run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           cache: yarn
 
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile --ignore-scripts
+        run: yarn install --frozen-lockfile
 
       - name: Set up database
         run: |
@@ -144,7 +144,7 @@ jobs:
           cache: yarn
 
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile --ignore-scripts
+        run: yarn install --frozen-lockfile
 
       - name: Set up database
         run: |
@@ -235,7 +235,7 @@ jobs:
           cache: yarn
 
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile --ignore-scripts
+        run: yarn install --frozen-lockfile
 
       - name: Set up database
         run: |
@@ -317,7 +317,7 @@ jobs:
           cache: yarn
 
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile --ignore-scripts
+        run: yarn install --frozen-lockfile
 
       - name: Set up database
         run: |
@@ -384,7 +384,7 @@ jobs:
           cache: yarn
 
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile --ignore-scripts
+        run: yarn install --frozen-lockfile
 
       - name: Run JS tests
         run: bin/rake karma:run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           cache: yarn
 
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Set up database
         run: |

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.ignore-scripts true

--- a/bin/setup
+++ b/bin/setup
@@ -30,7 +30,7 @@ FileUtils.chdir APP_ROOT do
 
   # Install JavaScript dependencies
   system("command -v yarn 2> /dev/null") || system!("script/nodenv-install.sh")
-  system!("bin/yarn --ignore-scripts")
+  system!("bin/yarn")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")

--- a/bin/setup
+++ b/bin/setup
@@ -30,7 +30,7 @@ FileUtils.chdir APP_ROOT do
 
   # Install JavaScript dependencies
   system("command -v yarn 2> /dev/null") || system!("script/nodenv-install.sh")
-  system!("bin/yarn")
+  system!("bin/yarn --ignore-scripts")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
@@ -57,7 +57,7 @@ FileUtils.chdir APP_ROOT do
   # system! "bin/rails restart"
   # Faster to do it manually:
   system! "touch tmp/restart.txt"
-  
+
   # puts "\n== Configuring puma-dev =="
   # system "ln -nfs #{APP_ROOT} ~/.puma-dev/#{APP_NAME}"
   # system "curl -Is https://#{APP_NAME}.test/up | head -n 1"


### PR DESCRIPTION

## What? Why?
Node supply chain attack very often relies on install script. Disabling install script on package install protects us from a whole range of supply chain attack. This is one of the recommendation listed here : https://safedep.io/keyv-npm-supply-chain-compromise/


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

:green_circle: Green specs

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.



