### PR TITLE
[Linked vars] Show enterprises who can create linked vars on OC incoming screen

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/services/enterprise.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/services/enterprise.js.coffee
@@ -18,7 +18,7 @@ angular.module('admin.orderCycles').factory('Enterprise', ($resource) ->
     	Enterprise.index params, (data) =>
         for enterprise in data
           @enterprises[enterprise.id] = enterprise
-          @producer_enterprises.push(enterprise) if enterprise.is_primary_producer
+          @producer_enterprises.push(enterprise) if enterprise.can_create_variants
           @hub_enterprises.push(enterprise) if enterprise.sells == 'any'
 
         @loaded = true

--- a/app/assets/javascripts/templates/admin/panels/exchange_products_panel_header.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_panel_header.html.haml
@@ -1,7 +1,6 @@
 .exchange-load-all-variants
   %div
-    {{ 'js.admin.panels.exchange_products.variants_loaded' | t:{ num_of_variants_loaded: enterprises[exchange.enterprise_id].loaded_variants, total_number_of_variants: exchangeTotalVariants(exchange) } }}
-    %em{ 'ng-if': 'enterprises[exchange.enterprise_id].loaded_variants > exchangeTotalVariants(exchange)' }
-      {{ 'js.admin.panels.exchange_products.some_variants_hidden' | t }}
+    %span{ 'ng-if': 'enterprises[exchange.enterprise_id].loaded_variants <= exchangeTotalVariants(exchange)' }
+      {{ 'js.admin.panels.exchange_products.variants_loaded' | t:{ num_of_variants_loaded: enterprises[exchange.enterprise_id].loaded_variants, total_number_of_variants: exchangeTotalVariants(exchange) } }}
     %a{ 'ng-click' => 'loadAllExchangeProducts(exchange)', 'ng-show' => 'enterprises[exchange.enterprise_id].last_page_loaded < enterprises[exchange.enterprise_id].num_of_pages' }
       {{ 'js.admin.panels.exchange_products.load_all_variants' | t }}

--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -171,22 +171,20 @@ module Admin
     end
 
     def allowed_producers
-      OpenFoodNetwork::Permissions.new(spree_current_user)
+      permissions
         .managed_product_enterprises
         .is_primary_producer
         .by_name
     end
 
     def allowed_source_producers
-      @allowed_source_producers ||= OpenFoodNetwork::Permissions.new(spree_current_user)
-        .enterprises_granting_linked_variants.is_primary_producer.by_name
+      @allowed_source_producers ||= permissions.enterprises_granting_linked_variants
+                                               .is_primary_producer.by_name
     end
 
     def available_tags
       variants = Spree::Variant.where(
-        product: OpenFoodNetwork::Permissions.new(spree_current_user)
-          .editable_and_read_only_products
-          .merge(product_scope)
+        product: permissions.editable_and_read_only_products.merge(product_scope)
       )
 
       ActsAsTaggableOn::Tag.joins(:taggings).where(
@@ -195,7 +193,7 @@ module Admin
     end
 
     def fetch_products
-      product_query = OpenFoodNetwork::Permissions.new(spree_current_user)
+      product_query = permissions
         .editable_and_read_only_products
         .merge(product_scope_with_includes)
         .ransack(ransack_query)
@@ -370,6 +368,10 @@ module Admin
 
     def init_none_tag
       @none_tag_value = '""'
+    end
+
+    def permissions
+      @permissions ||= OpenFoodNetwork::Permissions.new(spree_current_user)
     end
   end
 end

--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -171,15 +171,13 @@ module Admin
     end
 
     def allowed_producers
-      permissions
-        .managed_product_enterprises
-        .is_primary_producer
-        .by_name
+      @allowed_producers ||= permissions.managed_product_enterprises.is_primary_producer +
+                             permissions.enterprises_granted_linked_variants
     end
 
     def allowed_source_producers
       @allowed_source_producers ||= permissions.enterprises_granting_linked_variants
-                                               .is_primary_producer.by_name
+        .is_primary_producer.by_name
     end
 
     def available_tags

--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -171,7 +171,7 @@ module Admin
     end
 
     def allowed_producers
-      @allowed_producers ||= permissions.allowed_producers
+      @allowed_producers ||= permissions.enterprises_can_create_variants
     end
 
     def allowed_source_producers

--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -171,13 +171,11 @@ module Admin
     end
 
     def allowed_producers
-      @allowed_producers ||= permissions.managed_product_enterprises.is_primary_producer +
-                             permissions.enterprises_granted_linked_variants
+      @allowed_producers ||= permissions.allowed_producers
     end
 
     def allowed_source_producers
-      @allowed_source_producers ||= permissions.enterprises_granting_linked_variants
-        .is_primary_producer.by_name
+      @allowed_source_producers ||= permissions.allowed_source_producers
     end
 
     def available_tags

--- a/app/controllers/admin/products_v3_controller.rb
+++ b/app/controllers/admin/products_v3_controller.rb
@@ -175,7 +175,7 @@ module Admin
     end
 
     def allowed_source_producers
-      @allowed_source_producers ||= permissions.allowed_source_producers
+      @allowed_source_producers ||= permissions.enterprises_granting_linked_variants
     end
 
     def available_tags

--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -8,7 +8,8 @@ module Api
       class EnterpriseSerializer < ActiveModel::Serializer
         attributes :id, :name, :managed,
                    :issues_summary_supplier, :issues_summary_distributor,
-                   :is_primary_producer, :is_distributor, :sells
+                   :is_primary_producer, :is_distributor, :sells,
+                   :can_create_variants
 
         def issues_summary_supplier
           issues =
@@ -28,6 +29,11 @@ module Api
 
         def managed
           Enterprise.managed_by(options[:spree_current_user]).include? object
+        end
+
+        def can_create_variants
+          is_primary_producer ||
+            EnterpriseRelationship.permitting(object).with_permission(:create_linked_variants).any?
         end
 
         private

--- a/app/services/exchange_products_renderer.rb
+++ b/app/services/exchange_products_renderer.rb
@@ -21,7 +21,7 @@ class ExchangeProductsRenderer
     variants_relation = Spree::Variant.
       where(product_id: exchange_products(incoming, enterprise).select(&:id))
 
-    filter_visible(variants_relation)
+    filter_visible(variants_relation, enterprise)
   end
 
   private
@@ -38,6 +38,7 @@ class ExchangeProductsRenderer
     filter_visible(products_relation, enterprises_query_matcher)
   end
 
+  # Filter product or variant relation for the enterprise
   def filter_visible(relation, enterprise)
     if @order_cycle.present? &&
        options[:inventory_enabled] &&
@@ -45,7 +46,8 @@ class ExchangeProductsRenderer
       relation.visible_for(@order_cycle.coordinator)
     else
       # Include only variants owned by this enterprise
-      relation.includes(:variants).where(spree_variants: { enterprise: })
+      relation = relation.includes(:variants) if relation.model == Spree::Product
+      relation.where(spree_variants: { enterprise: })
     end
   end
 

--- a/app/services/exchange_products_renderer.rb
+++ b/app/services/exchange_products_renderer.rb
@@ -35,14 +35,17 @@ class ExchangeProductsRenderer
   def supplied_products(enterprises_query_matcher)
     products_relation = Spree::Product.in_enterprise(enterprises_query_matcher).order(:name)
 
-    filter_visible(products_relation)
+    filter_visible(products_relation, enterprises_query_matcher)
   end
 
-  def filter_visible(relation)
+  def filter_visible(relation, enterprise)
     if @order_cycle.present? &&
        options[:inventory_enabled] &&
        @order_cycle.prefers_product_selection_from_coordinator_inventory_only?
       relation = relation.visible_for(@order_cycle.coordinator)
+    else
+      # Include only variants owned by this enterprise
+      relation = relation.includes(:variants).where(spree_variants: { enterprise: })
     end
 
     relation

--- a/app/services/exchange_products_renderer.rb
+++ b/app/services/exchange_products_renderer.rb
@@ -42,13 +42,11 @@ class ExchangeProductsRenderer
     if @order_cycle.present? &&
        options[:inventory_enabled] &&
        @order_cycle.prefers_product_selection_from_coordinator_inventory_only?
-      relation = relation.visible_for(@order_cycle.coordinator)
+      relation.visible_for(@order_cycle.coordinator)
     else
       # Include only variants owned by this enterprise
-      relation = relation.includes(:variants).where(spree_variants: { enterprise: })
+      relation.includes(:variants).where(spree_variants: { enterprise: })
     end
-
-    relation
   end
 
   def products_for_outgoing_exchange

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3768,8 +3768,7 @@ en:
           select_all_variants: "Select All %{total_number_of_variants} Variants"
           variants_loaded: "%{num_of_variants_loaded} of %{total_number_of_variants} Variants Loaded"
           loading_variants: "Loading Variants"
-          no_variants: "No variant available for this product (hidden via inventory settings)."
-          some_variants_hidden: "(Some variants might be hidden via inventory settings)"
+          no_variants: "No variant available for this product."
       enterprise_fees:
         inherit_from_product: "Inherit From Product"
       orders:

--- a/lib/open_food_network/column_preference_defaults.rb
+++ b/lib/open_food_network/column_preference_defaults.rb
@@ -146,9 +146,11 @@ module OpenFoodNetwork
       }
     end
 
+    # Show the column only if there's more than one enterprise that could appear there.
     def display_producer_column?(user)
       permissions = OpenFoodNetwork::Permissions.new(user)
-      (permissions.allowed_producers | permissions.allowed_source_producers).many?
+      (permissions.allowed_producers |
+        permissions.enterprises_granting_linked_variants).many?
     end
   end
 end

--- a/lib/open_food_network/column_preference_defaults.rb
+++ b/lib/open_food_network/column_preference_defaults.rb
@@ -147,10 +147,8 @@ module OpenFoodNetwork
     end
 
     def display_producer_column?(user)
-      producers = OpenFoodNetwork::Permissions.new(user)
-        .managed_product_enterprises.is_primary_producer
-
-      producers.many?
+      permissions = OpenFoodNetwork::Permissions.new(user)
+      (permissions.allowed_producers | permissions.allowed_source_producers).many?
     end
   end
 end

--- a/lib/open_food_network/column_preference_defaults.rb
+++ b/lib/open_food_network/column_preference_defaults.rb
@@ -149,7 +149,7 @@ module OpenFoodNetwork
     # Show the column only if there's more than one enterprise that could appear there.
     def display_producer_column?(user)
       permissions = OpenFoodNetwork::Permissions.new(user)
-      (permissions.allowed_producers |
+      (permissions.enterprises_can_create_variants |
         permissions.enterprises_granting_linked_variants).many?
     end
   end

--- a/lib/open_food_network/permissions.rb
+++ b/lib/open_food_network/permissions.rb
@@ -98,16 +98,12 @@ module OpenFoodNetwork
       managed_product_enterprises.or(Enterprise.where(id: enterprises_granting_linked_variants))
     end
 
-    def enterprises_granted_linked_variants
-      Enterprise.where(id:
+    # User's enterprises that are able to have variants either as producer, or linked.
+    def enterprises_can_create_variants
+      managed_product_enterprises.is_primary_producer.or(Enterprise.where(id:
         EnterpriseRelationship.with_permission(:create_linked_variants)
           .permitting(@user.enterprises)
-          .select(:child_id))
-    end
-
-    # User's enterprises that are allowed to have variants in some way
-    def allowed_producers
-      managed_product_enterprises.is_primary_producer + enterprises_granted_linked_variants
+          .select(:child_id))).distinct
     end
 
     def manages_one_enterprise?

--- a/lib/open_food_network/permissions.rb
+++ b/lib/open_food_network/permissions.rb
@@ -98,6 +98,13 @@ module OpenFoodNetwork
       managed_product_enterprises.or(Enterprise.where(id: enterprises_granting_linked_variants))
     end
 
+    def enterprises_granted_linked_variants
+      Enterprise.where(id:
+        EnterpriseRelationship.with_permission(:create_linked_variants)
+          .permitting(@user.enterprises)
+          .select(:child_id))
+    end
+
     def manages_one_enterprise?
       @user.enterprises.length == 1
     end

--- a/lib/open_food_network/permissions.rb
+++ b/lib/open_food_network/permissions.rb
@@ -110,11 +110,6 @@ module OpenFoodNetwork
       managed_product_enterprises.is_primary_producer + enterprises_granted_linked_variants
     end
 
-    # Enterprises that user is allowed to create linked variants from
-    def allowed_source_producers
-      enterprises_granting_linked_variants.is_primary_producer
-    end
-
     def manages_one_enterprise?
       @user.enterprises.length == 1
     end

--- a/lib/open_food_network/permissions.rb
+++ b/lib/open_food_network/permissions.rb
@@ -105,6 +105,16 @@ module OpenFoodNetwork
           .select(:child_id))
     end
 
+    # User's enterprises that are allowed to have variants in some way
+    def allowed_producers
+      managed_product_enterprises.is_primary_producer + enterprises_granted_linked_variants
+    end
+
+    # Enterprises that user is allowed to create linked variants from
+    def allowed_source_producers
+      enterprises_granting_linked_variants.is_primary_producer
+    end
+
     def manages_one_enterprise?
       @user.enterprises.length == 1
     end

--- a/spec/javascripts/unit/admin/order_cycles/services/enterprise_spec.js.coffee
+++ b/spec/javascripts/unit/admin/order_cycles/services/enterprise_spec.js.coffee
@@ -8,7 +8,7 @@ describe 'Enterprise service', ->
       Enterprise = $injector.get('Enterprise')
       $httpBackend = _$httpBackend_
       $httpBackend.whenGET('/admin/enterprises/for_order_cycle.json').respond [
-        {id: 1, name: 'One', is_primary_producer: true}
+        {id: 1, name: 'One', can_create_variants: true}
         {id: 2, name: 'Two'}
         {id: 3, name: 'Three', sells: 'any'}
         ]
@@ -17,7 +17,7 @@ describe 'Enterprise service', ->
     enterprises = Enterprise.index()
     $httpBackend.flush()
     expect(enterprises).toEqual
-      1: new Enterprise.Enterprise({id: 1, name: 'One', is_primary_producer: true})
+      1: new Enterprise.Enterprise({id: 1, name: 'One', can_create_variants: true})
       2: new Enterprise.Enterprise({id: 2, name: 'Two'})
       3: new Enterprise.Enterprise({id: 3, name: 'Three', sells: 'any'})
 
@@ -30,7 +30,7 @@ describe 'Enterprise service', ->
   it 'loads producers as an array', ->
     Enterprise.index()
     $httpBackend.flush()
-    expect(Enterprise.producer_enterprises).toEqual [new Enterprise.Enterprise({id: 1, name: 'One', is_primary_producer: true})]
+    expect(Enterprise.producer_enterprises).toEqual [new Enterprise.Enterprise({id: 1, name: 'One', can_create_variants: true})]
 
   it 'loads hubs as an array', ->
     Enterprise.index()

--- a/spec/lib/open_food_network/permissions_spec.rb
+++ b/spec/lib/open_food_network/permissions_spec.rb
@@ -364,6 +364,21 @@ RSpec.describe OpenFoodNetwork::Permissions do
     end
   end
 
+  describe "#enterprises_granted_linked_variants" do
+    it "returns only my enterprises that are granted permission to create_linked_variants" do
+      e1 = create(:enterprise)
+      create(:enterprise_relationship, parent: create(:enterprise), child: e1,
+                                       permissions_list: [:create_linked_variants])
+      e2 = create(:enterprise)
+      create(:enterprise_relationship, parent: create(:enterprise), child: e2,
+                                       permissions_list: [:manage_products])
+      # User manages two enterprises, which have different permissions.
+      allow(user).to receive(:enterprises).and_return([e1, e2])
+
+      expect(permissions.enterprises_granted_linked_variants).to eq([e1])
+    end
+  end
+
   ########################################
 
   describe "finding related enterprises with a particular permission" do

--- a/spec/lib/open_food_network/permissions_spec.rb
+++ b/spec/lib/open_food_network/permissions_spec.rb
@@ -364,7 +364,18 @@ RSpec.describe OpenFoodNetwork::Permissions do
     end
   end
 
-  describe "#enterprises_granted_linked_variants" do
+  describe "#enterprises_can_create_variants" do
+    let(:user) { create(:user) }
+
+    it "returns only my enterprises that are primary producers" do
+      e1 = create(:enterprise, is_primary_producer: true)
+      e2 = create(:enterprise, is_primary_producer: false)
+      user.enterprises = [e1, e2]
+      e3 = create(:enterprise, is_primary_producer: true) # someone else's enterprise
+
+      expect(permissions.enterprises_can_create_variants).to eq([e1])
+    end
+
     it "returns only my enterprises that are granted permission to create_linked_variants" do
       e1 = create(:enterprise)
       create(:enterprise_relationship, parent: create(:enterprise), child: e1,
@@ -373,9 +384,24 @@ RSpec.describe OpenFoodNetwork::Permissions do
       create(:enterprise_relationship, parent: create(:enterprise), child: e2,
                                        permissions_list: [:manage_products])
       # User manages two enterprises, which have different permissions.
-      allow(user).to receive(:enterprises).and_return([e1, e2])
+      user.enterprises = [e1, e2]
 
-      expect(permissions.enterprises_granted_linked_variants).to eq([e1])
+      # someone else's enterprise
+      e3 = create(:enterprise)
+      create(:enterprise_relationship, parent: create(:enterprise), child: e3,
+                                       permissions_list: [:create_linked_variants])
+
+      expect(permissions.enterprises_can_create_variants).to eq([e1])
+    end
+
+    it "avoids duplicates" do
+      # Enterprise is primary _and_ permitted create_linked_variants
+      e1 = create(:enterprise, is_primary_producer: true)
+      create(:enterprise_relationship, parent: create(:enterprise), child: e1,
+                                       permissions_list: [:create_linked_variants])
+      user.enterprises = [e1]
+
+      expect(permissions.enterprises_can_create_variants).to eq([e1])
     end
   end
 

--- a/spec/serializers/api/admin/for_order_cycle/enterprise_serializer_spec.rb
+++ b/spec/serializers/api/admin/for_order_cycle/enterprise_serializer_spec.rb
@@ -71,4 +71,32 @@ RSpec.describe Api::Admin::ForOrderCycle::EnterpriseSerializer do
       end
     end
   end
+
+  describe "can_create_variants" do
+    subject{ serialized_enterprise.can_create_variants }
+
+    context "producer" do
+      let(:enterprise) { create(:enterprise, is_primary_producer: true) }
+
+      it { is_expected.to be true }
+    end
+
+    context "not producer" do
+      let(:enterprise) { create(:enterprise, is_primary_producer: false) }
+
+      it { is_expected.to be false }
+
+      context "with create_linked_variants permission" do
+        before do
+          EnterpriseRelationship.create(
+            parent: create(:enterprise),
+            child: enterprise,
+            permissions_list: [:create_linked_variants]
+          )
+        end
+
+        it { is_expected.to be true }
+      end
+    end
+  end
 end

--- a/spec/services/exchange_products_renderer_spec.rb
+++ b/spec/services/exchange_products_renderer_spec.rb
@@ -25,6 +25,27 @@ RSpec.describe ExchangeProductsRenderer do
         )
       end
 
+      context "with variants owned by other enterprises" do
+        let(:enterprise) { create(:supplier_enterprise) }
+        let(:product) { create(:product, enterprise_id: enterprise.id) }
+        let(:my_variant) { product.variants.first }
+        let(:other_variant) { create(:variant, product:, enterprise: create(:enterprise)) }
+        let(:order_cycle) {
+          create(:simple_order_cycle, suppliers: [enterprise],
+                                      variants: [my_variant, other_variant] )
+        }
+
+        it "doesn't load variants owned by other enterprises" do
+          products = renderer.exchange_products(true, exchange.sender)
+          # #count on the variants association would produce the total number of 2, but due to
+          # filtering, the length of the array will be 1.
+          variants = products.first.variants.to_a
+
+          expect(variants.count).to eq 1
+          expect(variants.first.enterprise).to eq enterprise
+        end
+      end
+
       context "showing products from coordinator inventory only" do
         before {
           order_cycle.update prefers_product_selection_from_coordinator_inventory_only: true

--- a/spec/system/admin/products_v3/actions_spec.rb
+++ b/spec/system/admin/products_v3/actions_spec.rb
@@ -240,6 +240,7 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
     end
 
     describe "Create linked variant" do
+      let(:enterprise) { create(:supplier_enterprise, name: "My Hub Enterprise") }
       let!(:other_enterprise) { create(:supplier_enterprise, name: "Other enterprise") }
       let!(:other_variant) {
         create(:variant, display_name: "My friends box", enterprise: other_enterprise)
@@ -297,7 +298,7 @@ RSpec.describe 'As an enterprise user, I can perform actions on the products scr
 
             within last_box do
               # The linked variant must be owned by the enterprise that created it
-              expect(page).to have_content "My Enterprise"
+              expect(page).to have_content "My Hub Enterprise"
 
               # And I can perform actions on the new variant
               page.find(".vertical-ellipsis-menu").click

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -170,12 +170,6 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
       it "shows sourced variant with indicator" do
         visit admin_products_url
 
-        # Show Enterprise column
-        ofn_drop_down("Columns").click
-        within ofn_drop_down("Columns") do
-          check "Producer"
-        end
-
         within row_containing_name("Variant-sourced") do
           expect(page).to have_selector 'span[title*="Sourced from: "]'
           expect(page).to have_selector 'span[title*="Producer: Producer Enterprise"]'

--- a/spec/system/admin/products_v3/index_spec.rb
+++ b/spec/system/admin/products_v3/index_spec.rb
@@ -142,7 +142,8 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
 
     context "with sourced variant" do
       let(:source_enterprise) { create(:supplier_enterprise, name: "Producer Enterprise") }
-      let(:hub) { create(:distributor_enterprise) }
+      let(:enterprise) { create(:distributor_enterprise, name: "My Hub Enterprise") }
+      let(:other_hub) { create(:distributor_enterprise) }
       let!(:p1) { create(:product, name: "Product1", enterprise_id: source_enterprise.id) }
 
       let!(:v_source) { p1.variants.first }
@@ -151,14 +152,14 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
                          enterprise:)
       }
       let!(:enterprise_relationship) {
-        # Enterprise grants me access to manage their variant
+        # Enterprise grants me access to link to their variant
         create(:enterprise_relationship, parent: source_enterprise, child: enterprise,
-                                         permissions_list: [:manage_products])
+                                         permissions_list: [:create_linked_variants])
       }
 
       # I don't manage this hub, so shouldn't see see the sourced variant
       let!(:v_sourced_hidden) {
-        create(:variant, display_name: "Variant-hidden", product: p1, enterprise: hub)
+        create(:variant, display_name: "Variant-hidden", product: p1, enterprise: other_hub)
       }
 
       before do
@@ -169,13 +170,19 @@ RSpec.describe 'As an enterprise user, I can browse my products' do
       it "shows sourced variant with indicator" do
         visit admin_products_url
 
+        # Show Enterprise column
+        ofn_drop_down("Columns").click
+        within ofn_drop_down("Columns") do
+          check "Producer"
+        end
+
         within row_containing_name("Variant-sourced") do
           expect(page).to have_selector 'span[title*="Sourced from: "]'
           expect(page).to have_selector 'span[title*="Producer: Producer Enterprise"]'
 
           # Can't change the enterprise of a linked variant
           expect(page).not_to have_select "Enterprise"
-          expect(page).to have_content "My Enterprise"
+          expect(page).to have_content "My Hub Enterprise"
         end
 
         # But not variants sourced by other hubs


### PR DESCRIPTION
⚠️ Please use clockify code 76a Source variant when working on this

## What? Why?

- Closes #14229

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
As on issue:
> 1. As a producer, give the ability to a hub to create linked variants
> 2. check the hub can create _and_ edit them on `admin/products`
> 3. Check the hub can add them to their order cycle and in a shopfront the producer of the source variant is correctly displayed
> 4. Check the hub can give other enterprise "add to order cycle" permissions and that in this case, these enterprises can sell the same linked variants in their own OC

## Release notes
Considered feature toggled, behind "[BETA]" enterprise permission

## Documentation updates
I think it must be time to start documenting this in the guide.