### PR TITLE
Fix/wishlist 571 checkout layout consistency

### DIFF
--- a/app/views/checkout/_delivery_details.html.haml
+++ b/app/views/checkout/_delivery_details.html.haml
@@ -1,4 +1,5 @@
 %div
+  %br
   .summary-subtitle
     = t("checkout.step3.delivery_details.address")
   %span

--- a/app/views/checkout/_summary.html.haml
+++ b/app/views/checkout/_summary.html.haml
@@ -7,13 +7,21 @@
         %a.summary-edit{ href: main_app.checkout_step_path(:details), data: { action: "guest-checkout#removeUnloadEvent" } }
           = t("checkout.step3.delivery_details.edit")
 
-      .summary-subtitle
-        = @order.shipping_method.name
-        %em.fees= payment_or_shipping_price(@order.shipping_method, @order)
+      - if @order.shipping_method.delivery?
+        %div
+          = @order.shipping_method.name
+          %em.fees= payment_or_shipping_price(@order.shipping_method, @order)
       .two-columns
-        = render "delivery_details" if @order.shipping_method.delivery?
+        - if @order.shipping_method.delivery?
+          = render "delivery_details"
+        - else
+          %div
+            = @order.shipping_method.name
+            %em.fees= payment_or_shipping_price(@order.shipping_method, @order)
         - if @order.shipping_method.description.present?
           %div
+            - if @order.shipping_method.delivery?
+              %br
             .summary-subtitle
               = t("checkout.step3.delivery_details.instructions")
             %div


### PR DESCRIPTION
## What? Why?

- Closes openfoodfoundation/openfoodnetwork#14702

The checkout summary page (step 3) had two layout inconsistencies:

1. The shipping method name was wrapped in `.summary-subtitle` (bold), while
   the payment method name was not, making them visually inconsistent.
2. When the shipping method was a pick-up, the instructions block shifted to
   the left column because nothing occupied the left side of the two-column
   grid, making the layout chaotic.

**Delivery:** shipping method name + fees are displayed full-width above the
two-column grid. Left column shows the delivery address; right column shows
instructions — both subtitles vertically aligned.

**Pick-up:** the two-column grid is used directly. Left column shows the
shipping method name + fees; right column shows instructions.

## What should we test?

- Go to the shop, add a product to the cart and proceed to checkout.
- Complete steps 1 and 2, then reach the **Order summary** (step 3).
- With a **pick-up** shipping method:
  - Shipping method name appears in the left column (not bold).
  - Instructions appear in the right column, aligned with the method name.
  - No empty left column pushing instructions to the wrong side.
- With a **delivery** shipping method:
  - Shipping method name appears full-width above the two columns.
  - Left column shows the delivery address with "Delivery address" subtitle.
  - Right column shows instructions aligned with the "Delivery address" title.
- Verify the **payment method** name styling matches the shipping method name
  styling (both plain, not bold).

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes

## Dependencies

None.

## Documentation updates

None required.