### PR TITLE
Fix last_pending_paypal_payment for payments with no payment method

### DIFF
--- a/app/services/orders/find_payment_service.rb
+++ b/app/services/orders/find_payment_service.rb
@@ -25,7 +25,7 @@ module Orders
     def last_pending_paypal_payment
       last(
         @order.pending_payments.select do |payment|
-          payment.payment_method.type == "Spree::Gateway::PayPalExpress"
+          payment.payment_method&.type == "Spree::Gateway::PayPalExpress"
         end
       )
     end

--- a/spec/services/orders/find_payment_service_spec.rb
+++ b/spec/services/orders/find_payment_service_spec.rb
@@ -87,6 +87,18 @@ RSpec.describe Orders::FindPaymentService do
         expect(finder.last_customer_credit).to eq(last_credit_payment)
       end
     end
+
+    context "when the only pending payment has no associated payment method" do
+      let(:credit_payment) { nil }
+      let(:last_credit_payment) { nil }
+      let!(:payment_without_method) {
+        create(:payment, order:, state: "processing", payment_method: nil)
+      }
+
+      it "returns nil" do
+        expect(finder.last_customer_credit).to be_nil
+      end
+    end
   end
 
   describe "#last_pending_paypal_payment" do

--- a/spec/services/orders/find_payment_service_spec.rb
+++ b/spec/services/orders/find_payment_service_spec.rb
@@ -129,5 +129,15 @@ RSpec.describe Orders::FindPaymentService do
         expect(finder.last_pending_paypal_payment).to be_nil
       end
     end
+
+    context "when a pending payment has no associated payment method" do
+      let!(:payment_without_method) {
+        create(:payment, order:, state: "processing", payment_method: nil)
+      }
+
+      it "returns nil" do
+        expect(finder.last_pending_paypal_payment).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## What? Why?

- Closes #14639

`Orders::FindPaymentService#last_pending_paypal_payment` raised `NoMethodError` when a pending payment had no associated `payment_method`, since it called `payment.payment_method.type` without a nil check. Payments without a payment method should simply be excluded from the paypal lookup and the method should return `nil` in that case, consistent with the other "no match" scenarios already covered by this method.

While investigating, I checked the sibling method `last_customer_credit`, which compares `payment.payment_method == Spree::PaymentMethod.customer_credit` rather than calling a method on it, so it already safely returns `nil` for a payment with no payment method. Added a spec to document and lock in that existing behaviour rather than changing code that wasn't broken.

## What should we test?

- Covered by the added specs in `spec/services/orders/find_payment_service_spec.rb`:
  - `last_pending_paypal_payment` on an order whose only pending payment has no `payment_method` returns `nil` instead of raising.
  - `last_customer_credit` on an order whose only pending payment has no `payment_method` returns `nil` (already-correct behaviour, now covered by a spec).

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

## Dependencies

None.

## Documentation updates

None.