### PR TITLE
Fix enterprise privilege escalation

### DIFF
--- a/app/controllers/admin/enterprise_relationships_controller.rb
+++ b/app/controllers/admin/enterprise_relationships_controller.rb
@@ -15,6 +15,13 @@ module Admin
     def create
       @enterprise_relationship = EnterpriseRelationship.new enterprise_relationship_params
 
+      # Given that we get an empty object when checking for :create ability
+      # Admin::ResourceController, we can't check the user manages the parent enterprise with
+      # an ability. So we do it manually here.
+      unless spree_current_user.enterprises.include?(@enterprise_relationship.parent)
+        return head :forbidden
+      end
+
       if @enterprise_relationship.save
         render plain: Api::Admin::EnterpriseRelationshipSerializer
           .new(@enterprise_relationship).to_json

--- a/app/controllers/admin/enterprise_relationships_controller.rb
+++ b/app/controllers/admin/enterprise_relationships_controller.rb
@@ -15,10 +15,10 @@ module Admin
     def create
       @enterprise_relationship = EnterpriseRelationship.new enterprise_relationship_params
 
-      # Given that we get an empty object when checking for :create ability
+      # Given that we get an empty object when checking for :create ability in
       # Admin::ResourceController, we can't check the user manages the parent enterprise with
       # an ability. So we do it manually here.
-      unless spree_current_user.enterprises.include?(@enterprise_relationship.parent)
+      unless can_grant_permission?
         return head :forbidden
       end
 
@@ -41,6 +41,12 @@ module Admin
 
     def enterprise_relationship_params
       params.require(:enterprise_relationship).permit(:parent_id, :child_id, permissions_list: [])
+    end
+
+    def can_grant_permission?
+      return true if spree_current_user.admin
+
+      spree_current_user.enterprises.include?(@enterprise_relationship.parent)
     end
   end
 end

--- a/app/controllers/admin/enterprise_relationships_controller.rb
+++ b/app/controllers/admin/enterprise_relationships_controller.rb
@@ -13,14 +13,14 @@ module Admin
     end
 
     def create
-      @enterprise_relationship = EnterpriseRelationship.new enterprise_relationship_params
-
       # Given that we get an empty object when checking for :create ability in
       # Admin::ResourceController, we can't check the user manages the parent enterprise with
       # an ability. So we do it manually here.
       unless can_grant_permission?
-        return head :forbidden
+        raise CanCan::AccessDenied
       end
+
+      @enterprise_relationship = EnterpriseRelationship.new enterprise_relationship_params
 
       if @enterprise_relationship.save
         render plain: Api::Admin::EnterpriseRelationshipSerializer
@@ -44,9 +44,9 @@ module Admin
     end
 
     def can_grant_permission?
-      return true if spree_current_user.admin
-
-      spree_current_user.enterprises.include?(@enterprise_relationship.parent)
+      OpenFoodNetwork::Permissions.new(spree_current_user).managed_enterprises.where(
+        id: enterprise_relationship_params[:parent_id]
+      ).exists?
     end
   end
 end

--- a/spec/requests/admin/enterprise_relationships_spec.rb
+++ b/spec/requests/admin/enterprise_relationships_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe "/admin/enterprise_relationships" do
+  let(:enterprise) { create(:supplier_enterprise, name: "Parent") }
+  let(:enterprise_user) { create(:user, enterprise_limit: 1) }
+  let(:child_enterprise) { create(:supplier_enterprise, name: "Child") }
+
+  before do
+    enterprise_user.enterprise_roles.build(enterprise:).save
+    sign_in enterprise_user
+  end
+
+  describe "POST /admin/enterprises/" do
+    it "creates a new relationshsip" do
+      params = {
+        enterprise_relationship: {
+          parent_id: enterprise.id,
+          child_id: child_enterprise.id,
+          permissions_list: ["manage_products"]
+        }
+      }
+      post(admin_enterprise_relationships_path(enterprise), params: )
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.parsed_body)
+      expect(json["parent_id"]).to eq(enterprise.id)
+      expect(json["child_id"]).to eq(child_enterprise.id)
+      expect(json["permissions"][0]["name"]).to eq("manage_products")
+    end
+
+    context "with a parent enterprise the user doesn't manage" do
+      it "returns forbidden" do
+        other_enterprise = create(:supplier_enterprise)
+        params = {
+          enterprise_relationship: {
+            parent_id: other_enterprise.id,
+            child_id: child_enterprise.id,
+            permissions_list: ["manage_products"]
+          }
+        }
+        post(admin_enterprise_relationships_path(enterprise), params: )
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when an error occurs when saving the relationship" do
+      it "returs a bad request with an error message" do
+        params = {
+          enterprise_relationship: {
+            parent_id: enterprise.id,
+            child_id: -99,
+            permissions_list: ["manage_products"]
+          }
+        }
+
+        post(admin_enterprise_relationships_path(enterprise), params: )
+
+        json = response.parsed_body
+        expect(response).to have_http_status(:bad_request)
+        expect(json["errors"]).to eq("Child must exist")
+      end
+    end
+  end
+end

--- a/spec/requests/admin/enterprise_relationships_spec.rb
+++ b/spec/requests/admin/enterprise_relationships_spec.rb
@@ -44,6 +44,33 @@ RSpec.describe "/admin/enterprise_relationships" do
       end
     end
 
+    context "with an admin user" do
+      let(:admin) { create(:user, admin: true) }
+
+      before do
+        sign_in admin
+      end
+
+      it "can add permission for an enterprise they don't manage" do
+        other_enterprise = create(:supplier_enterprise)
+
+        params = {
+          enterprise_relationship: {
+            parent_id: other_enterprise.id,
+            child_id: child_enterprise.id,
+            permissions_list: ["manage_products"]
+          }
+        }
+        post(admin_enterprise_relationships_path(enterprise), params: )
+
+        expect(response).to have_http_status(:ok)
+
+        relation = EnterpriseRelationship.where(parent: other_enterprise,
+                                                child: child_enterprise).first
+        expect(relation.permissions_list).to include("manage_products")
+      end
+    end
+
     context "when an error occurs when saving the relationship" do
       it "returs a bad request with an error message" do
         params = {

--- a/spec/requests/admin/enterprise_relationships_spec.rb
+++ b/spec/requests/admin/enterprise_relationships_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "/admin/enterprise_relationships" do
         }
         post(admin_enterprise_relationships_path(enterprise), params: )
 
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to redirect_to unauthorized_path
       end
     end
 

--- a/spec/requests/admin/enterprise_relationships_spec.rb
+++ b/spec/requests/admin/enterprise_relationships_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe "/admin/enterprise_relationships" do
       expect(json["parent_id"]).to eq(enterprise.id)
       expect(json["child_id"]).to eq(child_enterprise.id)
       expect(json["permissions"][0]["name"]).to eq("manage_products")
+
+      relation = EnterpriseRelationship.where(parent: enterprise, child: child_enterprise).first
+      expect(relation.permissions_list).to include("manage_products")
     end
 
     context "with a parent enterprise the user doesn't manage" do


### PR DESCRIPTION
## What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/security/advisories/GHSA-76cj-668v-vc5x <!-- Insert issue number here. -->

This PR add a check on the parent enterprise to make sure it's an enterprise the current user can manage, thus preventing a user from granting themselves privilege on enterprise any enterprise.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Enterprise permission are managed via Enterprises -> Permissions in the backoffice
As an enteprise manager :
- craft a permission granting request (using Curl or similar ) using an enterprise id the user doesn't manage as the `parent_id`
  -> You should get a Forbidden error 

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.