### PR TITLE
Fix loading scope for payment

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -3,7 +3,7 @@
 module Spree
   module Admin
     class PaymentsController < Spree::Admin::BaseController
-      before_action :load_order, except: [:show]
+      before_action :load_order
       before_action :load_payment, only: [:fire, :show]
       before_action :load_data, except: [:credit_customer]
       before_action :can_transition_to_payment
@@ -182,7 +182,7 @@ module Spree
       end
 
       def load_payment
-        @payment = Payment.find(params[:id])
+        @payment = @order.payments.find(params[:id])
       end
 
       def authorize_stripe_sca_payment

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Spree::Admin::PaymentsController do
 
       before do
         request.env["HTTP_REFERER"] = "http://test.host"
-        allow(Spree::Payment).to receive(:find).with(payment.id.to_s) { payment }
+        return_mocked_payment(payment)
       end
 
       it 'handles gateway errors' do
@@ -193,7 +193,7 @@ RSpec.describe Spree::Admin::PaymentsController do
 
       before do
         request.env["HTTP_REFERER"] = "http://test.host"
-        allow(Spree::Payment).to receive(:find).with(payment.id.to_s) { payment }
+        return_mocked_payment(payment)
       end
 
       it 'handles gateway errors' do
@@ -231,7 +231,7 @@ RSpec.describe Spree::Admin::PaymentsController do
       before do
         allow(PaymentMailer).to receive(:authorize_payment) { mail_mock }
         request.env["HTTP_REFERER"] = "http://test.host"
-        allow(Spree::Payment).to receive(:find).with(payment.id.to_s) { payment }
+        return_mocked_payment(payment)
         allow(payment).to receive(:redirect_auth_url).and_return("https://www.stripe.com/authorize")
         allow(payment).to receive(:requires_authorization?) { true }
       end
@@ -250,7 +250,7 @@ RSpec.describe Spree::Admin::PaymentsController do
 
       before do
         request.env["HTTP_REFERER"] = "http://test.host"
-        allow(Spree::Payment).to receive(:find).with(payment.id.to_s) { payment }
+        return_mocked_payment(payment)
       end
 
       it 'does not process the event' do
@@ -328,5 +328,10 @@ RSpec.describe Spree::Admin::PaymentsController do
         expect(response.location).to eq spree.edit_admin_order_url(order)
       end
     end
+  end
+
+  def return_mocked_payment(payment)
+    allow(Spree::Order).to receive(:find_by!).and_return(order)
+    allow(order.payments).to receive(:find).with(payment.id.to_s).and_return(payment)
   end
 end

--- a/spec/requests/spree/admin/payments_spec.rb
+++ b/spec/requests/spree/admin/payments_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe Spree::Admin::PaymentsController do
 
     context "with 'void' event" do
       before do
-        allow(Spree::Payment).to receive(:find).and_return(payment)
+        return_mocked_payment(payment)
       end
 
       it "calls void_transaction! on payment" do
@@ -276,7 +276,7 @@ RSpec.describe Spree::Admin::PaymentsController do
 
     context "with 'capture_and_complete_order' event" do
       before do
-        allow(Spree::Payment).to receive(:find).and_return(payment)
+        return_mocked_payment(payment)
       end
 
       it "calls capture_and_complete_order! on payment" do
@@ -390,7 +390,7 @@ RSpec.describe Spree::Admin::PaymentsController do
 
     context "when something unexpected happen" do
       before do
-        allow(Spree::Payment).to receive(:find).and_return(payment)
+        return_mocked_payment(payment)
         allow(payment).to receive(:void_transaction!).and_raise(StandardError, "Unexpected !")
       end
 
@@ -468,5 +468,10 @@ RSpec.describe Spree::Admin::PaymentsController do
   def add_voucher_to_order(voucher, order)
     voucher.create_adjustment(voucher.code, order)
     OrderManagement::Order::Updater.new(order).update_voucher
+  end
+
+  def return_mocked_payment(payment)
+    allow(Spree::Order).to receive(:find_by!).and_return(order)
+    allow(order.payments).to receive(:find).with(payment.id.to_s).and_return(payment)
   end
 end

--- a/spec/requests/spree/admin/payments_spec.rb
+++ b/spec/requests/spree/admin/payments_spec.rb
@@ -8,6 +8,46 @@ RSpec.describe Spree::Admin::PaymentsController do
     sign_in user
   end
 
+  describe "GET /admin/order/:order_number/payments/:id" do
+    let(:payment) do
+      create(
+        :payment,
+        order:,
+        response_code: "pi_123",
+        amount: order.total,
+        state: "completed"
+      )
+    end
+
+    before do
+      order.update(payments: [])
+      order.payments << payment
+    end
+
+    it "shows a payment" do
+      get "/admin/orders/#{order.number}/payments/#{payment.id}"
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "with a payment that doesn't belong to the order" do
+      let(:other_payment) do
+        create(
+          :payment,
+          response_code: "pi_123",
+          amount: 250.00,
+          state: "completed"
+        )
+      end
+
+      it "returns not found" do
+        get "/admin/orders/#{order.number}/payments/#{other_payment.id}"
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe "POST /admin/orders/:order_number/payments.json" do
     let(:params) do
       {
@@ -167,7 +207,29 @@ RSpec.describe Spree::Admin::PaymentsController do
       end
     end
 
-    # TODO with internal_void event
+    context "with a payment that doesn't belong to the order" do
+      let(:other_payment) do
+        create(
+          :payment,
+          payment_method: stripe_payment_method,
+          response_code: "pi_123",
+          amount: 250.00,
+          state: "completed"
+        )
+      end
+
+      it "returns not found" do
+        put(
+          "/admin/orders/#{order.number}/payments/#{other_payment.id}/fire?e=void",
+          params: {},
+          headers:
+        )
+
+        expect(response).to have_http_status(:not_found)
+        expect(other_payment.reload.state).to eq("completed")
+      end
+    end
+
     context "with 'void' event" do
       before do
         allow(Spree::Payment).to receive(:find).and_return(payment)


### PR DESCRIPTION
## What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/security/advisories/GHSA-gvhh-8qj9-6gr3 <!-- Insert issue number here. -->

Properly scope loading payment to the current order, it prevents user from manipulating payments not related to the current order.


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

As an enterprise manager
- Try accessing a payment you should not have access to : http://<ofn-instance>/admin/orders/<order_number>/payments/<payment_not_linked_to_order.id>
  --> you should get a Not found error

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.