### PR TITLE
Fix flaky shipping method order

### DIFF
--- a/engines/order_management/app/services/order_management/stock/package.rb
+++ b/engines/order_management/app/services/order_management/stock/package.rb
@@ -80,7 +80,7 @@ module OrderManagement
       def shipping_methods
         return [] if order.distributor.blank?
 
-        order.distributor.shipping_methods.uniq.to_a
+        order.distributor.shipping_methods.order(:id).uniq.to_a
       end
 
       def inspect


### PR DESCRIPTION

## What? Why?

- Fixes https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/31979652599/job/95244288832

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I couldn't reproduce it locally but it failed in CI once:

```
Failures:

  1) Spree::Shipment shipping_rates refresh_rates should request new rates, and maintain shipping_method selection
     Failure/Error: expect(shipment.refresh_rates).to eq shipping_rates

       expected: [#<Spree::ShippingRate id: 204, shipment_id: 168, shipping_method_id: 165, selected: true, cost: 0.1e...eated_at: "2026-08-16 23:42:29.155440552 +0000", updated_at: "2026-08-16 23:42:29.155440552 +0000">]
            got: #<ActiveRecord::Associations::CollectionProxy [#<Spree::ShippingRate id: 205, shipment_id: 168, shipp...ated_at: "2026-08-16 23:42:29.154504000 +0000", updated_at: "2026-08-16 23:42:29.154504000 +0000">]>

       (compared using ==)

       Diff:
       @@ -1,2 +1,16 @@
       -[#<Spree::ShippingRate id: 204, shipment_id: 168, shipping_method_id: 165, selected: true, cost: 0.1e2, created_at: "2026-08-16 23:42:29.154504237 +0000", updated_at: "2026-08-16 23:42:29.154504237 +0000">,
       - #<Spree::ShippingRate id: 205, shipment_id: 168, shipping_method_id: 166, selected: false, cost: 0.2e2, created_at: "2026-08-16 23:42:29.155440552 +0000", updated_at: "2026-08-16 23:42:29.155440552 +0000">]
       +[#<Spree::ShippingRate:0x00007fe50a81de80
       +  id: 205,
       +  shipment_id: 168,
       +  shipping_method_id: 166,
       +  selected: true,
       +  cost: 0.2e2,
       +  created_at: "2026-08-16 23:42:29.155440000 +0000",
       +  updated_at: "2026-08-16 23:42:29.158202000 +0000">,
       + #<Spree::ShippingRate:0x00007fe50a81dd40
       +  id: 204,
       +  shipment_id: 168,
       +  shipping_method_id: 165,
       +  selected: false,
       +  cost: 0.1e2,
       +  created_at: "2026-08-16 23:42:29.154504000 +0000",
       +  updated_at: "2026-08-16 23:42:29.154504000 +0000">]

     # ./spec/models/spree/shipment_spec.rb:127:in 'block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:159:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:159:in 'block (2 levels) in <top (required)>'

Finished in 2 minutes 41.9 seconds (files took 8.94 seconds to load)
557 examples, 1 failure, 2 pending

Failed examples:

rspec ./spec/models/spree/shipment_spec.rb:120 # Spree::Shipment shipping_rates refresh_rates should request new rates, and maintain shipping_method selection
https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/31979652599/job/95244288832
```


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
