### PR TITLE
Let the footer keep room for its logo instead of the .footer-pad class

### DIFF
--- a/app/views/checkout/edit.html.haml
+++ b/app/views/checkout/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for(:title) do
   = checkout_page_title
 
-.darkswarm.footer-pad{"data-turbo": "true"}
+.darkswarm{"data-turbo": "true"}
   - content_for :order_cycle_form do
     %closing
       = t :checkout_now

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -4,7 +4,7 @@
 - content_for :injection_data do
   = inject_groups
 
-#groups.pad-top.footer-pad{"ng-controller" => "GroupsCtrl"}
+#groups.pad-top{"ng-controller" => "GroupsCtrl"}
   .row
     .small-12.medium-6.medium-offset-3.columns.text-center
       %h1

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -17,7 +17,7 @@
   - cache(*CacheService::FragmentCaching.ams_all_properties) do
     = inject_properties
 
-#group-page.row.pad-top.footer-pad{"ng-controller" => "GroupPageCtrl"}
+#group-page.row.pad-top{"ng-controller" => "GroupPageCtrl"}
   .small-12.columns.pad-top
     %header
       .row

--- a/app/views/groups/signup.html.haml
+++ b/app/views/groups/signup.html.haml
@@ -67,7 +67,7 @@
         %a.button.transparent{href: "hello@openfoodnetwork.org?subject=I'd%20like%20to%20talk%20to%20you%20about%20groups%20on%20the%20Open%20Food%20Network".reverse, target: '_blank', mailto: true}
           = t :groups_signup_email
 
-  #hub-details.pane.footer-pad
+  #hub-details.pane
     .row
       .small-12.medium-10.medium-offset-1.columns
         %h2.text-center

--- a/app/views/producers/signup.html.haml
+++ b/app/views/producers/signup.html.haml
@@ -42,7 +42,7 @@
         %a.button.transparent{href: "/register"}
           = t :producers_signup_cta_action
 
-  #producer-details.pane.footer-pad
+  #producer-details.pane
     .row
       .small-12.medium-10.medium-offset-1.columns
         %h2.text-center

--- a/app/views/shop/messages/_customer_required.html.haml
+++ b/app/views/shop/messages/_customer_required.html.haml
@@ -1,5 +1,5 @@
 .content
-  .row.footer-pad
+  .row
     .small-12.columns{ "data-controller": "login-modal" }
       %strong
         = t '.require_customer_login'

--- a/app/views/shop/messages/_select_oc.html.haml
+++ b/app/views/shop/messages/_select_oc.html.haml
@@ -1,4 +1,4 @@
-.content.footer-pad{ "ng-show" => "order_cycle.order_cycle_id == null" }
+.content{ "ng-show" => "order_cycle.order_cycle_id == null" }
   .row
     .small-12.columns
       .select-oc-message

--- a/app/views/shop/products/_form.html.haml
+++ b/app/views/shop/products/_form.html.haml
@@ -7,7 +7,7 @@
       = render partial: "shop/products/searchbar"
 
       .row
-        .footer-pad.small-12.columns.product-listing
+        .small-12.columns.product-listing
           .row.full
             .medium-12.large-9.columns.full
               = render partial: "shop/products/search_feedback"

--- a/app/views/shops/signup.html.haml
+++ b/app/views/shops/signup.html.haml
@@ -41,7 +41,7 @@
         %a.button.transparent{href: "/register"}
           = t :shops_signup_action
 
-  #hub-details.pane.footer-pad
+  #hub-details.pane
     .row
       .small-12.medium-10.medium-offset-1.columns
         %h2.text-center

--- a/app/views/spree/orders/show.html.haml
+++ b/app/views/spree/orders/show.html.haml
@@ -7,7 +7,7 @@
 .darkswarm
   = render "shopping_shared/header" if current_distributor.present?
 
-  %fieldset#order_summary.footer-pad
+  %fieldset#order_summary
     .row
       .columns.large-12.text-center
         %h2

--- a/app/views/spree/users/show.html.haml
+++ b/app/views/spree/users/show.html.haml
@@ -23,7 +23,7 @@
     = render 'settings'
     = render 'developer_settings' if @user.show_api_key_view
 
-  .row.tabset-ctrl#account-tabs{ style: 'margin-bottom: 100px', navigate: 'true', selected: 'orders', prefix: 'account' }
+  .row.tabset-ctrl#account-tabs{ navigate: 'true', selected: 'orders', prefix: 'account' }
     .small.12.medium-3.columns.tab{ name: "orders" }
       %a=t('.tabs.orders')
     - if Spree::Config.stripe_connect_enabled && Stripe.publishable_key

--- a/app/webpacker/css/darkswarm/cart-page.scss
+++ b/app/webpacker/css/darkswarm/cart-page.scss
@@ -1,6 +1,5 @@
 #cart-container {
   padding: 25px;
-  padding-bottom: 100px;
 }
 
 #update-cart {

--- a/app/webpacker/css/darkswarm/footer.scss
+++ b/app/webpacker/css/darkswarm/footer.scss
@@ -1,3 +1,31 @@
+// The logo pokes out of the top of the footer and overlaps the page above it.
+// Pages used to leave room for it with the `.footer-pad` class. The footer asks
+// for that room itself now: whatever sits directly above the footer keeps space
+// below its content, so that its background still runs into the footer.
+//
+// This selector is deliberately weak: sections which set their own bottom
+// padding, like the hub, producer and group lists, have room already and keep
+// what they have.
+:has(+ footer) {
+  padding-bottom: $footer-clearance;
+}
+
+// Panes span the full width of the page and bring their own background. The
+// room for the logo belongs inside the last pane, not below it.
+#panes:has(+ footer) {
+  padding-bottom: 0;
+
+  > .pane:last-child {
+    padding-bottom: $footer-clearance;
+  }
+}
+
+// Same for the shop: its panel paints the background and keeps the room
+// (see shop_tabs.scss).
+shop:has(+ footer) {
+  padding-bottom: 0;
+}
+
 footer {
   .row {
     p {
@@ -18,17 +46,17 @@ footer {
 
   .footer-global {
     background-color: $ofn-grey;
-    padding-top: 60px;
+    padding-top: $footer-padding-top;
     padding-bottom: 40px;
 
     .logo {
-      width: 200px;
-      height: 200px;
+      width: $footer-logo-size;
+      height: $footer-logo-size;
       background: $ofn-grey;
 
       @include border-radius(120px);
 
-      margin: (-140px) auto 0 auto;
+      margin: (-$footer-logo-offset) auto 0 auto;
 
       img {
         margin-top: 36px;

--- a/app/webpacker/css/darkswarm/shop_tabs.scss
+++ b/app/webpacker/css/darkswarm/shop_tabs.scss
@@ -77,7 +77,9 @@
   .page-view {
     background: none;
     border: none;
-    padding-bottom: 5em;
+
+    // Keeps room for the logo poking out of the footer below.
+    padding-bottom: $footer-clearance;
 
     .content {
       padding: 1.25em 0;

--- a/app/webpacker/css/darkswarm/typography.scss
+++ b/app/webpacker/css/darkswarm/typography.scss
@@ -117,10 +117,6 @@ ul.check-list {
   font-weight: normal;
 }
 
-.footer-pad {
-  padding-bottom: 100px;
-}
-
 // These selectors match the default Foundation selectors
 // For clean overriden magic
 table tr th, table tr td {

--- a/app/webpacker/css/darkswarm/variables.scss
+++ b/app/webpacker/css/darkswarm/variables.scss
@@ -37,6 +37,14 @@ $sidebar-medium-width: 65%;
 $sidebar-large-width: 45%;
 $sidebar-footer-height: 5em;
 
+// The logo of the global footer is pulled up out of the footer and pokes into
+// the page above it. Pages need to keep that much room below their content.
+$footer-logo-size: 200px;
+$footer-logo-offset: 140px; // how far the logo is pulled up out of the footer
+$footer-padding-top: 60px;
+$footer-logo-overhang: $footer-logo-offset - $footer-padding-top;
+$footer-clearance: $footer-logo-overhang + 20px;
+
 $radius-small: 0.25em;
 $radius-medium: 0.5em;
 


### PR DESCRIPTION
## What? Why?

The logo of the global footer is pulled up out of the footer and pokes into the page above it. Every page that ended with content close to the footer had to remember to add the `.footer-pad` class to leave room for it, and a couple of pages hard-coded the same 100px in their own styles.

The footer asks for that room itself now. Whatever element sits directly above the footer keeps space below its content:

```scss
:has(+ footer) {
  padding-bottom: $footer-clearance;
}
```

Padding rather than a margin on the footer, because a margin sits outside every background: the pink, mint and grey sections would stop short of the footer and the logo would float in a band of body white. With padding, the page's own background still runs all the way into the footer.

The selector is deliberately weak (it weighs a single type selector), so sections which already pad themselves - the hub, producer and group lists - keep what they have and nothing doubles up. Panes and the shop panel paint their background one level deeper, so they get the room inside them instead.

The amount is no longer a magic number. The logo is pulled up 140px while the footer pads 60px, so 80px of it hangs over the page, plus a little breathing room:

```scss
$footer-logo-overhang: $footer-logo-offset - $footer-padding-top;
$footer-clearance: $footer-logo-overhang + 20px;
```

Gone with `.footer-pad`: its ten uses in templates, `padding-bottom: 100px` on `#cart-container`, and the inline `margin-bottom: 100px` on the account tabs.

Note on the shopfront: `<shop>` is a custom element, which browsers lay out inline, so padding on it does nothing. The room goes on `.page-view` in `shop_tabs.scss`, which is the element painting the panel background. Its `5em` became the shared `$footer-clearance`, which is why the shopfront grows 20px.

## What should we test?

Scroll to the bottom of these pages and check that the logo doesn't clash with the page content and that the background above the footer looks unchanged:

- Home page and /sell - both end with 100px more of their own background than before, everything else looks the same.
- /shops, /producers, /groups, a group page, /shops/signup, /producers/signup - unchanged to the pixel, verified against master.
- A shopfront: with an open order cycle, with none selected, and when the shop is closed. Also as a customer of a shop that requires login.
- Cart, checkout and order confirmation. These need a session, so I couldn't compare them automatically - they wrap their content in a plain `.darkswarm` div which the generic rule pads.
- The account page, which used to carry the inline margin.
- An embedded shopfront, where the footer is hidden.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
