### PR TITLE
Remove Supplier and Hub columns from spree_variants table

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -11,8 +11,6 @@ module Spree
 
     self.belongs_to_required_by_default = false
 
-    self.ignored_columns += ['hub_id', 'supplier_id']
-
     # 2 not to be persisted attributes to store preferences.
     # Values to be set via the UI that can be passed by back to UI
     # in a not yet persisted variant. Setters are below.

--- a/db/migrate/20260818061627_remove_supplier_and_hub_from_variants.rb
+++ b/db/migrate/20260818061627_remove_supplier_and_hub_from_variants.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveSupplierAndHubFromVariants < ActiveRecord::Migration[7.2]
+  def change
+    remove_reference :spree_variants, :supplier, foreign_key: { to_table: :enterprises }
+    remove_reference :spree_variants, :hub, foreign_key: { to_table: :enterprises }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_17_124355) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_18_061627) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -1001,18 +1001,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_17_124355) do
     t.bigint "tax_category_id"
     t.bigint "shipping_category_id"
     t.bigint "primary_taxon_id"
-    t.bigint "supplier_id"
     t.float "variant_unit_scale"
     t.string "variant_unit_name", limit: 255
-    t.bigint "hub_id"
     t.bigint "enterprise_id"
     t.index ["enterprise_id"], name: "index_spree_variants_on_enterprise_id"
-    t.index ["hub_id"], name: "index_spree_variants_on_hub_id"
     t.index ["primary_taxon_id"], name: "index_spree_variants_on_primary_taxon_id"
     t.index ["product_id"], name: "index_variants_on_product_id"
     t.index ["shipping_category_id"], name: "index_spree_variants_on_shipping_category_id"
     t.index ["sku"], name: "index_spree_variants_on_sku"
-    t.index ["supplier_id"], name: "index_spree_variants_on_supplier_id"
     t.index ["tax_category_id"], name: "index_spree_variants_on_tax_category_id"
     t.check_constraint "unit_value > 0::double precision", name: "positive_unit_value"
   end
@@ -1267,8 +1263,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_17_124355) do
   add_foreign_key "spree_users", "spree_addresses", column: "bill_address_id", name: "spree_users_bill_address_id_fk"
   add_foreign_key "spree_users", "spree_addresses", column: "ship_address_id", name: "spree_users_ship_address_id_fk"
   add_foreign_key "spree_variants", "enterprises"
-  add_foreign_key "spree_variants", "enterprises", column: "hub_id"
-  add_foreign_key "spree_variants", "enterprises", column: "supplier_id"
   add_foreign_key "spree_variants", "spree_products", column: "product_id", name: "spree_variants_product_id_fk"
   add_foreign_key "spree_variants", "spree_shipping_categories", column: "shipping_category_id"
   add_foreign_key "spree_variants", "spree_tax_categories", column: "tax_category_id"


### PR DESCRIPTION
```
⚠️ Please use clockify code 76a Sourced variant when working on this
```

## What? Why?

- Finally closes #14201 



## What should we test?
I think green specs should be sufficient.

## Dependencies
- Requires https://github.com/openfoodfoundation/openfoodnetwork/pull/14590 to be released and deployed first (probably after 24th August)