### PR TITLE
Stop the state spec from deleting the seeded states

### DIFF
--- a/spec/models/spree/state_spec.rb
+++ b/spec/models/spree/state_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Spree::State do
-  before(:all) do
-    Spree::State.destroy_all
-  end
-
   it "can find a state by name or abbr" do
     state = create(:state, name: "California", abbr: "CA")
     expect(Spree::State.find_all_by_name_or_abbr("California")).to include(state)

--- a/spec/support/seeds.rb
+++ b/spec/support/seeds.rb
@@ -6,19 +6,29 @@
 # Countries and states are seeded once in the beginning. The database cleaner
 # leaves them there when deleting the rest (see spec/spec_helper.rb).
 # You can add more entries here if you need them for your tests.
+#
+# Every record is seeded on its own so that a partially seeded database is
+# completed instead of being left in an inconsistent state.
 
-if Spree::Country.where(name: "Australia").empty?
-  Spree::Country.create!({ "name" => "Australia", "iso3" => "AUS", "iso" => "AU",
-                           "iso_name" => "AUSTRALIA", "numcode" => "36" })
-  country = Spree::Country.find_by(name: 'Australia')
-  Spree::State.create!({ "name" => "Victoria", "abbr" => "Vic", :country => country })
-  Spree::State.create!({ "name" => "New South Wales", "abbr" => "NSW", :country => country })
-end
+{
+  { "name" => "Australia", "iso3" => "AUS", "iso" => "AU",
+    "iso_name" => "AUSTRALIA", "numcode" => "36" } => [
+      { "name" => "Victoria", "abbr" => "Vic" },
+      { "name" => "New South Wales", "abbr" => "NSW" },
+    ],
+  { "name" => "France", "iso3" => "FRA", "iso" => "FR",
+    "iso_name" => "FRANCE", "numcode" => "250" } => [
+      { "name" => "Alsace", "abbr" => "Als" },
+      { "name" => "Aquitaine", "abbr" => "Aq" },
+    ],
+}.each do |country_attributes, states|
+  country = Spree::Country.find_or_create_by!(name: country_attributes["name"]) do |new_country|
+    new_country.attributes = country_attributes
+  end
 
-if Spree::Country.where(name: "France").empty?
-  Spree::Country.create!({ "name" => "France", "iso3" => "FRA", "iso" => "FR",
-                           "iso_name" => "FRANCE", "numcode" => "250" })
-  country = Spree::Country.find_by(name: 'France')
-  Spree::State.create!({ "name" => "Alsace", "abbr" => "Als", :country => country })
-  Spree::State.create!({ "name" => "Aquitaine", "abbr" => "Aq", :country => country })
+  states.each do |state_attributes|
+    Spree::State.find_or_create_by!(name: state_attributes["name"], country:) do |new_state|
+      new_state.abbr = state_attributes["abbr"]
+    end
+  end
 end


### PR DESCRIPTION
## What? Why?

`spec/models/spree/state_spec.rb` called `Spree::State.destroy_all` in a
`before(:all)` hook. That hook runs outside of the per-example transaction, so
the delete was committed rather than rolled back.

The seeded countries and states are meant to survive that: the database cleaner
excludes `spree_countries` and `spree_states`, and `spec/support/seeds.rb` runs
once when the process boots. But the seeds only re-created the states inside a
`Spree::Country.where(name: ...).empty?` guard. The countries were still there,
so the guard skipped, and the states were never restored.

Locally that means any run of `spec/models` before `spec/requests`, `spec/system`
or `spec/views` leaves the database without states for the rest of the run, and
for every run after it, until the states happen to be re-seeded by hand.

Two changes:

1. Remove the `before(:all)` hook. `git log` shows it was added for a second
   example that asserted the exact result of `states_group_by_country_id`. That
   example has since been deleted, and the remaining one matches with `include`,
   so nothing needs the states gone any more.

2. Seed each country and each state on its own with `find_or_create_by!`,
   instead of guarding a whole group of records on the absence of one of them.
   A partially seeded database now gets completed instead of being left as it is,
   so we recover from this class of problem rather than carrying it forward.

## What should we test?

This only touches the test setup, so there is nothing to click through. CI
covers it, and locally:

- `bundle exec rspec spec/models/spree/state_spec.rb` still passes, and leaves
  the four seeded states in place afterwards (`Spree::State.count` == 4).
- Deleting the states by hand and then booting the specs restores them:
  `Spree::State.destroy_all` followed by any spec run gives 4 states and still
  only 2 countries, so nothing is duplicated.
- Specs that look the seeded states up directly still pass, for example
  `spec/models/spree/zone_spec.rb`,
  `spec/controllers/api/v0/states_controller_spec.rb`,
  `spec/controllers/concerns/address_transformation_spec.rb` and
  `spec/controllers/admin/enterprises_controller_spec.rb`.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only
