### PR TITLE
Fix extra slash in CQCM authentification issuer URL

### DIFF
--- a/engines/dfc_provider/app/services/authorization_control.rb
+++ b/engines/dfc_provider/app/services/authorization_control.rb
@@ -17,7 +17,7 @@ class AuthorizationControl
       -----END PUBLIC KEY-----
     KEY
 
-    "https:///authentification.cqcm.coop/realms/cqcm" => <<~KEY,
+    "https://authentification.cqcm.coop/realms/cqcm" => <<~KEY,
       -----BEGIN PUBLIC KEY-----
       MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhz7dK3xQAWL+u++E/64T1OHEvnFrZRLzgCmw0leib3JL/XbaE4Jbd3fs2+zc3+dCwvCuLEKKO9Hc9wg79ifjtMKFfZDE1Ba+qhw7J9tYnu7TBtaxKuWUCdtwuultEdW+NFndaUvhD/TdyjDkRiO98mgvUbm2A3q/zyDmoUpR2IEfevkMSz8MnxUo1bDTJIyoYoKwnbToI1E9RVx2uYsYKk24Pfd+r6oTbi7TxA6Ia4EiREFki2gNIAdp66IqF0Gxyd+nGlkIbQGrW+9xynU4ar3ZNq/P8EZFdO57AdEvC3ZAzpTvOVcQ0cQ4XbRSYWQHyZ8jnjggpeddTGSqVlgx1wIDAQAB
       -----END PUBLIC KEY-----


### PR DESCRIPTION
## What? Why?

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The `AuthorizationControl::PUBLIC_KEYS` hash had `https:///authentification.cqcm.coop/realms/cqcm` (three slashes) as a key. This key is looked up using the JWT `iss` claim, which is `https://authentification.cqcm.coop/realms/cqcm` (as also used in `api_user.rb`). Because of the extra slash, the lookup never matched, so the public key for this issuer could never be resolved and tokens issued by CQCM's authentification server would fail authorization.

Fixed the URL to have the correct two slashes.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Confirm DFC API requests authenticated with a token issued by `https://authentification.cqcm.coop/realms/cqcm` are now authorized correctly.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

The title of the pull request will be included in the release notes.


## Dependencies

None.

## Documentation updates

None.