### PR TITLE
Sanitize invoice id used to build invoice PDF file path

### DIFF
--- a/app/controllers/spree/admin/invoices_controller.rb
+++ b/app/controllers/spree/admin/invoices_controller.rb
@@ -34,7 +34,8 @@ module Spree
       private
 
       def filepath(invoice_id)
-        "tmp/invoices/#{invoice_id}.pdf"
+        sanitized_id = ActiveStorage::Filename.new(invoice_id.to_s).sanitized
+        "tmp/invoices/#{sanitized_id}.pdf"
       end
     end
   end

--- a/spec/controllers/spree/admin/orders/invoices_spec.rb
+++ b/spec/controllers/spree/admin/orders/invoices_spec.rb
@@ -146,6 +146,63 @@ RSpec.describe Spree::Admin::InvoicesController do
     end
   end
 
+  describe "#show" do
+    let(:user) { create(:admin_user) }
+    let(:invoices_dir) { Rails.root.join("tmp/invoices") }
+
+    before do
+      allow(controller).to receive(:spree_current_user) { user }
+      FileUtils.mkdir_p(invoices_dir)
+    end
+
+    after { FileUtils.rm_rf(invoices_dir) }
+
+    context "when the invoice file exists" do
+      let(:invoice_id) { "42" }
+
+      before { File.write(invoices_dir.join("#{invoice_id}.pdf"), "%PDF-1.4") }
+
+      it "sends the invoice PDF" do
+        spree_get :show, id: invoice_id
+
+        expect(response).to have_http_status :success
+        expect(response.media_type).to eq "application/pdf"
+      end
+    end
+
+    context "when the invoice file does not exist" do
+      it "renders not found" do
+        spree_get :show, id: "unknown"
+
+        expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when the id attempts a path traversal attack" do
+      let(:malicious_id) { "../../../../etc/passwd" }
+
+      it "does not serve a file from outside the invoices directory" do
+        spree_get :show, id: malicious_id
+
+        expect(response).to have_http_status :not_found
+        expect(Dir.children(invoices_dir)).to be_empty
+      end
+
+      it "sanitizes the id into a plain filename confined to the invoices directory" do
+        sanitized_id = ActiveStorage::Filename.new(malicious_id).sanitized
+        expect(sanitized_id).not_to include("/")
+
+        # Only reachable if the controller confines the lookup to `invoices_dir`
+        # using the same sanitized name.
+        File.write(invoices_dir.join("#{sanitized_id}.pdf"), "%PDF-1.4")
+
+        spree_get :show, id: malicious_id
+
+        expect(response).to have_http_status :success
+      end
+    end
+  end
+
   describe "#generate" do
     let(:user) { create(:user) }
     let(:enterprise_user) { create(:user, enterprises: [create(:enterprise)]) }


### PR DESCRIPTION
## What? Why?

`Spree::Admin::InvoicesController#show` built the invoice PDF path by directly interpolating the user-controlled `id` param:

```ruby
def filepath(invoice_id)
  "tmp/invoices/#{invoice_id}.pdf"
end
```

This allowed path traversal sequences (e.g. `../../../../etc/some_file.pdf`) into the path passed to `send_file`.

Fixed by sanitizing the id with `ActiveStorage::Filename#sanitized`, which strips path separators (`/`, `\`, etc.), so the resulting path stays confined to `tmp/invoices`.

## What should we test?

- Visit `/admin/orders/invoices/:id` (via the "Generate invoice"/"Bulk invoice" flows) as an admin/enterprise manager and confirm existing invoice PDFs still load correctly (`inline`, `application/pdf`).
- Requesting a non-existent or malicious id should render the 404 "not found" page rather than any file outside `tmp/invoices`.

Added `#show` spec coverage in `spec/controllers/spree/admin/orders/invoices_spec.rb`:
- serves an existing PDF
- 404s when the file doesn't exist
- confirms a path-traversal id cannot escape `tmp/invoices` and is sanitized to a plain filename

I ran this spec both with the fix (18/18 passing) and with the fix reverted (the new path-traversal test fails with a 404, confirming it actually catches the vulnerability).

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

The title of the pull request will be included in the release notes.

## Dependencies

None.

## Documentation updates

None.