### PR TITLE
Restrict disabling a user to the admin endpoint

### DIFF
--- a/app/controllers/spree/admin/users_controller.rb
+++ b/app/controllers/spree/admin/users_controller.rb
@@ -115,7 +115,7 @@ module Spree
 
       def user_params
         ::PermittedAttributes::User.new(params).call(
-          %i[admin enterprise_limit show_api_key_view]
+          %i[admin enterprise_limit show_api_key_view disabled]
         )
       end
     end

--- a/app/services/permitted_attributes/user.rb
+++ b/app/services/permitted_attributes/user.rb
@@ -16,7 +16,7 @@ module PermittedAttributes
 
     def permitted_attributes
       [
-        :email, :locale, :password, :password_confirmation, :disabled,
+        :email, :locale, :password, :password_confirmation,
         { webhook_endpoints_attributes: [:id, :url] },
       ]
     end

--- a/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/spec/controllers/spree/admin/users_controller_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Spree::Admin::UsersController do
 
         expect(response).to render_template :edit
       end
+
+      it "allows admins to disable a user" do
+        spree_put :update, id: test_user.id, user: { disabled: "1" }
+
+        expect(test_user.reload.disabled).to eq true
+      end
     end
 
     it 'should deny access to users without an admin role' do

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -61,6 +61,26 @@ RSpec.describe Spree::UsersController do
     end
   end
 
+  describe '#update' do
+    let!(:user) { create(:user) }
+
+    before do
+      allow(controller).to receive_messages(spree_current_user: user)
+    end
+
+    it "does not allow a user to disable themselves" do
+      spree_put :update, user: { disabled: "1" }
+
+      expect(user.reload.disabled).to eq false
+    end
+
+    it "still allows updating other permitted attributes" do
+      spree_put :update, user: { locale: "es" }
+
+      expect(user.reload.locale).to eq "es"
+    end
+  end
+
   describe '#create' do
     it 'creates a new user' do
       post :create,

--- a/spec/services/permitted_attributes/user_spec.rb
+++ b/spec/services/permitted_attributes/user_spec.rb
@@ -27,6 +27,24 @@ module PermittedAttributes
       end
     end
 
+    describe "disabled attribute" do
+      let(:params) {
+        ActionController::Parameters.new(user: { disabled: "1" })
+      }
+
+      it "does not permit disabling a user by default" do
+        permitted_attributes = PermittedAttributes::User.new(params).call
+
+        expect(permitted_attributes[:disabled]).to be_nil
+      end
+
+      it "permits disabling a user when explicitly allowed" do
+        permitted_attributes = PermittedAttributes::User.new(params).call([:disabled])
+
+        expect(permitted_attributes[:disabled]).to eq "1"
+      end
+    end
+
     describe "with custom resource_name" do
       let(:user_permitted_attributes) { PermittedAttributes::User.new(params, :spree_user) }
       let(:params) {


### PR DESCRIPTION
## What? Why?

`PermittedAttributes::User` permitted `:disabled` in its shared `permitted_attributes` list, used by every caller of the service — including `Spree::UsersController#update`, the self-service "my account" endpoint where `@user = spree_current_user`. This meant any signed-in user could send `user[disabled]=1` in an update request and disable their own account.

Fixed by removing `:disabled` from the shared list and only allowing it as an extra permitted attribute in `Spree::Admin::UsersController#user_params`, so only the admin endpoint can disable a user.

## What should we test?

- As a regular signed-in user, edit your account (`/account`) — you should still be able to update email/locale/password etc., but there is no way to disable your own account.
- As an admin, edit another user in the admin panel (`/admin/users/:id`) — you should still be able to disable/enable that user as before.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

The title of the pull request will be included in the release notes.

## Dependencies

None.

## Documentation updates

None.