### PR TITLE
Fix admin customer creation not finding existing customer with different email case

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -36,7 +36,9 @@ module Admin
     end
 
     def create
-      @customer = Customer.find_or_initialize_by(customer_params.slice(:email, :enterprise_id))
+      lookup_params = customer_params.slice(:email, :enterprise_id)
+      lookup_params[:email] = lookup_params[:email]&.downcase
+      @customer = Customer.find_or_initialize_by(lookup_params)
 
       if user_can_create_customer?
         @customer.created_manually = true

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -221,6 +221,25 @@ RSpec.describe Admin::CustomersController do
           expect { create_customer enterprise }.to change { Customer.count }.by(1)
         end
       end
+
+      context "where a customer already exists with the same email in a different case" do
+        let!(:customer) { create(:customer, enterprise:, email: "existing@example.com") }
+
+        before do
+          allow(controller).to receive(:spree_current_user) { enterprise.owner }
+        end
+
+        it "finds the existing customer instead of failing a duplicate-email validation" do
+          expect {
+            spree_put :create, format: :json,
+                               customer: { email: "Existing@Example.com",
+                                           enterprise_id: enterprise.id }
+          }.to change { Customer.count }.by(0)
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["id"]).to eq customer.id
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What? Why?

`Admin::CustomersController#create` looks up an existing customer with
`Customer.find_or_initialize_by(customer_params.slice(:email, :enterprise_id))`,
using the raw email from params. `Customer` normalizes and persists
email as downcased only in a `before_validation` callback, which runs
after this lookup.

As a result, creating a customer whose email differs only in case from
an already-existing customer for the same enterprise (e.g.
`Foo@Example.com` vs. the stored `foo@example.com`) fails to find the
existing record, builds a new one, and then fails the model's
email-uniqueness validation — returning a confusing
"already associated with an existing customer" `400` error instead of
transparently resolving to the existing customer.

This PR downcases the email before the lookup, matching how it's
normalized before being persisted, so the existing customer is found
and returned instead.

## What should we test?

- As an enterprise admin, create a customer with email
  `foo@example.com` for a shop.
- Create another customer for the same shop with email
  `Foo@Example.com` (different case). Before this fix, this failed
  with a duplicate-email validation error; after the fix, it returns
  the existing customer record instead.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

## Dependencies



## Documentation updates