### PR TITLE
Auto-move any ready PRs to Code Review

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -10,5 +10,7 @@ permissions:
 jobs:
   assign-author:
     runs-on: ubuntu-latest
+
+    if: github.event.pull_request.assignees == null || github.event.pull_request.assignees[0] == null
     steps:
       - uses: toshimaru/auto-author-assign@v3.0.2

--- a/.github/workflows/move-ready-pr-to-code-review.yml
+++ b/.github/workflows/move-ready-pr-to-code-review.yml
@@ -1,21 +1,22 @@
-name: Auto-move Dependabot PRs to Code Review
+name: Auto-move ready PRs to Code Review
 permissions:
   contents: read
   pull-requests: read
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 jobs:
   move-pr-to-code-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || startsWith(github.event.pull_request.title, 'Bump')
+    if: github.event.pull_request.draft == false
     steps:
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
+          # (This workflow was previously only used for dependabot PRs)
           client-id: ${{ secrets.DEPENDABOT_PR_APP_ID }}
           private-key: ${{ secrets.DEPENDABOT_PR_APP_PRIVATE_KEY }}
 


### PR DESCRIPTION
That way we don't miss out on them. If they're not really ready, we can quickly move them back to in progress. This still won't capture the case where a PR got updated (eg new commits). But it's likely that it will be in response to a comment from a team member, who would get a notification about the change and act on it anyway.

I asked Co-pilot who suggested I might be able to use a Project workflow, but it didn't have enough control, so I adjusted the existing dependabot workflow. Co-pilot told me which conditions to use which probably saved me a few minutes to read and understand the documentation, yay!

It was suggested and agreed here: https://openfoodnetwork.slack.com/archives/C01T75H6G0Z/p1784504154836829?thread_ts=1784249326.388089&cid=C01T75H6G0Z

PS I added another little optimisation.

## What should we test?
I think the only way to test is to merge it and see what happens.
