### PR TITLE
Avoid duplicate CI runs on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,29 @@ permissions:
   contents: read
 
 jobs:
+  # Check if we are on a branch with an open pull request.
+  # Then we just run the PR build but not the branch build.
+  decide:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # pull_request runs (upstream) always proceed
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # push run: skip if an open PR upstream already covers this branch
+          count=$(gh api \
+            "repos/openfoodfoundation/openfoodnetwork/pulls?state=open&head=${{ github.repository_owner }}:${{ github.ref_name }}" \
+            --jq "length")
+          [ "$count" -gt 0 ] && echo "run=false" >> "$GITHUB_OUTPUT" || echo "run=true" >> "$GITHUB_OUTPUT"
   controllers_and_models:
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
     runs-on: ubuntu-22.04
     services:
       # Postgres settings shared with all jobs
@@ -117,6 +139,8 @@ jobs:
           if-no-files-found: ignore
 
   system:
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
     runs-on: ubuntu-22.04
     services:
       postgres: *postgres
@@ -203,6 +227,8 @@ jobs:
           if-no-files-found: ignore
 
   engines:
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
     runs-on: ubuntu-22.04
     services:
       postgres: *postgres
@@ -281,6 +307,8 @@ jobs:
           if-no-files-found: ignore
 
   test_the_rest:
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
     runs-on: ubuntu-22.04
     services:
       postgres: *postgres
@@ -359,6 +387,8 @@ jobs:
           if-no-files-found: ignore
 
   non_knapsack_jest_karma:
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
     runs-on: ubuntu-22.04
     services:
       postgres: *postgres


### PR DESCRIPTION


## What? Why?

CI runs on our fork branches which I find quite useful to test before opening a pull request. But once a pull request has been opened, we were running the CI build twice, once on the merge commit of the PR and once on the branch within the fork. This was wasting over 3 hours of run time for each push.

The solution was written by AI. Maybe this AI use was saving emissions for once. *wink*


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- [x] CI ran on this this branch before the PR was opened. _Yes, it took 6 seconds. The API query took 3s, the rest is overhead._
- [x] CI ran on the pull request within the main repository. _Yes, it took 3 seconds. All individual steps took 0 seconds.
- [x] Shall I push something else to verify that my fork doesn't run again?

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
