### PR TITLE
Fix flaky voucher recalculation spec

### DIFF
--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -281,10 +281,11 @@ RSpec.describe CheckoutController do
             let(:new_shipping_method) { create(:shipping_method, distributors: [distributor]) }
 
             before do
-              # Add a shipping rates for the new shipping method to prevent
-              # order.select_shipping_method from failing
-              order.shipment.shipping_rates <<
-                Spree::ShippingRate.create(shipping_method: new_shipping_method, selected: true)
+              # Add a shipping rate for the new shipping method to prevent
+              # order.select_shipping_method from failing. It must not be selected, otherwise
+              # the shipment has two selected rates and Shipment#selected_shipping_rate
+              # picks one of them at random.
+              order.shipment.add_shipping_method(new_shipping_method)
             end
 
             it "recalculates the voucher adjustment" do


### PR DESCRIPTION
## What? Why?

Fixes a flaky spec seen on master, for example in [this run](https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/33028556756/job/98375502171):

```
1) CheckoutController#update details step with complete data with a voucher
   when updating shipping method recalculates the voucher adjustment
   Failure/Error: expect(service).to receive(:update)
     (InstanceDouble(VoucherAdjustmentsService) (anonymous)).update(*(any args))
         expected: 1 time with any arguments
         received: 0 times with any arguments
```

The spec's setup added a second shipping rate with `selected: true`:

```ruby
order.shipment.shipping_rates <<
  Spree::ShippingRate.create(shipping_method: new_shipping_method, selected: true)
```

But the shipment created by the order factory already has a selected rate (`spec/factories/shipment_factory.rb`, via `add_shipping_method(create(:shipping_method), true)`), so the shipment ended up with two rows where `selected = true`.

`Spree::Shipment#selected_shipping_rate` is `shipping_rates.find_by(selected: true)`, which runs `... WHERE selected = TRUE LIMIT 1` with no `ORDER BY`. With two matching rows, Postgres is free to return either one, in whatever order the scan happens to hit them.

That decides the outcome of the test, because `CheckoutController#update_order` guards the recalculation on it:

```ruby
shipping_method_updated = @order.shipping_method&.id != params[:shipping_method_id].to_i
...
recalculate_voucher(shipping_method_updated)
```

- Scan returns the old rate → shipping method looks changed → `VoucherAdjustmentsService#update` is called → pass.
- Scan returns the new rate (the one the request is switching to) → shipping method looks unchanged → the service is never called → fail.

Heap order flips whenever the original row's tuple is rewritten (an `UPDATE` relocates it after the newer row) or whenever the new `INSERT` lands in recycled free space ahead of it, which is why it only shows up occasionally and depends on what else ran in the same Knapsack shard.

The rate does not need to be selected at all: `Order#select_shipping_method` looks it up by `shipping_method_id`, not by the selected flag. So the fix is to add it unselected, via the existing `add_shipping_method` helper.

I confirmed the diagnosis by adding a single `update_columns` on the original rate in the `before` block, which reproduced the CI failure exactly, including the nested "when no shipments available" example still passing (that one destroys all shipments, so `shipping_method` is `nil` and the guard is true regardless of row order).

## What should we test?

No user facing change, this is a test-only fix.

- `bundle exec rspec spec/controllers/checkout_controller_spec.rb` passes (44 examples, 0 failures).
- With the tuple rewrite simulation applied on top of this fix, the examples still pass, so the result no longer depends on row order.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

## Dependencies

None.

## Documentation updates

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
