### PR TITLE
Tell the admin when the customer they add already exists

### DIFF
--- a/app/assets/javascripts/admin/customers/directives/new_customer_dialog.js.coffee
+++ b/app/assets/javascripts/admin/customers/directives/new_customer_dialog.js.coffee
@@ -6,20 +6,27 @@ angular.module("admin.customers").directive 'newCustomerDialog', ($rootScope, $c
     scope.submitted = false
     scope.email = ""
     scope.errors = []
+    scope.notice = null
 
     scope.addCustomer = ->
       scope.new_customer_form.$setPristine()
       scope.submitted = true
       scope.errors = []
+      scope.notice = null
       if scope.new_customer_form.$valid
         params =
           enterprise_id: CurrentShop.shop.id
           email: scope.email
-        Customers.add(params).$promise.then (data) ->
-          if data.id
+        Customers.add(params).then (result) ->
+          if result.customer.id
             scope.email = ""
             scope.submitted = false
-            template.dialog('close')
+            if result.existed
+              # Keep the dialog open so that the admin sees what happened.
+              scope.notice = t('js.admin.customers.index.customer_already_exists',
+                email: result.customer.email, shop_name: CurrentShop.shop.name)
+            else
+              template.dialog('close')
             $rootScope.$evalAsync()
         , (response) ->
           if response.data.errors

--- a/app/assets/javascripts/admin/resources/services/customers.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/customers.js.coffee
@@ -10,10 +10,21 @@ angular.module("admin.resources").factory "Customers", ($q, $injector, InfoDialo
 
     add: (params) ->
       CustomerResource.create params, (customer) =>
-        if customer.id
-          @all.unshift customer
-          @byID[customer.id] = customer
-          @pristineByID[customer.id] = angular.copy(customer)
+        @merge(customer) if customer.id
+
+    # Add the customer to the collection, or refresh it if we know it already.
+    #
+    # The server may respond with a customer we listed already, for example
+    # when the given email differs only in case. Listing it twice breaks the
+    # index table, because its ng-repeat tracks customers by id.
+    merge: (customer) ->
+      known = @byID[customer.id]
+      if known?
+        angular.extend known, customer
+      else
+        @all.unshift customer
+        @byID[customer.id] = customer
+      @pristineByID[customer.id] = angular.copy(@byID[customer.id])
 
     remove: (customer) ->
       params = id: customer.id

--- a/app/assets/javascripts/admin/resources/services/customers.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/customers.js.coffee
@@ -8,9 +8,15 @@ angular.module("admin.resources").factory "Customers", ($q, $injector, InfoDialo
       if $injector.has('customers')
         @load($injector.get('customers'))
 
+    # Resolves with the customer and whether it existed before this request.
     add: (params) ->
-      CustomerResource.create params, (customer) =>
+      deferred = $q.defer()
+      CustomerResource.create params, (customer, headers, status) =>
         @merge(customer) if customer.id
+        deferred.resolve(customer: customer, existed: status == 200)
+      , (response) ->
+        deferred.reject(response)
+      deferred.promise
 
     # Add the customer to the collection, or refresh it if we know it already.
     #

--- a/app/assets/javascripts/templates/admin/new_customer_dialog.html.haml
+++ b/app/assets/javascripts/templates/admin/new_customer_dialog.html.haml
@@ -2,6 +2,8 @@
   .text-normal.margin-bottom-30.text-center
     {{ 'js.admin.customers.index.add_a_new_customer_for' | t:{ shop_name: CurrentShop.shop.name } }}
 
+  .alert-box.warning#new-customer-notice{ "ng-if": "notice", "ng-bind": "notice" }
+
   %form{ name: 'new_customer_form', novalidate: true, "ng-submit": "addCustomer()" }
 
     .text-center.margin-bottom-30

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -39,12 +39,14 @@ module Admin
       lookup_params = customer_params.slice(:email, :enterprise_id)
       lookup_params[:email] = lookup_params[:email]&.downcase
       @customer = Customer.find_or_initialize_by(lookup_params)
+      customer_existed = @customer.persisted?
 
       if user_can_create_customer?
         @customer.created_manually = true
         if @customer.save
           tag_rule_mapping = TagRule.mapping_for(Enterprise.where(id: @customer.enterprise))
-          render_as_json @customer, tag_rule_mapping:
+          render_as_json @customer, tag_rule_mapping:,
+                                    status: customer_existed ? :ok : :created
         else
           render json: { errors: @customer.errors.full_messages }, status: :bad_request
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3849,6 +3849,7 @@ en:
           add_a_new_customer_for: "Add a new customer for %{shop_name}"
           customer_placeholder: "customer@example.org"
           valid_email_error: "Please enter a valid email address"
+          customer_already_exists: "%{email} is already a customer of %{shop_name}. You can find them in the customer list."
       subscriptions:
         error_saving: "Error saving subscription"
         new:

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -527,7 +527,8 @@ RSpec.describe 'Customers' do
 
             expect do
               click_button 'Add Customer'
-              expect(page).not_to have_selector "#new-customer-dialog"
+              expect(page).to have_selector "#new-customer-notice",
+                                            text: "#{customer1.email} is already a customer"
               customer1.reload
             end
               .to change { customer1.created_manually }.from(false).to(true)
@@ -536,6 +537,23 @@ RSpec.describe 'Customers' do
             expect(page).to have_content customer1.email
             expect(page).to have_field "first_name", with: "John"
             expect(page).to have_field "last_name", with: "Doe"
+          end
+
+          it "tells the user about a listed customer with the same email in a different case" do
+            click_link('New Customer')
+            fill_in 'email', with: customer2.email.upcase
+
+            expect do
+              click_button 'Add Customer'
+              expect(page).to have_selector "#new-customer-notice",
+                                            text: "#{customer2.email} is already a customer"
+            end.not_to change { Customer.count }
+
+            # The customer wasn't listed twice, so the list keeps working. #14669
+            fill_in 'email', with: "new@email.com"
+            click_button 'Add Customer'
+            expect(page).not_to have_selector "#new-customer-dialog"
+            expect(page).to have_content "new@email.com"
           end
         end
       end


### PR DESCRIPTION
## What? Why?

Follow-up to #14669, addressing the UX remark from @AMEA-LYON in that PR:

> when entering an existing customer email with a different email case, the modal window closes without informing the user that the customer is already existing... It can be a little confusing...

While looking into it, I found the silence isn't the only problem. `Admin::CustomersController#create` resolves to the existing customer and answers with its id. `Customers.add` then pushed that customer into its collection unconditionally, so a customer that was listed already ended up in there twice. The index table's `ng-repeat` tracks customers by id, and AngularJS raises `ngRepeat:dupes` on a duplicate key, which aborts the digest.

The result is that the table stops updating altogether. Customers added after that point are saved but never appear until the page is reloaded:

```
rows before:        2   Customers.all = [468, 469]
after dupe add:     2   Customers.all = [468, 468, 469]
after adding a new
customer:           2   Customers.all = [470, 468, 468, 469]   <- row never appears
```

So this PR does two things:

1. **Don't list an existing customer twice.** `Customers.add` now merges the response into the customer we know instead of pushing a second copy. This keeps the table working.
2. **Say what happened.** The controller answers `201 Created` for a new customer and `200 OK` for one it found, so the dialog can tell the two apart. When the customer existed, the dialog stays open and shows a notice instead of closing silently:

   > nga@example.com is already a customer of My Shop. You can find them in the customer list.

The notice names the *normalised* email, so it also shows the admin that `Foo@Example.com` and `foo@example.com` are the same customer.

I kept the message inside the dialog rather than opening an `InfoDialog` on top of it: it reuses the spot where the dialog already shows validation errors, it avoids stacking two jQuery UI dialogs, and it's guaranteed to be seen.

Note that this changes the behaviour for hidden customers too. Adding a customer who exists but isn't listed yet (no completed order, `created_manually` false) already worked, and still makes them visible, but now says so as well. I've updated that spec accordingly.

## What should we test?

- Visit the *Customers* page and select a shop.
- Add a customer with a new email, e.g. `foo@example.com`. The dialog should close and the customer should appear at the top of the list, as before.
- Click *New Customer* again and enter the same email in a different case, e.g. `Foo@Example.com`. The dialog should stay open and tell you that `foo@example.com` is already a customer of that shop. No new customer is created.
- Close the dialog and check that the customer is listed only once.
- Add another new email, e.g. `bar@example.com`. It should appear in the list. On `master` it doesn't, which is the bug described above.
- Also worth checking with a customer who has ordered from the shop but was never added manually: adding their email should show the same notice, and they should now appear in the list with their name filled in.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

## Dependencies

None. #14669 is already merged.

## Documentation updates

None.
