### PR TITLE
Add FDC portal for testing on staging

### DIFF
--- a/engines/dfc_provider/app/services/api_user.rb
+++ b/engines/dfc_provider/app/services/api_user.rb
@@ -28,6 +28,11 @@ class ApiUser
       webhook: "/api/webhooks/ofn",
       tokens: "https://login.fooddatacollaboration.org.uk/realms/dev/protocol/openid-connect/token",
     },
+    'fdc-staging' => {
+      id: "https://fdc-djangoldp-central.jcloud-ver-jpe.ik-server.com/profile",
+      webhook: "/djangoldp-dfc/webhook/",
+      tokens: "https://login.fooddatacollaboration.org.uk/realms/dev/protocol/openid-connect/token",
+    },
 
   }.freeze
   CLIENT_MAP = PLATFORMS.keys.index_by { |key| PLATFORMS.dig(key, :id) }.freeze

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -78,6 +78,9 @@ module OpenFoodNetwork
         When enabled for an enterprise, only products with 'group buy' enabled
         appear in bulk co-op reports for that enterprise.
       DESC
+      "fdc-staging" => <<~DESC,
+        Show DFC Permissions interface to share data with the FDC staging platform.
+      DESC
     }.merge(conditional_features).freeze;
 
     # Features you would like to be enabled to start with.


### PR DESCRIPTION
## What? Why?

Enables @RaggedStaff to test the new portal with OFN data. The plan is to share all enterprises on staging UK.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- For @RaggedStaff 

We can create permissions for all enterprises like this:
```sql
  INSERT INTO dfc_permissions (user_id, enterprise_id, grantee, scope, created_at, updated_at)
  SELECT e.owner_id, e.id, g.grantee, s.scope, NOW(), NOW()
  FROM enterprises e
  CROSS JOIN (VALUES
    ('ReadEnterprise'), ('ReadProducts'), ('ReadOrders'),
    ('WriteEnterprise'), ('WriteProducts'), ('WriteOrders')
  ) AS s(scope)
  CROSS JOIN (VALUES
    ('fdc-staging')
  ) AS g(grantee)
  WHERE NOT EXISTS (
    SELECT 1 FROM dfc_permissions p
    WHERE p.enterprise_id = e.id
      AND p.user_id       = e.owner_id
      AND p.grantee       = g.grantee
      AND p.scope         = s.scope
  );
```

This won't trigger the portal to load the list. You either do that manually or change one permission through the OFN UX which will trigger the webhook.


## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [x] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
