### PR TITLE
Add instance-level address display format setting

### DIFF
--- a/app/assets/javascripts/templates/partials/enterprise_header.html.haml
+++ b/app/assets/javascripts/templates/partials/enterprise_header.html.haml
@@ -9,5 +9,5 @@
         %i{"ng-class" => "::enterprise.icon_font"}
         %span{"ng-bind" => "::enterprise.name"}
     .small-12.medium-5.large-4.columns.text-right.small-only-text-left
-      %p{"ng-bind" => "::[enterprise.address.city, enterprise.address.state_name] | printArray"}
+      %p{"ng-bind" => "::enterprise.address.address_part2"}
   %img.hero-img{"ng-src" => "{{::enterprise.promo_image}}"}

--- a/app/assets/javascripts/templates/partials/hub_details.html.haml
+++ b/app/assets/javascripts/templates/partials/hub_details.html.haml
@@ -21,5 +21,5 @@
           .hub-name{"ng-bind" => "::enterprise.name"}
           %span{"ng-if" => "::enterprise.active"} ({{'maps_open' | t}})
           %span{"ng-if" => "::!enterprise.active"} ({{'maps_closed' | t}})
-          .button-address{"ng-bind" => "::[enterprise.address.city, enterprise.address.state_name] | printArray"}
+          .button-address{"ng-bind" => "::enterprise.address.address_part2"}
           / %i.ofn-i_007-caret-right

--- a/app/assets/javascripts/templates/partials/producer_details.html.haml
+++ b/app/assets/javascripts/templates/partials/producer_details.html.haml
@@ -19,4 +19,4 @@
           .hub-name{"ng-bind" => "::hub.name"}
           %span{"ng-if" => "::hub.active"} ({{'maps_open' | t}})
           %span{"ng-if" => "::!hub.active"} ({{'maps_closed' | t}})
-          .button-address{"ng-bind" => "::[hub.address.city, hub.address.state_name] | printArray"}
+          .button-address{"ng-bind" => "::hub.address.address_part2"}

--- a/app/models/invoice/data_presenter/address.rb
+++ b/app/models/invoice/data_presenter/address.rb
@@ -17,11 +17,19 @@ class Invoice
       end
 
       def address_part2
-        render_address([city, zipcode, state&.name])
+        if postal_code_first?
+          render_address([zipcode, city])
+        else
+          render_address([city, zipcode, state&.name])
+        end
       end
 
       def full_address
-        render_address([address1, address2, city, zipcode, state&.name])
+        if postal_code_first?
+          render_address([address1, address2, zipcode, city])
+        else
+          render_address([address1, address2, city, zipcode, state&.name])
+        end
       end
 
       def blank?
@@ -29,6 +37,10 @@ class Invoice
       end
 
       private
+
+      def postal_code_first?
+        Spree::Config[:address_display_format] == "postal_code_first"
+      end
 
       def render_address(address_parts)
         address_parts.compact_blank.join(', ')

--- a/app/models/spree/address.rb
+++ b/app/models/spree/address.rb
@@ -114,7 +114,11 @@ module Spree
     end
 
     def full_address
-      render_address([address1, address2, city, zipcode, state&.name])
+      if postal_code_first?
+        render_address([address1, address2, zipcode, city])
+      else
+        render_address([address1, address2, city, zipcode, state&.name])
+      end
     end
 
     def address_part1
@@ -122,7 +126,11 @@ module Spree
     end
 
     def address_part2
-      render_address([city, zipcode, state&.name])
+      if postal_code_first?
+        render_address([zipcode, city])
+      else
+        render_address([city, zipcode, state&.name])
+      end
     end
 
     def address_and_city
@@ -130,6 +138,10 @@ module Spree
     end
 
     private
+
+    def postal_code_first?
+      Spree::Config[:address_display_format] == "postal_code_first"
+    end
 
     def require_zipcode?
       true

--- a/app/models/spree/app_configuration.rb
+++ b/app/models/spree/app_configuration.rb
@@ -131,6 +131,9 @@ module Spree
     preference :enable_products_cache?, :boolean,
                default: Rails.env.production? || Rails.env.staging?
 
+    # Address display
+    preference :address_display_format, :string, default: "default"
+
     # Available units
     preference :available_units, :string, default: "g,kg,T,mL,L,kL"
 

--- a/app/serializers/api/address_serializer.rb
+++ b/app/serializers/api/address_serializer.rb
@@ -6,7 +6,7 @@ class Api::AddressSerializer < ActiveModel::Serializer
 
   attributes :id, :zipcode, :city, :state_name, :state_id,
              :phone, :firstname, :lastname, :address1, :address2, :city, :country_id,
-             :zipcode, :country_name
+             :zipcode, :country_name, :address_part2
 
   def country_name
     object.country&.name

--- a/app/views/checkout/_delivery_details.html.haml
+++ b/app/views/checkout/_delivery_details.html.haml
@@ -15,11 +15,7 @@
     %div
       = @order.ship_address.address2
   %div
-    = @order.ship_address.city
-  %div
-    = @order.ship_address.state
-  %div
-    = @order.ship_address.zipcode
+    = @order.ship_address.address_part2
   %div
     = @order.ship_address.country
   - if @order.special_instructions.present?

--- a/app/views/groups/_contact.html.haml
+++ b/app/views/groups/_contact.html.haml
@@ -43,6 +43,4 @@
           = @group.address2
         - if @group.city.present?
           %br
-          = @group.city
-          = @group.state
-          = @group.zipcode
+          = @group.address.address_part2

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -131,9 +131,7 @@
       %br
         = @coordinator.address.address1
       %br
-        = @coordinator.address.city
-      %br
-        = @coordinator.address.zipcode
+        = @coordinator.address.address_part2
     %p
       = @coordinator.phone
     %p

--- a/app/views/producers/_fat.html.haml
+++ b/app/views/producers/_fat.html.haml
@@ -89,4 +89,4 @@
             %i.ofn-i_068-shop-reversed{"ng-if" => "::hub.active"}
             %i.ofn-i_068-shop-reversed{"ng-if" => "::!hub.active"}
             .hub-name{"ng-bind" => "::hub.name"}
-            .button-address{"ng-bind" => "::[hub.address.city, hub.address.state_name] | printArray"}
+            .button-address{"ng-bind" => "::hub.address.address_part2"}

--- a/app/views/shopping_shared/tabs/_contact.html.haml
+++ b/app/views/shopping_shared/tabs/_contact.html.haml
@@ -12,9 +12,7 @@
               %br
               = current_distributor.address.address2
             %br
-            = current_distributor.address.city
-            = current_distributor.address.state
-            = current_distributor.address.zipcode
+            = current_distributor.address.address_part2
 
     .small-12.large-4.columns
       - if current_distributor.website || current_distributor.email_address || current_distributor.phone || current_distributor.whatsapp_phone

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -39,6 +39,11 @@
             .field
               = label_tag(:embedded_shopfronts_whitelist, t('admin.shopfront_settings.embedded_shopfronts_whitelist')) + tag(:br)
               = preference_field_tag(:embedded_shopfronts_whitelist, Spree::Config[:embedded_shopfronts_whitelist], type: Spree::Config.preference_type(:embedded_shopfronts_whitelist))
+          %fieldset.address_display.no-border-bottom
+            %legend{:align => "center"}= t('admin.address_display.address_display_settings')
+            .field
+              = label_tag(:address_display_format, Spree.t(:address_display_format) + ': ') + tag(:br)
+              = select_tag(:address_display_format, options_for_select([[Spree.t(:address_display_format_default), 'default'], [Spree.t(:address_display_format_postal_code_first), 'postal_code_first']], Spree::Config[:address_display_format]))
 
         .omega.six.columns
           %fieldset.currency.no-border-bottom

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -828,6 +828,9 @@ en:
       number_localization_settings: "Number Localization Settings"
       enable_localized_number: "Use the international thousand/decimal separator logic"
 
+    address_display:
+      address_display_settings: "Address Display Settings"
+
     invoice_settings:
       edit:
         title: "Invoice Settings"
@@ -4309,6 +4312,9 @@ en:
     hide_cents: "Hide cents"
     display_currency: "Display currency"
     choose_currency: "Choose Currency"
+    address_display_format: "Address display format"
+    address_display_format_default: "Default"
+    address_display_format_postal_code_first: "Postal code first"
 
     mail_method_settings: "Mail Method Settings"
     mail_settings_notice_html: "<b>Changes made here will be temporary</b> for debugging only, and may get reverted in the future. <br>Permanent changes can be made by updating the instance's secrets and provisioning them using <a href='https://github.com/openfoodfoundation/ofn-install'>ofn-install</a>. Reach out to the OFN global team for further details."

--- a/spec/models/invoice/data_presenter/address_spec.rb
+++ b/spec/models/invoice/data_presenter/address_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe Invoice::DataPresenter::Address do
+  subject(:presenter) { described_class.new(data) }
+
+  let(:data) do
+    {
+      city: "Luzern",
+      zipcode: "6004",
+      state: { name: "Luzern" }
+    }
+  end
+
+  describe "#address_part2" do
+    it "displays city, zipcode and state by default" do
+      expect(presenter.address_part2).to eq("Luzern, 6004, Luzern")
+    end
+
+    context "when postal_code_first format is configured" do
+      before do
+        allow(Spree::Config).to receive(:[])
+          .with(:address_display_format).and_return("postal_code_first")
+      end
+
+      it "displays postal code before city and omits state" do
+        expect(presenter.address_part2).to eq("6004, Luzern")
+      end
+    end
+  end
+
+  describe "#full_address" do
+    let(:data) do
+      {
+        address1: "Street 1",
+        address2: "Suite 2",
+        city: "Luzern",
+        zipcode: "6004",
+        state: { name: "Luzern" }
+      }
+    end
+
+    it "displays address in default format" do
+      expect(presenter.full_address).to eq("Street 1, Suite 2, Luzern, 6004, Luzern")
+    end
+
+    context "when postal_code_first format is configured" do
+      before do
+        allow(Spree::Config).to receive(:[])
+          .with(:address_display_format).and_return("postal_code_first")
+      end
+
+      it "displays postal code before city and omits state" do
+        expect(presenter.full_address).to eq("Street 1, Suite 2, 6004, Luzern")
+      end
+    end
+  end
+end

--- a/spec/models/spree/addresses_spec.rb
+++ b/spec/models/spree/addresses_spec.rb
@@ -58,6 +58,46 @@ RSpec.describe Spree::Address do
 
       expect(address.full_address.split(',').length).to eql(3)
     end
+
+    context "when postal_code_first format is configured" do
+      before do
+        allow(Spree::Config).to receive(:[])
+          .with(:address_display_format).and_return("postal_code_first")
+      end
+
+      it "displays postal code before city and omits state" do
+        expect(address.full_address).to include(address.address1)
+        expect(address.full_address).to include(address.address2)
+        expect(address.full_address).to include(address.zipcode)
+        expect(address.full_address).to include(address.city)
+        expect(address.full_address).not_to include(address.state.name)
+        expect(address.full_address).to match(/#{address.zipcode}.*#{address.city}/)
+      end
+    end
+  end
+
+  describe "address_part2" do
+    let(:address) { FactoryBot.build(:address) }
+
+    it "displays city, zipcode and state by default" do
+      expect(address.address_part2).to include(address.city)
+      expect(address.address_part2).to include(address.zipcode)
+      expect(address.address_part2).to include(address.state.name)
+    end
+
+    context "when postal_code_first format is configured" do
+      before do
+        allow(Spree::Config).to receive(:[])
+          .with(:address_display_format).and_return("postal_code_first")
+      end
+
+      it "displays postal code before city and omits state" do
+        expect(address.address_part2).to include(address.city)
+        expect(address.address_part2).to include(address.zipcode)
+        expect(address.address_part2).not_to include(address.state.name)
+        expect(address.address_part2).to match(/#{address.zipcode}.*#{address.city}/)
+      end
+    end
   end
 
   describe "setters" do


### PR DESCRIPTION
This adds a configurable instance preference that lets instances choose how postal addresses are displayed according to their regional conventions. The whole need was further described here: https://github.com/openfoodfoundation/openfoodnetwork/issues/14706

The preference currently supports:
- the default format (city, state, postal code)
- a postal-code-first format (postal code, city, with state omitted)

This makes it possible for instances in regions where the postal-code-first convention is used to display addresses consistently throughout the application.

Changes:
- New Spree::Config preference `:address_display_format`
- Update Spree::Address#full_address and #address_part2
- Update Invoice::DataPresenter::Address similarly
- Expose address_part2 through API::AddressSerializer
- Replace inline city/state/zipcode rendering in views with address_part2 / full_address
- Add setting dropdown on admin/general_settings/edit
- Add specs and translations

## What? Why?

- Closes # <!-- Insert issue number here. -->

OFN currently uses a common address display format across the application, but address conventions vary between countries and regions.

In some regions, for example, the postal code is conventionally displayed before the city, and the state or other administrative subdivision is not normally included in the displayed address.

This PR introduces an instance-level setting so that instances can choose a more appropriate address display format for their region. The selected format is applied consistently across the different places where addresses are displayed.

The goal is to support regional address conventions without changing how addresses are stored or collected.

## What should we test?

<!-- List which features should be tested and how.
     Also think of other parts of the app which could be affected
     by your change. -->

- Go to Admin → Configuration → General Settings.
- Change the address display format.
- Verify that addresses are displayed according to the selected format.
- Check address displays in the shopfront, hub/producer listings, checkout, order summaries, emails and invoices.
- Verify that the default setting preserves the existing address format.
- Verify that the API returns the formatted `address_part2` correctly.

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains this change to
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->


## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->