### PR TITLE
Add a webhook for orders placed with a balance still due

### DIFF
--- a/app/components/webhook_endpoint_form_component.rb
+++ b/app/components/webhook_endpoint_form_component.rb
@@ -10,7 +10,8 @@ class WebhookEndpointFormComponent < ViewComponent::Base
 
   attr_reader :webhooks, :webhook_type
 
-  def is_webhook_payment_status?
-    webhook_type == "payment_status_changed"
+  # The webhook types we can send test data for.
+  def testable?
+    webhook_type.in?(%w(payment_status_changed order_payment_due))
   end
 end

--- a/app/components/webhook_endpoint_form_component.rb
+++ b/app/components/webhook_endpoint_form_component.rb
@@ -12,6 +12,6 @@ class WebhookEndpointFormComponent < ViewComponent::Base
 
   # The webhook types we can send test data for.
   def testable?
-    webhook_type.in?(%w(payment_status_changed order_payment_due))
+    webhook_type.in?(%w(payment_status_changed order_balance_due))
   end
 end

--- a/app/components/webhook_endpoint_form_component/webhook_endpoint_form_component.html.haml
+++ b/app/components/webhook_endpoint_form_component/webhook_endpoint_form_component.html.haml
@@ -21,7 +21,7 @@
                                                                              data: { confirm: I18n.t(:are_you_sure) } do
           = I18n.t(:delete)
 
-        - if is_webhook_payment_status?
+        - if testable?
           = form_tag helpers.webhook_endpoint_test_account_path(webhook_endpoint), class: "button_to", 'data-turbo': true do
             = button_tag type: "submit", class: "tiny alert no-margin", data: { confirm: I18n.t(:are_you_sure) } do
               = I18n.t("components.webhook_endpoint_form.test_endpoint")

--- a/app/controllers/webhook_endpoints_controller.rb
+++ b/app/controllers/webhook_endpoints_controller.rb
@@ -26,12 +26,15 @@ class WebhookEndpointsController < BaseController
   end
 
   def test
-    at = Time.zone.now
-    test_payload = Payments::WebhookPayload.test_data.to_hash
+    event, payload = test_delivery
 
-    WebhookDeliveryJob.perform_later(@webhook_endpoint.url, "payment.completed", test_payload, at:)
+    if event
+      WebhookDeliveryJob.perform_later(@webhook_endpoint.url, event, payload, at: Time.zone.now)
+      flash[:success] = t(".success")
+    else
+      flash[:error] = t(".unsupported")
+    end
 
-    flash[:success] = t(".success")
     respond_with do |format|
       format.turbo_stream do
         render turbo_stream: turbo_stream.update(
@@ -42,6 +45,16 @@ class WebhookEndpointsController < BaseController
   end
 
   private
+
+  # The event and payload to preview, for the webhook types we can describe.
+  def test_delivery
+    case @webhook_endpoint.webhook_type
+    when "payment_status_changed"
+      ["payment.completed", Payments::WebhookPayload.test_data.to_hash]
+    when "order_payment_due"
+      ["order.payment_due", Orders::WebhookPayload.test_data.to_hash]
+    end
+  end
 
   def load_resource
     @webhook_endpoint = spree_current_user.webhook_endpoints.find(params[:id])

--- a/app/controllers/webhook_endpoints_controller.rb
+++ b/app/controllers/webhook_endpoints_controller.rb
@@ -51,8 +51,8 @@ class WebhookEndpointsController < BaseController
     case @webhook_endpoint.webhook_type
     when "payment_status_changed"
       ["payment.completed", Payments::WebhookPayload.test_data.to_hash]
-    when "order_payment_due"
-      ["order.payment_due", Orders::WebhookPayload.test_data.to_hash]
+    when "order_balance_due"
+      ["order.balance_due", Orders::WebhookPayload.test_data.to_hash]
     end
   end
 

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -413,6 +413,8 @@ module Spree
 
       deliver_order_confirmation_email
 
+      Orders::WebhookService.create_payment_due_job(order: self) if payment_state == 'balance_due'
+
       state_changes.create(
         previous_state: 'cart',
         next_state: 'complete',

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -413,7 +413,7 @@ module Spree
 
       deliver_order_confirmation_email
 
-      Orders::WebhookService.create_payment_due_job(order: self) if payment_state == 'balance_due'
+      Orders::WebhookService.create_balance_due_job(order: self) if payment_state == 'balance_due'
 
       state_changes.create(
         previous_state: 'cart',

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -2,11 +2,12 @@
 
 # Records a webhook url to send notifications to
 class WebhookEndpoint < ApplicationRecord
-  WEBHOOK_TYPES = %w(order_cycle_opened payment_status_changed).freeze
+  WEBHOOK_TYPES = %w(order_cycle_opened payment_status_changed order_payment_due).freeze
 
   validates :url, presence: true
   validates :webhook_type, presence: true, inclusion: { in: WEBHOOK_TYPES }
 
   scope :order_cycle_opened, -> { where(webhook_type: "order_cycle_opened") }
   scope :payment_status, -> { where(webhook_type: "payment_status_changed") }
+  scope :order_payment_due, -> { where(webhook_type: "order_payment_due") }
 end

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -2,12 +2,12 @@
 
 # Records a webhook url to send notifications to
 class WebhookEndpoint < ApplicationRecord
-  WEBHOOK_TYPES = %w(order_cycle_opened payment_status_changed order_payment_due).freeze
+  WEBHOOK_TYPES = %w(order_cycle_opened payment_status_changed order_balance_due).freeze
 
   validates :url, presence: true
   validates :webhook_type, presence: true, inclusion: { in: WEBHOOK_TYPES }
 
   scope :order_cycle_opened, -> { where(webhook_type: "order_cycle_opened") }
   scope :payment_status, -> { where(webhook_type: "payment_status_changed") }
-  scope :order_payment_due, -> { where(webhook_type: "order_payment_due") }
+  scope :order_balance_due, -> { where(webhook_type: "order_balance_due") }
 end

--- a/app/services/orders/find_payment_service.rb
+++ b/app/services/orders/find_payment_service.rb
@@ -14,6 +14,16 @@ module Orders
       last(@order.pending_payments)
     end
 
+    # The payment the customer chose to pay with. Customer credit is applied on
+    # top of it and isn't a method anyone selects, so it's excluded here.
+    def last_pending_payment_excluding_credit
+      last(
+        @order.pending_payments.reject do |payment|
+          payment.payment_method == Spree::PaymentMethod.customer_credit
+        end
+      )
+    end
+
     def last_customer_credit
       last(
         @order.pending_payments.select do |payment|

--- a/app/services/orders/webhook_payload.rb
+++ b/app/services/orders/webhook_payload.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Create a webhook payload for an order-level event, such as an order placed
+# while a payment is still due. The payload will be delivered asynchronously.
+
+module Orders
+  class WebhookPayload
+    def initialize(order:, payment:, enterprise:)
+      @order = order
+      @payment = payment
+      @enterprise = enterprise
+    end
+
+    def to_hash
+      {
+        order: @order.slice(:number, :email, :total, :currency)
+          .merge(outstanding_balance: @order.new_outstanding_balance),
+        payment_method: {
+          name: @payment&.payment_method&.name,
+          type: @payment&.payment_method&.type
+        },
+        enterprise: @enterprise.slice(:abn, :acn, :name)
+          .merge(address: @enterprise.address.slice(:address1, :address2, :city, :zipcode))
+      }.with_indifferent_access
+    end
+  end
+end

--- a/app/services/orders/webhook_payload.rb
+++ b/app/services/orders/webhook_payload.rb
@@ -15,10 +15,7 @@ module Orders
       {
         order: @order.slice(:number, :email, :total, :currency)
           .merge(outstanding_balance: @order.new_outstanding_balance),
-        payment_method: {
-          name: @payment&.payment_method&.name,
-          type: @payment&.payment_method&.type
-        },
+        payment_method: @payment.payment_method.slice(:id, :name),
         enterprise: @enterprise.slice(:abn, :acn, :name)
           .merge(address: @enterprise.address.slice(:address1, :address2, :city, :zipcode))
       }.with_indifferent_access

--- a/app/services/orders/webhook_payload.rb
+++ b/app/services/orders/webhook_payload.rb
@@ -20,5 +20,44 @@ module Orders
           .merge(address: @enterprise.address.slice(:address1, :address2, :city, :zipcode))
       }.with_indifferent_access
     end
+
+    def self.test_data
+      new(order: test_order, payment: test_payment, enterprise: test_enterprise)
+    end
+
+    def self.test_order
+      Spree::Order.new(
+        number: "R555555555",
+        email: "test@example.com",
+        total: 20.00,
+        payment_total: 0.00,
+        currency: "AUD",
+      )
+    end
+
+    def self.test_payment
+      Spree::Payment.new(
+        amount: 20.00,
+        payment_method: Spree::PaymentMethod::Check.new(id: 0, name: "Test payment method")
+      )
+    end
+
+    def self.test_enterprise
+      enterprise = Enterprise.new(
+        abn: "65797115831",
+        acn: "",
+        name: "TEST Enterprise",
+      )
+      enterprise.address = Spree::Address.new(
+        address1: "1 testing street",
+        address2: "",
+        city: "TestCity",
+        zipcode: "1234"
+      )
+
+      enterprise
+    end
+
+    private_class_method :test_order, :test_payment, :test_enterprise
   end
 end

--- a/app/services/orders/webhook_payload.rb
+++ b/app/services/orders/webhook_payload.rb
@@ -25,6 +25,9 @@ module Orders
       new(order: test_order, payment: test_payment, enterprise: test_enterprise)
     end
 
+    # The test records below are never meant to reach the database, so they are
+    # all marked readonly. `readonly!` returns true rather than the record, so
+    # it can't be chained directly.
     def self.test_order
       Spree::Order.new(
         number: "R555555555",
@@ -32,14 +35,15 @@ module Orders
         total: 20.00,
         payment_total: 0.00,
         currency: "AUD",
-      )
+      ).tap(&:readonly!)
     end
 
     def self.test_payment
-      Spree::Payment.new(
-        amount: 20.00,
-        payment_method: Spree::PaymentMethod::Check.new(id: 0, name: "Test payment method")
-      )
+      payment_method = Spree::PaymentMethod::Check.new(
+        id: 0, name: "Test payment method"
+      ).tap(&:readonly!)
+
+      Spree::Payment.new(amount: 20.00, payment_method:).tap(&:readonly!)
     end
 
     def self.test_enterprise
@@ -53,9 +57,9 @@ module Orders
         address2: "",
         city: "TestCity",
         zipcode: "1234"
-      )
+      ).tap(&:readonly!)
 
-      enterprise
+      enterprise.tap(&:readonly!)
     end
 
     private_class_method :test_order, :test_payment, :test_enterprise

--- a/app/services/orders/webhook_payload.rb
+++ b/app/services/orders/webhook_payload.rb
@@ -21,47 +21,14 @@ module Orders
       }.with_indifferent_access
     end
 
+    # A balance is still due, so the order isn't paid for and its payment is
+    # still waiting at checkout.
     def self.test_data
-      new(order: test_order, payment: test_payment, enterprise: test_enterprise)
-    end
-
-    # The test records below are never meant to reach the database, so they are
-    # all marked readonly. `readonly!` returns true rather than the record, so
-    # it can't be chained directly.
-    def self.test_order
-      Spree::Order.new(
-        number: "R555555555",
-        email: "test@example.com",
-        total: 20.00,
-        payment_total: 0.00,
-        currency: "AUD",
-      ).tap(&:readonly!)
-    end
-
-    def self.test_payment
-      payment_method = Spree::PaymentMethod::Check.new(
-        id: 0, name: "Test payment method"
-      ).tap(&:readonly!)
-
-      Spree::Payment.new(amount: 20.00, payment_method:).tap(&:readonly!)
-    end
-
-    def self.test_enterprise
-      enterprise = Enterprise.new(
-        abn: "65797115831",
-        acn: "",
-        name: "TEST Enterprise",
+      new(
+        order: WebhookTestData.order(total: 20.00),
+        payment: WebhookTestData.payment(amount: 20.00, state: "checkout"),
+        enterprise: WebhookTestData.enterprise
       )
-      enterprise.address = Spree::Address.new(
-        address1: "1 testing street",
-        address2: "",
-        city: "TestCity",
-        zipcode: "1234"
-      ).tap(&:readonly!)
-
-      enterprise.tap(&:readonly!)
     end
-
-    private_class_method :test_order, :test_payment, :test_enterprise
   end
 end

--- a/app/services/orders/webhook_payload.rb
+++ b/app/services/orders/webhook_payload.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Create a webhook payload for an order-level event, such as an order placed
-# while a payment is still due. The payload will be delivered asynchronously.
+# while a balance is still due. The payload will be delivered asynchronously.
 
 module Orders
   class WebhookPayload

--- a/app/services/orders/webhook_service.rb
+++ b/app/services/orders/webhook_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Notify configured webhook endpoints when an order is placed while a payment is
+# still due, so an integration can initiate an external payment flow (e.g. a
+# local currency) without the Open Food Network natively supporting it.
+# The payload is delivered asynchronously.
+
+module Orders
+  class WebhookService
+    def self.create_payment_due_job(order:)
+      return if order.order_cycle.nil?
+
+      payment = order.pending_payments.first
+      payload = WebhookPayload.new(order:, payment:, enterprise: order.distributor).to_hash
+
+      coordinator = order.order_cycle.coordinator
+      Payments::WebhookService.webhook_urls(coordinator).each do |url|
+        WebhookDeliveryJob.perform_later(url, "order.payment_due", payload)
+      end
+    end
+  end
+end

--- a/app/services/orders/webhook_service.rb
+++ b/app/services/orders/webhook_service.rb
@@ -14,8 +14,7 @@ module Orders
       payload = WebhookPayload.new(order:, payment:, enterprise: order.distributor).to_hash
 
       coordinator = order.order_cycle.coordinator
-      urls = WebhookUrlsService.for_coordinator(coordinator,
-                                                webhook_type: "payment_status_changed")
+      urls = WebhookUrlsService.for_coordinator(coordinator, webhook_type: "order_payment_due")
       urls.each do |url|
         WebhookDeliveryJob.perform_later(url, "order.payment_due", payload)
       end

--- a/app/services/orders/webhook_service.rb
+++ b/app/services/orders/webhook_service.rb
@@ -10,7 +10,11 @@ module Orders
     def self.create_payment_due_job(order:)
       return if order.order_cycle.nil?
 
-      payment = order.pending_payments.first
+      payment = FindPaymentService.new(order).last_pending_payment_excluding_credit
+
+      # Without a payment method there is nothing for an integration to act on.
+      return if payment&.payment_method.nil?
+
       payload = WebhookPayload.new(order:, payment:, enterprise: order.distributor).to_hash
 
       coordinator = order.order_cycle.coordinator

--- a/app/services/orders/webhook_service.rb
+++ b/app/services/orders/webhook_service.rb
@@ -14,7 +14,9 @@ module Orders
       payload = WebhookPayload.new(order:, payment:, enterprise: order.distributor).to_hash
 
       coordinator = order.order_cycle.coordinator
-      Payments::WebhookService.webhook_urls(coordinator).each do |url|
+      urls = WebhookUrlsService.for_coordinator(coordinator,
+                                                webhook_type: "payment_status_changed")
+      urls.each do |url|
         WebhookDeliveryJob.perform_later(url, "order.payment_due", payload)
       end
     end

--- a/app/services/orders/webhook_service.rb
+++ b/app/services/orders/webhook_service.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-# Notify configured webhook endpoints when an order is placed while a payment is
+# Notify configured webhook endpoints when an order is placed while a balance is
 # still due, so an integration can initiate an external payment flow (e.g. a
 # local currency) without the Open Food Network natively supporting it.
 # The payload is delivered asynchronously.
 
 module Orders
   class WebhookService
-    def self.create_payment_due_job(order:)
+    def self.create_balance_due_job(order:)
       return if order.order_cycle.nil?
 
       payment = FindPaymentService.new(order).last_pending_payment_excluding_credit
@@ -18,9 +18,9 @@ module Orders
       payload = WebhookPayload.new(order:, payment:, enterprise: order.distributor).to_hash
 
       coordinator = order.order_cycle.coordinator
-      urls = WebhookUrlsService.for_coordinator(coordinator, webhook_type: "order_payment_due")
+      urls = WebhookUrlsService.for_coordinator(coordinator, webhook_type: "order_balance_due")
       urls.each do |url|
-        WebhookDeliveryJob.perform_later(url, "order.payment_due", payload)
+        WebhookDeliveryJob.perform_later(url, "order.balance_due", payload)
       end
     end
   end

--- a/app/services/payments/webhook_payload.rb
+++ b/app/services/payments/webhook_payload.rb
@@ -18,55 +18,12 @@ module Payments
     end
 
     def self.test_data
-      new(payment: test_payment, order: test_order, enterprise: test_enterprise)
-    end
-
-    def self.test_payment
-      {
-        updated_at: Time.zone.now,
-        amount: 0.00,
-        state: "completed"
-      }
-    end
-
-    def self.test_order
-      order = Spree::Order.new(
-        number: "R555555555",
-        total: 0.00,
-        currency: "AUD",
+      new(
+        payment: WebhookTestData.payment,
+        order: WebhookTestData.order,
+        enterprise: WebhookTestData.enterprise
       )
-
-      tax_category = Spree::TaxCategory.new(name: "VAT")
-      product = Spree::Product.new(name: "Test product")
-      Spree::Variant.new(product:, display_name: "")
-      order.line_items << Spree::LineItem.new(
-        quantity: 1,
-        price: 20.00,
-        tax_category:,
-        product:,
-        unit_presentation: "1kg"
-      )
-
-      order
     end
-
-    def self.test_enterprise
-      enterprise = Enterprise.new(
-        abn: "65797115831",
-        acn: "",
-        name: "TEST Enterprise",
-      )
-      enterprise.address = Spree::Address.new(
-        address1: "1 testing street",
-        address2: "",
-        city: "TestCity",
-        zipcode: "1234"
-      )
-
-      enterprise
-    end
-
-    private_class_method :test_payment, :test_order, :test_enterprise
 
     private
 

--- a/app/services/payments/webhook_service.rb
+++ b/app/services/payments/webhook_service.rb
@@ -10,21 +10,11 @@ module Payments
       payload = WebhookPayload.new(payment:, order:, enterprise: order.distributor).to_hash
 
       coordinator = payment.order.order_cycle.coordinator
-      webhook_urls(coordinator).each do |url|
+      urls = WebhookUrlsService.for_coordinator(coordinator,
+                                                webhook_type: "payment_status_changed")
+      urls.each do |url|
         WebhookDeliveryJob.perform_later(url, event, payload, at:)
       end
-    end
-
-    def self.webhook_urls(coordinator)
-      # url for coordinator owner
-      webhook_urls = coordinator.owner.webhook_endpoints.payment_status.pluck(:url)
-
-      # plus url for coordinator manager (ignore duplicate)
-      users_webhook_urls = coordinator.users.flat_map do |user|
-        user.webhook_endpoints.payment_status.pluck(:url)
-      end
-
-      webhook_urls | users_webhook_urls
     end
   end
 end

--- a/app/services/webhook_test_data.rb
+++ b/app/services/webhook_test_data.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Example records describing the shape of a webhook payload, used by the
+# "Test webhook endpoint" button so integrators can see what they will receive.
+#
+# None of these records are meant to reach the database, so they are all marked
+# readonly. `readonly!` returns true rather than the record, so it is applied
+# with tap.
+
+class WebhookTestData
+  def self.order(attributes = {})
+    order = Spree::Order.new(
+      {
+        number: "R555555555",
+        email: "test@example.com",
+        total: 0.00,
+        payment_total: 0.00,
+        currency: "AUD",
+      }.merge(attributes)
+    )
+    order.line_items << line_item
+
+    order.tap(&:readonly!)
+  end
+
+  def self.payment(attributes = {})
+    Spree::Payment.new(
+      {
+        updated_at: Time.zone.now,
+        amount: 0.00,
+        state: "completed",
+        payment_method: payment_method,
+      }.merge(attributes)
+    ).tap(&:readonly!)
+  end
+
+  def self.enterprise
+    enterprise = Enterprise.new(
+      abn: "65797115831",
+      acn: "",
+      name: "TEST Enterprise",
+    )
+    enterprise.address = Spree::Address.new(
+      address1: "1 testing street",
+      address2: "",
+      city: "TestCity",
+      zipcode: "1234"
+    ).tap(&:readonly!)
+
+    enterprise.tap(&:readonly!)
+  end
+
+  def self.payment_method
+    Spree::PaymentMethod::Check.new(id: 0, name: "Test payment method").tap(&:readonly!)
+  end
+
+  def self.line_item
+    tax_category = Spree::TaxCategory.new(name: "VAT").tap(&:readonly!)
+    product = Spree::Product.new(name: "Test product")
+    Spree::Variant.new(product:, display_name: "")
+
+    Spree::LineItem.new(
+      quantity: 1,
+      price: 20.00,
+      tax_category:,
+      product: product.tap(&:readonly!),
+      unit_presentation: "1kg"
+    ).tap(&:readonly!)
+  end
+
+  private_class_method :payment_method, :line_item
+end

--- a/app/services/webhook_urls_service.rb
+++ b/app/services/webhook_urls_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Collect the webhook urls configured for a given webhook type by the people who
+# manage an order cycle coordinator: its owner and its managers.
+
+class WebhookUrlsService
+  def self.for_coordinator(coordinator, webhook_type:)
+    # url for coordinator owner
+    webhook_urls = endpoint_urls(coordinator.owner, webhook_type)
+
+    # plus url for coordinator manager (ignore duplicate)
+    users_webhook_urls = coordinator.users.flat_map do |user|
+      endpoint_urls(user, webhook_type)
+    end
+
+    webhook_urls | users_webhook_urls
+  end
+
+  def self.endpoint_urls(user, webhook_type)
+    user.webhook_endpoints.where(webhook_type:).pluck(:url)
+  end
+
+  private_class_method :endpoint_urls
+end

--- a/app/views/spree/users/_webhook_endpoints.html.haml
+++ b/app/views/spree/users/_webhook_endpoints.html.haml
@@ -12,3 +12,4 @@
     %tbody
       = render WebhookEndpointFormComponent.new(webhooks: @user.webhook_endpoints.order_cycle_opened, webhook_type: "order_cycle_opened")
       = render WebhookEndpointFormComponent.new(webhooks: @user.webhook_endpoints.payment_status, webhook_type: "payment_status_changed")
+      = render WebhookEndpointFormComponent.new(webhooks: @user.webhook_endpoints.order_payment_due, webhook_type: "order_payment_due")

--- a/app/views/spree/users/_webhook_endpoints.html.haml
+++ b/app/views/spree/users/_webhook_endpoints.html.haml
@@ -12,4 +12,4 @@
     %tbody
       = render WebhookEndpointFormComponent.new(webhooks: @user.webhook_endpoints.order_cycle_opened, webhook_type: "order_cycle_opened")
       = render WebhookEndpointFormComponent.new(webhooks: @user.webhook_endpoints.payment_status, webhook_type: "payment_status_changed")
-      = render WebhookEndpointFormComponent.new(webhooks: @user.webhook_endpoints.order_payment_due, webhook_type: "order_payment_due")
+      = render WebhookEndpointFormComponent.new(webhooks: @user.webhook_endpoints.order_balance_due, webhook_type: "order_balance_due")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4184,6 +4184,7 @@ en:
       error: Webhook endpoint failed to delete
     test:
       success: Some test data will be sent to the webhook url
+      unsupported: There is no test data for this webhook type
 
   spree:
     order_updated: "Order Updated"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5204,6 +5204,7 @@ en:
       event_types:
         order_cycle_opened: Order Cycle Opened
         payment_status_changed: Post webhook on Payment status change
+        order_payment_due: Post webhook on Order placed with payment due
       test_endpoint: Test webhook endpoint 
 
   # Gem to prevent bot form submissions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5205,7 +5205,7 @@ en:
       event_types:
         order_cycle_opened: Order Cycle Opened
         payment_status_changed: Post webhook on Payment status change
-        order_payment_due: Post webhook on Order placed with payment due
+        order_balance_due: Post webhook on Order placed with balance due
       test_endpoint: Test webhook endpoint 
 
   # Gem to prevent bot form submissions

--- a/docs/api-strategy.md
+++ b/docs/api-strategy.md
@@ -1,0 +1,148 @@
+# OFN API Strategy: DFC first, V1 for the gap
+
+> **Status:** draft for cohort review — June 2026
+> **Scope:** complements `AGENTS-api.md`. Establishes the strategic position on which API layer owns which resources, and why.
+
+---
+
+## The question
+
+OFN has two active, non-deprecated API layers: the DFC provider (`engines/dfc_provider/`, JSON-LD, semantic web) and V1 (`app/controllers/api/v1/`, standard Rails REST/JSON). A common instinct is to treat them as serving separate audiences — DFC for platform-to-platform federation, V1 for hub-manager-to-tools operational integration — and develop them in parallel.
+
+This document argues for a different split: **use DFC wherever the standard covers the resource; use V1 only for what falls outside DFC's scope.** The two APIs are not parallel tracks. DFC is the primary layer; V1 is the residual one.
+
+---
+
+## Why DFC first
+
+### The consumption-complexity objection no longer holds
+
+The traditional argument against DFC for operational integrations is that JSON-LD is hard to consume from automation tools like n8n, Zapier, or ERP connectors. Those tools expect flat REST/JSON, not semantic graphs with `@context` and IRI-namespaced properties.
+
+This objection weakens substantially in a workflow where LLMs build integrations from API specs. Given a well-formed OpenAPI/YAML spec, an LLM generates a working n8n workflow or ERP connector against DFC just as readily as against V1. The JSON-LD structure is the LLM's problem to handle, not the hub manager's. What matters to the hub manager is what data is available and whether the spec accurately documents it.
+
+The consumption argument was always about human developers reading raw wire responses. In an LLM-assisted integration workflow, that is increasingly not the dominant path.
+
+### A single API surface has real maintenance advantages
+
+Two APIs covering the same resource — say, products in DFC and products in V1 — means two serializers to keep in sync, two auth paths to audit, two sets of docs to update when the data model changes. Every resource that lives in exactly one layer is one fewer synchronization problem.
+
+### DFC is already further along than it looks
+
+The DFC engine already has routed, working endpoints for enterprises, products, catalog items (variants with per-hub stock and pricing), offers, addresses, persons, enterprise groups, product groups, and social media. Beyond what's routed, builders for `Order`, `OrderLine`, and `SaleSession` (order cycles) already exist in the engine — they map OFN records to DFC concepts and are used internally for the affiliate sales data endpoint. The data modelling work has already been done; those concepts just need routing.
+
+### DFC participation has value beyond OFN
+
+DFC is a community standard. Exposing OFN data through it means OFN instances can federate with FarmOS, Katuma, La Ruche Qui Dit Oui, and any other platform that speaks the protocol — without custom integration work on either side. Building operational endpoints in V1 instead of DFC keeps that interoperability locked out of the parts of OFN that need it most (order data, sales reporting inputs).
+
+---
+
+## Pros and cons
+
+### Pros of DFC first
+
+- **Reduces long-term API surface.** Fewer endpoints to maintain, document, and test when one layer owns each resource.
+- **Interoperability by default.** Any endpoint built in DFC is immediately usable by other DFC-participant platforms, not just OFN's own integrations.
+- **Semantic richness.** DFC's ontology carries meaning that plain REST/JSON doesn't — product types, quantity units, certification status — which makes integrations more robust and less brittle to field name changes.
+- **Existing infrastructure.** Auth, serialization patterns, and the DFC connector library are already established in the engine. New endpoints follow a clear pattern.
+- **LLM-friendly by spec.** A well-documented DFC API (YAML spec) is as LLM-friendly as V1. The spec is the interface, not the wire format.
+- **Alignment with the DFC standard limits local drift.** When DFC evolves, OFN benefits from upstream improvements. Building the same thing privately in V1 creates a local fork that drifts.
+
+### Cons / risks of DFC first
+
+- **DFC standard coverage has gaps.** Reports, variant overrides, subscriptions, payment workflows, and order cycle management have no DFC concept. Forcing them into DFC would require either extending the standard (slow) or creating OFN-specific vocabulary (a fork in practice). These genuinely belong in V1.
+- **Upstream coordination takes time.** Where OFN needs DFC to cover something it doesn't today (richer SaleSession fields, order filtering patterns), that requires proposing changes to the DFC consortium. This is not always fast.
+- **DFC's endpoint patterns are less flexible for operational queries.** Hub managers need to filter orders by date range, order cycle, fulfilment status — query patterns that don't map cleanly onto DFC's resource-oriented structure. Some V1 complement may be needed even where DFC owns the data model.
+- **JSON-LD has a debugging cost.** Even if LLMs generate integration code, developers debugging a failing integration still read raw responses. JSON-LD with nested `@context` resolution is harder to trace in a browser network panel or n8n log than flat JSON. This is a friction point, not a blocker.
+
+---
+
+## The split
+
+### DFC API — owns these resources
+
+The DFC engine already exposes these. Do not duplicate them in V1.
+
+| OFN resource | DFC concept | Current DFC status |
+|---|---|---|
+| Enterprises (hubs, producers) | `dfc-b:Enterprise` | ✅ Routed — `GET /enterprises`, `GET /enterprises/:id` |
+| Products / variants | `dfc-b:SuppliedProduct` | ✅ Routed — `GET/POST/PUT /enterprises/:id/supplied_products` |
+| Catalog items (variant + per-hub stock) | `dfc-b:CatalogItem` | ✅ Routed — `GET/PUT /enterprises/:id/catalog_items` |
+| Pricing | `dfc-b:Offer` | ✅ Routed — `GET/PUT /enterprises/:id/offers` |
+| Addresses | address | ✅ Routed — `GET /addresses/:id` |
+| Users / persons | `dfc-b:Person` | ✅ Routed — `GET /persons/:id` |
+| Product groups / categories | `dfc-b:ProductGroup` | ✅ Routed — `GET /product_groups/:id` |
+| Enterprise groups | `dfc-b:EnterpriseGroup` | ✅ Routed — `GET /enterprise_groups` |
+| Social media links | `dfc-b:SocialMedia` | ✅ Routed — `GET /enterprises/:id/social_medias` |
+| Platform connections | — | ✅ Routed — `GET/PUT /enterprises/:id/platforms` |
+| Inbound platform events (from other platforms) | — | ✅ Routed — `POST /events` |
+| Aggregate affiliate sales data | — | ✅ Routed — `GET /affiliate_sales_data` |
+
+#### DFC concepts already modelled, not yet routed — extend DFC here, not V1
+
+`OrderBuilder`, `OrderLineBuilder`, and `SaleSessionBuilder` exist in the engine and map OFN records to DFC types. They are used internally but not exposed as endpoints. These should be wired up in DFC rather than built as parallel V1 endpoints.
+
+| OFN resource | DFC concept | Current status | Notes |
+|---|---|---|---|
+| Orders (read) | `dfc-b:Order` | Builder exists, not routed | Index/show scoped to managed enterprises |
+| Line items (read) | `dfc-b:OrderLine` | Builder exists, not routed | Nested under orders |
+| Order cycles (read) | `dfc-b:SaleSession` | Builder exists, not routed | `SaleSessionBuilder` already maps `orders_open_at`/`orders_close_at`; expose index/show scoped to managed enterprises |
+
+**Caveat on order cycles:** `dfc-b:SaleSession` captures the temporal window and coordinator. The full OFN order cycle — exchanges, enterprise fees, distributor and producer lists, subscription sync — has no DFC equivalent beyond that. Read access via DFC is straightforward; creation and management belong in V1.
+
+---
+
+### V1 API — owns these resources
+
+These have no DFC standard concept. They belong in V1 without qualification.
+
+| Resource | Reason |
+|---|---|
+| **Reports** (packing, sales tax, xero invoices, revenues_by_hub, etc.) | OFN-specific operational reporting. No DFC concept. Primary unblock for n8n/ERP workflows. |
+| **Order cycle create / clone / update** | `CloneService` and the full exchange/fee/subscription sync structure are OFN-specific. `dfc-b:SaleSession` is a data type, not a management API. |
+| **Variant overrides** | Hub-level price and stock overrides per producer variant. No DFC concept. |
+| **Customers** (OFN customer records) | OFN's customer model (per-enterprise records, tags, balance) is distinct from `dfc-b:Person` which represents a platform user. |
+| **Customer account transactions** | OFN credit/balance system. No DFC equivalent. |
+| **Subscriptions** | Recurring orders with OFN-specific scheduling, proxy orders, and subscription coordination. No DFC concept. |
+| **Payments** | OFN payment methods, payment workflow, and the planned payment-due webhook + update endpoint (issue #14406). No DFC equivalent. |
+| **Outbound webhooks** | OFN's webhook delivery infrastructure (`order_cycle_opened`, `payment_status_changed`, planned `payment_due`). OFN infrastructure, not a DFC data concept. |
+| **Pickup / delivery logistics** | `pickup_time`, `pickup_instructions`, `receival_instructions` live on the `exchanges` table. No DFC concept. |
+
+---
+
+## Grey areas and decision rules
+
+### Orders: DFC for the resource, V1 complement for complex queries
+
+`dfc-b:Order` covers the order entity cleanly. But filtering orders by date range, order cycle, fulfilment status, and distributor — the queries hub managers actually need — does not map onto DFC's resource-oriented endpoint pattern. **Rule:** expose orders as a DFC resource; if operational query needs exceed what DFC's structure supports cleanly, add a V1 `GET /api/v1/orders` with filtering. Do not duplicate the data model — the V1 query endpoint uses the same underlying data, just with a different interface.
+
+### Order cycles: DFC for read, V1 for write
+
+Expose `GET /dfc/enterprises/:id/sale_sessions` for read using `SaleSessionBuilder`. Keep `POST /api/v1/order_cycles` (clone/create via `CloneService`) in V1. Management is OFN-specific; read access is not.
+
+### Customers: V1 for now, revisit if DFC extends
+
+OFN's customer entity carries OFN-specific fields (enterprise scope, balance, tags) that don't fit `dfc-b:Person`. Keep in V1. Revisit if the DFC standard adds a customer-relationship concept.
+
+---
+
+## Decision rule for new endpoints
+
+When scoping any new endpoint, ask in order:
+
+1. **Does DFC have a concept for this resource?** → Build in DFC.
+2. **Does DFC partially cover it?** → Build what DFC covers in DFC; put the OFN-specific remainder in V1.
+3. **Is it purely OFN-specific with no DFC analogue?** → Build in V1.
+
+Never build the same resource in both layers. If something lands in V1 because DFC doesn't cover it today, note explicitly whether a future DFC concept could absorb it.
+
+---
+
+## Documentation requirement
+
+Both APIs must have complete, accurate OpenAPI/YAML specs. This is the prerequisite that makes LLM-assisted integration building work — the spec is the interface the LLM works from, not the source code.
+
+- **DFC:** `swagger/dfc.yaml` — generated from the DFC engine's request specs
+- **V1:** `swagger/v1.yaml` — regenerate with `bundle exec rake rswag:specs:swaggerize` after each change
+
+A spec that is incomplete or out of date with the implementation undermines the entire integration workflow. Keeping specs current is not documentation work — it is functional work.

--- a/spec/controllers/webhook_endpoints_controller_spec.rb
+++ b/spec/controllers/webhook_endpoints_controller_spec.rb
@@ -78,12 +78,47 @@ RSpec.describe WebhookEndpointsController do
 
     it "enqueus a webhook job" do
       expect { subject }.to enqueue_job(WebhookDeliveryJob).exactly(1).times
+        .with("https://url", "payment.completed", any_args)
     end
 
     it "shows a success mesage" do
       subject
 
       expect(flash[:success]).to eq "Some test data will be sent to the webhook url"
+    end
+
+    context "with an order payment due endpoint" do
+      let(:webhook_endpoint) {
+        user.webhook_endpoints.create(url: "https://url", webhook_type: "order_payment_due")
+      }
+
+      it "enqueues a webhook job with the order payment due test data" do
+        expect { subject }.to enqueue_job(WebhookDeliveryJob).exactly(1).times
+          .with("https://url", "order.payment_due", any_args)
+      end
+
+      it "describes the payload an integration will receive" do
+        payload = Orders::WebhookPayload.test_data.to_hash
+
+        expect(payload[:order]).to include("number", "email", "outstanding_balance")
+        expect(payload[:payment_method].keys).to contain_exactly("id", "name")
+      end
+    end
+
+    context "with a webhook type we have no test data for" do
+      let(:webhook_endpoint) {
+        user.webhook_endpoints.create(url: "https://url", webhook_type: "order_cycle_opened")
+      }
+
+      it "does not enqueue a webhook job" do
+        expect { subject }.not_to enqueue_job(WebhookDeliveryJob)
+      end
+
+      it "shows an error message" do
+        subject
+
+        expect(flash[:error]).to eq "There is no test data for this webhook type"
+      end
     end
   end
 end

--- a/spec/controllers/webhook_endpoints_controller_spec.rb
+++ b/spec/controllers/webhook_endpoints_controller_spec.rb
@@ -87,14 +87,14 @@ RSpec.describe WebhookEndpointsController do
       expect(flash[:success]).to eq "Some test data will be sent to the webhook url"
     end
 
-    context "with an order payment due endpoint" do
+    context "with an order balance due endpoint" do
       let(:webhook_endpoint) {
-        user.webhook_endpoints.create(url: "https://url", webhook_type: "order_payment_due")
+        user.webhook_endpoints.create(url: "https://url", webhook_type: "order_balance_due")
       }
 
-      it "enqueues a webhook job with the order payment due test data" do
+      it "enqueues a webhook job with the order balance due test data" do
         expect { subject }.to enqueue_job(WebhookDeliveryJob).exactly(1).times
-          .with("https://url", "order.payment_due", any_args)
+          .with("https://url", "order.balance_due", any_args)
       end
 
       it "describes the payload an integration will receive" do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -276,6 +276,26 @@ RSpec.describe Spree::Order do
       expect(order.updater).to receive(:shipping_address_from_distributor)
       order.finalize!
     end
+
+    context "when a payment is still due" do
+      let(:order) { create(:order_ready_for_confirmation) }
+
+      it "notifies the order.payment_due webhook" do
+        expect(Orders::WebhookService).to receive(:create_payment_due_job).with(order:)
+        order.finalize!
+      end
+    end
+
+    context "when the order is paid in full" do
+      let(:order) { create(:order_ready_for_confirmation) }
+
+      it "does not notify the order.payment_due webhook" do
+        order.payments.first.capture!
+
+        expect(Orders::WebhookService).not_to receive(:create_payment_due_job)
+        order.finalize!
+      end
+    end
   end
 
   describe "#process_payments!" do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -277,11 +277,11 @@ RSpec.describe Spree::Order do
       order.finalize!
     end
 
-    context "when a payment is still due" do
+    context "when a balance is still due" do
       let(:order) { create(:order_ready_for_confirmation) }
 
-      it "notifies the order.payment_due webhook" do
-        expect(Orders::WebhookService).to receive(:create_payment_due_job).with(order:)
+      it "notifies the order.balance_due webhook" do
+        expect(Orders::WebhookService).to receive(:create_balance_due_job).with(order:)
         order.finalize!
       end
     end
@@ -289,10 +289,10 @@ RSpec.describe Spree::Order do
     context "when the order is paid in full" do
       let(:order) { create(:order_ready_for_confirmation) }
 
-      it "does not notify the order.payment_due webhook" do
+      it "does not notify the order.balance_due webhook" do
         order.payments.first.capture!
 
-        expect(Orders::WebhookService).not_to receive(:create_payment_due_job)
+        expect(Orders::WebhookService).not_to receive(:create_balance_due_job)
         order.finalize!
       end
     end

--- a/spec/models/webhook_endpoint_spec.rb
+++ b/spec/models/webhook_endpoint_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe WebhookEndpoint do
     it { is_expected.to validate_presence_of(:url) }
     it {
       is_expected.to validate_inclusion_of(:webhook_type)
-        .in_array(%w(order_cycle_opened payment_status_changed))
+        .in_array(%w(order_cycle_opened payment_status_changed order_payment_due))
     }
   end
 end

--- a/spec/models/webhook_endpoint_spec.rb
+++ b/spec/models/webhook_endpoint_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe WebhookEndpoint do
     it { is_expected.to validate_presence_of(:url) }
     it {
       is_expected.to validate_inclusion_of(:webhook_type)
-        .in_array(%w(order_cycle_opened payment_status_changed order_payment_due))
+        .in_array(%w(order_cycle_opened payment_status_changed order_balance_due))
     }
   end
 end

--- a/spec/services/orders/find_payment_service_spec.rb
+++ b/spec/services/orders/find_payment_service_spec.rb
@@ -33,6 +33,27 @@ RSpec.describe Orders::FindPaymentService do
     end
   end
 
+  describe "#last_pending_payment_excluding_credit" do
+    let!(:credit_payment) {
+      create(:payment, order:, payment_method: Spree::PaymentMethod.customer_credit,
+                       skip_source_validation: true, source: nil)
+    }
+
+    context "when the order only has a customer credit payment" do
+      it "returns nil" do
+        expect(finder.last_pending_payment_excluding_credit).to be nil
+      end
+    end
+
+    context "when the customer also chose a payment method" do
+      let!(:chosen_payment) { create(:payment, order:) }
+
+      it "returns the payment the customer chose" do
+        expect(finder.last_pending_payment_excluding_credit).to eq chosen_payment
+      end
+    end
+  end
+
   describe "#last_payment" do
     context "when order has several non pending payments" do
       let!(:failed_payment) { create(:payment, order:, state: 'failed') }

--- a/spec/services/orders/webhook_payload_spec.rb
+++ b/spec/services/orders/webhook_payload_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe Orders::WebhookPayload do
+  describe "#to_hash" do
+    let(:order_cycle) { create(:simple_order_cycle) }
+    let(:order) { create(:completed_order_with_totals, order_cycle:) }
+    let(:payment) { create(:payment, order:) }
+
+    subject { described_class.new(order:, payment:, enterprise: order.distributor) }
+
+    it "returns a hash with the order, payment method and enterprise data" do
+      enterprise = order.distributor
+
+      payload = {
+        order: {
+          number: order.number,
+          email: order.email,
+          total: order.total,
+          currency: order.currency,
+          outstanding_balance: order.new_outstanding_balance
+        },
+        payment_method: {
+          name: payment.payment_method.name,
+          type: payment.payment_method.type
+        },
+        enterprise: {
+          abn: enterprise.abn,
+          acn: enterprise.acn,
+          name: enterprise.name,
+          address: {
+            address1: enterprise.address.address1,
+            address2: enterprise.address.address2,
+            city: enterprise.address.city,
+            zipcode: enterprise.address.zipcode
+          }
+        }
+      }.with_indifferent_access
+
+      expect(subject.to_hash).to eq(payload)
+    end
+
+    context "without a pending payment" do
+      subject { described_class.new(order:, payment: nil, enterprise: order.distributor) }
+
+      it "returns nil payment method details" do
+        expect(subject.to_hash[:payment_method]).to eq(
+          "name" => nil, "type" => nil
+        )
+      end
+    end
+  end
+end

--- a/spec/services/orders/webhook_payload_spec.rb
+++ b/spec/services/orders/webhook_payload_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Orders::WebhookPayload do
           outstanding_balance: order.new_outstanding_balance
         },
         payment_method: {
-          name: payment.payment_method.name,
-          type: payment.payment_method.type
+          id: payment.payment_method.id,
+          name: payment.payment_method.name
         },
         enterprise: {
           abn: enterprise.abn,
@@ -39,14 +39,8 @@ RSpec.describe Orders::WebhookPayload do
       expect(subject.to_hash).to eq(payload)
     end
 
-    context "without a pending payment" do
-      subject { described_class.new(order:, payment: nil, enterprise: order.distributor) }
-
-      it "returns nil payment method details" do
-        expect(subject.to_hash[:payment_method]).to eq(
-          "name" => nil, "type" => nil
-        )
-      end
+    it "doesn't expose the payment method class name" do
+      expect(subject.to_hash[:payment_method].keys).to contain_exactly("id", "name")
     end
   end
 end

--- a/spec/services/orders/webhook_payload_spec.rb
+++ b/spec/services/orders/webhook_payload_spec.rb
@@ -54,23 +54,11 @@ RSpec.describe Orders::WebhookPayload do
       expect(payload[:payment_method].keys).to contain_exactly("id", "name")
     end
 
-    it "can't be saved to the database" do
-      payment = described_class.__send__(:test_payment)
-      enterprise = described_class.__send__(:test_enterprise)
-      records = [
-        described_class.__send__(:test_order),
-        payment,
-        payment.payment_method,
-        enterprise,
-        enterprise.address,
-      ]
+    it "shows a balance still due" do
+      payload = subject.to_hash
 
-      expect(records).to all(be_readonly)
-      records.each do |record|
-        # Skipping validation so we reach the readonly guard rather than
-        # failing earlier on incomplete test data.
-        expect{ record.save!(validate: false) }.to raise_error(ActiveRecord::ReadOnlyRecord)
-      end
+      expect(payload[:order][:total]).to eq 20.00
+      expect(payload[:order][:outstanding_balance]).to eq 20.00
     end
   end
 end

--- a/spec/services/orders/webhook_payload_spec.rb
+++ b/spec/services/orders/webhook_payload_spec.rb
@@ -43,4 +43,34 @@ RSpec.describe Orders::WebhookPayload do
       expect(subject.to_hash[:payment_method].keys).to contain_exactly("id", "name")
     end
   end
+
+  describe ".test_data" do
+    subject { described_class.test_data }
+
+    it "describes the payload an integration will receive" do
+      payload = subject.to_hash
+
+      expect(payload[:order]).to include("number", "email", "outstanding_balance")
+      expect(payload[:payment_method].keys).to contain_exactly("id", "name")
+    end
+
+    it "can't be saved to the database" do
+      payment = described_class.__send__(:test_payment)
+      enterprise = described_class.__send__(:test_enterprise)
+      records = [
+        described_class.__send__(:test_order),
+        payment,
+        payment.payment_method,
+        enterprise,
+        enterprise.address,
+      ]
+
+      expect(records).to all(be_readonly)
+      records.each do |record|
+        # Skipping validation so we reach the readonly guard rather than
+        # failing earlier on incomplete test data.
+        expect{ record.save!(validate: false) }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      end
+    end
+  end
 end

--- a/spec/services/orders/webhook_service_spec.rb
+++ b/spec/services/orders/webhook_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe Orders::WebhookService do
+  let(:order_cycle) { create(:simple_order_cycle) }
+  let(:order) { create(:completed_order_with_totals, order_cycle:) }
+  let!(:payment) { create(:payment, order:) }
+
+  before { order.payments.reload }
+
+  subject { described_class.create_payment_due_job(order:) }
+
+  describe "creating payloads" do
+    context "with order cycle coordinator owner webhook endpoints configured" do
+      before do
+        order.order_cycle.coordinator.owner.webhook_endpoints.payment_status.create!(
+          url: "http://coordinator.payment.url"
+        )
+      end
+
+      it "enqueues an order.payment_due delivery for the coordinator owner" do
+        expect{ subject }
+          .to enqueue_job(WebhookDeliveryJob).exactly(1).times
+          .with("http://coordinator.payment.url", "order.payment_due", any_args)
+      end
+
+      it "includes the order, amount due and payment method in the payload" do
+        data = {
+          order: {
+            number: order.number,
+            email: order.email,
+            total: order.total,
+            currency: order.currency,
+            outstanding_balance: order.new_outstanding_balance
+          },
+          payment_method: {
+            name: payment.payment_method.name,
+            type: payment.payment_method.type
+          }
+        }
+
+        expect{ subject }
+          .to enqueue_job(WebhookDeliveryJob).exactly(1).times
+          .with("http://coordinator.payment.url", "order.payment_due", hash_including(data))
+      end
+
+      context "with coordinator managers with webhook endpoints configured" do
+        let(:user1) { create(:user) }
+        let(:user2) { create(:user) }
+
+        before do
+          coordinator = order.order_cycle.coordinator
+          coordinator.users << user1
+          coordinator.users << user2
+        end
+
+        it "enqueues a delivery for every unique configured endpoint" do
+          user1.webhook_endpoints.payment_status.create!(url: "http://coordinator.payment.url")
+          user2.webhook_endpoints.payment_status.create!(url: "http://user2.payment.url")
+
+          expect{ subject }
+            .to enqueue_job(WebhookDeliveryJob)
+            .with("http://coordinator.payment.url", "order.payment_due", any_args)
+            .and enqueue_job(WebhookDeliveryJob)
+            .with("http://user2.payment.url", "order.payment_due", any_args)
+        end
+      end
+    end
+
+    context "with no webhook configured" do
+      it "does not enqueue a delivery" do
+        expect{ subject }.not_to enqueue_job(WebhookDeliveryJob)
+      end
+    end
+  end
+end

--- a/spec/services/orders/webhook_service_spec.rb
+++ b/spec/services/orders/webhook_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Orders::WebhookService do
   describe "creating payloads" do
     context "with order cycle coordinator owner webhook endpoints configured" do
       before do
-        order.order_cycle.coordinator.owner.webhook_endpoints.payment_status.create!(
+        order.order_cycle.coordinator.owner.webhook_endpoints.order_payment_due.create!(
           url: "http://coordinator.payment.url"
         )
       end
@@ -54,8 +54,8 @@ RSpec.describe Orders::WebhookService do
         end
 
         it "enqueues a delivery for every unique configured endpoint" do
-          user1.webhook_endpoints.payment_status.create!(url: "http://coordinator.payment.url")
-          user2.webhook_endpoints.payment_status.create!(url: "http://user2.payment.url")
+          user1.webhook_endpoints.order_payment_due.create!(url: "http://coordinator.payment.url")
+          user2.webhook_endpoints.order_payment_due.create!(url: "http://user2.payment.url")
 
           expect{ subject }
             .to enqueue_job(WebhookDeliveryJob)
@@ -68,6 +68,16 @@ RSpec.describe Orders::WebhookService do
 
     context "with no webhook configured" do
       it "does not enqueue a delivery" do
+        expect{ subject }.not_to enqueue_job(WebhookDeliveryJob)
+      end
+    end
+
+    context "with only a payment status webhook configured" do
+      it "does not enqueue a delivery" do
+        order.order_cycle.coordinator.owner.webhook_endpoints.payment_status.create!(
+          url: "http://coordinator.payment.url"
+        )
+
         expect{ subject }.not_to enqueue_job(WebhookDeliveryJob)
       end
     end

--- a/spec/services/orders/webhook_service_spec.rb
+++ b/spec/services/orders/webhook_service_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Orders::WebhookService do
             outstanding_balance: order.new_outstanding_balance
           },
           payment_method: {
-            name: payment.payment_method.name,
-            type: payment.payment_method.type
+            id: payment.payment_method.id,
+            name: payment.payment_method.name
           }
         }
 
@@ -67,6 +67,46 @@ RSpec.describe Orders::WebhookService do
     end
 
     context "with no webhook configured" do
+      it "does not enqueue a delivery" do
+        expect{ subject }.not_to enqueue_job(WebhookDeliveryJob)
+      end
+    end
+
+    # Customer credit is applied before the customer picks a payment method, so an
+    # order can carry both when it's placed.
+    context "with a customer credit payment" do
+      let!(:credit_payment) {
+        create(:payment, order:, payment_method: Spree::PaymentMethod.customer_credit,
+                         skip_source_validation: true, source: nil)
+      }
+      let!(:chosen_payment) { create(:payment, order:) }
+
+      before do
+        order.payments.reload
+        order.order_cycle.coordinator.owner.webhook_endpoints.order_payment_due.create!(
+          url: "http://coordinator.payment.url"
+        )
+      end
+
+      it "reports the payment method the customer chose, not the credit" do
+        expect{ subject }
+          .to enqueue_job(WebhookDeliveryJob).exactly(1).times
+          .with("http://coordinator.payment.url", "order.payment_due",
+                hash_including("payment_method" => {
+                                 "id" => chosen_payment.payment_method.id,
+                                 "name" => chosen_payment.payment_method.name
+                               }))
+      end
+    end
+
+    context "without a payment to report" do
+      before do
+        order.payments.destroy_all
+        order.order_cycle.coordinator.owner.webhook_endpoints.order_payment_due.create!(
+          url: "http://coordinator.payment.url"
+        )
+      end
+
       it "does not enqueue a delivery" do
         expect{ subject }.not_to enqueue_job(WebhookDeliveryJob)
       end

--- a/spec/services/orders/webhook_service_spec.rb
+++ b/spec/services/orders/webhook_service_spec.rb
@@ -7,20 +7,20 @@ RSpec.describe Orders::WebhookService do
 
   before { order.payments.reload }
 
-  subject { described_class.create_payment_due_job(order:) }
+  subject { described_class.create_balance_due_job(order:) }
 
   describe "creating payloads" do
     context "with order cycle coordinator owner webhook endpoints configured" do
       before do
-        order.order_cycle.coordinator.owner.webhook_endpoints.order_payment_due.create!(
+        order.order_cycle.coordinator.owner.webhook_endpoints.order_balance_due.create!(
           url: "http://coordinator.payment.url"
         )
       end
 
-      it "enqueues an order.payment_due delivery for the coordinator owner" do
+      it "enqueues an order.balance_due delivery for the coordinator owner" do
         expect{ subject }
           .to enqueue_job(WebhookDeliveryJob).exactly(1).times
-          .with("http://coordinator.payment.url", "order.payment_due", any_args)
+          .with("http://coordinator.payment.url", "order.balance_due", any_args)
       end
 
       it "includes the order, amount due and payment method in the payload" do
@@ -40,7 +40,7 @@ RSpec.describe Orders::WebhookService do
 
         expect{ subject }
           .to enqueue_job(WebhookDeliveryJob).exactly(1).times
-          .with("http://coordinator.payment.url", "order.payment_due", hash_including(data))
+          .with("http://coordinator.payment.url", "order.balance_due", hash_including(data))
       end
 
       context "with coordinator managers with webhook endpoints configured" do
@@ -54,14 +54,14 @@ RSpec.describe Orders::WebhookService do
         end
 
         it "enqueues a delivery for every unique configured endpoint" do
-          user1.webhook_endpoints.order_payment_due.create!(url: "http://coordinator.payment.url")
-          user2.webhook_endpoints.order_payment_due.create!(url: "http://user2.payment.url")
+          user1.webhook_endpoints.order_balance_due.create!(url: "http://coordinator.payment.url")
+          user2.webhook_endpoints.order_balance_due.create!(url: "http://user2.payment.url")
 
           expect{ subject }
             .to enqueue_job(WebhookDeliveryJob)
-            .with("http://coordinator.payment.url", "order.payment_due", any_args)
+            .with("http://coordinator.payment.url", "order.balance_due", any_args)
             .and enqueue_job(WebhookDeliveryJob)
-            .with("http://user2.payment.url", "order.payment_due", any_args)
+            .with("http://user2.payment.url", "order.balance_due", any_args)
         end
       end
     end
@@ -83,7 +83,7 @@ RSpec.describe Orders::WebhookService do
 
       before do
         order.payments.reload
-        order.order_cycle.coordinator.owner.webhook_endpoints.order_payment_due.create!(
+        order.order_cycle.coordinator.owner.webhook_endpoints.order_balance_due.create!(
           url: "http://coordinator.payment.url"
         )
       end
@@ -91,7 +91,7 @@ RSpec.describe Orders::WebhookService do
       it "reports the payment method the customer chose, not the credit" do
         expect{ subject }
           .to enqueue_job(WebhookDeliveryJob).exactly(1).times
-          .with("http://coordinator.payment.url", "order.payment_due",
+          .with("http://coordinator.payment.url", "order.balance_due",
                 hash_including("payment_method" => {
                                  "id" => chosen_payment.payment_method.id,
                                  "name" => chosen_payment.payment_method.name
@@ -102,7 +102,7 @@ RSpec.describe Orders::WebhookService do
     context "without a payment to report" do
       before do
         order.payments.destroy_all
-        order.order_cycle.coordinator.owner.webhook_endpoints.order_payment_due.create!(
+        order.order_cycle.coordinator.owner.webhook_endpoints.order_balance_due.create!(
           url: "http://coordinator.payment.url"
         )
       end

--- a/spec/services/webhook_test_data_spec.rb
+++ b/spec/services/webhook_test_data_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe WebhookTestData do
+  describe ".order" do
+    it "describes an order with a line item" do
+      order = described_class.order
+
+      expect(order.number).to eq "R555555555"
+      expect(order.line_items.map(&:price)).to eq [20.00]
+    end
+
+    it "accepts overrides" do
+      expect(described_class.order(total: 20.00).total).to eq 20.00
+    end
+  end
+
+  describe ".payment" do
+    it "describes a completed payment with a payment method" do
+      payment = described_class.payment
+
+      expect(payment.state).to eq "completed"
+      expect(payment.payment_method.name).to eq "Test payment method"
+    end
+
+    it "accepts overrides" do
+      expect(described_class.payment(state: "checkout").state).to eq "checkout"
+    end
+  end
+
+  describe ".enterprise" do
+    it "describes an enterprise with an address" do
+      enterprise = described_class.enterprise
+
+      expect(enterprise.name).to eq "TEST Enterprise"
+      expect(enterprise.address.city).to eq "TestCity"
+    end
+  end
+
+  it "can't be saved to the database" do
+    order = described_class.order
+    payment = described_class.payment
+    enterprise = described_class.enterprise
+    records = [
+      order,
+      order.line_items.first,
+      payment,
+      payment.payment_method,
+      enterprise,
+      enterprise.address,
+    ]
+
+    expect(records).to all(be_readonly)
+    records.each do |record|
+      # Skipping validation so we reach the readonly guard rather than
+      # failing earlier on incomplete test data.
+      expect{ record.save!(validate: false) }.to raise_error(ActiveRecord::ReadOnlyRecord)
+    end
+  end
+end

--- a/spec/services/webhook_urls_service_spec.rb
+++ b/spec/services/webhook_urls_service_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe WebhookUrlsService do
+  subject { described_class.for_coordinator(coordinator, webhook_type: "payment_status_changed") }
+
+  let(:coordinator) { create(:enterprise) }
+
+  it "returns nothing when no endpoint is configured" do
+    expect(subject).to eq []
+  end
+
+  it "returns the endpoints of the coordinator owner" do
+    coordinator.owner.webhook_endpoints.payment_status.create!(url: "http://owner.url")
+
+    expect(subject).to eq ["http://owner.url"]
+  end
+
+  it "returns the endpoints of the coordinator managers" do
+    manager = create(:user)
+    coordinator.users << manager
+    manager.webhook_endpoints.payment_status.create!(url: "http://manager.url")
+
+    expect(subject).to eq ["http://manager.url"]
+  end
+
+  it "ignores duplicate urls" do
+    manager = create(:user)
+    coordinator.users << manager
+    coordinator.owner.webhook_endpoints.payment_status.create!(url: "http://shared.url")
+    manager.webhook_endpoints.payment_status.create!(url: "http://shared.url")
+
+    expect(subject).to eq ["http://shared.url"]
+  end
+
+  it "ignores endpoints configured for another webhook type" do
+    coordinator.owner.webhook_endpoints.order_cycle_opened.create!(url: "http://order.cycle.url")
+
+    expect(subject).to eq []
+  end
+end

--- a/spec/services/webhook_urls_service_spec.rb
+++ b/spec/services/webhook_urls_service_spec.rb
@@ -37,4 +37,36 @@ RSpec.describe WebhookUrlsService do
 
     expect(subject).to eq []
   end
+
+  it "ignores endpoints of people who don't manage this coordinator" do
+    other_enterprise = create(:enterprise)
+    other_manager = create(:user)
+    other_enterprise.users << other_manager
+
+    other_enterprise.owner.webhook_endpoints.payment_status.create!(url: "http://other.owner.url")
+    other_manager.webhook_endpoints.payment_status.create!(url: "http://other.manager.url")
+    create(:user).webhook_endpoints.payment_status.create!(url: "http://stranger.url")
+
+    expect(subject).to eq []
+  end
+
+  context "for the order balance due webhook type" do
+    subject { described_class.for_coordinator(coordinator, webhook_type: "order_balance_due") }
+
+    it "returns the endpoints of the coordinator owner and managers" do
+      manager = create(:user)
+      coordinator.users << manager
+      coordinator.owner.webhook_endpoints.order_balance_due.create!(url: "http://owner.url")
+      manager.webhook_endpoints.order_balance_due.create!(url: "http://manager.url")
+
+      expect(subject).to contain_exactly("http://owner.url", "http://manager.url")
+    end
+
+    it "ignores endpoints of people who don't manage this coordinator" do
+      other_enterprise = create(:enterprise)
+      other_enterprise.owner.webhook_endpoints.order_balance_due.create!(url: "http://other.url")
+
+      expect(subject).to eq []
+    end
+  end
 end


### PR DESCRIPTION
## What? Why?

- Closes #14406

Picks up @kenlacroix's work in #14454, which stalled. His commit is the first one here, unchanged
and with his authorship — the rest of the branch addresses the review. #14454 can be closed in
favour of this.

The existing `payment.<state>` webhook only fires on payment **state transitions**. For cash and
other offline payment methods that transition only happens when the hub manager manually marks the
order as paid, so nothing fires at order placement time. This adds an `order.payment_due` event,
fired when an order is placed while a payment is still due, so an integration can start an external
payment flow — a local currency, or any provider OFN doesn't support natively — and tell the
customer, instead of the hub manager doing it by hand.

To be explicit about a constraint raised in the design thread: this event is *not* a payment
confirmation. It says a balance is due, nothing more. Confirming an offline payment stays a
deliberate, separate step.

What changed since #14454, following @rioug's summary:

- The event has its own `order_payment_due` webhook type, so existing `payment_status_changed`
  subscribers don't start receiving an event they never asked for, and it can be subscribed to on
  its own. It appears on the customer account developer settings screen.
- The payload no longer exposes `payment_method.type` (the STI class name). It carries the payment
  method `id` and `name` instead, so a rename doesn't break integrations. The customer email stays
  — the use case is emailing the customer, and until V1 has an orders endpoint the only re-fetch
  path is V0.
- "Test webhook endpoint" can send test data for the new type, so the payload shape can be
  inspected before wiring anything up.
- `Payments::WebhookService.webhook_urls` moved to its own `WebhookUrlsService`, so the order
  webhook no longer reaches into the payments namespace for it.

Payload:

```json
{
  "order": { "number": "R555555555", "email": "test@example.com", "total": 20.0,
             "currency": "AUD", "outstanding_balance": 20.0 },
  "payment_method": { "id": 0, "name": "Test payment method" },
  "enterprise": { "abn": "...", "acn": "", "name": "...", "address": { } }
}
```

<img width="1154" height="355" alt="Developper Settings screenshot" src="https://github.com/user-attachments/assets/4a1d25ee-6416-4580-afa8-488b13fe7ebb" />

### Known limitation: silent failure

@mkllnk raised this when the feature was discussed: a payment-method integration guarantees the
process was user-initiated, whereas a webhook can fail silently in the background with no feedback
to anyone. That's true here — if delivery exhausts its retries, the customer never receives their
payment link and the hub manager isn't told. This PR doesn't change that, and it applies equally to
the existing webhooks, so I've left it alone rather than reworking `WebhookDeliveryJob` here. Happy
to open a follow-up issue for delivery-failure feedback if you agree it's worth doing separately.

### Three things I'd like your view on

1. **`WebhookUrlsService` signature.** @rioug suggested `for_coordinator(coordinator)`. With two
   webhook types now asking the same question I've made it
   `for_coordinator(coordinator, webhook_type:)`. Say if you'd rather it stayed type-free.
2. **Picking the payment to report.** The original commit used `order.pending_payments.first`.
   `pending_payments` is unordered (`has_many :payments` has no `order` clause), so `.first` is
   effectively "lowest id". An order can hold a customer credit payment alongside the method the
   customer chose — `Spree::Payment#invalidate_old_payments` deliberately leaves credit payments
   alone, so both can be pending at once. I've used `Orders::FindPaymentService` instead, which is
   what `OrderHelper#order_payment_method` already does, and added
   `last_pending_payment_excluding_credit` to it. Note `Orders::CaptureService` still uses
   `pending_payments.first`; I couldn't construct a case where it picks wrongly, so I've left it.
3. **Subscription orders.** They go through `Spree::Order#finalize!` too, so a subscription order
   placed with a balance due will emit this event. That seems right, but it's worth confirming.

Also minor: `WebhookEndpointsController#test` previously sent payment test data for *any* endpoint
id, including `order_cycle_opened` ones (no button exists for those, but the route is reachable).
It now says there's no test data for that type instead.

## What should we test?

You can use a service like https://webhook.site/ to prepare an example webhook endpoint.

- On the customer account **developer settings** tab, there are now three webhook rows. Create an
  endpoint for **"Post webhook on Order placed with payment due"**.
- Press **Test webhook endpoint** on that row → test data is delivered as an `order.payment_due`
  event. The payload shows the order, the amount due and the payment method name/id.
- As a customer, place an order with an offline/cash payment method at a shop whose order cycle
  coordinator has that endpoint configured → an `order.payment_due` event is delivered.
- Place an order paid in full at checkout (e.g. Stripe) → **no** `order.payment_due` event.
- Existing behaviour is unchanged: a `payment_status_changed` endpoint still receives
  `payment.<state>` events and its test button still sends payment test data.

Automated coverage: `spec/services/orders/webhook_service_spec.rb`,
`spec/services/orders/webhook_payload_spec.rb`, `spec/services/webhook_urls_service_spec.rb`,
`spec/services/orders/find_payment_service_spec.rb`,
`spec/controllers/webhook_endpoints_controller_spec.rb`, `spec/models/webhook_endpoint_spec.rb`,
and `#finalize!` examples in `spec/models/spree/order_spec.rb`.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] API changes (V0, V1, DFC or Webhook)

## Dependencies

None.

## Documentation updates

The webhook documentation should mention the new `order_payment_due` type and the
`order.payment_due` payload — happy to do that once the payload is agreed.

<!-- screenshot of the developer settings screen to be attached -->
