### PR TITLE
Load DFC vocabularies into each connector

### DIFF
--- a/engines/dfc_provider/app/services/dfc_loader.rb
+++ b/engines/dfc_provider/app/services/dfc_loader.rb
@@ -29,9 +29,13 @@ class DfcLoader
     load_thesaurus(connector, name)
   end
 
+  # Each connector needs its own copy of a thesaurus. Caching only by name
+  # would leave whichever connector asked second without the vocabulary, and it
+  # would then deserialise terms like "dfc-v:Held" into a parsed URI Hash
+  # instead of a SKOSConcept.
   def self.load_thesaurus(connector, name)
     @vocabs ||= {}
-    @vocabs[name] ||= connector.__send__(:loadThesaurus, read_file(name))
+    @vocabs[[connector.class, name]] ||= connector.__send__(:loadThesaurus, read_file(name))
   end
 
   def self.read_file(name)

--- a/engines/dfc_provider/spec/services/dfc_loader_spec.rb
+++ b/engines/dfc_provider/spec/services/dfc_loader_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe DfcLoader do
     expect(connector.PRODUCT_TYPES.DRINK.semanticId).to end_with "#drink"
   end
 
+  it "loads vocabularies into each connector, whatever the order" do
+    # A dfc-v2 request may be served before any v1 request after boot. The v1
+    # connector still has to understand vocabulary terms afterwards, otherwise
+    # it deserialises them into a parsed URI Hash.
+    DfcLoader.instance_variable_set(:@vocabs, nil)
+    DfcLoader.instance_variable_set(:@connector_v2, nil)
+    DfcLoader.connector_v2
+
+    expect(DfcLoader.vocabulary("vocabulary").STATES.ORDERSTATE.HELD)
+      .to be_a DataFoodConsortium::ConnectorV1::SKOSConcept
+  end
+
   it "retries loading when the first attempt fails" do
     DfcLoader.instance_variable_set(:@connector, nil)
 


### PR DESCRIPTION
## What? Why?

Fixing a recent order-dependent flaky spec like this one:

- https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/33478903396/job/99763945763?pr=14707

Also prevents a bug in production when the DFCv2 API is actually used.

The following comes from Claude:


`DfcLoader.load_thesaurus` cached by name only, so whichever of the two connectors asked for a vocabulary first got it and the other never did. While the vocabulary is the same, the v2 connector fails to load it correctly and returns a hash instead of an SKOS concept. This patch makes sure that we always use the vocabulary loaded by the v1 connector.

## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Specs only

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
