### PR TITLE
Add multilingual category names via name_i18n jsonb

### DIFF
--- a/app/controllers/admin/ajax_search_controller.rb
+++ b/app/controllers/admin/ajax_search_controller.rb
@@ -12,9 +12,7 @@ module Admin
     end
 
     def categories
-      query = Spree::Taxon.all
-
-      render json: build_search_response(query)
+      render json: build_taxon_search_response
     end
 
     def tax_categories
@@ -35,6 +33,36 @@ module Admin
       results = format_results(items)
 
       { results: results, pagination: { more: (page * per_page) < total_count } }
+    end
+
+    def build_taxon_search_response
+      page = (params[:page] || 1).to_i
+      per_page = 30
+
+      # Taxon#name is locale-aware (resolved from name_i18n in Ruby), so it can't be
+      # filtered/sorted/paginated in SQL via pluck/where/order like the other search
+      # endpoints in this controller. We load all taxons and do it in Ruby instead.
+      # Instances are expected to have a reduced number of taxons, so this should be negligible;
+      # revisit if that assumption changes
+      taxons = Spree::Taxon.all.to_a
+      taxons = filter_taxons(taxons)
+      taxons = taxons.sort_by(&:name)
+      total_count = taxons.size
+      items = taxons.slice((page - 1) * per_page, per_page) || []
+
+      results = items.map { |t| { value: t.id, label: t.name } }
+      { results: results, pagination: { more: (page * per_page) < total_count } }
+    end
+
+    def filter_taxons(taxons)
+      search_term = params[:q]
+      return taxons if search_term.blank?
+
+      pattern = Regexp.new(Regexp.escape(search_term), Regexp::IGNORECASE)
+      taxons.select do |taxon|
+        taxon.name.match?(pattern) ||
+          taxon.name_i18n.values.any? { |v| pattern.match?(v.to_s) }
+      end
     end
 
     def apply_search_filter(query)

--- a/app/controllers/admin/ajax_search_controller.rb
+++ b/app/controllers/admin/ajax_search_controller.rb
@@ -40,12 +40,10 @@ module Admin
       per_page = 30
 
       # Taxon#name is locale-aware (resolved from name_i18n in Ruby), so it can't be
-      # filtered/sorted/paginated in SQL via pluck/where/order like the other search
-      # endpoints in this controller. We load all taxons and do it in Ruby instead.
-      # Instances are expected to have a reduced number of taxons, so this should be negligible;
-      # revisit if that assumption changes
-      taxons = Spree::Taxon.all.to_a
-      taxons = filter_taxons(taxons)
+      # sorted/paginated in SQL via order/limit like the other search endpoints.
+      # We filter in SQL when possible (to avoid instantiating all records for a search)
+      # then sort and paginate in Ruby.
+      taxons = filter_taxons_sql.to_a
       taxons = taxons.sort_by(&:name)
       total_count = taxons.size
       items = taxons.slice((page - 1) * per_page, per_page) || []
@@ -54,15 +52,14 @@ module Admin
       { results: results, pagination: { more: (page * per_page) < total_count } }
     end
 
-    def filter_taxons(taxons)
+    def filter_taxons_sql
       search_term = params[:q]
-      return taxons if search_term.blank?
+      return Spree::Taxon.all if search_term.blank?
 
-      pattern = Regexp.new(Regexp.escape(search_term), Regexp::IGNORECASE)
-      taxons.select do |taxon|
-        taxon.name.match?(pattern) ||
-          taxon.name_i18n.values.any? { |v| pattern.match?(v.to_s) }
-      end
+      escaped = ActiveRecord::Base.sanitize_sql_like(search_term)
+      # Casting jsonb to text searches across all locale keys and values.
+      # A GIN index on name_i18n helps PostgreSQL skip rows that can't match.
+      Spree::Taxon.where("name_i18n::text ILIKE ?", "%#{escaped}%")
     end
 
     def apply_search_filter(query)

--- a/app/controllers/api/v0/taxons_controller.rb
+++ b/app/controllers/api/v0/taxons_controller.rb
@@ -51,7 +51,9 @@ module Api
       def taxon_params
         return if params[:taxon].blank?
 
-        params.require(:taxon).permit([:name, :position])
+        params.require(:taxon).permit(
+          [:name, :position, { name_i18n: OpenFoodNetwork::I18nConfig.selectable_locales }]
+        )
       end
     end
   end

--- a/app/controllers/spree/admin/taxons_controller.rb
+++ b/app/controllers/spree/admin/taxons_controller.rb
@@ -65,8 +65,9 @@ module Spree
 
       def taxon_params
         params.require(:taxon).permit(
-          :name, :position, :icon, :description, :permalink,
-          :meta_description, :meta_keywords, :meta_title, :dfc_id
+          :position, :icon, :description, :permalink,
+          :meta_description, :meta_keywords, :meta_title, :dfc_id,
+          name_i18n: OpenFoodNetwork::I18nConfig.selectable_locales
         )
       end
     end

--- a/app/models/spree/taxon.rb
+++ b/app/models/spree/taxon.rb
@@ -7,7 +7,43 @@ module Spree
 
     has_many :products, through: :variants, dependent: nil
 
-    validates :name, presence: true
+    validate :name_i18n_has_at_least_one_translation
+
+    before_validation :sync_legacy_name_column,
+                      if: -> { self[:name].blank? && name_i18n.present? }
+
+    # The admin form (and API) only submit the currently selectable locales
+    # (OpenFoodNetwork::I18nConfig.selectable_locales), which may not include every
+    # locale already stored on the record (e.g. a locale that was later removed from
+    # AVAILABLE_LOCALES, or the default locale when it isn't itself selectable).
+    # A plain attribute assignment would replace the whole hash and silently drop
+    # those translations, so merge instead of overwriting.
+    def name_i18n=(value)
+      super((name_i18n || {}).merge(value || {}))
+    end
+
+    def sync_legacy_name_column
+      fallback = name_i18n[I18n.default_locale.to_s].presence || name_i18n.values.find(&:present?)
+      self[:name] = fallback
+    end
+
+    def name_i18n_has_at_least_one_translation
+      return if name_i18n.is_a?(Hash) && name_i18n.values.any?(&:present?)
+
+      errors.add(:name_i18n, :blank)
+    end
+
+    def name
+      name_i18n[I18n.locale.to_s].presence ||
+        name_i18n[I18n.default_locale.to_s].presence ||
+        name_i18n.values.find(&:present?) ||
+        read_attribute(:name)
+    end
+
+    def name=(value)
+      self.name_i18n = (name_i18n || {}).merge(I18n.locale.to_s => value)
+      write_attribute(:name, value)
+    end
 
     # Indicate which filters should be used for this taxon
     def applicable_filters

--- a/app/models/spree/taxon.rb
+++ b/app/models/spree/taxon.rb
@@ -45,7 +45,13 @@ module Spree
     end
 
     def name=(value)
-      self.name_i18n = (name_i18n || {}).merge(I18n.locale.to_s => value)
+      updates = { I18n.locale.to_s => value }
+      # Validation requires the default locale. If it isn't present yet,
+      # mirror the value there so legacy usage (factory, plain `name` param)
+      # remains valid regardless of the current locale context.
+      updates[I18n.default_locale.to_s] = value if
+        name_i18n[I18n.default_locale.to_s].blank?
+      self.name_i18n = (name_i18n || {}).merge(updates)
       write_attribute(:name, value)
     end
 

--- a/app/models/spree/taxon.rb
+++ b/app/models/spree/taxon.rb
@@ -9,6 +9,10 @@ module Spree
 
     validate :name_i18n_has_at_least_one_translation
 
+    # The legacy `name` column is kept for now to make rollback easy if issues
+    # arise. It will be removed in a follow-up PR once we confirm nothing still
+    # reads it directly. The `name=` setter also stays in place so the API v0
+    # endpoint can continue accepting a plain `name` parameter.
     before_validation :sync_legacy_name_column,
                       if: -> { self[:name].blank? && name_i18n.present? }
 
@@ -28,7 +32,7 @@ module Spree
     end
 
     def name_i18n_has_at_least_one_translation
-      return if name_i18n.is_a?(Hash) && name_i18n.values.any?(&:present?)
+      return if name_i18n.is_a?(Hash) && name_i18n[I18n.default_locale.to_s].present?
 
       errors.add(:name_i18n, :blank)
     end

--- a/app/serializers/api/taxon_serializer.rb
+++ b/app/serializers/api/taxon_serializer.rb
@@ -2,7 +2,10 @@
 
 class Api::TaxonSerializer < ActiveModel::Serializer
   cached
-  delegate :cache_key, to: :object
+
+  def cache_key
+    [object.cache_key, I18n.locale].join("/")
+  end
 
   attributes :id, :name, :permalink, :position
 end

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -34,7 +34,7 @@ class CacheService
 
     def self.ams_all_taxons
       [
-        "inject-all-taxons-#{CacheService.latest_timestamp_by_class(Spree::Taxon)}",
+        "inject-all-taxons-#{CacheService.latest_timestamp_by_class(Spree::Taxon)}-#{I18n.locale}",
         { skip_digest: true }
       ]
     end

--- a/app/views/spree/admin/products/_primary_taxon_form.html.haml
+++ b/app/views/spree/admin/products/_primary_taxon_form.html.haml
@@ -2,10 +2,13 @@
   = f.label :primary_taxon_id, t('.product_category')
   %span.required *
   %br
+  -# Taxon#name is locale-aware (resolved from name_i18n in Ruby), so it can't be
+  -# plucked/ordered in SQL like before. We load full records and sort in Ruby instead.
+  -# Instances are expected to have a reduced number of 100 taxons, so this should be negligible.
   = render(SearchableDropdownComponent.new(form: f,
       name: :primary_taxon_id,
       aria_label: t('.product_category'),
-      options: Spree::Taxon.select(:name, :id).order(:name).pluck(:name, :id),
+      options: Spree::Taxon.all.sort_by(&:name).map { |t| [t.name, t.id] },
       selected_option: @product.primary_taxon_id,
       include_blank: true,
       placeholder_value: t('.search_for_categories')))

--- a/app/views/spree/admin/products/_primary_taxon_form.html.haml
+++ b/app/views/spree/admin/products/_primary_taxon_form.html.haml
@@ -4,7 +4,8 @@
   %br
   -# Taxon#name is locale-aware (resolved from name_i18n in Ruby), so it can't be
   -# plucked/ordered in SQL like before. We load full records and sort in Ruby instead.
-  -# Instances are expected to have a reduced number of 100 taxons, so this should be negligible.
+  -# Instances are expected to have <100 taxons, so this should be negligible.
+  -# The options list here is a good candidate for low-level template caching if needed.
   = render(SearchableDropdownComponent.new(form: f,
       name: :primary_taxon_id,
       aria_label: t('.product_category'),

--- a/app/views/spree/admin/taxons/_form.html.haml
+++ b/app/views/spree/admin/taxons/_form.html.haml
@@ -1,11 +1,14 @@
 .row
   .alpha.five.columns
-    = f.field_container :name do
-      = f.label :name, t(".name")
-      %span.required *
-      %br/
-      = error_message_on :taxon, :name
-      = text_field :taxon, :name, class: 'fullwidth'
+    = f.field_container :name_i18n do
+      - OpenFoodNetwork::I18nConfig.selectable_locales.each do |locale|
+        = f.label "name_i18n[#{locale}]", "#{t('.name')} (#{locale})"
+        - if locale == I18n.default_locale.to_s
+          %span.required *
+        %br/
+        = f.text_field "name_i18n[#{locale}]", value: f.object.name_i18n[locale.to_s], class: 'fullwidth'
+        %br/
+      = error_message_on :taxon, :name_i18n
     = f.field_container :meta_title do
       = f.label :meta_title, t(".meta_title")
       %br/

--- a/db/migrate/20260814120000_add_name_i18n_to_spree_taxons.rb
+++ b/db/migrate/20260814120000_add_name_i18n_to_spree_taxons.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNameI18nToSpreeTaxons < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_taxons, :name_i18n, :jsonb, null: false, default: {}
+  end
+end

--- a/db/migrate/20260814120001_backfill_name_i18n_in_spree_taxons.rb
+++ b/db/migrate/20260814120001_backfill_name_i18n_in_spree_taxons.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BackfillNameI18nInSpreeTaxons < ActiveRecord::Migration[7.2]
+  class Taxon < ApplicationRecord
+    self.table_name = "spree_taxons"
+  end
+
+  def up
+    Taxon.find_each do |taxon|
+      taxon.update_column(:name_i18n, { I18n.default_locale.to_s => taxon.name })
+    end
+  end
+
+  def down
+    Taxon.update_all(name_i18n: {})
+  end
+end

--- a/db/migrate/20260814120001_backfill_name_i18n_in_spree_taxons.rb
+++ b/db/migrate/20260814120001_backfill_name_i18n_in_spree_taxons.rb
@@ -6,9 +6,12 @@ class BackfillNameI18nInSpreeTaxons < ActiveRecord::Migration[7.2]
   end
 
   def up
-    Taxon.find_each do |taxon|
-      taxon.update_column(:name_i18n, { I18n.default_locale.to_s => taxon.name })
-    end
+    locale = I18n.default_locale.to_s
+
+    execute <<~SQL
+      UPDATE spree_taxons
+      SET name_i18n = jsonb_build_object(#{connection.quote(locale)}, name)
+    SQL
   end
 
   def down

--- a/db/migrate/20260814120001_backfill_name_i18n_in_spree_taxons.rb
+++ b/db/migrate/20260814120001_backfill_name_i18n_in_spree_taxons.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class BackfillNameI18nInSpreeTaxons < ActiveRecord::Migration[7.2]
-  class Taxon < ApplicationRecord
+  # Use a migration-local model to avoid coupling to application code that may
+  # change over time (the app Taxon class will gain i18n behaviour that this
+  # backfill doesn't need and that could break in future refactors).
+  class Taxon < ActiveRecord::Base
     self.table_name = "spree_taxons"
   end
 
   def up
     locale = I18n.default_locale.to_s
 
-    execute <<~SQL
+    execute <<~SQL.squish
       UPDATE spree_taxons
       SET name_i18n = jsonb_build_object(#{connection.quote(locale)}, name)
     SQL

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -925,6 +925,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_27_000000) do
     t.string "meta_description", limit: 255
     t.string "meta_keywords", limit: 255
     t.string "dfc_id"
+    t.jsonb "name_i18n", default: {}, null: false
     t.index ["permalink"], name: "index_taxons_on_permalink"
   end
 

--- a/spec/controllers/api/v0/taxons_controller_spec.rb
+++ b/spec/controllers/api/v0/taxons_controller_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Api::V0::TaxonsController do
       expect(json_names).to include(taxon.name, taxon2.name)
     end
 
+    it "returns taxon names in the current locale" do
+      taxon.update_column(:name_i18n, { "en" => "Vegetables", "es" => "Verduras" })
+      I18n.with_locale(:es) do
+        api_get :index
+        expect(json_response.pluck(:name)).to include("Verduras")
+      end
+    end
+
     it "can search for a single taxon" do
       api_get :index, q: { name_cont: "Ruby" }
 
@@ -68,7 +76,7 @@ RSpec.describe Api::V0::TaxonsController do
       errors = json_response["errors"]
 
       expect(Spree::Taxon.last).to eq taxon2
-      expect(errors['name']).to eq ["can't be blank"]
+      expect(errors['name_i18n']).to eq ["can't be blank"]
     end
 
     it "can destroy" do

--- a/spec/controllers/spree/admin/taxons_controller_spec.rb
+++ b/spec/controllers/spree/admin/taxons_controller_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Spree::Admin::TaxonsController do
 
   let!(:taxon) { create(:taxon, name: "Ruby") }
   let!(:taxon2) { create(:taxon, name: "Rails") }
-  let(:valid_attributes) { attributes_for(:taxon) }
+  let(:valid_attributes) {
+    { name_i18n: { I18n.default_locale.to_s => "Ruby on Rails" } }
+  }
 
   before do
     allow(controller).to receive(:spree_current_user) { current_api_user }
@@ -34,25 +36,40 @@ RSpec.describe Spree::Admin::TaxonsController do
 
     context "create" do
       it "persist data with valid attributes" do
-        spree_post :create, valid_attributes
+        spree_post :create, taxon: valid_attributes
 
-        expect(Spree::Taxon.last.name).to eq valid_attributes[:name]
+        expect(Spree::Taxon.last.name).to eq "Ruby on Rails"
         expect(response).to have_http_status :found
       end
 
       it "returns error with invalid attributes" do
-        spree_post :create, { name: '' }
+        spree_post :create, taxon: { name_i18n: { I18n.default_locale.to_s => '' } }
 
         expect(Spree::Taxon.count).to eq 2
         expect(response).to have_http_status :unprocessable_entity
       end
+
+      it "stores translations for multiple locales" do
+        spree_post :create, taxon: {
+          name_i18n: { I18n.default_locale.to_s => "Vegetables", "es" => "Verduras" }
+        }
+
+        taxon = Spree::Taxon.last
+        expect(taxon.name_i18n).to eq(
+          { "es" => "Verduras", I18n.default_locale.to_s => "Vegetables" }
+        )
+        expect(taxon.name).to eq("Vegetables")
+      end
     end
 
     context "update" do
-      let!(:new_taxon) { create(:taxon, valid_attributes) }
+      let!(:new_taxon) { create(:taxon, name: "Ruby on Rails") }
+
       it "persist data with valid attributes" do
         spree_post :update, id: new_taxon.id,
-                            taxon: valid_attributes.merge({ name: 'Taxon name updated' })
+                            taxon: {
+                              name_i18n: { I18n.default_locale.to_s => 'Taxon name updated' }
+                            }
 
         expect(new_taxon.reload.name).to eq 'Taxon name updated'
         expect(response).to have_http_status :found
@@ -60,10 +77,20 @@ RSpec.describe Spree::Admin::TaxonsController do
 
       it "returns error with invalid attributes" do
         spree_post :update, id: new_taxon.id,
-                            taxon: { **valid_attributes, name: '' }
+                            taxon: { name_i18n: { I18n.default_locale.to_s => '' } }
 
-        expect(new_taxon.reload.name).to eq valid_attributes[:name]
+        expect(new_taxon.reload.name).to eq "Ruby on Rails"
         expect(response).to have_http_status :unprocessable_entity
+      end
+
+      it "updates translations for multiple locales" do
+        spree_post :update, id: new_taxon.id, taxon: {
+          name_i18n: { I18n.default_locale.to_s => "Vegetables", "es" => "Verduras" }
+        }
+
+        expect(new_taxon.reload.name_i18n).to eq(
+          { "es" => "Verduras", I18n.default_locale.to_s => "Vegetables" }
+        )
       end
     end
   end

--- a/spec/controllers/spree/admin/taxons_controller_spec.rb
+++ b/spec/controllers/spree/admin/taxons_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Spree::Admin::TaxonsController do
 
         taxon = Spree::Taxon.last
         expect(taxon.name_i18n).to eq(
-          { "es" => "Verduras", I18n.default_locale.to_s => "Vegetables" }
+          { I18n.default_locale.to_s => "Vegetables", "es" => "Verduras" }
         )
         expect(taxon.name).to eq("Vegetables")
       end
@@ -89,7 +89,7 @@ RSpec.describe Spree::Admin::TaxonsController do
         }
 
         expect(new_taxon.reload.name_i18n).to eq(
-          { "es" => "Verduras", I18n.default_locale.to_s => "Vegetables" }
+          { I18n.default_locale.to_s => "Vegetables", "es" => "Verduras" }
         )
       end
     end

--- a/spec/lib/reports/products_and_inventory_report_spec.rb
+++ b/spec/lib/reports/products_and_inventory_report_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe Reporting::Reports::ProductsAndInventory::Base do
                                        ]])
     end
 
+    it "renders taxon names in the current locale" do
+      taxon = create(:taxon, name: "Vegetables")
+      taxon.update_column(:name_i18n, { "en" => "Vegetables", "es" => "Verduras" })
+      product = create(:simple_product, primary_taxon: taxon)
+      variant = product.variants.first
+      allow(subject).to receive(:query_result).and_return [variant]
+
+      I18n.with_locale(:es) do
+        expect(subject.table_rows.first[4]).to eq("Verduras")
+      end
+    end
+
     it "fetches variants for some params" do
       expect(subject).to receive(:child_variants).and_return ["children"]
       expect(subject).to receive(:filter).with(['children']).and_return ["filter_children"]

--- a/spec/models/spree/taxon_spec.rb
+++ b/spec/models/spree/taxon_spec.rb
@@ -104,4 +104,134 @@ RSpec.describe Spree::Taxon do
       end.to change { taxon2.reload.updated_at }
     end
   end
+
+  describe "#name_i18n=" do
+    it "merges into the existing hash instead of replacing it" do
+      taxon = create(:taxon, name: "Fruit")
+      taxon.update_column(:name_i18n, { "en_TST" => "Fruit" })
+
+      # Simulates an admin update that only submits the currently selectable
+      # locales, which may not include every locale already stored (e.g. a
+      # locale removed from AVAILABLE_LOCALES, or a default locale that isn't
+      # itself selectable).
+      taxon.update(name_i18n: { "es" => "Fruta" })
+
+      expect(taxon.reload.name_i18n).to eq({ "en_TST" => "Fruit", "es" => "Fruta" })
+    end
+
+    it "overwrites a locale's translation when it is resubmitted" do
+      taxon = create(:taxon, name: "Fruit")
+      taxon.update_column(:name_i18n, { "en" => "Fruit", "es" => "Fruta vieja" })
+
+      taxon.update(name_i18n: { "es" => "Fruta" })
+
+      expect(taxon.reload.name_i18n).to eq({ "en" => "Fruit", "es" => "Fruta" })
+    end
+  end
+
+  describe "name_i18n column" do
+    let(:taxon) { create(:taxon, name: "Vegetables") }
+
+    it "defaults to an empty hash for an unsaved record" do
+      new_taxon = described_class.new
+      expect(new_taxon.name_i18n).to eq({})
+    end
+
+    it "allows storing translations per locale" do
+      taxon.update_column(:name_i18n, { "en" => "Vegetables", "es" => "Verduras" })
+      expect(taxon.reload.name_i18n).to eq({ "en" => "Vegetables", "es" => "Verduras" })
+    end
+
+    it "still exposes the original name column via read_attribute" do
+      expect(taxon.read_attribute(:name)).to eq("Vegetables")
+    end
+
+    context "after backfilling name_i18n from the legacy name column" do
+      before do
+        taxon.update_column(:name_i18n, { I18n.default_locale.to_s => taxon.name })
+      end
+
+      it "has a non-empty name_i18n hash" do
+        expect(taxon.reload.name_i18n).not_to be_empty
+      end
+
+      it "stores the legacy name under the default locale" do
+        expect(taxon.name_i18n[I18n.default_locale.to_s]).to eq("Vegetables")
+      end
+    end
+  end
+
+  describe "#name" do
+    let(:taxon) { create(:taxon, name: "Vegetables") }
+
+    context "when the current locale has a translation" do
+      it "returns the translation for the current locale" do
+        taxon.update_column(:name_i18n, { "en" => "Vegetables", "es" => "Verduras" })
+        I18n.with_locale(:es) do
+          expect(taxon.reload.name).to eq("Verduras")
+        end
+      end
+    end
+
+    context "when the current locale is missing but default locale is present" do
+      it "falls back to the default locale" do
+        taxon.update_column(:name_i18n, { "en" => "Vegetables" })
+        I18n.with_locale(:es) do
+          expect(taxon.reload.name).to eq("Vegetables")
+        end
+      end
+    end
+
+    context "when both current and default locales are missing" do
+      it "falls back to the first available translation" do
+        taxon.update_column(:name_i18n, { "eu" => "Barazkiak" })
+        I18n.with_locale(:es) do
+          expect(taxon.reload.name).to eq("Barazkiak")
+        end
+      end
+    end
+
+    context "when name_i18n is completely empty" do
+      it "falls back to the legacy name column" do
+        taxon.update_column(:name_i18n, {})
+        expect(taxon.reload.name).to eq("Vegetables")
+      end
+    end
+
+    context "when the default locale translation is blank but another locale is filled" do
+      it "falls back to the first present translation instead of the blank one" do
+        taxon.update_column(:name_i18n, { "en" => "", "es" => "Verduras" })
+        I18n.with_locale(:en) do
+          expect(taxon.reload.name).to eq("Verduras")
+        end
+      end
+    end
+  end
+
+  describe "#name=" do
+    it "writes into name_i18n keyed by the current locale" do
+      I18n.with_locale(:es) do
+        taxon = described_class.new(name: "Verduras")
+        expect(taxon.name_i18n).to eq({ "es" => "Verduras" })
+      end
+    end
+  end
+
+  describe "#sync_legacy_name_column" do
+    context "when the default locale translation is blank but another locale is filled" do
+      it "populates the legacy name column with the first present translation" do
+        taxon = described_class.new(name_i18n: { "en" => "", "es" => "Verduras" })
+        taxon.valid?
+        expect(taxon.read_attribute(:name)).to eq("Verduras")
+      end
+    end
+  end
+
+  describe "validations" do
+    it "is invalid when name_i18n is empty" do
+      taxon = described_class.new
+      expect(taxon).not_to be_valid
+      expect(taxon.errors[:name_i18n]).to include("can't be blank")
+    end
+  end
 end

--- a/spec/models/spree/taxon_spec.rb
+++ b/spec/models/spree/taxon_spec.rb
@@ -210,7 +210,9 @@ RSpec.describe Spree::Taxon do
     it "writes into name_i18n keyed by the current locale" do
       I18n.with_locale(:es) do
         taxon = described_class.new(name: "Verduras")
-        expect(taxon.name_i18n).to eq({ "es" => "Verduras" })
+        expect(taxon.name_i18n).to eq(
+          { "es" => "Verduras", I18n.default_locale.to_s => "Verduras" }
+        )
       end
     end
   end

--- a/spec/models/spree/taxon_spec.rb
+++ b/spec/models/spree/taxon_spec.rb
@@ -121,11 +121,20 @@ RSpec.describe Spree::Taxon do
 
     it "overwrites a locale's translation when it is resubmitted" do
       taxon = create(:taxon, name: "Fruit")
-      taxon.update_column(:name_i18n, { "en" => "Fruit", "es" => "Fruta vieja" })
+      taxon.update_column(:name_i18n,
+                          {
+                            I18n.default_locale.to_s => "Fruit",
+                            "es" => "Fruta vieja"
+                          })
 
       taxon.update(name_i18n: { "es" => "Fruta" })
 
-      expect(taxon.reload.name_i18n).to eq({ "en" => "Fruit", "es" => "Fruta" })
+      expect(taxon.reload.name_i18n).to eq(
+        {
+          I18n.default_locale.to_s => "Fruit",
+          "es" => "Fruta"
+        }
+      )
     end
   end
 
@@ -145,20 +154,6 @@ RSpec.describe Spree::Taxon do
     it "still exposes the original name column via read_attribute" do
       expect(taxon.read_attribute(:name)).to eq("Vegetables")
     end
-
-    context "after backfilling name_i18n from the legacy name column" do
-      before do
-        taxon.update_column(:name_i18n, { I18n.default_locale.to_s => taxon.name })
-      end
-
-      it "has a non-empty name_i18n hash" do
-        expect(taxon.reload.name_i18n).not_to be_empty
-      end
-
-      it "stores the legacy name under the default locale" do
-        expect(taxon.name_i18n[I18n.default_locale.to_s]).to eq("Vegetables")
-      end
-    end
   end
 
   describe "#name" do
@@ -175,7 +170,10 @@ RSpec.describe Spree::Taxon do
 
     context "when the current locale is missing but default locale is present" do
       it "falls back to the default locale" do
-        taxon.update_column(:name_i18n, { "en" => "Vegetables" })
+        taxon.update_column(:name_i18n, {
+                              "en_AU" => "Veggies",
+                              I18n.default_locale.to_s => "Vegetables"
+                            })
         I18n.with_locale(:es) do
           expect(taxon.reload.name).to eq("Vegetables")
         end
@@ -232,6 +230,17 @@ RSpec.describe Spree::Taxon do
       taxon = described_class.new
       expect(taxon).not_to be_valid
       expect(taxon.errors[:name_i18n]).to include("can't be blank")
+    end
+
+    it "is invalid when only a non-default locale is present" do
+      taxon = described_class.new(name_i18n: { "es" => "Verduras" })
+      expect(taxon).not_to be_valid
+      expect(taxon.errors[:name_i18n]).to include("can't be blank")
+    end
+
+    it "is valid when the default locale is present" do
+      taxon = described_class.new(name_i18n: { I18n.default_locale.to_s => "Vegetables" })
+      expect(taxon).to be_valid
     end
   end
 end

--- a/spec/requests/admin/ajax_search_spec.rb
+++ b/spec/requests/admin/ajax_search_spec.rb
@@ -151,6 +151,17 @@ RSpec.describe "/admin/ajax_search" do
         expect(json_response["pagination"]["more"]).to be false
       end
 
+      it "returns translated category names in the current locale" do
+        category1.update_column(:name_i18n, { "en" => "Vegetables", "es" => "Verduras" })
+        category2.update_column(:name_i18n, { "en" => "Fruits", "es" => "Frutas" })
+        category3.update_column(:name_i18n, { "en" => "Dairy", "es" => "Lácteos" })
+
+        get admin_ajax_search_categories_path(locale: "es")
+
+        json_response = response.parsed_body
+        expect(json_response["results"].pluck("label")).to eq(['Frutas', 'Lácteos', 'Verduras'])
+      end
+
       it "filters categories by search query" do
         get admin_ajax_search_categories_path, params: { q: "fruit" }
 

--- a/spec/requests/shops_controller_spec.rb
+++ b/spec/requests/shops_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe "Shops" do
+  let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
+  let(:producer) { create(:supplier_enterprise) }
+  let!(:taxon) {
+    t = create(:taxon, name: "Fruit")
+    t.update_column(:name_i18n, { "en" => "Fruit", "es" => "Fruta" })
+    t
+  }
+  let!(:product) { create(:simple_product, enterprise_id: producer.id, primary_taxon: taxon) }
+  let!(:order_cycle) {
+    create(
+      :simple_order_cycle,
+      distributors: [distributor],
+      coordinator: create(:distributor_enterprise),
+      variants: [product.variants.first]
+    )
+  }
+
+  describe "GET /shops" do
+    it "injects taxon names in the current locale" do
+      get shops_path(locale: "en")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('"name":"Fruit"')
+    end
+
+    it "injects taxon names in Spanish when the locale is es" do
+      get shops_path(locale: "es")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('"name":"Fruta"')
+    end
+  end
+end

--- a/spec/serializers/api/admin/taxon_serializer_spec.rb
+++ b/spec/serializers/api/admin/taxon_serializer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Admin::TaxonSerializer do
+  let(:taxon) { create(:taxon, name: "Vegetables") }
+  let(:serializer) { described_class.new(taxon) }
+
+  before do
+    taxon.update_column(:name_i18n, { "en" => "Vegetables", "es" => "Verduras" })
+  end
+
+  it "serializes the taxon name in the current locale" do
+    I18n.with_locale(:es) do
+      expect(serializer.serializable_hash[:name]).to eq("Verduras")
+    end
+  end
+
+  it "falls back to the default locale when the current locale is missing" do
+    I18n.with_locale(:fr) do
+      expect(serializer.serializable_hash[:name]).to eq("Vegetables")
+    end
+  end
+end

--- a/spec/serializers/api/admin/taxon_serializer_spec.rb
+++ b/spec/serializers/api/admin/taxon_serializer_spec.rb
@@ -5,16 +5,17 @@ RSpec.describe Api::Admin::TaxonSerializer do
   let(:serializer) { described_class.new(taxon) }
 
   before do
-    taxon.update_column(:name_i18n, { "en" => "Vegetables", "es" => "Verduras" })
+    taxon.update_column(:name_i18n, {
+                          I18n.default_locale.to_s => "Vegetables",
+                          "es" => "Verduras"
+                        })
   end
 
-  it "serializes the taxon name in the current locale" do
+  it "serializes the taxon name correctly across locale switches" do
     I18n.with_locale(:es) do
       expect(serializer.serializable_hash[:name]).to eq("Verduras")
     end
-  end
 
-  it "falls back to the default locale when the current locale is missing" do
     I18n.with_locale(:fr) do
       expect(serializer.serializable_hash[:name]).to eq("Vegetables")
     end

--- a/spec/serializers/api/taxon_serializer_spec.rb
+++ b/spec/serializers/api/taxon_serializer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::TaxonSerializer do
+  let(:taxon) { create(:taxon, name: "Vegetables") }
+  let(:serializer) { described_class.new(taxon) }
+
+  before do
+    taxon.update_column(:name_i18n, { "en" => "Vegetables", "es" => "Verduras" })
+  end
+
+  it "serializes the taxon name in the current locale" do
+    I18n.with_locale(:es) do
+      expect(serializer.serializable_hash[:name]).to eq("Verduras")
+    end
+  end
+
+  it "falls back to the default locale when the current locale is missing" do
+    I18n.with_locale(:fr) do
+      expect(serializer.serializable_hash[:name]).to eq("Vegetables")
+    end
+  end
+end

--- a/spec/serializers/api/taxon_serializer_spec.rb
+++ b/spec/serializers/api/taxon_serializer_spec.rb
@@ -5,16 +5,17 @@ RSpec.describe Api::TaxonSerializer do
   let(:serializer) { described_class.new(taxon) }
 
   before do
-    taxon.update_column(:name_i18n, { "en" => "Vegetables", "es" => "Verduras" })
+    taxon.update_column(:name_i18n, {
+                          I18n.default_locale.to_s => "Vegetables",
+                          "es" => "Verduras"
+                        })
   end
 
-  it "serializes the taxon name in the current locale" do
+  it "serializes the taxon name in the current locale without cache leaking" do
     I18n.with_locale(:es) do
       expect(serializer.serializable_hash[:name]).to eq("Verduras")
     end
-  end
 
-  it "falls back to the default locale when the current locale is missing" do
     I18n.with_locale(:fr) do
       expect(serializer.serializable_hash[:name]).to eq("Vegetables")
     end


### PR DESCRIPTION
## What? Why?

- Closes https://github.com/openfoodfoundation/wishlist/issues/576
- Discussion: https://openfoodnetwork.slack.com/archives/C2GQ45KNU/p1787305922060359

Category names are currently stored as a single string, so multi-language instances
can't show the same category translated per shopper/producer locale — e.g.
"Vegetables" (en) and "Verduras" (es) end up as two disconnected taxons instead of
one category with two names. This PR adds a `name_i18n` jsonb column to
`spree_taxons` so a category name can be stored and displayed per locale, with a
sensible fallback chain when a translation is missing.

**Data layer:**
- Migration adds `name_i18n` to `spree_taxons`.
- Backfill migration copies existing names into `name_i18n[default_locale]`.
- Old `name` column is kept for now; deprecation in a follow-up PR.

**Model layer:**
- `Spree::Taxon#name` reads from `name_i18n` with three-tier fallback: current
  locale -> default locale -> first available translation -> legacy column.
- `Spree::Taxon#name=` writes into `name_i18n` keyed by current locale.
- `name_i18n=` merges into the existing hash rather than overwriting it, so a
  partial update (e.g. admin form only submitting the currently selectable
  locales) doesn't silently drop translations for locales no longer in
  `AVAILABLE_LOCALES`.
- Custom validation ensures at least one non-empty translation exists.

**Admin UI:**
- Taxon edit form shows one field per enabled locale (`selectable_locales` from
  `AVAILABLE_LOCALES` env var).
- Admin AJAX search returns locale-aware category labels.
- Product primary taxon dropdown uses translated names.

**Frontend / serializers:**
- `Api::TaxonSerializer` cache key now includes `I18n.locale`.
- Fragment cache for `inject_taxons` is scoped by locale (fixes a cache-poisoning
  bug where one locale's cached taxon labels could be served to another locale).
- Shops, shopfronts, producers, and groups all get per-language taxon JSON.

**Reports:**
- `ProductsAndInventory` reports render translated taxon names automatically
  (via `variant.primary_taxon.name` -> locale-aware accessor).

## What should we test?

- Visit **Admin > Categories** (`/admin/taxons`) and edit a category: confirm one
  input is shown per enabled locale, the default locale is required, and saving
  only updates the submitted locales without dropping translations for other
  locales already stored on the record.
- Create a new category with only a non-default locale filled in: confirm it
  saves successfully and displays using that translation.
- Switch the shopfront language and confirm category names/filters display in
  the selected locale, falling back to the default locale when a translation is
  missing.
- Check the product edit form's "Primary category" dropdown shows translated
  names and search still works.
- Check the admin category search (autocomplete) returns results in the current
  locale and matches search terms typed in any stored translation.
- Run the `ProductsAndInventory` report and confirm category names shown match
  the current locale.
- Regression: switch locales while browsing shops/shopfronts/producers/groups
  pages and confirm taxon names update correctly (this exercises the fragment
  cache locale-scoping fix).

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Addressing this wishlist ticket: https://github.com/openfoodfoundation/wishlist/issues/576


## Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

None.

## Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->