### PR TITLE
Replace Admin::OrdersReflex#capture with a Turbo-based endpoint

### DIFF
--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -9,7 +9,7 @@ module Spree
 
       helper CheckoutHelper
 
-      before_action :load_order, only: [:edit, :update, :fire, :resend, :invoice, :print]
+      before_action :load_order, only: [:edit, :update, :fire, :resend, :invoice, :print, :capture]
       before_action :refuse_changing_shipped_orders, only: [:update]
       before_action :load_distribution_choices, only: [:new, :create, :edit, :update]
       before_action :require_distributor_abn, only: :invoice
@@ -119,6 +119,22 @@ module Spree
           type: "application/pdf",
           disposition: "inline"
         )
+      end
+
+      def capture
+        payment_capture = ::Orders::CaptureService.new(@order)
+
+        if payment_capture.call
+          render turbo_stream: turbo_stream.replace(
+            "order_#{@order.id}",
+            partial: "spree/admin/orders/table_row", locals: { order: @order.reload, success: true }
+          )
+        else
+          flash.now[:error] = payment_capture.gateway_error || t(:payment_processing_failed)
+          render turbo_stream: turbo_stream.append(
+            "flashes", partial: "admin/shared/flashes", locals: { flashes: flash }
+          )
+        end
       end
 
       def bulk_credit

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -363,7 +363,7 @@ module Spree
           can_edit_as_producer(order, user)
       end
 
-      can [:fire, :resend, :invoice, :print], Spree::Order do |order|
+      can [:fire, :resend, :invoice, :print, :capture], Spree::Order do |order|
         # We allow editing orders with a nil distributor as this state occurs
         # during the order creation process from the admin backend
         order.distributor.nil? ||

--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -2,21 +2,7 @@
 
 module Admin
   class OrdersReflex < ApplicationReflex
-    before_reflex :authorize_order, only: [:capture, :ship]
-
-    def capture
-      payment_capture = Orders::CaptureService.new(@order)
-
-      if payment_capture.call
-        cable_ready.replace(selector: dom_id(@order),
-                            html: render(partial: "spree/admin/orders/table_row",
-                                         locals: { order: @order.reload, success: true }))
-        morph :nothing
-      else
-        flash[:error] = payment_capture.gateway_error || I18n.t(:payment_processing_failed)
-        morph_admin_flashes
-      end
-    end
+    before_reflex :authorize_order, only: [:ship]
 
     def ship
       @order.send_shipment_email = false unless params[:send_shipment_email]

--- a/app/views/admin/shared/_tooltip_button.html.haml
+++ b/app/views/admin/shared/_tooltip_button.html.haml
@@ -2,7 +2,8 @@
   - if local_assigns[:shipment]
     %button{class: button_class,"data-controller": "modal-link", "data-action": "click->modal-link#open", "data-modal-link-target-value": "ship_order_#{reflex_data_id}", "data-id": reflex_data_id, "data-tooltip-target": "element" }
   - else
-    %button{class: button_class, "data-reflex": button_reflex, "data-id": reflex_data_id, "data-tooltip-target": "element" }
+    = button_to "", button_url, method: :put, class: button_class,
+                form: { data: { turbo: true } }, data: { tooltip_target: "element" }
   .tooltip-container
     .tooltip{"data-tooltip-target": "tooltip"}
       = sanitize tooltip_text

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -53,4 +53,4 @@
       = render partial: 'admin/shared/tooltip_button', locals: {button_class: "icon-road icon_link with-tip no-text", reflex_data_id: order.id.to_s, tooltip_text: t('spree.admin.orders.index.ship'), shipment: true}
 
     - if can?(:manage_order_sections, order) && can?(:update, Spree::Payment) && order.payment_required? && order.pending_payments.reject(&:requires_authorization?).any?
-      = render partial: 'admin/shared/tooltip_button', locals: {button_class: "icon-capture icon_link no-text", button_reflex: "click->Admin::OrdersReflex#capture", reflex_data_id: order.id.to_s,  tooltip_text: t('spree.admin.orders.index.capture')}
+      = render partial: 'admin/shared/tooltip_button', locals: {button_class: "icon-capture icon_link no-text", button_url: capture_admin_order_path(order), tooltip_text: t('spree.admin.orders.index.capture')}

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -82,6 +82,7 @@ Spree::Core::Engine.routes.draw do
         get :resend
         get :invoice
         get :print
+        put :capture
       end
 
       collection do

--- a/spec/requests/spree/admin/orders_spec.rb
+++ b/spec/requests/spree/admin/orders_spec.rb
@@ -355,6 +355,51 @@ RSpec.describe Spree::Admin::OrdersController do
     end
   end
 
+  describe "#capture" do
+    let(:distributor) { create(:distributor_enterprise) }
+    let(:order) { create(:order_with_totals, distributor:) }
+    let(:capture_service) { instance_double(Orders::CaptureService) }
+
+    before do
+      sign_in distributor.owner
+      allow(Orders::CaptureService).to receive(:new).with(order).and_return(capture_service)
+    end
+
+    context "when the capture succeeds" do
+      it "replaces the order row" do
+        allow(capture_service).to receive(:call).and_return(true)
+
+        put("/admin/orders/#{order.number}/capture", params: { format: :turbo_stream })
+
+        expect(response).to have_http_status :ok
+        expect(response.body).to include("order_#{order.id}")
+      end
+    end
+
+    context "when the capture fails" do
+      it "displays the gateway error as a flash message" do
+        allow(capture_service).to receive(:call).and_return(false)
+        allow(capture_service).to receive(:gateway_error).and_return("Card declined")
+
+        put("/admin/orders/#{order.number}/capture", params: { format: :turbo_stream })
+
+        expect(response).to have_http_status :ok
+        expect(response.body).to include("flashes")
+        expect(flash[:error]).to eq "Card declined"
+      end
+    end
+
+    context "when the user cannot manage the order" do
+      it "denies access" do
+        sign_in create(:user)
+
+        put("/admin/orders/#{order.number}/capture", params: { format: :turbo_stream })
+
+        expect(response).to redirect_to "/unauthorized"
+      end
+    end
+  end
+
   describe "#bulk_credit" do
     let(:order) { create(:order_with_totals, payment_state: "credit_owed", distributor:) }
     let(:order1) { create(:order_with_totals, payment_state: "credit_owed", distributor:) }


### PR DESCRIPTION
## What? Why?

Part of #13851, first of several PRs to remove `Admin::OrdersReflex` (the last
functional StimulusReflex reflex in the app, per the epic in #13850).

This PR migrates just the `capture` action (the "Capture" button in the admin
orders index): it replaces the reflex with a plain `PUT` endpoint on
`Spree::Admin::OrdersController` returning a Turbo Stream, following the same
pattern already used by `#bulk_credit` in the same controller.

- Added `capture_admin_order` route and `Spree::Admin::OrdersController#capture`,
  which calls the existing `Orders::CaptureService` and responds with a
  `turbo_stream.replace` of the order row (or a flash append on gateway error).
- Reflexes bypass CanCan entirely, so `:capture` is added to `Spree::Ability`
  alongside its siblings `:fire`/`:resend`/`:invoice`/`:print` — otherwise every
  non-superadmin (e.g. an enterprise manager) would be redirected to
  `/unauthorized` when clicking Capture.
- Swapped the button's `data-reflex` attribute for a `button_to`, and removed
  the now-dead `capture` method from `Admin::OrdersReflex` (`ship` and the bulk
  actions still use the reflex; they're follow-up PRs).
- The admin layout sets `data-turbo="false"` on `<body>`, so the generated form
  needs an explicit `data: { turbo: true }` to actually get Turbo-Drive-managed
  instead of falling back to a full-page submission — there's existing
  precedent for this override elsewhere in the app (e.g. `_login_tab.html.haml`).

## What should we test?

- As an admin, visit `/admin/orders`, find a completed order with an
  uncaptured payment, and click the Capture icon.
- The row should update in place (a success tick appears, the Capture icon
  disappears) without a full page reload.
- As an enterprise manager who manages the order's distributor, confirm the
  same button works (this is the authorization regression this PR guards
  against with a dedicated spec).
- Trigger a gateway failure (e.g. a payment method that raises
  `Spree::Core::GatewayError`) and confirm the error flash appears without a
  page reload.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

## Dependencies



## Documentation updates