### PR TITLE
Replace Admin::OrdersReflex resend/send-invoice bulk actions with Turbo endpoints

### DIFF
--- a/app/components/confirm_modal_component.rb
+++ b/app/components/confirm_modal_component.rb
@@ -5,6 +5,7 @@ class ConfirmModalComponent < ModalComponent
   def initialize(
     id:,
     reflex: nil,
+    url: nil,
     controller: nil,
     message: nil,
     confirm_actions: nil,
@@ -17,6 +18,7 @@ class ConfirmModalComponent < ModalComponent
     super(id:, close_button: true)
     @confirm_actions = confirm_actions
     @reflex = reflex
+    @url = url
     @confirm_reflexes = confirm_reflexes
     @controller = controller
     @message = message

--- a/app/components/confirm_modal_component/confirm_modal_component.html.haml
+++ b/app/components/confirm_modal_component/confirm_modal_component.html.haml
@@ -1,4 +1,4 @@
-%div{ id: @id, "data-controller": "modal #{@controller}", "data-action": "keyup@document->modal#closeIfEscapeKey", "data-#{@controller}-reflex-value": @reflex }
+%div{ id: @id, "data-controller": "modal #{@controller}", "data-action": "keyup@document->modal#closeIfEscapeKey", "data-#{@controller}-reflex-value": @reflex, "data-#{@controller}-url-value": @url }
   .reveal-modal-bg.fade{ "data-modal-target": "background", "data-action": "click->modal#close" }
   .reveal-modal.fade.tiny.modal-component{ "data-modal-target": "modal" }
     = content

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -150,7 +150,44 @@ module Spree
         render turbo_stream: streams
       end
 
+      def resend_confirmation_emails
+        editable_orders.where(id: params[:bulk_ids]).find_each do |order|
+          next unless can? :resend, order
+
+          Spree::OrderMailer.confirm_email_for_customer(order.id, true).deliver_later
+        end
+
+        bulk_action_feedback("admin.resend_confirmation_emails_feedback", params[:bulk_ids].count)
+      end
+
+      def send_invoices
+        count = 0
+        editable_orders.invoiceable.where(id: params[:bulk_ids]).find_each do |order|
+          next unless order.distributor.can_invoice?
+
+          Spree::OrderMailer.invoice_email(order.id, current_user_id: spree_current_user.id).
+            deliver_later
+          count += 1
+        end
+
+        bulk_action_feedback("admin.send_invoice_feedback", count)
+      end
+
       private
+
+      def editable_orders
+        Permissions::Order.new(spree_current_user).editable_orders
+      end
+
+      def bulk_action_feedback(i18n_key, count)
+        flash.now[:success] = t(i18n_key, count:)
+        render turbo_stream: [
+          turbo_stream.dispatch_event("modal:close"),
+          turbo_stream.append(
+            "flashes", partial: "admin/shared/flashes", locals: { flashes: flash }
+          )
+        ]
+      end
 
       def line_items_present?
         return true if @order.line_items.any?

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -352,7 +352,8 @@ module Spree
       can [:create], Spree::Order
 
       # Spree::Admin::PaymentController need to load the order to credit_customer
-      can [:read, :update, :credit_customer, :bulk_credit], Spree::Order do |order|
+      can [:read, :update, :credit_customer, :bulk_credit,
+           :resend_confirmation_emails, :send_invoices], Spree::Order do |order|
         # We allow editing orders with a nil distributor as this state occurs
         # during the order creation process from the admin backend
         order.distributor.nil? ||

--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -76,40 +76,12 @@ module Admin
       morph :nothing
     end
 
-    def resend_confirmation_emails(params)
-      editable_orders.where(id: params[:bulk_ids]).find_each do |order|
-        next unless can? :resend, order
-
-        Spree::OrderMailer.confirm_email_for_customer(order.id, true).deliver_later
-      end
-
-      success("admin.resend_confirmation_emails_feedback", params[:bulk_ids].count)
-    end
-
-    def send_invoices(params)
-      count = 0
-      editable_orders.invoiceable.where(id: params[:bulk_ids]).find_each do |o|
-        next unless o.distributor.can_invoice?
-
-        Spree::OrderMailer.invoice_email(o.id, current_user_id: current_user.id).deliver_later
-        count += 1
-      end
-
-      success("admin.send_invoice_feedback", count)
-    end
-
     private
 
     def authorize_order
       id = element.dataset[:id] || params[:id]
       @order = Spree::Order.find_by(id:)
       authorize! :admin, @order
-    end
-
-    def success(i18n_key, count)
-      flash[:success] = I18n.t(i18n_key, count:)
-      cable_ready.dispatch_event(name: "modal:close")
-      morph_admin_flashes
     end
 
     def editable_orders

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -21,11 +21,11 @@
 
 = render 'spree/admin/shared/custom-confirm'
 
-= render ConfirmModalComponent.new(id: "resend_confirmation", confirm_actions: "click->bulk-actions#perform", controller: "bulk-actions", reflex: "Admin::Orders#resend_confirmation_emails") do
+= render ConfirmModalComponent.new(id: "resend_confirmation", confirm_actions: "click->bulk-actions#turboPerform", controller: "bulk-actions", url: "orders/resend_confirmation_emails") do
   .margin-bottom-30
     = t('.resend_confirmation_confirm_html')
 
-= render ConfirmModalComponent.new(id: "send_invoice", confirm_actions: "click->bulk-actions#perform", controller: "bulk-actions", reflex: "Admin::Orders#send_invoices") do
+= render ConfirmModalComponent.new(id: "send_invoice", confirm_actions: "click->bulk-actions#turboPerform", controller: "bulk-actions", url: "orders/send_invoices") do
   .margin-bottom-30
     = t('.send_invoice_confirm_html')
 

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -74,6 +74,8 @@ Spree::Core::Engine.routes.draw do
 
 
     post "orders/bulk_credit", to: "orders#bulk_credit"
+    post "orders/resend_confirmation_emails", to: "orders#resend_confirmation_emails"
+    post "orders/send_invoices", to: "orders#send_invoices"
 
     resources :orders, except: [:show, :destroy] do
       member do

--- a/spec/requests/spree/admin/orders_spec.rb
+++ b/spec/requests/spree/admin/orders_spec.rb
@@ -355,6 +355,92 @@ RSpec.describe Spree::Admin::OrdersController do
     end
   end
 
+  describe "#resend_confirmation_emails" do
+    let(:distributor) { create(:distributor_enterprise) }
+    let(:order) { create(:order_with_totals, distributor:) }
+    let(:other_order) { create(:order_with_totals, distributor: create(:distributor_enterprise)) }
+
+    before { sign_in distributor.owner }
+
+    it "resends the confirmation email for editable orders and closes the modal" do
+      expect {
+        post(
+          "/admin/orders/resend_confirmation_emails",
+          params: { bulk_ids: [order.id, other_order.id], format: :turbo_stream }
+        )
+      }.to have_enqueued_mail(Spree::OrderMailer, :confirm_email_for_customer)
+        .with(order.id, true).once
+
+      expect(response).to have_http_status :ok
+      expect(response.body).to include("modal:close")
+      # Matches the count of orders requested, not the count actually resent
+      expect(flash[:success]).to eq "Confirmation emails sent for 2 orders."
+    end
+
+    context "when the user cannot manage the order" do
+      it "denies access" do
+        sign_in create(:user)
+
+        post(
+          "/admin/orders/resend_confirmation_emails",
+          params: { bulk_ids: [order.id], format: :turbo_stream }
+        )
+
+        expect(response).to redirect_to "/unauthorized"
+      end
+    end
+  end
+
+  describe "#send_invoices" do
+    let(:distributor) { create(:distributor_enterprise, abn: "12345678901") }
+    let(:order) { create(:completed_order_with_totals, distributor:) }
+    let(:other_distributor) { create(:distributor_enterprise) }
+    let(:other_order) { create(:completed_order_with_totals, distributor: other_distributor) }
+
+    before { sign_in distributor.owner }
+
+    it "sends the invoice email for invoiceable orders and closes the modal" do
+      expect {
+        post(
+          "/admin/orders/send_invoices",
+          params: { bulk_ids: [order.id, other_order.id], format: :turbo_stream }
+        )
+      }.to have_enqueued_mail(Spree::OrderMailer, :invoice_email).once
+
+      expect(response).to have_http_status :ok
+      expect(response.body).to include("modal:close")
+      expect(flash[:success]).to eq "Invoice email sent for 1 order."
+    end
+
+    context "when the distributor cannot invoice" do
+      it "skips the order" do
+        allow_any_instance_of(Enterprise).to receive(:can_invoice?).and_return(false)
+
+        expect {
+          post(
+            "/admin/orders/send_invoices",
+            params: { bulk_ids: [order.id], format: :turbo_stream }
+          )
+        }.not_to have_enqueued_mail(Spree::OrderMailer, :invoice_email)
+
+        expect(flash[:success]).to eq "Invoice emails sent for 0 orders."
+      end
+    end
+
+    context "when the user cannot manage the order" do
+      it "denies access" do
+        sign_in create(:user)
+
+        post(
+          "/admin/orders/send_invoices",
+          params: { bulk_ids: [order.id], format: :turbo_stream }
+        )
+
+        expect(response).to redirect_to "/unauthorized"
+      end
+    end
+  end
+
   describe "#bulk_credit" do
     let(:order) { create(:order_with_totals, payment_state: "credit_owed", distributor:) }
     let(:order1) { create(:order_with_totals, payment_state: "credit_owed", distributor:) }


### PR DESCRIPTION
## What? Why?

Part of #13851, continuing the removal of `Admin::OrdersReflex` (the last
functional StimulusReflex reflex in the app, per the epic in #13850). Builds
on the same pattern as #14724 (capture) and the already-migrated `bulk_credit`
action.

This PR migrates the "Resend Confirmation" and "Send Invoices" bulk actions
from the admin orders index:

- Added `POST orders/resend_confirmation_emails` and `POST orders/send_invoices`
  and the matching `Spree::Admin::OrdersController` actions, ported 1:1 from
  the reflex (including its existing per-order `can? :resend` / `can_invoice?`
  filtering).
- Both respond with a `turbo_stream.dispatch_event("modal:close")` (closing
  the confirm modal, replacing `cable_ready.dispatch_event`) plus a
  `turbo_stream.append` of the flash.
- `:resend_confirmation_emails` and `:send_invoices` are added to
  `Spree::Ability` alongside `:bulk_credit` — reflexes bypass CanCan entirely,
  so without this every non-superadmin (e.g. an enterprise manager) would be
  redirected to `/unauthorized`.
- Added a `url:` option to `ConfirmModalComponent` (alongside the existing
  `reflex:`), so its confirm button can drive
  `bulk-actions#turboPerform` — a plain `fetch` + `Turbo.renderStreamMessage`
  already used by "Credit Orders" — instead of `stimulate()`. Swapped both
  modals over.
- Removed the now-dead `resend_confirmation_emails`/`send_invoices`/`success`
  methods from `Admin::OrdersReflex` (`cancel_orders`, `bulk_invoice` and
  `ship` still use it — follow-up PRs).

Unlike a plain `button_to` (see #14723's fixup), this doesn't need any
`data: { turbo: true }` workaround for the admin layout's `data-turbo="false"`:
`turboPerform()` drives the request with a raw `fetch()` and manually calls
`Turbo.renderStreamMessage()`, so it never goes through Turbo Drive's link/form
interception in the first place.

### Note: pre-existing inconsistency in the success count, carried over as-is

The two actions report their "N orders" success count differently, and this
PR is a straight port of that, not a fix:

- `resend_confirmation_emails` reports `params[:bulk_ids].count` — the number
  of orders *requested*, regardless of whether each one was actually skipped
  by the `can? :resend, order` check.
- `send_invoices` reports an incrementing `count` — the number *actually*
  processed, correctly excluding orders whose distributor can't invoice.

So selecting 2 orders and resending confirmation for 1 (the other being
skipped) says "Confirmation emails sent for 2 orders", while doing the
equivalent with Send Invoices correctly says "sent for 1 order". This
discrepancy already existed in `Admin::OrdersReflex` before this PR; I kept
both behaviours unchanged (and pinned them with specs) rather than fixing it
silently as part of an otherwise mechanical migration. Happy to fix
`resend_confirmation_emails` to use a real count in this PR or a follow-up if
that's wanted.

## What should we test?

- As an admin, visit `/admin/orders`, select a few orders, open Actions →
  "Resend Confirmation", confirm. The modal should close and a success flash
  should appear without a page reload; the customers' confirmation emails
  should be (re-)queued.
- Same for "Send Invoices" — check invoice emails are queued for
  complete/resumed orders with an invoiceable distributor, and skipped
  otherwise.
- As an enterprise manager who manages some but not all of the selected
  orders, confirm only their own orders are actioned (this is covered by a
  dedicated request spec, and by the existing "permission revoked" system
  spec).

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

## Dependencies



## Documentation updates
