### PR TITLE
Replace Admin::OrdersReflex#cancel_orders with a Turbo-based endpoint

### DIFF
--- a/app/components/confirm_modal_component.rb
+++ b/app/components/confirm_modal_component.rb
@@ -5,6 +5,7 @@ class ConfirmModalComponent < ModalComponent
   def initialize(
     id:,
     reflex: nil,
+    url: nil,
     controller: nil,
     message: nil,
     confirm_actions: nil,
@@ -17,6 +18,7 @@ class ConfirmModalComponent < ModalComponent
     super(id:, close_button: true)
     @confirm_actions = confirm_actions
     @reflex = reflex
+    @url = url
     @confirm_reflexes = confirm_reflexes
     @controller = controller
     @message = message

--- a/app/components/confirm_modal_component/confirm_modal_component.html.haml
+++ b/app/components/confirm_modal_component/confirm_modal_component.html.haml
@@ -1,4 +1,4 @@
-%div{ id: @id, "data-controller": "modal #{@controller}", "data-action": "keyup@document->modal#closeIfEscapeKey", "data-#{@controller}-reflex-value": @reflex }
+%div{ id: @id, "data-controller": "modal #{@controller}", "data-action": "keyup@document->modal#closeIfEscapeKey", "data-#{@controller}-reflex-value": @reflex, "data-#{@controller}-url-value": @url }
   .reveal-modal-bg.fade{ "data-modal-target": "background", "data-action": "click->modal#close" }
   .reveal-modal.fade.tiny.modal-component{ "data-modal-target": "modal" }
     = content

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -150,6 +150,19 @@ module Spree
         render turbo_stream: streams
       end
 
+      def cancel_orders
+        cancelled_orders = ::Orders::BulkCancelService.new(params, spree_current_user).call
+
+        render turbo_stream: [
+          turbo_stream.dispatch_event("modal:close"),
+          *cancelled_orders.map { |order|
+            turbo_stream.replace(
+              "order_#{order.id}", partial: "spree/admin/orders/table_row", locals: { order: }
+            )
+          }
+        ]
+      end
+
       private
 
       def line_items_present?

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -352,7 +352,7 @@ module Spree
       can [:create], Spree::Order
 
       # Spree::Admin::PaymentController need to load the order to credit_customer
-      can [:read, :update, :credit_customer, :bulk_credit], Spree::Order do |order|
+      can [:read, :update, :credit_customer, :bulk_credit, :cancel_orders], Spree::Order do |order|
         # We allow editing orders with a nil distributor as this state occurs
         # during the order creation process from the admin backend
         order.distributor.nil? ||

--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -60,22 +60,6 @@ module Admin
       morph :nothing
     end
 
-    def cancel_orders(params)
-      cancelled_orders = Orders::BulkCancelService.new(params, current_user).call
-
-      cable_ready.dispatch_event(name: "modal:close")
-
-      cancelled_orders.each do |order|
-        cable_ready.replace(
-          selector: dom_id(order),
-          html: render(partial: "spree/admin/orders/table_row", locals: { order: })
-        )
-      end
-
-      cable_ready.broadcast
-      morph :nothing
-    end
-
     def resend_confirmation_emails(params)
       editable_orders.where(id: params[:bulk_ids]).find_each do |order|
         next unless can? :resend, order

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -29,6 +29,6 @@
   .margin-bottom-30
     = t('.send_invoice_confirm_html')
 
-= render ConfirmModalComponent.new(id: "cancel_orders", confirm_actions: "click->bulk-actions#perform", controller: "bulk-actions", reflex: "Admin::Orders#cancel_orders", message: "spree/admin/orders/messages/cancel_orders") do
+= render ConfirmModalComponent.new(id: "cancel_orders", confirm_actions: "click->bulk-actions#turboPerform", controller: "bulk-actions", url: "orders/cancel_orders", message: "spree/admin/orders/messages/cancel_orders") do
   .margin-bottom-30
     = t("js.admin.orders.cancel_the_order_html")

--- a/app/webpacker/controllers/bulk_actions_controller.js
+++ b/app/webpacker/controllers/bulk_actions_controller.js
@@ -21,10 +21,15 @@ export default class extends ApplicationController {
 
   turboPerform() {
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute("content");
+    let params = { bulk_ids: this.getSelectedIds() };
+
+    if (this.hasExtraParamsTarget) {
+      Object.assign(params, this.extraFormData());
+    }
 
     fetch(this.urlValue, {
       method: "POST",
-      body: JSON.stringify({ bulk_ids: this.getSelectedIds() }),
+      body: JSON.stringify(params),
       headers: {
         "Content-Type": "application/json",
         Accept: "text/vnd.turbo-stream.html",

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -74,6 +74,7 @@ Spree::Core::Engine.routes.draw do
 
 
     post "orders/bulk_credit", to: "orders#bulk_credit"
+    post "orders/cancel_orders", to: "orders#cancel_orders"
 
     resources :orders, except: [:show, :destroy] do
       member do

--- a/spec/requests/spree/admin/orders_spec.rb
+++ b/spec/requests/spree/admin/orders_spec.rb
@@ -355,6 +355,60 @@ RSpec.describe Spree::Admin::OrdersController do
     end
   end
 
+  describe "#cancel_orders" do
+    let(:distributor) { create(:distributor_enterprise) }
+    let(:order) { create(:completed_order_with_totals, distributor:) }
+    let(:other_order) {
+      create(:completed_order_with_totals, distributor: create(:distributor_enterprise))
+    }
+
+    before { sign_in distributor.owner }
+
+    it "cancels editable orders and closes the modal" do
+      expect {
+        post(
+          "/admin/orders/cancel_orders",
+          params: { bulk_ids: [order.id, other_order.id], format: :turbo_stream }
+        )
+      }.to change { order.reload.state }.to("canceled")
+
+      expect(other_order.reload.state).to eq "complete"
+      expect(response).to have_http_status :ok
+      expect(response.body).to include("modal:close")
+      expect(response.body).to include("order_#{order.id}")
+      expect(response.body).not_to include("order_#{other_order.id}")
+    end
+
+    it "forwards the cancellation options to the service" do
+      expect(Orders::BulkCancelService).to receive(:new).
+        and_wrap_original do |original, params, user|
+          expect(params[:send_cancellation_email]).to be_nil
+          expect(params[:restock_items]).to eq "1"
+          original.call(params, user)
+        end
+
+      post(
+        "/admin/orders/cancel_orders",
+        params: { bulk_ids: [order.id], restock_items: "1", format: :turbo_stream }
+      )
+
+      expect(response).to have_http_status :ok
+    end
+
+    context "when the user cannot manage the order" do
+      it "denies access" do
+        sign_in create(:user)
+
+        post(
+          "/admin/orders/cancel_orders",
+          params: { bulk_ids: [order.id], format: :turbo_stream }
+        )
+
+        expect(response).to redirect_to "/unauthorized"
+      end
+    end
+  end
+
   describe "#bulk_credit" do
     let(:order) { create(:order_with_totals, payment_state: "credit_owed", distributor:) }
     let(:order1) { create(:order_with_totals, payment_state: "credit_owed", distributor:) }


### PR DESCRIPTION
## What? Why?

Part of #13851, continuing the removal of `Admin::OrdersReflex` (the last
functional StimulusReflex reflex in the app, per the epic in #13850). Same
pattern as #14724 (capture) and #14725 (resend/send-invoice).

This PR migrates the "Cancel Orders" bulk action from the admin orders index:

- Added `POST orders/cancel_orders` and the matching
  `Spree::Admin::OrdersController#cancel_orders` action. It delegates to the
  existing `Orders::BulkCancelService` (unchanged) and responds with a
  `turbo_stream.dispatch_event("modal:close")` plus a `table_row` replace per
  cancelled order — the Turbo equivalent of the reflex's `cable_ready`
  calls.
- `:cancel_orders` is added to `Spree::Ability` alongside `:bulk_credit` —
  reflexes bypass CanCan entirely, so without this every non-superadmin
  (e.g. an enterprise manager) would be redirected to `/unauthorized`.
- Added a `url:` option to `ConfirmModalComponent` (alongside the existing
  `reflex:`), so its confirm button can drive `bulk-actions#turboPerform`
  instead of `stimulate()`, and swapped the Cancel Orders modal over.
- **`turboPerform()` didn't forward the modal's `extraParams` form** (the
  "send cancellation email" / "restock items" checkboxes) the way the
  reflex's `perform()` did — only `bulk_ids`. Fixed it to merge
  `extraFormData()` in, same as `perform()`, otherwise cancelling would
  silently ignore both checkboxes.
- Removed the now-dead `cancel_orders` method from `Admin::OrdersReflex`
  (`bulk_invoice` and `ship` still use it — follow-up PRs).

## What should we test?

- As an admin, visit `/admin/orders`, select a couple of orders, open
  Actions → "Cancel Orders".
- Confirm with both checkboxes ("send cancellation email", "restock items")
  left checked — orders should cancel, modal closes without a page reload,
  rows update to CANCELLED, and a cancellation email is queued.
- Repeat unchecking "Send a cancellation email to the customer" — orders
  should still cancel but no email should be queued (this is the
  `extraParams` fix; it's covered by the existing
  `spec/system/admin/orders/bulk_actions_spec.rb` "can bulk cancel 2 orders"
  scenario, which passes with this change and would have caught the missing
  forwarding).
- As an enterprise manager who manages some but not all of the selected
  orders, confirm only their own orders get cancelled (covered by a
  dedicated request spec, and by the existing "permission revoked" style
  system spec for this action).

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

## Dependencies



## Documentation updates