### PR TITLE
Replace Admin::OrdersReflex#bulk_invoice with a Turbo endpoint, fixing intermittent hangs

### DIFF
--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -150,7 +150,59 @@ module Spree
         render turbo_stream: streams
       end
 
+      def bulk_invoice
+        visible_orders = bulk_load_orders
+
+        abn_issue_stream = abn_related_issue_stream(visible_orders)
+        return render turbo_stream: abn_issue_stream if abn_issue_stream
+
+        # Preserve order of bulk_ids.
+        # The ids are supplied in the sequence of the orders screen and may be
+        # sorted, for example by last name of the customer.
+        visible_order_ids = params[:bulk_ids].map(&:to_i) & visible_orders.pluck(:id)
+
+        file_id = "#{Time.zone.now.to_i}-#{SecureRandom.hex(2)}"
+
+        BulkInvoiceJob.perform_later(
+          visible_order_ids,
+          "tmp/invoices/#{file_id}.pdf",
+          current_user_id: spree_current_user.id
+        )
+
+        render turbo_stream: turbo_stream.append(
+          "orders-index", partial: "spree/admin/orders/bulk/invoice_modal",
+                          locals: { invoice_url: "/admin/orders/invoices/#{file_id}" }
+        )
+      end
+
       private
+
+      def bulk_load_orders
+        Permissions::Order.new(spree_current_user).editable_orders.invoiceable.where(
+          id: params[:bulk_ids]
+        )
+      end
+
+      def abn_related_issue_stream(orders)
+        return unless abn_required?
+
+        distributors = distributors_without_abn(orders)
+        return if distributors.empty?
+
+        flash.now[:error] = t(:must_have_valid_business_number,
+                              enterprise_name: distributors.pluck(:name).join(", "))
+        turbo_stream.append("flashes", partial: "admin/shared/flashes", locals: { flashes: flash })
+      end
+
+      def abn_required?
+        Spree::Config.enterprise_number_required_on_invoices?
+      end
+
+      def distributors_without_abn(orders)
+        abn = OpenFoodNetwork::FeatureToggle.enabled?(:invoices) ? [nil, ""] : [nil]
+
+        Enterprise.where(id: orders.select(:distributor_id), abn:)
+      end
 
       def line_items_present?
         return true if @order.line_items.any?

--- a/app/jobs/bulk_invoice_job.rb
+++ b/app/jobs/bulk_invoice_job.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class BulkInvoiceJob < ApplicationJob
-  include CableReady::Broadcaster
-
-  delegate :render, to: ActionController::Base
   attr_reader :options
 
   def perform(order_ids, filepath, options = {})
@@ -17,8 +14,6 @@ class BulkInvoiceJob < ApplicationJob
     ensure_directory_exists filepath
 
     pdf.save filepath
-
-    broadcast(filepath, options[:channel]) if options[:channel]
   end
 
   private
@@ -36,18 +31,6 @@ class BulkInvoiceJob < ApplicationJob
                     end
     invoice = renderer.render_to_string(renderer_data, current_user)
     pdf << CombinePDF.parse(invoice)
-  end
-
-  def broadcast(filepath, channel)
-    file_id = filepath.split("/").last.split(".").first
-
-    cable_ready[channel].
-      inner_html(
-        selector: "#bulk_invoices_modal .modal-content",
-        html: render(partial: "spree/admin/orders/bulk/invoice_link",
-                     locals: { invoice_url: "/admin/orders/invoices/#{file_id}" })
-      ).
-      broadcast
   end
 
   def ensure_directory_exists(filepath)

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -352,7 +352,7 @@ module Spree
       can [:create], Spree::Order
 
       # Spree::Admin::PaymentController need to load the order to credit_customer
-      can [:read, :update, :credit_customer, :bulk_credit], Spree::Order do |order|
+      can [:read, :update, :credit_customer, :bulk_credit, :bulk_invoice], Spree::Order do |order|
         # We allow editing orders with a nil distributor as this state occurs
         # during the order creation process from the admin backend
         order.distributor.nil? ||

--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -32,34 +32,6 @@ module Admin
       end
     end
 
-    def bulk_invoice(params)
-      visible_orders = bulk_load_orders(params)
-
-      return if notify_if_abn_related_issue(visible_orders)
-
-      file_id = "#{Time.zone.now.to_i}-#{SecureRandom.hex(2)}"
-
-      cable_ready.append(
-        selector: "#orders-index",
-        html: render(partial: "spree/admin/orders/bulk/invoice_modal",
-                     locals: { invoice_url: "/admin/orders/invoices/#{file_id}" })
-      ).broadcast
-
-      # Preserve order of bulk_ids.
-      # The ids are supplied in the sequence of the orders screen and may be
-      # sorted, for example by last name of the customer.
-      visible_order_ids = params[:bulk_ids].map(&:to_i) & visible_orders.pluck(:id)
-
-      BulkInvoiceJob.perform_later(
-        visible_order_ids,
-        "tmp/invoices/#{file_id}.pdf",
-        channel: SessionChannel.for_request(request),
-        current_user_id: current_user.id
-      )
-
-      morph :nothing
-    end
-
     def cancel_orders(params)
       cancelled_orders = Orders::BulkCancelService.new(params, current_user).call
 
@@ -118,44 +90,6 @@ module Admin
 
     def set_param_for_controller
       params[:id] = @order.number
-    end
-
-    def render_business_number_required_error(distributors)
-      distributor_names = distributors.pluck(:name)
-
-      flash[:error] = I18n.t(:must_have_valid_business_number,
-                             enterprise_name: distributor_names.join(", "))
-      morph_admin_flashes
-    end
-
-    def bulk_load_orders(params)
-      editable_orders.invoiceable.where(id: params[:bulk_ids])
-    end
-
-    def notify_if_abn_related_issue(orders)
-      return false unless abn_required?
-
-      distributors = distributors_without_abn(orders)
-      return false if distributors.empty?
-
-      render_business_number_required_error(distributors)
-      true
-    end
-
-    def abn_required?
-      Spree::Config.enterprise_number_required_on_invoices?
-    end
-
-    def distributors_without_abn(orders)
-      abn = if OpenFoodNetwork::FeatureToggle.enabled?(:invoices)
-              [nil, ""]
-            else
-              [nil]
-            end
-      Enterprise.where(
-        id: orders.select(:distributor_id),
-        abn:,
-      )
     end
   end
 end

--- a/app/views/spree/admin/orders/_bulk_actions.html.haml
+++ b/app/views/spree/admin/orders/_bulk_actions.html.haml
@@ -17,7 +17,7 @@
             %span.name{ "data-controller": "modal-link", "data-action": "click->modal-link#open", "data-modal-link-target-value": "send_invoice" }
               = t('spree.admin.orders.index.send_invoice')
           .menu_item
-            %span.name{ "data-controller": "bulk-actions", "data-action": "click->bulk-actions#perform", "data-bulk-actions-reflex-value": "Admin::Orders#bulk_invoice" }
+            %span.name{ "data-controller": "bulk-actions", "data-action": "click->bulk-actions#turboPerform", "data-bulk-actions-url-value": "orders/bulk_invoice" }
               = t('spree.admin.orders.index.print_invoices')
         .menu_item
           %span.name{ "data-controller": "modal-link", "data-action": "click->modal-link#open", "data-modal-link-target-value": "cancel_orders" }

--- a/app/webpacker/controllers/file_loading_controller.js
+++ b/app/webpacker/controllers/file_loading_controller.js
@@ -1,11 +1,13 @@
 import { Controller } from "stimulus";
-const NOTIFICATION_TIME = 5000; // 5 seconds
+const INITIAL_POLL_INTERVAL = 1000; // 1 second
+const MAX_POLL_INTERVAL = 5000; // 5 seconds
 const HIDE_CLASS = "hidden";
 
 export default class extends Controller {
   static targets = ["loading", "loaded", "link"];
 
   connect() {
+    this.pollInterval = INITIAL_POLL_INTERVAL;
     this.setTimeout();
   }
 
@@ -26,13 +28,15 @@ export default class extends Controller {
         }
         this.loadedTarget.classList.remove(HIDE_CLASS);
       } else {
+        // Poll quickly at first (most jobs finish in well under a second), then back off.
+        this.pollInterval = Math.min(this.pollInterval * 2, MAX_POLL_INTERVAL);
         this.setTimeout();
       }
     });
   }
 
   setTimeout() {
-    this.timeout = setTimeout(this.checkFile.bind(this), NOTIFICATION_TIME);
+    this.timeout = setTimeout(this.checkFile.bind(this), this.pollInterval);
   }
   clearTimeout() {
     clearTimeout(this.timeout);

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -74,6 +74,7 @@ Spree::Core::Engine.routes.draw do
 
 
     post "orders/bulk_credit", to: "orders#bulk_credit"
+    post "orders/bulk_invoice", to: "orders#bulk_invoice"
 
     resources :orders, except: [:show, :destroy] do
       member do

--- a/spec/requests/spree/admin/orders_spec.rb
+++ b/spec/requests/spree/admin/orders_spec.rb
@@ -355,6 +355,70 @@ RSpec.describe Spree::Admin::OrdersController do
     end
   end
 
+  describe "#bulk_invoice" do
+    let(:distributor) { create(:distributor_enterprise, abn: "12345678901") }
+    let(:order) { create(:completed_order_with_totals, distributor:) }
+    let(:other_order) {
+      create(:completed_order_with_totals, distributor: create(:distributor_enterprise))
+    }
+
+    before do
+      sign_in distributor.owner
+      Spree::Config[:enterprise_number_required_on_invoices?] = false
+    end
+
+    it "enqueues a bulk invoice job and shows the compiling modal" do
+      expect {
+        post(
+          "/admin/orders/bulk_invoice",
+          params: { bulk_ids: [order.id, other_order.id], format: :turbo_stream }
+        )
+      }.to have_enqueued_job(BulkInvoiceJob).with { |order_ids, filepath, options|
+        expect(order_ids).to eq [order.id]
+        expect(filepath).to match(%r{\Atmp/invoices/\d+-[0-9a-f]+\.pdf\z})
+        expect(options[:current_user_id]).to eq distributor.owner.id
+        expect(options[:channel]).to be_nil
+      }
+
+      expect(response).to have_http_status :ok
+      expect(response.body).to include("bulk_invoices_modal")
+      expect(response.body).to include("orders-index")
+    end
+
+    context "when a distributor is missing a business number" do
+      before do
+        Spree::Config[:enterprise_number_required_on_invoices?] = true
+        distributor.update!(abn: nil)
+      end
+
+      it "shows an error and does not enqueue the job" do
+        expect {
+          post(
+            "/admin/orders/bulk_invoice",
+            params: { bulk_ids: [order.id], format: :turbo_stream }
+          )
+        }.not_to have_enqueued_job(BulkInvoiceJob)
+
+        expect(response).to have_http_status :ok
+        expect(response.body).to include("flashes")
+        expect(flash[:error]).to include(distributor.name)
+      end
+    end
+
+    context "when the user cannot manage the order" do
+      it "denies access" do
+        sign_in create(:user)
+
+        post(
+          "/admin/orders/bulk_invoice",
+          params: { bulk_ids: [order.id], format: :turbo_stream }
+        )
+
+        expect(response).to redirect_to "/unauthorized"
+      end
+    end
+  end
+
   describe "#bulk_credit" do
     let(:order) { create(:order_with_totals, payment_state: "credit_owed", distributor:) }
     let(:order1) { create(:order_with_totals, payment_state: "credit_owed", distributor:) }

--- a/spec/system/admin/orders/bulk_actions_spec.rb
+++ b/spec/system/admin/orders/bulk_actions_spec.rb
@@ -287,27 +287,6 @@ RSpec.describe '
             it_behaves_like "can bulk print invoices from 2 orders"
           end
 
-          context "when cable_ready fails" do
-            # The backup polling is slower. Let's wait for it.
-            around do |example|
-              polling_interval = 5 # seconds
-              wait_time = Capybara.default_max_wait_time + polling_interval
-
-              using_wait_time(wait_time) do
-                example.run
-              end
-            end
-
-            # Don't send anything via web sockets.
-            before do
-              expect_any_instance_of(BulkInvoiceJob)
-                .to receive(:broadcast)
-                .and_return(nil) # do nothing
-            end
-
-            it_behaves_like "can bulk print invoices from 2 orders"
-          end
-
           context "one of the two orders is not invoiceable" do
             before do
               order4.cancel!


### PR DESCRIPTION
## What? Why?

Part of #13851, continuing the removal of `Admin::OrdersReflex` (the last
functional StimulusReflex reflex in the app, per the epic in #13850). Same
pattern as #14724/#14725/#14726.

Closes #13368 ("Print invoice not working sometimes").

### The actual bug

"Print Invoices" enqueues `BulkInvoiceJob`, which generates the PDF then
tells the browser it's ready by broadcasting over ActionCable to a
`SessionChannel`. As the epic and #13368 both describe, that broadcast is
occasionally lost (particularly under load), leaving the user staring at an
infinite "Compiling Invoices" spinner even though the PDF was generated fine.

There's already a **backup polling mechanism** in
`file_loading_controller.js` — the modal is rendered with the final,
deterministic `invoice_url` baked in from the start (just hidden), and the
controller polls that URL until it 200s. It already works completely
standalone; the websocket broadcast is pure duplication of a working
mechanism, and it's the flaky half.

### Changes

- Added `POST orders/bulk_invoice` and
  `Spree::Admin::OrdersController#bulk_invoice`, ported 1:1 from the reflex
  (including the "distributor missing a business number" guard, which now
  renders a turbo_stream flash instead of morphing it directly). Responds by
  appending the "Compiling Invoices" modal to `#orders-index` and enqueuing
  `BulkInvoiceJob` — **without** a channel.
- `:bulk_invoice` added to `Spree::Ability` alongside `:bulk_credit` — reflexes
  bypass CanCan entirely, so without this every non-superadmin (e.g. an
  enterprise manager) would be redirected to `/unauthorized`.
- **`BulkInvoiceJob` no longer broadcasts anything** — dropped
  `CableReady::Broadcaster`, the `channel` option, and the `broadcast` method.
  It now just generates and saves the PDF.
- **Tuned the polling interval**: since most jobs finish in well under a
  second, `file_loading_controller.js` now does its first check after 1s
  (previously a flat 5s before the first check at all) and backs off up to
  5s on repeated misses, instead of a fixed 5s throughout.
- Wired the "Print Invoices" menu item to the new endpoint and deleted the
  now-dead `bulk_invoice`/ABN-check methods from `Admin::OrdersReflex`
  (`cancel_orders`, `resend_confirmation_emails`, `send_invoices` still use
  it — later PRs).
- Removed the `spec/system/admin/orders/bulk_actions_spec.rb` "when
  cable_ready fails" context: that fallback-polling behaviour is now the
  *only* behaviour, already covered by the surrounding examples that used
  to test the (now nonexistent) websocket happy path.

`SessionChannel` itself is untouched — `Admin::ConnectedAppsController` still
uses it for connecting external apps (Vine etc.), an unrelated feature.

## What should we test?

- As an admin, visit `/admin/orders`, select a few complete orders, Actions →
  "Print Invoices". The modal should appear and, once Sidekiq processes the
  job, switch to the download link — without needing a websocket connection
  at all (you can verify this by throttling/blocking the `/cable` connection
  in devtools and confirming it still completes via polling).
- As an enterprise manager who manages some but not all of the selected
  orders, confirm only their own orders are invoiced (request spec).
- Trigger the "missing business number" case (with
  `enterprise_number_required_on_invoices?` on and a distributor without an
  ABN) and confirm the error flash appears without a page reload.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

## Dependencies



## Documentation updates