### PR TITLE
Replace Admin::OrdersReflex#ship with a Turbo-based endpoint

### DIFF
--- a/app/components/confirm_modal_component.rb
+++ b/app/components/confirm_modal_component.rb
@@ -9,6 +9,7 @@ class ConfirmModalComponent < ModalComponent
     message: nil,
     confirm_actions: nil,
     confirm_reflexes: nil,
+    confirm_button_type: "button",
     confirm_button_class: :primary,
     confirm_button_text: I18n.t('js.admin.modals.confirm'),
     cancel_button_text: I18n.t('js.admin.modals.cancel'),
@@ -20,6 +21,7 @@ class ConfirmModalComponent < ModalComponent
     @confirm_reflexes = confirm_reflexes
     @controller = controller
     @message = message
+    @confirm_button_type = confirm_button_type
     @confirm_button_class = confirm_button_class
     @confirm_button_text = confirm_button_text
     @cancel_button_text = cancel_button_text

--- a/app/components/confirm_modal_component/confirm_modal_component.html.haml
+++ b/app/components/confirm_modal_component/confirm_modal_component.html.haml
@@ -7,4 +7,4 @@
 
     %div{ class: "modal-actions #{@actions_alignment_class}" }
       %input{ class: "button icon-plus #{close_button_class}", type: 'button', value: @cancel_button_text, "data-action": "click->modal#close" }
-      %input{ id: 'modal-confirm-button', class: "button icon-plus #{@confirm_button_class}", type: 'button', value: @confirm_button_text, "data-action": @confirm_actions, "data-reflex": @confirm_reflexes }
+      %input{ id: 'modal-confirm-button', class: "button icon-plus #{@confirm_button_class}", type: @confirm_button_type, value: @confirm_button_text, "data-action": @confirm_actions, "data-reflex": @confirm_reflexes }

--- a/app/components/ship_order_component.html.haml
+++ b/app/components/ship_order_component.html.haml
@@ -1,8 +1,9 @@
-= render ConfirmModalComponent.new(id: dom_id(@order, :ship), confirm_actions: "click->modal#close", confirm_reflexes: "click->Admin::OrdersReflex#ship", controller: "orders", reflex: "Admin::Orders#ship") do
-  %div{class: "margin-bottom-30"}
-    %p= t('spree.admin.orders.shipment.mark_as_shipped_message_html')
-  %div{class: "margin-bottom-30"}
-    = hidden_field_tag :id, @order.id
-    = label_tag do
-      = check_box_tag :send_shipment_email, "1", true
-      = t('spree.admin.orders.shipment.mark_as_shipped_label_message')
+= form_with url: helpers.spree.ship_admin_order_path(@order), method: :put, data: { turbo: true } do
+  = render ConfirmModalComponent.new(id: dom_id(@order, :ship), confirm_button_type: "submit") do
+    %div{class: "margin-bottom-30"}
+      %p= t('spree.admin.orders.shipment.mark_as_shipped_message_html')
+    %div{class: "margin-bottom-30"}
+      = hidden_field_tag :replace_row, @replace_row
+      = label_tag do
+        = check_box_tag :send_shipment_email, "1", true
+        = t('spree.admin.orders.shipment.mark_as_shipped_label_message')

--- a/app/components/ship_order_component.rb
+++ b/app/components/ship_order_component.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ShipOrderComponent < ViewComponent::Base
-  def initialize(order:)
+  def initialize(order:, replace_row: false)
     @order = order
+    @replace_row = replace_row
   end
 end

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -9,7 +9,7 @@ module Spree
 
       helper CheckoutHelper
 
-      before_action :load_order, only: [:edit, :update, :fire, :resend, :invoice, :print]
+      before_action :load_order, only: [:edit, :update, :fire, :resend, :invoice, :print, :ship]
       before_action :refuse_changing_shipped_orders, only: [:update]
       before_action :load_distribution_choices, only: [:new, :create, :edit, :update]
       before_action :require_distributor_abn, only: :invoice
@@ -119,6 +119,29 @@ module Spree
           type: "application/pdf",
           disposition: "inline"
         )
+      end
+
+      def ship
+        @order.send_shipment_email = params[:send_shipment_email].present?
+
+        unless @order.ship
+          flash.now[:error] = t("api.orders.failed_to_update")
+          return render turbo_stream: turbo_stream.append(
+            "flashes", partial: "admin/shared/flashes", locals: { flashes: flash }
+          )
+        end
+
+        if params[:replace_row] == "true"
+          render turbo_stream: [
+            turbo_stream.dispatch_event("modal:close"),
+            turbo_stream.replace(
+              "order_#{@order.id}", partial: "spree/admin/orders/table_row",
+                                    locals: { order: @order.reload, success: true }
+            )
+          ]
+        else
+          redirect_back_or_to(spree.edit_admin_order_path(@order))
+        end
       end
 
       def bulk_credit

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -363,7 +363,7 @@ module Spree
           can_edit_as_producer(order, user)
       end
 
-      can [:fire, :resend, :invoice, :print], Spree::Order do |order|
+      can [:fire, :resend, :invoice, :print, :ship], Spree::Order do |order|
         # We allow editing orders with a nil distributor as this state occurs
         # during the order creation process from the admin backend
         order.distributor.nil? ||

--- a/app/reflexes/admin/orders_reflex.rb
+++ b/app/reflexes/admin/orders_reflex.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class OrdersReflex < ApplicationReflex
-    before_reflex :authorize_order, only: [:capture, :ship]
+    before_reflex :authorize_order, only: [:capture]
 
     def capture
       payment_capture = Orders::CaptureService.new(@order)
@@ -14,20 +14,6 @@ module Admin
         morph :nothing
       else
         flash[:error] = payment_capture.gateway_error || I18n.t(:payment_processing_failed)
-        morph_admin_flashes
-      end
-    end
-
-    def ship
-      @order.send_shipment_email = false unless params[:send_shipment_email]
-      if @order.ship
-        paths = %w[edit customer payments adjustments invoices return_authorizations].freeze
-        return set_param_for_controller if Regexp.union(paths).match? request.url
-
-        morph dom_id(@order), render(partial: "spree/admin/orders/table_row",
-                                     locals: { order: @order.reload, success: true })
-      else
-        flash[:error] = I18n.t("api.orders.failed_to_update")
         morph_admin_flashes
       end
     end
@@ -114,10 +100,6 @@ module Admin
 
     def editable_orders
       Permissions::Order.new(current_user).editable_orders
-    end
-
-    def set_param_for_controller
-      params[:id] = @order.number
     end
 
     def render_business_number_required_error(distributors)

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -10,8 +10,7 @@
         = "-"
         %button{"class": "ship button icon-arrow-right","data-controller": "modal-link",
                 "data-action": "click->modal-link#open", "data-modal-link-target-value": dom_id(order, :ship)}= t(:ship)
-        %form
-          = render ShipOrderComponent.new(order: order)
+        = render ShipOrderComponent.new(order: order)
 
   %table.stock-contents.index
     %colgroup

--- a/app/views/spree/admin/orders/_table_row.html.haml
+++ b/app/views/spree/admin/orders/_table_row.html.haml
@@ -48,8 +48,7 @@
         %i.success.icon-ok-sign{"data-controller": "ephemeral"}
     = render TooltipComponent.new(text: t('spree.admin.orders.index.edit'), element_text: "", link: edit_admin_order_path(order), element_class: "icon_link with-tip icon-edit no-text")
     - if can?(:manage_order_sections, order) && order.ready_to_ship?
-      %form
-        = render ShipOrderComponent.new(order: order)
+      = render ShipOrderComponent.new(order: order, replace_row: true)
       = render partial: 'admin/shared/tooltip_button', locals: {button_class: "icon-road icon_link with-tip no-text", reflex_data_id: order.id.to_s, tooltip_text: t('spree.admin.orders.index.ship'), shipment: true}
 
     - if can?(:manage_order_sections, order) && can?(:update, Spree::Payment) && order.payment_required? && order.pending_payments.reject(&:requires_authorization?).any?

--- a/app/views/spree/admin/shared/_order_links.html.haml
+++ b/app/views/spree/admin/shared/_order_links.html.haml
@@ -20,5 +20,4 @@
 
 = render 'spree/admin/shared/custom-confirm'
 - if order_shipment_ready?(@order)
-  %form
-    = render ShipOrderComponent.new(order: @order)
+  = render ShipOrderComponent.new(order: @order)

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -82,6 +82,7 @@ Spree::Core::Engine.routes.draw do
         get :resend
         get :invoice
         get :print
+        put :ship
       end
 
       collection do

--- a/spec/requests/spree/admin/orders_spec.rb
+++ b/spec/requests/spree/admin/orders_spec.rb
@@ -409,6 +409,22 @@ RSpec.describe Spree::Admin::OrdersController do
       end
     end
 
+    context "when the order fails to ship" do
+      it "shows an error without redirecting" do
+        allow_any_instance_of(Spree::Order).to receive(:ship).and_return(false)
+
+        put(
+          "/admin/orders/#{order.number}/ship",
+          params: { replace_row: "true", format: :turbo_stream }
+        )
+
+        expect(order.reload.shipment_state).not_to eq "shipped"
+        expect(response).to have_http_status :ok
+        expect(response.body).to include("flashes")
+        expect(flash[:error]).to eq "Failed to update order"
+      end
+    end
+
     context "when the user cannot manage the order" do
       it "denies access" do
         sign_in create(:user)

--- a/spec/requests/spree/admin/orders_spec.rb
+++ b/spec/requests/spree/admin/orders_spec.rb
@@ -355,6 +355,74 @@ RSpec.describe Spree::Admin::OrdersController do
     end
   end
 
+  describe "#ship" do
+    let(:distributor) { create(:distributor_enterprise) }
+    let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor]) }
+    let!(:order) do
+      order = create(:order_with_totals_and_distribution, distributor:, order_cycle:,
+                                                          state: "complete",
+                                                          payment_state: "balance_due")
+      order.finalize!
+      order.payments << create(:check_payment, order:, amount: order.total)
+      order.payments.first.capture!
+      order.reload
+    end
+
+    before { sign_in distributor.owner }
+
+    context "when submitted from the orders index" do
+      it "ships the order, sends the notification email, and replaces the row" do
+        expect {
+          put(
+            "/admin/orders/#{order.number}/ship",
+            params: { send_shipment_email: "1", replace_row: "true", format: :turbo_stream }
+          )
+        }.to have_enqueued_mail(Spree::ShipmentMailer, :shipped_email).once
+
+        expect(order.reload.shipment_state).to eq "shipped"
+        expect(response).to have_http_status :ok
+        expect(response.body).to include("modal:close")
+        expect(response.body).to include("order_#{order.id}")
+      end
+
+      it "does not send the notification email when unchecked" do
+        expect {
+          put(
+            "/admin/orders/#{order.number}/ship",
+            params: { replace_row: "true", format: :turbo_stream }
+          )
+        }.not_to have_enqueued_mail(Spree::ShipmentMailer, :shipped_email)
+
+        expect(order.reload.shipment_state).to eq "shipped"
+      end
+    end
+
+    context "when submitted from a detail page" do
+      it "ships the order and redirects back to it" do
+        put(
+          "/admin/orders/#{order.number}/ship",
+          params: { send_shipment_email: "1" }
+        )
+
+        expect(order.reload.shipment_state).to eq "shipped"
+        expect(response).to redirect_to spree.edit_admin_order_path(order)
+      end
+    end
+
+    context "when the user cannot manage the order" do
+      it "denies access" do
+        sign_in create(:user)
+
+        put(
+          "/admin/orders/#{order.number}/ship",
+          params: { replace_row: "true", format: :turbo_stream }
+        )
+
+        expect(response).to redirect_to "/unauthorized"
+      end
+    end
+  end
+
   describe "#bulk_credit" do
     let(:order) { create(:order_with_totals, payment_state: "credit_owed", distributor:) }
     let(:order1) { create(:order_with_totals, payment_state: "credit_owed", distributor:) }


### PR DESCRIPTION
## What? Why?

Part of #13851, continuing the removal of `Admin::OrdersReflex` (the last
functional StimulusReflex reflex in the app, per the epic in #13850). Same
pattern as #14724/#14725/#14726/#14727.

This is the fiddliest of the six actions: `ShipOrderComponent` (the "mark as
shipped" confirm modal) renders in three different contexts, and the reflex
behaved differently depending on where it was triggered from.

### The old behaviour

- On the **orders index**, the reflex replaced the order's row in place.
- On any **order detail page** (edit, customer details, payments,
  adjustments, invoices, return authorizations), it instead fell through to
  a full page morph, detected by regex-matching the request URL against a
  hardcoded list of six path fragments (`set_param_for_controller` /
  `Regexp.union(paths).match? request.url`).

### The new behaviour

Rather than port the URL-sniffing, the caller now says up front which
behaviour it wants:

- `ShipOrderComponent.new(order:, replace_row: true)` (used only by the
  orders-index row) → the controller responds with a `turbo_stream.replace`
  of the row.
- `ShipOrderComponent.new(order:)` (`replace_row` defaults to `false`, used
  by the two detail-page callers) → the controller does a plain
  `redirect_back_or_to`.

### Changes

- Added `PUT :ship` route/action on `Spree::Admin::OrdersController`
  (`load_order`-authorized, like `capture`/`fire`/`resend`/etc). `:ship`
  added to `Spree::Ability` alongside them — reflexes bypass CanCan
  entirely, so without this every non-superadmin (e.g. an enterprise
  manager) would be redirected to `/unauthorized`.
- **`ShipOrderComponent` now owns a real `form_with`** (`PUT
  ship_admin_order_path`, `data: { turbo: true }` since the admin layout
  sets `data-turbo="false"` on `<body>`) instead of relying on a bare
  wrapper `%form` + StimulusReflex's automatic form serialization. No custom
  JS needed — just a real submit button, matching the `button_to` pattern
  used for `capture` in #14724.
- `ConfirmModalComponent` gains a `confirm_button_type:` option (default
  `"button"`, so every other modal is unaffected) so its confirm button can
  be a real `type="submit"` here.
- Dropped `controller: "orders"` from `ShipOrderComponent` — it was already
  dead code (no `orders_controller.js` exists anywhere in the app; Stimulus
  was silently logging a missing-controller warning on every admin orders
  page).
- Deleted the now-dead `ship`/`set_param_for_controller` methods from
  `Admin::OrdersReflex` (`bulk_invoice`, `cancel_orders`,
  `resend_confirmation_emails`, `send_invoices` remain — final teardown PR).

## What should we test?

- As an admin, ship a ready order from the **orders index** — row should
  update in place (success tick, ship/capture icons disappear) without a
  page reload.
- Ship a ready order from **every detail page** it's reachable from: order
  edit page (both the shipment-fieldset "Ship" button and the header
  dropdown), customer details, payments, adjustments, invoices, return
  authorizations. Each should redirect back to the same page showing
  "SHIPPED", not navigate anywhere else.
- Toggle "Send a shipment/pick up notification email" off and confirm no
  email is queued either way.
- As an enterprise manager, confirm shipping still works for orders they
  manage.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

## Dependencies



## Documentation updates