### PR TITLE
Add proper scoping to Variant search

### DIFF
--- a/lib/open_food_network/permissions.rb
+++ b/lib/open_food_network/permissions.rb
@@ -73,17 +73,21 @@ module OpenFoodNetwork
       )
     end
 
+    def visible_variants
+      return Spree::Variant.all if admin?
+
+      Spree::Variant.where(enterprise_id: @user.enterprises).or(
+        Spree::Variant.where(
+          enterprise_id: related_enterprises_granting(:manage_products) |
+            related_enterprises_granting(:add_to_order_cycle)
+        )
+      )
+    end
+
     def visible_products
       return Spree::Product.all if admin?
 
-      product_with_variants.where(spree_variants: { enterprise_id: @user.enterprises }).or(
-        product_with_variants.where(
-          spree_variants: {
-            enterprise_id: related_enterprises_granting(:manage_products) |
-              related_enterprises_granting(:add_to_order_cycle)
-          }
-        )
-      )
+      product_with_variants.where(spree_variants: { id: visible_variants })
     end
 
     def managed_product_enterprises

--- a/lib/open_food_network/scope_variants_for_search.rb
+++ b/lib/open_food_network/scope_variants_for_search.rb
@@ -36,7 +36,8 @@ module OpenFoodNetwork
     end
 
     def query_scope
-      Spree::Variant.
+      permission = OpenFoodNetwork::Permissions.new(spree_current_user)
+      permission.visible_variants.
         ransack(search_params.merge(m: 'or')).
         result.
         order("spree_products.name, display_name, display_as, spree_variants.variant_unit_name").

--- a/spec/lib/open_food_network/permissions_spec.rb
+++ b/spec/lib/open_food_network/permissions_spec.rb
@@ -258,49 +258,51 @@ RSpec.describe OpenFoodNetwork::Permissions do
     end
   end
 
-  describe "finding visible products" do
-    let!(:p1) { create(:simple_product, enterprise_id: create(:supplier_enterprise).id ) }
-    let!(:p2) { create(:simple_product, enterprise_id: create(:supplier_enterprise).id ) }
-    let!(:p3) { create(:simple_product, enterprise_id: create(:supplier_enterprise).id ) }
+  describe "#visible_products" do
+    let(:s1) { create(:supplier_enterprise) }
+    let(:s2) { create(:supplier_enterprise) }
+    let(:s3) { create(:supplier_enterprise) }
+    let!(:p1) { create(:simple_product, enterprise_id: s1.id) }
+    let!(:p2) { create(:simple_product, enterprise_id: s2.id) }
+    let!(:p3) { create(:simple_product, enterprise_id: s3.id) }
 
     before do
-      allow(permissions).to receive(:managed_enterprise_products) { Spree::Product.where("1=0") }
-      allow(permissions).to receive(:related_enterprises_granting).with(:manage_products) {
-                              Enterprise.where("1=0").select(:id)
-                            }
-      allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle) {
-                              Enterprise.where("1=0").select(:id)
-                            }
+      allow(permissions).to receive(:related_enterprises_granting).with(:manage_products).and_return(
+        Enterprise.where("1=0").select(:id)
+      )
+      allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle).and_return(
+        Enterprise.where("1=0").select(:id)
+      )
     end
 
     it "returns products produced by managed enterprises" do
-      allow(user).to receive(:admin?) { false }
-      allow(user).to receive(:enterprises) { Enterprise.where(id: p1.variants.first.enterprise_id) }
+      allow(user).to receive(:admin?).and_return(false)
+      allow(user).to receive(:enterprises).and_return([s1])
 
       expect(permissions.visible_products).to eq([p1])
     end
 
     it "returns products produced by enterprises that have granted manage products" do
-      allow(user).to receive(:admin?) { false }
-      allow(user).to receive(:enterprises) { [] }
+      allow(user).to receive(:admin?).and_return(false)
+      allow(user).to receive(:enterprises).and_return([])
       allow(permissions).to receive(:related_enterprises_granting).
-        with(:manage_products) { Enterprise.where(id: p2.variants.first.enterprise) }
+        with(:manage_products).and_return( Enterprise.where(id: s2))
 
       expect(permissions.visible_products).to eq([p2])
     end
 
     it "returns products produced by enterprises that have granted P-OC" do
-      allow(user).to receive(:admin?) { false }
-      allow(user).to receive(:enterprises) { [] }
+      allow(user).to receive(:admin?).and_return(false)
+      allow(user).to receive(:enterprises).and_return([])
       allow(permissions).to receive(:related_enterprises_granting).
-        with(:add_to_order_cycle) { Enterprise.where(id: p3.variants.first.enterprise).select(:id) }
+        with(:add_to_order_cycle).and_return(Enterprise.where(id: s3).select(:id))
 
       expect(permissions.visible_products).to eq([p3])
     end
 
     context "as superadmin" do
       it "returns all products" do
-        allow(user).to receive(:admin?) { true }
+        allow(user).to receive(:admin?).and_return(true)
 
         expect(permissions.visible_products.to_a).to include p1, p2, p3
       end

--- a/spec/lib/open_food_network/permissions_spec.rb
+++ b/spec/lib/open_food_network/permissions_spec.rb
@@ -194,10 +194,10 @@ RSpec.describe OpenFoodNetwork::Permissions do
     before do
       allow(permissions).to receive(:managed_enterprise_products) { Spree::Product.where('1=0') }
       allow(permissions).to receive(:related_enterprises_granting).with(:manage_products) {
-                              Enterprise.where("1=0").select(:id)
+                              Enterprise.none.select(:id)
                             }
       allow(permissions).to receive(:related_enterprises_granting).with(:create_linked_variants) {
-                              Enterprise.where("1=0").select(:id)
+                              Enterprise.none.select(:id)
                             }
     end
 
@@ -222,7 +222,7 @@ RSpec.describe OpenFoodNetwork::Permissions do
         allow(user).to receive(:admin?) { false }
         allow(user).to receive(:enterprises) { [] }
         allow(permissions).to receive(:related_enterprises_granting).
-          with(:manage_products) { Enterprise.where("1=0").select(:id) }
+          with(:manage_products) { Enterprise.none.select(:id) }
         allow(permissions).to receive(:related_enterprises_granting).
           with(:create_linked_variants) {
             Enterprise.where(id: p1.variants.first.enterprise).select(:id)
@@ -268,9 +268,9 @@ RSpec.describe OpenFoodNetwork::Permissions do
 
     before do
       allow(permissions).to receive(:related_enterprises_granting).with(:manage_products)
-        .and_return(Enterprise.where("1=0").select(:id))
+        .and_return(Enterprise.none.select(:id))
       allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle)
-        .and_return(Enterprise.where("1=0").select(:id))
+        .and_return(Enterprise.none.select(:id))
     end
 
     it "returns products produced by managed enterprises" do
@@ -320,10 +320,10 @@ RSpec.describe OpenFoodNetwork::Permissions do
 
     before do
       allow(permissions).to receive(:related_enterprises_granting).with(:manage_products)
-        .and_return(Enterprise.where("1=0").select(:id))
+        .and_return(Enterprise.none.select(:id))
 
       allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle)
-        .and_return(Enterprise.where("1=0").select(:id))
+        .and_return(Enterprise.none.select(:id))
     end
 
     it "returns variants produced by managed enterprises" do
@@ -381,7 +381,7 @@ RSpec.describe OpenFoodNetwork::Permissions do
         .and_return(Enterprise.where(id: enterprise))
       expect(permissions).to receive(:related_enterprises_granting)
         .with(:create_linked_variants)
-        .and_return(Enterprise.where("1=0").select(:id))
+        .and_return(Enterprise.none.select(:id))
 
       expect(permissions.managed_product_enterprises_and_enterprises_granting_linked_variants)
         .to eq([enterprise])
@@ -391,7 +391,7 @@ RSpec.describe OpenFoodNetwork::Permissions do
       enterprise = create(:enterprise)
       expect(permissions).to receive(:managed_and_related_enterprises_granting)
         .with(:manage_products)
-        .and_return(Enterprise.where("1=0"))
+        .and_return(Enterprise.none)
       expect(permissions).to receive(:related_enterprises_granting)
         .with(:create_linked_variants)
         .and_return(Enterprise.where(id: enterprise).select(:id))

--- a/spec/lib/open_food_network/permissions_spec.rb
+++ b/spec/lib/open_food_network/permissions_spec.rb
@@ -309,6 +309,61 @@ RSpec.describe OpenFoodNetwork::Permissions do
     end
   end
 
+  describe "#visible_variants" do
+    let(:s1) { create(:supplier_enterprise) }
+    let(:s2) { create(:supplier_enterprise) }
+    let(:s3) { create(:supplier_enterprise) }
+    let(:p1) { create(:simple_product, enterprise_id: s1.id) }
+    let(:p2) { create(:simple_product, enterprise_id: s2.id) }
+    let(:p3) { create(:simple_product, enterprise_id: s3.id) }
+    let!(:v1) { p1.variants.first }
+    let!(:v2) { p2.variants.first }
+    let!(:v3) { p3.variants.first }
+
+    before do
+      allow(permissions).to receive(:related_enterprises_granting).with(:manage_products).and_return(
+        Enterprise.where("1=0").select(:id)
+      )
+
+      allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle).and_return(
+        Enterprise.where("1=0").select(:id)
+      )
+    end
+
+    it "returns variants produced by managed enterprises" do
+      allow(user).to receive(:admin?).and_return(false)
+      allow(user).to receive(:enterprises).and_return([s1])
+
+      expect(permissions.visible_variants).to eq([v1])
+    end
+
+    it "returns variants produced by enterprises that have granted manage products" do
+      allow(user).to receive(:admin?).and_return(false)
+      allow(user).to receive(:enterprises).and_return([])
+      allow(permissions).to receive(:related_enterprises_granting).
+        with(:manage_products).and_return(Enterprise.where(id: s2))
+
+      expect(permissions.visible_variants).to eq([v2])
+    end
+
+    it "returns variants produced by enterprises that have granted P-OC" do
+      allow(user).to receive(:admin?).and_return(false)
+      allow(user).to receive(:enterprises).and_return([])
+      allow(permissions).to receive(:related_enterprises_granting).
+        with(:add_to_order_cycle).and_return(Enterprise.where(id: s3).select(:id))
+
+      expect(permissions.visible_variants).to eq([v3])
+    end
+
+    context "as superadmin" do
+      it "returns all products" do
+        allow(user).to receive(:admin?).and_return(true)
+
+        expect(permissions.visible_variants).to include v1, v2, v3
+      end
+    end
+  end
+
   describe "finding enterprises that we manage products for" do
     let(:e) { double(:enterprise) }
 

--- a/spec/lib/open_food_network/permissions_spec.rb
+++ b/spec/lib/open_food_network/permissions_spec.rb
@@ -267,12 +267,10 @@ RSpec.describe OpenFoodNetwork::Permissions do
     let!(:p3) { create(:simple_product, enterprise_id: s3.id) }
 
     before do
-      allow(permissions).to receive(:related_enterprises_granting).with(:manage_products).and_return(
-        Enterprise.where("1=0").select(:id)
-      )
-      allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle).and_return(
-        Enterprise.where("1=0").select(:id)
-      )
+      allow(permissions).to receive(:related_enterprises_granting).with(:manage_products)
+        .and_return(Enterprise.where("1=0").select(:id))
+      allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle)
+        .and_return(Enterprise.where("1=0").select(:id))
     end
 
     it "returns products produced by managed enterprises" do
@@ -321,13 +319,11 @@ RSpec.describe OpenFoodNetwork::Permissions do
     let!(:v3) { p3.variants.first }
 
     before do
-      allow(permissions).to receive(:related_enterprises_granting).with(:manage_products).and_return(
-        Enterprise.where("1=0").select(:id)
-      )
+      allow(permissions).to receive(:related_enterprises_granting).with(:manage_products)
+        .and_return(Enterprise.where("1=0").select(:id))
 
-      allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle).and_return(
-        Enterprise.where("1=0").select(:id)
-      )
+      allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle)
+        .and_return(Enterprise.where("1=0").select(:id))
     end
 
     it "returns variants produced by managed enterprises" do

--- a/spec/lib/open_food_network/scope_variants_for_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_for_search_spec.rb
@@ -3,16 +3,16 @@
 require 'open_food_network/scope_variants_for_search'
 
 RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
-  let!(:p1) { create(:simple_product, name: 'Product 1') }
-  let!(:p2) { create(:simple_product, sku: 'Product 1a') }
-  let!(:p3) { create(:simple_product, name: 'Product 3') }
-  let!(:p4) { create(:simple_product, name: 'Product 4') }
-  let!(:v1) { p1.variants.first }
-  let!(:v2) { p2.variants.first }
-  let!(:v3) { p3.variants.first }
-  let!(:v4) { p4.variants.first }
-  let!(:d1)  { create(:distributor_enterprise) }
-  let!(:d2)  { create(:distributor_enterprise) }
+  let!(:p1) { create(:simple_product, name: 'Product 1', enterprise_id: d1.id) }
+  let!(:p2) { create(:simple_product, sku: 'Product 1a', enterprise_id: d1.id) }
+  let!(:p3) { create(:simple_product, name: 'Product 3', enterprise_id: d1.id) }
+  let!(:p4) { create(:simple_product, name: 'Product 4', enterprise_id: d2.id) }
+  let(:v1) { p1.variants.first }
+  let(:v2) { p2.variants.first }
+  let(:v3) { p3.variants.first }
+  let(:v4) { p4.variants.first }
+  let(:d1)  { create(:distributor_enterprise) }
+  let(:d2)  { create(:distributor_enterprise) }
   let!(:oc1) { create(:simple_order_cycle, distributors: [d1], variants: [v1, v3]) }
   let!(:oc2) { create(:simple_order_cycle, distributors: [d1], variants: [v2]) }
   let!(:oc3) { create(:simple_order_cycle, distributors: [d2], variants: [v4]) }
@@ -22,8 +22,13 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
 
   let(:scoper) { OpenFoodNetwork::ScopeVariantsForSearch.new(params, spree_current_user) }
 
-  describe "search" do
-    let(:result) { scoper.search }
+  before do
+    spree_current_user.enterprise_roles.create(enterprise: d1)
+    spree_current_user.enterprise_roles.create(enterprise: d2)
+  end
+
+  describe "#search" do
+    subject(:result) { scoper.search }
 
     context "when a search query is provided" do
       let(:params) { { q: "product 1" } }
@@ -68,7 +73,8 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
         expect{ result }.to query_database [
           "Enterprise Load",
           "EnterpriseGroup Load",
-          "OrderCycle Exists?",
+          "Enterprise Pluck",
+          "Enterprise Pluck",
           "Enterprise Load",
           "VariantOverride Load",
           "SQL"
@@ -211,11 +217,10 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
       let(:params) { { q: "product", search_variants_as: 'supplier', order_id: order.id } }
       let(:producer) { create(:supplier_enterprise) }
       let(:ability) { instance_double('Spree::Ability', can?: true) }
-      let!(:spree_current_user) {
-        instance_double('Spree::User', enterprises: Enterprise.where(id: producer.id))
-      }
 
       before do
+        spree_current_user.enterprise_roles.destroy_all
+        spree_current_user.enterprise_roles.create(enterprise: producer)
         allow(Spree::Ability).to receive(:new).with(spree_current_user).and_return(ability)
         allow(ability).to receive(:can?).with(:edit_as_producer_only, order).and_return(true)
       end

--- a/spec/lib/open_food_network/scope_variants_for_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_for_search_spec.rb
@@ -240,7 +240,9 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
 
     context "when searching for non accessible variant" do
       let(:params) { { q: "product" } }
-      let!(:non_accessible_product) { create(:simple_product, name: 'product', enterprise_id: other_distributor.id) }
+      let!(:non_accessible_product) {
+        create(:simple_product, name: 'product', enterprise_id: other_distributor.id)
+      }
       let(:non_accessible_variant) { non_accessible_product.variants.first }
       let(:other_distributor)  { create(:distributor_enterprise) }
 

--- a/spec/lib/open_food_network/scope_variants_for_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_for_search_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
       end
 
       context "matching both product SKUs and variant SKUs" do
-        let!(:v5) { create(:variant, sku: "Product 1b") }
+        let!(:v5) { create(:variant, sku: "Product 1b", enterprise: d1) }
 
         it "returns all variants whose SKU or product's SKU match the query" do
           expect(result).to include v1, v2, v5
@@ -76,6 +76,8 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
           "Enterprise Pluck",
           "Enterprise Pluck",
           "Enterprise Load",
+          "Enterprise Load",
+          "Enterprise Load",
           "VariantOverride Load",
           "SQL"
         ]
@@ -104,21 +106,21 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
           create_variant_with_variant_override_for(d1, on_demand: false, count_on_hand: 0)
         end
         let!(:distributor1_variant_with_override_not_in_stock_but_producer_in_stock) do
-          variant = create(:simple_product).variants.first
+          variant = create(:simple_product, enterprise_id: d1.id).variants.first
           variant.stock_items.first.update!(backorderable: false, count_on_hand: 1)
           create(:simple_order_cycle, distributors: [d1], variants: [variant])
           create(:variant_override, variant:, hub: d1, on_demand: false, count_on_hand: 0)
           variant
         end
         let!(:distributor1_variant_with_override_without_stock_level_set_and_no_producer_stock) do
-          variant = create(:simple_product).variants.first
+          variant = create(:simple_product, enterprise_id: d1.id).variants.first
           variant.stock_items.first.update!(backorderable: false, count_on_hand: 0)
           create(:simple_order_cycle, distributors: [d1], variants: [variant])
           create(:variant_override, variant:, hub: d1, on_demand: nil, count_on_hand: nil)
           variant
         end
         let!(:distributor1_variant_with_override_without_stock_level_set_but_producer_in_stock) do
-          variant = create(:simple_product).variants.first
+          variant = create(:simple_product, enterprise_id: d1.id).variants.first
           variant.stock_items.first.update!(backorderable: false, count_on_hand: 1)
           create(:simple_order_cycle, distributors: [d1], variants: [variant])
           create(:variant_override, variant:, hub: d1, on_demand: nil, count_on_hand: nil)
@@ -235,19 +237,31 @@ RSpec.describe OpenFoodNetwork::ScopeVariantsForSearch do
         expect(result).not_to include v3, v4
       end
     end
+
+    context "when searching for non accessible variant" do
+      let(:params) { { q: "product" } }
+      let!(:non_accessible_product) { create(:simple_product, name: 'product', enterprise_id: other_distributor.id) }
+      let(:non_accessible_variant) { non_accessible_product.variants.first }
+      let(:other_distributor)  { create(:distributor_enterprise) }
+
+      it "returns only variant the user has access to" do
+        expect(result).to include v1, v2, v3, v4
+        expect(result).not_to include non_accessible_variant
+      end
+    end
   end
 
   private
 
   def create_variant_with_stock_item_for(distributor, stock_item_attributes)
-    variant = create(:simple_product).variants.first
+    variant = create(:simple_product, enterprise_id: distributor.id).variants.first
     variant.stock_items.first.update!(stock_item_attributes)
     create(:simple_order_cycle, distributors: [distributor], variants: [variant])
     variant
   end
 
   def create_variant_with_variant_override_for(distributor, variant_override_attributes)
-    variant = create(:simple_product).variants.first
+    variant = create(:simple_product, enterprise_id: distributor.id).variants.first
     variant.stock_items.first.update!(backorderable: false, count_on_hand: 0)
     create(:simple_order_cycle, distributors: [distributor], variants: [variant])
     create(:variant_override, {

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe '
   include AuthenticationHelper
 
   let(:user) { create(:user) }
-  let(:product) { create(:simple_product) }
+  let(:product) { create(:simple_product, enterprise_id: distributor.id) }
   let(:distributor) { create(:distributor_enterprise, owner: user, charges_sales_tax: true) }
   let(:order_cycle) do
     create(:simple_order_cycle, name: 'One', distributors: [distributor],


### PR DESCRIPTION
## What? Why?

- Closes: https://github.com/openfoodfoundation/openfoodnetwork/security/advisories/GHSA-g347-rpvg-vq66

The admin search variant endpoint doesn't properly scope the search to the current user, meaning it allows any admin user full access the everyone's product. This PR add proper scoping, the search is now scoped to variant visible to the user, ie variant belonging to user's enterprise or variant the user has been granted permission for.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

:green_circle:  Green spec should be enough.

Manual test:
- Log in as an enterprise user 
- load the search endpoint url : http://<ofn_instance_url>/admin/variants/search.json?q=<search_term>, replace `ofn_isntance_url` by the correct url, and `<search_term>` by the name of a product the user should not have access to 
 -> you should a response not including the product the user doesn't have access to. 

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.