### PR TITLE
Fix silent stock failure when adding a variant to an admin order

### DIFF
--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -90,7 +90,7 @@ $(document).ready(function() {
   }
 });
 
-adjustItems = function(shipment_number, variant_id, quantity, restock_item, event){
+adjustItems = function(shipment_number, variant_id, quantity, restock_item, event, onFail){
   var shipment = _.findWhere(shipments, {number: shipment_number + ''});
   var inventory_units = _.where(shipment.inventory_units, {variant_id: variant_id});
 
@@ -102,17 +102,17 @@ adjustItems = function(shipment_number, variant_id, quantity, restock_item, even
           redirectTo.searchParams.append("send_cancellation_email", sendEmailCancellation);
           redirectTo.searchParams.append("restock_item", restock_item);
           window.location.href = redirectTo.toString();
-        });
+        }, onFail);
       }
     }, undefined, event);
     return;
   }
   doAdjustItems(shipment_number, variant_id, quantity, inventory_units, restock_item, () => {
     window.location.reload();
-  });
+  }, onFail);
 }
 
-doAdjustItems = function(shipment_number, variant_id, quantity, inventory_units, restock_item, callback) {
+doAdjustItems = function(shipment_number, variant_id, quantity, inventory_units, restock_item, callback, onFail) {
   var url = Spree.routes.orders_api + "/" + order_number + "/shipments/" + shipment_number;
 
   var new_quantity = 0;
@@ -137,6 +137,9 @@ doAdjustItems = function(shipment_number, variant_id, quantity, inventory_units,
       data: data
     }).done(function( msg ) {
       callback();
+    }).fail(function( xhr ) {
+      ofnAlert(errorMessageFromResponse(xhr));
+      if (onFail) { onFail(); }
     });
   }
 }
@@ -200,12 +203,15 @@ addVariantFromStockLocation = function() {
       data: { variant_id: variant_id, quantity: quantity }
     }).done(function( msg ) {
       window.location.reload();
-    }).error(function( msg ) {
-      console.log(msg);
+    }).fail(function( xhr ) {
+      ofnAlert(errorMessageFromResponse(xhr));
+      $('#stock_details').show();
     });
   }else{
     //add to existing shipment
-    adjustItems(shipment.number, variant_id, quantity, true);
+    adjustItems(shipment.number, variant_id, quantity, true, undefined, function() {
+      $('#stock_details').show();
+    });
   }
   return 1
 }
@@ -226,6 +232,17 @@ initConfirm = function() {
 ofnAlert = function(message) {
   $('#custom-alert .message').text(message);
   $('#custom-alert').show();
+}
+
+errorMessageFromResponse = function(xhr) {
+  var response = xhr.responseJSON;
+  if (response && response.errors && response.errors.quantity && response.errors.quantity.length > 0) {
+    return response.errors.quantity.join(", ");
+  }
+  if (response && response.error) {
+    return response.error;
+  }
+  return t("js.admin.orders.could_not_add_item");
 }
 
 ofnCancelOrderAlert = function(callback, i18nKey, event) {

--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -16,7 +16,8 @@ module Api
         quantity = params[:quantity].to_i
         @shipment = @order.shipment || @order.shipments.create
 
-        @order.contents.add(variant, quantity, @shipment)
+        line_item = @order.contents.add(variant, quantity, @shipment)
+        return invalid_resource!(line_item) unless line_item.errors.empty?
 
         @shipment.refresh_rates
         @shipment.save!
@@ -72,7 +73,9 @@ module Api
         variant = scoped_variant(params[:variant_id])
         quantity = params[:quantity].to_i
 
-        @order.contents.add(variant, quantity, @shipment)
+        line_item = @order.contents.add(variant, quantity, @shipment)
+        return invalid_resource!(line_item) unless line_item.errors.empty?
+
         @order.recreate_all_fees!
         AmendBackorderJob.perform_later(@order) if @order.completed?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3815,6 +3815,7 @@ en:
           invalid: "invalid"
         quantity_unavailable: "Insufficient stock available. Line item unsaved!"
         quantity_unchanged: "Quantity unchanged from previous amount."
+        could_not_add_item: "Could not update order. Please try again."
         cancel_the_order_html: "This will cancel the current order.<br />Are you sure you want to proceed?"
         cancel_the_order_send_cancelation_email: "Send a cancellation email to the customer"
         restock_item: "Restock Items: return this item to stock"

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -109,6 +109,19 @@ RSpec.describe Api::V0::ShipmentsController do
         expect_error_response
       end
 
+      it 'returns a validation error when quantity exceeds available stock' do
+        variant.on_hand = 1
+        variant.save!
+        original_total = order.total
+
+        spree_post :create, params
+
+        expect(response).to have_http_status :unprocessable_entity
+        expect(json_response["errors"]["quantity"]).to be_present
+        expect(order.reload.line_items).to be_empty
+        expect(order.total).to eq original_total
+      end
+
       it "applies any enterprise fees that are present" do
         order_cycle = create(:simple_order_cycle,
                              coordinator: order.distributor,
@@ -369,6 +382,17 @@ RSpec.describe Api::V0::ShipmentsController do
           expect_error_response
         end
 
+        it 'returns a validation error when quantity exceeds available stock' do
+          variant.on_hand = 1
+          variant.save!
+
+          spree_put :add, params
+
+          expect(response).to have_http_status :unprocessable_entity
+          expect(json_response["errors"]["quantity"]).to be_present
+          expect(inventory_units_for(variant)).to be_empty
+        end
+
         it 'adds a variant override to the shipment', feature: :inventory do
           hub = create(:distributor_enterprise)
           order.update_attribute(:distributor, hub)
@@ -394,7 +418,9 @@ RSpec.describe Api::V0::ShipmentsController do
             allow(Spree::Order).to receive(:find_by!) { fee_order }
             allow(controller).to receive(:refuse_changing_cancelled_orders)
             allow(fee_order).to receive(:contents) { contents }
-            allow(contents).to receive_messages(add: {}, remove: {})
+            allow(contents).to receive_messages(
+              add: instance_double(Spree::LineItem, errors: []), remove: {}
+            )
             allow(fee_order).to receive_message_chain(:shipments, :find_by!) { fee_order_shipment }
             allow(fee_order_shipment).to receive_messages(update: nil, reload: nil, persisted?: nil)
             allow(fee_order).to receive(:recreate_all_fees!)


### PR DESCRIPTION
## What? Why?

- Closes #14536

In the admin order edit page, an admin can add a variant to an order via an autocomplete widget. The request goes to `Api::V0::ShipmentsController#create` (brand new order, no shipment yet) or `#add` (existing shipment). Both call `@order.contents.add(variant, quantity, @shipment)`, which runs `Stock::AvailabilityValidator` — if the requested quantity exceeds the variant's `on_hand` (and it isn't `on_demand`), the resulting `Spree::LineItem` fails validation and is never persisted, and `OrderContents#add` returns that line item with `.errors` populated.

**The bug:** both controller actions discarded that return value entirely. The request still proceeded through `@shipment.refresh_rates` / `@shipment.save!` (or `@order.recreate_all_fees!`) and returned a 200 OK, even though nothing was actually added. The admin UI's JS had no error handling at all on the more common "add to existing shipment" path, so the page just silently reloaded as if the add had succeeded — an out-of-stock add could easily go unnoticed by a hub manager processing an order.

**The fix:**
- Both actions now capture the line item and check its errors before any side effects run: `line_item = @order.contents.add(...); return invalid_resource!(line_item) unless line_item.errors.empty?` — responding 422 with the validation error.
- The JS now surfaces that error via `ofnAlert` on both AJAX paths (previously the create-path handler used `.error()`, which doesn't exist in the jQuery 3.x this app ships — that handler was silently broken already), and keeps the Add Product panel open on failure so the quantity can be corrected and resubmitted without re-selecting the variant.
- One new i18n fallback key for the rare case the response doesn't carry a specific quantity error.

## What should we test?

1. On an existing order's admin edit page, use the "Add Product" autocomplete to add a variant with a quantity greater than its available stock, to a shipment that already exists.
   - Expected: an alert with the specific "X is out of stock" message, the Add Product panel stays open, no line item is added, order total unchanged.
   - Previously: silent page reload, no error shown, no line item added (misleadingly looked like nothing happened rather than like a rejected request).
2. Same scenario but on a brand-new order (no shipment created yet) — same expected behavior.
3. Confirm adding a variant within available stock still works normally on both paths.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [X] User facing changes

The title of the pull request will be included in the release notes.