### PR TITLE
Remove the ability to update Customer enterprise 

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -55,7 +55,7 @@ module Admin
 
     # copy of Admin::ResourceController without flash notice
     def update
-      if @object.update(permitted_resource_params)
+      if @object.update(customer_params.except("enterprise_id"))
         respond_with(@object) do |format|
           format.html { redirect_to location_after_save }
           format.js   { render layout: false }
@@ -129,11 +129,6 @@ module Admin
         ship_address_attributes: PermittedAttributes::Address.attributes,
         bill_address_attributes: PermittedAttributes::Address.attributes,
       )
-    end
-
-    # Used in Admin::ResourceController#update
-    def permitted_resource_params
-      customer_params
     end
 
     def tag_rule_mapping

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -106,7 +106,9 @@ module Admin
     end
 
     def managed_enterprise_id
-      @managed_enterprise_id ||= Enterprise.managed_by(spree_current_user).
+      return @managed_enterprise_id if defined?(@managed_enterprise_id)
+
+      @managed_enterprise_id = Enterprise.managed_by(spree_current_user).
         select('enterprises.id').find_by(id: params[:enterprise_id])
     end
 

--- a/app/controllers/api/v0/customers_controller.rb
+++ b/app/controllers/api/v0/customers_controller.rb
@@ -34,7 +34,7 @@ module Api
       end
 
       def customer_params
-        params.require(:customer).permit(:code, :email, :enterprise_id, :allow_charges)
+        params.require(:customer).permit(:code, :email, :allow_charges)
       end
     end
   end

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -44,7 +44,7 @@ module Api
       end
 
       def update
-        if customer.update(customer_params)
+        if customer.update(customer_params.except("enterprise_id"))
           render json: Api::V1::CustomerSerializer.new(customer)
         else
           invalid_resource! customer

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -163,6 +163,17 @@ RSpec.describe Admin::CustomersController do
           expect(assigns(:customer)).to eq customer
           expect(customer.reload.email).to eq 'new.email@gmail.com'
         end
+
+        it "ignores the enterprise id parameter" do
+          spree_put :update, format: :json, id: customer.id,
+                             customer: {
+                               email: 'new.email@gmail.com', enterprise_id: another_enterprise.id
+                             }
+          expect(response.parsed_body["id"]).to eq customer.id
+          expect(response.parsed_body["enterprise_id"]).to eq enterprise.id
+          expect(assigns(:customer)).to eq customer
+          expect(customer.reload.email).to eq 'new.email@gmail.com'
+        end
       end
 
       context "where I don't manage the customer's enterprise" do

--- a/spec/controllers/api/v0/customers_controller_spec.rb
+++ b/spec/controllers/api/v0/customers_controller_spec.rb
@@ -40,6 +40,25 @@ module Api
         end
       end
 
+      context "when updating the enterprise id" do
+        let(:new_enterprise) { create(:enterprise) }
+        let(:params) {
+          {
+            format: :json,
+            id: customer.id,
+            customer: { code: '123', enterprise_id: new_enterprise.id }
+          }
+        }
+
+        before do
+          allow(controller).to receive(:spree_current_user) { user }
+        end
+
+        it "ignores the enterprise_id parameter" do
+          expect { spree_post :update, params }.not_to change { customer.reload.enterprise }
+        end
+      end
+
       context "as the user associated with the customer" do
         before do
           allow(controller).to receive(:spree_current_user) { user }

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe "Customers", swagger_doc: "v1.yaml" do
 
       parameter name: :customer, in: :body, schema: {
         type: :object,
-        properties: CustomerSchema.writable_attributes,
+        properties: CustomerSchema.writable_attributes.except(:enterprise_id),
         required: CustomerSchema.required_attributes
       }
 
@@ -366,6 +366,22 @@ RSpec.describe "Customers", swagger_doc: "v1.yaml" do
           expect(json_response[:data][:attributes]).to include(
             tags: ["long-term"],
           )
+        end
+      end
+
+      describe "updating enterprise" do
+        let(:new_enterprise) { create(:enterprise) }
+
+        it "ignores the enterprise_id parameter " do
+          expect {
+            put "/api/v1/customers/#{customer1.id}", params: {
+              customer: {
+                enterprise_id: new_enterprise.id,
+              }
+            }
+          }.not_to change { customer1.reload.enterprise }
+
+          expect(response).to have_http_status :ok
         end
       end
 

--- a/swagger/v1.yaml
+++ b/swagger/v1.yaml
@@ -392,7 +392,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/error_response"
         '401':
-          description: Access forbidden
+          description: Unauthorized
       requestBody:
         content:
           application/json:
@@ -682,9 +682,6 @@ paths:
             schema:
               type: object
               properties:
-                enterprise_id:
-                  type: integer
-                  example: 2
                 first_name:
                   type: string
                   nullable: true


### PR DESCRIPTION
## What? Why?

- Closes https://github.com/openfoodfoundation/openfoodnetwork/security/advisories/GHSA-3f4x-grmj-89vx <!-- Insert issue number here. -->

The v0 and v1 customer api endpoint allows a user to update a customer's enterprise id, thus moving a customer to another enterprise. This is not something we should be doing, we should be creating a new customer for the other enterprise. This PR remove the ability to update the customer's enterprise.
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

:green_circle: spec should be enough

Manual testing, via http://<ofn_instance_url>/api-docs/
- Try updating a customer passing an `enterprise_id`
  -> the api should perform the update but ignore `enterprise_id`


## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [x] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.