### PR TITLE
Fix flaky variant autocomplete spec by retrying the remote select2 search

### DIFF
--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -64,17 +64,37 @@ module WebHelper
   def select2_select(value, options)
     open_select2("#s2id_#{options[:from]}")
 
-    if options[:search]
-      page.find(:xpath, '//body')
-        .find(:css, '.select2-drop-active input.select2-input, ' \
-                    '.select2-dropdown-open input.select2-input')
-        .set(value)
-    end
+    search_select2(value, options) if options[:search]
 
     page.find(:xpath, '//body')
       .find(:css, '.select2-drop-active .select2-result-label',
             text: options[:select_text] || value)
       .click
+  end
+
+  # Type a search term and wait for the select2 to show results.
+  #
+  # A remote select2 sends a single (debounced) request per search term and
+  # remembers the term it last queried for, so it never asks the server again for
+  # the same input. If that one request fails to produce results, the dropdown is
+  # stuck on "No matches found" and Capybara's retrying can't recover: nothing on
+  # the page will ever change again. Closing and re-opening the select2 clears the
+  # remembered term, so typing it again triggers a fresh request.
+  def search_select2(value, options, attempts: 2)
+    attempts.times do |attempt|
+      if attempt.positive?
+        close_select2
+        open_select2("#s2id_#{options[:from]}") # re-opening clears the remembered term
+      end
+
+      select2_search_field.set(value)
+      break if page.has_css?('.select2-drop-active .select2-result-label')
+    end
+  end
+
+  def select2_search_field
+    page.find(:xpath, '//body').find(:css, '.select2-drop-active input.select2-input, ' \
+                                           '.select2-dropdown-open input.select2-input')
   end
 
   def open_select2(selector)


### PR DESCRIPTION
## What? Why?

`spec/system/admin/fees_on_orders_spec.rb:651` ("creating an order with distributor and order cycle") has been failing intermittently on master. Three failures in four days, always on the same line:

```
Capybara::ElementNotFound:
  Unable to find css ".select2-drop-active .select2-result-label" within <body>
# ./spec/support/request/web_helper.rb:75:in 'WebHelper#select2_select'
# ./spec/system/admin/fees_on_orders_spec.rb:657
```

- https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/34294129395/job/102286941108
- https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/34168673455
- https://github.com/openfoodfoundation/openfoodnetwork/actions/runs/34106998983

All three failure screenshots are identical: the complete, correct product name is typed into the variant search box and the dropdown says **NO MATCHES FOUND**.

**Root cause.** The variant autocomplete is a *remote* select2. Select2 3.x sends exactly one debounced request per search term and remembers the term it last queried for:

```js
// prevent duplicate queries against the same term
if (initial !== true && lastTerm && equal(term, lastTerm)) return;
```

So when that single request produces no results, the dropdown stays on "No matches found" permanently — Capybara's retrying can't recover, because nothing on the page will ever change again. The helper had zero tolerance for one bad response.

I confirmed this is the mechanism by making the first variant search of the example return an empty list and changing nothing else: on the old helper that reproduces the CI failure verbatim — same exception, same line, and a screenshot pixel-identical to the CI ones.

I could not reproduce the underlying empty response itself (~150 runs of the example, plus replays of the exact knapsack batch, with CPU throttling and CI env vars). I did rule the data out: logging every search request server-side shows the query string, distributor, order cycle, `search_variants_as` and stock are correct in every run, both of the order cycle's products are findable, and the sidebar tabs in the failure screenshots only render when the order has both a distributor and an order cycle — so the request the browser made was well formed.

**Fix.** `select2_select` now retries the remote search. Closing and re-opening the select2 clears the remembered term (`close` clears the search field, `open` calls `updateResults(true)`, which skips the duplicate guard), so typing the term again runs a fresh search. On the last attempt the term is left in place so a genuine failure still shows the familiar error and screenshot. Select2s without `search: true` are untouched.

Two related findings I left alone, happy to follow up separately:

- ~~`variant_autocomplete.js.coffee` has `datatype: "json"` (lowercase `t`), so `dataType` is undefined and jQuery sniffs the content type.~~ **Corrected:** the typo is a no-op. Select2 defaults the option itself (`dataType: options.dataType || "json"`) and the later `$.extend` cannot unset it, because `jQuery.extend` skips undefined values — so the response is already parsed strictly. That matters for reading the screenshots: a non-JSON, empty or error response leaves the dropdown on "Searching…" and never calls select2's `results` callback, so "No matches found" means the app genuinely returned a parseable, empty JSON array. Details in [this comment](https://github.com/openfoodfoundation/openfoodnetwork/pull/14754#issuecomment-5673441882).
- `let(:product) { order_cycle1.products.first }` in `fees_on_orders_spec.rb` is nondeterministic — `OrderCycle#products` has no `ORDER BY`, so which of the order cycle's two products is picked flips between runs. Both work today, so it isn't this flake, but it makes the spec's data non-reproducible.

## What should we test?

This only touches a system-spec helper, so CI is the test. The specs using `select2_select ..., search: true` all pass locally:

- `spec/system/admin/fees_on_orders_spec.rb:651`
- `spec/system/admin/order_spec.rb`
- `spec/system/admin/variant_overrides_spec.rb:476`
- `spec/system/admin/enterprise_groups_spec.rb` (multi-select2 with a local search)
- `spec/system/admin/subscriptions/crud_spec.rb`
- `spec/system/admin/orders/having_producer_products/{hub,producer}_actions_spec.rb`

To see the failure this fixes, prepend a module to `Spree::Admin::VariantsController` that makes the first `search` call `render json: []`, then run `spec/system/admin/fees_on_orders_spec.rb:651`: it fails on master and passes here.

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] Technical changes only

