### PR TITLE
Display special characters correctly in schedule names

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/ofn-select2.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/ofn-select2.js.coffee
@@ -39,7 +39,6 @@ angular.module("admin.utils").directive "ofnSelect2", ($sanitize, $timeout, $fil
     init = ->
       scope.data.unshift(scope.blank) if scope.blank? && typeof scope.blank is "object"
 
-      item.name = $sanitize(item.name) for item in scope.data
       element.select2
         multiple: scope.multiple
         placeholder: scope.placeholder
@@ -48,6 +47,6 @@ angular.module("admin.utils").directive "ofnSelect2", ($sanitize, $timeout, $fil
           filtered = $filter('filter')(scope.data,scope.filter)
           { results: filtered, text: scope.text }
         formatSelection: (item) ->
-          item[scope.text]
+          $sanitize(item[scope.text])
         formatResult: (item) ->
-          item[scope.text]
+          $sanitize(item[scope.text])

--- a/spec/system/admin/schedules_spec.rb
+++ b/spec/system/admin/schedules_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe 'Schedules' do
     before { login_as user }
 
     describe "Adding a new Schedule" do
-      it "immediately shows the schedule in the order cycle list once created" do
+      it "shows a schedule with special characters immediately and after reloading" do
+        schedule_name = "wöchentlich"
+
         visit spree.admin_dashboard_path
         click_link 'Order cycles'
         expect(page).to have_selector ".order-cycle-#{oc1.id}"
@@ -41,7 +43,7 @@ RSpec.describe 'Schedules' do
           expect(page).to have_selector '#available-order-cycles .order-cycle', text: oc3.name
           expect(page).not_to have_selector '#available-order-cycles .order-cycle', text: oc4.name
           expect(page).to have_selector '#available-order-cycles .order-cycle', text: oc5.name
-          fill_in 'name', with: "Fortnightly"
+          fill_in 'name', with: schedule_name
           find("#available-order-cycles .order-cycle", text: oc1.name).click
           find("#add-remove-buttons a.add").click
           # Selection of an order cycles limits available options to those with the same coordinator
@@ -52,21 +54,27 @@ RSpec.describe 'Schedules' do
         end
 
         save_bar = find("#save-bar")
-        expect(save_bar).to have_content "Created schedule: 'Fortnightly'"
+        expect(save_bar).to have_content "Created schedule: '#{schedule_name}'"
 
         within ".order-cycle-#{oc1.id} td.schedules" do
           expect(page).to have_selector "a", text: "Weekly"
-          expect(page).to have_selector "a", text: "Fortnightly"
+          expect(page).to have_selector "a", text: schedule_name
         end
 
         within ".order-cycle-#{oc2.id} td.schedules" do
           expect(page).to have_selector "a", text: "Weekly"
-          expect(page).not_to have_selector "a", text: "Fortnightly"
+          expect(page).not_to have_selector "a", text: schedule_name
         end
 
         within ".order-cycle-#{oc3.id} td.schedules" do
           expect(page).to have_selector "a", text: "Weekly"
-          expect(page).to have_selector "a", text: "Fortnightly"
+          expect(page).to have_selector "a", text: schedule_name
+        end
+
+        refresh
+
+        within ".order-cycle-#{oc1.id} td.schedules" do
+          expect(page).to have_selector "a", text: schedule_name
         end
       end
     end


### PR DESCRIPTION
## What? Why?

- Closes #14499.

Schedule names containing characters such as `ö`, `ü`, `ä`, or `ß` were displayed as HTML entities after the order cycles page was reloaded.

The `ofnSelect2` directive sanitized names by overwriting objects in its shared data collection. Because schedule objects are reused by the order cycle list, this mutation replaced the original name with its encoded representation.

This change leaves the shared objects untouched and sanitizes only the values returned to Select2 for rendering.

This follows the investigation and original fix proposed by @Aaryanpal in #14502. This PR adds the requested regression coverage and carries that work through to completion.

## What should we test?

- Visit `/admin/order_cycles`.
- Create a schedule named `wöchentlich` and assign it to an order cycle.
- Confirm the name is displayed correctly immediately after creation.
- Reload the page and confirm it is still displayed as `wöchentlich`.
- Confirm the schedule and enterprise Select2 filters still render and select values normally.

Automated coverage:

- `bundle exec rspec spec/system/admin/schedules_spec.rb`
- Result: 3 examples, 0 failures

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled
