### PR TITLE
Show the producer, not the linked-variant owner, in reports and emails

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -87,7 +87,7 @@ class ProducerMailer < ApplicationMailer
 
       {
         sku: line_item.variant.sku,
-        supplier_name: line_item.supplier.name,
+        supplier_name: line_item.variant.producer.name,
         product_and_full_name: line_item.product_and_full_name,
         quantity: line_item.quantity,
         first_name: order.billing_address.first_name,

--- a/app/models/invoice/data_presenter/line_item.rb
+++ b/app/models/invoice/data_presenter/line_item.rb
@@ -6,7 +6,7 @@ class Invoice
       attributes :id, :added_tax, :currency, :included_tax, :price_with_adjustments, :quantity,
                  :variant_id, :unit_price, :unit_presentation,
                  :enterprise_fee_additional_tax, :enterprise_fee_included_tax
-      attributes_with_presenter :variant, :supplier
+      attributes_with_presenter :variant, :producer
       invoice_generation_attributes :added_tax, :included_tax, :price_with_adjustments,
                                     :quantity, :variant_id
 

--- a/app/models/invoice/data_presenter/producer.rb
+++ b/app/models/invoice/data_presenter/producer.rb
@@ -2,7 +2,7 @@
 
 class Invoice
   class DataPresenter
-    class Supplier < Invoice::DataPresenter::Base
+    class Producer < Invoice::DataPresenter::Base
       attributes :name
     end
   end

--- a/app/serializers/invoice/line_item_serializer.rb
+++ b/app/serializers/invoice/line_item_serializer.rb
@@ -6,6 +6,11 @@ class Invoice
                :variant_id, :unit_price, :unit_presentation,
                :enterprise_fee_additional_tax, :enterprise_fee_included_tax
     has_one :variant, serializer: Invoice::VariantSerializer
+    has_one :producer, serializer: Invoice::EnterpriseSerializer
+
+    def producer
+      object.variant.producer
+    end
 
     def enterprise_fee_additional_tax
       EnterpriseFeeAdjustments.new(object.enterprise_fee_adjustments).total_additional_tax

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -40,7 +40,7 @@
             = line_items.first.variant.sku
           - if @distributors_pickup_times.many?
             %td
-              = line_items.first.supplier.name
+              = line_items.first.variant.producer.name
           %td
             = product_and_full_name
           %td.text-right

--- a/app/views/spree/admin/orders/_invoice_table.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table.html.haml
@@ -16,7 +16,7 @@
           = render 'spree/shared/line_item_name', line_item: item
           %br
           %small
-            %em= item.supplier.name
+            %em= item.variant.producer.name
         %td{:align => "right"}
           = item.quantity
         %td{:align => "right"}

--- a/app/views/spree/admin/orders/_invoice_table2.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table2.html.haml
@@ -19,7 +19,7 @@
           = render 'spree/shared/line_item_name', line_item: item
           %br
           %small
-            %em= item.supplier.name
+            %em= item.variant.producer.name
         %td{:align => "right"}
           = item.quantity
         %td{:align => "right"}

--- a/app/views/spree/admin/orders/_invoice_table4.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table4.html.haml
@@ -22,7 +22,7 @@
           = render 'spree/admin/orders/_invoice/line_item_name', line_item: item
           %br
           %small
-            %em= item.supplier.name
+            %em= item.producer.name
         %td{:align => "right"}
           = item.quantity
         %td{:align => "right"}

--- a/app/views/spree/order_mailer/_order_summary.html.haml
+++ b/app/views/spree/order_mailer/_order_summary.html.haml
@@ -20,7 +20,7 @@
           = render 'spree/shared/line_item_name', line_item: item
           %br
           %small
-            %em= item.supplier.name
+            %em= item.variant.producer.name
         %td
           - if item.variant.sku.blank?
             \-

--- a/lib/reporting/queries/tables.rb
+++ b/lib/reporting/queries/tables.rb
@@ -31,6 +31,24 @@ module Reporting
         Enterprise.arel_table.alias(:product_supplier)
       end
 
+      # The producer is the first enterprise in the chain of linked variants, if
+      # any, otherwise the variant's own enterprise. Mirrors Spree::Variant#producer,
+      # but resolved as a correlated subquery so it can be used in report SQL.
+      def producer_name_field
+        Arel.sql(<<~SQL.squish)
+          (
+            SELECT enterprises.name FROM variant_links
+            INNER JOIN spree_variants AS source_variant_for_producer
+              ON source_variant_for_producer.id = variant_links.source_variant_id
+            INNER JOIN enterprises
+              ON enterprises.id = source_variant_for_producer.enterprise_id
+            WHERE variant_links.target_variant_id = spree_variants.id
+            ORDER BY source_variant_for_producer.id ASC
+            LIMIT 1
+          )
+        SQL
+      end
+
       def bill_address_alias
         Spree::Address.arel_table.alias(:bill_address)
       end

--- a/lib/reporting/reports/bulk_coop/supplier_report.rb
+++ b/lib/reporting/reports/bulk_coop/supplier_report.rb
@@ -45,7 +45,7 @@ module Reporting
         private
 
         def variant_supplier_name(line_items)
-          line_items.first.supplier.name
+          line_items.first.variant.producer.name
         end
       end
     end

--- a/lib/reporting/reports/orders_and_fulfillment/base.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/base.rb
@@ -49,11 +49,11 @@ module Reporting
         end
 
         def supplier_name
-          proc { |line_items| line_items.first.supplier.name }
+          proc { |line_items| line_items.first.variant.producer.name }
         end
 
         def supplier_charges_sales_tax?
-          proc { |line_items| line_items.first.supplier.charges_sales_tax }
+          proc { |line_items| line_items.first.variant.producer.charges_sales_tax }
         end
 
         def product_name

--- a/lib/reporting/reports/packing/base.rb
+++ b/lib/reporting/reports/packing/base.rb
@@ -46,7 +46,7 @@ module Reporting
               last_name: mask_customer_name(bill_address_alias[:lastname]),
               first_name: mask_customer_name(bill_address_alias[:firstname]),
               phone: mask_contact_data(bill_address_alias[:phone]),
-              supplier: supplier_alias[:name],
+              supplier: coalesce(producer_name_field, supplier_alias[:name]),
               product: product_table[:name],
               variant: variant_full_name,
               weight: line_item_table[:weight],

--- a/lib/reporting/reports/packing/supplier.rb
+++ b/lib/reporting/reports/packing/supplier.rb
@@ -46,7 +46,7 @@ module Reporting
           lambda do
             [
               distributor_alias[:name],
-              supplier_alias[:name],
+              Arel.sql("supplier"),
               Arel.sql("product"),
               Arel.sql("variant"),
               Arel.sql("last_name")

--- a/lib/reporting/reports/products_and_inventory/base.rb
+++ b/lib/reporting/reports/products_and_inventory/base.rb
@@ -13,8 +13,8 @@ module Reporting
         # rubocop:disable-next Metrics/AbcSize
         def columns
           {
-            supplier: proc { |variant| variant.enterprise.name },
-            producer_suburb: proc { |variant| variant.enterprise.address.city },
+            supplier: proc { |variant| variant.producer.name },
+            producer_suburb: proc { |variant| variant.producer.address.city },
             product: proc { |variant| variant.product.name },
             product_properties: proc { |v| v.product.properties.map(&:name).join(", ") },
             taxons: proc { |variant| variant.primary_taxon.name },

--- a/lib/reporting/reports/sales_tax/sales_tax_totals_by_producer.rb
+++ b/lib/reporting/reports/sales_tax/sales_tax_totals_by_producer.rb
@@ -33,7 +33,7 @@ module Reporting
             end.group_by do |hash|
             [
               hash[:tax_rate_id],
-              hash[:line_item].supplier_id,
+              hash[:line_item].variant.producer.id,
               hash[:line_item].order.distributor_id,
               hash[:line_item].order.order_cycle_id
             ]
@@ -103,11 +103,11 @@ module Reporting
         end
 
         def producer(query_result_row)
-          first_line_item(query_result_row).supplier.name
+          first_line_item(query_result_row).variant.producer.name
         end
 
         def producer_tax_status(query_result_row)
-          first_line_item(query_result_row).supplier.charges_sales_tax
+          first_line_item(query_result_row).variant.producer.charges_sales_tax
         end
 
         def order_cycle(query_result_row)

--- a/lib/reporting/reports/suppliers/helpers/line_items_access_helper.rb
+++ b/lib/reporting/reports/suppliers/helpers/line_items_access_helper.rb
@@ -14,7 +14,7 @@ module Reporting
           end
 
           def supplier(line_item)
-            variant(line_item).enterprise
+            variant(line_item).producer
           end
 
           def distributor(line_item)

--- a/spec/lib/reports/products_and_inventory_report_spec.rb
+++ b/spec/lib/reports/products_and_inventory_report_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Reporting::Reports::ProductsAndInventory::Base do
                                  full_name: "Variant Name",
                                  count_on_hand: 10,
                                  price: 100)
-      allow(variant).to receive_message_chain(:enterprise, :name).and_return("Supplier")
-      allow(variant).to receive_message_chain(:enterprise, :address, :city).and_return("A city")
+      allow(variant).to receive_message_chain(:producer, :name).and_return("Supplier")
+      allow(variant).to receive_message_chain(:producer, :address, :city).and_return("A city")
       allow(variant).to receive_message_chain(:product, :name).and_return("Product Name")
       allow(variant).to receive_message_chain(:product, :properties)
         .and_return [double(name: "property1"), double(name: "property2")]


### PR DESCRIPTION
## What? Why?

- Closes #14691

When a hub creates a linked variant from a producer's product, the variant's owning enterprise becomes the hub, not the original producer. Several reports and customer/producer-facing emails were displaying that owning enterprise (`variant.enterprise` / `Spree::LineItem#supplier`) as the "supplier", so for linked variants the hub was shown instead of the actual producer.

This switches those to `Spree::Variant#producer`, which resolves through the linked-variant chain (`source_variants`) back to the original producer, falling back to the variant's own enterprise when it isn't a linked variant.

**Reports fixed:** `bulk_coop/supplier_report`, `order_cycle_supplier_totals`, `order_cycle_supplier_totals_by_distributor`, `order_cycle_distributor_totals_by_supplier`, `order_cycle_customer_totals`, `products_and_inventory/all_products`, `sales_tax_totals_by_producer`, `suppliers/pay_your_suppliers`, and the packing reports (`customer`, `product`, `supplier`). The packing reports run a single SQL query rather than loading AR objects, so a correlated SQL subquery mirrors `Variant#producer`'s logic there.

**Emails fixed:** the order confirmation/cancellation emails (`Spree::OrderMailer`), the producer order-cycle notification email (`ProducerMailer`), and invoice PDFs attached to the invoice email (all three invoice template versions). The v3 invoice template's supplier field was actually dead code (the serializer never emitted it, so it always rendered blank) — this PR wires up a working `producer` field there instead.

The consumer checkout flow (details/payment/summary steps, confirmation page) was also audited but doesn't display any supplier/producer field today, so no changes were needed there.

## What should we test?

- As a hub, create a linked variant from a producer's product, add it to an order cycle, and place an order.
- Check the order confirmation email (and cancellation email) — the producer's name should show under the product, not the hub's.
- Check the producer's order-cycle notification email — same.
- Generate an invoice PDF for the order (all invoice styles if togglable) — the producer's name should show, not the hub's.
- Run the "Pack by supplier" (and by customer/product) reports, `bulk_coop` supplier report, `orders_and_fulfillment` supplier/distributor reports, `products_and_inventory` all products report, `sales_tax_totals_by_producer`, and `pay_your_suppliers` — all should group/label by the producer, not the hub.
- Confirm non-linked variants are unaffected (producer falls back to the variant's own enterprise).

## Release notes

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

## Dependencies

None.

## Documentation updates

None.