### PR TITLE
Fix checkout flacky spec

### DIFF
--- a/spec/system/consumer/checkout/tax_not_incl_spec.rb
+++ b/spec/system/consumer/checkout/tax_not_incl_spec.rb
@@ -103,10 +103,11 @@ RSpec.describe "As a consumer, I want to see adjustment breakdown" do
 
         click_button "Next - Payment method"
 
+        click_on "Next - Order summary"
+
         # DB checks
         expect(order_within_zone.reload.additional_tax_total).to eq(1.3)
 
-        click_on "Next - Order summary"
         click_on "Complete order"
 
         # UI checks


### PR DESCRIPTION

## What? Why?

- Closes # <!-- Insert issue number here. -->

The order's adjustments should be updated by the time the "Payment step" is loaded. But there seem to be some race condition on slow machine that results in the DB check executing before the order's adjustments have been saved. By moving the DB check later, we ensure the order's adjustments are already saved.

Example of failure: 

```
1) As a consumer, I want to see adjustment breakdown a not-included tax for a customer with shipping address within the tax zone will be charged tax on the order
     Failure/Error: expect(order_within_zone.reload.additional_tax_total).to eq(1.3)
     
       expected: 1.3
            got: 0.0
     
       (compared using ==)
     
     [Screenshot Image]: /home/runner/work/openfoodnetwork/openfoodnetwork/tmp/capybara/failures_r_spec_example_groups_as_a_consumer_i_want_to_see_adjustment_breakdown_a_not_included_tax_for_a_customer_with_shipping_address_within_the_tax_zone_will_be_charged_tax_on_the_order_315.png

     
     # ./spec/system/consumer/checkout/tax_not_incl_spec.rb:107:in 'block (4 levels) in <top (required)>'
     # ./spec/system/support/cuprite_setup.rb:61:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:159:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:159:in 'block (2 levels) in <top (required)>'

Finished in 5 minutes 4 seconds (files took 8.65 seconds to load)
52 examples, 1 failure, 1 pending

Failed examples:

rspec ./spec/system/consumer/checkout/tax_not_incl_spec.rb:99 # As a consumer, I want to see adjustment breakdown a not-included tax for a customer with shipping address within the tax zone will be charged tax on the order
```
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->


## What should we test?

:green_circle: spec is enough

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [ ] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [x] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
