### PR TITLE
Fix network alert when changing page on Bulk Product Edit

### DIFF
--- a/app/views/admin/shared/_stimulus_pagination.html.haml
+++ b/app/views/admin/shared/_stimulus_pagination.html.haml
@@ -3,7 +3,7 @@
 %nav.pagination{ "aria-label": t('.navigation'), "data-controller": "search" }
   - if pagy.prev
     %a.page.prev{ href: "#", rel: "prev", "aria-label": t('.previous'), data: { action: 'click->search#changePage', page: pagy.prev } }
-      %i.icon-chevron-left{ data: { action: 'click->search#changePage', page: pagy.prev } }
+      %i.icon-chevron-left
 
   %ul.pagelist
     - pagy.series.each do |item|                      # series example: [1, :gap, 7, 8, "9", 10, 11, :gap, 36]
@@ -23,4 +23,4 @@
 
   - if pagy.next
     %a.page.next{ href: "#", rel: "next", "aria-label": t('.next'), data: { action: 'click->search#changePage', page: pagy.next } }
-      %i.icon-chevron-right{ data: { action: 'click->search#changePage', page: pagy.next } }
+      %i.icon-chevron-right

--- a/app/views/admin/shared/_stimulus_pagination.html.haml
+++ b/app/views/admin/shared/_stimulus_pagination.html.haml
@@ -2,14 +2,14 @@
 
 %nav.pagination{ "aria-label": t('.navigation'), "data-controller": "search" }
   - if pagy.prev
-    %a.page.prev{ href: "#", rel: "prev", "aria-label": t('.previous'), data: { action: 'click->search#changePage', page: pagy.prev } }
+    %a.page.prev{ href: "#", rel: "prev", "aria-label": t('.previous'), data: { action: 'click->search#changePage', 'search-page-param': pagy.prev } }
       %i.icon-chevron-left
 
   %ul.pagelist
     - pagy.series.each do |item|                      # series example: [1, :gap, 7, 8, "9", 10, 11, :gap, 36]
       - if item.is_a?(Integer)                        # page link
         %li
-          %a.page{ href: "#", "aria-label": t('.page', number: item), data: { action: 'click->search#changePage', page: item } }= item
+          %a.page{ href: "#", "aria-label": t('.page', number: item), data: { action: 'click->search#changePage', 'search-page-param': item } }= item
 
       - elsif item.is_a?(String)                      # current page
         %li
@@ -22,5 +22,5 @@
           %span.page.gap.pagination-ellipsis!= pagy_t('pagy.gap')
 
   - if pagy.next
-    %a.page.next{ href: "#", rel: "next", "aria-label": t('.next'), data: { action: 'click->search#changePage', page: pagy.next } }
+    %a.page.next{ href: "#", rel: "next", "aria-label": t('.next'), data: { action: 'click->search#changePage', 'search-page-param': pagy.next } }
       %i.icon-chevron-right

--- a/app/webpacker/controllers/search_controller.js
+++ b/app/webpacker/controllers/search_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
     const productsForm = document.querySelector("#products-form");
     if (productsForm) productsForm.scrollIntoView({ behavior: "smooth" });
 
-    this.page.value = event.target.dataset.page;
+    this.page.value = event.params.page;
     this.submitSearch();
     this.page.value = 1;
   }


### PR DESCRIPTION
## What? Why?

- Addresses part 2 and closes #13775  <!-- Insert issue number here. -->

Both the link and the icon within link had the action to load the next/previous page resulting in 2 request sent each time a user try to navigate to the next/previous page. This PR remove the redundant action and fix the  way the page parameter is pass to the action,
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



## What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

* Go to Admin > Products if you have access to more than 15 products
* Scroll to bottom and click ">" next page
 -> no network error
* Scroll to bottom and click "<" previous page
 -> no network error

## Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category (reviewers may add a label for the release notes):

- [x] User facing changes
- [ ] API changes (V0, V1, DFC or Webhook)
- [ ] Technical changes only
- [ ] Feature toggled

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.